### PR TITLE
feat: extract license matches by using ScanStrategy with optimize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +444,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "include_dir"
@@ -695,6 +773,7 @@ dependencies = [
  "chrono",
  "clap",
  "content_inspector",
+ "derive_builder",
  "env_logger",
  "flate2",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ unicode-normalization = "0.1.8"
 
 zstd = "0.13"
 flate2 = { version = "1.0.14", optional = true }
+derive_builder = "0.20.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 flate2 = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 keywords = ["scancode", "license", "analysis", "rust"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
-authors = ["Maxim Stykow"]
+authors = ["Maxim Stykow", "Adrian Braemer"]
 
 [dependencies]
 chrono = "0.4.40"

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1,6 +1,7 @@
-use serde::{Serialize, Deserialize};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Debug)]
+#[derive(Debug, Builder, Serialize)]
 pub struct FileInfo {
     pub name: String,
     pub base_name: String,
@@ -8,23 +9,35 @@ pub struct FileInfo {
     pub path: String,
     #[serde(rename = "type")] // name used by ScanCode
     pub file_type: FileType,
+    #[builder(default)]
     pub mime_type: Option<String>,
     pub size: u64,
+    #[builder(default)]
     pub date: Option<String>,
+    #[builder(default)]
     pub sha1: Option<String>,
+    #[builder(default)]
     pub md5: Option<String>,
+    #[builder(default)]
     pub sha256: Option<String>,
+    #[builder(default)]
     pub programming_language: Option<String>,
+    #[builder(default)]
     pub package_data: Vec<PackageData>,
     #[serde(rename = "detected_license_expression_spdx")] // name used by ScanCode
+    #[builder(default)]
     pub license_expression: Option<String>,
+    #[builder(default)]
     pub license_detections: Vec<LicenseDetection>,
+    #[builder(default)]
     pub copyrights: Vec<Copyright>,
+    #[builder(default)]
     pub urls: Vec<OutputURL>,
+    #[builder(default)]
     pub scan_errors: Vec<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct PackageData {
     #[serde(rename = "type")] // name used by ScanCode
     pub package_type: Option<String>,
@@ -40,14 +53,14 @@ pub struct PackageData {
     pub purl: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct LicenseDetection {
     #[serde(rename = "license_expression_spdx")] // name used by ScanCode
     pub license_expression: String,
     pub matches: Vec<Match>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Match {
     pub score: f64,
     pub start_line: usize,
@@ -58,31 +71,31 @@ pub struct Match {
     pub matched_text: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Copyright {
     pub copyright: String,
     pub start_line: usize,
     pub end_line: usize,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Dependency {
     pub purl: Option<String>,
     pub scope: Option<String>,
     pub is_optional: bool,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Party {
     pub email: StringOrArray,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct OutputURL {
     pub url: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FileType {
     File,
     Directory,

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -67,7 +67,7 @@ pub struct Match {
     pub end_line: usize,
     #[serde(rename = "license_expression_spdx")] // name used by ScanCode
     pub license_expression: String,
-    pub rule_identifier: String,
+    pub rule_identifier: Option<String>,
     pub matched_text: Option<String>,
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,5 @@
 mod file_info;
 mod output;
 
-pub use file_info::{FileInfo, FileType};
-pub use output::{ExtraData, Header, Output, SystemEnvironment, SCANCODE_OUTPUT_FORMAT_VERSION};
+pub use file_info::{FileInfo, FileInfoBuilder, FileType, LicenseDetection, Match};
+pub use output::{ExtraData, Header, Output, SCANCODE_OUTPUT_FORMAT_VERSION, SystemEnvironment};

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -109,7 +109,9 @@ fn process_file(path: &Path, metadata: &fs::Metadata, scan_strategy: &ScanStrate
     };
     file_info_builder.scan_errors(scan_errors);
 
-    return file_info_builder.build().expect("");
+    return file_info_builder
+        .build()
+        .expect("FileInformationBuild not completely initialized");
 }
 
 fn add_path_information(file_info_builder: &mut FileInfoBuilder, path: &Path) -> () {

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -189,7 +189,7 @@ fn extract_license_information(
                 end_line: detection.line_range.1,
                 license_expression: detection.license.name.to_string(),
                 matched_text: None, //TODO
-                rule_identifier: "".to_string(),
+                rule_identifier: None,
             }],
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
Changes:
* uses `derive_builder` to create a builder for `FileInformation`
* restructure information extraction using the builder
* change `Store` to `ScanStrategy`
* convert `ContainedLicense` into `LicenseDetection` and `Match`