### PR TITLE
feat: broaden score fixture parity

### DIFF
--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -20,7 +20,7 @@ implementation-plans/
 ### Post-Processing (`post-processing/`)
 
 - **[SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md)** - License/copyright tallies, facets, classification
-  - Status: 🟡 Active — key-file tagging, shared provenance cleanup, the current tally stack, file facets/by-facet tallies, package-preferred summary origin, generated-file detection, a broad active summary/score parity subset, and the main active classify fixture parity are implemented; remaining package tally work and only the residual summary/score/classify edge cases are tracked in [SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md)
+  - Status: 🟡 Active — key-file tagging, shared provenance cleanup, the current tally stack, file facets/by-facet tallies, package-preferred summary origin, generated-file detection, a broader active summary/score parity subset, and the main active classify fixture parity are implemented; remaining package tally work and only the residual summary/score/classify edge cases are tracked in [SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md)
 
 ### Infrastructure (`infrastructure/`)
 

--- a/docs/implementation-plans/post-processing/SUMMARIZATION_PLAN.md
+++ b/docs/implementation-plans/post-processing/SUMMARIZATION_PLAN.md
@@ -165,6 +165,10 @@ Summarization is a **consumer**, not a normalizer.
   - top-level/community classification on normal root-prefixed scans feeding summary/score correctly
   - empty declared-holder output when no holder can be established
   - primary-language fallback from tallied sources when top-level packages disagree
+  - multi-holder aggregation for a single top-level key file
+  - score parity for `no_license_text` and `no_license_or_copyright`
+  - score parity for single joined-expression declarations without false ambiguity
+  - score parity for nested manifest-style key files without declared copyrights
 - ✅ Broader classify parity for active fixtures:
   - resource-level `is_top_level` on root directories and their direct children
   - `is_legal` / `is_readme` checks using both file name and base name
@@ -200,7 +204,7 @@ Summarization is a **consumer**, not a normalizer.
 5. **Phase 4**: Initial non-license-dependent summary fields ✅
 6. **Phase 5**: Core codebase tallies (`--tallies`) over existing declared/discovered evidence. ✅ for top-level `detected_license_expression`, `copyrights`, `holders`, `authors`, and `programming_language`; package tallies remain open.
 7. **Phase 6**: Detailed tally variants (`--tallies-with-details`, `--tallies-key-files`, `--tallies-by-facet`). 🟡 Top-level `tallies_of_key_files`, per-resource `files[*].tallies`, and top-level `tallies_by_facet` are implemented; package tallies and some CLI gating remain open.
-8. **Phase 7**: Full license clarity parity. 🟡 Implemented: declared-license/identification/text/copyright scoring, joined-expression primary-license resolution, and ambiguity/conflict penalties. Remaining work: ScanCode-quality license match filtering and the remaining score edge cases.
+8. **Phase 7**: Full license clarity parity. 🟡 Implemented: declared-license/identification/text/copyright scoring, joined-expression primary-license resolution, ambiguity/conflict penalties, no-license-\* score cases, and the active jar-style nested-manifest score fixture. Remaining work: ScanCode-quality license match filtering and the residual score edge cases.
 9. **Phase 8**: Generated-code detection parity plus remaining classify/facet parity gaps. 🟡 Implemented: file-level `is_generated` detection from conspicuous header clues plus the main active classify fixture parity around legal/readme/manifest/community/top-level semantics. Remaining work: heuristic breadth and any residual classify gaps.
 10. **Phase 9**: Comprehensive `--summary` parity over the completed tally/clarity/classification inputs. 🟡 Implemented: package-preferred origin fields, `other_license_expressions`/`other_holders`, package-datafile holder fallback, empty declared-holder parity, tallied-language fallback when packages disagree, and the main active ambiguity/holder fixtures. Remaining work: broader package-precedence and the residual summary edge-case fixtures.
 11. **Phase 10**: CLI parity wiring for the remaining summary/tally/classify/facet/generated options and regression coverage. 🟡 Implemented: `--summary`, `--license-clarity-score`, `--tallies`, `--tallies-key-files`, `--tallies-with-details`, and `--generated` gating. Remaining work: package-tally CLI surface and broader compatibility edge cases.

--- a/docs/improvements/summarization-foundations.md
+++ b/docs/improvements/summarization-foundations.md
@@ -115,6 +115,10 @@ The current branch also closes several active upstream fixture gaps:
 - summary holder selection now keeps null `other_holders` buckets while still removing the declared holders themselves
 - summary now emits an empty declared-holder string when no holder can be established
 - summary falls back to the tallied primary language when top-level packages disagree on language
+- multiple holders detected in a single top-level key file are now joined into the declared holder output
+- `no_license_text` and `no_license_or_copyright` now match the active zero-score fixture behavior
+- a single joined declaration such as `MIT OR Apache-2.0` no longer triggers false ambiguity in score mode
+- nested manifest-style key files now participate in the active jar score fixture behavior
 
 ### Active classify parity fixture coverage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1879,13 +1879,20 @@ fn compute_declared_holders(files: &[FileInfo], packages: &[Package]) -> Vec<Str
     }
 
     if counts.is_empty() {
+        let mut key_file_holders = Vec::new();
         for holder in files
             .iter()
             .filter(|file| file.is_key_file)
             .flat_map(|file| file.holders.iter())
             .map(|holder| holder.holder.clone())
         {
-            *counts.entry(holder).or_insert(0) += 1;
+            if !key_file_holders.contains(&holder) {
+                key_file_holders.push(holder);
+            }
+        }
+
+        if !key_file_holders.is_empty() {
+            return key_file_holders;
         }
     }
 

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1711,6 +1711,282 @@ fn compute_summary_serializes_empty_declared_holder_when_none_found() {
 }
 
 #[test]
+fn compute_summary_joins_multiple_holders_from_single_top_level_license_file() {
+    let mut license = file("codebase/jetty.LICENSE");
+    license.is_key_file = true;
+    license.is_legal = true;
+    license.is_top_level = true;
+    license.license_expression = Some("jetty".to_string());
+    license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "jetty".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-jetty".to_string(),
+        matches: vec![Match {
+            license_expression: "jetty".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-jetty".to_string(),
+            from_file: Some("codebase/jetty.LICENSE".to_string()),
+            start_line: 1,
+            end_line: 132,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(996),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+    license.copyrights = vec![Copyright {
+        copyright: "Copyright Mort Bay and Sun Microsystems.".to_string(),
+        start_line: 1,
+        end_line: 1,
+    }];
+    license.holders = vec![
+        Holder {
+            holder: "Mort Bay Consulting Pty. Ltd. (Australia) and others".to_string(),
+            start_line: 1,
+            end_line: 1,
+        },
+        Holder {
+            holder: "Sun Microsystems".to_string(),
+            start_line: 2,
+            end_line: 2,
+        },
+    ];
+
+    let summary = compute_summary(&[license], &[]).expect("summary exists");
+
+    assert_eq!(
+        summary.declared_holder.as_deref(),
+        Some("Mort Bay Consulting Pty. Ltd. (Australia) and others, Sun Microsystems")
+    );
+}
+
+#[test]
+fn compute_score_mode_without_license_text_returns_zero_with_copyright_only() {
+    let mut package = package("pkg:npm/demo?uuid=test", "no_license_text/package.json");
+    package.declared_license_expression = Some("mit".to_string());
+
+    let mut package_json = file("no_license_text/package.json");
+    package_json.is_manifest = true;
+    package_json.is_key_file = true;
+    package_json.is_top_level = true;
+    package_json.for_packages = vec![package.package_uid.clone()];
+    package_json.copyrights = vec![Copyright {
+        copyright: "Copyright Example Corp.".to_string(),
+        start_line: 1,
+        end_line: 1,
+    }];
+
+    let summary = compute_summary_with_options(&[package_json], &[package], false, true)
+        .expect("score-only summary exists");
+    let score = summary.license_clarity_score.expect("clarity exists");
+
+    assert!(summary.declared_license_expression.is_none());
+    assert_eq!(score.score, 0);
+    assert!(!score.declared_license);
+    assert!(!score.identification_precision);
+    assert!(!score.has_license_text);
+    assert!(score.declared_copyrights);
+    assert!(score.ambiguous_compound_licensing);
+}
+
+#[test]
+fn compute_score_mode_without_license_or_copyright_returns_zero() {
+    let package = package(
+        "pkg:npm/demo?uuid=test",
+        "no_license_or_copyright/package.json",
+    );
+
+    let mut package_json = file("no_license_or_copyright/package.json");
+    package_json.is_manifest = true;
+    package_json.is_key_file = true;
+    package_json.is_top_level = true;
+    package_json.for_packages = vec![package.package_uid.clone()];
+
+    let summary = compute_summary_with_options(&[package_json], &[package], false, true)
+        .expect("score-only summary exists");
+    let score = summary.license_clarity_score.expect("clarity exists");
+
+    assert!(summary.declared_license_expression.is_none());
+    assert_eq!(score.score, 0);
+    assert!(!score.declared_license);
+    assert!(!score.identification_precision);
+    assert!(!score.has_license_text);
+    assert!(!score.declared_copyrights);
+    assert!(score.ambiguous_compound_licensing);
+}
+
+#[test]
+fn compute_score_mode_uses_single_joined_expression_without_ambiguity() {
+    let mut cargo = file("no_license_ambiguity/Cargo.toml");
+    cargo.is_manifest = true;
+    cargo.is_key_file = true;
+    cargo.is_top_level = true;
+    cargo.license_expression = Some("mit OR apache-2.0".to_string());
+    cargo.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit OR apache-2.0".to_string(),
+        license_expression_spdx: "MIT OR Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "mit OR apache-2.0".to_string(),
+            license_expression_spdx: "MIT OR Apache-2.0".to_string(),
+            from_file: Some("no_license_ambiguity/Cargo.toml".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+    cargo.copyrights = vec![Copyright {
+        copyright: "Copyright The Rand Project Developers.".to_string(),
+        start_line: 1,
+        end_line: 1,
+    }];
+
+    let mut apache = file("no_license_ambiguity/LICENSE-APACHE");
+    apache.is_legal = true;
+    apache.is_key_file = true;
+    apache.is_top_level = true;
+    apache.license_expression = Some("apache-2.0".to_string());
+    apache.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some("no_license_ambiguity/LICENSE-APACHE".to_string()),
+            start_line: 1,
+            end_line: 176,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(1410),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+
+    let mut mit = file("no_license_ambiguity/LICENSE-MIT");
+    mit.is_legal = true;
+    mit.is_key_file = true;
+    mit.is_top_level = true;
+    mit.license_expression = Some("mit".to_string());
+    mit.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("no_license_ambiguity/LICENSE-MIT".to_string()),
+            start_line: 1,
+            end_line: 18,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(161),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+
+    let summary = compute_summary_with_options(&[cargo, apache, mit], &[], false, true)
+        .expect("score-only summary exists");
+    let score = summary.license_clarity_score.expect("clarity exists");
+
+    assert_eq!(
+        summary.declared_license_expression.as_deref(),
+        Some("mit OR apache-2.0")
+    );
+    assert_eq!(score.score, 100);
+    assert!(!score.ambiguous_compound_licensing);
+}
+
+#[test]
+fn compute_score_mode_scores_nested_manifest_key_file_without_copyright() {
+    let mut pom = file("jar/META-INF/maven/org.jboss.logging/jboss-logging/pom.xml");
+    pom.is_manifest = true;
+    pom.is_key_file = true;
+    pom.is_top_level = true;
+    pom.license_expression = Some("apache-2.0".to_string());
+    pom.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some(
+                "jar/META-INF/maven/org.jboss.logging/jboss-logging/pom.xml".to_string(),
+            ),
+            start_line: 1,
+            end_line: 2,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(16),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+
+    let mut license = file("jar/META-INF/LICENSE.txt");
+    license.is_legal = true;
+    license.is_key_file = true;
+    license.is_top_level = true;
+    license.license_expression = Some("apache-2.0".to_string());
+    license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some("jar/META-INF/LICENSE.txt".to_string()),
+            start_line: 1,
+            end_line: 176,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(1410),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+
+    let summary = compute_summary_with_options(&[pom, license], &[], false, true)
+        .expect("score-only summary exists");
+    let score = summary.license_clarity_score.expect("clarity exists");
+
+    assert_eq!(
+        summary.declared_license_expression.as_deref(),
+        Some("apache-2.0")
+    );
+    assert_eq!(score.score, 90);
+    assert!(score.declared_license);
+    assert!(score.identification_precision);
+    assert!(score.has_license_text);
+    assert!(!score.declared_copyrights);
+}
+
+#[test]
 fn compute_summary_without_license_evidence_has_no_clarity_score() {
     let uid = "pkg:gem/demo@1.0.0?uuid=test";
     let mut root_package = package(uid, "demo/demo.gemspec");


### PR DESCRIPTION
## Summary
- align more of the active ScanCode score fixtures by supporting multi-holder aggregation from a single top-level key file, zero-score no-license cases, single joined-expression scoring without false ambiguity, and jar-style nested-manifest score behavior
- keep this slice within the active emitted summary/score surface instead of widening into dormant package-tally internals
- continue tracking fuller score heuristics and residual summary/classify edge cases separately in the summarization roadmap docs

## Verification
- cargo fmt --all
- cargo test --bin provenant main_test::
- cargo test --lib output::tests::
- cargo test --lib cli::tests::
- cargo test --test output_format_golden
- npm run check:docs