### PR TITLE
test(ci): namespace parser goldens and scope release shards

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,13 +56,19 @@ jobs:
         include:
           - shard: copyright
             filter: "copyright::golden_test::tests::"
+            profile: release
           - shard: assembly
             filter: "assembly::assembly_golden_test::"
+            profile: debug
           - shard: finder
             filter: "finder::golden_test::tests::"
+            profile: debug
           - shard: license-detection
             filter: "license_detection::golden_test::golden_tests::"
+            profile: release
           - shard: parsers
+            filter: "parsers::golden_test::"
+            profile: debug
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -74,46 +80,19 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: golden-tests-release
+          shared-key: golden-tests-${{ matrix.profile }}
 
       - name: Run golden test shard
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.shard }}" == "parsers" ]]; then
-            cargo test --lib --release --verbose --features golden-tests --no-run
-
-            test_binary=""
-            while IFS= read -r candidate; do
-              if [[ -f "$candidate" && -x "$candidate" ]]; then
-                test_binary="$candidate"
-                break
-              fi
-            done < <(ls -t target/release/deps/provenant-* 2>/dev/null)
-
-            if [[ -z "$test_binary" ]]; then
-              echo "Could not determine parser golden test binary path" >&2
-              exit 1
-            fi
-
-            shopt -s nullglob
-            parser_files=(src/parsers/*_golden_test.rs)
-            if (( ${#parser_files[@]} == 0 )); then
-              echo "No parser golden test modules found"
-              exit 1
-            fi
-
-            for parser_file in "${parser_files[@]}"; do
-              module_name="${parser_file#src/parsers/}"
-              module_name="${module_name%.rs}"
-              filter="parsers::${module_name}::"
-              echo "Running golden filter: $filter"
-              "$test_binary" "$filter"
-            done
-          else
-            echo "Running golden filter: ${{ matrix.filter }}"
-            cargo test --lib --release --verbose --features golden-tests "${{ matrix.filter }}"
+          cargo_args=(test --lib --verbose --features golden-tests "${{ matrix.filter }}")
+          if [[ "${{ matrix.profile }}" == "release" ]]; then
+            cargo_args=(test --lib --release --verbose --features golden-tests "${{ matrix.filter }}")
           fi
+
+          echo "Running golden filter: ${{ matrix.filter }} (${{ matrix.profile }})"
+          cargo "${cargo_args[@]}"
 
   docs-quality:
     name: Documentation Quality

--- a/src/parsers/conda_golden_test.rs
+++ b/src/parsers/conda_golden_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod golden_tests {
-    use super::super::PackageParser;
-    use super::super::conda::{CondaEnvironmentYmlParser, CondaMetaYamlParser};
-    use super::super::conda_meta_json::CondaMetaJsonParser;
+    use crate::parsers::PackageParser;
+    use crate::parsers::conda::{CondaEnvironmentYmlParser, CondaMetaYamlParser};
+    use crate::parsers::conda_meta_json::CondaMetaJsonParser;
     use crate::test_utils::compare_package_data_parser_only;
     use std::path::PathBuf;
 

--- a/src/parsers/cran_golden_test.rs
+++ b/src/parsers/cran_golden_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod golden_tests {
-    use super::super::PackageParser;
-    use super::super::cran::CranParser;
+    use crate::parsers::PackageParser;
+    use crate::parsers::cran::CranParser;
     use crate::test_utils::compare_package_data_parser_only;
 
     use std::path::PathBuf;

--- a/src/parsers/golden_test.rs
+++ b/src/parsers/golden_test.rs
@@ -1,0 +1,110 @@
+#[path = "about_golden_test.rs"]
+mod about_golden_test;
+#[path = "alpine_golden_test.rs"]
+mod alpine_golden_test;
+#[path = "arch_golden_test.rs"]
+mod arch_golden_test;
+#[path = "autotools_golden_test.rs"]
+mod autotools_golden_test;
+#[path = "bazel_golden_test.rs"]
+mod bazel_golden_test;
+#[path = "bazel_module_golden_test.rs"]
+mod bazel_module_golden_test;
+#[path = "bower_golden_test.rs"]
+mod bower_golden_test;
+#[path = "buck_golden_test.rs"]
+mod buck_golden_test;
+#[path = "bun_lock_golden_test.rs"]
+mod bun_lock_golden_test;
+#[path = "bun_lockb_golden_test.rs"]
+mod bun_lockb_golden_test;
+#[path = "cargo_golden_test.rs"]
+mod cargo_golden_test;
+#[path = "chef_golden_test.rs"]
+mod chef_golden_test;
+#[path = "clojure_golden_test.rs"]
+mod clojure_golden_test;
+#[path = "cocoapods_golden_test.rs"]
+mod cocoapods_golden_test;
+#[path = "composer_golden_test.rs"]
+mod composer_golden_test;
+#[path = "conan_golden_test.rs"]
+mod conan_golden_test;
+#[path = "conda_golden_test.rs"]
+mod conda_golden_test;
+#[path = "cpan_golden_test.rs"]
+mod cpan_golden_test;
+#[path = "cran_golden_test.rs"]
+mod cran_golden_test;
+#[path = "dart_golden_test.rs"]
+mod dart_golden_test;
+#[path = "debian_golden_test.rs"]
+mod debian_golden_test;
+#[path = "deno_golden_test.rs"]
+mod deno_golden_test;
+#[path = "docker_golden_test.rs"]
+mod docker_golden_test;
+#[path = "freebsd_golden_test.rs"]
+mod freebsd_golden_test;
+#[path = "gitmodules_golden_test.rs"]
+mod gitmodules_golden_test;
+#[path = "go_golden_test.rs"]
+mod go_golden_test;
+#[path = "gradle_golden_test.rs"]
+mod gradle_golden_test;
+#[path = "gradle_module_golden_test.rs"]
+mod gradle_module_golden_test;
+#[path = "hackage_golden_test.rs"]
+mod hackage_golden_test;
+#[path = "haxe_golden_test.rs"]
+mod haxe_golden_test;
+#[path = "helm_golden_test.rs"]
+mod helm_golden_test;
+#[path = "hex_lock_golden_test.rs"]
+mod hex_lock_golden_test;
+#[path = "maven_golden_test.rs"]
+mod maven_golden_test;
+#[path = "meson_golden_test.rs"]
+mod meson_golden_test;
+#[path = "microsoft_update_manifest_golden_test.rs"]
+mod microsoft_update_manifest_golden_test;
+#[path = "nix_golden_test.rs"]
+mod nix_golden_test;
+#[path = "npm_golden_test.rs"]
+mod npm_golden_test;
+#[path = "nuget_golden_test.rs"]
+mod nuget_golden_test;
+#[path = "opam_golden_test.rs"]
+mod opam_golden_test;
+#[path = "os_release_golden_test.rs"]
+mod os_release_golden_test;
+#[path = "pip_inspect_deplock_golden_test.rs"]
+mod pip_inspect_deplock_golden_test;
+#[path = "pipfile_lock_golden_test.rs"]
+mod pipfile_lock_golden_test;
+#[path = "pixi_golden_test.rs"]
+mod pixi_golden_test;
+#[path = "pnpm_lock_golden_test.rs"]
+mod pnpm_lock_golden_test;
+#[path = "poetry_lock_golden_test.rs"]
+mod poetry_lock_golden_test;
+#[path = "pylock_toml_golden_test.rs"]
+mod pylock_toml_golden_test;
+#[path = "python_golden_test.rs"]
+mod python_golden_test;
+#[path = "readme_golden_test.rs"]
+mod readme_golden_test;
+#[path = "requirements_txt_golden_test.rs"]
+mod requirements_txt_golden_test;
+#[path = "rpm_golden_test.rs"]
+mod rpm_golden_test;
+#[path = "ruby_golden_test.rs"]
+mod ruby_golden_test;
+#[path = "sbt_golden_test.rs"]
+mod sbt_golden_test;
+#[path = "swift_golden_test.rs"]
+mod swift_golden_test;
+#[path = "uv_lock_golden_test.rs"]
+mod uv_lock_golden_test;
+#[path = "vcpkg_golden_test.rs"]
+mod vcpkg_golden_test;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,86 +1,52 @@
 mod about;
-#[cfg(all(test, feature = "golden-tests"))]
-mod about_golden_test;
 #[cfg(test)]
 mod about_test;
 mod alpine;
-#[cfg(all(test, feature = "golden-tests"))]
-mod alpine_golden_test;
 mod arch;
-#[cfg(all(test, feature = "golden-tests"))]
-mod arch_golden_test;
 #[cfg(test)]
 mod arch_test;
 mod autotools;
-#[cfg(all(test, feature = "golden-tests"))]
-mod autotools_golden_test;
 #[cfg(test)]
 mod autotools_test;
 mod bazel;
-#[cfg(all(test, feature = "golden-tests"))]
-mod bazel_golden_test;
-#[cfg(all(test, feature = "golden-tests"))]
-mod bazel_module_golden_test;
 #[cfg(test)]
 mod bazel_module_test;
 #[cfg(test)]
 mod bazel_test;
 mod bower;
-#[cfg(all(test, feature = "golden-tests"))]
-mod bower_golden_test;
 #[cfg(test)]
 mod bower_test;
 mod buck;
-#[cfg(all(test, feature = "golden-tests"))]
-mod buck_golden_test;
 #[cfg(test)]
 mod buck_test;
 mod bun_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod bun_lock_golden_test;
 #[cfg(test)]
 mod bun_lock_test;
 mod bun_lockb;
-#[cfg(all(test, feature = "golden-tests"))]
-mod bun_lockb_golden_test;
 #[cfg(test)]
 mod bun_lockb_test;
 mod cargo;
-#[cfg(all(test, feature = "golden-tests"))]
-mod cargo_golden_test;
 mod cargo_lock;
 #[cfg(test)]
 mod cargo_lock_test;
 #[cfg(test)]
 mod cargo_test;
 mod chef;
-#[cfg(all(test, feature = "golden-tests"))]
-mod chef_golden_test;
 #[cfg(test)]
 mod chef_test;
 mod clojure;
-#[cfg(all(test, feature = "golden-tests"))]
-mod clojure_golden_test;
 #[cfg(test)]
 mod clojure_test;
-#[cfg(all(test, feature = "golden-tests"))]
-mod cocoapods_golden_test;
 mod composer;
-#[cfg(all(test, feature = "golden-tests"))]
-mod composer_golden_test;
 #[cfg(test)]
 mod composer_test;
 mod conan;
 mod conan_data;
 #[cfg(test)]
 mod conan_data_test;
-#[cfg(all(test, feature = "golden-tests"))]
-mod conan_golden_test;
 #[cfg(test)]
 mod conan_test;
 mod conda;
-#[cfg(all(test, feature = "golden-tests"))]
-mod conda_golden_test;
 mod conda_meta_json;
 #[cfg(test)]
 mod conda_meta_json_test;
@@ -90,115 +56,75 @@ mod cpan;
 mod cpan_dist_ini;
 #[cfg(test)]
 mod cpan_dist_ini_test;
-#[cfg(all(test, feature = "golden-tests"))]
-mod cpan_golden_test;
 mod cpan_makefile_pl;
 #[cfg(test)]
 mod cpan_makefile_pl_test;
 #[cfg(test)]
 mod cpan_test;
 mod cran;
-#[cfg(all(test, feature = "golden-tests"))]
-mod cran_golden_test;
 #[cfg(test)]
 mod cran_test;
 mod dart;
-#[cfg(all(test, feature = "golden-tests"))]
-mod dart_golden_test;
 #[cfg(test)]
 mod dart_test;
 mod debian;
-#[cfg(all(test, feature = "golden-tests"))]
-mod debian_golden_test;
 #[cfg(test)]
 mod debian_test;
 mod deno;
-#[cfg(all(test, feature = "golden-tests"))]
-mod deno_golden_test;
 mod deno_lock;
 #[cfg(test)]
 mod deno_lock_test;
 #[cfg(test)]
 mod deno_test;
 mod docker;
-#[cfg(all(test, feature = "golden-tests"))]
-mod docker_golden_test;
 #[cfg(test)]
 mod docker_test;
 mod freebsd;
-#[cfg(all(test, feature = "golden-tests"))]
-mod freebsd_golden_test;
 #[cfg(test)]
 mod freebsd_test;
 mod gitmodules;
-#[cfg(all(test, feature = "golden-tests"))]
-mod gitmodules_golden_test;
 mod go;
-#[cfg(all(test, feature = "golden-tests"))]
-mod go_golden_test;
 mod go_mod_graph;
 #[cfg(test)]
 mod go_test;
 #[cfg(test)]
 mod go_work_test;
 mod gradle;
-#[cfg(all(test, feature = "golden-tests"))]
-mod gradle_golden_test;
 mod gradle_lock;
 #[cfg(test)]
 mod gradle_lock_test;
 mod gradle_module;
-#[cfg(all(test, feature = "golden-tests"))]
-mod gradle_module_golden_test;
 #[cfg(test)]
 mod gradle_module_test;
 mod hackage;
-#[cfg(all(test, feature = "golden-tests"))]
-mod hackage_golden_test;
 #[cfg(test)]
 mod hackage_test;
 mod haxe;
-#[cfg(all(test, feature = "golden-tests"))]
-mod haxe_golden_test;
 #[cfg(test)]
 mod haxe_test;
 mod helm;
-#[cfg(all(test, feature = "golden-tests"))]
-mod helm_golden_test;
 #[cfg(test)]
 mod helm_test;
 mod hex_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod hex_lock_golden_test;
 #[cfg(test)]
 mod hex_lock_test;
 mod maven;
-#[cfg(all(test, feature = "golden-tests"))]
-mod maven_golden_test;
 #[cfg(test)]
 mod maven_test;
 mod meson;
-#[cfg(all(test, feature = "golden-tests"))]
-mod meson_golden_test;
 #[cfg(test)]
 mod meson_test;
 pub mod metadata;
 mod microsoft_update_manifest;
-#[cfg(all(test, feature = "golden-tests"))]
-mod microsoft_update_manifest_golden_test;
 #[cfg(test)]
 mod microsoft_update_manifest_test;
 mod misc;
 #[cfg(test)]
 mod misc_test;
 mod nix;
-#[cfg(all(test, feature = "golden-tests"))]
-mod nix_golden_test;
 #[cfg(test)]
 mod nix_test;
 mod npm;
-#[cfg(all(test, feature = "golden-tests"))]
-mod npm_golden_test;
 mod npm_lock;
 #[cfg(test)]
 mod npm_lock_test;
@@ -208,39 +134,25 @@ mod npm_workspace;
 #[cfg(test)]
 mod npm_workspace_test;
 mod nuget;
-#[cfg(all(test, feature = "golden-tests"))]
-mod nuget_golden_test;
 #[cfg(test)]
 mod nuget_test;
 mod opam;
-#[cfg(all(test, feature = "golden-tests"))]
-mod opam_golden_test;
 mod os_release;
-#[cfg(all(test, feature = "golden-tests"))]
-mod os_release_golden_test;
 #[cfg(test)]
 mod os_release_test;
 #[cfg(test)]
 mod osgi_test;
 mod pep508;
 mod pip_inspect_deplock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod pip_inspect_deplock_golden_test;
 #[cfg(test)]
 mod pip_inspect_deplock_test;
 mod pipfile_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod pipfile_lock_golden_test;
 #[cfg(test)]
 mod pipfile_lock_test;
 mod pixi;
-#[cfg(all(test, feature = "golden-tests"))]
-mod pixi_golden_test;
 #[cfg(test)]
 mod pixi_test;
 mod pnpm_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod pnpm_lock_golden_test;
 #[cfg(test)]
 mod pnpm_lock_test;
 mod podfile;
@@ -252,34 +164,22 @@ mod podspec_json;
 #[cfg(test)]
 mod podspec_json_test;
 mod poetry_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod poetry_lock_golden_test;
 #[cfg(test)]
 mod poetry_lock_test;
 mod pylock_toml;
-#[cfg(all(test, feature = "golden-tests"))]
-mod pylock_toml_golden_test;
 #[cfg(test)]
 mod pylock_toml_test;
 mod python;
-#[cfg(all(test, feature = "golden-tests"))]
-mod python_golden_test;
 #[cfg(test)]
 mod python_test;
 mod readme;
-#[cfg(all(test, feature = "golden-tests"))]
-mod readme_golden_test;
 #[cfg(test)]
 mod readme_test;
 mod requirements_txt;
-#[cfg(all(test, feature = "golden-tests"))]
-mod requirements_txt_golden_test;
 #[cfg(test)]
 mod requirements_txt_test;
 pub(crate) mod rfc822;
 mod rpm_db;
-#[cfg(all(test, feature = "golden-tests"))]
-mod rpm_golden_test;
 mod rpm_license_files;
 #[cfg(test)]
 mod rpm_license_files_test;
@@ -292,17 +192,11 @@ mod rpm_specfile;
 mod rpm_specfile_test;
 mod rpm_yumdb;
 mod ruby;
-#[cfg(all(test, feature = "golden-tests"))]
-mod ruby_golden_test;
 #[cfg(test)]
 mod ruby_test;
 mod sbt;
-#[cfg(all(test, feature = "golden-tests"))]
-mod sbt_golden_test;
 #[cfg(test)]
 mod sbt_test;
-#[cfg(all(test, feature = "golden-tests"))]
-mod swift_golden_test;
 mod swift_manifest_json;
 #[cfg(test)]
 mod swift_manifest_json_test;
@@ -314,18 +208,17 @@ mod swift_show_dependencies;
 mod swift_show_dependencies_test;
 pub mod utils;
 mod uv_lock;
-#[cfg(all(test, feature = "golden-tests"))]
-mod uv_lock_golden_test;
 #[cfg(test)]
 mod uv_lock_test;
 mod vcpkg;
-#[cfg(all(test, feature = "golden-tests"))]
-mod vcpkg_golden_test;
 #[cfg(test)]
 mod vcpkg_test;
 mod yarn_lock;
 #[cfg(test)]
 mod yarn_lock_test;
+
+#[cfg(all(test, feature = "golden-tests"))]
+mod golden_test;
 
 use std::path::Path;
 

--- a/src/parsers/opam_golden_test.rs
+++ b/src/parsers/opam_golden_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod golden_tests {
-    use super::super::PackageParser;
-    use super::super::opam::OpamParser;
+    use crate::parsers::PackageParser;
+    use crate::parsers::opam::OpamParser;
     use crate::test_utils::compare_package_data_parser_only;
     use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- move parser golden tests under a real `parsers::golden_test::` namespace so CI can shard them with a normal Rust test filter instead of custom bash discovery
- keep `assembly`, `finder`, and `parsers` goldens in debug mode while leaving `license-detection` and `copyright` in release mode, matching the recent CI runtime evidence
- update the few parser golden modules that relied on `super::super` imports so they still resolve under the shared namespace

## Verification
- `cargo check --lib --features golden-tests`
- `cargo test --lib --features golden-tests "parsers::golden_test::" -- --list`
- `cargo test --lib --features golden-tests "parsers::golden_test::conda_golden_test::golden_tests::test_golden_meta_yaml_abeona"`
- `cargo test --lib --features golden-tests "parsers::golden_test::cran_golden_test::golden_tests::test_golden_geometry"`
- `cargo test --lib --features golden-tests "parsers::golden_test::opam_golden_test::golden_tests::test_golden_sample1"`