### PR TITLE
perf(license-detection): cache qspan HashSets to avoid redundant allocations (36% faster)

### DIFF
--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -111,13 +111,21 @@ fn is_redundant_same_expression_seq_container(
         return false;
     }
 
-    let mut contained: Vec<&LicenseMatch> = candidate_contained_matches
+    let container_qspan_set: HashSet<usize> = container.qspan().into_iter().collect();
+
+    let mut contained: Vec<(&LicenseMatch, Vec<usize>)> = candidate_contained_matches
         .iter()
-        .filter(|m| {
-            m.matcher == MatcherKind::Aho
+        .filter_map(|m| {
+            if m.matcher == MatcherKind::Aho
                 && has_full_match_coverage(m)
                 && m.license_expression == container.license_expression
-                && (container.qcontains(m) || container.qoverlap(m) > 0)
+                && (container.qcontains_with_set(m, &container_qspan_set)
+                    || container.qoverlap_with_set(m, &container_qspan_set) > 0)
+            {
+                Some((m, m.qspan()))
+            } else {
+                None
+            }
         })
         .collect();
 
@@ -125,28 +133,34 @@ fn is_redundant_same_expression_seq_container(
         return false;
     }
 
-    let material_children = contained.iter().filter(|m| m.matched_length > 1).count();
+    let material_children = contained
+        .iter()
+        .filter(|(m, _)| m.matched_length > 1)
+        .count();
     if material_children < 2 {
         return false;
     }
 
-    contained.sort_by_key(|m| m.qspan_bounds());
+    contained.sort_by_key(|(m, _)| m.qspan_bounds());
 
-    let container_qspan: HashSet<usize> = container.qspan().into_iter().collect();
     let mut child_union = HashSet::new();
-    for child in &contained {
-        child_union.extend(child.qspan());
+    for (_, qspan) in &contained {
+        child_union.extend(qspan.iter().copied());
     }
 
-    let container_only_positions: HashSet<usize> =
-        container_qspan.difference(&child_union).copied().collect();
-    let child_only_positions: HashSet<usize> =
-        child_union.difference(&container_qspan).copied().collect();
+    let container_only_positions: HashSet<usize> = container_qspan_set
+        .difference(&child_union)
+        .copied()
+        .collect();
+    let child_only_positions: HashSet<usize> = child_union
+        .difference(&container_qspan_set)
+        .copied()
+        .collect();
 
     let mut bridge_positions = HashSet::new();
     for pair in contained.windows(2) {
-        let (_, previous_end) = pair[0].qspan_bounds();
-        let (next_start, _) = pair[1].qspan_bounds();
+        let (_, previous_end) = pair[0].0.qspan_bounds();
+        let (next_start, _) = pair[1].0.qspan_bounds();
 
         if next_start < previous_end {
             return false;
@@ -172,12 +186,12 @@ fn is_redundant_same_expression_seq_container(
     {
         let earliest_child = contained
             .iter()
-            .map(|m| m.qspan_bounds().0)
+            .map(|(m, _)| m.qspan_bounds().0)
             .min()
             .unwrap_or(usize::MAX);
         let latest_child = contained
             .iter()
-            .map(|m| m.qspan_bounds().1.saturating_sub(1))
+            .map(|(m, _)| m.qspan_bounds().1.saturating_sub(1))
             .max()
             .unwrap_or(0);
 
@@ -222,13 +236,21 @@ fn is_redundant_low_coverage_composite_seq_wrapper(
         return false;
     }
 
-    let children: Vec<&LicenseMatch> = candidate_contained_matches
+    let container_qspan_set: HashSet<usize> = container.qspan().into_iter().collect();
+
+    let children: Vec<(&LicenseMatch, Vec<usize>)> = candidate_contained_matches
         .iter()
-        .filter(|m| {
-            m.matcher == aho_match::MATCH_AHO
+        .filter_map(|m| {
+            if m.matcher == aho_match::MATCH_AHO
                 && has_full_match_coverage(m)
                 && m.license_expression != container.license_expression
-                && (container.qcontains(m) || container.qoverlap(m) > 0)
+                && (container.qcontains_with_set(m, &container_qspan_set)
+                    || container.qoverlap_with_set(m, &container_qspan_set) > 0)
+            {
+                Some((m, m.qspan()))
+            } else {
+                None
+            }
         })
         .collect();
 
@@ -238,30 +260,33 @@ fn is_redundant_low_coverage_composite_seq_wrapper(
 
     let unique_expressions: HashSet<&str> = children
         .iter()
-        .map(|m| m.license_expression.as_str())
+        .map(|(m, _)| m.license_expression.as_str())
         .collect();
     if unique_expressions.len() < 2 {
         return false;
     }
 
-    let container_qspan: HashSet<usize> = container.qspan().into_iter().collect();
     let mut child_union = HashSet::new();
-    for child in &children {
-        child_union.extend(child.qspan());
+    for (_, qspan) in &children {
+        child_union.extend(qspan.iter().copied());
     }
 
-    let container_only_positions: HashSet<usize> =
-        container_qspan.difference(&child_union).copied().collect();
-    let child_only_positions: HashSet<usize> =
-        child_union.difference(&container_qspan).copied().collect();
+    let container_only_positions: HashSet<usize> = container_qspan_set
+        .difference(&child_union)
+        .copied()
+        .collect();
+    let child_only_positions: HashSet<usize> = child_union
+        .difference(&container_qspan_set)
+        .copied()
+        .collect();
 
     let mut sorted_children = children;
-    sorted_children.sort_by_key(|m| m.qspan_bounds());
+    sorted_children.sort_by_key(|(m, _)| m.qspan_bounds());
 
     let mut bridge_positions = HashSet::new();
     for pair in sorted_children.windows(2) {
-        let (_, previous_end) = pair[0].qspan_bounds();
-        let (next_start, _) = pair[1].qspan_bounds();
+        let (_, previous_end) = pair[0].0.qspan_bounds();
+        let (next_start, _) = pair[1].0.qspan_bounds();
         bridge_positions.extend(previous_end..next_start);
     }
 

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -593,6 +593,14 @@ impl LicenseMatch {
         self.start_token <= other.start_token && self.end_token >= other.end_token
     }
 
+    pub fn qcontains_with_set(&self, other: &LicenseMatch, self_set: &HashSet<usize>) -> bool {
+        if let Some(other_positions) = &other.qspan_positions {
+            return other_positions.iter().all(|p| self_set.contains(p));
+        }
+
+        (other.start_token..other.end_token).all(|p| self_set.contains(&p))
+    }
+
     pub fn qoverlap(&self, other: &LicenseMatch) -> usize {
         if let (Some(self_positions), Some(other_positions)) =
             (&self.qspan_positions, &other.qspan_positions)
@@ -630,6 +638,19 @@ impl LicenseMatch {
         let start = self.start_token.max(other.start_token);
         let end = self.end_token.min(other.end_token);
         end.saturating_sub(start)
+    }
+
+    pub fn qoverlap_with_set(&self, other: &LicenseMatch, self_set: &HashSet<usize>) -> usize {
+        if let Some(other_positions) = &other.qspan_positions {
+            return other_positions
+                .iter()
+                .filter(|p| self_set.contains(p))
+                .count();
+        }
+
+        (other.start_token..other.end_token)
+            .filter(|p| self_set.contains(p))
+            .count()
     }
 
     pub fn qspan_overlap(&self, other: &LicenseMatch) -> usize {


### PR DESCRIPTION
## Summary
Optimizes two hotspot functions in license detection by caching qspan HashSets instead of repeatedly recreating them.

## Problem
`is_redundant_same_expression_seq_container()` and `is_redundant_low_coverage_composite_seq_wrapper()` were repeatedly creating HashSets:
- Container's qspan was converted to HashSet inside filter closures (once per candidate match)
- Children's qspans were computed during filtering, then recomputed for child_union

## Solution
- Pre-compute container's qspan HashSet once before filtering
- Add `qcontains_with_set()` and `qoverlap_with_set()` methods that accept pre-computed HashSets
- Cache children's qspans during filtering and reuse for child_union computation

## Performance Results
Benchmarked on opossum-file.rs repository:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total runtime | 106s | 68s | **36% faster** |
| `is_redundant_low_coverage_composite_seq_wrapper` | 47% of total time | 15.76% | 66% reduction |
| `is_redundant_same_expression_seq_container` | Significant | 0.06% | Now negligible |

## Changes
- `src/license_detection/models/license_match.rs`: Add `qcontains_with_set()` and `qoverlap_with_set()` methods
- `src/license_detection/mod.rs`: Refactor both hotspot functions to use cached qspans