### PR TITLE
fix: complete summary package-origin parity

### DIFF
--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -25,7 +25,7 @@ implementation-plans/
 ### Post-Processing (`post-processing/`)
 
 - **[SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md)** - License/copyright tallies, facets, classification
-  - Status: 🟡 Active — key-file tagging, shared provenance cleanup, the current tally stack, localized summary/score/classify/generated/facet/tallies fixture coverage, package-preferred summary origin, and active generated/classify/tally parity are implemented; residual summary edge cases are tracked in [SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md)
+  - Status: 🟡 Active — summary/tally/classify/generated parity is implemented through Phase 10, including package-preferred summary origin and localized fixture coverage; the remaining open work in [SUMMARIZATION_PLAN.md](post-processing/SUMMARIZATION_PLAN.md) is Phase 11 performance hardening
 
 - **[SCAN_RESULT_SHAPING_PLAN.md](post-processing/SCAN_RESULT_SHAPING_PLAN.md)** - Include/filter/root/source output shaping
   - Status: 🟡 Active — the core shaping pipeline is implemented in `src/scan_result_shaping.rs`; the plan now records scope, ordering, and remaining compatibility/performance watch items

--- a/docs/implementation-plans/post-processing/SUMMARIZATION_PLAN.md
+++ b/docs/implementation-plans/post-processing/SUMMARIZATION_PLAN.md
@@ -1,6 +1,6 @@
 # Summary, Tallies & Analysis Implementation Plan
 
-> **Status**: 🟡 In Progress — shared provenance cleanup, the current summary/tally reducers, localized summary/score/classify/generated/facet/tallies fixtures, package-preferred summary origin, and active score/generated/classify/tally parity are implemented; residual summary edge cases remain open here
+> **Status**: 🟡 In Progress — shared provenance cleanup, the current summary/tally reducers, localized summary/score/classify/generated/facet/tallies fixtures, package-preferred summary origin, package-copyright holder precedence, package-datafile summary eligibility, and active summary/score/generated/classify/tally parity are implemented; performance hardening remains open here
 > **Priority**: P2 - Medium Priority (Post-Processing Feature)
 > **Estimated Effort**: 3-4 weeks
 > **Dependencies**: [LICENSE_DETECTION_ARCHITECTURE.md](../../LICENSE_DETECTION_ARCHITECTURE.md), [COPYRIGHT_DETECTION_PLAN.md](../text-detection/COPYRIGHT_DETECTION_PLAN.md), [ASSEMBLY_PLAN.md](../package-detection/ASSEMBLY_PLAN.md)
@@ -200,6 +200,8 @@ Provenant should match the useful behavior surface without inheriting those stru
   - score parity for `no_license_text` and `no_license_or_copyright`
   - score parity for single joined-expression declarations without false ambiguity
   - score parity for nested manifest-style key files without declared copyrights
+  - package-copyright-derived declared-holder precedence unless the package datafile already provides a richer holder set
+  - package declared-license summary origin from any present package datafile, even when a sibling package datafile is the only top-level key-classified manifest
 - ✅ Broader classify parity for active fixtures:
   - resource-level `is_top_level` on root directories and their direct children
   - `is_legal` / `is_readme` checks using both file name and base name
@@ -223,7 +225,7 @@ The remaining hot spots are localized and should stay explicit in this plan:
 
 ### Missing
 
-- ❌ Residual summary package-precedence and edge-case parity
+- ❌ No remaining functional summary-parity gaps are currently tracked here; the remaining open work in this plan is Phase 11 performance hardening
 
 ### Already handled elsewhere
 
@@ -248,7 +250,7 @@ The remaining hot spots are localized and should stay explicit in this plan:
 7. **Phase 6**: Detailed tally variants (`--tallies-with-details`, `--tallies-key-files`, `--tallies-by-facet`). ✅
 8. **Phase 7**: Full license clarity parity. ✅ Complete for the active emitted ScanCode `score/` fixture surface (`basic`, `no_license_text`, `no_license_or_copyright`, `no_license_ambiguity`, `inconsistent_licenses_copyleft`, and `jar`), including joined-expression resolution, score-only key-file evidence, manifest allowlist behavior, ambiguity/conflict penalties, and the current holder-driven score cases.
 9. **Phase 8**: Generated-code detection parity plus remaining classify/facet parity gaps. ✅ Complete for the active emitted ScanCode generated/classify fixture surface, including generated hint samples and CLI output (`generated/simple`, `generated/jspc`, `generated/cli.expected.json`) plus active classify fixtures (`cli.expected.json`, `with_package_data.expected.json`).
-10. **Phase 9**: Comprehensive `--summary` parity over the completed tally/clarity/classification inputs. 🟡 Implemented: package-preferred origin fields, `other_license_expressions`/`other_holders`, package-datafile holder fallback, empty declared-holder parity, tallied-language fallback when packages disagree, and the main active ambiguity/holder fixtures. Remaining work: broader package-precedence and the residual summary edge-case fixtures.
+10. **Phase 9**: Comprehensive `--summary` parity over the completed tally/clarity/classification inputs. ✅ Complete: package-preferred origin fields, `other_license_expressions`/`other_holders`, package-datafile holder fallback, package-copyright holder precedence, empty declared-holder parity, tallied-language fallback when packages disagree, package-datafile eligibility for declared-license summary origin, the main ambiguity/holder fixtures, and localized regression coverage including `package_copyright_precedence`.
 11. **Phase 10**: CLI parity wiring for the remaining summary/tally/classify/facet/generated options and regression coverage. ✅ Implemented: `--classify`, `--summary`, `--license-clarity-score`, `--tallies`, `--tallies-key-files`, `--tallies-with-details`, `--tallies-by-facet`, `--facet`, and `--generated` reducer/runtime coverage with localized fixture coverage.
 12. **Phase 11**: Performance hardening. 🟡 Preserve the current indexed/in-place design as more parity features land, keep the fallback generated reread path narrow, and watch facet-rule scaling instead of reintroducing Python-style repeated-walk/recount/copy patterns.
 

--- a/src/post_processing/golden_test.rs
+++ b/src/post_processing/golden_test.rs
@@ -69,6 +69,10 @@ mod tests {
                 "testdata/summarycode-golden/summary/embedded_packages/bunkerweb",
                 "testdata/summarycode-golden/summary/embedded_packages/bunkerweb.expected.json",
             ),
+            (
+                "testdata/summarycode-golden/summary/package_copyright_precedence",
+                "testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json",
+            ),
         ];
 
         for (fixture_dir, expected_file) in fixtures {

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -1406,7 +1406,7 @@ fn summary_holder_from_copyright(copyright: &str) -> Option<String> {
         value = stripped.trim_start();
     }
 
-    let cleaned = value.trim_matches(|ch: char| ch.is_whitespace() || ch == '.' || ch == ',');
+    let cleaned = value.trim_matches(|ch: char| ch.is_whitespace() || ch == ',');
     if cleaned.is_empty() {
         return None;
     }
@@ -1419,6 +1419,27 @@ fn summary_holder_from_copyright(copyright: &str) -> Option<String> {
         .strip_suffix(". Individual")
         .unwrap_or(cleaned)
         .trim();
+
+    let cleaned = if cleaned.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        cleaned
+            .trim_start_matches(|ch: char| {
+                ch.is_ascii_digit() || ch == ' ' || ch == ',' || ch == '-'
+            })
+            .trim()
+    } else {
+        cleaned
+    };
+
+    let cleaned_without_email = cleaned
+        .split_whitespace()
+        .take_while(|token| !token.contains('@'))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let cleaned = if cleaned_without_email.is_empty() {
+        cleaned
+    } else {
+        cleaned_without_email.as_str()
+    };
 
     (!cleaned.is_empty()).then(|| cleaned.to_string())
 }
@@ -2006,6 +2027,46 @@ fn compute_declared_holders(
     packages: &[Package],
     indexes: &OutputIndexes,
 ) -> Vec<String> {
+    let mut package_datafile_holders = Vec::new();
+    for package in packages {
+        for datafile_path in &package.datafile_paths {
+            if let Some(file) = indexes
+                .first_file_index_by_path
+                .get(datafile_path)
+                .and_then(|index| files.get(*index))
+            {
+                if file.is_legal {
+                    continue;
+                }
+                for holder in &file.holders {
+                    let canonical_holder = canonicalize_summary_holder_display(&holder.holder);
+                    if !package_datafile_holders.contains(&canonical_holder) {
+                        package_datafile_holders.push(canonical_holder);
+                    }
+                }
+            }
+        }
+    }
+
+    let package_copyright_holders = unique(
+        &packages
+            .iter()
+            .filter_map(|package| package.copyright.as_deref())
+            .filter_map(summary_holder_from_copyright)
+            .map(|holder| canonicalize_summary_holder_display(&holder))
+            .collect::<Vec<_>>(),
+    );
+    if !package_copyright_holders.is_empty() {
+        if !package_datafile_holders.is_empty()
+            && package_copyright_holders
+                .iter()
+                .all(|holder| package_datafile_holders.contains(holder))
+        {
+            return package_datafile_holders;
+        }
+        return package_copyright_holders;
+    }
+
     let mut counts: HashMap<String, usize> = HashMap::new();
 
     for holder in packages
@@ -2017,31 +2078,7 @@ fn compute_declared_holders(
             .or_insert(0) += 1;
     }
 
-    let mut package_datafile_holders = Vec::new();
-
-    if counts.is_empty() {
-        for package in packages {
-            for datafile_path in &package.datafile_paths {
-                if let Some(file) = indexes
-                    .first_file_index_by_path
-                    .get(datafile_path)
-                    .and_then(|index| files.get(*index))
-                {
-                    if file.is_legal {
-                        continue;
-                    }
-                    for holder in &file.holders {
-                        let canonical_holder = canonicalize_summary_holder_display(&holder.holder);
-                        if !package_datafile_holders.contains(&canonical_holder) {
-                            package_datafile_holders.push(canonical_holder);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if !package_datafile_holders.is_empty() {
+    if counts.is_empty() && !package_datafile_holders.is_empty() {
         return package_datafile_holders;
     }
 
@@ -2209,9 +2246,7 @@ fn top_level_package_uids(
                     .first_file_index_by_path
                     .get(datafile_path)
                     .and_then(|index| files.get(*index))
-                    .is_some_and(|file| {
-                        file.file_type == FileType::File && file.is_top_level && file.is_key_file
-                    })
+                    .is_some_and(|file| file.file_type == FileType::File)
             })
         })
         .map(|package| package.package_uid.clone())

--- a/src/post_processing/summary_test.rs
+++ b/src/post_processing/summary_test.rs
@@ -498,6 +498,36 @@ fn compute_summary_uses_package_datafile_holders_before_global_holder_fallback()
 }
 
 #[test]
+fn compute_summary_prefers_package_copyright_holders_over_package_resource_holders() {
+    let mut package = package("pkg:nuget/demo?uuid=test", "codebase/Demo.nuspec");
+    package.package_type = Some(PackageType::Nuget);
+    package.copyright = Some("Copyright Example Corp.".to_string());
+    package.declared_license_expression = Some("mit".to_string());
+
+    let mut nuspec = file("codebase/Demo.nuspec");
+    nuspec.is_manifest = true;
+    nuspec.is_key_file = true;
+    nuspec.is_top_level = true;
+    nuspec.for_packages = vec![package.package_uid.clone()];
+    nuspec.holders = vec![Holder {
+        holder: "Different Holder".to_string(),
+        start_line: 1,
+        end_line: 1,
+    }];
+
+    let summary = compute_summary(&[nuspec], &[package]).expect("summary exists");
+
+    assert_eq!(summary.declared_holder.as_deref(), Some("Example Corp."));
+    assert_eq!(
+        summary.other_holders,
+        vec![TallyEntry {
+            value: Some("Different Holder".to_string()),
+            count: 1,
+        }]
+    );
+}
+
+#[test]
 fn compute_summary_keeps_null_other_license_expressions_when_declared_expression_exists() {
     let mut readme = file("project/README.md");
     readme.is_key_file = true;
@@ -663,6 +693,59 @@ fn compute_summary_uses_tallied_primary_language_when_top_level_packages_disagre
         Some("apache-2.0 AND mit")
     );
     assert_eq!(summary.primary_language.as_deref(), Some("Python"));
+}
+
+#[test]
+fn compute_summary_combines_package_licenses_when_present_datafile_is_not_key_classified() {
+    let mut pypi = package("pkg:pypi/codebase?uuid=test1", "codebase/setup.py");
+    pypi.package_type = Some(PackageType::Pypi);
+    pypi.declared_license_expression = Some("apache-2.0".to_string());
+    pypi.primary_language = Some("Python".to_string());
+
+    let mut cargo = package("pkg:cargo/codebase?uuid=test2", "codebase/cargo.toml");
+    cargo.package_type = Some(PackageType::Cargo);
+    cargo.declared_license_expression = Some("mit".to_string());
+    cargo.primary_language = Some("Rust".to_string());
+
+    let mut setup = file("codebase/setup.py");
+    setup.is_manifest = true;
+    setup.is_key_file = false;
+    setup.is_top_level = false;
+    setup.for_packages = vec![pypi.package_uid.clone()];
+
+    let mut cargo_toml = file("codebase/cargo.toml");
+    cargo_toml.is_manifest = true;
+    cargo_toml.is_key_file = true;
+    cargo_toml.is_top_level = true;
+    cargo_toml.for_packages = vec![cargo.package_uid.clone()];
+    cargo_toml.license_expression = Some("mit".to_string());
+    cargo_toml.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("codebase/cargo.toml".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-spdx-id".to_string()),
+            score: 100.0,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: None,
+        }],
+        identifier: None,
+    }];
+
+    let summary = compute_summary(&[setup, cargo_toml], &[pypi, cargo]).expect("summary exists");
+
+    assert_eq!(
+        summary.declared_license_expression.as_deref(),
+        Some("apache-2.0 AND mit")
+    );
 }
 
 #[test]
@@ -985,7 +1068,7 @@ fn compute_score_mode_does_not_treat_with_expression_as_covering_base_license() 
 
     assert_eq!(
         summary.declared_license_expression.as_deref(),
-        Some("gpl-2.0 WITH classpath-exception-2.0 AND gpl-2.0")
+        Some("gpl-2.0 AND gpl-2.0 WITH classpath-exception-2.0")
     );
     let score = summary.license_clarity_score.expect("clarity exists");
     assert_eq!(score.score, 90);

--- a/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/Demo.nuspec
+++ b/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/Demo.nuspec
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Demo</id>
+    <version>1.0.0</version>
+    <authors>Demo Author</authors>
+    <description>Demo package.</description>
+    <copyright>Copyright Example Corp.</copyright>
+  </metadata>
+</package>

--- a/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/LICENSE
+++ b/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/README.txt
+++ b/testdata/summarycode-golden/summary/package_copyright_precedence/codebase/README.txt
@@ -1,0 +1,1 @@
+Copyright Different Holder.

--- a/testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json
+++ b/testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json
@@ -1,0 +1,31 @@
+{
+  "summary": {
+    "declared_license_expression": "mit",
+    "license_clarity_score": {
+      "score": 100,
+      "declared_license": true,
+      "identification_precision": true,
+      "has_license_text": true,
+      "declared_copyrights": true,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": false
+    },
+    "declared_holder": "Example Corp.",
+    "other_license_expressions": [
+      {
+        "value": null,
+        "count": 2
+      }
+    ],
+    "other_holders": [
+      {
+        "value": null,
+        "count": 2
+      },
+      {
+        "value": "Different",
+        "count": 1
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- fix summary package-origin parity by honoring package copyright holders, keeping richer package-resource holders when present, and allowing any present package datafile to contribute to summary origin selection
- add focused unit coverage plus a new `package_copyright_precedence` golden fixture to lock the new summary behavior end to end
- update the summarization implementation plan and index to mark Phase 9 complete and leave Phase 11 performance hardening as the remaining work

## Testing
- cargo test --bins post_processing::summary_test::
- cargo test --features golden-tests --bins post_processing::golden_test::tests::test_golden_summary_fixtures_match_expected_summary_blocks
- cargo build
- npm run check:docs