### PR TITLE
ci: stop consuming Git LFS bandwidth in Actions

### DIFF
--- a/.github/actions/download-embedded-license-index/action.yml
+++ b/.github/actions/download-embedded-license-index/action.yml
@@ -1,0 +1,35 @@
+name: Download embedded license index
+description: Restore the generated embedded license index artifact into the repository path
+inputs:
+  artifact-name:
+    description: Workflow artifact name for the embedded license index
+    required: false
+    default: embedded-license-index
+  destination:
+    description: Directory where the embedded license index should be restored
+    required: false
+    default: resources/license_detection
+runs:
+  using: composite
+  steps:
+    - name: Download embedded license index
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.destination }}
+
+    - name: Verify embedded license index download
+      shell: bash
+      run: |
+        set -euo pipefail
+        artifact="${{ inputs.destination }}/license_index.bincode.zst"
+
+        if [[ ! -f "$artifact" ]]; then
+          echo "Embedded license index was not restored to $artifact"
+          exit 1
+        fi
+
+        if grep -q '^version https://git-lfs.github.com/spec/v1$' "$artifact"; then
+          echo "Embedded license index download restored an LFS pointer instead of artifact contents"
+          exit 1
+        fi

--- a/.github/actions/prepare-embedded-license-index/action.yml
+++ b/.github/actions/prepare-embedded-license-index/action.yml
@@ -1,0 +1,61 @@
+name: Prepare embedded license index
+description: Regenerate, verify, and upload the embedded license index artifact
+inputs:
+  artifact-name:
+    description: Workflow artifact name for the generated embedded license index
+    required: false
+    default: embedded-license-index
+  artifact-path:
+    description: Path to the embedded license index in the repository
+    required: false
+    default: resources/license_detection/license_index.bincode.zst
+  retention-days:
+    description: Artifact retention in days
+    required: false
+    default: "1"
+runs:
+  using: composite
+  steps:
+    - name: Capture checked-in license index metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        artifact="${{ inputs.artifact-path }}"
+        expected_oid=$(grep '^oid sha256:' "$artifact" | cut -d: -f2)
+        expected_size=$(grep '^size ' "$artifact" | awk '{print $2}')
+        echo "expected_oid=$expected_oid" >> "$GITHUB_ENV"
+        echo "expected_size=$expected_size" >> "$GITHUB_ENV"
+
+    - name: Regenerate embedded license index
+      shell: bash
+      run: cargo run --locked --manifest-path xtask/Cargo.toml --bin generate-index-artifact -- --output "${{ inputs.artifact-path }}"
+
+    - name: Verify generated index matches checked-in artifact metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        artifact="${{ inputs.artifact-path }}"
+        actual_oid=$(sha256sum "$artifact" | awk '{print $1}')
+        actual_size=$(wc -c < "$artifact" | tr -d '[:space:]')
+
+        if [[ "$actual_oid" != "$expected_oid" ]]; then
+          echo "Generated artifact sha256 does not match checked-in LFS pointer metadata"
+          echo "expected: $expected_oid"
+          echo "actual:   $actual_oid"
+          exit 1
+        fi
+
+        if [[ "$actual_size" != "$expected_size" ]]; then
+          echo "Generated artifact size does not match checked-in LFS pointer metadata"
+          echo "expected: $expected_size"
+          echo "actual:   $actual_size"
+          exit 1
+        fi
+
+    - name: Upload embedded license index
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust-quality:
-    name: Code Quality
+  license-index:
+    name: Prepare Embedded License Index
     runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
@@ -21,7 +21,33 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           submodules: recursive
-          lfs: true
+          lfs: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: embedded-license-index
+
+      - name: Prepare embedded license index
+        uses: ./.github/actions/prepare-embedded-license-index
+
+  rust-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    needs: license-index
+    if: |
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          submodules: recursive
+          lfs: false
+
+      - name: Download embedded license index
+        uses: ./.github/actions/download-embedded-license-index
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
@@ -58,6 +84,7 @@ jobs:
   rust-scan-integration-tests:
     name: Scan and Integration Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    needs: license-index
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     strategy:
@@ -72,7 +99,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           submodules: recursive
-          lfs: true
+          lfs: false
+
+      - name: Download embedded license index
+        uses: ./.github/actions/download-embedded-license-index
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
@@ -105,6 +135,7 @@ jobs:
   golden-tests:
     name: Golden Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    needs: license-index
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     strategy:
@@ -139,7 +170,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           submodules: recursive
-          lfs: true
+          lfs: false
+
+      - name: Download embedded license index
+        uses: ./.github/actions/download-embedded-license-index
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,33 @@ permissions:
   contents: write
 
 jobs:
+  license-index:
+    name: Prepare Embedded License Index
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          submodules: recursive
+          lfs: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          key: embedded-license-index
+
+      - name: Prepare embedded license index
+        uses: ./.github/actions/prepare-embedded-license-index
+
   build:
     name: Build ${{ matrix.target }}
+    needs: license-index
     strategy:
       fail-fast: false
       matrix:
@@ -48,8 +73,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          submodules: recursive
-          lfs: true
+          lfs: false
+
+      - name: Download embedded license index
+        uses: ./.github/actions/download-embedded-license-index
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     "rust-toolchain.toml",
     ".nvmrc",
     "renovate.json",
-    ".github/workflows/**"
+    ".github/workflows/**",
+    ".github/actions/**"
   ],
   "addLabels": ["dependencies"],
   "automergeType": "branch",

--- a/scripts/check_xtask_lockfile_sync.sh
+++ b/scripts/check_xtask_lockfile_sync.sh
@@ -4,14 +4,27 @@ set -euo pipefail
 
 ROOT_MANIFEST="Cargo.toml"
 XTASK_LOCKFILE="xtask/Cargo.lock"
+WORKSPACE_LOCKFILE="Cargo.lock"
 
-python3 - "$ROOT_MANIFEST" "$XTASK_LOCKFILE" <<'PY'
+python3 - "$ROOT_MANIFEST" "$XTASK_LOCKFILE" "$WORKSPACE_LOCKFILE" <<'PY'
 import pathlib
 import re
 import sys
 
 root_manifest = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-xtask_lockfile = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+xtask_lockfile_path = pathlib.Path(sys.argv[2])
+workspace_lockfile_path = pathlib.Path(sys.argv[3])
+
+if xtask_lockfile_path.exists():
+    xtask_lockfile = xtask_lockfile_path.read_text(encoding="utf-8")
+    lockfile_label = str(xtask_lockfile_path)
+elif workspace_lockfile_path.exists():
+    xtask_lockfile = workspace_lockfile_path.read_text(encoding="utf-8")
+    lockfile_label = str(workspace_lockfile_path)
+else:
+    raise SystemExit(
+        "Could not find xtask/Cargo.lock or workspace Cargo.lock for sync check"
+    )
 
 root_version_match = re.search(r'^version = "([^"]+)"$', root_manifest, re.MULTILINE)
 if root_version_match is None:
@@ -29,13 +42,12 @@ for block in xtask_lockfile.split("[[package]]"):
         break
 
 if xtask_version is None:
-    raise SystemExit("Could not determine provenant-cli version from xtask/Cargo.lock")
+    raise SystemExit(f"Could not determine provenant-cli version from {lockfile_label}")
 
 if root_version != xtask_version:
     raise SystemExit(
-        "xtask/Cargo.lock is out of sync with Cargo.toml: "
-        f"root crate is {root_version}, xtask lockfile has {xtask_version}.\n"
-        "Refresh it with: cargo generate-lockfile --manifest-path xtask/Cargo.toml\n"
-        "Then stage the updated xtask/Cargo.lock."
+        f"{lockfile_label} is out of sync with Cargo.toml: "
+        f"root crate is {root_version}, lockfile has {xtask_version}.\n"
+        "Refresh it with: cargo generate-lockfile --manifest-path xtask/Cargo.toml"
     )
 PY

--- a/setup.sh
+++ b/setup.sh
@@ -3,10 +3,6 @@
 # Setup script for Provenant development
 #
 # This script initializes git submodules and, when Node tooling is present, installs git hooks.
-#
-# The license detection index is already embedded in the binary at:
-#   resources/license_detection/license_index_loader.msgpack.zst
-#
 # License rules and licenses are in the reference/scancode-toolkit submodule.
 #
 # You only need to run this script if you:


### PR DESCRIPTION
## Summary

- generate the embedded license index once per workflow and fan it out to downstream jobs via local composite actions
- stop check and release builds from downloading the LFS-tracked license index directly
- extend Renovate coverage to `.github/actions/**` so the new action pins stay updated

## Scope and exclusions

- Included:
  - check and release workflow changes for artifact-based embedded-index reuse
  - local composite actions for preparing and downloading the embedded license index
  - Renovate config updates for local action files
  - removal of the stale embedded-index path comment in `setup.sh`
- Explicit exclusions:
  - no changes to the embedded license index contents
  - no scanner/runtime behavior changes outside CI and maintenance config