### PR TITLE
perf(license-detection): precompute high_sets_by_rid for early candidate rejection

### DIFF
--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -317,6 +317,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     let mut tids_by_rid: Vec<Vec<TokenId>> = Vec::with_capacity(rules.len());
     let mut sets_by_rid: HashMap<usize, HashSet<TokenId>> = HashMap::new();
     let mut msets_by_rid: HashMap<usize, HashMap<TokenId, usize>> = HashMap::new();
+    let mut high_sets_by_rid: HashMap<usize, HashSet<TokenId>> = HashMap::new();
     let mut high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>> = HashMap::new();
     let mut false_positive_rids: HashSet<usize> = HashSet::new();
     let mut approx_matchable_rids: HashSet<usize> = HashSet::new();
@@ -425,6 +426,10 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         let tids_set_high = high_tids_set_subset(&tids_set, &dictionary);
         let mset_high = high_multiset_subset(&mset, &dictionary);
 
+        if !tids_set_high.is_empty() {
+            high_sets_by_rid.insert(rid, tids_set_high.clone());
+        }
+
         // Build inverted index: map high-value tokens to rules containing them
         if approx_matchable_rids.contains(&rid) {
             for &tid in &tids_set_high {
@@ -500,6 +505,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         unknown_automaton,
         sets_by_rid,
         msets_by_rid,
+        high_sets_by_rid,
         high_postings_by_rid,
         false_positive_rids,
         approx_matchable_rids,

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -115,6 +115,15 @@ pub struct LicenseIndex {
     /// Corresponds to Python: `self.msets_by_rid = []` (line 213)
     pub msets_by_rid: HashMap<usize, HashMap<TokenId, usize>>,
 
+    /// High-value token sets per rule for early candidate rejection.
+    ///
+    /// Maps rule IDs to sets containing only high-value (legalese) token IDs.
+    /// This is a subset of `sets_by_rid` for faster intersection computation
+    /// and early rejection of candidates that won't pass the high-token threshold.
+    ///
+    /// Precomputed during index building to avoid redundant filtering at runtime.
+    pub high_sets_by_rid: HashMap<usize, HashSet<TokenId>>,
+
     /// Inverted index of high-value token positions per rule.
     ///
     /// Maps rule IDs to a mapping from high-value token IDs to their positions
@@ -221,6 +230,7 @@ impl LicenseIndex {
                 .expect("Failed to create empty automaton"),
             sets_by_rid: HashMap::new(),
             msets_by_rid: HashMap::new(),
+            high_sets_by_rid: HashMap::new(),
             high_postings_by_rid: HashMap::new(),
             false_positive_rids: HashSet::new(),
             approx_matchable_rids: HashSet::new(),

--- a/src/license_detection/seq_match/candidates.rs
+++ b/src/license_detection/seq_match/candidates.rs
@@ -3,7 +3,7 @@
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::index::token_sets::{
-    build_set_and_mset, high_multiset_subset, high_tids_set_subset, tids_set_counter,
+    build_set_and_mset, high_multiset_subset, tids_set_counter,
 };
 use crate::license_detection::models::Rule;
 use crate::license_detection::query::QueryRun;
@@ -324,23 +324,29 @@ pub fn compute_candidates_with_msets(
         let Some(rule_set) = index.sets_by_rid.get(&rid) else {
             continue;
         };
-        let Some(_rule_mset) = index.msets_by_rid.get(&rid) else {
+        let Some(rule_high_set) = index.high_sets_by_rid.get(&rid) else {
             continue;
         };
 
-        let intersection: HashSet<TokenId> = query_set.intersection(rule_set).copied().collect();
-        if intersection.is_empty() {
+        // STEP 1: Compute HIGH intersection first (smaller sets, faster)
+        // Check size without allocation for early rejection
+        let high_intersection_size = query_high_set.intersection(rule_high_set).count();
+        if high_intersection_size < rule.min_high_matched_length_unique {
             continue;
         }
 
-        let high_set_intersection = high_tids_set_subset(&intersection, &index.dictionary);
+        // Allocate the high intersection (passed threshold check)
+        let high_set_intersection: HashSet<TokenId> = query_high_set
+            .intersection(rule_high_set)
+            .copied()
+            .collect();
         if high_set_intersection.is_empty() {
             continue;
         }
 
-        // Check high token threshold (this is separate from matched_length!)
-        let high_matched_length = tids_set_counter(&high_set_intersection);
-        if high_matched_length < rule.min_high_matched_length_unique {
+        // STEP 2: Only now compute FULL intersection (fewer candidates reach here)
+        let intersection: HashSet<TokenId> = query_set.intersection(rule_set).copied().collect();
+        if intersection.is_empty() {
             continue;
         }
 

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -41,7 +41,7 @@ mod tests {
     use crate::license_detection::models::Rule;
     use crate::license_detection::query::Query;
     use crate::license_detection::test_utils::create_test_index;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     pub(super) fn create_seq_match_test_index() -> LicenseIndex {
         create_test_index(
@@ -64,8 +64,17 @@ mod tests {
             .collect();
 
         let (set, mset) = build_set_and_mset(&tokens);
-        let _ = index.sets_by_rid.insert(rid, set);
+        let _ = index.sets_by_rid.insert(rid, set.clone());
         let _ = index.msets_by_rid.insert(rid, mset);
+
+        let high_set: HashSet<TokenId> = set
+            .iter()
+            .filter(|&&tid| index.dictionary.token_kind(tid) == TokenKind::Legalese)
+            .copied()
+            .collect();
+        if !high_set.is_empty() {
+            let _ = index.high_sets_by_rid.insert(rid, high_set);
+        }
 
         let mut high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
         for (pos, &tid) in tokens.iter().enumerate() {


### PR DESCRIPTION
Add precomputed high token sets to LicenseIndex to enable early rejection of candidates before computing full intersections.

Changes:
- Add high_sets_by_rid field to LicenseIndex containing only high-value (legalese) tokens per rule
- Populate during index building (reuse already-computed tids_set_high)
- Reverse intersection check order in compute_candidates_with_msets: check high intersection first, only compute full intersection if high threshold passes

Performance results (60 files, profiling build):
- Total time: 66.25s -> 60.54s (-8.6%)
- Scan time: 55.89s -> 50.13s (-10.3%)
- compute_candidates_with_msets: ~4% -> 3.16% (-21%)