### PR TITLE
ci: split scan and integration tests into two shards

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,10 +64,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: scanner-integration
-            shared_key: rust-scan-integration-tests-release-scanner-integration
-          - shard: scan-contract-and-output
-            shared_key: rust-scan-integration-tests-release-scan-contract-and-output
+          - shard: parser-scan-contracts
+            shared_key: rust-scan-integration-tests-release-parser-scan-contracts
+          - shard: integration-suites
+            shared_key: rust-scan-integration-tests-release-integration-suites
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -83,23 +83,23 @@ jobs:
           shared-key: ${{ matrix.shared_key }}
 
       - name: Run parser-local scanner/assembly contract tests
-        if: matrix.shard == 'scan-contract-and-output'
+        if: matrix.shard == 'parser-scan-contracts'
         run: "cargo test --lib --release --verbose _scan_test::"
 
       - name: Run scanner integration suite
-        if: matrix.shard == 'scanner-integration'
+        if: matrix.shard == 'integration-suites'
         run: cargo test --test scanner_integration --release --verbose
 
       - name: Run scanner copyright/credits integration suite
-        if: matrix.shard == 'scan-contract-and-output'
+        if: matrix.shard == 'integration-suites'
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite
-        if: matrix.shard == 'scan-contract-and-output'
+        if: matrix.shard == 'integration-suites'
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'scan-contract-and-output'
+        if: matrix.shard == 'integration-suites'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:


### PR DESCRIPTION
## Summary

- split `Scan and Integration Tests` into two shards
- keep `_scan_test::` on its own runner and keep all existing `cargo test --test ...` integration targets together on the other runner so they still share the same cold integration build
- this avoids the regression from the first split, where moving `scanner_integration` to a separate runner made the remaining integration suites much slower
- on the regrouped run, the scan critical path dropped from about 17m19s to about 13m53s

## Scope and exclusions

- Included: `.github/workflows/check.yml` only.

## Follow-up work

- If we want a larger win than this, the next step is probably a test-structure refactor rather than more CI command reshuffling.