### PR TITLE
fix(license): align spdx id match parity

### DIFF
--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{KnownToken, QueryToken, TokenId, TokenKind};
+use crate::license_detection::spdx_lid::split_spdx_lid;
 use crate::license_detection::tokenize::STOPWORDS;
 use crate::license_detection::tokenize::tokenize_as_ids;
 use bit_set::BitSet;
@@ -566,11 +567,14 @@ impl<'a> Query<'a> {
             if let Some(offset) = spdx_start_offset
                 && let Some(line_first_known_pos) = line_first_known_pos
             {
+                let (spdx_prefix, spdx_expression) = split_spdx_lid(line);
+                let spdx_text = format!("{}{}", spdx_prefix.unwrap_or_default(), spdx_expression);
                 let spdx_start_known_pos = line_first_known_pos + offset as i32;
+
                 if spdx_start_known_pos <= line_last_known_pos {
                     let spdx_start = spdx_start_known_pos as usize;
                     let spdx_end = (line_last_known_pos + 1) as usize;
-                    spdx_lines.push((line_trimmed.to_string(), spdx_start, spdx_end));
+                    spdx_lines.push((spdx_text, spdx_start, spdx_end));
                 }
             }
 

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -14,6 +14,7 @@
 //! This enables correct `start_token` and `end_token` values in LicenseMatches.
 
 use regex::Regex;
+use sha1::{Digest, Sha1};
 
 use crate::license_detection::expression::{LicenseExpression, parse_expression};
 use crate::license_detection::index::LicenseIndex;
@@ -160,6 +161,48 @@ pub(crate) fn normalize_spdx_key(key: &str) -> String {
     key.to_lowercase().replace("_", "-")
 }
 
+fn python_safe_name(s: &str) -> String {
+    let mut result = String::new();
+    let mut prev_underscore = false;
+
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            result.push(c);
+            prev_underscore = false;
+        } else if !prev_underscore {
+            result.push('_');
+            prev_underscore = true;
+        }
+    }
+
+    result.trim_matches('_').to_string()
+}
+
+fn python_str_repr(s: &str) -> String {
+    if s.contains('\'') && !s.contains('"') {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+    }
+}
+
+fn synthetic_spdx_rule_identifier(license_expression: &str, text: &str) -> String {
+    let mut hasher = Sha1::new();
+    let content = format!(
+        "{}{}",
+        python_str_repr(license_expression),
+        python_str_repr(text)
+    );
+    hasher.update(content.as_bytes());
+    let digest = hex::encode(hasher.finalize());
+
+    format!(
+        "spdx-license-identifier-{}-{}",
+        python_safe_name(license_expression),
+        digest
+    )
+}
+
 const DEPRECATED_SPDX_EXPRESSION_SUBS: &[(&str, &str)] = &[
     ("ecos-2.0", "gpl-2.0-plus with ecos-exception-2.0"),
     (
@@ -277,45 +320,28 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
         if let Some(license_expression) =
             find_matching_rule_for_expression(index, &resolved_expression)
         {
-            let matched_length = spdx_expression.len();
+            let matched_length = end_token.saturating_sub(*start_token);
             let match_coverage = 100.0;
 
             let start_line = query.line_for_pos(*start_token).unwrap_or(1);
-            let end_line = query.line_for_pos(*end_token).unwrap_or(start_line);
+            let end_line = end_token
+                .checked_sub(1)
+                .and_then(|pos| query.line_for_pos(pos))
+                .unwrap_or(start_line);
 
-            let (rid, rule_relevance, rule_identifier, rule_url, rule_length, referenced_filenames) =
-                index
-                    .rid_by_spdx_key
-                    .get(&license_expression)
-                    .map(|&rid| {
-                        let rule = &index.rules_by_rid[rid];
-                        (
-                            rid,
-                            rule.relevance,
-                            rule.identifier.clone(),
-                            rule.rule_url().unwrap_or_default(),
-                            rule.tokens.len(),
-                            rule.referenced_filenames.clone(),
-                        )
-                    })
-                    .unwrap_or_else(|| {
-                        let unknown_rid = index.unknown_spdx_rid.unwrap_or(0);
-                        if unknown_rid < index.rules_by_rid.len() {
-                            let rule = &index.rules_by_rid[unknown_rid];
-                            (
-                                unknown_rid,
-                                rule.relevance,
-                                rule.identifier.clone(),
-                                rule.rule_url().unwrap_or_default(),
-                                rule.tokens.len(),
-                                rule.referenced_filenames.clone(),
-                            )
-                        } else {
-                            (0, 100_u8, String::new(), String::new(), 0_usize, None)
-                        }
-                    });
+            let rid = index
+                .rid_by_spdx_key
+                .get(&resolved_expression)
+                .copied()
+                .or(index.unknown_spdx_rid)
+                .unwrap_or(0);
 
-            let score = rule_relevance as f32 / 100.0;
+            let rule_relevance = 100;
+            let rule_identifier = synthetic_spdx_rule_identifier(&license_expression, spdx_text);
+            let rule_url = String::new();
+            let rule_length = matched_length;
+            let referenced_filenames = None;
+            let score = 100.0;
 
             let license_match = LicenseMatch {
                 license_expression,

--- a/src/license_detection/spdx_lid/test.rs
+++ b/src/license_detection/spdx_lid/test.rs
@@ -326,6 +326,16 @@ mod tests {
         assert_eq!(matches[0].start_line, 1);
         assert_eq!(matches[0].end_line, 1);
         assert_eq!(matches[0].matcher, MATCH_SPDX_ID);
+        assert_eq!(matches[0].matched_length, 4);
+        assert_eq!(matches[0].rule_length, 4);
+        assert_eq!(matches[0].score, 100.0);
+        assert_eq!(matches[0].rule_relevance, 100);
+        assert!(
+            matches[0]
+                .rule_identifier
+                .starts_with("spdx-license-identifier-mit-")
+        );
+        assert!(matches[0].rule_url.is_empty());
     }
 
     #[test]
@@ -381,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_spdx_lid_match_score_from_relevance() {
+    fn test_spdx_lid_match_uses_synthetic_rule_metadata() {
         let mut index = create_test_index(
             &[("spdx", 0), ("license", 1), ("identifier", 2), ("mit", 3)],
             3,
@@ -393,7 +403,37 @@ mod tests {
         let matches = spdx_lid_match(&index, &query);
 
         assert_eq!(matches.len(), 1);
-        assert!((matches[0].score - 0.8).abs() < 0.01);
+        assert_eq!(matches[0].score, 100.0);
+        assert_eq!(matches[0].rule_relevance, 100);
+        assert!(
+            matches[0]
+                .rule_identifier
+                .starts_with("spdx-license-identifier-mit-")
+        );
+        assert!(matches[0].rule_url.is_empty());
+    }
+
+    #[test]
+    fn test_spdx_lid_match_uses_full_line_span_when_expression_tokens_are_unknown() {
+        let mut index = create_test_index(&[("spdx", 0), ("license", 1), ("identifier", 2)], 3);
+        let apache_rid = index.rules_by_rid.len();
+        index
+            .rules_by_rid
+            .push(create_mock_rule_simple("apache-2.0", 100));
+        index
+            .rid_by_spdx_key
+            .insert("apache-2.0".to_string(), apache_rid);
+
+        let text = "// SPDX-License-Identifier: Apache-2.0\nconst answer = 42;";
+        let query = Query::from_extracted_text(text, &index, false).unwrap();
+        let matches = spdx_lid_match(&index, &query);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start_line, 1);
+        assert_eq!(matches[0].end_line, 1);
+        assert_eq!(matches[0].matched_length, 3);
+        assert_eq!(matches[0].rule_length, 3);
+        assert_eq!(matches[0].score, 100.0);
     }
 
     #[test]
@@ -607,6 +647,56 @@ mod tests {
                 "Token positions should be valid (not hardcoded 0, 0)"
             );
         }
+    }
+
+    #[test]
+    fn test_spdx_match_respects_prefix_offset_on_same_line() {
+        let mut index = create_test_index(
+            &[
+                ("notice", 0),
+                ("spdx", 1),
+                ("license", 2),
+                ("identifier", 3),
+                ("mit", 4),
+            ],
+            1,
+        );
+        index.rules_by_rid.push(create_mock_rule_simple("mit", 100));
+        index.rid_by_spdx_key.insert("mit".to_string(), 0);
+
+        let text = "NOTICE SPDX-License-Identifier: MIT";
+        let query = Query::from_extracted_text(text, &index, false).unwrap();
+        let matches = spdx_lid_match(&index, &query);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start_token, 1);
+        assert_eq!(matches[0].end_token, 5);
+        assert_eq!(matches[0].matched_length, 4);
+    }
+
+    #[test]
+    fn test_spdx_match_rule_identifier_preserves_trailing_expression_spaces() {
+        let mut index = create_test_index(
+            &[("spdx", 0), ("license", 1), ("identifier", 2), ("mit", 3)],
+            1,
+        );
+        index.rules_by_rid.push(create_mock_rule_simple("mit", 100));
+        index.rid_by_spdx_key.insert("mit".to_string(), 0);
+
+        let plain =
+            Query::from_extracted_text("// SPDX-License-Identifier: MIT", &index, false).unwrap();
+        let spaced =
+            Query::from_extracted_text("// SPDX-License-Identifier: MIT  ", &index, false).unwrap();
+
+        let plain_matches = spdx_lid_match(&index, &plain);
+        let spaced_matches = spdx_lid_match(&index, &spaced);
+
+        assert_eq!(plain_matches.len(), 1);
+        assert_eq!(spaced_matches.len(), 1);
+        assert_ne!(
+            plain_matches[0].rule_identifier, spaced_matches[0].rule_identifier,
+            "Synthetic SPDX identifiers should preserve trailing expression whitespace like ScanCode"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- align `1-spdx-id` matches with ScanCode-style SPDX parity by restoring synthetic rule identifiers, `null` rule URLs, and `100.0` scores for SPDX tag matches
- fix SPDX query span handling so same-line prefixes, single-line end positions, and trailing-space-sensitive synthetic IDs follow the ScanCode matching model more closely
- add focused regressions for unknown-token SPDX expressions, prefix offsets, and synthetic identifier stability

## Scope and exclusions

- Included: `Query::spdx_lines` construction, SPDX match metadata/scoring in `spdx_lid_match`, and SPDX-specific regression tests
- Explicit exclusions: broader non-SPDX score parity changes and expected-output fixture updates

## Intentional differences from Python

- None intended; this change narrows Provenant's `1-spdx-id` behavior toward ScanCode parity.