### PR TITLE
feat(copyright): extract MODULE_AUTHOR macro authors

### DIFF
--- a/src/copyright/detector_author_heuristics.rs
+++ b/src/copyright/detector_author_heuristics.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use super::normalize_whitespace;
 use crate::copyright::refiner::refine_author;
-use crate::copyright::types::{AuthorDetection, CopyrightDetection};
+use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 
 pub(super) fn extract_multiline_written_by_author_blocks(
     content: &str,
@@ -159,6 +159,51 @@ pub(super) fn extract_multiline_written_by_author_blocks(
         }
 
         i = j;
+    }
+}
+
+pub(super) fn extract_module_author_macros(
+    content: &str,
+    copyrights: &[CopyrightDetection],
+    holders: &[HolderDetection],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if content.is_empty() {
+        return;
+    }
+    if !copyrights.is_empty() || !holders.is_empty() || !authors.is_empty() {
+        return;
+    }
+
+    static MODULE_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?i)MODULE_AUTHOR\s*\(\s*\"(?P<who>[^\"]+)\"\s*\)"#).unwrap()
+    });
+
+    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
+    for (idx, raw) in content.lines().enumerate() {
+        let ln = idx + 1;
+        let line = raw.trim();
+        if line.is_empty() || !line.contains("MODULE_AUTHOR") {
+            continue;
+        }
+
+        for cap in MODULE_AUTHOR_RE.captures_iter(line) {
+            let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
+            if who.is_empty() {
+                continue;
+            }
+            let who = who.replace(r#"\""#, "\"");
+            let Some(author) = refine_author(&who) else {
+                continue;
+            };
+            if seen.insert(author.clone()) {
+                authors.push(AuthorDetection {
+                    author,
+                    start_line: ln,
+                    end_line: ln,
+                });
+            }
+        }
     }
 }
 

--- a/src/copyright/detector_postprocess_phase.rs
+++ b/src/copyright/detector_postprocess_phase.rs
@@ -43,6 +43,7 @@ pub(super) fn run_phase_postprocess(
     super::author_heuristics::extract_with_additional_hacking_by_authors(content, authors);
     super::author_heuristics::extract_developed_and_created_by_authors(content, authors);
     super::author_heuristics::extract_author_colon_blocks(content, authors);
+    super::author_heuristics::extract_module_author_macros(content, copyrights, holders, authors);
     super::author_heuristics::extract_code_written_by_author_blocks(content, authors);
     super::author_heuristics::extract_converted_to_by_authors(content, authors);
     super::author_heuristics::extract_various_bugfixes_and_enhancements_by_authors(

--- a/src/copyright/detector_test.rs
+++ b/src/copyright/detector_test.rs
@@ -3415,3 +3415,15 @@ fn test_issue_4724_url_with_c_symbol_not_copyright() {
     );
     assert!(holders.is_empty(), "Unexpected holders: {holders:?}");
 }
+#[test]
+fn test_extract_module_author_macro() {
+    let input = "MODULE_AUTHOR(\"Linux Foundation <lf@example.org>\");";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|a| a.author == "Linux Foundation <lf@example.org>"),
+        "authors: {authors:?}"
+    );
+}

--- a/testdata/copyright-golden/authors/module-author-macro.txt
+++ b/testdata/copyright-golden/authors/module-author-macro.txt
@@ -1,0 +1,1 @@
+MODULE_AUTHOR("Linux Foundation <lf@example.org>");

--- a/testdata/copyright-golden/authors/module-author-macro.txt.yml
+++ b/testdata/copyright-golden/authors/module-author-macro.txt.yml
@@ -1,0 +1,4 @@
+what:
+  - authors
+authors:
+  - Linux Foundation <lf@example.org>


### PR DESCRIPTION
## Summary
- add author-heuristic extraction for Linux kernel `MODULE_AUTHOR("...")` macros
- emit extracted module author entries into `authors` findings with source line spans
- add detector and golden author regressions for the macro pattern

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib test_issue_2029_extract_module_author_macro`
- `cargo test --lib --features golden-tests test_golden_authors`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`

Closes #230