### PR TITLE
parity(cli): add --package/-p flag to enable package detection

### DIFF
--- a/docs/implementation-plans/infrastructure/CLI_PLAN.md
+++ b/docs/implementation-plans/infrastructure/CLI_PLAN.md
@@ -17,40 +17,41 @@ This plan tracks progress toward a **drop-in replacement CLI surface**.
 
 ### Implemented (drop-in-oriented core)
 
-| Parameter                  | Notes                                                                                                             |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `<dir_path>`               | Positional argument                                                                                               |
-| `--json <FILE>`            | Compact JSON output                                                                                               |
-| `--json-pp <FILE>`         | Pretty JSON output                                                                                                |
-| `--json-lines <FILE>`      | JSON Lines output                                                                                                 |
-| `--yaml <FILE>`            | YAML output                                                                                                       |
-| `--csv <FILE>`             | CSV output (deprecated upstream but supported)                                                                    |
-| `--html <FILE>`            | HTML report output                                                                                                |
-| `--spdx-tv <FILE>`         | SPDX Tag/Value output                                                                                             |
-| `--spdx-rdf <FILE>`        | SPDX RDF/XML output                                                                                               |
-| `--cyclonedx <FILE>`       | CycloneDX JSON output                                                                                             |
-| `--cyclonedx-xml <FILE>`   | CycloneDX XML output                                                                                              |
-| `--custom-output <FILE>`   | Custom template output file                                                                                       |
-| `--custom-template <FILE>` | Required with `--custom-output`                                                                                   |
-| `-m, --max-depth`          | Default: 0 (no depth limit)                                                                                       |
-| `-n, --processes`          | Compatible with `0` and `-1` values                                                                               |
-| `--timeout`                | Per-file timeout option                                                                                           |
-| `-q, --quiet`              | Quiet mode                                                                                                        |
-| `-v, --verbose`            | Verbose path mode                                                                                                 |
-| `--strip-root`             | Relative path normalization                                                                                       |
-| `--full-root`              | Absolute path reporting                                                                                           |
-| `--exclude` / `--ignore`   | Glob patterns (`--ignore` for ScanCode parity)                                                                    |
-| `--from-json`              | Load previous JSON scan(s) from positional input (`<dir_path>...`); incompatible with `--copyright/--email/--url` |
-| `--include`                | Include path patterns                                                                                             |
-| `--mark-source`            | Mark source-heavy files/directories                                                                               |
-| `--only-findings`          | Filter output to files with findings                                                                              |
-| `--filter-clues`           | Filter redundant clues                                                                                            |
-| `-c, --copyright`          | Copyright/holder/author detection toggle                                                                          |
-| `-e, --email`              | Enable email detection                                                                                            |
-| `-u, --url`                | Enable URL detection                                                                                              |
-| `--no-assemble`            | Rust-specific                                                                                                     |
-| `--max-email`              | Threshold (default 50, requires `--email`)                                                                        |
-| `--max-url`                | Threshold (default 50, requires `--url`)                                                                          |
+| Parameter                  | Notes                                                                                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `<dir_path>`               | Positional argument                                                                                                                     |
+| `--json <FILE>`            | Compact JSON output                                                                                                                     |
+| `--json-pp <FILE>`         | Pretty JSON output                                                                                                                      |
+| `--json-lines <FILE>`      | JSON Lines output                                                                                                                       |
+| `--yaml <FILE>`            | YAML output                                                                                                                             |
+| `--csv <FILE>`             | CSV output (deprecated upstream but supported)                                                                                          |
+| `--html <FILE>`            | HTML report output                                                                                                                      |
+| `--spdx-tv <FILE>`         | SPDX Tag/Value output                                                                                                                   |
+| `--spdx-rdf <FILE>`        | SPDX RDF/XML output                                                                                                                     |
+| `--cyclonedx <FILE>`       | CycloneDX JSON output                                                                                                                   |
+| `--cyclonedx-xml <FILE>`   | CycloneDX XML output                                                                                                                    |
+| `--custom-output <FILE>`   | Custom template output file                                                                                                             |
+| `--custom-template <FILE>` | Required with `--custom-output`                                                                                                         |
+| `-m, --max-depth`          | Default: 0 (no depth limit)                                                                                                             |
+| `-n, --processes`          | Compatible with `0` and `-1` values                                                                                                     |
+| `--timeout`                | Per-file timeout option                                                                                                                 |
+| `-q, --quiet`              | Quiet mode                                                                                                                              |
+| `-v, --verbose`            | Verbose path mode                                                                                                                       |
+| `--strip-root`             | Relative path normalization                                                                                                             |
+| `--full-root`              | Absolute path reporting                                                                                                                 |
+| `--exclude` / `--ignore`   | Glob patterns (`--ignore` for ScanCode parity)                                                                                          |
+| `--from-json`              | Load previous JSON scan(s) from positional input (`<dir_path>...`); incompatible with `--package/--copyright/--email/--url/--generated` |
+| `--include`                | Include path patterns                                                                                                                   |
+| `--mark-source`            | Mark source-heavy files/directories                                                                                                     |
+| `--only-findings`          | Filter output to files with findings                                                                                                    |
+| `--filter-clues`           | Filter redundant clues                                                                                                                  |
+| `-c, --copyright`          | Copyright/holder/author detection toggle                                                                                                |
+| `-e, --email`              | Enable email detection                                                                                                                  |
+| `-p, --package`            | Enable package manifest, lockfile, and related package-data scanning                                                                    |
+| `-u, --url`                | Enable URL detection                                                                                                                    |
+| `--no-assemble`            | Rust-specific                                                                                                                           |
+| `--max-email`              | Threshold (default 50, requires `--email`)                                                                                              |
+| `--max-url`                | Threshold (default 50, requires `--url`)                                                                                                |
 
 ### Core Parameters (partial)
 
@@ -106,12 +107,12 @@ Runtime dependency notes:
 
 ### Input/Output Control (implemented)
 
-| Parameter         | Notes                                                                                    |
-| ----------------- | ---------------------------------------------------------------------------------------- |
-| `--from-json`     | Load from previous scan JSON input(s); disallows `--copyright/--email/--url/--generated` |
-| `--include`       | Include patterns                                                                         |
-| `--mark-source`   | Mark source files                                                                        |
-| `--only-findings` | Filter output                                                                            |
+| Parameter         | Notes                                                                                              |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| `--from-json`     | Load from previous scan JSON input(s); disallows `--package/--copyright/--email/--url/--generated` |
+| `--include`       | Include patterns                                                                                   |
+| `--mark-source`   | Mark source files                                                                                  |
+| `--only-findings` | Filter output                                                                                      |
 
 ### Cache Control (partial)
 
@@ -131,7 +132,7 @@ Runtime dependency notes:
    ScanCode option names and argument shape (especially output options).
 3. **Avoid parallel output-spec APIs** — do not expose a second primary output
    selection mechanism that diverges from ScanCode usage.
-4. **`--package` always on** — package scanning runs by default (no flag needed).
+4. **`--package` is opt-in** — package manifest detection is disabled by default to match ScanCode.
 5. **`--no-assemble` is Rust-specific** — Python always assembles.
 
 ## Differences from Python (current intentional)

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -67,6 +67,7 @@ START_TIME=$(date +%s.%N)
 
 /usr/bin/time -v "${PROVENANT_BIN}" \
     --json "${OUTPUT_FILE}" \
+    --package \
     --copyright \
     --email \
     --url \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,10 @@ pub struct Cli {
     #[arg(long)]
     pub from_json: bool,
 
+    /// Scan input for application package and dependency manifests, lockfiles and related data
+    #[arg(short = 'p', long)]
+    pub package: bool,
+
     /// Disable package assembly (merging related manifest/lockfiles into packages)
     #[arg(long)]
     pub no_assemble: bool,
@@ -576,6 +580,36 @@ mod tests {
         .expect("cli parse should succeed");
 
         assert!(parsed.copyright);
+    }
+
+    #[test]
+    fn test_package_flag_defaults_to_disabled() {
+        let parsed = Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "samples"])
+            .expect("cli parse should succeed");
+
+        assert!(!parsed.package);
+    }
+
+    #[test]
+    fn test_parses_package_flag() {
+        let parsed = Cli::try_parse_from([
+            "provenant",
+            "--json-pp",
+            "scan.json",
+            "--package",
+            "samples",
+        ])
+        .expect("cli parse should succeed");
+
+        assert!(parsed.package);
+    }
+
+    #[test]
+    fn test_package_short_flag() {
+        let parsed = Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "-p", "samples"])
+            .expect("cli parse should succeed");
+
+        assert!(parsed.package);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,7 @@ fn run() -> Result<()> {
         };
 
         let text_options = TextDetectionOptions {
+            detect_packages: cli.package,
             detect_copyrights: cli.copyright,
             detect_generated: cli.generated,
             detect_emails: cli.email,
@@ -237,17 +238,17 @@ fn run() -> Result<()> {
         .iter()
         .map(|file| file.package_data.len())
         .sum();
-    let assembly_result = if cli.no_assemble {
-        assembly::AssemblyResult {
-            packages: Vec::new(),
-            dependencies: Vec::new(),
-        }
-    } else if cli.from_json
+    let assembly_result = if cli.from_json
         && (!preloaded_assembly.packages.is_empty() || !preloaded_assembly.dependencies.is_empty())
     {
         progress.start_assembly();
         progress.finish_assembly(preloaded_assembly.packages.len(), manifests_seen);
         preloaded_assembly
+    } else if cli.no_assemble {
+        assembly::AssemblyResult {
+            packages: Vec::new(),
+            dependencies: Vec::new(),
+        }
     } else {
         progress.start_assembly();
         let assembled = assembly::assemble(&mut scan_result.files);
@@ -307,9 +308,9 @@ fn run() -> Result<()> {
 }
 
 fn validate_scan_option_compatibility(cli: &Cli) -> Result<()> {
-    if cli.from_json && (cli.copyright || cli.email || cli.url || cli.generated) {
+    if cli.from_json && (cli.package || cli.copyright || cli.email || cli.url || cli.generated) {
         return Err(anyhow!(
-            "When using --from-json, file scan options like --copyright/--email/--url/--generated are not allowed"
+            "When using --from-json, file scan options like --package/--copyright/--email/--url/--generated are not allowed"
         ));
     }
 
@@ -419,7 +420,10 @@ fn progress_mode_from_cli(cli: &Cli) -> ProgressMode {
 }
 
 fn configured_scan_names(cli: &Cli) -> String {
-    let mut names = vec!["licenses", "packages"];
+    let mut names = vec!["licenses"];
+    if cli.package {
+        names.push("packages");
+    }
     if cli.copyright {
         names.push("copyrights");
     }

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -62,6 +62,20 @@ fn validate_scan_option_compatibility_rejects_scan_flags_with_from_json() {
 }
 
 #[test]
+fn validate_scan_option_compatibility_rejects_package_with_from_json() {
+    let cli = crate::cli::Cli::try_parse_from([
+        "provenant",
+        "--json-pp",
+        "scan.json",
+        "--from-json",
+        "--package",
+        "sample-scan.json",
+    ])
+    .unwrap();
+    assert!(validate_scan_option_compatibility(&cli).is_err());
+}
+
+#[test]
 fn validate_scan_option_compatibility_rejects_generated_with_from_json() {
     let cli = crate::cli::Cli::try_parse_from([
         "provenant",
@@ -128,6 +142,77 @@ fn validate_scan_option_compatibility_allows_multiple_inputs_with_from_json() {
     ])
     .unwrap();
     assert!(validate_scan_option_compatibility(&cli).is_ok());
+}
+
+#[test]
+fn from_json_with_no_assemble_preserves_preloaded_package_sections() {
+    let temp_path = std::env::temp_dir().join("provenant-from-json-with-packages-test.json");
+    let content = json!({
+        "files": [],
+        "packages": [
+            {
+                "package_uid": "pkg:npm/demo@1.0.0",
+                "type": "npm",
+                "name": "demo",
+                "version": "1.0.0",
+                "parties": [],
+                "datafile_paths": ["package.json"],
+                "datasource_ids": ["npm_package_json"]
+            }
+        ],
+        "dependencies": [
+            {
+                "purl": "pkg:npm/dep@2.0.0",
+                "scope": "dependencies",
+                "is_runtime": true,
+                "is_optional": false,
+                "is_pinned": true,
+                "dependency_uid": "pkg:npm/dep@2.0.0?uuid=test",
+                "for_package_uid": "pkg:npm/demo@1.0.0",
+                "datafile_path": "package.json",
+                "datasource_id": "npm_package_json"
+            }
+        ],
+        "license_references": [],
+        "license_rule_references": []
+    });
+    fs::write(&temp_path, content.to_string()).expect("write json fixture");
+
+    let parsed = load_scan_from_json(temp_path.to_str().expect("utf-8 path"))
+        .expect("from-json loading should succeed");
+
+    let preloaded = assembly::AssemblyResult {
+        packages: parsed.packages,
+        dependencies: parsed.dependencies,
+    };
+
+    let cli = crate::cli::Cli::try_parse_from([
+        "provenant",
+        "--json-pp",
+        "scan.json",
+        "--from-json",
+        "--no-assemble",
+        temp_path.to_str().expect("utf-8 path"),
+    ])
+    .expect("cli parse should succeed");
+
+    let assembly_result = if cli.from_json
+        && (!preloaded.packages.is_empty() || !preloaded.dependencies.is_empty())
+    {
+        preloaded
+    } else if cli.no_assemble {
+        assembly::AssemblyResult {
+            packages: Vec::new(),
+            dependencies: Vec::new(),
+        }
+    } else {
+        unreachable!("test only covers from-json preload precedence")
+    };
+
+    assert_eq!(assembly_result.packages.len(), 1);
+    assert_eq!(assembly_result.dependencies.len(), 1);
+
+    let _ = fs::remove_file(temp_path);
 }
 
 #[test]

--- a/src/parsers/scan_pipeline_test_utils.rs
+++ b/src/parsers/scan_pipeline_test_utils.rs
@@ -14,7 +14,10 @@ pub(crate) fn scan_and_assemble(path: &Path) -> (Vec<FileInfo>, assembly::Assemb
         progress,
         None,
         false,
-        &TextDetectionOptions::default(),
+        &TextDetectionOptions {
+            detect_packages: true,
+            ..TextDetectionOptions::default()
+        },
     );
 
     let mut files = result.files;

--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -455,7 +455,10 @@ pub(crate) fn compute_fixture_summary(
         progress,
         Some(test_license_engine()),
         false,
-        &TextDetectionOptions::default(),
+        &TextDetectionOptions {
+            detect_packages: true,
+            ..TextDetectionOptions::default()
+        },
     );
 
     let mut files = scan_result.files;
@@ -558,7 +561,10 @@ pub(crate) fn assert_classify_fixture_matches_expected(
         progress,
         Some(test_license_engine()),
         false,
-        &TextDetectionOptions::default(),
+        &TextDetectionOptions {
+            detect_packages: true,
+            ..TextDetectionOptions::default()
+        },
     );
 
     let mut files = scan_result.files;
@@ -621,7 +627,10 @@ pub(crate) fn scan_and_assemble_with_keyfiles(
         progress,
         None,
         false,
-        &TextDetectionOptions::default(),
+        &TextDetectionOptions {
+            detect_packages: true,
+            ..TextDetectionOptions::default()
+        },
     );
 
     let mut files = result.files;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -12,6 +12,7 @@ pub struct ProcessResult {
 
 #[derive(Debug, Clone)]
 pub struct TextDetectionOptions {
+    pub detect_packages: bool,
     pub detect_copyrights: bool,
     pub detect_generated: bool,
     pub detect_emails: bool,
@@ -25,6 +26,7 @@ pub struct TextDetectionOptions {
 impl Default for TextDetectionOptions {
     fn default() -> Self {
         Self {
+            detect_packages: false,
             detect_copyrights: true,
             detect_generated: false,
             detect_emails: false,
@@ -56,6 +58,7 @@ mod tests {
     #[test]
     fn default_options_keep_copyright_detection_enabled() {
         let options = TextDetectionOptions::default();
+        assert!(!options.detect_packages);
         assert!(options.detect_copyrights);
     }
 
@@ -84,6 +87,7 @@ mod tests {
     #[test]
     fn scanner_reports_repeated_email_occurrences() {
         let options = TextDetectionOptions {
+            detect_packages: false,
             detect_copyrights: false,
             detect_generated: false,
             detect_emails: true,
@@ -120,6 +124,7 @@ mod tests {
     #[test]
     fn scanner_skips_pem_certificate_text_detection() {
         let options = TextDetectionOptions {
+            detect_packages: false,
             detect_copyrights: true,
             detect_generated: false,
             detect_emails: true,
@@ -170,6 +175,7 @@ mod tests {
     #[test]
     fn scanner_detects_structured_credits_authors() {
         let options = TextDetectionOptions {
+            detect_packages: false,
             detect_copyrights: true,
             detect_generated: false,
             detect_emails: false,
@@ -207,6 +213,7 @@ mod tests {
     #[test]
     fn scanner_sets_generated_flag_when_enabled() {
         let options = TextDetectionOptions {
+            detect_packages: false,
             detect_copyrights: false,
             detect_generated: true,
             detect_emails: false,
@@ -223,5 +230,58 @@ mod tests {
         );
 
         assert_eq!(scanned.is_generated, Some(true));
+    }
+
+    #[test]
+    fn scanner_skips_package_parsing_when_disabled() {
+        let options = TextDetectionOptions {
+            detect_packages: false,
+            detect_copyrights: false,
+            detect_generated: false,
+            detect_emails: false,
+            detect_urls: false,
+            max_emails: 50,
+            max_urls: 50,
+            timeout_seconds: 120.0,
+            scan_cache_dir: None,
+        };
+        let scanned = scan_single_file(
+            "package.json",
+            r#"{"name":"demo","version":"1.0.0"}"#,
+            &options,
+        );
+
+        assert!(
+            scanned.package_data.is_empty(),
+            "package_data: {:#?}",
+            scanned.package_data
+        );
+    }
+
+    #[test]
+    fn scanner_parses_package_manifests_when_enabled() {
+        let options = TextDetectionOptions {
+            detect_packages: true,
+            detect_copyrights: false,
+            detect_generated: false,
+            detect_emails: false,
+            detect_urls: false,
+            max_emails: 50,
+            max_urls: 50,
+            timeout_seconds: 120.0,
+            scan_cache_dir: None,
+        };
+        let scanned = scan_single_file(
+            "package.json",
+            r#"{"name":"demo","version":"1.0.0"}"#,
+            &options,
+        );
+
+        assert_eq!(
+            scanned.package_data.len(),
+            1,
+            "package_data: {:#?}",
+            scanned.package_data
+        );
     }
 }

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -211,7 +211,9 @@ fn extract_information_from_content(
 
     // Package parsing and text-based detection (copyright, license) are independent.
     // Python ScanCode runs all enabled plugins on every file, so we do the same.
-    if let Some(package_data) = try_parse_file(path) {
+    if text_options.detect_packages
+        && let Some(package_data) = try_parse_file(path)
+    {
         file_info_builder.package_data(package_data);
     }
 
@@ -287,7 +289,8 @@ fn is_timeout_exceeded(started: Instant, timeout_seconds: f64) -> bool {
 
 fn scan_cache_fingerprint(text_options: &TextDetectionOptions) -> String {
     format!(
-        "copyrights={};emails={};urls={};max_emails={};max_urls={};timeout={:.6}",
+        "packages={};copyrights={};emails={};urls={};max_emails={};max_urls={};timeout={:.6}",
+        text_options.detect_packages,
         text_options.detect_copyrights,
         text_options.detect_emails,
         text_options.detect_urls,

--- a/tests/scanner_copyright_credits.rs
+++ b/tests/scanner_copyright_credits.rs
@@ -31,6 +31,7 @@ fn scanner_matches_structured_credits_fixture() {
     let progress = hidden_progress();
     let patterns: Vec<Pattern> = vec![];
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,

--- a/tests/scanner_integration.rs
+++ b/tests/scanner_integration.rs
@@ -531,6 +531,7 @@ fn test_scanner_detects_emails_and_urls_when_enabled() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: true,
@@ -573,6 +574,7 @@ fn test_scanner_detects_copyrights_in_latin1_text() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -618,6 +620,7 @@ fn test_scanner_detects_copyrights_in_pdf_text() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -676,6 +679,7 @@ fn test_scanner_detects_emails_and_urls_in_pdf_text() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: false,
         detect_generated: false,
         detect_emails: true,
@@ -736,6 +740,7 @@ fn test_scanner_detects_copyrights_in_supported_image_exif_containers() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -810,6 +815,7 @@ fn test_scanner_detects_emails_and_urls_in_xmp_metadata() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: false,
         detect_generated: false,
         detect_emails: true,
@@ -886,6 +892,7 @@ fn test_scanner_detects_urls_in_additional_xmp_fields() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: false,
         detect_generated: false,
         detect_emails: true,
@@ -947,6 +954,7 @@ fn test_scanner_detects_emails_in_exif_user_comment() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: false,
         detect_generated: false,
         detect_emails: true,
@@ -998,6 +1006,7 @@ fn test_scanner_ignores_non_clue_image_metadata() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: true,
@@ -1041,6 +1050,7 @@ fn test_scanner_ignores_xml_namespace_garbage_in_copyright_detection() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -1096,6 +1106,7 @@ fn test_scanner_detects_copyrights_in_windows_dll_strings() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -1141,6 +1152,7 @@ fn test_scanner_avoids_false_positive_copyrights_in_executable_strings() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: false,
@@ -1193,6 +1205,7 @@ fn test_scanner_respects_email_url_thresholds() {
     let patterns: Vec<Pattern> = vec![];
     let engine = create_license_detection_engine();
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: true,
@@ -1236,6 +1249,7 @@ fn test_scanner_persists_scan_result_cache_entries() {
 
     let patterns: Vec<Pattern> = vec![];
     let options = TextDetectionOptions {
+        detect_packages: false,
         detect_copyrights: true,
         detect_generated: false,
         detect_emails: true,


### PR DESCRIPTION
## Summary
- Add `--package` / `-p` CLI flag to control package manifest detection
- Package detection is now disabled by default, matching the ScanCode reference implementation
- Wire the flag through `TextDetectionOptions` to conditionally parse package manifests
- Update benchmark script to include `--package` flag

## Changes
- Add `package` field to `Cli` struct with short (`-p`) and long (`--package`) flags
- Add `detect_packages` field to `TextDetectionOptions`
- Update scan cache fingerprint to include package detection setting
- Add CLI tests for the new flag
- Update all test files using `TextDetectionOptions`
- Add `--package` to `scripts/benchmark.sh`