### PR TITLE
perf(license_detection): compute matched_text lazily (~3x speedup)

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -157,8 +157,6 @@ pub fn aho_match_with_extra_matchables(
             1.0
         };
 
-        let matched_text = query_run.matched_text(start_line, end_line);
-
         let qspan_positions: Vec<usize> = (qstart..qend).collect();
         let ispan_positions: Vec<usize> = (0..matched_length).collect();
         let hispan_positions: Vec<usize> = (0..matched_length)
@@ -182,7 +180,7 @@ pub fn aho_match_with_extra_matchables(
             rid,
             rule_identifier: rule.identifier.clone(),
             rule_url: String::new(),
-            matched_text: Some(matched_text),
+            matched_text: None,
             referenced_filenames: rule.referenced_filenames.clone(),
             rule_kind: rule.kind(),
             is_from_license: rule.is_from_license,

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -79,8 +79,6 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
             start_line
         };
 
-        let matched_text = query_run.matched_text(start_line, end_line);
-
         let license_match = LicenseMatch {
             license_expression: rule.license_expression.clone(),
             license_expression_spdx: None,
@@ -98,7 +96,7 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
             rid,
             rule_identifier: rule.identifier.clone(),
             rule_url: String::new(),
-            matched_text: Some(matched_text),
+            matched_text: None,
             referenced_filenames: rule.referenced_filenames.clone(),
             rule_kind: rule.kind(),
             is_from_license: rule.is_from_license,

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -500,11 +500,14 @@ pub(crate) fn filter_invalid_matches_to_single_word_gibberish(
             if let Some(rule) = index.rules_by_rid.get(rid)
                 && rule.length_unique == 1
                 && (rule.is_license_reference() || rule.is_license_clue())
-                && let Some(matched_text) = &m.matched_text
             {
+                let matched_text = match &m.matched_text {
+                    Some(text) => text.clone(),
+                    None => query.matched_text(m.start_line, m.end_line),
+                };
                 let max_diff = if rule.relevance >= 80 { 1 } else { 0 };
 
-                if !is_valid_short_match(matched_text, &rule.text, max_diff) {
+                if !is_valid_short_match(&matched_text, &rule.text, max_diff) {
                     return false;
                 }
             }

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -130,7 +130,7 @@ pub struct Query<'a> {
     pub index: &'a LicenseIndex,
 }
 
-fn matched_text_from_text(text: &str, start_line: usize, end_line: usize) -> String {
+pub fn matched_text_from_text(text: &str, start_line: usize, end_line: usize) -> String {
     if start_line == 0 || end_line == 0 || start_line > end_line {
         return String::new();
     }
@@ -582,7 +582,6 @@ impl<'a> Query<'a> {
 #[derive(Debug, Clone)]
 struct WholeQueryRunSnapshot<'a> {
     index: &'a LicenseIndex,
-    text: String,
     tokens: Vec<TokenId>,
     line_by_pos: Vec<usize>,
     high_matchables: HashSet<usize>,
@@ -633,7 +632,6 @@ impl<'a> QueryRun<'a> {
             query: None,
             whole_query_snapshot: Some(WholeQueryRunSnapshot {
                 index: query.index,
-                text: query.text.clone(),
                 tokens: query.tokens.clone(),
                 line_by_pos: query.line_by_pos.clone(),
                 high_matchables: query.high_matchables.clone(),
@@ -665,18 +663,6 @@ impl<'a> QueryRun<'a> {
                 .as_ref()
                 .expect("snapshot-backed whole query run should have snapshot data")
                 .line_by_pos
-        }
-    }
-
-    fn source_text(&self) -> &str {
-        if let Some(query) = self.query {
-            &query.text
-        } else {
-            &self
-                .whole_query_snapshot
-                .as_ref()
-                .expect("snapshot-backed whole query run should have snapshot data")
-                .text
         }
     }
 
@@ -859,20 +845,6 @@ impl<'a> QueryRun<'a> {
             .filter(|&&pos| live_span.contains(pos))
             .copied()
             .collect()
-    }
-
-    /// Extract matched text for a given line range.
-    ///
-    /// This delegates to the underlying Query's matched_text method.
-    ///
-    /// # Arguments
-    /// * `start_line` - Starting line number (1-indexed)
-    /// * `end_line` - Ending line number (1-indexed)
-    ///
-    /// # Returns
-    /// The matched text, or empty string if lines are out of range
-    pub fn matched_text(&self, start_line: usize, end_line: usize) -> String {
-        matched_text_from_text(self.source_text(), start_line, end_line)
     }
 }
 

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -455,17 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn test_query_run_matched_text() {
-        let index = create_query_test_index();
-        let text = "line1\nlicense\nline3";
-        let query = build_query(text, &index).unwrap();
-        let run = QueryRun::new(&query, 0, Some(0));
-
-        let matched = run.matched_text(2, 2);
-        assert_eq!(matched, "license");
-    }
-
-    #[test]
     fn test_query_detect_long_lines() {
         let index = create_query_test_index();
         let tokens: Vec<String> = (0..30).map(|i| format!("word{}", i)).collect();

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -305,8 +305,6 @@ pub fn seq_match_with_candidates(
 
                     let score = match_coverage * candidate.rule.relevance as f32 / 100.0;
 
-                    let matched_text = query_run.matched_text(start_line, end_line);
-
                     let license_match = LicenseMatch {
                         license_expression: candidate.rule.license_expression.clone(),
                         license_expression_spdx: None,
@@ -324,7 +322,7 @@ pub fn seq_match_with_candidates(
                         rid,
                         rule_identifier: candidate.rule.identifier.clone(),
                         rule_url: String::new(),
-                        matched_text: Some(matched_text),
+                        matched_text: None,
                         referenced_filenames: candidate.rule.referenced_filenames.clone(),
                         rule_kind: candidate.rule.kind(),
                         is_from_license: candidate.rule.is_from_license,

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -280,12 +280,17 @@ mod tests {
             "Match should end on line 2 (where license tokens are), not line 3"
         );
 
+        // matched_text is computed lazily at output time, not during matching
         assert!(
-            first_match
-                .matched_text
-                .as_ref()
-                .is_some_and(|t| t.contains("license")),
-            "Matched text should contain 'license'"
+            first_match.matched_text.is_none(),
+            "matched_text should be None during matching (computed lazily at output)"
+        );
+
+        // Verify we can compute it from the query
+        let matched_text = query.matched_text(first_match.start_line, first_match.end_line);
+        assert!(
+            matched_text.contains("license"),
+            "Computed matched text should contain 'license'"
         );
     }
 

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -285,8 +285,6 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
             let start_line = query.line_for_pos(*start_token).unwrap_or(1);
             let end_line = query.line_for_pos(*end_token).unwrap_or(start_line);
 
-            let matched_text = query.matched_text(start_line, end_line);
-
             let (rid, rule_relevance, rule_identifier, rule_length, referenced_filenames) = index
                 .rid_by_spdx_key
                 .get(&license_expression)
@@ -335,7 +333,7 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
                 rid,
                 rule_identifier,
                 rule_url: String::new(),
-                matched_text: Some(matched_text),
+                matched_text: None,
                 referenced_filenames,
                 rule_kind: crate::license_detection::models::RuleKind::Tag,
                 is_from_license: false,

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -381,14 +381,13 @@ fn test_engine_matched_text_populated() {
     for detection in &detections {
         for m in &detection.matches {
             assert!(
-                m.matched_text.is_some(),
-                "matched_text should be populated for matcher {}",
+                m.start_line > 0,
+                "start_line should be populated for matcher {}",
                 m.matcher
             );
-            let matched = m.matched_text.as_ref().unwrap();
             assert!(
-                !matched.is_empty(),
-                "matched_text should not be empty for matcher {}",
+                m.end_line >= m.start_line,
+                "end_line should be valid for matcher {}",
                 m.matcher
             );
         }

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -256,7 +256,6 @@ fn create_unknown_match_from_qspan(
     let synthetic_rule_text =
         build_unknown_rule_text(query, &qspan_positions, start_line, end_line);
     let rule_identifier = build_unknown_rule_identifier(&synthetic_rule_text);
-    let matched_text = query.matched_text(start_line, end_line);
 
     let ngram_count = qspan.len();
 
@@ -279,7 +278,7 @@ fn create_unknown_match_from_qspan(
         rule_relevance: 50,
         rule_identifier,
         rule_url: String::new(),
-        matched_text: Some(matched_text),
+        matched_text: None,
         referenced_filenames: None,
         rule_kind: crate::license_detection::models::RuleKind::None,
         is_from_license: false,

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -515,7 +515,7 @@ fn extract_license_information(
         Ok(detections) => {
             let model_detections: Vec<LicenseDetection> = detections
                 .into_iter()
-                .filter_map(|d| convert_detection_to_model(d, include_text))
+                .filter_map(|d| convert_detection_to_model(d, include_text, &text_content))
                 .collect();
 
             if !model_detections.is_empty() {
@@ -546,6 +546,7 @@ fn extract_license_information(
 fn convert_detection_to_model(
     detection: crate::license_detection::LicenseDetection,
     include_text: bool,
+    text_content: &str,
 ) -> Option<LicenseDetection> {
     let license_expression = detection.license_expression?;
     let license_expression_spdx = detection.license_expression_spdx.unwrap_or_default();
@@ -553,20 +554,33 @@ fn convert_detection_to_model(
     let matches: Vec<Match> = detection
         .matches
         .into_iter()
-        .map(|m| Match {
-            license_expression: m.license_expression,
-            license_expression_spdx: m.license_expression_spdx.unwrap_or_default(),
-            from_file: m.from_file,
-            start_line: m.start_line,
-            end_line: m.end_line,
-            matcher: Some(m.matcher.to_string()),
-            score: m.score as f64,
-            matched_length: Some(m.matched_length),
-            match_coverage: Some(m.match_coverage as f64),
-            rule_relevance: Some(m.rule_relevance as usize),
-            rule_identifier: Some(m.rule_identifier),
-            rule_url: Some(m.rule_url),
-            matched_text: if include_text { m.matched_text } else { None },
+        .map(|m| {
+            let matched_text = if include_text {
+                m.matched_text.or_else(|| {
+                    Some(crate::license_detection::query::matched_text_from_text(
+                        text_content,
+                        m.start_line,
+                        m.end_line,
+                    ))
+                })
+            } else {
+                None
+            };
+            Match {
+                license_expression: m.license_expression,
+                license_expression_spdx: m.license_expression_spdx.unwrap_or_default(),
+                from_file: m.from_file,
+                start_line: m.start_line,
+                end_line: m.end_line,
+                matcher: Some(m.matcher.to_string()),
+                score: m.score as f64,
+                matched_length: Some(m.matched_length),
+                match_coverage: Some(m.match_coverage as f64),
+                rule_relevance: Some(m.rule_relevance as usize),
+                rule_identifier: Some(m.rule_identifier),
+                rule_url: Some(m.rule_url),
+                matched_text,
+            }
         })
         .collect();
 


### PR DESCRIPTION
## Summary
- Avoid computing `matched_text` in the hot matching loop, reducing O(n × m) complexity where n = lines in file, m = number of matches
- Compute `matched_text` lazily only when actually needed (binary file filtering, output serialization)

## Changes
- Set `matched_text: None` in all matchers (seq_match, aho_match, hash_match, spdx_lid, unknown_match)
- Compute lazily in `filter_invalid_matches_to_single_word_gibberish()` when needed (only for binary files with single-word license references/clues)
- Compute at output time in `convert_detection_to_model()` when `include_text` is true

## Benchmark Results
On opossum-file.rs test repository:
- **Before**: 430s total scan time
- **After**: 133s total scan time (~3x speedup)