### PR TITLE
fix(copyright): ignore URL-embedded (c) holder false positives

### DIFF
--- a/src/copyright/detector.rs
+++ b/src/copyright/detector.rs
@@ -4701,6 +4701,33 @@ fn drop_trailing_software_line_from_holders(content: &str, holders: &mut [Holder
     }
 }
 
+fn drop_url_embedded_c_symbol_false_positive_holders(
+    content: &str,
+    holders: &mut Vec<HolderDetection>,
+) {
+    static URL_EMBEDDED_C_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)https?://\S*\(c\)\S*").expect("valid URL embedded (c) regex")
+    });
+
+    let lines: Vec<&str> = content.lines().collect();
+    holders.retain(|holder| {
+        let Some(raw_line) = lines.get(holder.start_line.saturating_sub(1)) else {
+            return true;
+        };
+        if !URL_EMBEDDED_C_RE.is_match(raw_line) {
+            return true;
+        }
+
+        let value = holder.holder.trim();
+        let is_single_token = !value.chars().any(char::is_whitespace);
+        let is_lower_pathish = value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_');
+
+        !(is_single_token && is_lower_pathish)
+    });
+}
+
 fn extract_following_authors_holders(content: &str, holders: &mut Vec<HolderDetection>) {
     if content.is_empty() {
         return;

--- a/src/copyright/detector_postprocess_phase.rs
+++ b/src/copyright/detector_postprocess_phase.rs
@@ -28,6 +28,7 @@ pub(super) fn run_phase_postprocess(
     super::fix_sundry_contributors_truncation(content, copyrights, holders);
     super::restore_bare_holder_angle_emails(copyrights, holders);
     super::drop_trailing_software_line_from_holders(content, holders);
+    super::drop_url_embedded_c_symbol_false_positive_holders(content, holders);
 
     super::author_heuristics::merge_metadata_author_and_email_lines(content, authors);
     super::author_heuristics::extract_debian_maintainer_authors(content, authors);

--- a/src/copyright/detector_test.rs
+++ b/src/copyright/detector_test.rs
@@ -3404,3 +3404,14 @@ fn test_detect_copyright_with_dots_multiline() {
         h
     );
 }
+
+#[test]
+fn test_issue_4724_url_with_c_symbol_not_copyright() {
+    let input = "http://example.com/path/(c)/search";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+    assert!(
+        copyrights.is_empty(),
+        "Unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "Unexpected holders: {holders:?}");
+}

--- a/testdata/copyright-golden/copyrights/issue-4724-url-embedded-c-marker.txt
+++ b/testdata/copyright-golden/copyrights/issue-4724-url-embedded-c-marker.txt
@@ -1,0 +1,1 @@
+http://example.com/path/(c)/search

--- a/testdata/copyright-golden/copyrights/issue-4724-url-embedded-c-marker.txt.yml
+++ b/testdata/copyright-golden/copyrights/issue-4724-url-embedded-c-marker.txt.yml
@@ -1,0 +1,5 @@
+what:
+  - copyrights
+  - holders
+copyrights: []
+holders: []


### PR DESCRIPTION
## Summary
- Fixes false positive holder extraction when URL paths contain embedded `(c)` markers (issue #267 / upstream #4724).
- Adds a targeted postprocess filter in the copyright detector to drop path-like single-token holder artifacts only when the source line matches URL-embedded `(c)` patterns.
- Adds both unit and golden regression coverage:
  - `test_issue_4724_url_with_c_symbol_not_copyright`
  - `testdata/copyright-golden/copyrights/issue-4724-url-embedded-c-marker.txt(.yml)`

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib test_issue_4724_url_with_c_symbol_not_copyright`
- `cargo test --lib --features golden-tests test_golden_copyrights`
- `cargo build`

Closes #267