### PR TITLE
fix(scanner): replace tokei with file-identify detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -137,15 +137,6 @@ name = "ar"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arrayref"
@@ -359,28 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.3",
- "phf_codegen",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,16 +367,6 @@ checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
-]
-
-[[package]]
-name = "clap-cargo"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
-dependencies = [
- "anstyle",
- "clap",
 ]
 
 [[package]]
@@ -453,16 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +420,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -535,15 +484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -665,21 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "serde",
-]
-
-[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,17 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -818,15 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
-
-[[package]]
 name = "enum-display-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,18 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -938,6 +832,21 @@ name = "file-format"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d9ccda37e95b4f0978a3074b4a9939979103a7256459cfb449c9c84d1adf23"
+
+[[package]]
+name = "file-identify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76557a9e4e1e2d1184808a7c5e7171fe17f818e0b91e252ae42202972b45babf"
+dependencies = [
+ "clap",
+ "once_cell",
+ "phf 0.12.1",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "filetime"
@@ -1082,30 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grep-matcher"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "grep-searcher"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
-dependencies = [
- "bstr",
- "encoding_rs",
- "encoding_rs_io",
- "grep-matcher",
- "log",
- "memchr",
- "memmap2",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,24 +1049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -1574,17 +1441,6 @@ dependencies = [
 
 [[package]]
 name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
-name = "json5"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
@@ -1700,7 +1556,7 @@ dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1714,15 +1570,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1828,15 +1675,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mime"
@@ -2011,38 +1849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.18",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,11 +2002,22 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_macros 0.12.1",
+ "phf_shared 0.12.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -2227,12 +2044,35 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_generator"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+dependencies = [
+ "phf_generator 0.12.1",
+ "phf_shared 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2253,6 +2093,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -2387,6 +2236,7 @@ dependencies = [
  "deunicode",
  "env_logger",
  "file-format",
+ "file-identify",
  "flate2",
  "glob",
  "hex",
@@ -2395,7 +2245,7 @@ dependencies = [
  "indicatif",
  "indicatif-log-bridge",
  "inventory",
- "json5 1.3.1",
+ "json5",
  "kamadak-exif",
  "lazy_static",
  "liblzma",
@@ -2425,8 +2275,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tera",
- "tokei",
- "toml 1.1.0+spec-1.1.0",
+ "toml",
  "unicode-normalization",
  "url",
  "urlencoding",
@@ -2546,15 +2395,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2691,7 +2531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2773,12 +2613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,15 +2660,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2930,16 +2755,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -3047,17 +2862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "table_formatter"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef5d3fd5472c911d41286849de6a9aee93327f7fae9fb9148fe9ff0102c17d"
-dependencies = [
- "colored",
- "itertools 0.11.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,7 +2882,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3087,30 +2891,14 @@ version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
 dependencies = [
- "chrono",
- "chrono-tz",
  "globwalk",
- "humansize",
  "lazy_static",
- "percent-encoding",
  "pest",
  "pest_derive",
- "rand",
  "regex",
  "serde",
  "serde_json",
- "slug",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3233,47 +3021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokei"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de7875c0c312f30e090edb0da5df9f6586033132d36d94c8f9133e82826797"
-dependencies = [
- "aho-corasick",
- "arbitrary",
- "clap-cargo",
- "crossbeam-channel",
- "dashmap",
- "encoding_rs_io",
- "etcetera",
- "grep-searcher",
- "ignore",
- "json5 0.4.1",
- "log",
- "once_cell",
- "parking_lot",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "table_formatter",
- "tera",
- "term_size",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,20 +3028,11 @@ checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -3307,33 +3045,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3695,35 +3413,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3786,159 +3482,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ blake3 = "1.8.4"
 once_cell = "1.21.4"
 deunicode = "1.6.2"
 tera = { version = "1.20.1", default-features = false }
-tokei = { version = "14.0.0", default-features = false }
+file-identify = "0.2.0"
 env_logger = "0.11.10"
 ar = "0.9"           # Unix ar archive format (for .deb)
 rpm = { version = "0.19.0", default-features = false, features = ["gzip-compression", "xz-compression", "zstd-compression", "bzip2-compression"] }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1644,4 +1644,68 @@ mod tests {
         assert!(classification.is_script);
         assert_eq!(classification.file_type, "python script, text executable");
     }
+
+    #[test]
+    fn test_classify_file_info_preserves_language_detection_precedence_matrix() {
+        let cases = [
+            (
+                Path::new("bin/run"),
+                b"#!/usr/bin/env node\nconsole.log('hello');\n".as_slice(),
+                Some("JavaScript"),
+                true,
+                true,
+            ),
+            (
+                Path::new("Dockerfile"),
+                b"FROM scratch\n".as_slice(),
+                Some("Dockerfile"),
+                true,
+                false,
+            ),
+            (
+                Path::new("package.json"),
+                br#"{"name":"demo"}"#.as_slice(),
+                None,
+                false,
+                false,
+            ),
+            (
+                Path::new("config.yaml"),
+                b"key: value\n".as_slice(),
+                None,
+                false,
+                false,
+            ),
+            (
+                Path::new("Makefile"),
+                b"all:\n\techo hi\n".as_slice(),
+                None,
+                false,
+                false,
+            ),
+        ];
+
+        for (path, bytes, expected_language, expected_is_source, expected_is_script) in cases {
+            let classification = classify_file_info(path, bytes);
+
+            assert_eq!(
+                classification.programming_language.as_deref(),
+                expected_language,
+                "unexpected language for {}",
+                path.display()
+            );
+            assert_eq!(
+                classification.is_source,
+                expected_is_source,
+                "unexpected is_source for {}",
+                path.display()
+            );
+            assert_eq!(
+                classification.is_script,
+                expected_is_script,
+                "unexpected is_script for {}",
+                path.display()
+            );
+        }
+    }
 }

--- a/src/utils/language.rs
+++ b/src/utils/language.rs
@@ -1,7 +1,8 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use content_inspector::{ContentType, inspect};
-use tokei::LanguageType;
+use file_identify::tags_from_filename;
 
 fn is_utf8_text(content_type: ContentType) -> bool {
     content_type == ContentType::UTF_8 || content_type == ContentType::UTF_8_BOM
@@ -14,11 +15,11 @@ pub fn detect_language(path: &Path, content: &[u8]) -> Option<String> {
         return Some(language);
     }
 
-    if let Some(language) = detect_special_file_name_language(path) {
+    if let Some(language) = detect_file_identify_language(path) {
         return Some(language);
     }
 
-    if let Some(language) = detect_tokei_extension_language(path) {
+    if let Some(language) = detect_repo_special_file_name_language(path) {
         return Some(language);
     }
 
@@ -89,7 +90,136 @@ fn detect_shebang_language(content: &[u8]) -> Option<String> {
     }
 }
 
-fn detect_special_file_name_language(path: &Path) -> Option<String> {
+fn detect_file_identify_language(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    let tags = tags_from_filename(file_name);
+
+    map_file_identify_tags(&tags).map(str::to_string)
+}
+
+fn map_file_identify_tags(tags: &HashSet<&'static str>) -> Option<&'static str> {
+    if tags.contains("dockerfile") {
+        return Some("Dockerfile");
+    }
+    if tags.contains("makefile") {
+        return Some("Makefile");
+    }
+    if tags.contains("rust") {
+        return Some("Rust");
+    }
+    if tags.contains("python") {
+        return Some("Python");
+    }
+    if tags.contains("javascript") || tags.contains("jsx") {
+        return Some("JavaScript");
+    }
+    if tags.contains("ts") || tags.contains("tsx") {
+        return Some("TypeScript");
+    }
+    if tags.contains("html") {
+        return Some("HTML");
+    }
+    if tags.contains("css") {
+        return Some("CSS");
+    }
+    if tags.contains("c") {
+        return Some("C");
+    }
+    if tags.contains("cpp") {
+        return Some("C++");
+    }
+    if tags.contains("java") {
+        return Some("Java");
+    }
+    if tags.contains("go") {
+        return Some("Go");
+    }
+    if tags.contains("ruby") {
+        return Some("Ruby");
+    }
+    if tags.contains("php") {
+        return Some("PHP");
+    }
+    if tags.contains("perl") {
+        return Some("Perl");
+    }
+    if tags.contains("swift") {
+        return Some("Swift");
+    }
+    if tags.contains("shell") || tags.contains("bash") || tags.contains("zsh") {
+        return Some("Shell");
+    }
+    if tags.contains("kotlin") {
+        return Some("Kotlin");
+    }
+    if tags.contains("dart") {
+        return Some("Dart");
+    }
+    if tags.contains("scala") {
+        return Some("Scala");
+    }
+    if tags.contains("csharp") {
+        return Some("C#");
+    }
+    if tags.contains("fsharp") {
+        return Some("F#");
+    }
+    if tags.contains("r") {
+        return Some("R");
+    }
+    if tags.contains("lua") {
+        return Some("Lua");
+    }
+    if tags.contains("julia") {
+        return Some("Julia");
+    }
+    if tags.contains("elixir") {
+        return Some("Elixir");
+    }
+    if tags.contains("clojure") {
+        return Some("Clojure");
+    }
+    if tags.contains("haskell") {
+        return Some("Haskell");
+    }
+    if tags.contains("erlang") {
+        return Some("Erlang");
+    }
+    if tags.contains("sql") {
+        return Some("SQL");
+    }
+    if tags.contains("tex") {
+        return Some("TeX");
+    }
+    if tags.contains("groovy") || tags.contains("gradle") {
+        return Some("Groovy");
+    }
+    if tags.contains("nix") {
+        return Some("Nix");
+    }
+    if tags.contains("zig") {
+        return Some("Zig");
+    }
+    if tags.contains("powershell") {
+        return Some("PowerShell");
+    }
+    if tags.contains("starlark") {
+        return Some("Starlark");
+    }
+    if tags.contains("awk") {
+        return Some("Awk");
+    }
+    if tags.contains("ocaml") {
+        return Some("OCaml");
+    }
+    if tags.contains("meson") {
+        return Some("Meson");
+    }
+
+    None
+}
+
+fn detect_repo_special_file_name_language(path: &Path) -> Option<String> {
     let file_name = path
         .file_name()
         .and_then(|n| n.to_str())
@@ -98,13 +228,6 @@ fn detect_special_file_name_language(path: &Path) -> Option<String> {
 
     if matches!(
         file_name.as_str(),
-        "dockerfile" | "containerfile" | "containerfile.core"
-    ) {
-        Some("Dockerfile".to_string())
-    } else if matches!(file_name.as_str(), "makefile" | "makefile.inc") {
-        Some("Makefile".to_string())
-    } else if matches!(
-        file_name.as_str(),
         "gemfile" | "rakefile" | "podfile" | "vagrantfile" | "brewfile"
     ) {
         Some("Ruby".to_string())
@@ -112,6 +235,8 @@ fn detect_special_file_name_language(path: &Path) -> Option<String> {
         Some("Shell".to_string())
     } else if matches!(file_name.as_str(), "meson.build") {
         Some("Meson".to_string())
+    } else if matches!(file_name.as_str(), "containerfile.core") {
+        Some("Dockerfile".to_string())
     } else if matches!(file_name.as_str(), "build" | "workspace" | "buck") {
         Some("Starlark".to_string())
     } else if matches!(
@@ -122,12 +247,6 @@ fn detect_special_file_name_language(path: &Path) -> Option<String> {
     } else {
         None
     }
-}
-
-fn detect_tokei_extension_language(path: &Path) -> Option<String> {
-    let extension = path.extension()?.to_str()?.to_ascii_lowercase();
-    let language = LanguageType::from_file_extension(&extension)?;
-    map_tokei_language(language).map(str::to_string)
 }
 
 fn detect_manual_extension_language(path: &Path) -> Option<String> {
@@ -176,47 +295,6 @@ fn detect_manual_extension_language(path: &Path) -> Option<String> {
         "bzl" | "bazel" | "star" | "sky" => Some("Starlark".to_string()),
         "awk" => Some("Awk".to_string()),
         "ml" | "mli" => Some("OCaml".to_string()),
-        _ => None,
-    }
-}
-
-fn map_tokei_language(language: LanguageType) -> Option<&'static str> {
-    match language {
-        LanguageType::Rust => Some("Rust"),
-        LanguageType::Python => Some("Python"),
-        LanguageType::JavaScript | LanguageType::Jsx => Some("JavaScript"),
-        LanguageType::TypeScript | LanguageType::Tsx => Some("TypeScript"),
-        LanguageType::Html => Some("HTML"),
-        LanguageType::Css => Some("CSS"),
-        LanguageType::C | LanguageType::CHeader => Some("C"),
-        LanguageType::Cpp | LanguageType::CppHeader | LanguageType::CppModule => Some("C++"),
-        LanguageType::AssemblyGAS => Some("GAS"),
-        LanguageType::Java => Some("Java"),
-        LanguageType::Go => Some("Go"),
-        LanguageType::Ruby | LanguageType::Rakefile => Some("Ruby"),
-        LanguageType::Php => Some("PHP"),
-        LanguageType::Perl => Some("Perl"),
-        LanguageType::Swift => Some("Swift"),
-        LanguageType::Bash
-        | LanguageType::CShell
-        | LanguageType::Fish
-        | LanguageType::Ksh
-        | LanguageType::Sh
-        | LanguageType::Zsh => Some("Shell"),
-        LanguageType::Kotlin => Some("Kotlin"),
-        LanguageType::Dart => Some("Dart"),
-        LanguageType::Scala => Some("Scala"),
-        LanguageType::CSharp => Some("C#"),
-        LanguageType::FSharp => Some("F#"),
-        LanguageType::R => Some("R"),
-        LanguageType::Lua => Some("Lua"),
-        LanguageType::Julia => Some("Julia"),
-        LanguageType::Elixir => Some("Elixir"),
-        LanguageType::Clojure | LanguageType::ClojureC => Some("Clojure"),
-        LanguageType::Haskell => Some("Haskell"),
-        LanguageType::Erlang => Some("Erlang"),
-        LanguageType::Sql => Some("SQL"),
-        LanguageType::Tex => Some("TeX"),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- Replace `tokei` with `file-identify` for filename and extension-based language detection while keeping the existing shebang-first classification flow.
- Preserve the current scanner behavior for `package.json`, YAML, `Dockerfile`, `Makefile`, and script detection by keeping the downstream policy layer unchanged and adding a precedence regression test.
- Reduce dependency graph churn: the lockfile drops 49 packages overall and duplicate crate names drop from 38 to 24.

## Scope and exclusions

- Included:
  - swap the language-detection dependency from `tokei` to `file-identify`
  - map `file-identify` tags back to the repo's existing canonical language names
  - keep repo-specific fallback rules for cases not comfortably covered by `file-identify`
  - add an end-to-end classification precedence regression test
- Explicit exclusions:
  - no changes to the scanner's source/script policy layer beyond preserving current behavior
  - no changes to `rpm`, `pdf_oxide`, or other remaining duplicate-heavy dependencies

## Follow-up work

- Created or intentionally deferred:
  - consider centralizing the language/tag mapping and downstream source/script rules later to reduce drift across classification layers