### PR TITLE
ci: simplify release workflow and fix rpmdb platform gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+      - "v*.*.*"
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,13 +19,14 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
             archive_format: tar.gz
+            packages: pkg-config libsqlite3-dev
 
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             archive_format: tar.gz
-            use_cross: true
+            packages: pkg-config libsqlite3-dev
 
           # x86_64-apple-darwin removed: macos-15-large requires paid plan
           # Intel Mac users can use Rosetta 2 to run ARM builds
@@ -33,11 +34,13 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             archive_format: tar.gz
+            packages: ""
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive_format: zip
             ext: .exe
+            packages: ""
 
     runs-on: ${{ matrix.os }}
 
@@ -48,27 +51,23 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
         with:
-          targets: ${{ matrix.target }}
+          cache: false
+          rustflags: ""
+          target: ${{ matrix.target }}
+
+      - name: Install system packages
+        if: matrix.packages != ''
+        run: sudo apt-get update && sudo apt-get install --assume-yes ${{ matrix.packages }}
 
       - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           key: ${{ matrix.target }}
 
-      - name: Install cross
-        if: matrix.use_cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
-
       - name: Build binary
-        run: |
-          if [ "${{ matrix.use_cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-        shell: bash
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Create archive (Unix)
         if: matrix.archive_format == 'tar.gz'
@@ -87,7 +86,8 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           7z a provenant-${{ matrix.target }}.zip provenant${{ matrix.ext }}
-          certutil -hashfile provenant-${{ matrix.target }}.zip SHA256 > provenant-${{ matrix.target }}.zip.sha256
+          $hash = (Get-FileHash "provenant-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  provenant-${{ matrix.target }}.zip" | Out-File -FilePath "provenant-${{ matrix.target }}.zip.sha256" -Encoding ascii
         shell: pwsh
 
       - name: Upload build artifacts
@@ -102,7 +102,6 @@ jobs:
   create-release:
     name: Create Release
     needs: build
-    if: always() # Run even if some builds fail
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -114,9 +113,10 @@ jobs:
         run: ls -R artifacts
 
       - name: Create Release with all assets
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: false
+          allowUpdates: true
+          artifacts: artifacts/*/*.tar.gz,artifacts/*/*.zip,artifacts/*/*.sha256
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: true
           prerelease: ${{ contains(github.ref, '-') }}
-          generate_release_notes: true
-          files: artifacts/*/*.{tar.gz,zip,sha256}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,12 @@ tera = { version = "1.20.1", default-features = false }
 env_logger = "0.11.9"
 ar = "0.9"           # Unix ar archive format (for .deb)
 rpm = { version = "0.19.0", default-features = false, features = ["gzip-compression", "xz-compression", "zstd-compression", "bzip2-compression"] }
-rpmdb = { version = "0.1.0", git = "https://github.com/yybit/rpmdb-rs", rev = "8a20c8b8" }
 strum = { version = "0.28.0", features = ["derive"] }
 rmp-serde = "1.3.1"
 bit-set = "0.9.1"
+
+[target.'cfg(unix)'.dependencies]
+rpmdb = { version = "0.1.0", git = "https://github.com/yybit/rpmdb-rs", rev = "8a20c8b8" }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "Cargo.lock",
     "package.json",
     "package-lock.json",
+    "rust-toolchain.toml",
     ".nvmrc",
     "renovate.json",
     ".github/workflows/**"
@@ -31,17 +32,7 @@
     "minimumReleaseAge": null
   },
   "osvVulnerabilityAlerts": true,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/.github/workflows/.+\\.ya?ml$/"],
-      "matchStrings": ["uses: dtolnay/rust-toolchain@(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)$"
-    }
-  ],
+  "customManagers": [],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on monday"],

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -44,6 +44,10 @@ impl PackageParser for RpmBdbDatabaseParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn is_match(path: &Path) -> bool {
+        if cfg!(target_os = "windows") {
+            return false;
+        }
+
         let path_str = path.to_string_lossy();
         (path_str.ends_with("/Packages") || path_str.contains("/var/lib/rpm/Packages"))
             && !path_str.ends_with(".db")
@@ -67,6 +71,10 @@ impl PackageParser for RpmNdbDatabaseParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn is_match(path: &Path) -> bool {
+        if cfg!(target_os = "windows") {
+            return false;
+        }
+
         let path_str = path.to_string_lossy();
         path_str.ends_with("/Packages.db") || path_str.contains("usr/lib/sysimage/rpm/Packages.db")
     }
@@ -89,6 +97,10 @@ impl PackageParser for RpmSqliteDatabaseParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn is_match(path: &Path) -> bool {
+        if cfg!(target_os = "windows") {
+            return false;
+        }
+
         let path_str = path.to_string_lossy();
         path_str.ends_with("/rpmdb.sqlite") || path_str.contains("rpm/rpmdb.sqlite")
     }
@@ -113,6 +125,7 @@ fn parse_rpm_database(
     path: &Path,
     datasource_id: DatasourceId,
 ) -> Result<Vec<PackageData>, String> {
+    #[cfg(unix)]
     match rpmdb::read_packages(path.to_path_buf()) {
         Ok(packages) => Ok(packages
             .into_iter()
@@ -253,6 +266,15 @@ fn parse_rpm_database(
             .collect()),
         Err(e) => Err(format!("Failed to read RPM database: {:?}", e)),
     }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (path, datasource_id);
+        Err(format!(
+            "RPM database parsing is only supported on Unix targets (current target: {})",
+            std::env::consts::OS
+        ))
+    }
 }
 
 fn build_evr_version(epoch: i32, version: &str, release: &str) -> Option<String> {
@@ -378,6 +400,7 @@ mod tests {
         assert_eq!(build_evr_version(0, "", ""), None);
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_parse_rpm_database_sqlite() {
         let test_file = PathBuf::from("testdata/rpm/rpmdb.sqlite");
@@ -392,6 +415,7 @@ mod tests {
         assert!(pkg.name.is_some());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_parse_rpm_database_sqlite_preserves_release_in_version() {
         let test_file = PathBuf::from("testdata/rpm/rpmdb.sqlite");
@@ -419,6 +443,7 @@ mod tests {
     }
 }
 
+#[cfg(unix)]
 crate::register_parser!(
     "RPM installed package database",
     &[

--- a/src/parsers/rpm_db_scan_test.rs
+++ b/src/parsers/rpm_db_scan_test.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use std::fs;
     use std::path::Path;

--- a/src/parsers/rpm_golden_test.rs
+++ b/src/parsers/rpm_golden_test.rs
@@ -47,6 +47,7 @@ mod golden_tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_golden_rpm_sqlite_db() {
         let test_file = PathBuf::from("testdata/rpm/rpmdb.sqlite");
@@ -60,6 +61,7 @@ mod golden_tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_golden_rpm_bdb_default() {
         let test_file = PathBuf::from("testdata/rpm/var/lib/rpm/Packages");
@@ -73,6 +75,7 @@ mod golden_tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_golden_rpm_ndb_default() {
         let test_file = PathBuf::from("testdata/rpm/usr/lib/sysimage/rpm/Packages.db");


### PR DESCRIPTION
## Summary
- replace the Linux ARM release cross-build with a native `ubuntu-24.04-arm` job and install explicit SQLite/pkg-config packages for both GNU/Linux release targets
- switch release automation to Renovate-friendly pinned actions by using `setup-rust-toolchain`, `rust-cache`, and `ncipollo/release-action`, while fixing the tag glob and normalizing Windows checksum output
- gate `rpmdb` dependency usage, parser registration, and related tests to Unix so Windows releases stop compiling unsupported RPM DB code

## Verification
- `cargo check`
- `cargo test rpm_db --lib`
- `cargo test test_golden_rpm_sqlite_db --lib --features golden-tests`
- pre-commit hooks passed during commit (`clippy`, supported formats generation, Prettier)