### PR TITLE
fix(ci): tighten unused dependency checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,18 +170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,20 +270,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "blake3"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
 
 [[package]]
 name = "block-buffer"
@@ -848,12 +822,6 @@ dependencies = [
  "syn 2.0.117",
  "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diff"
@@ -1544,25 +1512,6 @@ checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -2813,7 +2762,6 @@ dependencies = [
  "ar",
  "base64",
  "bit-set 0.9.1",
- "blake3",
  "bzip2",
  "chrono",
  "clap",
@@ -2821,7 +2769,6 @@ dependencies = [
  "csv",
  "daachorse",
  "derive_builder",
- "deunicode",
  "env_logger",
  "file-format",
  "file-identify",
@@ -2829,7 +2776,6 @@ dependencies = [
  "glob",
  "hex",
  "image 0.25.10",
- "include_dir",
  "indicatif",
  "indicatif-log-bridge",
  "inventory",
@@ -2865,11 +2811,8 @@ dependencies = [
  "tempfile",
  "tera",
  "toml",
- "unicode-normalization",
  "url",
- "urlencoding",
  "uuid",
- "xml-rs",
  "yaml_serde",
  "zip",
  "zstd",
@@ -4268,21 +4211,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
-]
-
-[[package]]
-name = "xml"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
-
-[[package]]
-name = "xml-rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
-dependencies = [
- "xml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ lazy_static = { workspace = true }
 liblzma = "0.4.6"
 log = "0.4.29"
 regex = { workspace = true }
-unicode-normalization = "0.1.25"
 base64 = "0.22.1"
 chrono = "0.4.44"
 clap = { workspace = true }
@@ -79,7 +78,6 @@ zstd = { workspace = true }
 derive_builder = "0.20.2"
 glob = "0.3.3"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
-include_dir = "0.7.4"
 indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"
 json5 = "1.3.1"
@@ -103,14 +101,10 @@ tar = "0.4.45"
 tempfile = { workspace = true }
 toml = "1.0.6"
 url = { workspace = true }
-urlencoding = "2.1.3"
-xml-rs = "1.0.0"
 quick-xml = "0.39.2"
 zip = "8.4.0"
 uuid = { version = "1.23.0", features = ["v4"] }
-blake3 = "1.8.4"
 once_cell = "1.21.4"
-deunicode = "1.6.2"
 tera = { version = "1.20.1", default-features = false }
 file-identify = "0.2.0"
 env_logger = "0.11.10"

--- a/scripts/check_unused_deps.sh
+++ b/scripts/check_unused_deps.sh
@@ -1,22 +1,12 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 if ! command -v cargo-machete &> /dev/null; then
     echo "Installing cargo-machete..."
     cargo install cargo-machete
 fi
 
-# cargo machete exits 1 when *any* Cargo.toml has unused deps (including testdata fixtures).
-# We only care about our own Cargo.toml, so we capture output and check manually.
-# Runs without --with-metadata to avoid generating stray Cargo.lock files in submodules.
-# False positives from renamed crates (e.g. md-5 -> md5) are handled via
-# [package.metadata.cargo-machete] ignored list in Cargo.toml.
-output=$(cargo machete 2>&1 || true)
+cargo machete ./Cargo.toml
+cargo machete ./xtask/Cargo.toml
 
-if echo "$output" | grep -q "^provenant -- ./Cargo.toml:"; then
-    echo "Unused dependencies found in Cargo.toml:"
-    echo "$output" | sed -n '/^provenant/,/^$/p'
-    exit 1
-fi
-
-echo "No unused dependencies in Cargo.toml."
+echo "No unused dependencies in checked Cargo.toml files."


### PR DESCRIPTION
## Summary

- scope the unused dependency check to the first-party root manifests instead of scraping a whole-repo `cargo machete` run
- include `xtask/Cargo.toml` in that check so both maintained workspace manifests are covered
- remove the unused root dependencies surfaced by the corrected check: `xml-rs`, `blake3`, `deunicode`, `include_dir`, `unicode-normalization`, and `urlencoding`

## Scope and exclusions

- Included: `Cargo.toml` / `Cargo.lock` cleanup and `scripts/check_unused_deps.sh` hardening
- Explicit exclusions: no `content_inspector` replacement and no parser or output behavior changes

## Follow-up work

- Created or intentionally deferred: `content_inspector` remains the next deeper dependency review because it is used on the core file-classification path and is not a simple cleanup