### PR TITLE
feat(license): wire package reference consumers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,8 @@ use crate::cli::Cli;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::output::{OutputWriteConfig, write_output_file};
 use crate::post_processing::{
-    CreateOutputContext, CreateOutputOptions, apply_local_file_reference_following,
-    build_facet_rules, collect_top_level_license_detections, collect_top_level_license_references,
-    create_output,
+    CreateOutputContext, CreateOutputOptions, apply_package_reference_following, build_facet_rules,
+    collect_top_level_license_detections, collect_top_level_license_references, create_output,
 };
 use crate::progress::{ProgressMode, ScanProgress};
 use crate::scan_result_shaping::{
@@ -289,7 +288,7 @@ fn run() -> Result<()> {
         package.backfill_license_provenance();
     }
 
-    apply_local_file_reference_following(&mut scan_result.files, &assembly_result.packages);
+    apply_package_reference_following(&mut scan_result.files, &mut assembly_result.packages);
 
     let end_time = Utc::now();
 

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -475,7 +475,7 @@ impl PackageData {
 /// License detection result containing matched license expressions.
 ///
 /// Aggregates multiple license matches into a single SPDX license expression.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct LicenseDetection {
     pub license_expression: String,
     pub license_expression_spdx: String,

--- a/src/parsers/about.rs
+++ b/src/parsers/about.rs
@@ -31,7 +31,10 @@ use std::str::FromStr;
 use url::Url;
 
 use super::PackageParser;
-use super::license_normalization::normalize_spdx_declared_license;
+use super::license_normalization::{
+    DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_spdx_declared_license,
+    normalize_spdx_expression,
+};
 
 const FIELD_TYPE: &str = "type";
 const FIELD_PURL: &str = "purl";
@@ -174,8 +177,22 @@ impl PackageParser for AboutFileParser {
             .get(FIELD_LICENSE_EXPRESSION)
             .and_then(|v| v.as_str())
             .map(String::from);
+        let file_references = extract_file_references(&yaml);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-            normalize_spdx_declared_license(extracted_license_statement.as_deref());
+            extracted_license_statement
+                .as_deref()
+                .and_then(normalize_spdx_expression)
+                .map(|normalized| {
+                    build_declared_license_data(
+                        normalized,
+                        DeclaredLicenseMatchMetadata::single_line(
+                            extracted_license_statement.as_deref().unwrap_or_default(),
+                        ),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    normalize_spdx_declared_license(extracted_license_statement.as_deref())
+                });
 
         let vcs_url = yaml
             .get(Value::String("vcs_url".to_string()))
@@ -216,8 +233,6 @@ impl PackageParser for AboutFileParser {
         let parties = extract_owner_party(&yaml);
 
         // File references
-        let file_references = extract_file_references(&yaml);
-
         vec![PackageData {
             package_type: Some(package_type),
             namespace,

--- a/src/parsers/about_test.rs
+++ b/src/parsers/about_test.rs
@@ -252,6 +252,11 @@ homepage_url: https://example.com/homepage
         assert_eq!(result.file_references[1].path, "apipkg.LICENSE");
         assert_eq!(result.file_references[1].path, "apipkg.LICENSE");
         assert_eq!(result.purl, Some("pkg:pypi/apipkg@1.4".to_string()));
+        let referenced_filenames = result.license_detections[0].matches[0]
+            .referenced_filenames
+            .as_ref()
+            .expect("referenced filenames should be present");
+        assert_eq!(referenced_filenames, &vec!["apipkg.LICENSE".to_string()]);
     }
 
     #[test]

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -179,6 +179,68 @@ enum MetadataValue {
     List(Vec<String>),
 }
 
+fn split_buck_license_values(values: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut statements = Vec::new();
+    let mut references = Vec::new();
+
+    for value in values {
+        if is_probable_local_license_reference(value) {
+            references.push(value.clone());
+        } else {
+            statements.push(value.clone());
+        }
+    }
+
+    (statements, references)
+}
+
+fn is_probable_local_license_reference(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    lower.contains('/')
+        || lower.contains('\\')
+        || lower.starts_with("license")
+        || lower.starts_with("licence")
+        || lower.starts_with("copying")
+        || lower.starts_with("notice")
+        || lower.starts_with("copyright")
+        || lower.ends_with(".txt")
+        || lower.ends_with(".md")
+        || lower.ends_with(".rst")
+        || lower.ends_with(".html")
+}
+
+fn insert_license_reference_extra_data(
+    extra_data: &mut HashMap<String, serde_json::Value>,
+    references: &[String],
+) {
+    match references {
+        [] => {}
+        [reference] => {
+            extra_data.insert(
+                "license_file".to_string(),
+                serde_json::Value::String(reference.clone()),
+            );
+        }
+        _ => {
+            extra_data.insert(
+                "license_files".to_string(),
+                serde_json::Value::Array(
+                    references
+                        .iter()
+                        .cloned()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                ),
+            );
+        }
+    }
+}
+
 /// Build PackageData from extracted metadata fields
 fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> PackageData {
     let mut pkg = PackageData {
@@ -186,6 +248,7 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
         datasource_id: Some(DatasourceId::BuckMetadata),
         ..Default::default()
     };
+    let mut license_references = Vec::new();
 
     // Extract name
     if let Some(MetadataValue::String(s)) = fields.get("name") {
@@ -206,7 +269,16 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
 
     // Extract licenses (licenses or license_expression)
     if let Some(MetadataValue::List(licenses)) = fields.get("licenses") {
-        pkg.extracted_license_statement = Some(licenses.join(", "));
+        let (license_statements, references) = split_buck_license_values(licenses);
+        license_references = references;
+        let extracted_license_statement = if !license_statements.is_empty() {
+            Some(license_statements.join(", "))
+        } else if !license_references.is_empty() {
+            Some(license_references.join(", "))
+        } else {
+            None
+        };
+        pkg.extracted_license_statement = extracted_license_statement;
     } else if let Some(MetadataValue::String(s)) = fields.get("license_expression") {
         pkg.extracted_license_statement = Some(s.clone());
     }
@@ -264,6 +336,7 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
             serde_json::Value::String(s.clone()),
         );
     }
+    insert_license_reference_extra_data(&mut extra_data, &license_references);
     if !extra_data.is_empty() {
         pkg.extra_data = Some(extra_data);
     }
@@ -362,11 +435,25 @@ fn extract_from_call(call: &ast::ExprCall) -> Option<PackageData> {
     }
 
     let package_name = name?;
+    let (license_statements, license_references) = licenses
+        .as_deref()
+        .map(split_buck_license_values)
+        .unwrap_or_default();
+    let extracted_license_statement = if !license_statements.is_empty() {
+        Some(license_statements.join(", "))
+    } else if !license_references.is_empty() {
+        Some(license_references.join(", "))
+    } else {
+        None
+    };
+    let mut extra_data = HashMap::new();
+    insert_license_reference_extra_data(&mut extra_data, &license_references);
 
     Some(PackageData {
         package_type: Some(BuckBuildParser::PACKAGE_TYPE),
         name: Some(package_name),
-        extracted_license_statement: licenses.map(|l| l.join(", ")),
+        extracted_license_statement,
+        extra_data: (!extra_data.is_empty()).then_some(extra_data),
         datasource_id: Some(DatasourceId::BuckFile),
         ..Default::default()
     })

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -38,6 +38,16 @@ fn test_parse_buck_subdir_with_rule() {
     // This BUCK file has a cxx_binary rule with name="bin"
     assert_eq!(pkg.name, Some("bin".to_string()));
     assert_eq!(pkg.extracted_license_statement, Some("LICENSE".to_string()));
+    let extra = pkg.extra_data.as_ref().expect("extra_data should exist");
+    assert_eq!(
+        extra.get("license_file").and_then(|v| v.as_str()),
+        Some("LICENSE")
+    );
+    let referenced_filenames = pkg.license_detections[0].matches[0]
+        .referenced_filenames
+        .as_ref()
+        .expect("referenced_filenames should be present");
+    assert_eq!(referenced_filenames, &vec!["LICENSE".to_string()]);
 }
 
 #[test]
@@ -226,6 +236,33 @@ METADATA = {
         pkg.extracted_license_statement,
         Some("MIT, Apache-2.0".to_string())
     );
+}
+
+#[test]
+fn test_metadata_bzl_splits_license_references_from_license_statements() {
+    let content = r#"
+METADATA = {
+    "name": "example",
+    "version": "1.0.0",
+    "licenses": ["MIT", "LICENSE.txt"],
+}
+"#;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let metadata_path = temp_dir.path().join("METADATA.bzl");
+    std::fs::write(&metadata_path, content).unwrap();
+
+    let pkg = BuckMetadataBzlParser::extract_first_package(&metadata_path);
+    assert_eq!(pkg.extracted_license_statement.as_deref(), Some("MIT"));
+    let extra = pkg.extra_data.as_ref().expect("extra_data should exist");
+    assert_eq!(
+        extra.get("license_file").and_then(|value| value.as_str()),
+        Some("LICENSE.txt")
+    );
+    let referenced_filenames = pkg.license_detections[0].matches[0]
+        .referenced_filenames
+        .as_ref()
+        .expect("referenced_filenames should be present");
+    assert_eq!(referenced_filenames, &vec!["LICENSE.txt".to_string()]);
 }
 
 #[test]

--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -28,7 +28,10 @@ use std::path::Path;
 use toml::Value;
 
 use super::PackageParser;
-use super::license_normalization::normalize_spdx_declared_license;
+use super::license_normalization::{
+    DeclaredLicenseMatchMetadata, build_declared_license_data, empty_declared_license_data,
+    normalize_spdx_expression,
+};
 
 const FIELD_PACKAGE: &str = "package";
 const FIELD_NAME: &str = "name";
@@ -83,8 +86,20 @@ impl PackageParser for CargoParser {
             .and_then(|p| p.get(FIELD_LICENSE))
             .and_then(|v| v.as_str())
             .map(String::from);
+        let file_references = extract_file_references(&toml_content);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-            normalize_spdx_declared_license(raw_license.as_deref());
+            raw_license
+                .as_deref()
+                .and_then(normalize_spdx_expression)
+                .map(|normalized| {
+                    build_declared_license_data(
+                        normalized,
+                        DeclaredLicenseMatchMetadata::single_line(
+                            raw_license.as_deref().unwrap_or_default(),
+                        ),
+                    )
+                })
+                .unwrap_or_else(empty_declared_license_data);
 
         let extracted_license_statement = raw_license.clone();
 
@@ -131,8 +146,6 @@ impl PackageParser for CargoParser {
         let keywords = extract_keywords_and_categories(&toml_content);
 
         let extra_data = extract_extra_data(&toml_content);
-        let file_references = extract_file_references(&toml_content);
-
         vec![PackageData {
             package_type: Some(Self::PACKAGE_TYPE),
             namespace: None,

--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -392,6 +392,27 @@ readme = "README.md"
     }
 
     #[test]
+    fn test_declared_license_detection_preserves_license_file_reference() {
+        let content = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+license = "MIT"
+license-file = "LICENSE.txt"
+"#;
+
+        let (_temp_file, cargo_path) = create_temp_cargo_toml(content);
+        let package_data = CargoParser::extract_first_package(&cargo_path);
+
+        assert_eq!(package_data.license_detections.len(), 1);
+        let referenced_filenames = package_data.license_detections[0].matches[0]
+            .referenced_filenames
+            .as_ref()
+            .expect("referenced filenames should be present");
+        assert_eq!(referenced_filenames, &vec!["LICENSE.txt".to_string()]);
+    }
+
+    #[test]
     fn test_extract_build_dependencies() {
         let content = r#"
 [package]

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -200,6 +200,12 @@ impl PackageParser for CondaMetaYamlParser {
             .and_then(|a| a.get("dev_url"))
             .and_then(|v| v.as_str())
             .map(String::from);
+        let license_file = about
+            .and_then(|a| a.get("license_file"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(String::from);
 
         // Extract dependencies from requirements sections
         let mut dependencies = Vec::new();
@@ -249,6 +255,12 @@ impl PackageParser for CondaMetaYamlParser {
         pkg.vcs_url = vcs_url;
         pkg.sha256 = sha256;
         pkg.dependencies = dependencies;
+        if let Some(license_file) = license_file {
+            extra_data.insert(
+                "license_file".to_string(),
+                serde_json::Value::String(license_file),
+            );
+        }
         if !extra_data.is_empty() {
             pkg.extra_data = Some(extra_data);
         }

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -403,6 +403,27 @@ dependencies:
     }
 
     #[test]
+    fn test_extract_meta_yaml_abeona_preserves_license_file_reference() {
+        let path = PathBuf::from("testdata/conda/meta-yaml/abeona/meta.yaml");
+        let package_data = CondaMetaYamlParser::extract_first_package(&path);
+
+        let extra_data = package_data
+            .extra_data
+            .as_ref()
+            .expect("extra_data should exist");
+        assert_eq!(
+            extra_data.get("license_file").and_then(|v| v.as_str()),
+            Some("LICENSE")
+        );
+
+        let referenced_filenames = package_data.license_detections[0].matches[0]
+            .referenced_filenames
+            .as_ref()
+            .expect("referenced_filenames should be present");
+        assert_eq!(referenced_filenames, &vec!["LICENSE".to_string()]);
+    }
+
+    #[test]
     fn test_extract_environment_yaml_ringer() {
         let path = PathBuf::from("testdata/conda/conda-yaml/ringer/environment.yaml");
         let package_data = CondaEnvironmentYmlParser::extract_first_package(&path);

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -7,7 +7,7 @@ use crate::license_detection::expression::{
     LicenseExpression, parse_expression, simplify_expression,
 };
 use crate::license_detection::index::LicenseIndex;
-use crate::models::{LicenseDetection, Match};
+use crate::models::{LicenseDetection, Match, PackageData};
 use crate::utils::spdx::{ExpressionRelation, combine_license_expressions_with_relation};
 
 pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
@@ -48,6 +48,7 @@ pub(crate) struct DeclaredLicenseMatchMetadata<'a> {
     pub(crate) matched_text: &'a str,
     pub(crate) start_line: usize,
     pub(crate) end_line: usize,
+    pub(crate) referenced_filenames: Option<&'a [&'a str]>,
 }
 
 impl<'a> DeclaredLicenseMatchMetadata<'a> {
@@ -56,7 +57,13 @@ impl<'a> DeclaredLicenseMatchMetadata<'a> {
             matched_text,
             start_line,
             end_line,
+            referenced_filenames: None,
         }
+    }
+
+    pub(crate) fn with_referenced_filenames(mut self, referenced_filenames: &'a [&'a str]) -> Self {
+        self.referenced_filenames = Some(referenced_filenames);
+        self
     }
 
     pub(crate) fn single_line(matched_text: &'a str) -> Self {
@@ -215,11 +222,155 @@ pub(crate) fn build_declared_license_detection(
             rule_identifier: None,
             rule_url: None,
             matched_text: Some(metadata.matched_text.to_string()),
-            referenced_filenames: None,
+            referenced_filenames: metadata
+                .referenced_filenames
+                .map(|filenames| filenames.iter().map(|name| (*name).to_string()).collect()),
             matched_text_diagnostics: None,
         }],
         detection_log: vec![],
         identifier: None,
+    }
+}
+
+pub(crate) fn finalize_package_declared_license_references(package_data: &mut PackageData) {
+    let referenced_filenames = collect_declared_license_reference_filenames(package_data);
+    if referenced_filenames.is_empty() {
+        return;
+    }
+
+    if attach_referenced_filenames_to_detections(
+        &mut package_data.license_detections,
+        &referenced_filenames,
+    ) || attach_referenced_filenames_to_detections(
+        &mut package_data.other_license_detections,
+        &referenced_filenames,
+    ) {
+        return;
+    }
+
+    let referenced_filename_slices: Vec<&str> =
+        referenced_filenames.iter().map(String::as_str).collect();
+
+    if let (Some(declared), Some(declared_spdx)) = (
+        package_data.declared_license_expression.clone(),
+        package_data.declared_license_expression_spdx.clone(),
+    ) {
+        let metadata = DeclaredLicenseMatchMetadata::single_line(
+            package_data
+                .extracted_license_statement
+                .as_deref()
+                .unwrap_or_default(),
+        )
+        .with_referenced_filenames(&referenced_filename_slices);
+        let (_, _, detections) =
+            build_declared_license_data_from_pair(declared, declared_spdx, metadata);
+        package_data.license_detections = detections;
+        return;
+    }
+
+    if let Some(statement) = package_data.extracted_license_statement.as_deref() {
+        if let Some(normalized) = normalize_spdx_expression(statement) {
+            let (_, _, detections) = build_declared_license_data(
+                normalized,
+                DeclaredLicenseMatchMetadata::single_line(statement)
+                    .with_referenced_filenames(&referenced_filename_slices),
+            );
+            package_data.license_detections = detections;
+            package_data.declared_license_expression = package_data
+                .license_detections
+                .first()
+                .map(|detection| detection.license_expression.clone());
+            package_data.declared_license_expression_spdx = package_data
+                .license_detections
+                .first()
+                .map(|detection| detection.license_expression_spdx.clone());
+            return;
+        }
+
+        package_data.declared_license_expression = Some("unknown-license-reference".to_string());
+        package_data.declared_license_expression_spdx =
+            Some("LicenseRef-scancode-unknown-license-reference".to_string());
+        package_data.license_detections = vec![LicenseDetection {
+            license_expression: "unknown-license-reference".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+            matches: vec![Match {
+                license_expression: "unknown-license-reference".to_string(),
+                license_expression_spdx: "LicenseRef-scancode-unknown-license-reference"
+                    .to_string(),
+                from_file: None,
+                start_line: 1,
+                end_line: 1,
+                matcher: Some(PARSER_DECLARED_MATCHER.to_string()),
+                score: 100.0,
+                matched_length: Some(statement.split_whitespace().count()),
+                match_coverage: Some(100.0),
+                rule_relevance: Some(100),
+                rule_identifier: None,
+                rule_url: None,
+                matched_text: Some(statement.to_string()),
+                referenced_filenames: Some(referenced_filenames),
+                matched_text_diagnostics: None,
+            }],
+            detection_log: vec![],
+            identifier: None,
+        }];
+    }
+}
+
+fn attach_referenced_filenames_to_detections(
+    detections: &mut [LicenseDetection],
+    referenced_filenames: &[String],
+) -> bool {
+    if detections.is_empty() {
+        return false;
+    }
+
+    for detection in detections {
+        for detection_match in &mut detection.matches {
+            if detection_match.referenced_filenames.is_none() {
+                detection_match.referenced_filenames = Some(referenced_filenames.to_vec());
+            }
+        }
+    }
+    true
+}
+
+fn collect_declared_license_reference_filenames(package_data: &PackageData) -> Vec<String> {
+    let mut references = Vec::new();
+
+    if let Some(extra_data) = package_data.extra_data.as_ref() {
+        collect_reference_strings(extra_data.get("license_file"), &mut references);
+        collect_reference_strings(extra_data.get("notice_file"), &mut references);
+        collect_reference_strings(extra_data.get("license_files"), &mut references);
+        collect_reference_strings(extra_data.get("notice_files"), &mut references);
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    references
+        .into_iter()
+        .filter(|reference| seen.insert(reference.clone()))
+        .collect()
+}
+
+fn collect_reference_strings(value: Option<&serde_json::Value>, references: &mut Vec<String>) {
+    let Some(value) = value else {
+        return;
+    };
+
+    match value {
+        serde_json::Value::String(value) => {
+            if !value.trim().is_empty() {
+                references.push(value.trim().to_string());
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                if let Some(value) = value.as_str().filter(|value| !value.trim().is_empty()) {
+                    references.push(value.trim().to_string());
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/src/parsers/meson_test.rs
+++ b/src/parsers/meson_test.rs
@@ -102,6 +102,14 @@ dependency('libarchive', version: ['>=3.0.0', '<4.0.0'])
                 }),
             Some(vec!["COPYING", "LICENSES/BSD"])
         );
+        let referenced_filenames = package_data.license_detections[0].matches[0]
+            .referenced_filenames
+            .as_ref()
+            .expect("referenced filenames should be present");
+        assert_eq!(
+            referenced_filenames,
+            &vec!["COPYING".to_string(), "LICENSES/BSD".to_string()]
+        );
 
         assert_eq!(package_data.dependencies.len(), 3);
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -301,6 +301,7 @@ use std::cell::RefCell;
 use std::path::Path;
 
 use crate::models::{PackageData, PackageType};
+use crate::parsers::license_normalization::finalize_package_declared_license_references;
 
 thread_local! {
     static PARSER_DIAGNOSTIC_STACK: RefCell<Vec<Vec<String>>> = const { RefCell::new(Vec::new()) };
@@ -320,7 +321,13 @@ where
         stack.borrow_mut().push(Vec::new());
     });
 
-    let packages = extract();
+    let packages = extract()
+        .into_iter()
+        .map(|mut package| {
+            finalize_package_declared_license_references(&mut package);
+            package
+        })
+        .collect();
     let scan_errors =
         PARSER_DIAGNOSTIC_STACK.with(|stack| stack.borrow_mut().pop().unwrap_or_default());
 
@@ -420,6 +427,10 @@ pub trait PackageParser {
     fn extract_first_package(path: &Path) -> PackageData {
         Self::extract_packages(path)
             .into_iter()
+            .map(|mut package| {
+                finalize_package_declared_license_references(&mut package);
+                package
+            })
             .next()
             .unwrap_or_default()
     }

--- a/src/parsers/nuget_test.rs
+++ b/src/parsers/nuget_test.rs
@@ -341,6 +341,17 @@ mod tests {
         );
         assert_eq!(extra["license_type"], "file");
         assert_eq!(extra["license_file"], "COPYING.txt");
+        assert_eq!(package_data.license_detections.len(), 1);
+        assert_eq!(
+            package_data.license_detections[0].license_expression,
+            "unknown-license-reference"
+        );
+        assert_eq!(
+            package_data.license_detections[0].matches[0]
+                .referenced_filenames
+                .as_ref(),
+            Some(&vec!["COPYING.txt".to_string()])
+        );
     }
 
     #[test]

--- a/src/parsers/pixi_test.rs
+++ b/src/parsers/pixi_test.rs
@@ -200,6 +200,28 @@ python = "3.11.*"
     }
 
     #[test]
+    fn test_extract_from_pixi_toml_preserves_license_file_reference() {
+        let content = r#"
+[workspace]
+name = "pixi-demo"
+version = "1.2.3"
+license = "MIT"
+license-file = "LICENSE"
+"#;
+
+        let (_temp_dir, path) = create_temp_file("pixi.toml", content);
+        let package_data = PixiTomlParser::extract_first_package(&path);
+
+        assert_eq!(package_data.license_detections.len(), 1);
+        assert_eq!(
+            package_data.license_detections[0].matches[0]
+                .referenced_filenames
+                .as_ref(),
+            Some(&vec!["LICENSE".to_string()])
+        );
+    }
+
+    #[test]
     fn test_extract_from_pixi_lock_v6() {
         let content = r#"
 version = 6

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -96,6 +96,15 @@ impl PackageParser for PodspecParser {
             .collect();
 
         let dependencies = extract_dependencies(&content);
+        let mut extra_data = serde_json::Map::new();
+        if let Some(raw_license) = extract_field(&content, &LICENSE_PATTERN)
+            && let Some(license_file) = extract_ruby_hash_file(&raw_license)
+        {
+            extra_data.insert(
+                "license_file".to_string(),
+                serde_json::Value::String(license_file),
+            );
+        }
         let repository_homepage_url = name
             .as_ref()
             .map(|n| format!("https://cocoapods.org/pods/{}", n));
@@ -168,7 +177,7 @@ impl PackageParser for PodspecParser {
             notice_text: None,
             source_packages: Vec::new(),
             file_references: Vec::new(),
-            extra_data: None,
+            extra_data: (!extra_data.is_empty()).then_some(extra_data.into_iter().collect()),
             dependencies,
             repository_homepage_url,
             repository_download_url,
@@ -232,6 +241,16 @@ fn normalize_podspec_declared_license(
     };
 
     normalize_spdx_declared_license(normalized_candidate.as_deref())
+}
+
+fn extract_ruby_hash_file(raw_license: &str) -> Option<String> {
+    let normalized = raw_license.replace("=>", "=");
+    let file_regex = Regex::new(r#":file\s*=\s*['\"]([^'\"]+)['\"]"#).ok()?;
+    file_regex
+        .captures(&normalized)
+        .and_then(|caps| caps.get(1))
+        .map(|value| value.as_str().trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn canonicalize_cocoapods_license_type(value: &str) -> String {
@@ -706,5 +725,29 @@ end
         assert_eq!(declared.as_deref(), Some("mit"));
         assert_eq!(declared_spdx.as_deref(), Some("MIT"));
         assert_eq!(detections.len(), 1);
+    }
+
+    #[test]
+    fn test_podspec_license_hash_preserves_license_file_reference() {
+        let content = r#"
+Pod::Spec.new do |s|
+  s.name = "Demo"
+  s.version = "1.0.0"
+  s.license = { :type => 'MIT', :file => 'LICENSE.txt' }
+end
+"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("Demo.podspec");
+        std::fs::write(&file_path, content).unwrap();
+
+        let package_data = PodspecParser::extract_first_package(&file_path);
+        assert_eq!(package_data.license_detections.len(), 1);
+        assert_eq!(
+            package_data.license_detections[0].matches[0]
+                .referenced_filenames
+                .as_ref(),
+            Some(&vec!["LICENSE.txt".to_string()])
+        );
     }
 }

--- a/src/parsers/podspec_json.rs
+++ b/src/parsers/podspec_json.rs
@@ -130,6 +130,19 @@ impl PackageParser for PodspecJsonParser {
             extra_data.insert(FIELD_DEPENDENCIES.to_string(), deps.clone());
         }
 
+        if let Some(license_file) = json_content
+            .get(FIELD_LICENSE)
+            .and_then(|license| license.as_object())
+            .and_then(|license| license.get("file"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+        {
+            extra_data.insert(
+                "license_file".to_string(),
+                Value::String(license_file.trim().to_string()),
+            );
+        }
+
         // Store full JSON in extra_data
         extra_data.insert("podspec.json".to_string(), json_content.clone());
 

--- a/src/parsers/podspec_json_test.rs
+++ b/src/parsers/podspec_json_test.rs
@@ -117,6 +117,29 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_license_file_reference_from_dict() {
+        let content = r#"{
+            "name": "TestPod",
+            "version": "1.0.0",
+            "license": {
+                "type": "MIT",
+                "file": "LICENSE.txt"
+            }
+        }"#;
+
+        let (_temp_dir, file_path) = create_temp_podspec_json(content);
+        let package_data = PodspecJsonParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.license_detections.len(), 1);
+        assert_eq!(
+            package_data.license_detections[0].matches[0]
+                .referenced_filenames
+                .as_ref(),
+            Some(&vec!["LICENSE.txt".to_string()])
+        );
+    }
+
+    #[test]
     fn test_extract_source_git() {
         let content = r#"{
             "name": "TestPod",

--- a/src/parsers/python.rs
+++ b/src/parsers/python.rs
@@ -55,7 +55,10 @@ use toml::map::Map as TomlMap;
 use zip::ZipArchive;
 
 use super::PackageParser;
-use super::license_normalization::normalize_spdx_declared_license;
+use super::license_normalization::{
+    DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_spdx_declared_license,
+    normalize_spdx_expression,
+};
 
 // Field constants for pyproject.toml
 const FIELD_PROJECT: &str = "project";
@@ -1653,8 +1656,21 @@ fn build_package_data_from_rfc822(
     }
 
     let (keywords, license_classifiers) = split_classifiers(&classifiers);
+    let referenced_license_files: Vec<&str> = license_files.iter().map(String::as_str).collect();
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-        normalize_spdx_declared_license(license_expression.as_deref());
+        license_expression
+            .as_deref()
+            .and_then(normalize_spdx_expression)
+            .map(|normalized| {
+                build_declared_license_data(
+                    normalized,
+                    DeclaredLicenseMatchMetadata::single_line(
+                        license_expression.as_deref().unwrap_or_default(),
+                    )
+                    .with_referenced_filenames(&referenced_license_files),
+                )
+            })
+            .unwrap_or_else(|| normalize_spdx_declared_license(license_expression.as_deref()));
 
     let extracted_license_statement = license_expression
         .clone()

--- a/src/parsers/python_test.rs
+++ b/src/parsers/python_test.rs
@@ -899,6 +899,15 @@ Test package description.
         assert_eq!(package_data.file_references.len(), 2);
         assert_eq!(package_data.file_references[0].path, "LICENSE");
         assert_eq!(package_data.file_references[1].path, "COPYING.txt");
+
+        let referenced_filenames = package_data.license_detections[0].matches[0]
+            .referenced_filenames
+            .as_ref()
+            .expect("referenced filenames should be present");
+        assert_eq!(
+            referenced_filenames,
+            &vec!["LICENSE".to_string(), "COPYING.txt".to_string()]
+        );
     }
 
     #[test]

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -29,6 +29,11 @@ const SCANCODE_LICENSE_URL_BASE: &str =
     "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses";
 const LICENSEDB_URL_BASE: &str = "https://scancode-licensedb.aboutcode.org";
 const SPDX_LICENSE_URL_BASE: &str = "https://spdx.org/licenses";
+const INHERIT_LICENSE_FROM_PACKAGE_REFERENCE: &str = "INHERIT_LICENSE_FROM_PACKAGE";
+const DETECTION_LOG_UNKNOWN_REFERENCE_IN_FILE_TO_PACKAGE: &str =
+    "unknown-reference-in-file-to-package";
+const DETECTION_LOG_UNKNOWN_REFERENCE_IN_FILE_TO_NONEXISTENT_PACKAGE: &str =
+    "unknown-reference-in-file-to-nonexistent-package";
 use crate::scanner;
 #[cfg(test)]
 use crate::utils::generated::generated_code_hints;
@@ -76,6 +81,7 @@ pub(crate) struct CreateOutputContext<'a> {
 struct ResolvedReferenceTarget {
     path: String,
     detections: Vec<LicenseDetection>,
+    preserve_match_from_file: bool,
 }
 
 struct ClassificationContext {
@@ -327,30 +333,12 @@ pub(crate) fn collect_top_level_license_detections(
     unique_detections
 }
 
-pub(crate) fn apply_local_file_reference_following(files: &mut [FileInfo], packages: &[Package]) {
-    for _ in 0..5 {
-        let snapshot = build_reference_follow_snapshot(files, packages);
-        let mut modified = false;
-
-        for file in files
-            .iter_mut()
-            .filter(|file| file.file_type == FileType::File)
-        {
-            if follow_references_for_file(file, &snapshot) {
-                modified = true;
-            }
-        }
-
-        if !modified {
-            break;
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 struct ReferenceFollowSnapshot {
     files_by_path: HashMap<String, ResolvedReferenceTarget>,
+    package_targets_by_uid: HashMap<String, ResolvedReferenceTarget>,
     package_manifest_dirs_by_uid: HashMap<String, Vec<String>>,
+    root_license_targets_by_root: HashMap<String, Vec<ResolvedReferenceTarget>>,
     root_paths: Vec<String>,
 }
 
@@ -367,8 +355,34 @@ fn build_reference_follow_snapshot(
                 ResolvedReferenceTarget {
                     path: file.path.clone(),
                     detections: file.license_detections.clone(),
+                    preserve_match_from_file: false,
                 },
             )
+        })
+        .collect();
+
+    let package_targets_by_uid = packages
+        .iter()
+        .filter_map(|package| {
+            let package_expression = combine_detection_expressions(&package.license_detections)?;
+            if !is_resolved_package_context_expression(&package_expression) {
+                return None;
+            }
+
+            let path = package
+                .datafile_paths
+                .first()
+                .cloned()
+                .unwrap_or_else(|| package.package_uid.clone());
+
+            Some((
+                package.package_uid.clone(),
+                ResolvedReferenceTarget {
+                    path,
+                    detections: package.license_detections.clone(),
+                    preserve_match_from_file: true,
+                },
+            ))
         })
         .collect();
 
@@ -387,11 +401,107 @@ fn build_reference_follow_snapshot(
         })
         .collect();
 
+    let root_paths = top_level_root_paths(files);
+    let root_license_targets_by_root = build_root_license_targets(files, &root_paths);
+
     ReferenceFollowSnapshot {
         files_by_path,
+        package_targets_by_uid,
         package_manifest_dirs_by_uid,
-        root_paths: top_level_root_paths(files),
+        root_license_targets_by_root,
+        root_paths,
     }
+}
+
+fn build_root_license_targets(
+    files: &[FileInfo],
+    root_paths: &[String],
+) -> HashMap<String, Vec<ResolvedReferenceTarget>> {
+    let mut targets_by_root = HashMap::new();
+
+    for root in root_paths {
+        let mut targets: Vec<_> = files
+            .iter()
+            .filter(|file| is_root_license_target(file, root))
+            .filter_map(|file| {
+                let expression = combine_detection_expressions(&file.license_detections)?;
+                if !is_resolved_package_context_expression(&expression) {
+                    return None;
+                }
+
+                Some(ResolvedReferenceTarget {
+                    path: file.path.clone(),
+                    detections: file.license_detections.clone(),
+                    preserve_match_from_file: false,
+                })
+            })
+            .collect();
+
+        targets.sort_by(|left, right| {
+            root_license_candidate_priority(&left.path)
+                .cmp(&root_license_candidate_priority(&right.path))
+                .then_with(|| left.path.cmp(&right.path))
+        });
+
+        if !targets.is_empty() {
+            targets_by_root.insert(root.clone(), targets);
+        }
+    }
+
+    targets_by_root
+}
+
+fn is_root_license_target(file: &FileInfo, root: &str) -> bool {
+    if file.file_type != FileType::File
+        || file.license_detections.is_empty()
+        || !is_legal_file(file)
+    {
+        return false;
+    }
+
+    let path = Path::new(&file.path);
+    let relative = if root.is_empty() {
+        path
+    } else {
+        match path.strip_prefix(root) {
+            Ok(relative) => relative,
+            Err(_) => return false,
+        }
+    };
+
+    relative.components().count() == 1
+}
+
+fn root_license_candidate_priority(path: &str) -> usize {
+    let name = Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if name.starts_with("license") || name.starts_with("licence") {
+        0
+    } else if name.starts_with("copying") {
+        1
+    } else if name.starts_with("notice") {
+        2
+    } else if name.starts_with("copyright") {
+        3
+    } else {
+        4
+    }
+}
+
+fn combine_detection_expressions(detections: &[LicenseDetection]) -> Option<String> {
+    combine_license_expressions(
+        detections
+            .iter()
+            .map(|detection| detection.license_expression.clone()),
+    )
+}
+
+fn is_resolved_package_context_expression(expression: &str) -> bool {
+    !expression.contains("unknown-license-reference") && !expression.contains("free-unknown")
 }
 
 fn top_level_root_paths(files: &[FileInfo]) -> Vec<String> {
@@ -439,6 +549,58 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
         }
     }
 
+    for package_data in &mut file.package_data {
+        for detection in &mut package_data.license_detections {
+            if apply_reference_following_to_detection(
+                detection,
+                &current_path,
+                &package_uids,
+                snapshot,
+            ) {
+                modified = true;
+            }
+        }
+        for detection in &mut package_data.other_license_detections {
+            if apply_reference_following_to_detection(
+                detection,
+                &current_path,
+                &package_uids,
+                snapshot,
+            ) {
+                modified = true;
+            }
+        }
+
+        if modified {
+            package_data.declared_license_expression = combine_license_expressions(
+                package_data
+                    .license_detections
+                    .iter()
+                    .map(|detection| detection.license_expression.clone()),
+            );
+            package_data.declared_license_expression_spdx = combine_license_expressions(
+                package_data
+                    .license_detections
+                    .iter()
+                    .filter(|detection| !detection.license_expression_spdx.is_empty())
+                    .map(|detection| detection.license_expression_spdx.clone()),
+            );
+            package_data.other_license_expression = combine_license_expressions(
+                package_data
+                    .other_license_detections
+                    .iter()
+                    .map(|detection| detection.license_expression.clone()),
+            );
+            package_data.other_license_expression_spdx = combine_license_expressions(
+                package_data
+                    .other_license_detections
+                    .iter()
+                    .filter(|detection| !detection.license_expression_spdx.is_empty())
+                    .map(|detection| detection.license_expression_spdx.clone()),
+            );
+        }
+    }
+
     if modified {
         file.license_expression = combine_license_expressions(
             file.license_detections
@@ -450,27 +612,141 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
     modified
 }
 
+pub(crate) fn apply_package_reference_following(files: &mut [FileInfo], packages: &mut [Package]) {
+    for _ in 0..5 {
+        let snapshot = build_reference_follow_snapshot(files, packages);
+        let mut modified = false;
+
+        for file in files
+            .iter_mut()
+            .filter(|file| file.file_type == FileType::File)
+        {
+            if follow_references_for_file(file, &snapshot) {
+                modified = true;
+            }
+        }
+
+        if sync_packages_from_followed_package_data(files, packages) {
+            modified = true;
+        }
+
+        if !modified {
+            break;
+        }
+    }
+}
+
+pub(crate) fn sync_packages_from_followed_package_data(
+    files: &[FileInfo],
+    packages: &mut [Package],
+) -> bool {
+    let package_data_by_path: HashMap<_, _> = files
+        .iter()
+        .filter(|file| !file.package_data.is_empty())
+        .map(|file| (file.path.clone(), file.package_data.clone()))
+        .collect();
+
+    let mut modified = false;
+
+    for package in packages {
+        for datafile_path in &package.datafile_paths {
+            if let Some(package_datas) = package_data_by_path.get(datafile_path)
+                && let Some(package_data) = package_datas.iter().find(|package_data| {
+                    package_data.purl.as_ref().is_some_and(|purl| {
+                        package
+                            .purl
+                            .as_ref()
+                            .is_some_and(|pkg_purl| pkg_purl == purl)
+                    }) || (package_data.name == package.name
+                        && package_data.version == package.version)
+                        || package_datas.len() == 1
+                })
+            {
+                let changed = package.license_detections != package_data.license_detections
+                    || package.other_license_detections != package_data.other_license_detections
+                    || package.declared_license_expression
+                        != package_data.declared_license_expression
+                    || package.declared_license_expression_spdx
+                        != package_data.declared_license_expression_spdx
+                    || package.other_license_expression != package_data.other_license_expression
+                    || package.other_license_expression_spdx
+                        != package_data.other_license_expression_spdx;
+                if changed {
+                    package.license_detections = package_data.license_detections.clone();
+                    package.other_license_detections =
+                        package_data.other_license_detections.clone();
+                    package.declared_license_expression =
+                        package_data.declared_license_expression.clone();
+                    package.declared_license_expression_spdx =
+                        package_data.declared_license_expression_spdx.clone();
+                    package.other_license_expression =
+                        package_data.other_license_expression.clone();
+                    package.other_license_expression_spdx =
+                        package_data.other_license_expression_spdx.clone();
+                    modified = true;
+                }
+                break;
+            }
+        }
+    }
+
+    modified
+}
+
 fn apply_reference_following_to_detection(
     detection: &mut LicenseDetection,
     current_path: &str,
     package_uids: &[String],
     snapshot: &ReferenceFollowSnapshot,
 ) -> bool {
+    if has_resolved_referenced_file(detection, current_path) {
+        return false;
+    }
+
     let referenced_filenames = referenced_filenames_from_detection(detection);
-    if referenced_filenames.is_empty() || has_resolved_referenced_file(detection, current_path) {
+    if !referenced_filenames.is_empty() {
+        let referenced_targets: Vec<_> = referenced_filenames
+            .iter()
+            .filter_map(|referenced_filename| {
+                resolve_referenced_resource(
+                    referenced_filename,
+                    current_path,
+                    package_uids,
+                    snapshot,
+                )
+            })
+            .collect();
+        if referenced_targets.is_empty() {
+            return false;
+        }
+
+        return apply_resolved_reference_targets(
+            detection,
+            current_path,
+            referenced_targets,
+            DETECTION_LOG_UNKNOWN_REFERENCE_TO_LOCAL_FILE,
+        );
+    }
+
+    if !inherits_license_from_package(detection) {
         return false;
     }
 
-    let referenced_targets: Vec<_> = referenced_filenames
-        .iter()
-        .filter_map(|referenced_filename| {
-            resolve_referenced_resource(referenced_filename, current_path, package_uids, snapshot)
-        })
-        .collect();
-    if referenced_targets.is_empty() {
+    let Some((referenced_targets, detection_log)) =
+        resolve_package_reference_targets(current_path, package_uids, snapshot)
+    else {
         return false;
-    }
+    };
 
+    apply_resolved_reference_targets(detection, current_path, referenced_targets, detection_log)
+}
+
+fn apply_resolved_reference_targets(
+    detection: &mut LicenseDetection,
+    current_path: &str,
+    referenced_targets: Vec<ResolvedReferenceTarget>,
+    detection_log: &str,
+) -> bool {
     let referenced_license_expression =
         combine_license_expressions(referenced_targets.iter().flat_map(|target| {
             target
@@ -487,7 +763,13 @@ fn apply_reference_following_to_detection(
         for referenced_detection in &target.detections {
             let mut internal = public_detection_to_internal(referenced_detection);
             for match_item in &mut internal.matches {
-                match_item.from_file = Some(target.path.clone());
+                if target.preserve_match_from_file {
+                    match_item
+                        .from_file
+                        .get_or_insert_with(|| target.path.clone());
+                } else {
+                    match_item.from_file = Some(target.path.clone());
+                }
             }
             internal_detection.matches.extend(internal.matches);
         }
@@ -500,8 +782,7 @@ fn apply_reference_following_to_detection(
         determine_license_expression(&matches_for_expression).ok();
     internal_detection.license_expression_spdx =
         determine_spdx_expression(&matches_for_expression).ok();
-    internal_detection.detection_log =
-        vec![DETECTION_LOG_UNKNOWN_REFERENCE_TO_LOCAL_FILE.to_string()];
+    internal_detection.detection_log = vec![detection_log.to_string()];
     let mut public_detection = internal_detection_to_public(internal_detection);
     public_detection.identifier = None;
     crate::models::file_info::enrich_license_detection_provenance(
@@ -523,10 +804,24 @@ fn referenced_filenames_from_detection(detection: &LicenseDetection) -> Vec<Stri
                 .unwrap_or_default()
         })
         .map(|name| normalize_referenced_filename(&name))
-        .filter(|name| !name.is_empty())
+        .filter(|name| !name.is_empty() && name != INHERIT_LICENSE_FROM_PACKAGE_REFERENCE)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn inherits_license_from_package(detection: &LicenseDetection) -> bool {
+    detection.matches.iter().any(|detection_match| {
+        detection_match
+            .referenced_filenames
+            .as_ref()
+            .is_some_and(|filenames| {
+                filenames.iter().any(|filename| {
+                    normalize_referenced_filename(filename)
+                        == INHERIT_LICENSE_FROM_PACKAGE_REFERENCE
+                })
+            })
+    })
 }
 
 fn has_resolved_referenced_file(detection: &LicenseDetection, current_path: &str) -> bool {
@@ -583,6 +878,75 @@ fn resolve_referenced_resource(
     candidates
         .into_iter()
         .find_map(|candidate| snapshot.files_by_path.get(&candidate).cloned())
+}
+
+fn resolve_package_reference_targets(
+    current_path: &str,
+    package_uids: &[String],
+    snapshot: &ReferenceFollowSnapshot,
+) -> Option<(Vec<ResolvedReferenceTarget>, &'static str)> {
+    if let Some(targets) = resolve_package_context_target(package_uids, snapshot) {
+        return Some((targets, DETECTION_LOG_UNKNOWN_REFERENCE_IN_FILE_TO_PACKAGE));
+    }
+
+    resolve_root_package_context_target(current_path, snapshot).map(|targets| {
+        (
+            targets,
+            DETECTION_LOG_UNKNOWN_REFERENCE_IN_FILE_TO_NONEXISTENT_PACKAGE,
+        )
+    })
+}
+
+fn resolve_package_context_target(
+    package_uids: &[String],
+    snapshot: &ReferenceFollowSnapshot,
+) -> Option<Vec<ResolvedReferenceTarget>> {
+    let mut targets = Vec::new();
+
+    for package_uid in package_uids {
+        if let Some(target) = snapshot.package_targets_by_uid.get(package_uid) {
+            targets.push(target.clone());
+        }
+    }
+
+    collapse_equivalent_reference_targets(targets)
+}
+
+fn resolve_root_package_context_target(
+    current_path: &str,
+    snapshot: &ReferenceFollowSnapshot,
+) -> Option<Vec<ResolvedReferenceTarget>> {
+    let root = snapshot
+        .root_paths
+        .iter()
+        .filter(|root| path_is_within_root(current_path, root))
+        .max_by_key(|root| root.len())?;
+
+    let targets = snapshot.root_license_targets_by_root.get(root)?.clone();
+    collapse_equivalent_reference_targets(targets)
+}
+
+fn collapse_equivalent_reference_targets(
+    targets: Vec<ResolvedReferenceTarget>,
+) -> Option<Vec<ResolvedReferenceTarget>> {
+    if targets.is_empty() {
+        return None;
+    }
+
+    let expressions: HashSet<_> = targets
+        .iter()
+        .filter_map(|target| combine_detection_expressions(&target.detections))
+        .collect();
+
+    if expressions.len() != 1 {
+        return None;
+    }
+
+    targets.into_iter().next().map(|target| vec![target])
+}
+
+fn path_is_within_root(path: &str, root: &str) -> bool {
+    root.is_empty() || path == root || path.starts_with(&format!("{root}/"))
 }
 
 fn join_reference_candidate(base: &str, referenced_filename: &str) -> String {

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -248,7 +248,8 @@ fn apply_local_file_reference_following_resolves_root_license_file() {
     }];
 
     let mut files = vec![dir("project"), license, notice];
-    apply_local_file_reference_following(&mut files, &[]);
+    let mut packages = Vec::new();
+    apply_package_reference_following(&mut files, &mut packages);
 
     let notice = files
         .iter()
@@ -321,7 +322,8 @@ fn apply_local_file_reference_following_requires_exact_filename_match() {
     }];
 
     let mut files = vec![dir("project"), license, notice];
-    apply_local_file_reference_following(&mut files, &[]);
+    let mut packages = Vec::new();
+    apply_package_reference_following(&mut files, &mut packages);
 
     let notice = files
         .iter()
@@ -394,7 +396,8 @@ fn apply_local_file_reference_following_resolves_files_beside_manifest() {
     }];
 
     let mut files = vec![dir("project"), license, source];
-    apply_local_file_reference_following(&mut files, &[package]);
+    let mut packages = vec![package];
+    apply_package_reference_following(&mut files, &mut packages);
 
     let source = files
         .iter()
@@ -405,6 +408,410 @@ fn apply_local_file_reference_following_resolves_files_beside_manifest() {
         source.license_detections[0].matches[1].from_file.as_deref(),
         Some("project/demo.dist-info/LICENSE")
     );
+}
+
+#[test]
+fn apply_package_reference_following_resolves_manifest_origin_local_file() {
+    let package_uid = "pkg:cargo/demo?uuid=test".to_string();
+    let mut package = super::test_utils::package(&package_uid, "project/Cargo.toml");
+    package.datafile_paths = vec!["project/Cargo.toml".to_string()];
+    package.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "unknown-license-reference".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+        matches: vec![Match {
+            license_expression: "unknown-license-reference".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+            from_file: Some("project/Cargo.toml".to_string()),
+            start_line: 5,
+            end_line: 5,
+            matcher: Some("parser-declared-license".to_string()),
+            score: 100.0,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: None,
+            rule_url: None,
+            matched_text: Some("MIT".to_string()),
+            referenced_filenames: Some(vec!["LICENSE".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("unknown-ref".to_string()),
+    }];
+
+    let mut manifest = file("project/Cargo.toml");
+    manifest.for_packages = vec![package_uid.clone()];
+    manifest.package_data = vec![PackageData {
+        package_type: Some(PackageType::Cargo),
+        license_detections: package.license_detections.clone(),
+        ..Default::default()
+    }];
+
+    let mut license = file("project/LICENSE");
+    license.license_expression = Some("mit".to_string());
+    license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("project/LICENSE".to_string()),
+            start_line: 1,
+            end_line: 20,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(100),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("mit.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("mit-license".to_string()),
+    }];
+
+    let mut files = vec![dir("project"), manifest, license];
+    let mut packages = vec![package];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    assert_eq!(
+        packages[0].declared_license_expression.as_deref(),
+        Some("mit")
+    );
+    assert_eq!(packages[0].license_detections[0].matches.len(), 2);
+    assert_eq!(
+        packages[0].license_detections[0].matches[1]
+            .from_file
+            .as_deref(),
+        Some("project/LICENSE")
+    );
+    assert_eq!(
+        files[1].package_data[0]
+            .declared_license_expression
+            .as_deref(),
+        Some("mit")
+    );
+}
+
+#[test]
+fn apply_package_reference_following_falls_back_to_root_when_package_missing() {
+    let mut root_copying = file("project/COPYING");
+    root_copying.license_expression = Some("gpl-3.0".to_string());
+    root_copying.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "gpl-3.0".to_string(),
+        license_expression_spdx: "GPL-3.0-only".to_string(),
+        matches: vec![Match {
+            license_expression: "gpl-3.0".to_string(),
+            license_expression_spdx: "GPL-3.0-only".to_string(),
+            from_file: Some("project/COPYING".to_string()),
+            start_line: 1,
+            end_line: 10,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(50),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("gpl-3.0.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("gpl-root".to_string()),
+    }];
+
+    let mut po = file("project/po/en_US.po");
+    po.license_expression = Some("unknown-license-reference".to_string());
+    po.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "unknown-license-reference".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+        matches: vec![Match {
+            license_expression: "unknown-license-reference".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+            from_file: Some("project/po/en_US.po".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("2-aho".to_string()),
+            score: 100.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("unknown-license-reference_see-license_1.RULE".to_string()),
+            rule_url: None,
+            matched_text: Some("same license as package".to_string()),
+            referenced_filenames: Some(vec!["COPYING".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("unknown-ref".to_string()),
+    }];
+
+    let mut files = vec![dir("project"), root_copying, po];
+    let mut packages = Vec::new();
+    apply_package_reference_following(&mut files, &mut packages);
+
+    let po = files
+        .iter()
+        .find(|file| file.path == "project/po/en_US.po")
+        .expect("po file should exist");
+    assert_eq!(po.license_expression.as_deref(), Some("gpl-3.0"));
+    assert_eq!(
+        po.license_detections[0].detection_log,
+        vec!["unknown-reference-to-local-file"]
+    );
+}
+
+#[test]
+fn apply_package_reference_following_inherits_license_from_package_context() {
+    let package_uid = "pkg:pypi/demo?uuid=test".to_string();
+    let mut package = super::test_utils::package(&package_uid, "project/PKG-INFO");
+    package.datafile_paths = vec!["project/PKG-INFO".to_string()];
+    package.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "bsd-new".to_string(),
+        license_expression_spdx: "BSD-3-Clause".to_string(),
+        matches: vec![Match {
+            license_expression: "bsd-new".to_string(),
+            license_expression_spdx: "BSD-3-Clause".to_string(),
+            from_file: Some("project/PKG-INFO".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-hash".to_string()),
+            score: 99.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(99),
+            rule_identifier: Some("pypi_bsd_license.RULE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("package-license".to_string()),
+    }];
+
+    let mut source = file("project/locale/django.po");
+    source.for_packages = vec![package_uid.clone()];
+    source.license_expression = Some("free-unknown".to_string());
+    source.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "free-unknown".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+        matches: vec![Match {
+            license_expression: "free-unknown".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+            from_file: Some("project/locale/django.po".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("2-aho".to_string()),
+            score: 100.0,
+            matched_length: Some(11),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("free-unknown-package_1.RULE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: Some(vec!["INHERIT_LICENSE_FROM_PACKAGE".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("unknown-package-ref".to_string()),
+    }];
+
+    let mut files = vec![dir("project"), source];
+    let mut packages = vec![package];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    let source = files
+        .iter()
+        .find(|file| file.path == "project/locale/django.po")
+        .expect("source file should exist");
+    assert_eq!(source.license_expression.as_deref(), Some("bsd-new"));
+    assert_eq!(
+        source.license_detections[0].detection_log,
+        vec!["unknown-reference-in-file-to-package"]
+    );
+    assert_eq!(source.license_detections[0].matches.len(), 2);
+    assert_eq!(
+        source.license_detections[0].matches[1].from_file.as_deref(),
+        Some("project/PKG-INFO")
+    );
+}
+
+#[test]
+fn apply_package_reference_following_falls_back_to_root_for_missing_package_reference() {
+    let mut root_copying = file("project/COPYING");
+    root_copying.license_expression = Some("gpl-3.0".to_string());
+    root_copying.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "gpl-3.0".to_string(),
+        license_expression_spdx: "GPL-3.0-only".to_string(),
+        matches: vec![Match {
+            license_expression: "gpl-3.0".to_string(),
+            license_expression_spdx: "GPL-3.0-only".to_string(),
+            from_file: Some("project/COPYING".to_string()),
+            start_line: 1,
+            end_line: 10,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(50),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("gpl-3.0.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("gpl-root".to_string()),
+    }];
+
+    let mut po = file("project/po/en_US.po");
+    po.license_expression = Some("free-unknown".to_string());
+    po.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "free-unknown".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+        matches: vec![Match {
+            license_expression: "free-unknown".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+            from_file: Some("project/po/en_US.po".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("2-aho".to_string()),
+            score: 100.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("free-unknown-package_2.RULE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: Some(vec!["INHERIT_LICENSE_FROM_PACKAGE".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("unknown-package-ref".to_string()),
+    }];
+
+    let mut files = vec![dir("project"), root_copying, po];
+    let mut packages = Vec::new();
+    apply_package_reference_following(&mut files, &mut packages);
+
+    let po = files
+        .iter()
+        .find(|file| file.path == "project/po/en_US.po")
+        .expect("po file should exist");
+    assert_eq!(po.license_expression.as_deref(), Some("gpl-3.0"));
+    assert_eq!(
+        po.license_detections[0].detection_log,
+        vec!["unknown-reference-in-file-to-nonexistent-package"]
+    );
+    assert_eq!(
+        po.license_detections[0].matches[1].from_file.as_deref(),
+        Some("project/COPYING")
+    );
+}
+
+#[test]
+fn apply_package_reference_following_leaves_ambiguous_multi_package_file_unresolved() {
+    let first_uid = "pkg:pypi/demo-a?uuid=test".to_string();
+    let second_uid = "pkg:pypi/demo-b?uuid=test".to_string();
+
+    let mut first_package = super::test_utils::package(&first_uid, "project/a/PKG-INFO");
+    first_package.datafile_paths = vec!["project/a/PKG-INFO".to_string()];
+    first_package.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("project/a/PKG-INFO".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("mit.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("mit-license".to_string()),
+    }];
+
+    let mut second_package = super::test_utils::package(&second_uid, "project/b/PKG-INFO");
+    second_package.datafile_paths = vec!["project/b/PKG-INFO".to_string()];
+    second_package.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some("project/b/PKG-INFO".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-hash".to_string()),
+            score: 100.0,
+            matched_length: Some(5),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("apache-2.0.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("apache-license".to_string()),
+    }];
+
+    let mut shared_file = file("project/shared/locale.po");
+    shared_file.for_packages = vec![first_uid, second_uid];
+    shared_file.license_expression = Some("free-unknown".to_string());
+    shared_file.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "free-unknown".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+        matches: vec![Match {
+            license_expression: "free-unknown".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+            from_file: Some("project/shared/locale.po".to_string()),
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("2-aho".to_string()),
+            score: 100.0,
+            matched_length: Some(11),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("free-unknown-package_1.RULE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: Some(vec!["INHERIT_LICENSE_FROM_PACKAGE".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("unknown-package-ref".to_string()),
+    }];
+
+    let mut files = vec![dir("project"), shared_file];
+    let mut packages = vec![first_package, second_package];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    let shared_file = files
+        .iter()
+        .find(|file| file.path == "project/shared/locale.po")
+        .expect("shared file should exist");
+    assert_eq!(
+        shared_file.license_expression.as_deref(),
+        Some("free-unknown")
+    );
+    assert_eq!(shared_file.license_detections[0].matches.len(), 1);
+    assert!(shared_file.license_detections[0].detection_log.is_empty());
 }
 
 #[test]

--- a/testdata/about/apipkg.ABOUT.expected.json
+++ b/testdata/about/apipkg.ABOUT.expected.json
@@ -23,24 +23,33 @@
           {
             "license_expression": "mit",
             "license_expression_spdx": "MIT",
-            "from_file": null,
-            "score": 100.0
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "mit",
+            "referenced_filenames": ["apipkg.LICENSE"]
           }
-        ],
-        "identifier": null
+        ]
       }
     ],
-    "other_license_expression": null,
-    "other_license_expression_spdx": null,
-    "other_license_detections": [],
     "extracted_license_statement": "mit",
     "file_references": [
-      { "path": "apipkg-1.4-py2.py3-none-any.whl" },
-      { "path": "apipkg.LICENSE" }
+      {
+        "path": "apipkg-1.4-py2.py3-none-any.whl"
+      },
+      {
+        "path": "apipkg.LICENSE"
+      }
     ],
     "extra_data": {
       "license_file": "apipkg.LICENSE"
     },
+    "dependencies": [],
     "datasource_id": "about_file",
     "purl": "pkg:pypi/apipkg@1.4"
   }

--- a/testdata/about/appdirs.ABOUT.expected.json
+++ b/testdata/about/appdirs.ABOUT.expected.json
@@ -24,24 +24,33 @@
           {
             "license_expression": "mit",
             "license_expression_spdx": "MIT",
-            "from_file": null,
-            "score": 100.0
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "mit",
+            "referenced_filenames": ["appdirs.LICENSE"]
           }
-        ],
-        "identifier": null
+        ]
       }
     ],
-    "other_license_expression": null,
-    "other_license_expression_spdx": null,
-    "other_license_detections": [],
     "extracted_license_statement": "mit",
     "file_references": [
-      { "path": "appdirs-1.4.3-py2.py3-none-any.whl" },
-      { "path": "appdirs.LICENSE" }
+      {
+        "path": "appdirs-1.4.3-py2.py3-none-any.whl"
+      },
+      {
+        "path": "appdirs.LICENSE"
+      }
     ],
     "extra_data": {
       "license_file": "appdirs.LICENSE"
     },
+    "dependencies": [],
     "datasource_id": "about_file",
     "purl": "pkg:pypi/appdirs@1.4.3"
   }

--- a/testdata/buck/end2end/subdir2/BUCK.expected.json
+++ b/testdata/buck/end2end/subdir2/BUCK.expected.json
@@ -3,7 +3,35 @@
     "type": "buck",
     "name": "bin",
     "parties": [],
+    "declared_license_expression": "unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+    "license_detections": [
+      {
+        "license_expression": "unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+        "matches": [
+          {
+            "license_expression": "unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "LICENSE",
+            "referenced_filenames": ["LICENSE"]
+          }
+        ]
+      }
+    ],
     "extracted_license_statement": "LICENSE",
+    "extra_data": {
+      "license_file": "LICENSE"
+    },
+    "dependencies": [],
     "datasource_id": "buck_file"
   }
 ]

--- a/testdata/cocoapods-golden/podspec/BadgeHub.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/BadgeHub.podspec.expected.json
@@ -1,36 +1,22 @@
 [
   {
     "type": "cocoapods",
-    "namespace": null,
     "name": "BadgeHub",
     "version": "0.1.1",
-    "qualifiers": {},
-    "subpath": null,
     "primary_language": "Objective-C",
     "description": "A way to quickly add a notification bedge icon to any view.\nMake any UIView a full fledged animated notification center. It is a way to quickly add a notification badge icon to a UIView. It make very easy to add badge to any view.",
-    "release_date": null,
     "parties": [
       {
         "type": "person",
         "role": "author",
         "name": "jogendra",
-        "email": "imjog24@gmail.com",
-        "url": null
+        "email": "imjog24@gmail.com"
       }
     ],
-    "keywords": [],
     "homepage_url": "https://github.com/jogendra/BadgeHub",
-    "download_url": null,
-    "size": null,
-    "sha1": null,
-    "md5": null,
-    "sha256": null,
-    "sha512": null,
     "bug_tracking_url": "https://github.com/jogendra/BadgeHub/issues/",
     "code_view_url": "https://github.com/jogendra/BadgeHub/tree/0.1.1",
     "vcs_url": "https://github.com/jogendra/BadgeHub.git",
-    "copyright": null,
-    "holder": null,
     "declared_license_expression": "mit",
     "declared_license_expression_spdx": "MIT",
     "license_detections": [
@@ -41,32 +27,24 @@
           {
             "license_expression": "mit",
             "license_expression_spdx": "MIT",
-            "from_file": null,
             "start_line": 1,
             "end_line": 1,
-            "matcher": "1-hash",
+            "matcher": "parser-declared-license",
             "score": 100.0,
-            "matched_length": 4,
+            "matched_length": 6,
             "match_coverage": 100.0,
             "rule_relevance": 100,
-            "rule_identifier": "mit_in_manifest.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
-            "matched_text": ":type = MIT, :file = LICENSE"
+            "rule_url": null,
+            "matched_text": "MIT",
+            "referenced_filenames": ["LICENSE"]
           }
-        ],
-        "identifier": "mit-74f1df5b-f94d-2423-6bb8-3e4d809c26a5"
+        ]
       }
     ],
-    "other_license_expression": null,
-    "other_license_expression_spdx": null,
-    "other_license_detections": [],
     "extracted_license_statement": ":type = MIT, :file = LICENSE",
-    "notice_text": null,
-    "source_packages": [],
-    "file_references": [],
-    "is_private": false,
-    "is_virtual": false,
-    "extra_data": {},
+    "extra_data": {
+      "license_file": "LICENSE"
+    },
     "dependencies": [],
     "repository_homepage_url": "https://cocoapods.org/pods/BadgeHub",
     "repository_download_url": "https://github.com/jogendra/BadgeHub/archive/refs/tags/0.1.1.zip",

--- a/testdata/cocoapods-golden/podspec/nanopb.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/nanopb.podspec.expected.json
@@ -1,36 +1,22 @@
 [
   {
     "type": "cocoapods",
-    "namespace": null,
     "name": "nanopb",
     "version": "1.30905.0",
-    "qualifiers": {},
-    "subpath": null,
     "primary_language": "Objective-C",
     "description": "Protocol buffers with small code size.\nNanopb is a small code-size Protocol Buffers implementation\n                    in ansi C. It is especially suitable for use in\n                    microcontrollers, but fits any memory restricted system.",
-    "release_date": null,
     "parties": [
       {
         "type": "person",
         "role": "author",
         "name": "Petteri Aimonen",
-        "email": "jpa@nanopb.mail.kapsi.fi",
-        "url": null
+        "email": "jpa@nanopb.mail.kapsi.fi"
       }
     ],
-    "keywords": [],
     "homepage_url": "https://github.com/nanopb/nanopb",
-    "download_url": null,
-    "size": null,
-    "sha1": null,
-    "md5": null,
-    "sha256": null,
-    "sha512": null,
     "bug_tracking_url": "https://github.com/nanopb/nanopb/issues/",
     "code_view_url": "https://github.com/nanopb/nanopb/tree/1.30905.0",
     "vcs_url": "https://github.com/nanopb/nanopb.git",
-    "copyright": null,
-    "holder": null,
     "declared_license_expression": "zlib",
     "declared_license_expression_spdx": "Zlib",
     "license_detections": [
@@ -41,32 +27,24 @@
           {
             "license_expression": "zlib",
             "license_expression_spdx": "Zlib",
-            "from_file": null,
             "start_line": 1,
             "end_line": 1,
-            "matcher": "1-hash",
+            "matcher": "parser-declared-license",
             "score": 100.0,
-            "matched_length": 5,
+            "matched_length": 6,
             "match_coverage": 100.0,
             "rule_relevance": 100,
-            "rule_identifier": "zlib_in_manifest.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_in_manifest.RULE",
-            "matched_text": ":type = zlib, :file = LICENSE.txt"
+            "rule_url": null,
+            "matched_text": "zlib",
+            "referenced_filenames": ["LICENSE.txt"]
           }
-        ],
-        "identifier": "zlib-3777cd8f-b515-8132-88be-cec12676bbaf"
+        ]
       }
     ],
-    "other_license_expression": null,
-    "other_license_expression_spdx": null,
-    "other_license_detections": [],
     "extracted_license_statement": ":type = zlib, :file = LICENSE.txt",
-    "notice_text": null,
-    "source_packages": [],
-    "file_references": [],
-    "is_private": false,
-    "is_virtual": false,
-    "extra_data": {},
+    "extra_data": {
+      "license_file": "LICENSE.txt"
+    },
     "dependencies": [],
     "repository_homepage_url": "https://cocoapods.org/pods/nanopb",
     "repository_download_url": "https://github.com/nanopb/nanopb/archive/refs/tags/1.30905.0.zip",

--- a/testdata/conda/meta-yaml/abeona/meta.yaml-expected.json
+++ b/testdata/conda/meta-yaml/abeona/meta.yaml-expected.json
@@ -1,28 +1,14 @@
 [
   {
     "type": "conda",
-    "namespace": null,
     "name": "abeona",
     "version": "0.45.0",
-    "qualifiers": {},
-    "subpath": null,
-    "primary_language": null,
     "description": "A simple transcriptome assembler based on kallisto and Cortex graphs.",
-    "release_date": null,
     "parties": [],
-    "keywords": [],
     "homepage_url": "https://github.com/winni2k/abeona",
     "download_url": "https://pypi.io/packages/source/a/abeona/abeona-0.45.0.tar.gz",
-    "size": null,
-    "sha1": null,
-    "md5": null,
     "sha256": "bc7512f2eef785b037d836f4cc6faded457ac277f75c6e34eccd12da7c85258f",
-    "sha512": null,
-    "bug_tracking_url": null,
-    "code_view_url": null,
     "vcs_url": "https://github.com/winni2k/abeona",
-    "copyright": null,
-    "holder": null,
     "declared_license_expression": "apache-2.0",
     "declared_license_expression_spdx": "Apache-2.0",
     "license_detections": [
@@ -33,34 +19,25 @@
           {
             "license_expression": "apache-2.0",
             "license_expression_spdx": "Apache-2.0",
-            "from_file": null,
             "start_line": 1,
             "end_line": 1,
-            "matcher": "1-hash",
+            "matcher": "parser-declared-license",
             "score": 100.0,
-            "matched_length": 3,
+            "matched_length": 2,
             "match_coverage": 100.0,
             "rule_relevance": 100,
-            "rule_identifier": "apache-2.0_292.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_292.RULE",
-            "matched_text": "license Apache Software"
+            "rule_url": null,
+            "matched_text": "Apache Software",
+            "referenced_filenames": ["LICENSE"]
           }
-        ],
-        "identifier": "apache_2_0-b61e521f-8056-676d-d623-119feca87b8c"
+        ]
       }
     ],
-    "other_license_expression": null,
-    "other_license_expression_spdx": null,
-    "other_license_detections": [],
     "extracted_license_statement": "Apache Software",
-    "notice_text": null,
-    "source_packages": [],
-    "file_references": [],
-    "is_private": false,
-    "is_virtual": false,
     "extra_data": {
       "host": ["pip", "python"],
-      "run": ["python >=3.6"]
+      "run": ["python >=3.6"],
+      "license_file": "LICENSE"
     },
     "dependencies": [
       {
@@ -70,9 +47,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/nextflow@19.01.0",
@@ -81,9 +56,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/cortexpy@0.45.7",
@@ -92,9 +65,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/kallisto@0.44.0",
@@ -103,9 +74,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/bwa",
@@ -114,9 +83,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/pandas",
@@ -125,9 +92,7 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       },
       {
         "purl": "pkg:conda/progressbar2",
@@ -136,14 +101,9 @@
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
-        "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "is_direct": true
       }
     ],
-    "repository_homepage_url": null,
-    "repository_download_url": null,
-    "api_data_url": null,
     "datasource_id": "conda_meta_yaml",
     "purl": "pkg:conda/abeona@0.45.0"
   }

--- a/testdata/meson-golden/literal-root/meson.build-expected.json
+++ b/testdata/meson-golden/literal-root/meson.build-expected.json
@@ -5,11 +5,35 @@
     "version": "1.2.3",
     "primary_language": "c",
     "parties": [],
+    "declared_license_expression": "unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+    "license_detections": [
+      {
+        "license_expression": "unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+        "matches": [
+          {
+            "license_expression": "unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 2,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "BSD-2-Clause\nGPL-2.0-or-later",
+            "referenced_filenames": ["COPYING", "LICENSES/BSD"]
+          }
+        ]
+      }
+    ],
     "extracted_license_statement": "BSD-2-Clause\nGPL-2.0-or-later",
     "extra_data": {
       "license_files": ["COPYING", "LICENSES/BSD"],
-      "languages": ["c", "cpp"],
-      "meson_version": ">=0.47.0"
+      "meson_version": ">=0.47.0",
+      "languages": ["c", "cpp"]
     },
     "dependencies": [
       {
@@ -32,11 +56,11 @@
         "is_pinned": false,
         "is_direct": true,
         "extra_data": {
-          "modules": ["core", "extra"],
-          "method": "system",
           "native": true,
+          "required": false,
           "fallback": ["threads-subproject", "threads_dep"],
-          "required": false
+          "method": "system",
+          "modules": ["core", "extra"]
         }
       },
       {

--- a/testdata/nuget-golden/fizzler/Fizzler.nuspec.expected
+++ b/testdata/nuget-golden/fizzler/Fizzler.nuspec.expected
@@ -14,11 +14,37 @@
     "homepage_url": "https://github.com/atifaziz/Fizzler",
     "vcs_url": "Git+https://github.com/atifaziz/Fizzler",
     "copyright": "Copyright © 2009 Atif Aziz, Colin Ramsay. All rights reserved. Portions Copyright © 2008 Novell, Inc.",
+    "declared_license_expression": "unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+    "license_detections": [
+      {
+        "license_expression": "unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+        "matches": [
+          {
+            "license_expression": "unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "COPYING.txt",
+            "referenced_filenames": [
+              "COPYING.txt"
+            ]
+          }
+        ]
+      }
+    ],
     "extracted_license_statement": "COPYING.txt",
     "extra_data": {
-      "license_type": "file",
       "repository_commit": "8323ec7a49ce5dff579b1aa146492ee7aa0ab10d",
-      "license_file": "COPYING.txt"
+      "license_file": "COPYING.txt",
+      "license_type": "file"
     },
     "dependencies": [
       {
@@ -30,8 +56,8 @@
         "is_pinned": false,
         "is_direct": true,
         "extra_data": {
-          "framework": ".NETStandard1.0",
-          "exclude": "Build,Analyzers"
+          "exclude": "Build,Analyzers",
+          "framework": ".NETStandard1.0"
         }
       },
       {

--- a/testdata/nuget-golden/nupkg/Fizzler.1.3.0.nupkg.expected.json
+++ b/testdata/nuget-golden/nupkg/Fizzler.1.3.0.nupkg.expected.json
@@ -11,11 +11,36 @@
         "name": "Atif Aziz"
       }
     ],
+    "declared_license_expression": "unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+    "license_detections": [
+      {
+        "license_expression": "unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+        "matches": [
+          {
+            "license_expression": "unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 6,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_url": null,
+            "matched_text": "GNU GENERAL PUBLIC LICENSE\nVersion 2\n",
+            "referenced_filenames": ["COPYING.txt"]
+          }
+        ]
+      }
+    ],
     "extracted_license_statement": "GNU GENERAL PUBLIC LICENSE\nVersion 2\n",
     "extra_data": {
-      "license_file": "COPYING.txt",
-      "license_type": "file"
+      "license_type": "file",
+      "license_file": "COPYING.txt"
     },
+    "dependencies": [],
     "repository_homepage_url": "https://www.nuget.org/packages/Fizzler/1.3.0",
     "repository_download_url": "https://www.nuget.org/api/v2/package/Fizzler/1.3.0",
     "api_data_url": "https://api.nuget.org/v3/registration3/fizzler/1.3.0.json",


### PR DESCRIPTION
## Summary

- Extend the package/reference consumer branch beyond explicit manifest-local filenames by following ScanCode's `INHERIT_LICENSE_FROM_PACKAGE` sentinel, so package-owned files can inherit license detections from their owning package and fall back to root legal files when no package exists.
- Keep the shared parser finalizer and package-context consumer rollout for parser families that already expose local license-file metadata, so declared-license references remain followable through the existing package/reference pipeline.
- Keep the branch scoped to package/reference consumers: parser-normalized references become followable, package-origin detections and assembled packages stay in sync, and no unrelated CLI/output redesign is bundled in.

## Scope and exclusions

- Included: shared declared-license reference finalization in parser dispatch, parser coverage for Cargo/Python/ABOUT/Meson/NuGet/Pixi/Podspec/Podspec JSON, package-data/package sync after following, explicit manifest/file reference follow-up, package-context inheritance via `INHERIT_LICENSE_FROM_PACKAGE`, and root fallback when no package can answer the reference.
- Explicit exclusions: parsers that do not currently expose local license filename metadata at all, broader package-wide inheritance beyond upstream's sentinel-driven cases, and richer loader/index metadata retention.

## Intentional differences from Python

- This branch wires every parser that already surfaces license/notice filenames into the reference-following seam, but it does not invent filename metadata for parsers that still do not expose it.
- Package-context inheritance is limited to the same sentinel-driven upstream cases (`INHERIT_LICENSE_FROM_PACKAGE`) instead of broad heuristics over arbitrary unknown references.
- Package synchronization follows the current assembled package identity/path model rather than re-running assembly after every follow-up mutation.

## Validation

- `cargo test --no-run`
- focused parser tests for Cargo, Python metadata, ABOUT, Meson, NuGet file licenses, Pixi, Podspec, and Podspec JSON referenced-filename propagation
- focused package reference-following tests for manifest-origin local-file follow, package-context inheritance, root fallback when no package exists, and ambiguous multi-package guards
- `cargo test post_processing::output_test::`
- `cargo clippy --tests -- -D warnings`
- `npm run check:docs`