### PR TITLE
feat(cli): add --license/-l flag to make license detection opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Commonly used options include:
 - `--exclude/--ignore`, `--include`, `--max-depth`, `--processes`
 - `--cache-dir`, `--cache-clear`, `--from-json`, `--no-assemble`
 - `--filter-clues`, `--only-findings`, `--mark-source`
-- `--copyright`, `--email`, `--url`
+- `--license`, `--copyright`, `--email`, `--url`
 
 ### Example
 

--- a/docs/implementation-plans/infrastructure/CLI_PLAN.md
+++ b/docs/implementation-plans/infrastructure/CLI_PLAN.md
@@ -48,6 +48,8 @@ This plan tracks progress toward a **drop-in replacement CLI surface**.
 | `-c, --copyright`          | Copyright/holder/author detection toggle                                                                          |
 | `-e, --email`              | Enable email detection                                                                                            |
 | `-u, --url`                | Enable URL detection                                                                                              |
+| `-l, --license`            | License detection toggle                                                                                          |
+| `--include-text`           | Include matched text in license output (requires `--license`)                                                     |
 | `--no-assemble`            | Rust-specific                                                                                                     |
 | `--max-email`              | Threshold (default 50, requires `--email`)                                                                        |
 | `--max-url`                | Threshold (default 50, requires `--url`)                                                                          |
@@ -62,7 +64,6 @@ This plan tracks progress toward a **drop-in replacement CLI surface**.
 
 | Parameter                   | Blocked By                                                                     |
 | --------------------------- | ------------------------------------------------------------------------------ |
-| `--license`                 | [`LICENSE_DETECTION_ARCHITECTURE.md`](../../LICENSE_DETECTION_ARCHITECTURE.md) |
 | `--license-score`           | [`LICENSE_DETECTION_ARCHITECTURE.md`](../../LICENSE_DETECTION_ARCHITECTURE.md) |
 | `--license-text`            | [`LICENSE_DETECTION_ARCHITECTURE.md`](../../LICENSE_DETECTION_ARCHITECTURE.md) |
 | `--classify`                | [`SUMMARIZATION_PLAN.md`](../post-processing/SUMMARIZATION_PLAN.md)            |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,11 +155,11 @@ pub struct Cli {
 
     /// Path to license rules directory containing .LICENSE and .RULE files.
     /// If not specified, uses the built-in embedded license index.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", requires = "license")]
     pub license_rules_path: Option<String>,
 
     /// Include matched text in license detection output
-    #[arg(long)]
+    #[arg(long, requires = "license")]
     pub include_text: bool,
 
     #[arg(long)]
@@ -170,6 +170,10 @@ pub struct Cli {
 
     #[arg(long)]
     pub mark_source: bool,
+
+    /// Scan input for licenses
+    #[arg(short = 'l', long)]
+    pub license: bool,
 
     #[arg(short = 'c', long)]
     pub copyright: bool,
@@ -457,6 +461,40 @@ mod tests {
         .expect("cli parse should succeed");
 
         assert!(parsed.copyright);
+    }
+
+    #[test]
+    fn test_parses_license_flag() {
+        let parsed = Cli::try_parse_from([
+            "provenant",
+            "--json-pp",
+            "scan.json",
+            "--license",
+            "samples",
+        ])
+        .expect("cli parse should succeed");
+
+        assert!(parsed.license);
+    }
+
+    #[test]
+    fn test_license_short_flag() {
+        let parsed = Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "-l", "samples"])
+            .expect("cli parse should succeed");
+
+        assert!(parsed.license);
+    }
+
+    #[test]
+    fn test_include_text_requires_license() {
+        let result = Cli::try_parse_from([
+            "provenant",
+            "--json-pp",
+            "scan.json",
+            "--include-text",
+            "samples",
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,9 +151,14 @@ fn run() -> Result<()> {
             ));
         }
 
-        progress.start_license_detection_engine_creation();
-        let license_engine = init_license_engine(&cli.license_rules_path)?;
-        progress.finish_license_detection_engine_creation();
+        let license_engine = if cli.license {
+            progress.start_license_detection_engine_creation();
+            let engine = init_license_engine(&cli.license_rules_path)?;
+            progress.finish_license_detection_engine_creation();
+            Some(engine)
+        } else {
+            None
+        };
 
         let text_options = TextDetectionOptions {
             detect_copyrights: cli.copyright,
@@ -171,7 +176,7 @@ fn run() -> Result<()> {
             Ok(process_collected(
                 &collected,
                 Arc::clone(&progress),
-                Some(license_engine.clone()),
+                license_engine.clone(),
                 cli.include_text,
                 &text_options,
             ))


### PR DESCRIPTION
- Adds `-l, --license` flag for ScanCode CLI parity
- License detection is now opt-in (previously always enabled)
- `--license-rules-path` and `--include-text` now require `--license`
- Updates documentation in README.md and CLI_PLAN.md