### PR TITLE
chore(dev): streamline local cargo workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check compilation
         run: cargo check --all --verbose
 
-      - name: Run unit/integration/e2e/doc tests
+      - name: Run unit/integration/doc tests
         run: cargo test --all --verbose
 
       - name: Check for unused dependencies
@@ -79,6 +79,21 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${{ matrix.shard }}" == "parsers" ]]; then
+            cargo test --lib --verbose --features golden-tests --no-run
+
+            test_binary=""
+            while IFS= read -r candidate; do
+              if [[ -f "$candidate" && -x "$candidate" ]]; then
+                test_binary="$candidate"
+                break
+              fi
+            done < <(ls -t target/debug/deps/scancode_rust-* 2>/dev/null)
+
+            if [[ -z "$test_binary" ]]; then
+              echo "Could not determine parser golden test binary path" >&2
+              exit 1
+            fi
+
             shopt -s nullglob
             parser_files=(src/parsers/*_golden_test.rs)
             if (( ${#parser_files[@]} == 0 )); then
@@ -91,7 +106,7 @@ jobs:
               module_name="${module_name%.rs}"
               filter="parsers::${module_name}::"
               echo "Running golden filter: $filter"
-              cargo test --lib --verbose --features golden-tests "$filter"
+              "$test_binary" "$filter"
             done
           else
             echo "Running golden filter: ${{ matrix.filter }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,15 @@ git submodule update --init   # Ensure all submodules are initialized
 # Build & Test
 cargo build                   # Development build
 cargo build --release         # Optimized build
-cargo test                    # Run all tests (excludes golden tests)
-cargo test <test_name>        # Run specific test (e.g., test_extract_from_testdata)
-cargo test --lib              # Test library code only (faster)
-cargo test --features golden-tests  # Include golden tests (slower, compares against Python ScanCode)
+./scripts/dev.sh              # Canonical local test entrypoint: lib + integration + doctests
+./scripts/dev.sh full         # Include golden tests serially
+./scripts/dev.sh unit <filter> # Targeted library test loop
+./scripts/dev.sh integration <target-or-filter>... # Target integration suites by path/name
+./scripts/dev.sh parser-golden <parser>...  # Compile parser golden tests once, run many filters
+./scripts/dev.sh cargo build  # Shared-target build with wrapper lock
+./scripts/dev.sh cargo clippy --lib --bins --all-features -- -D warnings # Shared-target clippy
+./scripts/dev.sh isolated [--name <name>] <cargo...> # Opt-in parallel workflow with isolated target dir
+cargo test <test_name>        # Raw Cargo fallback for one-off test filters
 
 # Code Quality
 cargo fmt                     # Format code
@@ -84,6 +89,16 @@ cargo test parsers::npm_test::tests::test_extract_from_testdata
 cargo test parsers::npm_test::tests::test_is_match
 cargo test test_is_match       # Runs all tests with "test_is_match" in name
 ```
+
+## Agent Workflow Guidance
+
+- Prefer `./scripts/dev.sh` for routine local verification so agents converge on one cache-friendly workflow.
+- Shared-target `./scripts/dev.sh` modes take a repo-local lock, so parallel agents wait instead of stampeding the default Cargo target dir.
+- Prefer `./scripts/dev.sh cargo <cargo...>` over raw `cargo <...>` when the command builds against the shared target dir.
+- Prefer `./scripts/dev.sh isolated <cargo...>` when multiple agents must run Cargo concurrently on the same machine and you do not care about naming the isolated target dir yourself.
+- Prefer `./scripts/dev.sh isolated --name <name> <cargo...>` when multiple agents must run Cargo concurrently and you want predictable cache reuse for a named lane.
+- Avoid launching multiple raw `cargo test` / `cargo clippy` commands in parallel against the default target dir unless lock contention is acceptable.
+- Treat raw Cargo commands as the escape hatch for unusual one-off cases, not the default agent workflow.
 
 ## Project Architecture
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,19 @@ To contribute to `scancode-rust`, follow these steps to set up the repository fo
    cargo run --bin scancode-rust -- [OPTIONS] <DIR_PATH>
    ```
 
+   For the common local test workflow, prefer the repository helper script:
+
+   ```sh
+   ./scripts/dev.sh            # lib + integration + doctests, serially
+   ./scripts/dev.sh full       # include golden tests when needed
+   ```
+
+   If you intentionally want concurrent Cargo commands on the same machine, isolate them so they do not fight over the default target directory:
+
+   ```sh
+   ./scripts/dev.sh isolated --name golden test --lib --features golden-tests
+   ```
+
 ## Publishing a Release (Maintainers Only)
 
 Releases are automated using [`cargo-release`](https://github.com/crate-ci/cargo-release) and GitHub Actions.

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -336,7 +336,17 @@ cargo test --test '*'         # Run only integration tests
 cargo test --features golden-tests  # Include golden tests (slower, compares against Python ScanCode)
 ```
 
+Repository helper scripts for local development:
+
+```bash
+./scripts/dev.sh              # lib + integration + doctests, serially
+./scripts/dev.sh full         # same, plus golden tests
+./scripts/dev.sh parser-golden about cargo
+./scripts/dev.sh isolated --name golden test --lib --features golden-tests
+```
+
 > **Note**: Golden tests (comparing output against Python ScanCode reference) are gated behind the `golden-tests` feature flag because they are slow and require the reference submodule. They run automatically in CI but are excluded from `cargo test` by default for faster local development.
+> **Workflow note**: `cargo test` and `cargo test --features golden-tests` use different build graphs. On the same machine, run them serially if you want maximum cache reuse and to avoid Cargo lock contention. `./scripts/dev.sh` bakes that serial path in. Only split them into concurrent jobs when you also isolate build output with `./scripts/dev.sh isolated ...` or a separate `CARGO_TARGET_DIR`.
 
 ### Specific Test Categories
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,69 @@
 # Scripts Documentation
 
+## Local Development Workflow Helpers
+
+### Canonical Entry Point
+
+`dev.sh` is the stable, agent-friendly front door for local Rust workflows.
+
+**Why this exists**: agentic tooling works better when the repository exposes one obvious entrypoint instead of expecting every agent to rediscover which script or Cargo command to use. `dev.sh` delegates to the narrower helper scripts underneath.
+
+Examples:
+
+```bash
+./scripts/dev.sh
+./scripts/dev.sh full
+./scripts/dev.sh cargo build
+./scripts/dev.sh cargo clippy --lib --bins --all-features -- -D warnings
+./scripts/dev.sh integration tests/output_format_golden.rs test_spdx
+./scripts/dev.sh parser-golden about cargo
+./scripts/dev.sh isolated test --lib --no-run
+./scripts/dev.sh isolated --name golden test --lib --features golden-tests
+```
+
+Shared-target modes in `dev.sh` take a repository-local lock by default. If two agents both call `./scripts/dev.sh unit ...`, the second one waits instead of racing Cargo for the default target directory. Set `SCANCODE_RUST_DEV_NO_LOCK=1` only when you explicitly want to bypass that safeguard.
+
+`./scripts/dev.sh cargo ...` extends that same safeguard to non-test compile workflows like `build`, `check`, `clippy`, and `run`.
+
+### Serial Test Runner
+
+`dev_test.sh` packages the common local test flows into a single serial runner so developers can reuse the default Cargo target directory instead of manually juggling multiple `cargo test` commands.
+
+**Why this exists**: running lib, integration, doc, and golden test commands separately encourages repeated first-build cost and lock contention when developers kick them off in multiple terminals. This script keeps the cache-friendly path explicit.
+
+Examples:
+
+```bash
+./scripts/dev_test.sh                  # lib + integration + doctests
+./scripts/dev_test.sh full             # lib + integration + doctests + golden
+./scripts/dev_test.sh unit npm_test    # targeted lib tests
+./scripts/dev_test.sh integration tests/output_format_golden.rs test_spdx
+./scripts/dev_test.sh parser-golden about cargo
+./scripts/dev_test.sh parser-golden src/parsers/about_golden_test.rs
+```
+
+`parser-golden` is special: it compiles the golden lib test binary once with `--no-run`, then executes parser filters directly from that binary instead of re-entering Cargo for each parser module.
+
+### Isolated Cargo Wrapper
+
+`cargo_isolated.sh` runs Cargo with `CARGO_TARGET_DIR=target/isolated/<name>`.
+
+**Why this exists**: sometimes local development really does need two Cargo commands alive at once. In that case, isolated target directories reduce artifact-directory lock contention at the cost of extra disk use and less cache reuse.
+
+Examples:
+
+```bash
+./scripts/cargo_isolated.sh test --lib --no-run
+./scripts/cargo_isolated.sh --name golden test --lib --features golden-tests
+./scripts/cargo_isolated.sh run --bin scancode-rust -- --help
+```
+
+For day-to-day use, prefer `./scripts/dev.sh`. Reach for `cargo_isolated.sh` only when deliberate parallelism matters more than shared caching.
+
+If no explicit isolation name is provided, `cargo_isolated.sh` derives one from an agent/session environment variable when available and otherwise falls back to the current shell PID. Use `--name <name>` when you want predictable cache reuse for a named lane.
+
+For humans and agents alike, prefer `./scripts/dev.sh` as the canonical interface and treat `dev_test.sh` / `cargo_isolated.sh` as implementation details.
+
 ## Golden Fixture Helper Scripts
 
 ### Parser Golden Snapshots
@@ -12,6 +76,7 @@ Show CLI help:
 
 ```bash
 cargo run --bin update-parser-golden -- --help
+./scripts/update_parser_golden.sh --help
 ```
 
 CLI arguments:
@@ -35,6 +100,7 @@ Show CLI help:
 
 ```bash
 cargo run --bin update-copyright-golden -- --help
+./scripts/update_copyright_golden.sh --help
 ```
 
 CLI arguments:
@@ -167,10 +233,7 @@ Example output:
   continue-on-error: true # Informational only - doesn't block PRs
 ```
 
-Runs on:
-
-- Every push to `main` (when docs or scripts change)
-- Every pull request (when docs change)
+Runs on every push to `main` and every pull request.
 
 **Note**: URL validation is informational only and does not block PRs. This prevents contributors from being blocked by:
 

--- a/scripts/cargo_isolated.sh
+++ b/scripts/cargo_isolated.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/cargo_isolated.sh [--name <name>] <cargo-subcommand> [args...]
+
+Runs a Cargo command with an isolated target directory under:
+  target/isolated/<name>
+
+Use this only when you intentionally want multiple Cargo commands to run in
+parallel on the same machine without contending on the default target dir.
+
+Examples:
+  ./scripts/cargo_isolated.sh --name golden test --lib --features golden-tests
+  ./scripts/cargo_isolated.sh golden test --lib --features golden-tests
+  ./scripts/cargo_isolated.sh test --lib --no-run
+  ./scripts/cargo_isolated.sh cli run --bin scancode-rust -- --help
+EOF
+}
+
+auto_name() {
+    local candidate=''
+    local env_key
+
+    for env_key in \
+        OPENCODE_SESSION_ID \
+        OPENCODE_TASK_ID \
+        OMO_SESSION_ID \
+        OMO_TASK_ID \
+        OPENCODE_AGENT_NAME \
+        OMO_AGENT_NAME \
+        AGENT_NAME; do
+        candidate="${!env_key:-}"
+        if [[ -n "$candidate" ]]; then
+            break
+        fi
+    done
+
+    if [[ -z "$candidate" ]]; then
+        candidate="pid-${BASHPID:-$$}"
+    else
+        candidate="${candidate}-pid-${BASHPID:-$$}"
+    fi
+
+    printf '%s' "$candidate"
+}
+
+if (( $# < 1 )); then
+    usage >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--name" ]]; then
+    if (( $# < 3 )); then
+        usage >&2
+        exit 1
+    fi
+
+    name="$2"
+    shift 2
+else
+    name="$(auto_name)"
+fi
+
+if (( $# < 1 )); then
+    usage >&2
+    exit 1
+fi
+
+safe_name="$(printf '%s' "$name" | tr -cs '[:alnum:]._-' '-')"
+safe_name="${safe_name#-}"
+safe_name="${safe_name%-}"
+
+if [[ -z "$safe_name" ]]; then
+    echo "Isolated target-dir name must contain at least one alphanumeric character" >&2
+    exit 1
+fi
+
+export CARGO_TARGET_DIR="target/isolated/${safe_name}"
+
+printf '==> CARGO_TARGET_DIR=%q cargo' "$CARGO_TARGET_DIR"
+for arg in "$@"; do
+    printf ' %q' "$arg"
+done
+printf '\n'
+
+exec cargo "$@"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/dev.sh [all|full|unit|integration|doc|golden|parser-golden] [args...]
+  ./scripts/dev.sh cargo <cargo-subcommand> [args...]
+  ./scripts/dev.sh isolated [--name <name>] <cargo-subcommand> [args...]
+  ./scripts/dev.sh help
+
+Default modes delegate to ./scripts/dev_test.sh:
+  all            Run lib + integration + doctests serially.
+  full           Run all, then golden tests.
+  unit           Run cargo test --lib.
+  integration    Run all integration tests, or a selected integration target.
+  doc            Run cargo test --doc.
+  golden         Run cargo test --lib --features golden-tests.
+  parser-golden  Compile parser golden tests once, then run parser filters.
+  cargo          Run an arbitrary Cargo subcommand on the shared target dir,
+                 protected by the wrapper lock.
+
+The isolated mode delegates to ./scripts/cargo_isolated.sh so parallel Cargo
+commands can use separate target directories.
+
+Environment:
+  SCANCODE_RUST_DEV_NO_LOCK=1 Disable the shared-target workflow lock.
+
+Examples:
+  ./scripts/dev.sh
+  ./scripts/dev.sh unit npm_test
+  ./scripts/dev.sh cargo clippy --lib --bins --all-features -- -D warnings
+  ./scripts/dev.sh parser-golden about cargo
+  ./scripts/dev.sh isolated test --lib --no-run
+  ./scripts/dev.sh isolated --name golden test --lib --features golden-tests
+EOF
+}
+
+mode="${1:-all}"
+if (( $# > 0 )); then
+    shift
+fi
+
+shared_lock_dir="${SCANCODE_RUST_DEV_LOCK_DIR:-.scancode-rust-dev-lock}"
+
+lock_owner_is_alive() {
+    local owner_pid=''
+
+    if [[ ! -f "$shared_lock_dir/pid" ]]; then
+        return 1
+    fi
+
+    owner_pid="$(<"$shared_lock_dir/pid")"
+    [[ -n "$owner_pid" ]] && kill -0 "$owner_pid" 2>/dev/null
+}
+
+with_shared_lock() {
+    if [[ "${SCANCODE_RUST_DEV_NO_LOCK:-0}" == "1" ]]; then
+        "$@"
+        return
+    fi
+
+    while ! mkdir "$shared_lock_dir" 2>/dev/null; do
+        if ! lock_owner_is_alive; then
+            rm -rf "$shared_lock_dir"
+            continue
+        fi
+
+        local owner_pid='unknown'
+        local owner_mode='unknown'
+
+        if [[ -f "$shared_lock_dir/pid" ]]; then
+            owner_pid="$(<"$shared_lock_dir/pid")"
+        fi
+        if [[ -f "$shared_lock_dir/mode" ]]; then
+            owner_mode="$(<"$shared_lock_dir/mode")"
+        fi
+
+        echo "Another shared-target dev workflow is running (mode=${owner_mode}, pid=${owner_pid}). Waiting for the lock..." >&2
+        sleep 1
+    done
+
+    printf '%s\n' "${BASHPID:-$$}" > "$shared_lock_dir/pid"
+    printf '%s\n' "$mode" > "$shared_lock_dir/mode"
+    trap 'rm -rf "$shared_lock_dir"' EXIT INT TERM HUP
+
+    "$@"
+}
+
+case "$mode" in
+all|full|unit|integration|doc|golden|parser-golden|cargo)
+    with_shared_lock ./scripts/dev_test.sh "$mode" "$@"
+    ;;
+isolated)
+    exec ./scripts/cargo_isolated.sh "$@"
+    ;;
+help|-h|--help)
+    usage
+    ;;
+*)
+    echo "Unknown mode: $mode" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/dev_test.sh
+++ b/scripts/dev_test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/dev_test.sh [all]
+  ./scripts/dev_test.sh full
+  ./scripts/dev_test.sh unit [cargo-test-filter-or-args...]
+  ./scripts/dev_test.sh integration [integration-target-or-filter] [cargo-test-filter-or-args...]
+  ./scripts/dev_test.sh doc [cargo-test-args...]
+  ./scripts/dev_test.sh golden [cargo-test-filter-or-args...]
+  ./scripts/dev_test.sh parser-golden [parser-module-or-filter...] [-- <test-binary-args...>]
+  ./scripts/dev_test.sh cargo <cargo-subcommand> [args...]
+
+Modes:
+  all            Run common local test phases serially: lib, integration, doctests.
+  full           Run `all`, then golden tests.
+  unit           Run `cargo test --lib`.
+  integration    Run all integration tests, or a specific integration target when
+                 the first argument matches `tests/<name>.rs` or `<name>`.
+  doc            Run `cargo test --doc`.
+  golden         Run `cargo test --lib --features golden-tests`.
+  parser-golden  Compile parser golden tests once, then run parser-module filters
+                 directly from the built test binary. Accepts bare module names,
+                 parser file paths, or exact test filters.
+  cargo          Run an arbitrary Cargo subcommand through the wrapper.
+
+Examples:
+  ./scripts/dev_test.sh
+  ./scripts/dev_test.sh unit npm_test
+  ./scripts/dev_test.sh integration scanner_integration test_scanner_discovers_all_registered_parsers
+  ./scripts/dev_test.sh integration tests/output_format_golden.rs test_spdx
+  ./scripts/dev_test.sh golden cargo_golden
+  ./scripts/dev_test.sh parser-golden about cargo
+  ./scripts/dev_test.sh parser-golden src/parsers/about_golden_test.rs
+  ./scripts/dev_test.sh cargo build
+  ./scripts/dev_test.sh parser-golden about -- --nocapture
+EOF
+}
+
+run_cargo() {
+    printf '==> cargo'
+    for arg in "$@"; do
+        printf ' %q' "$arg"
+    done
+    printf '\n'
+
+    cargo "$@"
+}
+
+resolve_lib_test_binary() {
+    local target_dir="${CARGO_TARGET_DIR:-target}"
+    local candidate=''
+
+    cargo test --lib --features golden-tests --no-run
+
+    while IFS= read -r candidate; do
+        if [[ -f "$candidate" && -x "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(ls -t "$target_dir"/debug/deps/scancode_rust-* 2>/dev/null)
+
+    echo "Could not determine parser golden test binary path" >&2
+    return 1
+}
+
+run_parser_golden() {
+    local modules=()
+    local harness_args=()
+    local parsing_modules=true
+    local module
+    local filter
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--" && "$parsing_modules" == true ]]; then
+            parsing_modules=false
+            continue
+        fi
+
+        if [[ "$parsing_modules" == true ]]; then
+            modules+=("$arg")
+        else
+            harness_args+=("$arg")
+        fi
+    done
+
+    local test_binary
+    test_binary="$(resolve_lib_test_binary)"
+
+    if (( ${#modules[@]} == 0 )); then
+        printf '==> %q %q' "$test_binary" '_golden_test::'
+        for arg in "${harness_args[@]}"; do
+            printf ' %q' "$arg"
+        done
+        printf '\n'
+        "$test_binary" '_golden_test::' "${harness_args[@]}"
+        return
+    fi
+
+    for module in "${modules[@]}"; do
+        if [[ "$module" == *.rs ]]; then
+            module="${module##*/}"
+            module="${module%.rs}"
+        fi
+
+        if [[ "$module" == *"::"* ]]; then
+            if [[ "$module" == parsers::* ]]; then
+                filter="$module"
+            else
+                filter="parsers::${module}"
+            fi
+        else
+            if [[ "$module" != *_golden_test ]]; then
+                module="${module}_golden_test"
+            fi
+
+            filter="parsers::${module}::"
+        fi
+
+        printf '==> %q %q' "$test_binary" "$filter"
+        for arg in "${harness_args[@]}"; do
+            printf ' %q' "$arg"
+        done
+        printf '\n'
+        "$test_binary" "$filter" "${harness_args[@]}"
+    done
+}
+
+mode="${1:-all}"
+if (( $# > 0 )); then
+    shift
+fi
+
+case "$mode" in
+all)
+    run_cargo test --lib "$@"
+    run_cargo test --tests
+    run_cargo test --doc
+    ;;
+full)
+    run_cargo test --lib "$@"
+    run_cargo test --tests
+    run_cargo test --doc
+    run_cargo test --lib --features golden-tests
+    ;;
+unit)
+    run_cargo test --lib "$@"
+    ;;
+integration)
+    if (( $# > 0 )); then
+        integration_target="$1"
+        integration_target="${integration_target#tests/}"
+        integration_target="${integration_target%.rs}"
+
+        if [[ -f "tests/${integration_target}.rs" ]]; then
+            shift
+            run_cargo test --test "$integration_target" "$@"
+        else
+            run_cargo test --tests "$@"
+        fi
+    else
+        run_cargo test --tests
+    fi
+    ;;
+doc)
+    run_cargo test --doc "$@"
+    ;;
+golden)
+    run_cargo test --lib --features golden-tests "$@"
+    ;;
+parser-golden)
+    run_parser_golden "$@"
+    ;;
+cargo)
+    if (( $# == 0 )); then
+        echo "Usage: ./scripts/dev_test.sh cargo <cargo-subcommand> [args...]" >&2
+        exit 1
+    fi
+    run_cargo "$@"
+    ;;
+-h|--help|help)
+    usage
+    ;;
+*)
+    echo "Unknown mode: $mode" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -53,3 +53,4 @@ fi
 
 echo ""
 echo "Setup complete. Run 'cargo build --release' to embed license data into the binary."
+echo "For common local test phases, use './scripts/dev.sh'."


### PR DESCRIPTION
## Summary
- add canonical local workflow wrappers so shared-target Cargo work queues behind `./scripts/dev.sh` while deliberate parallel runs use isolated target directories
- batch parser golden execution in CI and local helpers so the golden lib test binary is built once and reused across parser filters
- document the new agent-friendly workflow in `AGENTS.md`, `README.md`, `docs/TESTING_STRATEGY.md`, `scripts/README.md`, and `setup.sh`