### PR TITLE
Migrate from bincode to rkyv for serialization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-resources/license_detection/*.bincode.zst filter=lfs diff=lfs merge=lfs -text
+resources/license_detection/*.zst filter=lfs diff=lfs merge=lfs -text

--- a/.github/actions/download-embedded-license-index/action.yml
+++ b/.github/actions/download-embedded-license-index/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        artifact="${{ inputs.destination }}/license_index.bincode.zst"
+        artifact="${{ inputs.destination }}/license_index.zst"
 
         if [[ ! -f "$artifact" ]]; then
           echo "Embedded license index was not restored to $artifact"

--- a/.github/actions/prepare-embedded-license-index/action.yml
+++ b/.github/actions/prepare-embedded-license-index/action.yml
@@ -8,7 +8,7 @@ inputs:
   artifact-path:
     description: Path to the embedded license index in the repository
     required: false
-    default: resources/license_detection/license_index.bincode.zst
+    default: resources/license_detection/license_index.zst
   retention-days:
     description: Artifact retention in days
     required: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,26 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +241,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +286,12 @@ name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
@@ -1657,6 +1666,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mutate_once"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,7 +2097,6 @@ dependencies = [
  "anyhow",
  "ar",
  "base64",
- "bincode 2.0.1",
  "bit-set",
  "blake3",
  "bzip2",
@@ -2102,6 +2130,7 @@ dependencies = [
  "quick-xml",
  "rayon",
  "regex",
+ "rkyv",
  "rmp-serde",
  "rpm",
  "rpmdb",
@@ -2132,13 +2161,13 @@ name = "provenant-xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bincode 2.0.1",
  "clap",
  "inventory",
  "lazy_static",
  "provenant-cli",
  "rayon",
  "regex",
+ "rkyv",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2146,6 +2175,26 @@ dependencies = [
  "tempfile",
  "url",
  "zstd",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2189,6 +2238,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -2314,6 +2372,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,7 +2465,7 @@ version = "0.1.0"
 source = "git+https://github.com/yybit/rpmdb-rs?rev=8a20c8b8#8a20c8b8e92df2c4ae3c5aa965354bb336a6ed6f"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode",
  "byteorder",
  "nix",
  "rusqlite",
@@ -2638,6 +2735,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3114,12 +3217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,12 +3278,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Maxim Stykow", "Adrian Braemer"]
 # Include only files needed to build from source
 include = [
     "src/**/*",
-    "/resources/license_detection/license_index.bincode.zst",
+    "/resources/license_detection/license_index.zst",
     "/Cargo.toml",
     "/Cargo.lock",
     "/README.md",
@@ -43,12 +43,12 @@ members = ["xtask"]
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-bincode = { version = "2.0.1", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
 inventory = "0.3.22"
 lazy_static = "1.5.0"
 rayon = "1.11.0"
 regex = "1.12.3"
+rkyv = { version = "0.8.15", features = ["bytecheck"] }
 rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
@@ -115,7 +115,7 @@ rpm = { version = "0.19.0", default-features = false, features = ["gzip-compress
 strum = { version = "0.28.0", features = ["derive"] }
 rmp-serde = { workspace = true }
 bit-set = "0.9.1"
-bincode = { workspace = true }
+rkyv = { workspace = true }
 daachorse = "1.0.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/release.sh
+++ b/release.sh
@@ -43,12 +43,12 @@ if [ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]; then
     cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact
     
     if [ -n "$EXECUTE_FLAG" ]; then
-        git add reference/scancode-toolkit resources/license_detection/license_index.bincode.zst
+        git add reference/scancode-toolkit resources/license_detection/license_index.zst
         git commit -m "chore: update license rules/licenses to latest"
         echo "✅ Committed license data update"
     else
         echo "ℹ️  License data would be updated (dry-run mode)"
-        git restore reference/scancode-toolkit resources/license_detection/license_index.bincode.zst
+        git restore reference/scancode-toolkit resources/license_detection/license_index.zst
     fi
 else
     echo "✅ License data already up to date"

--- a/resources/license_detection/license_index.bincode.zst
+++ b/resources/license_detection/license_index.bincode.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9eaf73d16f0f493cbf7d3c14e5ff4bb677ba2ff1804727298d428563b01eebc7
-size 115441397

--- a/resources/license_detection/license_index.zst
+++ b/resources/license_detection/license_index.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:773a37b80bf82d1fb79ab1d389ad5a872870121e49eb31d9143bb55b36f400bf
+size 117719982

--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -5,93 +5,20 @@
 //! ensure deterministic serialization, and byte vectors for automatons.
 
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::license_detection::automaton::Automaton;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId, TokenKind};
-use crate::license_detection::models::{License, Rule};
+use crate::license_detection::models::{License, Rule, RuleKind};
 
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 pub type HighPostingsEntry = (u16, Vec<usize>);
 pub type HighPostingsByRidEntry = (usize, Vec<HighPostingsEntry>);
-
-// This struct and its methods will be used by the xtask build process
-// and runtime index loading in upcoming phases.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SerializedLicenseIndex {
-    pub schema_version: u32,
-    pub data: Vec<u8>,
-}
-
-// These methods will be used by the xtask build process and runtime index loading.
-#[allow(dead_code)]
-impl SerializedLicenseIndex {
-    pub fn to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
-        let serialized =
-            bincode::serde::encode_to_vec(self, bincode::config::standard()).map_err(|e| {
-                SerializationError(format!("Failed to serialize SerializedLicenseIndex: {}", e))
-            })?;
-        Ok(serialized)
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
-        let (index, _): (Self, _) =
-            bincode::serde::decode_from_slice(bytes, bincode::config::standard()).map_err(|e| {
-                SerializationError(format!(
-                    "Failed to deserialize SerializedLicenseIndex: {}",
-                    e
-                ))
-            })?;
-        Ok(index)
-    }
-
-    pub fn decompress(&self) -> Result<EmbeddedLicenseIndex, SerializationError> {
-        let decompressed = zstd::decode_all(&self.data[..]).map_err(|e| {
-            SerializationError(format!("Failed to decompress license index: {}", e))
-        })?;
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard()).map_err(
-                |e| {
-                    SerializationError(format!("Failed to deserialize EmbeddedLicenseIndex: {}", e))
-                },
-            )?;
-        Ok(index)
-    }
-
-    pub fn decompress_from_bytes(bytes: &[u8]) -> Result<EmbeddedLicenseIndex, SerializationError> {
-        let serialized: SerializedLicenseIndex =
-            bincode::serde::decode_from_slice(bytes, bincode::config::standard())
-                .map_err(|e| {
-                    SerializationError(format!(
-                        "Failed to deserialize SerializedLicenseIndex: {}",
-                        e
-                    ))
-                })?
-                .0;
-
-        if serialized.schema_version != SCHEMA_VERSION {
-            return Err(SerializationError(format!(
-                "Schema version mismatch: expected {}, got {}",
-                SCHEMA_VERSION, serialized.schema_version
-            )));
-        }
-
-        let decompressed = zstd::decode_all(&serialized.data[..]).map_err(|e| {
-            SerializationError(format!("Failed to decompress license index: {}", e))
-        })?;
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard()).map_err(
-                |e| {
-                    SerializationError(format!("Failed to deserialize EmbeddedLicenseIndex: {}", e))
-                },
-            )?;
-        Ok(index)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct SerializationError(pub String);
@@ -104,19 +31,190 @@ impl std::fmt::Display for SerializationError {
 
 impl std::error::Error for SerializationError {}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
+pub struct EmbeddedRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl From<Range<usize>> for EmbeddedRange {
+    fn from(range: Range<usize>) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+}
+
+impl From<EmbeddedRange> for Range<usize> {
+    fn from(embedded: EmbeddedRange) -> Self {
+        embedded.start..embedded.end
+    }
+}
+
+impl From<ArchivedEmbeddedRange> for EmbeddedRange {
+    fn from(archived: ArchivedEmbeddedRange) -> Self {
+        Self {
+            start: u32::from(archived.start) as usize,
+            end: u32::from(archived.end) as usize,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
 pub struct EmbeddedTokenMetadata {
     pub kind: TokenKind,
     pub is_digit_only: bool,
     pub is_short_or_digit: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
 pub struct EmbeddedTokenDictionary {
     pub tokens_to_ids: Vec<(String, u16)>,
     pub token_metadata: Vec<Option<EmbeddedTokenMetadata>>,
     pub len_legalese: usize,
     pub next_id: u16,
+}
+
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
+pub struct EmbeddedRule {
+    pub identifier: String,
+    pub license_expression: String,
+    pub text: String,
+    pub tokens: Vec<u16>,
+    pub rule_kind: RuleKind,
+    pub is_false_positive: bool,
+    pub is_required_phrase: bool,
+    pub is_from_license: bool,
+    pub relevance: u8,
+    pub minimum_coverage: Option<u8>,
+    pub has_stored_minimum_coverage: bool,
+    pub is_continuous: bool,
+    pub required_phrase_spans: Vec<EmbeddedRange>,
+    pub stopwords_by_pos: Vec<(usize, usize)>,
+    pub referenced_filenames: Option<Vec<String>>,
+    pub ignorable_urls: Option<Vec<String>>,
+    pub ignorable_emails: Option<Vec<String>>,
+    pub ignorable_copyrights: Option<Vec<String>>,
+    pub ignorable_holders: Option<Vec<String>>,
+    pub ignorable_authors: Option<Vec<String>>,
+    pub language: Option<String>,
+    pub notes: Option<String>,
+    pub length_unique: usize,
+    pub high_length_unique: usize,
+    pub high_length: usize,
+    pub min_matched_length: usize,
+    pub min_high_matched_length: usize,
+    pub min_matched_length_unique: usize,
+    pub min_high_matched_length_unique: usize,
+    pub is_small: bool,
+    pub is_tiny: bool,
+    pub starts_with_license: bool,
+    pub ends_with_license: bool,
+    pub is_deprecated: bool,
+    pub spdx_license_key: Option<String>,
+    pub other_spdx_license_keys: Vec<String>,
+}
+
+impl From<&Rule> for EmbeddedRule {
+    fn from(rule: &Rule) -> Self {
+        let mut stopwords_by_pos: Vec<(usize, usize)> = rule
+            .stopwords_by_pos
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        stopwords_by_pos.sort_by_key(|(k, _)| *k);
+
+        Self {
+            identifier: rule.identifier.clone(),
+            license_expression: rule.license_expression.clone(),
+            text: rule.text.clone(),
+            tokens: rule.tokens.iter().map(|t| t.raw()).collect(),
+            rule_kind: rule.rule_kind,
+            is_false_positive: rule.is_false_positive,
+            is_required_phrase: rule.is_required_phrase,
+            is_from_license: rule.is_from_license,
+            relevance: rule.relevance,
+            minimum_coverage: rule.minimum_coverage,
+            has_stored_minimum_coverage: rule.has_stored_minimum_coverage,
+            is_continuous: rule.is_continuous,
+            required_phrase_spans: rule
+                .required_phrase_spans
+                .iter()
+                .map(|r| EmbeddedRange::from(r.clone()))
+                .collect(),
+            stopwords_by_pos,
+            referenced_filenames: rule.referenced_filenames.clone(),
+            ignorable_urls: rule.ignorable_urls.clone(),
+            ignorable_emails: rule.ignorable_emails.clone(),
+            ignorable_copyrights: rule.ignorable_copyrights.clone(),
+            ignorable_holders: rule.ignorable_holders.clone(),
+            ignorable_authors: rule.ignorable_authors.clone(),
+            language: rule.language.clone(),
+            notes: rule.notes.clone(),
+            length_unique: rule.length_unique,
+            high_length_unique: rule.high_length_unique,
+            high_length: rule.high_length,
+            min_matched_length: rule.min_matched_length,
+            min_high_matched_length: rule.min_high_matched_length,
+            min_matched_length_unique: rule.min_matched_length_unique,
+            min_high_matched_length_unique: rule.min_high_matched_length_unique,
+            is_small: rule.is_small,
+            is_tiny: rule.is_tiny,
+            starts_with_license: rule.starts_with_license,
+            ends_with_license: rule.ends_with_license,
+            is_deprecated: rule.is_deprecated,
+            spdx_license_key: rule.spdx_license_key.clone(),
+            other_spdx_license_keys: rule.other_spdx_license_keys.clone(),
+        }
+    }
+}
+
+impl From<EmbeddedRule> for Rule {
+    fn from(embedded: EmbeddedRule) -> Self {
+        Self {
+            identifier: embedded.identifier,
+            license_expression: embedded.license_expression,
+            text: embedded.text,
+            tokens: embedded.tokens.into_iter().map(TokenId::new).collect(),
+            rule_kind: embedded.rule_kind,
+            is_false_positive: embedded.is_false_positive,
+            is_required_phrase: embedded.is_required_phrase,
+            is_from_license: embedded.is_from_license,
+            relevance: embedded.relevance,
+            minimum_coverage: embedded.minimum_coverage,
+            has_stored_minimum_coverage: embedded.has_stored_minimum_coverage,
+            is_continuous: embedded.is_continuous,
+            required_phrase_spans: embedded
+                .required_phrase_spans
+                .into_iter()
+                .map(Range::from)
+                .collect(),
+            stopwords_by_pos: embedded.stopwords_by_pos.into_iter().collect(),
+            referenced_filenames: embedded.referenced_filenames,
+            ignorable_urls: embedded.ignorable_urls,
+            ignorable_emails: embedded.ignorable_emails,
+            ignorable_copyrights: embedded.ignorable_copyrights,
+            ignorable_holders: embedded.ignorable_holders,
+            ignorable_authors: embedded.ignorable_authors,
+            language: embedded.language,
+            notes: embedded.notes,
+            length_unique: embedded.length_unique,
+            high_length_unique: embedded.high_length_unique,
+            high_length: embedded.high_length,
+            min_matched_length: embedded.min_matched_length,
+            min_high_matched_length: embedded.min_high_matched_length,
+            min_matched_length_unique: embedded.min_matched_length_unique,
+            min_high_matched_length_unique: embedded.min_high_matched_length_unique,
+            is_small: embedded.is_small,
+            is_tiny: embedded.is_tiny,
+            starts_with_license: embedded.starts_with_license,
+            ends_with_license: embedded.ends_with_license,
+            is_deprecated: embedded.is_deprecated,
+            spdx_license_key: embedded.spdx_license_key,
+            other_spdx_license_keys: embedded.other_spdx_license_keys,
+        }
+    }
 }
 
 impl From<&TokenDictionary> for EmbeddedTokenDictionary {
@@ -178,13 +276,28 @@ impl From<EmbeddedTokenDictionary> for TokenDictionary {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl From<&ArchivedEmbeddedTokenDictionary> for TokenDictionary {
+    fn from(archived: &ArchivedEmbeddedTokenDictionary) -> Self {
+        let embedded: EmbeddedTokenDictionary =
+            rkyv::deserialize::<_, rkyv::rancor::Error>(archived).unwrap();
+        embedded.into()
+    }
+}
+
+impl From<&ArchivedEmbeddedRule> for Rule {
+    fn from(archived: &ArchivedEmbeddedRule) -> Self {
+        let embedded: EmbeddedRule = rkyv::deserialize::<_, rkyv::rancor::Error>(archived).unwrap();
+        embedded.into()
+    }
+}
+
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
 pub struct EmbeddedLicenseIndex {
     pub schema_version: u32,
     pub dictionary: EmbeddedTokenDictionary,
     pub len_legalese: usize,
     pub rid_by_hash: Vec<([u8; 20], usize)>,
-    pub rules_by_rid: Vec<Rule>,
+    pub rules_by_rid: Vec<EmbeddedRule>,
     pub tids_by_rid: Vec<Vec<u16>>,
     pub rules_automaton: Vec<u8>,
     pub unknown_automaton: Vec<u8>,
@@ -309,7 +422,7 @@ impl From<&LicenseIndex> for EmbeddedLicenseIndex {
             dictionary,
             len_legalese: index.len_legalese,
             rid_by_hash,
-            rules_by_rid: index.rules_by_rid.clone(),
+            rules_by_rid: index.rules_by_rid.iter().map(EmbeddedRule::from).collect(),
             tids_by_rid,
             rules_automaton,
             unknown_automaton,
@@ -328,153 +441,153 @@ impl From<&LicenseIndex> for EmbeddedLicenseIndex {
     }
 }
 
-impl TryFrom<EmbeddedLicenseIndex> for LicenseIndex {
+impl TryFrom<&ArchivedEmbeddedLicenseIndex> for LicenseIndex {
     type Error = SerializationError;
 
-    fn try_from(embedded: EmbeddedLicenseIndex) -> Result<Self, Self::Error> {
-        use std::time::Instant;
-        let t0 = Instant::now();
-
-        if embedded.schema_version != SCHEMA_VERSION {
+    fn try_from(archived: &ArchivedEmbeddedLicenseIndex) -> Result<Self, Self::Error> {
+        if u32::from(archived.schema_version) != SCHEMA_VERSION {
             return Err(SerializationError(format!(
                 "Schema version mismatch: expected {}, got {}",
-                SCHEMA_VERSION, embedded.schema_version
+                SCHEMA_VERSION,
+                u32::from(archived.schema_version)
             )));
         }
 
-        let dictionary = TokenDictionary::from(embedded.dictionary);
-        let t1 = Instant::now();
-        eprintln!(
-            "    [try_from] TokenDictionary::from took {:?}",
-            t1.duration_since(t0)
-        );
+        let dictionary = TokenDictionary::from(&archived.dictionary);
 
-        let rid_by_hash: HashMap<[u8; 20], usize> = embedded.rid_by_hash.into_iter().collect();
-        let t2 = Instant::now();
-        eprintln!(
-            "    [try_from] rid_by_hash.collect took {:?}",
-            t2.duration_since(t1)
-        );
+        let rid_by_hash: HashMap<[u8; 20], usize> = archived
+            .rid_by_hash
+            .iter()
+            .map(|entry| (entry.0, u32::from(entry.1) as usize))
+            .collect();
 
-        let tids_by_rid: Vec<Vec<TokenId>> = embedded
+        let tids_by_rid: Vec<Vec<TokenId>> = archived
             .tids_by_rid
-            .into_iter()
-            .map(|tids| tids.into_iter().map(TokenId::new).collect())
+            .iter()
+            .map(|tids| {
+                tids.iter()
+                    .map(|tid| TokenId::new(u16::from(*tid)))
+                    .collect()
+            })
             .collect();
-        let t3 = Instant::now();
-        eprintln!(
-            "    [try_from] tids_by_rid took {:?}",
-            t3.duration_since(t2)
-        );
 
-        let rules_automaton = Automaton::deserialize_unchecked(&embedded.rules_automaton);
-        let t4 = Instant::now();
-        eprintln!(
-            "    [try_from] rules_automaton.deserialize took {:?}",
-            t4.duration_since(t3)
-        );
+        let rules_automaton = Automaton::deserialize_unchecked(archived.rules_automaton.as_slice());
 
-        let unknown_automaton = Automaton::deserialize_unchecked(&embedded.unknown_automaton);
-        let t5 = Instant::now();
-        eprintln!(
-            "    [try_from] unknown_automaton.deserialize took {:?}",
-            t5.duration_since(t4)
-        );
+        let unknown_automaton =
+            Automaton::deserialize_unchecked(archived.unknown_automaton.as_slice());
 
-        let sets_by_rid: HashMap<usize, HashSet<TokenId>> = embedded
+        let sets_by_rid: HashMap<usize, HashSet<TokenId>> = archived
             .sets_by_rid
-            .into_iter()
-            .map(|(rid, tokens)| (rid, tokens.into_iter().map(TokenId::new).collect()))
+            .iter()
+            .map(|entry| {
+                (
+                    u32::from(entry.0) as usize,
+                    entry
+                        .1
+                        .iter()
+                        .map(|tid| TokenId::new(u16::from(*tid)))
+                        .collect(),
+                )
+            })
             .collect();
-        let t6 = Instant::now();
-        eprintln!(
-            "    [try_from] sets_by_rid took {:?}",
-            t6.duration_since(t5)
-        );
 
-        let msets_by_rid: HashMap<usize, HashMap<TokenId, usize>> = embedded
+        let msets_by_rid: HashMap<usize, HashMap<TokenId, usize>> = archived
             .msets_by_rid
-            .into_iter()
-            .map(|(rid, entries)| {
+            .iter()
+            .map(|entry| {
                 (
-                    rid,
-                    entries
-                        .into_iter()
-                        .map(|(tid, count)| (TokenId::new(tid), count as usize))
+                    u32::from(entry.0) as usize,
+                    entry
+                        .1
+                        .iter()
+                        .map(|pair| (TokenId::new(u16::from(pair.0)), u16::from(pair.1) as usize))
                         .collect(),
                 )
             })
             .collect();
-        let t7 = Instant::now();
-        eprintln!(
-            "    [try_from] msets_by_rid took {:?}",
-            t7.duration_since(t6)
-        );
 
-        let high_sets_by_rid: HashMap<usize, HashSet<TokenId>> = embedded
+        let high_sets_by_rid: HashMap<usize, HashSet<TokenId>> = archived
             .high_sets_by_rid
-            .into_iter()
-            .map(|(rid, tokens)| (rid, tokens.into_iter().map(TokenId::new).collect()))
-            .collect();
-        let t8 = Instant::now();
-        eprintln!(
-            "    [try_from] high_sets_by_rid took {:?}",
-            t8.duration_since(t7)
-        );
-
-        let high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>> = embedded
-            .high_postings_by_rid
-            .into_iter()
-            .map(|(rid, entries)| {
+            .iter()
+            .map(|entry| {
                 (
-                    rid,
-                    entries
-                        .into_iter()
-                        .map(|(tid, positions)| (TokenId::new(tid), positions))
+                    u32::from(entry.0) as usize,
+                    entry
+                        .1
+                        .iter()
+                        .map(|tid| TokenId::new(u16::from(*tid)))
                         .collect(),
                 )
             })
             .collect();
-        let t9 = Instant::now();
-        eprintln!(
-            "    [try_from] high_postings_by_rid took {:?}",
-            t9.duration_since(t8)
-        );
 
-        let false_positive_rids: HashSet<usize> =
-            embedded.false_positive_rids.into_iter().collect();
-
-        let approx_matchable_rids: HashSet<usize> =
-            embedded.approx_matchable_rids.into_iter().collect();
-
-        let licenses_by_key: HashMap<String, License> =
-            embedded.licenses_by_key.into_iter().collect();
-        let t10 = Instant::now();
-        eprintln!(
-            "    [try_from] licenses_by_key took {:?}",
-            t10.duration_since(t9)
-        );
-
-        let rid_by_spdx_key: HashMap<String, usize> =
-            embedded.rid_by_spdx_key.into_iter().collect();
-
-        let rids_by_high_tid: HashMap<TokenId, HashSet<usize>> = embedded
-            .rids_by_high_tid
-            .into_iter()
-            .map(|(tid, rids)| (TokenId::new(tid), rids.into_iter().collect()))
+        let high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>> = archived
+            .high_postings_by_rid
+            .iter()
+            .map(|entry| {
+                (
+                    u32::from(entry.0) as usize,
+                    entry
+                        .1
+                        .iter()
+                        .map(|pair| {
+                            (
+                                TokenId::new(u16::from(pair.0)),
+                                pair.1.iter().map(|p| u32::from(*p) as usize).collect(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
             .collect();
-        let t11 = Instant::now();
-        eprintln!(
-            "    [try_from] rids_by_high_tid took {:?}",
-            t11.duration_since(t10)
-        );
-        eprintln!("    [try_from] TOTAL took {:?}", t11.duration_since(t0));
+
+        let false_positive_rids: HashSet<usize> = archived
+            .false_positive_rids
+            .iter()
+            .map(|v| u32::from(*v) as usize)
+            .collect();
+
+        let approx_matchable_rids: HashSet<usize> = archived
+            .approx_matchable_rids
+            .iter()
+            .map(|v| u32::from(*v) as usize)
+            .collect();
+
+        let licenses_by_key: HashMap<String, License> = archived
+            .licenses_by_key
+            .iter()
+            .map(|entry| {
+                (
+                    entry.0.as_str().to_string(),
+                    rkyv::deserialize::<_, rkyv::rancor::Error>(&entry.1).unwrap(),
+                )
+            })
+            .collect();
+
+        let rid_by_spdx_key: HashMap<String, usize> = archived
+            .rid_by_spdx_key
+            .iter()
+            .map(|entry| (entry.0.as_str().to_string(), u32::from(entry.1) as usize))
+            .collect();
+
+        let rids_by_high_tid: HashMap<TokenId, HashSet<usize>> = archived
+            .rids_by_high_tid
+            .iter()
+            .map(|entry| {
+                (
+                    TokenId::new(u16::from(entry.0)),
+                    entry.1.iter().map(|v| u32::from(*v) as usize).collect(),
+                )
+            })
+            .collect();
+
+        let rules_by_rid: Vec<Rule> = archived.rules_by_rid.iter().map(Rule::from).collect();
 
         Ok(LicenseIndex {
             dictionary,
-            len_legalese: embedded.len_legalese,
+            len_legalese: u32::from(archived.len_legalese) as usize,
             rid_by_hash,
-            rules_by_rid: embedded.rules_by_rid,
+            rules_by_rid,
             tids_by_rid,
             rules_automaton,
             unknown_automaton,
@@ -485,77 +598,46 @@ impl TryFrom<EmbeddedLicenseIndex> for LicenseIndex {
             false_positive_rids,
             approx_matchable_rids,
             licenses_by_key,
-            pattern_id_to_rid: embedded.pattern_id_to_rid,
+            pattern_id_to_rid: archived
+                .pattern_id_to_rid
+                .iter()
+                .map(|v| v.iter().map(|p| u32::from(*p) as usize).collect())
+                .collect(),
             rid_by_spdx_key,
-            unknown_spdx_rid: embedded.unknown_spdx_rid,
+            unknown_spdx_rid: match &archived.unknown_spdx_rid {
+                rkyv::option::ArchivedOption::Some(v) => Some(u32::from(*v) as usize),
+                rkyv::option::ArchivedOption::None => None,
+            },
             rids_by_high_tid,
         })
     }
 }
 
-// This method will be used by the xtask build process in upcoming phases.
-#[allow(dead_code)]
+// This method is used by the xtask build process.
 impl EmbeddedLicenseIndex {
-    pub fn serialize(&self) -> Result<SerializedLicenseIndex, SerializationError> {
-        let bincode_data = bincode::serde::encode_to_vec(self, bincode::config::standard())
-            .map_err(|e| {
-                SerializationError(format!("Failed to serialize EmbeddedLicenseIndex: {}", e))
-            })?;
-
-        let compressed = zstd::encode_all(&bincode_data[..], 0)
-            .map_err(|e| SerializationError(format!("Failed to compress license index: {}", e)))?;
-
-        Ok(SerializedLicenseIndex {
-            schema_version: SCHEMA_VERSION,
-            data: compressed,
-        })
-    }
-
     pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
-        let bincode_data = bincode::serde::encode_to_vec(self, bincode::config::standard())
-            .map_err(|e| {
-                SerializationError(format!("Failed to serialize EmbeddedLicenseIndex: {}", e))
-            })?;
+        let rkyv_data = rkyv::to_bytes::<rkyv::rancor::Error>(self).map_err(|e| {
+            SerializationError(format!("Failed to serialize EmbeddedLicenseIndex: {}", e))
+        })?;
 
-        zstd::encode_all(&bincode_data[..], 0)
+        zstd::encode_all(&rkyv_data[..], 0)
             .map_err(|e| SerializationError(format!("Failed to compress license index: {}", e)))
     }
+}
 
-    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
-        use std::time::Instant;
-        let t0 = Instant::now();
+pub fn load_license_index_from_bytes(bytes: &[u8]) -> Result<LicenseIndex, SerializationError> {
+    let decompressed = zstd::decode_all(bytes)
+        .map_err(|e| SerializationError(format!("Failed to decompress license index: {}", e)))?;
 
-        let decompressed = zstd::decode_all(bytes).map_err(|e| {
-            SerializationError(format!("Failed to decompress license index: {}", e))
+    let archived: &ArchivedEmbeddedLicenseIndex =
+        rkyv::access::<_, rkyv::rancor::Error>(&decompressed).map_err(|e| {
+            SerializationError(format!(
+                "Failed to access archived EmbeddedLicenseIndex: {}",
+                e
+            ))
         })?;
-        let t1 = Instant::now();
-        eprintln!(
-            "  [deserialize_from_bytes] zstd::decode_all took {:?}",
-            t1.duration_since(t0)
-        );
-        eprintln!(
-            "  [deserialize_from_bytes] decompressed size: {} MB",
-            decompressed.len() / 1_000_000
-        );
 
-        let (index, _): (Self, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard()).map_err(
-                |e| {
-                    SerializationError(format!("Failed to deserialize EmbeddedLicenseIndex: {}", e))
-                },
-            )?;
-        let t2 = Instant::now();
-        eprintln!(
-            "  [deserialize_from_bytes] bincode::decode took {:?}",
-            t2.duration_since(t1)
-        );
-        eprintln!(
-            "  [deserialize_from_bytes] TOTAL took {:?}",
-            t2.duration_since(t0)
-        );
-
-        Ok(index)
-    }
+    LicenseIndex::try_from(archived)
 }
 
 #[cfg(test)]
@@ -693,8 +775,8 @@ mod tests {
         let original = create_test_license_index();
 
         let embedded = EmbeddedLicenseIndex::from(&original);
-
-        let restored = LicenseIndex::try_from(embedded).expect("Should deserialize");
+        let bytes = embedded.serialize_to_bytes().expect("Should serialize");
+        let restored = load_license_index_from_bytes(&bytes).expect("Should deserialize");
 
         assert_eq!(restored.len_legalese, original.len_legalese);
         assert_eq!(restored.rid_by_hash.len(), original.rid_by_hash.len());
@@ -735,18 +817,13 @@ mod tests {
     }
 
     #[test]
-    fn test_serialized_license_index_roundtrip() {
+    fn test_embedded_license_index_bytes_roundtrip() {
         let original = create_test_license_index();
 
         let embedded = EmbeddedLicenseIndex::from(&original);
-        let serialized = embedded.serialize().expect("Should serialize");
+        let bytes = embedded.serialize_to_bytes().expect("Should serialize");
 
-        let bytes = serialized.to_bytes().expect("Should convert to bytes");
-        let restored_serialized =
-            SerializedLicenseIndex::from_bytes(&bytes).expect("Should parse bytes");
-
-        let restored_embedded = restored_serialized.decompress().expect("Should decompress");
-        let restored = LicenseIndex::try_from(restored_embedded).expect("Should deserialize");
+        let restored = load_license_index_from_bytes(&bytes).expect("Should deserialize");
 
         assert_eq!(restored.len_legalese, original.len_legalese);
         assert_eq!(restored.rid_by_hash.len(), original.rid_by_hash.len());
@@ -762,7 +839,12 @@ mod tests {
         let mut embedded = EmbeddedLicenseIndex::from(&create_test_license_index());
         embedded.schema_version = 999;
 
-        let result = LicenseIndex::try_from(embedded);
+        let rkyv_bytes =
+            rkyv::to_bytes::<rkyv::rancor::Error>(&embedded).expect("Should serialize");
+        let archived: &ArchivedEmbeddedLicenseIndex =
+            rkyv::access::<_, rkyv::rancor::Error>(&rkyv_bytes).expect("Should access");
+
+        let result = LicenseIndex::try_from(archived);
         assert!(result.is_err());
         assert!(result.unwrap_err().0.contains("Schema version mismatch"));
     }
@@ -838,10 +920,8 @@ mod tests {
         let embedded1 = EmbeddedLicenseIndex::from(&index);
         let embedded2 = EmbeddedLicenseIndex::from(&index);
 
-        let bytes1 =
-            bincode::serde::encode_to_vec(&embedded1, bincode::config::standard()).unwrap();
-        let bytes2 =
-            bincode::serde::encode_to_vec(&embedded2, bincode::config::standard()).unwrap();
+        let bytes1 = embedded1.serialize_to_bytes().unwrap();
+        let bytes2 = embedded2.serialize_to_bytes().unwrap();
 
         assert_eq!(bytes1, bytes2, "Serialization should be deterministic");
 
@@ -852,18 +932,10 @@ mod tests {
     #[test]
     fn test_load_embedded_license_index_artifact() {
         let artifact_bytes =
-            include_bytes!("../../../resources/license_detection/license_index.bincode.zst");
+            include_bytes!("../../../resources/license_detection/license_index.zst");
 
-        let embedded = EmbeddedLicenseIndex::deserialize_from_bytes(artifact_bytes)
-            .expect("Should deserialize EmbeddedLicenseIndex");
-
-        assert_eq!(
-            embedded.schema_version, SCHEMA_VERSION,
-            "Embedded schema version should match"
-        );
-
-        let license_index =
-            LicenseIndex::try_from(embedded).expect("Should convert to LicenseIndex");
+        let license_index = load_license_index_from_bytes(artifact_bytes)
+            .expect("Should load LicenseIndex from bytes");
 
         assert!(
             !license_index.rules_by_rid.is_empty(),

--- a/src/license_detection/embedded_test.rs
+++ b/src/license_detection/embedded_test.rs
@@ -7,7 +7,7 @@
 //! - Packaging (verify artifact is loadable)
 
 use super::*;
-use crate::license_detection::embedded::index::{EmbeddedLicenseIndex, SCHEMA_VERSION};
+use crate::license_detection::embedded::index::SCHEMA_VERSION;
 use crate::license_detection::{SCANCODE_LICENSES_LICENSES_PATH, SCANCODE_LICENSES_RULES_PATH};
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
@@ -206,6 +206,7 @@ limitations under the License."#;
 
 mod determinism {
     use super::*;
+    use crate::license_detection::embedded::index::EmbeddedLicenseIndex;
 
     #[test]
     fn test_compression_is_deterministic() {
@@ -239,7 +240,7 @@ mod determinism {
         let generated_bytes = embedded.serialize_to_bytes().expect("Should serialize");
 
         let checked_in_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+            include_bytes!("../../resources/license_detection/license_index.zst");
 
         assert_eq!(
             generated_bytes.as_slice(),
@@ -278,7 +279,7 @@ mod packaging {
 
     #[test]
     fn test_embedded_artifact_exists() {
-        let artifact_path = PathBuf::from("resources/license_detection/license_index.bincode.zst");
+        let artifact_path = PathBuf::from("resources/license_detection/license_index.zst");
 
         assert!(
             artifact_path.exists(),
@@ -303,71 +304,76 @@ mod packaging {
 
     #[test]
     fn test_embedded_artifact_schema_version() {
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
 
         let decompressed =
             zstd::decode_all(&artifact_bytes[..]).expect("Should decompress artifact");
 
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
-                .expect("Should deserialize artifact");
+        let archived: &rkyv::Archived<
+            crate::license_detection::embedded::index::EmbeddedLicenseIndex,
+        > = rkyv::access::<_, rkyv::rancor::Error>(&decompressed)
+            .expect("Should access archived artifact");
 
         assert_eq!(
-            index.schema_version, SCHEMA_VERSION,
+            u32::from(archived.schema_version),
+            SCHEMA_VERSION,
             "Embedded artifact should have current schema version"
         );
     }
 
     #[test]
     fn test_embedded_artifact_has_non_empty_rules() {
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
 
         let decompressed =
             zstd::decode_all(&artifact_bytes[..]).expect("Should decompress artifact");
 
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
-                .expect("Should deserialize artifact");
+        let archived: &rkyv::Archived<
+            crate::license_detection::embedded::index::EmbeddedLicenseIndex,
+        > = rkyv::access::<_, rkyv::rancor::Error>(&decompressed)
+            .expect("Should access archived artifact");
 
         assert!(
-            !index.rules_by_rid.is_empty(),
+            !archived.rules_by_rid.is_empty(),
             "Embedded artifact should have rules"
         );
     }
 
     #[test]
     fn test_embedded_artifact_has_non_empty_licenses() {
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
 
         let decompressed =
             zstd::decode_all(&artifact_bytes[..]).expect("Should decompress artifact");
 
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
-                .expect("Should deserialize artifact");
+        let archived: &rkyv::Archived<
+            crate::license_detection::embedded::index::EmbeddedLicenseIndex,
+        > = rkyv::access::<_, rkyv::rancor::Error>(&decompressed)
+            .expect("Should access archived artifact");
 
         assert!(
-            !index.licenses_by_key.is_empty(),
+            !archived.licenses_by_key.is_empty(),
             "Embedded artifact should have licenses"
         );
     }
 
     #[test]
     fn test_embedded_artifact_rules_sorted() {
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
 
         let decompressed =
             zstd::decode_all(&artifact_bytes[..]).expect("Should decompress artifact");
 
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
-                .expect("Should deserialize artifact");
+        let archived: &rkyv::Archived<
+            crate::license_detection::embedded::index::EmbeddedLicenseIndex,
+        > = rkyv::access::<_, rkyv::rancor::Error>(&decompressed)
+            .expect("Should access archived artifact");
 
-        let identifiers: Vec<_> = index.rules_by_rid.iter().map(|r| &r.identifier).collect();
+        let identifiers: Vec<_> = archived
+            .rules_by_rid
+            .iter()
+            .map(|r| r.identifier.as_str())
+            .collect();
 
         let mut sorted_identifiers = identifiers.clone();
         sorted_identifiers.sort();
@@ -380,17 +386,21 @@ mod packaging {
 
     #[test]
     fn test_embedded_artifact_licenses_sorted() {
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
 
         let decompressed =
             zstd::decode_all(&artifact_bytes[..]).expect("Should decompress artifact");
 
-        let (index, _): (EmbeddedLicenseIndex, _) =
-            bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
-                .expect("Should deserialize artifact");
+        let archived: &rkyv::Archived<
+            crate::license_detection::embedded::index::EmbeddedLicenseIndex,
+        > = rkyv::access::<_, rkyv::rancor::Error>(&decompressed)
+            .expect("Should access archived artifact");
 
-        let keys: Vec<_> = index.licenses_by_key.iter().map(|(k, _)| k).collect();
+        let keys: Vec<_> = archived
+            .licenses_by_key
+            .iter()
+            .map(|entry| entry.0.as_str())
+            .collect();
 
         let mut sorted_keys = keys.clone();
         sorted_keys.sort();

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -641,7 +641,7 @@ pub fn build_index_from_loaded(
 ///
 /// NOTE: This function is kept for potential future use by the xtask build process
 /// or for tests that need to build indexes dynamically. The main code path now uses
-/// the complete pre-built license index from `license_index.bincode.zst`.
+/// the complete pre-built license index from `license_index.zst`.
 ///
 /// # Arguments
 /// * `loaded_rules` - Rules loaded from the loader stage

--- a/src/license_detection/index/dictionary.rs
+++ b/src/license_detection/index/dictionary.rs
@@ -7,7 +7,23 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub struct TokenId(u16);
 
 impl TokenId {
@@ -69,13 +85,37 @@ impl PartialOrd<TokenId> for u16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub enum TokenKind {
     Legalese,
     Regular,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub struct KnownToken {
     pub id: TokenId,
     pub kind: TokenKind,
@@ -83,14 +123,26 @@ pub struct KnownToken {
     pub is_short_or_digit: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub enum QueryToken {
     Known(KnownToken),
     Unknown,
     Stopword,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
 pub struct TokenMetadata {
     pub kind: TokenKind,
     pub is_digit_only: bool,

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -32,8 +32,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use crate::license_detection::embedded::index::EmbeddedLicenseIndex;
-use crate::license_detection::index::{LicenseIndex, build_index_from_loaded};
+use crate::license_detection::embedded::index::load_license_index_from_bytes;
+use crate::license_detection::index::build_index_from_loaded;
 use crate::license_detection::query::Query;
 use crate::license_detection::rules::{
     load_loaded_licenses_from_directory, load_loaded_rules_from_directory,
@@ -454,32 +454,23 @@ impl LicenseDetectionEngine {
         use std::time::Instant;
         let t0 = Instant::now();
 
-        let artifact_bytes =
-            include_bytes!("../../resources/license_detection/license_index.bincode.zst");
+        let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         eprintln!(
             "[from_embedded] artifact_bytes.len() = {} MB",
             artifact_bytes.len() / 1_000_000
         );
 
         let t1 = Instant::now();
-        let embedded = EmbeddedLicenseIndex::deserialize_from_bytes(artifact_bytes)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize embedded index: {}", e))?;
+        let index = load_license_index_from_bytes(artifact_bytes)
+            .map_err(|e| anyhow::anyhow!("Failed to load license index: {}", e))?;
         eprintln!(
-            "[from_embedded] deserialize_from_bytes took {:?}",
+            "[from_embedded] load_license_index_from_bytes took {:?}",
             t1.elapsed()
         );
 
         let t2 = Instant::now();
-        let index = LicenseIndex::try_from(embedded)
-            .map_err(|e| anyhow::anyhow!("Failed to convert embedded index: {}", e))?;
-        eprintln!(
-            "[from_embedded] LicenseIndex::try_from took {:?}",
-            t2.elapsed()
-        );
-
-        let t3 = Instant::now();
         let result = Self::from_index(index);
-        eprintln!("[from_embedded] from_index took {:?}", t3.elapsed());
+        eprintln!("[from_embedded] from_index took {:?}", t2.elapsed());
 
         eprintln!("[from_embedded] TOTAL took {:?}", t0.elapsed());
         result

--- a/src/license_detection/models/license.rs
+++ b/src/license_detection/models/license.rs
@@ -1,9 +1,20 @@
 //! License metadata loaded from .LICENSE files.
 
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
 /// License metadata loaded from .LICENSE files.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub struct License {
     /// Unique lowercase ASCII identifier for this license
     pub key: String,

--- a/src/license_detection/models/rule.rs
+++ b/src/license_detection/models/rule.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::license_detection::index::dictionary::TokenId;
@@ -59,7 +60,20 @@ mod stopwords_serde {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Default,
+    Serialize,
+    Deserialize,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
 )]
 pub enum RuleKind {
     #[default]
@@ -274,11 +288,8 @@ fn serialize_token_ids<S>(token_ids: &[TokenId], serializer: S) -> Result<S::Ok,
 where
     S: serde::Serializer,
 {
-    token_ids
-        .iter()
-        .map(|id| id.raw())
-        .collect::<Vec<_>>()
-        .serialize(serializer)
+    let raw_ids: Vec<u16> = token_ids.iter().map(|id| id.raw()).collect();
+    <Vec<u16> as serde::Serialize>::serialize(&raw_ids, serializer)
 }
 
 fn deserialize_token_ids<'de, D>(deserializer: D) -> Result<Vec<TokenId>, D::Error>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 url = { workspace = true }
 zstd = { workspace = true }
-bincode = { workspace = true }
+rkyv = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/xtask/src/bin/generate_index_artifact.rs
+++ b/xtask/src/bin/generate_index_artifact.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
 
     let output_path = args
         .output
-        .unwrap_or_else(|| PathBuf::from("resources/license_detection/license_index.bincode.zst"));
+        .unwrap_or_else(|| PathBuf::from("resources/license_detection/license_index.zst"));
     let rules_dir = args.rules.unwrap_or_else(|| {
         PathBuf::from(provenant::license_detection::SCANCODE_LICENSES_RULES_PATH)
     });


### PR DESCRIPTION
Replaces bincode with rkyv for serializing the embedded license index, enabling zero-copy deserialization and simpler code.

## Changes

- Replace `bincode 2.x` with `rkyv 0.8` for license index serialization
- Add rkyv derives (`Archive`, `RkyvSerialize`, `RkyvDeserialize`) to relevant types
- Create `EmbeddedRule` type using `Vec<(usize, usize)>` instead of `HashMap` for rkyv compatibility
- Implement `TryFrom<&ArchivedEmbeddedLicenseIndex> for LicenseIndex` for direct deserialization
- Add `load_license_index_from_bytes()` function for the production code path
- Remove dead `SerializedLicenseIndex` wrapper (schema version is already in `EmbeddedLicenseIndex`)
- Rename artifact from `license_index.bincode.zst` to `license_index.zst`
- Bump schema version to 2

## Removed

- `bincode` dependency from both `Cargo.toml` and `xtask/Cargo.toml`
- Inefficient `From<EmbeddedLicenseIndex> for LicenseIndex` impl (tests now use actual production path)