### PR TITLE
refactor(license): make match coordinates explicit

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -10,7 +10,7 @@
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::QueryRun;
 
@@ -149,41 +149,40 @@ pub fn aho_match_with_extra_matchables(
 
             let qspan = PositionSpan::range(qstart, qend);
             let ispan = PositionSpan::range(0, matched_length);
+            let hispan = PositionSpan::from_positions(
+                (0..matched_length)
+                    .filter(|&p| index.dictionary.token_kind(rule_tids[p]) == TokenKind::Legalese),
+            );
 
-            let license_match =
-                LicenseMatch {
-                    license_expression: rule.license_expression.clone(),
-                    license_expression_spdx: index
-                        .rule_metadata_by_identifier
-                        .get(&rule.identifier)
-                        .and_then(|metadata| metadata.license_expression_spdx.clone()),
-                    from_file: None,
-                    start_line,
-                    end_line,
-                    start_token: qstart,
-                    end_token: qend,
-                    matcher: MATCH_AHO,
-                    score,
-                    matched_length,
-                    rule_length,
-                    match_coverage,
-                    rule_relevance: rule.relevance,
-                    rid,
-                    rule_identifier: rule.identifier.clone(),
-                    rule_url: String::new(),
-                    matched_text: None,
-                    referenced_filenames: rule.referenced_filenames.clone(),
-                    rule_kind: rule.kind(),
-                    is_from_license: rule.is_from_license,
-                    rule_start_token: 0,
-                    qspan,
-                    ispan,
-                    hispan: PositionSpan::from_positions((0..matched_length).filter(|&p| {
-                        index.dictionary.token_kind(rule_tids[p]) == TokenKind::Legalese
-                    })),
-                    candidate_resemblance: 0.0,
-                    candidate_containment: 0.0,
-                };
+            let license_match = LicenseMatch {
+                license_expression: rule.license_expression.clone(),
+                license_expression_spdx: index
+                    .rule_metadata_by_identifier
+                    .get(&rule.identifier)
+                    .and_then(|metadata| metadata.license_expression_spdx.clone()),
+                from_file: None,
+                start_line,
+                end_line,
+                start_token: qstart,
+                end_token: qend,
+                matcher: MATCH_AHO,
+                score,
+                matched_length,
+                rule_length,
+                match_coverage,
+                rule_relevance: rule.relevance,
+                rid,
+                rule_identifier: rule.identifier.clone(),
+                rule_url: String::new(),
+                matched_text: None,
+                referenced_filenames: rule.referenced_filenames.clone(),
+                rule_kind: rule.kind(),
+                is_from_license: rule.is_from_license,
+                rule_start_token: 0,
+                coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
+                candidate_resemblance: 0.0,
+                candidate_containment: 0.0,
+            };
 
             matches.push(license_match);
         }

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -481,7 +481,9 @@ pub(super) fn classify_detection(detection: &LicenseDetection, min_score: f32) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::{LicenseMatch, MatcherKind, PositionSpan};
+    use crate::license_detection::models::{
+        LicenseMatch, MatchCoordinates, MatcherKind, PositionSpan,
+    };
 
     fn create_test_match(coverage: f32, rule_identifier: &str) -> LicenseMatch {
         LicenseMatch {
@@ -491,8 +493,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line: 1,
             end_line: 10,
-            start_token: 0,
-            end_token: 0,
+            start_token: 1,
+            end_token: 11,
             matcher: crate::license_detection::models::MatcherKind::Hash,
             score: 95.0,
             matched_length: 100,
@@ -506,9 +508,7 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 11)),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -534,8 +534,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line,
             end_line,
-            start_token: 0,
-            end_token: 0,
+            start_token: start_line,
+            end_token: end_line + 1,
             matcher: matcher.parse().expect("invalid test matcher"),
             score,
             matched_length,
@@ -549,9 +549,10 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/detection/grouping.rs
+++ b/src/license_detection/detection/grouping.rs
@@ -131,7 +131,7 @@ pub(super) fn is_correct_detection(matches: &[LicenseMatch]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::{LicenseMatch, PositionSpan};
+    use crate::license_detection::models::{LicenseMatch, MatchCoordinates, PositionSpan};
 
     fn create_test_match(
         start_line: usize,
@@ -146,8 +146,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line,
             end_line,
-            start_token: 0,
-            end_token: 0,
+            start_token: start_line,
+            end_token: end_line + 1,
             matcher: matcher.parse().expect("invalid test matcher"),
             score: 95.0,
             matched_length: 100,
@@ -161,9 +161,10 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -197,9 +198,10 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_token,
+                end_token,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/detection/identifier.rs
+++ b/src/license_detection/detection/identifier.rs
@@ -163,7 +163,7 @@ pub(super) fn compute_detection_coverage(matches: &[LicenseMatch]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::{LicenseMatch, PositionSpan};
+    use crate::license_detection::models::{LicenseMatch, MatchCoordinates, PositionSpan};
 
     fn create_test_match() -> LicenseMatch {
         LicenseMatch {
@@ -173,8 +173,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line: 1,
             end_line: 10,
-            start_token: 0,
-            end_token: 0,
+            start_token: 1,
+            end_token: 11,
             matcher: crate::license_detection::models::MatcherKind::Hash,
             score: 95.0,
             matched_length: 100,
@@ -188,9 +188,7 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 11)),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -503,7 +503,7 @@ fn license_keys_from_expression(expression: &str) -> Vec<String> {
 mod tests {
     use super::identifier::compute_detection_identifier;
     use super::*;
-    use crate::license_detection::models::{License, LicenseMatch, PositionSpan};
+    use crate::license_detection::models::{License, LicenseMatch, MatchCoordinates, PositionSpan};
     use crate::license_detection::spdx_mapping::build_spdx_mapping;
 
     fn create_test_match(
@@ -519,8 +519,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line,
             end_line,
-            start_token: 0,
-            end_token: 0,
+            start_token: start_line,
+            end_token: end_line + 1,
             matcher: matcher.parse().expect("invalid test matcher"),
             score: 95.0,
             matched_length: 100,
@@ -534,9 +534,10 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -53,7 +53,7 @@ pub struct LicenseDetection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::PositionSpan;
+    use crate::license_detection::models::{MatchCoordinates, PositionSpan};
 
     fn create_test_match(start_line: usize, end_line: usize) -> LicenseMatch {
         LicenseMatch {
@@ -63,8 +63,8 @@ mod tests {
             from_file: Some("test.txt".to_string()),
             start_line,
             end_line,
-            start_token: 0,
-            end_token: 0,
+            start_token: start_line,
+            end_token: end_line + 1,
             matcher: crate::license_detection::models::MatcherKind::Hash,
             score: 95.0,
             matched_length: 100,
@@ -78,9 +78,10 @@ mod tests {
             is_from_license: false,
             rule_length: 100,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -8,7 +8,7 @@ use sha1::{Digest, Sha1};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
 use crate::license_detection::query::QueryRun;
 
 pub const MATCH_HASH: MatcherKind = MatcherKind::Hash;
@@ -59,10 +59,6 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
 
         let rule_length = rule.tokens.len();
 
-        let end = query_run.end.unwrap_or(query_run.start);
-        let qspan = PositionSpan::range(query_run.start, end + 1);
-        let ispan = PositionSpan::range(0, rule_length);
-
         let matched_length = query_run.tokens().len();
         let match_coverage = 100.0;
 
@@ -72,6 +68,14 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
         } else {
             start_line
         };
+
+        let end = query_run.end.unwrap_or(query_run.start);
+        let qspan = PositionSpan::range(query_run.start, end + 1);
+        let ispan = PositionSpan::range(0, rule_length);
+        let hispan = PositionSpan::from_positions(
+            (0..rule_length)
+                .filter(|&p| index.dictionary.token_kind(itokens[p]) == TokenKind::Legalese),
+        );
 
         let license_match = LicenseMatch {
             license_expression: rule.license_expression.clone(),
@@ -98,12 +102,7 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
             rule_kind: rule.kind(),
             is_from_license: rule.is_from_license,
             rule_start_token: 0,
-            qspan,
-            ispan,
-            hispan: PositionSpan::from_positions(
-                (0..rule_length)
-                    .filter(|&p| index.dictionary.token_kind(itokens[p]) == TokenKind::Legalese),
-            ),
+            coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         };

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -169,7 +169,7 @@ pub fn filter_false_positive_license_lists_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::position_span::PositionSpan;
+    use crate::license_detection::models::{MatchCoordinates, PositionSpan};
 
     #[allow(clippy::too_many_arguments)]
     fn create_test_match_with_flags(
@@ -217,9 +217,7 @@ mod tests {
             .unwrap(),
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::range(0, matched_length),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, matched_length)),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -180,8 +180,11 @@ pub(crate) fn filter_matches_missing_required_phrases(
             continue;
         }
 
-        let ispan = m.effective_ispan();
-        let qspan_span = m.effective_span();
+        let Some(ispan) = m.rule_span().cloned() else {
+            kept.push(m.clone());
+            continue;
+        };
+        let qspan_span = m.query_span().clone();
         let ispan_set = ispan.to_position_set();
         let qspan = qspan_span.to_vec();
 
@@ -544,6 +547,7 @@ pub(crate) fn filter_too_short_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::license_detection::models::MatchCoordinates;
     use crate::license_detection::models::Rule;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::license_detection::unknown_match::MATCH_UNKNOWN;
@@ -590,9 +594,10 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -627,9 +632,10 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_token,
+                end_token,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -717,8 +723,11 @@ mod tests {
         let mut m = create_test_match("#1", 1, 10, 1.0, 100.0, 100);
         m.matcher = crate::license_detection::models::MatcherKind::Seq;
         m.matched_length = 50;
-        m.qspan = PositionSpan::range(0, 50);
-        m.ispan = PositionSpan::range(0, 50);
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(0, 50),
+            PositionSpan::range(0, 50),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m];
         let filtered = filter_spurious_matches(&matches, &query);
@@ -734,7 +743,8 @@ mod tests {
         m.matched_length = 5;
         m.start_token = 0;
         m.end_token = 100;
-        m.qspan = PositionSpan::from_positions(vec![0, 50, 75, 80, 99]);
+        m.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 50, 75, 80, 99]));
 
         let matches = vec![m];
         let filtered = filter_spurious_matches(&matches, &query);
@@ -750,7 +760,8 @@ mod tests {
         m.matched_length = 5;
         m.start_token = 0;
         m.end_token = 100;
-        m.qspan = PositionSpan::from_positions(vec![0, 50, 75, 80, 99]);
+        m.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 50, 75, 80, 99]));
 
         let matches = vec![m];
         let filtered = filter_spurious_matches(&matches, &query);
@@ -766,9 +777,11 @@ mod tests {
         m.matched_length = 25;
         m.start_token = 0;
         m.end_token = 30;
-        m.qspan = PositionSpan::range(0, 25);
-        m.ispan = PositionSpan::range(0, 25);
-        m.hispan = PositionSpan::range(0, 10);
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(0, 25),
+            PositionSpan::range(0, 25),
+            PositionSpan::range(0, 10),
+        );
 
         let matches = vec![m];
         let filtered = filter_spurious_matches(&matches, &query);
@@ -861,7 +874,11 @@ mod tests {
         let mut m = create_test_match("#0", 1, 10, 0.9, 50.0, 100);
         m.matcher = crate::license_detection::models::MatcherKind::Seq;
         m.matched_length = 5;
-        m.hispan = PositionSpan::range(0, 2);
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::range(0, 2),
+        );
 
         let matches = vec![m];
         let filtered = filter_too_short_matches(&index, &matches);
@@ -914,7 +931,11 @@ mod tests {
         let mut m = create_test_match("#0", 1, 10, 0.9, 90.0, 100);
         m.matcher = crate::license_detection::models::MatcherKind::Seq;
         m.matched_length = 15;
-        m.hispan = PositionSpan::range(0, 8);
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::range(0, 8),
+        );
 
         let matches = vec![m];
         let filtered = filter_too_short_matches(&index, &matches);

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -6,7 +6,6 @@
 use crate::license_detection::expression::licensing_contains;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::models::LicenseMatch;
-use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::position_set::PositionSet;
 
 use super::merge::merge_overlapping_matches;
@@ -345,17 +344,6 @@ pub fn filter_overlapping_matches(
     (matches, discarded)
 }
 
-fn match_to_qspan(m: &LicenseMatch) -> PositionSpan {
-    let effective = m.effective_span();
-    if !effective.is_empty() {
-        return effective;
-    }
-    if m.start_token == 0 && m.end_token == 0 {
-        return PositionSpan::range(m.start_line, m.end_line + 1);
-    }
-    effective
-}
-
 /// Restore non-overlapping discarded matches.
 ///
 /// After filtering, some matches may have been discarded that don't actually
@@ -374,7 +362,7 @@ pub fn restore_non_overlapping(
 ) -> (Vec<LicenseMatch>, Vec<LicenseMatch>) {
     let mut all_matched_positions = PositionSet::new();
     for m in matches {
-        all_matched_positions.extend_from_span(&match_to_qspan(m));
+        all_matched_positions.extend_from_span(m.query_span());
     }
 
     let mut to_keep = Vec::new();
@@ -383,8 +371,7 @@ pub fn restore_non_overlapping(
     let merged_discarded = merge_overlapping_matches(&discarded);
 
     for disc in merged_discarded {
-        let disc_span = match_to_qspan(&disc);
-        if !all_matched_positions.overlaps_span(&disc_span) {
+        if !all_matched_positions.overlaps_span(disc.query_span()) {
             to_keep.push(disc);
         } else {
             to_discard.push(disc);
@@ -397,6 +384,7 @@ pub fn restore_non_overlapping(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::license_detection::models::MatchCoordinates;
     use crate::license_detection::models::position_span::PositionSpan;
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
@@ -441,9 +429,10 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -478,9 +467,11 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::range(start_token, end_token),
-            ispan: PositionSpan::range(0, matched_length),
-            hispan: PositionSpan::range(0, matched_length / 2),
+            coordinates: MatchCoordinates::rule_aligned(
+                PositionSpan::range(start_token, end_token),
+                PositionSpan::range(0, matched_length),
+                PositionSpan::range(0, matched_length / 2),
+            ),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -519,10 +510,10 @@ mod tests {
     fn test_filter_contained_matches_different_rules() {
         let mut m1 = create_test_match("#1", 1, 20, 0.9, 90.0, 100);
         m1.matched_length = 200;
-        m1.qspan = PositionSpan::range(1, 21);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 21));
         let mut m2 = create_test_match("#2", 5, 15, 0.85, 85.0, 100);
         m2.matched_length = 100;
-        m2.qspan = PositionSpan::range(5, 16);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(5, 16));
         let matches = vec![m1, m2];
 
         let (filtered, _) = filter_contained_matches(&matches);
@@ -534,9 +525,9 @@ mod tests {
     #[test]
     fn test_filter_contained_matches_no_containment() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
         let mut m2 = create_test_match("#1", 15, 25, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(15, 26);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(15, 26));
         let matches = vec![m1, m2];
 
         let (filtered, _) = filter_contained_matches(&matches);
@@ -562,10 +553,10 @@ mod tests {
     fn test_filter_contained_matches_partial_overlap_no_containment() {
         let mut m1 = create_test_match("#1", 1, 20, 0.9, 90.0, 100);
         m1.matched_length = 150;
-        m1.qspan = PositionSpan::range(1, 21);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 21));
         let mut m2 = create_test_match("#2", 15, 30, 0.85, 85.0, 100);
         m2.matched_length = 100;
-        m2.qspan = PositionSpan::range(15, 31);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(15, 31));
         let matches = vec![m1, m2];
 
         let (filtered, _) = filter_contained_matches(&matches);
@@ -775,10 +766,10 @@ mod tests {
         let index = LicenseIndex::with_legalese_count(10);
         let mut m1 = create_test_match("#1", 1, 100, 0.9, 90.0, 100);
         m1.matched_length = 100;
-        m1.qspan = PositionSpan::range(1, 101);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 101));
         let mut m2 = create_test_match("#2", 5, 100, 0.85, 85.0, 100);
         m2.matched_length = 10;
-        m2.qspan = PositionSpan::range(5, 101);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(5, 101));
 
         let matches = vec![m1, m2];
 
@@ -794,10 +785,10 @@ mod tests {
         let index = LicenseIndex::with_legalese_count(10);
         let mut m1 = create_test_match("#1", 1, 100, 0.9, 90.0, 100);
         m1.matched_length = 100;
-        m1.qspan = PositionSpan::range(1, 101);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 101));
         let mut m2 = create_test_match("#2", 30, 100, 0.85, 85.0, 100);
         m2.matched_length = 10;
-        m2.qspan = PositionSpan::range(30, 101);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(30, 101));
 
         let matches = vec![m1, m2];
 
@@ -886,10 +877,10 @@ mod tests {
 
         let mut outer = create_test_match("#1", 1, 100, 0.9, 90.0, 100);
         outer.matched_length = 500;
-        outer.qspan = PositionSpan::range(1, 101);
+        outer.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 101));
         let mut inner = create_test_match("#2", 20, 30, 0.85, 85.0, 100);
         inner.matched_length = 50;
-        inner.qspan = PositionSpan::range(20, 31);
+        inner.coordinates = MatchCoordinates::query_region(PositionSpan::range(20, 31));
 
         let matches = vec![outer, inner];
 
@@ -903,9 +894,9 @@ mod tests {
     #[test]
     fn test_calculate_overlap_no_overlap() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
         let mut m2 = create_test_match("#2", 20, 30, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(20, 31);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(20, 31));
 
         assert_eq!(m1.qoverlap(&m2), 0);
         assert_eq!(m2.qoverlap(&m1), 0);
@@ -914,9 +905,9 @@ mod tests {
     #[test]
     fn test_calculate_overlap_partial() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
         let mut m2 = create_test_match("#2", 5, 15, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(5, 16);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(5, 16));
 
         assert_eq!(m1.qoverlap(&m2), 6);
         assert_eq!(m2.qoverlap(&m1), 6);
@@ -925,9 +916,9 @@ mod tests {
     #[test]
     fn test_calculate_overlap_contained() {
         let mut m1 = create_test_match("#1", 1, 20, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 21);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 21));
         let mut m2 = create_test_match("#2", 5, 15, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(5, 16);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(5, 16));
 
         assert_eq!(m1.qoverlap(&m2), 11);
         assert_eq!(m2.qoverlap(&m1), 11);
@@ -936,9 +927,9 @@ mod tests {
     #[test]
     fn test_calculate_overlap_identical() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
         let mut m2 = create_test_match("#2", 1, 10, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(1, 11);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
 
         assert_eq!(m1.qoverlap(&m2), 10);
     }
@@ -946,9 +937,9 @@ mod tests {
     #[test]
     fn test_calculate_overlap_adjacent() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
+        m1.coordinates = MatchCoordinates::query_region(PositionSpan::range(1, 11));
         let mut m2 = create_test_match("#2", 11, 20, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(11, 21);
+        m2.coordinates = MatchCoordinates::query_region(PositionSpan::range(11, 21));
 
         assert_eq!(m1.qoverlap(&m2), 0);
     }
@@ -1070,13 +1061,19 @@ mod tests {
         let mut m1 = create_test_match("#2", 50, 60, 0.85, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.qspan = PositionSpan::range(50, 61);
-        m1.ispan = PositionSpan::range(0, 11);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(50, 61),
+            PositionSpan::range(0, 11),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#2", 55, 65, 0.8, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 5;
-        m2.qspan = PositionSpan::range(55, 66);
-        m2.ispan = PositionSpan::range(5, 16);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(55, 66),
+            PositionSpan::range(5, 16),
+            PositionSpan::empty(),
+        );
 
         let discarded = vec![m1, m2];
 
@@ -1112,27 +1109,29 @@ mod tests {
 
     #[test]
     fn test_filter_overlapping_matches_prefers_higher_coverage() {
-        // Regression test: when two matches have identical qspan (100% overlap),
-        // the one with higher coverage should be kept.
-        // This was a bug where gfdl-1.1-plus (68.6%) was kept over gfdl-1.1 (78.7%)
-        // because they had identical tokens, hilen, and matcher_order.
         let index = LicenseIndex::with_legalese_count(10);
 
         let mut m1 = create_test_match("gfdl-1.1_13.RULE", 1, 10, 78.7, 78.7, 100);
         m1.start_token = 5;
         m1.end_token = 77;
         m1.matched_length = 48;
-        m1.hispan = PositionSpan::range(0, 14);
         m1.matcher = crate::license_detection::models::MatcherKind::Seq;
-        m1.qspan = PositionSpan::range(5, 77);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 77),
+            PositionSpan::empty(),
+            PositionSpan::range(0, 14),
+        );
 
         let mut m2 = create_test_match("gfdl-1.1-plus_5.RULE", 1, 10, 68.6, 68.6, 100);
         m2.start_token = 5;
         m2.end_token = 77;
         m2.matched_length = 48;
-        m2.hispan = PositionSpan::range(0, 14);
         m2.matcher = crate::license_detection::models::MatcherKind::Seq;
-        m2.qspan = PositionSpan::range(5, 77);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 77),
+            PositionSpan::empty(),
+            PositionSpan::range(0, 14),
+        );
 
         let matches = vec![m1, m2];
         let (kept, _discarded) = filter_overlapping_matches(matches, &index);

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -3,7 +3,8 @@
 //! This module contains functions for merging overlapping and adjacent matches,
 //! updating match scores, and filtering license references.
 
-use crate::license_detection::models::LicenseMatch;
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
+use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
 
 const MAX_DIST: usize = 50;
@@ -16,17 +17,29 @@ fn combine_matches(a: &LicenseMatch, b: &LicenseMatch) -> LicenseMatch {
     );
 
     let mut merged = a.clone();
+    let has_rule_alignment = a.has_rule_alignment() && b.has_rule_alignment();
 
     let mut qspan_set = a.qspan_set();
-    let b_qspan = b.effective_span();
+    let b_qspan = b.query_span().clone();
     qspan_set.extend_from_span(&b_qspan);
 
-    let mut ispan_set = a.ispan_set();
-    let b_ispan = b.effective_ispan();
-    ispan_set.extend_from_span(&b_ispan);
+    let (ispan_set, hispan_set) = if has_rule_alignment {
+        let mut ispan_set = a.ispan_set();
+        let b_ispan = b.effective_ispan();
+        ispan_set.extend_from_span(&b_ispan);
 
-    let mut hispan_set = a.hispan.to_position_set();
-    hispan_set.extend_from_span(&b.hispan);
+        let mut hispan_set = a
+            .coordinates
+            .hispan()
+            .map_or_else(PositionSet::new, |h| h.to_position_set());
+        if let Some(b_hispan) = b.coordinates.hispan() {
+            hispan_set.extend_from_span(b_hispan);
+        }
+
+        (Some(ispan_set), Some(hispan_set))
+    } else {
+        (None, None)
+    };
 
     merged.start_token = if qspan_set.is_empty() {
         a.start_token
@@ -38,18 +51,28 @@ fn combine_matches(a: &LicenseMatch, b: &LicenseMatch) -> LicenseMatch {
     } else {
         qspan_set.max_pos() + 1
     };
-    merged.rule_start_token = if ispan_set.is_empty() {
-        a.rule_start_token
-    } else {
-        ispan_set.min_pos()
-    };
+    merged.rule_start_token = ispan_set.as_ref().map_or(a.rule_start_token, |ispan_set| {
+        if ispan_set.is_empty() {
+            a.rule_start_token
+        } else {
+            ispan_set.min_pos()
+        }
+    });
     merged.matched_length = qspan_set.len();
-    merged.hispan = hispan_set.to_position_span();
     merged.start_line = a.start_line.min(b.start_line);
     merged.end_line = a.end_line.max(b.end_line);
     merged.score = a.score.max(b.score);
-    merged.qspan = qspan_set.to_position_span();
-    merged.ispan = ispan_set.to_position_span();
+
+    let qspan = qspan_set.to_position_span();
+    merged.coordinates = if let (Some(ispan_set), Some(hispan_set)) = (ispan_set, hispan_set) {
+        MatchCoordinates::rule_aligned(
+            qspan,
+            ispan_set.to_position_span(),
+            hispan_set.to_position_span(),
+        )
+    } else {
+        MatchCoordinates::query_region(qspan)
+    };
 
     if merged.rule_length > 0 {
         merged.match_coverage = LicenseMatch::round_metric(
@@ -120,21 +143,42 @@ pub fn merge_overlapping_matches(matches: &[LicenseMatch]) -> Vec<LicenseMatch> 
             while j < rule_matches.len() {
                 let current = &rule_matches[i];
                 let next = &rule_matches[j];
+                let same_coordinate_kind =
+                    current.has_rule_alignment() == next.has_rule_alignment();
+                let both_rule_aligned = current.has_rule_alignment() && next.has_rule_alignment();
 
-                if current.qdistance_to(next) > max_rule_side_dist
-                    || current.idistance_to(next) > max_rule_side_dist
+                if !same_coordinate_kind {
+                    j += 1;
+                    continue;
+                }
+
+                if !both_rule_aligned
+                    && current.matcher == MatcherKind::SpdxId
+                    && next.matcher == MatcherKind::SpdxId
                 {
+                    j += 1;
+                    continue;
+                }
+
+                if current.qdistance_to(next) > max_rule_side_dist {
+                    break;
+                }
+
+                if both_rule_aligned && current.idistance_to(next) > max_rule_side_dist {
                     break;
                 }
 
                 if current.qspan_set() == next.qspan_set()
-                    && current.ispan_set() == next.ispan_set()
+                    && (!both_rule_aligned || current.ispan_set() == next.ispan_set())
                 {
                     rule_matches.remove(j);
                     continue;
                 }
 
-                if current.ispan_set() == next.ispan_set() && current.qoverlap(next) > 0 {
+                if both_rule_aligned
+                    && current.ispan_set() == next.ispan_set()
+                    && current.qoverlap(next) > 0
+                {
                     let current_mag = current.qspan_magnitude();
                     let next_mag = next.qspan_magnitude();
                     if current_mag <= next_mag {
@@ -159,7 +203,9 @@ pub fn merge_overlapping_matches(matches: &[LicenseMatch]) -> Vec<LicenseMatch> 
 
                 if current.surround(next) {
                     let combined = combine_matches(current, next);
-                    if combined.effective_span().len() == combined.effective_ispan().len() {
+                    if !both_rule_aligned
+                        || combined.query_span().len() == combined.effective_ispan().len()
+                    {
                         rule_matches[i] = combined;
                         rule_matches.remove(j);
                         continue;
@@ -167,7 +213,9 @@ pub fn merge_overlapping_matches(matches: &[LicenseMatch]) -> Vec<LicenseMatch> 
                 }
                 if next.surround(current) {
                     let combined = combine_matches(current, next);
-                    if combined.effective_span().len() == combined.effective_ispan().len() {
+                    if !both_rule_aligned
+                        || combined.query_span().len() == combined.effective_ispan().len()
+                    {
                         rule_matches[j] = combined;
                         rule_matches.remove(i);
                         i = i.saturating_sub(1);
@@ -181,23 +229,25 @@ pub fn merge_overlapping_matches(matches: &[LicenseMatch]) -> Vec<LicenseMatch> 
                     continue;
                 }
 
-                let (cur_qstart, cur_qend) = current.qspan_bounds();
-                let (next_qstart, next_qend) = next.qspan_bounds();
-                let (cur_istart, cur_iend) = current.ispan_bounds();
-                let (next_istart, next_iend) = next.ispan_bounds();
+                if both_rule_aligned {
+                    let (cur_qstart, cur_qend) = current.qspan_bounds();
+                    let (next_qstart, next_qend) = next.qspan_bounds();
+                    let (cur_istart, cur_iend) = current.ispan_bounds();
+                    let (next_istart, next_iend) = next.ispan_bounds();
 
-                if cur_qstart <= next_qstart
-                    && cur_qend <= next_qend
-                    && cur_istart <= next_istart
-                    && cur_iend <= next_iend
-                {
-                    let qoverlap = current.qoverlap(next);
-                    if qoverlap > 0 {
-                        let ioverlap = current.ispan_overlap(next);
-                        if qoverlap == ioverlap {
-                            rule_matches[i] = combine_matches(current, next);
-                            rule_matches.remove(j);
-                            continue;
+                    if cur_qstart <= next_qstart
+                        && cur_qend <= next_qend
+                        && cur_istart <= next_istart
+                        && cur_iend <= next_iend
+                    {
+                        let qoverlap = current.qoverlap(next);
+                        if qoverlap > 0 {
+                            let ioverlap = current.ispan_overlap(next);
+                            if qoverlap == ioverlap {
+                                rule_matches[i] = combine_matches(current, next);
+                                rule_matches.remove(j);
+                                continue;
+                            }
                         }
                     }
                 }
@@ -318,7 +368,7 @@ pub(super) fn filter_license_references_with_text_match(
 mod tests {
     use super::*;
     use crate::license_detection::index::LicenseIndex;
-    use crate::license_detection::models::position_span::PositionSpan;
+    use crate::license_detection::models::PositionSpan;
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
         let trimmed = rule_identifier.trim();
@@ -340,6 +390,9 @@ mod tests {
         let matched_len = end_line - start_line + 1;
         let rule_len = matched_len;
         let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let qspan = PositionSpan::range(start_line, end_line + 1);
+        let ispan = PositionSpan::range(0, matched_len);
+        let hispan = PositionSpan::range(0, matched_len / 2);
         LicenseMatch {
             rid,
             license_expression: "mit".to_string(),
@@ -362,15 +415,53 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::range(start_line, end_line + 1),
-            ispan: PositionSpan::range(0, matched_len),
-            hispan: PositionSpan::range(0, matched_len / 2),
+            coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
     }
 
     fn create_test_match_with_tokens(
+        rule_identifier: &str,
+        start_token: usize,
+        end_token: usize,
+        matched_length: usize,
+    ) -> LicenseMatch {
+        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let qspan = PositionSpan::range(start_token, end_token);
+        LicenseMatch {
+            rid,
+            license_expression: "mit".to_string(),
+            license_expression_spdx: Some("MIT".to_string()),
+            from_file: None,
+            start_line: start_token,
+            end_line: end_token.saturating_sub(1),
+            start_token,
+            end_token,
+            matcher: crate::license_detection::models::MatcherKind::Aho,
+            score: 1.0,
+            matched_length,
+            rule_length: matched_length,
+            match_coverage: 100.0,
+            rule_relevance: 100,
+            rule_identifier: rule_identifier.to_string(),
+            rule_url: "https://example.com".to_string(),
+            matched_text: None,
+            referenced_filenames: None,
+            rule_kind: crate::license_detection::models::RuleKind::None,
+            is_from_license: false,
+            rule_start_token: 0,
+            coordinates: MatchCoordinates::rule_aligned(
+                qspan,
+                PositionSpan::empty(),
+                PositionSpan::empty(),
+            ),
+            candidate_resemblance: 0.0,
+            candidate_containment: 0.0,
+        }
+    }
+
+    fn create_test_query_region_match(
         rule_identifier: &str,
         start_token: usize,
         end_token: usize,
@@ -399,27 +490,13 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::range(start_token, end_token),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_token,
+                end_token,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
-    }
-
-    fn create_test_match_with_implicit_spans(
-        rule_identifier: &str,
-        start_token: usize,
-        end_token: usize,
-        rule_start_token: usize,
-        matched_length: usize,
-    ) -> LicenseMatch {
-        let mut m =
-            create_test_match_with_tokens(rule_identifier, start_token, end_token, matched_length);
-        m.rule_start_token = rule_start_token;
-        m.qspan = PositionSpan::empty();
-        m.ispan = PositionSpan::empty();
-        m
     }
 
     #[test]
@@ -453,11 +530,19 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 5, 15, 0.85, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 4;
-        m2.ispan = PositionSpan::range(4, 15);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 16),
+            PositionSpan::range(4, 15),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2];
 
@@ -475,11 +560,19 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 10, 20, 0.85, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 9;
-        m2.ispan = PositionSpan::range(9, 20);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(10, 21),
+            PositionSpan::range(9, 20),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2];
 
@@ -493,18 +586,35 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_adjacent_matches_uses_implicit_token_span_fallback() {
-        let mut m1 = create_test_match_with_implicit_spans("#1", 10, 20, 100, 10);
+    fn test_merge_adjacent_unknown_matches_preserve_query_region_coordinates() {
+        let mut m1 = create_test_query_region_match("#1", 10, 20, 10);
         m1.rule_length = 100;
-        let mut m2 = create_test_match_with_implicit_spans("#1", 20, 30, 110, 10);
+        m1.matcher = crate::license_detection::models::MatcherKind::Unknown;
+        let mut m2 = create_test_query_region_match("#1", 20, 30, 10);
         m2.rule_length = 100;
+        m2.matcher = crate::license_detection::models::MatcherKind::Unknown;
 
         let merged = merge_overlapping_matches(&[m1, m2]);
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].qspan_bounds(), (10, 30));
-        assert_eq!(merged[0].ispan_bounds(), (100, 120));
         assert_eq!(merged[0].matched_length, 20);
+        assert!(!merged[0].has_rule_alignment());
+    }
+
+    #[test]
+    fn test_do_not_merge_adjacent_spdx_query_region_matches() {
+        let mut m1 = create_test_query_region_match("#1", 10, 20, 10);
+        m1.rule_length = 100;
+        m1.matcher = crate::license_detection::models::MatcherKind::SpdxId;
+        let mut m2 = create_test_query_region_match("#1", 20, 30, 10);
+        m2.rule_length = 100;
+        m2.matcher = crate::license_detection::models::MatcherKind::SpdxId;
+
+        let merged = merge_overlapping_matches(&[m1, m2]);
+
+        assert_eq!(merged.len(), 2);
+        assert!(merged.iter().all(|m| !m.has_rule_alignment()));
     }
 
     #[test]
@@ -536,15 +646,27 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 5, 0.8, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.ispan = PositionSpan::range(0, 5);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 6),
+            PositionSpan::range(0, 5),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 5, 10, 0.9, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 4;
-        m2.ispan = PositionSpan::range(4, 10);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 11),
+            PositionSpan::range(4, 10),
+            PositionSpan::empty(),
+        );
         let mut m3 = create_test_match("#1", 10, 15, 0.85, 100.0, 100);
         m3.rule_length = 100;
         m3.rule_start_token = 9;
-        m3.ispan = PositionSpan::range(9, 15);
+        m3.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(10, 16),
+            PositionSpan::range(9, 15),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2, m3];
 
@@ -638,11 +760,19 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 15, 0.9, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.ispan = PositionSpan::range(0, 15);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 16),
+            PositionSpan::range(0, 15),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 10, 25, 0.85, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 9;
-        m2.ispan = PositionSpan::range(9, 25);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(10, 26),
+            PositionSpan::range(9, 25),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2];
 
@@ -657,10 +787,18 @@ mod tests {
     fn test_merge_matches_with_gap_larger_than_one() {
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 100.0, 100);
         m1.rule_length = 10;
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 20, 30, 0.85, 100.0, 100);
         m2.rule_length = 11;
-        m2.ispan = PositionSpan::range(19, 30);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(20, 31),
+            PositionSpan::range(19, 30),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2];
 
@@ -678,15 +816,27 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 10, 0.7, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 5, 15, 0.95, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 4;
-        m2.ispan = PositionSpan::range(4, 15);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 16),
+            PositionSpan::range(4, 15),
+            PositionSpan::empty(),
+        );
         let mut m3 = create_test_match("#1", 12, 20, 0.8, 100.0, 100);
         m3.rule_length = 100;
         m3.rule_start_token = 11;
-        m3.ispan = PositionSpan::range(11, 20);
+        m3.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(12, 21),
+            PositionSpan::range(11, 20),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2, m3];
 
@@ -701,13 +851,22 @@ mod tests {
         let mut m = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
         m.start_token = 5;
         m.end_token = 15;
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 15),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
         assert_eq!(m.qspan_magnitude(), 10);
     }
 
     #[test]
     fn test_qspan_magnitude_non_contiguous() {
         let mut m = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m.qspan = PositionSpan::from_positions(vec![4, 8]);
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::from_positions(vec![4, 8]),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
         assert_eq!(m.qspan_magnitude(), 5);
     }
 
@@ -716,7 +875,7 @@ mod tests {
         let mut m = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
         m.start_token = 5;
         m.end_token = 5;
-        m.qspan = PositionSpan::empty();
+        m.coordinates = MatchCoordinates::query_region(PositionSpan::empty());
         assert_eq!(m.qspan_magnitude(), 0);
     }
 
@@ -725,12 +884,20 @@ mod tests {
         let mut dense = create_test_match_with_tokens("#1", 1, 11, 100);
         dense.rule_start_token = 0;
         dense.matched_length = 100;
-        dense.qspan = PositionSpan::range(1, 11);
+        dense.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let mut sparse = create_test_match_with_tokens("#1", 1, 11, 100);
         sparse.rule_start_token = 0;
         sparse.matched_length = 100;
-        sparse.qspan = PositionSpan::from_positions(vec![1, 5, 10, 20, 50]);
+        sparse.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::from_positions(vec![1, 5, 10, 20, 50]),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let merged = merge_overlapping_matches(&[dense.clone(), sparse.clone()]);
 
@@ -743,12 +910,20 @@ mod tests {
         let mut dense = create_test_match_with_tokens("#1", 1, 11, 100);
         dense.rule_start_token = 0;
         dense.matched_length = 100;
-        dense.qspan = PositionSpan::range(1, 11);
+        dense.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let mut sparse = create_test_match_with_tokens("#1", 1, 11, 100);
         sparse.rule_start_token = 0;
         sparse.matched_length = 100;
-        sparse.qspan = PositionSpan::from_positions(vec![1, 5, 10, 20, 50]);
+        sparse.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::from_positions(vec![1, 5, 10, 20, 50]),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let merged = merge_overlapping_matches(&[sparse.clone(), dense.clone()]);
 

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -329,6 +329,7 @@ fn filter_binary_low_coverage_same_expression_seq_bridges(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::license_detection::models::MatchCoordinates;
     use crate::license_detection::models::position_span::PositionSpan;
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
@@ -373,9 +374,10 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(
+                start_line,
+                end_line + 1,
+            )),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -389,19 +391,31 @@ mod tests {
         let mut m1 = create_test_match("#1", 1, 10, 0.5, 100.0, 100);
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.qspan = PositionSpan::range(1, 11);
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 5, 15, 0.5, 100.0, 100);
         m2.rule_length = 100;
         m2.rule_start_token = 4;
-        m2.qspan = PositionSpan::range(5, 16);
-        m2.ispan = PositionSpan::range(4, 15);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(5, 16),
+            PositionSpan::range(4, 15),
+            PositionSpan::empty(),
+        );
         let mut m3 = create_test_match("#2", 20, 25, 0.5, 100.0, 80);
-        m3.qspan = PositionSpan::range(20, 26);
-        m3.ispan = PositionSpan::range(0, 6);
+        m3.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(20, 26),
+            PositionSpan::range(0, 6),
+            PositionSpan::empty(),
+        );
         let mut m4 = create_test_match("#99", 30, 35, 0.5, 100.0, 100);
-        m4.qspan = PositionSpan::range(30, 36);
-        m4.ispan = PositionSpan::range(0, 6);
+        m4.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(30, 36),
+            PositionSpan::range(0, 6),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2, m3, m4];
 
@@ -446,11 +460,17 @@ mod tests {
         let index = LicenseIndex::with_legalese_count(10);
 
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#2", 20, 30, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(20, 31);
-        m2.ispan = PositionSpan::range(0, 11);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(20, 31),
+            PositionSpan::range(0, 11),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2];
 
@@ -472,7 +492,11 @@ mod tests {
         exact.start_token = 10;
         exact.end_token = 16;
         exact.matched_length = 6;
-        exact.qspan = PositionSpan::range(10, 16);
+        exact.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(10, 16),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let mut seq = create_test_match("#2", 140, 141, 10.0, 52.9, 100);
         seq.license_expression = "bsd-new".to_string();
@@ -480,7 +504,11 @@ mod tests {
         seq.start_token = 10;
         seq.end_token = 18;
         seq.matched_length = 7;
-        seq.qspan = PositionSpan::from_positions(vec![10, 11, 12, 13, 14, 16, 17]);
+        seq.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::from_positions(vec![10, 11, 12, 13, 14, 16, 17]),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
 
         let filtered = filter_binary_low_coverage_same_expression_seq_bridges(
             vec![seq.clone(), exact.clone()],
@@ -497,14 +525,20 @@ mod tests {
         let mut first = create_test_match("#1", 1, 10, 0.9, 50.0, 100);
         first.rule_length = 20;
         first.rule_start_token = 0;
-        first.qspan = PositionSpan::range(1, 11);
-        first.ispan = PositionSpan::range(0, 10);
+        first.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
 
         let mut second = create_test_match("#1", 11, 20, 0.85, 50.0, 100);
         second.rule_length = 20;
         second.rule_start_token = 10;
-        second.qspan = PositionSpan::range(11, 21);
-        second.ispan = PositionSpan::range(10, 20);
+        second.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(11, 21),
+            PositionSpan::range(10, 20),
+            PositionSpan::empty(),
+        );
 
         let query = Query::from_extracted_text("test text", &index, false).unwrap();
         let refined = refine_aho_matches(&index, vec![first, second], &query);
@@ -520,14 +554,23 @@ mod tests {
         let index = LicenseIndex::with_legalese_count(10);
 
         let mut m1 = create_test_match("#1", 1, 10, 0.9, 90.0, 100);
-        m1.qspan = PositionSpan::range(1, 11);
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#2", 20, 30, 0.85, 85.0, 100);
-        m2.qspan = PositionSpan::range(20, 31);
-        m2.ispan = PositionSpan::range(0, 11);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(20, 31),
+            PositionSpan::range(0, 11),
+            PositionSpan::empty(),
+        );
         let mut m3 = create_test_match("#3", 40, 50, 0.8, 80.0, 100);
-        m3.qspan = PositionSpan::range(40, 51);
-        m3.ispan = PositionSpan::range(0, 11);
+        m3.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(40, 51),
+            PositionSpan::range(0, 11),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2, m3];
 
@@ -546,26 +589,38 @@ mod tests {
         m1.matched_length = 100;
         m1.rule_length = 100;
         m1.rule_start_token = 0;
-        m1.qspan = PositionSpan::range(1, 11);
-        m1.ispan = PositionSpan::range(0, 10);
+        m1.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(1, 11),
+            PositionSpan::range(0, 10),
+            PositionSpan::empty(),
+        );
         let mut m2 = create_test_match("#1", 8, 15, 0.8, 100.0, 100);
         m2.matched_length = 100;
         m2.rule_length = 100;
         m2.rule_start_token = 7;
-        m2.qspan = PositionSpan::range(8, 16);
-        m2.ispan = PositionSpan::range(7, 15);
+        m2.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(8, 16),
+            PositionSpan::range(7, 15),
+            PositionSpan::empty(),
+        );
         let mut m3 = create_test_match("#2", 20, 50, 0.9, 100.0, 100);
         m3.matched_length = 300;
         m3.rule_length = 300;
         m3.rule_start_token = 0;
-        m3.qspan = PositionSpan::range(20, 51);
-        m3.ispan = PositionSpan::range(0, 31);
+        m3.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(20, 51),
+            PositionSpan::range(0, 31),
+            PositionSpan::empty(),
+        );
         let mut m4 = create_test_match("#2", 25, 45, 0.85, 100.0, 100);
         m4.matched_length = 150;
         m4.rule_length = 300;
         m4.rule_start_token = 5;
-        m4.qspan = PositionSpan::range(25, 46);
-        m4.ispan = PositionSpan::range(5, 26);
+        m4.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(25, 46),
+            PositionSpan::range(5, 26),
+            PositionSpan::empty(),
+        );
 
         let matches = vec![m1, m2, m3, m4];
 

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -117,7 +117,7 @@ fn truncate_detection_text(clean_text: &str) -> &str {
 }
 
 fn query_span_for_match(m: &LicenseMatch) -> Option<models::PositionSpan> {
-    (m.end_token > m.start_token).then(|| models::PositionSpan::new(m.start_token, m.end_token))
+    (!m.query_span().is_empty()).then(|| m.query_span().clone())
 }
 
 fn has_full_match_coverage(m: &LicenseMatch) -> bool {
@@ -159,8 +159,7 @@ fn is_redundant_same_expression_seq_container(
 
     let mut child_union = PositionSet::new();
     for m in &contained {
-        let span = m.effective_span();
-        child_union.extend_from_span(&span);
+        child_union.extend_from_span(m.query_span());
     }
 
     let container_only_positions = container_qspan_set.difference(&child_union);
@@ -274,8 +273,7 @@ fn is_redundant_low_coverage_composite_seq_wrapper(
 
     let mut child_union = PositionSet::new();
     for m in &children {
-        let span = m.effective_span();
-        child_union.extend_from_span(&span);
+        child_union.extend_from_span(m.query_span());
     }
 
     let container_only_positions = container_qspan_set.difference(&child_union);
@@ -385,8 +383,8 @@ fn collect_whole_query_exact_followup_matches(
                 seq_match_with_candidates(index, whole_run, &near_dupe_candidates);
 
             for m in &near_dupe_matches {
-                if m.end_token > m.start_token {
-                    let span = models::PositionSpan::new(m.start_token, m.end_token);
+                if !m.query_span().is_empty() {
+                    let span = m.query_span().clone();
                     query.subtract(&span);
                     matched_qspans.push(span);
                 }
@@ -544,14 +542,13 @@ impl LicenseDetectionEngine {
         // Phase 1b: SPDX-LID matching
         {
             let spdx_matches = spdx_lid_match(&self.index, &query);
-            let merged_spdx = merge_overlapping_matches(&spdx_matches);
             subtract_spdx_match_qspans(
                 &mut query,
                 &mut matched_qspans,
                 &mut aho_extra_matchables,
-                &merged_spdx,
+                &spdx_matches,
             );
-            all_matches.extend(merged_spdx);
+            all_matches.extend(spdx_matches);
         }
 
         // Phase 1c: Aho-Corasick matching
@@ -705,14 +702,13 @@ impl LicenseDetectionEngine {
         // Phase 1b: SPDX-LID matching
         {
             let spdx_matches = spdx_lid_match(&self.index, &query);
-            let merged_spdx = merge_overlapping_matches(&spdx_matches);
             subtract_spdx_match_qspans(
                 &mut query,
                 &mut matched_qspans,
                 &mut aho_extra_matchables,
-                &merged_spdx,
+                &spdx_matches,
             );
-            all_matches.extend(merged_spdx);
+            all_matches.extend(spdx_matches);
         }
 
         // Phase 1c: Aho-Corasick matching

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -8,6 +8,75 @@ use crate::license_detection::models::RuleKind;
 use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::position_set::PositionSet;
 
+/// Coordinate data for a license match.
+///
+/// This enum distinguishes between:
+/// - `RuleAligned`: Matches that align query tokens to rule tokens (hash, aho, seq matchers)
+/// - `QueryRegion`: Matches that only have query-side location data (SPDX declarations, unknown regions)
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchCoordinates {
+    /// A match aligned between query and rule token sequences.
+    ///
+    /// Contains query span, rule span, and high-value legalese span within the rule.
+    RuleAligned {
+        qspan: PositionSpan,
+        ispan: PositionSpan,
+        hispan: PositionSpan,
+    },
+    /// A match that only has query-side coordinates.
+    ///
+    /// Used for SPDX declarations and unknown region matches which don't have
+    /// meaningful rule-side alignment.
+    QueryRegion { qspan: PositionSpan },
+}
+
+impl MatchCoordinates {
+    pub fn query_span(&self) -> &PositionSpan {
+        match self {
+            Self::RuleAligned { qspan, .. } => qspan,
+            Self::QueryRegion { qspan } => qspan,
+        }
+    }
+
+    pub fn rule_span(&self) -> Option<&PositionSpan> {
+        match self {
+            Self::RuleAligned { ispan, .. } => Some(ispan),
+            Self::QueryRegion { .. } => None,
+        }
+    }
+
+    pub fn hispan(&self) -> Option<&PositionSpan> {
+        match self {
+            Self::RuleAligned { hispan, .. } => Some(hispan),
+            Self::QueryRegion { .. } => None,
+        }
+    }
+
+    pub fn rule_aligned(qspan: PositionSpan, ispan: PositionSpan, hispan: PositionSpan) -> Self {
+        Self::RuleAligned {
+            qspan,
+            ispan,
+            hispan,
+        }
+    }
+
+    pub fn query_region(qspan: PositionSpan) -> Self {
+        Self::QueryRegion { qspan }
+    }
+
+    pub const fn has_rule_alignment(&self) -> bool {
+        matches!(self, Self::RuleAligned { .. })
+    }
+}
+
+impl Default for MatchCoordinates {
+    fn default() -> Self {
+        Self::QueryRegion {
+            qspan: PositionSpan::empty(),
+        }
+    }
+}
+
 /// Internal matcher kind used to create a license match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize)]
 pub enum MatcherKind {
@@ -150,14 +219,8 @@ pub struct LicenseMatch {
     /// For approximate matches (seq), this is the position in the rule where alignment begins.
     pub rule_start_token: usize,
 
-    /// Token positions matched in the query text.
-    pub qspan: PositionSpan,
-
-    /// Token positions matched in the rule text.
-    pub ispan: PositionSpan,
-
-    /// Token positions in the rule that are high-value legalese tokens.
-    pub hispan: PositionSpan,
+    /// Coordinate data distinguishing rule-aligned from query-region matches.
+    pub coordinates: MatchCoordinates,
 
     /// Candidate resemblance score from set similarity.
     /// Used for cross-license tie-breaking when matches overlap.
@@ -266,9 +329,7 @@ impl Default for LicenseMatch {
             rule_kind: RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::default(),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -313,39 +374,43 @@ impl LicenseMatch {
     }
 
     pub fn hilen(&self) -> usize {
-        self.hispan.len()
+        self.coordinates.hispan().map_or(0, |h| h.len())
+    }
+
+    pub fn query_span(&self) -> &PositionSpan {
+        self.coordinates.query_span()
+    }
+
+    pub fn rule_span(&self) -> Option<&PositionSpan> {
+        self.coordinates.rule_span()
+    }
+
+    pub fn has_rule_alignment(&self) -> bool {
+        self.coordinates.has_rule_alignment()
     }
 
     pub fn qstart(&self) -> usize {
-        let (min, _) = self.effective_span().bounds();
+        let (min, _) = self.query_span().bounds();
         min
     }
 
-    pub fn effective_span(&self) -> PositionSpan {
-        if !self.qspan.is_empty() {
-            self.qspan.clone()
-        } else if self.start_token < self.end_token {
-            PositionSpan::range(self.start_token, self.end_token)
-        } else {
-            PositionSpan::empty()
-        }
-    }
-
     pub(crate) fn effective_ispan(&self) -> PositionSpan {
-        if !self.ispan.is_empty() {
-            self.ispan.clone()
-        } else if self.matched_length > 0 {
-            PositionSpan::range(
+        if let Some(ispan) = self.rule_span()
+            && !ispan.is_empty()
+        {
+            return ispan.clone();
+        }
+        if self.matcher == MatcherKind::Unknown && self.matched_length > 0 {
+            return PositionSpan::range(
                 self.rule_start_token,
                 self.rule_start_token + self.matched_length,
-            )
-        } else {
-            PositionSpan::empty()
+            );
         }
+        PositionSpan::empty()
     }
 
     pub(crate) fn qspan_set(&self) -> PositionSet {
-        self.effective_span().to_position_set()
+        self.query_span().to_position_set()
     }
 
     pub(crate) fn ispan_set(&self) -> PositionSet {
@@ -368,16 +433,16 @@ impl LicenseMatch {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.effective_span().len()
+        self.query_span().len()
     }
 
     fn qregion_len(&self) -> usize {
-        let (min, max) = self.effective_span().bounds();
+        let (min, max) = self.query_span().bounds();
         max.saturating_sub(min)
     }
 
     pub fn qmagnitude(&self, query: &crate::license_detection::query::Query) -> usize {
-        let span = self.effective_span();
+        let span = self.query_span();
         let qregion_len = self.qregion_len();
         if span.is_empty() {
             return qregion_len;
@@ -432,39 +497,30 @@ impl LicenseMatch {
     }
 
     pub fn qcontains(&self, other: &LicenseMatch) -> bool {
-        let self_span = self.effective_span();
-        let other_span = other.effective_span();
-
-        if self_span.is_empty() && other_span.is_empty() {
-            return self.start_line <= other.start_line && self.end_line >= other.end_line;
-        }
-
-        other_span.iter().all(|pos| self_span.contains(pos))
+        other
+            .query_span()
+            .iter()
+            .all(|pos| self.query_span().contains(pos))
     }
 
     pub fn qoverlap(&self, other: &LicenseMatch) -> usize {
-        let self_span = self.effective_span();
-        let other_span = other.effective_span();
-
-        if self_span.is_empty() && other_span.is_empty() {
-            let start = self.start_line.max(other.start_line);
-            let end = self.end_line.min(other.end_line);
-            return if start <= end { end - start + 1 } else { 0 };
-        }
-
-        other_span.iter().filter(|&p| self_span.contains(p)).count()
+        other
+            .query_span()
+            .iter()
+            .filter(|&p| self.query_span().contains(p))
+            .count()
     }
 
     pub fn qspan_overlap(&self, other: &LicenseMatch) -> usize {
-        let self_set = self.effective_span().to_position_set();
-        let other_set = other.effective_span().to_position_set();
+        let self_set = self.query_span().to_position_set();
+        let other_set = other.query_span().to_position_set();
         self_set.intersection_len(&other_set)
     }
 
     /// Return true if all matched tokens are continuous without gaps or unknowns.
     /// Python: len() == qregion_len() == qmagnitude()
     pub fn is_continuous(&self, query: &crate::license_detection::query::Query) -> bool {
-        if !self.effective_span().is_contiguous() {
+        if !self.query_span().is_contiguous() {
             return false;
         }
         let len = self.len();
@@ -474,18 +530,11 @@ impl LicenseMatch {
     }
 
     pub fn overlaps_with(&self, other: &PositionSet) -> bool {
-        self.effective_span().overlaps_set(other)
+        self.query_span().overlaps_set(other)
     }
 
     pub fn qspan_eq(&self, other: &LicenseMatch) -> bool {
-        let self_span = self.effective_span();
-        let other_span = other.effective_span();
-
-        if self_span.is_empty() && other_span.is_empty() {
-            self.start_line == other.start_line && self.end_line == other.end_line
-        } else {
-            self_span == other_span
-        }
+        self.query_span() == other.query_span()
     }
 
     pub fn qdistance_to(&self, other: &LicenseMatch) -> usize {
@@ -510,7 +559,7 @@ impl LicenseMatch {
     }
 
     pub fn qspan_bounds(&self) -> (usize, usize) {
-        self.effective_span().bounds()
+        self.query_span().bounds()
     }
 
     pub fn qspan_magnitude(&self) -> usize {
@@ -523,8 +572,11 @@ impl LicenseMatch {
     }
 
     pub fn idistance_to(&self, other: &LicenseMatch) -> usize {
-        let (self_start, self_end) = self.ispan_bounds();
-        let (other_start, other_end) = other.ispan_bounds();
+        let (Some(self_span), Some(other_span)) = (self.rule_span(), other.rule_span()) else {
+            return 0;
+        };
+        let (self_start, self_end) = self_span.bounds();
+        let (other_start, other_end) = other_span.bounds();
 
         if self_start < other_end && other_start < self_end {
             return 0;
@@ -547,8 +599,12 @@ impl LicenseMatch {
 
         let q_after = self_qstart >= other_qend;
 
-        let (self_istart, _self_iend) = self.ispan_bounds();
-        let (_other_istart, other_iend) = other.ispan_bounds();
+        let (Some(self_ispan), Some(other_ispan)) = (self.rule_span(), other.rule_span()) else {
+            return q_after;
+        };
+
+        let (self_istart, _self_iend) = self_ispan.bounds();
+        let (_other_istart, other_iend) = other_ispan.bounds();
 
         let i_after = self_istart >= other_iend;
 
@@ -556,12 +612,12 @@ impl LicenseMatch {
     }
 
     pub fn ispan_overlap(&self, other: &LicenseMatch) -> usize {
-        let self_set = self.effective_ispan().to_position_set();
-        other
-            .effective_ispan()
-            .iter()
-            .filter(|&p| self_set.contains(p))
-            .count()
+        let (Some(self_ispan), Some(other_ispan)) = (self.rule_span(), other.rule_span()) else {
+            return 0;
+        };
+
+        let self_set = self_ispan.to_position_set();
+        other_ispan.iter().filter(|&p| self_set.contains(p)).count()
     }
 
     pub fn has_unknown(&self) -> bool {

--- a/src/license_detection/models/mod.rs
+++ b/src/license_detection/models/mod.rs
@@ -8,7 +8,7 @@ pub mod position_span;
 pub mod rule;
 
 pub use license::License;
-pub use license_match::{LicenseMatch, MatcherKind};
+pub use license_match::{LicenseMatch, MatchCoordinates, MatcherKind};
 pub use loaded_license::LoadedLicense;
 pub use loaded_rule::LoadedRule;
 pub use position_span::PositionSpan;

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -3,7 +3,9 @@ mod tests {
     use crate::license_detection::index::LicenseIndex;
     use crate::license_detection::index::dictionary::tid;
     use crate::license_detection::models::position_span::PositionSpan;
-    use crate::license_detection::models::{License, LicenseMatch, MatcherKind, Rule, RuleKind};
+    use crate::license_detection::models::{
+        License, LicenseMatch, MatchCoordinates, MatcherKind, Rule, RuleKind,
+    };
     use crate::license_detection::position_set::PositionSet;
     use crate::models::Match as OutputMatch;
     use std::collections::HashMap;
@@ -110,9 +112,11 @@ mod tests {
             rule_kind: RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::range(0, 100),
-            ispan: PositionSpan::range(0, 100),
-            hispan: PositionSpan::range(0, 50),
+            coordinates: MatchCoordinates::rule_aligned(
+                PositionSpan::range(0, 100),
+                PositionSpan::range(0, 100),
+                PositionSpan::range(0, 50),
+            ),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -527,9 +531,7 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         };
@@ -637,9 +639,11 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::rule_aligned(
+                PositionSpan::range(0, 100),
+                PositionSpan::range(0, 100),
+                PositionSpan::range(0, 50),
+            ),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         };
@@ -659,7 +663,8 @@ mod tests {
     #[test]
     fn test_len_non_contiguous() {
         let mut match_result = create_license_match();
-        match_result.qspan = PositionSpan::from_positions(vec![0, 2, 5, 10]);
+        match_result.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 2, 5, 10]));
         assert_eq!(match_result.len(), 4);
     }
 
@@ -668,7 +673,7 @@ mod tests {
         let mut match_result = create_license_match();
         match_result.start_token = 0;
         match_result.end_token = 0;
-        match_result.qspan = PositionSpan::empty();
+        match_result.coordinates = MatchCoordinates::query_region(PositionSpan::empty());
         assert_eq!(match_result.len(), 0);
     }
 
@@ -699,7 +704,8 @@ mod tests {
         use std::collections::HashMap;
         let index = create_test_index();
         let mut match_result = create_license_match();
-        match_result.qspan = PositionSpan::from_positions(vec![0, 10]);
+        match_result.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 10]));
         let query = crate::license_detection::query::Query {
             text: String::new(),
             tokens: vec![],
@@ -725,7 +731,7 @@ mod tests {
         let mut match_result = create_license_match();
         match_result.start_token = 0;
         match_result.end_token = 0;
-        match_result.qspan = PositionSpan::empty();
+        match_result.coordinates = MatchCoordinates::query_region(PositionSpan::empty());
         let query = crate::license_detection::query::Query {
             text: String::new(),
             tokens: vec![],
@@ -750,7 +756,8 @@ mod tests {
         let mut match_result = create_license_match();
         match_result.start_token = 0;
         match_result.end_token = 10;
-        match_result.qspan = PositionSpan::from_positions(vec![0, 5, 9]);
+        match_result.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 9]));
         let mut unknowns_by_pos = HashMap::new();
         unknowns_by_pos.insert(Some(0), 2);
         unknowns_by_pos.insert(Some(5), 3);
@@ -777,7 +784,8 @@ mod tests {
         use std::collections::HashMap;
         let index = create_test_index();
         let mut match_result = create_license_match();
-        match_result.qspan = PositionSpan::from_positions(vec![0, 5, 10]);
+        match_result.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 10]));
         let mut unknowns_by_pos = HashMap::new();
         unknowns_by_pos.insert(Some(0), 2);
         unknowns_by_pos.insert(Some(5), 3);
@@ -804,7 +812,8 @@ mod tests {
         use std::collections::HashMap;
         let index = create_test_index();
         let mut match_result = create_license_match();
-        match_result.qspan = PositionSpan::from_positions(vec![0, 5, 10]);
+        match_result.coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 10]));
         let mut unknowns_by_pos = HashMap::new();
         unknowns_by_pos.insert(Some(10), 100);
         let query = crate::license_detection::query::Query {
@@ -834,7 +843,11 @@ mod tests {
     fn test_idensity_sparse_ispan() {
         let mut match_result = create_license_match();
         match_result.matched_length = 2;
-        match_result.ispan = PositionSpan::from_positions(vec![0, 10]);
+        match_result.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::empty(),
+            PositionSpan::from_positions(vec![0, 10]),
+            PositionSpan::empty(),
+        );
         let expected = 2.0 / 11.0;
         assert!((match_result.idensity() - expected).abs() < 0.001);
     }
@@ -845,7 +858,11 @@ mod tests {
         match_result.start_token = 0;
         match_result.end_token = 20;
         match_result.matched_length = 5;
-        match_result.ispan = PositionSpan::from_positions(vec![0, 2, 4, 6, 8]);
+        match_result.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::empty(),
+            PositionSpan::from_positions(vec![0, 2, 4, 6, 8]),
+            PositionSpan::empty(),
+        );
         assert!((match_result.idensity() - (5.0 / 9.0)).abs() < 0.001);
     }
 
@@ -853,7 +870,11 @@ mod tests {
     fn test_idensity_zero() {
         let mut match_result = create_license_match();
         match_result.matched_length = 0;
-        match_result.ispan = PositionSpan::empty();
+        match_result.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+            PositionSpan::empty(),
+        );
         assert_eq!(match_result.idensity(), 0.0);
     }
 
@@ -879,7 +900,7 @@ mod tests {
             end_line: 20,
             start_token: 1,
             end_token: 20,
-            qspan: PositionSpan::range(1, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 20)),
             ..create_license_match()
         };
         let inner = LicenseMatch {
@@ -887,7 +908,7 @@ mod tests {
             end_line: 15,
             start_token: 1,
             end_token: 15,
-            qspan: PositionSpan::range(1, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 15)),
             ..create_license_match()
         };
         assert!(outer.surround(&inner));
@@ -900,7 +921,7 @@ mod tests {
             end_line: 20,
             start_token: 1,
             end_token: 20,
-            qspan: PositionSpan::range(1, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 20)),
             ..create_license_match()
         };
         let inner = LicenseMatch {
@@ -908,7 +929,7 @@ mod tests {
             end_line: 20,
             start_token: 5,
             end_token: 20,
-            qspan: PositionSpan::range(5, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 20)),
             ..create_license_match()
         };
         assert!(outer.surround(&inner));
@@ -921,7 +942,7 @@ mod tests {
             end_line: 15,
             start_token: 5,
             end_token: 15,
-            qspan: PositionSpan::range(5, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 15)),
             ..create_license_match()
         };
         let inner = LicenseMatch {
@@ -929,7 +950,7 @@ mod tests {
             end_line: 20,
             start_token: 1,
             end_token: 20,
-            qspan: PositionSpan::range(1, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 20)),
             ..create_license_match()
         };
         assert!(!outer.surround(&inner));
@@ -942,7 +963,7 @@ mod tests {
             end_line: 10,
             start_token: 1,
             end_token: 10,
-            qspan: PositionSpan::range(1, 10),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 10)),
             ..create_license_match()
         };
         let second = LicenseMatch {
@@ -950,7 +971,7 @@ mod tests {
             end_line: 20,
             start_token: 11,
             end_token: 20,
-            qspan: PositionSpan::range(11, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(11, 20)),
             ..create_license_match()
         };
         assert!(!first.surround(&second));
@@ -962,13 +983,13 @@ mod tests {
         let outer = LicenseMatch {
             start_token: 0,
             end_token: 20,
-            qspan: PositionSpan::range(0, 20),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 20)),
             ..create_license_match()
         };
         let inner = LicenseMatch {
             start_token: 5,
             end_token: 15,
-            qspan: PositionSpan::range(5, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 15)),
             ..create_license_match()
         };
         assert!(outer.qcontains(&inner));
@@ -980,13 +1001,13 @@ mod tests {
         let a = LicenseMatch {
             start_token: 0,
             end_token: 10,
-            qspan: PositionSpan::range(0, 10),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 10)),
             ..create_license_match()
         };
         let b = LicenseMatch {
             start_token: 0,
             end_token: 10,
-            qspan: PositionSpan::range(0, 10),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 10)),
             ..create_license_match()
         };
         assert!(a.qcontains(&b));
@@ -998,13 +1019,13 @@ mod tests {
         let a = LicenseMatch {
             start_token: 0,
             end_token: 10,
-            qspan: PositionSpan::range(0, 10),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 10)),
             ..create_license_match()
         };
         let b = LicenseMatch {
             start_token: 5,
             end_token: 15,
-            qspan: PositionSpan::range(5, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 15)),
             ..create_license_match()
         };
         assert!(!a.qcontains(&b));
@@ -1016,13 +1037,13 @@ mod tests {
         let a = LicenseMatch {
             start_token: 0,
             end_token: 5,
-            qspan: PositionSpan::range(0, 5),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 5)),
             ..create_license_match()
         };
         let b = LicenseMatch {
             start_token: 10,
             end_token: 15,
-            qspan: PositionSpan::range(10, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(10, 15)),
             ..create_license_match()
         };
         assert!(!a.qcontains(&b));
@@ -1034,13 +1055,13 @@ mod tests {
         let a = LicenseMatch {
             start_token: 0,
             end_token: 10,
-            qspan: PositionSpan::range(0, 10),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 10)),
             ..create_license_match()
         };
         let b = LicenseMatch {
             start_token: 0,
             end_token: 15,
-            qspan: PositionSpan::range(0, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 15)),
             ..create_license_match()
         };
         assert!(!a.qcontains(&b));
@@ -1052,126 +1073,17 @@ mod tests {
         let a = LicenseMatch {
             start_token: 5,
             end_token: 15,
-            qspan: PositionSpan::range(5, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 15)),
             ..create_license_match()
         };
         let b = LicenseMatch {
             start_token: 0,
             end_token: 15,
-            qspan: PositionSpan::range(0, 15),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 15)),
             ..create_license_match()
         };
         assert!(!a.qcontains(&b));
         assert!(b.qcontains(&a));
-    }
-
-    #[test]
-    fn test_qcontains_zero_tokens_fallback_line_contained() {
-        let outer = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 20,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let inner = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 5,
-            end_line: 15,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        assert!(outer.qcontains(&inner));
-        assert!(!inner.qcontains(&outer));
-    }
-
-    #[test]
-    fn test_qcontains_zero_tokens_fallback_same_lines() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        assert!(a.qcontains(&b));
-        assert!(b.qcontains(&a));
-    }
-
-    #[test]
-    fn test_qcontains_zero_tokens_fallback_no_containment() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 5,
-            end_line: 15,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        assert!(!a.qcontains(&b));
-        assert!(!b.qcontains(&a));
-    }
-
-    #[test]
-    fn test_qcontains_zero_tokens_fallback_different_lines() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 5,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 10,
-            end_line: 15,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        assert!(!a.qcontains(&b));
-        assert!(!b.qcontains(&a));
-    }
-
-    #[test]
-    fn test_qcontains_mixed_tokens_uses_token_positions() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 20,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 5,
-            end_token: 10,
-            start_line: 5,
-            end_line: 15,
-            qspan: PositionSpan::range(5, 10),
-            ..create_license_match()
-        };
-        assert!(!a.qcontains(&b));
     }
 
     #[test]
@@ -1179,11 +1091,11 @@ mod tests {
         let mut a = create_license_match();
         a.start_token = 0;
         a.end_token = 10;
-        a.qspan = PositionSpan::range(0, 10);
+        a.coordinates = MatchCoordinates::query_region(PositionSpan::range(0, 10));
         let mut b = create_license_match();
         b.start_token = 5;
         b.end_token = 15;
-        b.qspan = PositionSpan::range(5, 15);
+        b.coordinates = MatchCoordinates::query_region(PositionSpan::range(5, 15));
         assert_eq!(a.qdistance_to(&b), 0);
         assert_eq!(b.qdistance_to(&a), 0);
     }
@@ -1193,11 +1105,11 @@ mod tests {
         let mut a = create_license_match();
         a.start_token = 0;
         a.end_token = 10;
-        a.qspan = PositionSpan::range(0, 10);
+        a.coordinates = MatchCoordinates::query_region(PositionSpan::range(0, 10));
         let mut b = create_license_match();
         b.start_token = 10;
         b.end_token = 20;
-        b.qspan = PositionSpan::range(10, 20);
+        b.coordinates = MatchCoordinates::query_region(PositionSpan::range(10, 20));
         assert_eq!(a.qdistance_to(&b), 1);
         assert_eq!(b.qdistance_to(&a), 1);
     }
@@ -1207,11 +1119,11 @@ mod tests {
         let mut a = create_license_match();
         a.start_token = 0;
         a.end_token = 5;
-        a.qspan = PositionSpan::range(0, 5);
+        a.coordinates = MatchCoordinates::query_region(PositionSpan::range(0, 5));
         let mut b = create_license_match();
         b.start_token = 15;
         b.end_token = 20;
-        b.qspan = PositionSpan::range(15, 20);
+        b.coordinates = MatchCoordinates::query_region(PositionSpan::range(15, 20));
         assert_eq!(a.qdistance_to(&b), 11);
         assert_eq!(b.qdistance_to(&a), 11);
     }
@@ -1219,12 +1131,12 @@ mod tests {
     #[test]
     fn test_qdistance_to_gapped_spans_matches_python_semantics() {
         let mut a = create_license_match();
-        a.qspan = PositionSpan::from_positions(vec![55]);
+        a.coordinates = MatchCoordinates::query_region(PositionSpan::from_positions(vec![55]));
         a.start_token = 55;
         a.end_token = 56;
 
         let mut b = create_license_match();
-        b.qspan = PositionSpan::from_positions(vec![57, 58]);
+        b.coordinates = MatchCoordinates::query_region(PositionSpan::from_positions(vec![57, 58]));
         b.start_token = 57;
         b.end_token = 59;
 
@@ -1256,122 +1168,37 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_span_fallback_qspan_bounds() {
-        let mut m = create_license_match();
-        m.start_token = 10;
-        m.end_token = 20;
-        m.qspan = PositionSpan::empty();
-
-        let bounds = m.qspan_bounds();
-        assert_eq!(bounds, (10, 20));
-    }
-
-    #[test]
-    fn test_effective_span_fallback_ispan_bounds() {
+    fn test_query_region_matches_do_not_synthesize_ispan_bounds() {
         let mut m = create_license_match();
         m.rule_start_token = 5;
         m.matched_length = 30;
-        m.ispan = PositionSpan::empty();
+        m.matcher = crate::license_detection::models::MatcherKind::SpdxId;
+        m.coordinates = MatchCoordinates::query_region(PositionSpan::range(10, 40));
+
+        let bounds = m.ispan_bounds();
+        assert_eq!(bounds, (0, 0));
+        assert_eq!(m.idensity(), 0.0);
+    }
+
+    #[test]
+    fn test_unknown_query_region_uses_synthetic_ispan_bounds() {
+        let mut m = create_license_match();
+        m.rule_start_token = 5;
+        m.matched_length = 30;
+        m.matcher = crate::license_detection::models::MatcherKind::Unknown;
+        m.coordinates = MatchCoordinates::query_region(PositionSpan::range(10, 40));
 
         let bounds = m.ispan_bounds();
         assert_eq!(bounds, (5, 35));
+        assert_eq!(m.idensity(), 1.0);
     }
 
     #[test]
-    fn test_effective_span_fallback_qoverlap_lines() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 5,
-            end_line: 15,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-
-        assert_eq!(a.qoverlap(&b), 6);
-        assert_eq!(b.qoverlap(&a), 6);
-    }
-
-    #[test]
-    fn test_effective_span_fallback_qspan_eq_lines() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-
-        assert!(a.qspan_eq(&b));
-    }
-
-    #[test]
-    fn test_effective_span_fallback_qspan_eq_lines_differ() {
-        let a = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 10,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 0,
-            end_token: 0,
-            start_line: 1,
-            end_line: 20,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-
-        assert!(!a.qspan_eq(&b));
-    }
-
-    #[test]
-    fn test_effective_span_fallback_qoverlap_with_tokens_vs_empty() {
-        let a = LicenseMatch {
-            start_token: 10,
-            end_token: 20,
-            qspan: PositionSpan::empty(),
-            ..create_license_match()
-        };
-        let b = LicenseMatch {
-            start_token: 15,
-            end_token: 25,
-            qspan: PositionSpan::range(15, 25),
-            ..create_license_match()
-        };
-
-        let overlap_ab: usize = b.qspan.iter().filter(|&p| (10..20).contains(&p)).count();
-        let overlap_ba: usize = (10..20).filter(|p| (15..25).contains(p)).count();
-        assert_eq!(a.qoverlap(&b), overlap_ab);
-        assert_eq!(b.qoverlap(&a), overlap_ba);
-        assert_eq!(overlap_ab, overlap_ba);
-    }
-
-    #[test]
-    fn test_effective_span_nonempty_preferred_over_tokens() {
+    fn test_qspan_bounds_use_explicit_query_span() {
         let mut m = create_license_match();
         m.start_token = 100;
         m.end_token = 200;
-        m.qspan = PositionSpan::range(10, 20);
+        m.coordinates = MatchCoordinates::query_region(PositionSpan::range(10, 20));
 
         assert_eq!(m.qspan_bounds(), (10, 20));
     }

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -2,8 +2,8 @@
 
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenId;
-use crate::license_detection::models::LicenseMatch;
 use crate::license_detection::models::position_span::PositionSpan;
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates};
 use crate::license_detection::query::QueryRun;
 use bit_set::BitSet;
 use std::collections::HashMap;
@@ -283,15 +283,20 @@ pub fn seq_match_with_candidates(
                         continue;
                     }
 
-                    let qspan =
-                        PositionSpan::range(qpos + query_run.start, qpos + mlen + query_run.start);
-                    let ispan = PositionSpan::range(ipos, ipos + mlen);
-
                     let qend = qpos + mlen - 1;
                     let abs_qpos = qpos + query_run.start;
                     let abs_qend = qend + query_run.start;
                     let start_line = query_run.line_for_pos(abs_qpos).unwrap_or(1);
                     let end_line = query_run.line_for_pos(abs_qend).unwrap_or(start_line);
+
+                    let qspan =
+                        PositionSpan::range(qpos + query_run.start, qpos + mlen + query_run.start);
+                    let ispan = PositionSpan::range(ipos, ipos + mlen);
+                    let hispan = PositionSpan::from_positions((ipos..ipos + mlen).filter(|&p| {
+                        rule_tokens
+                            .get(p)
+                            .is_some_and(|t| t.as_usize() < len_legalese)
+                    }));
 
                     let rule_coverage = mlen as f32 / rule_length as f32;
                     let match_coverage = LicenseMatch::round_metric(rule_coverage * 100.0);
@@ -323,13 +328,7 @@ pub fn seq_match_with_candidates(
                         rule_kind: candidate.rule.kind(),
                         is_from_license: candidate.rule.is_from_license,
                         rule_start_token: ipos,
-                        qspan,
-                        ispan,
-                        hispan: PositionSpan::from_positions((ipos..ipos + mlen).filter(|&p| {
-                            rule_tokens
-                                .get(p)
-                                .is_some_and(|t| t.as_usize() < len_legalese)
-                        })),
+                        coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
                         candidate_resemblance: candidate.score_vec_full.resemblance,
                         candidate_containment: candidate.score_vec_full.containment,
                     };

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -19,7 +19,7 @@ use sha1::{Digest, Sha1};
 use crate::license_detection::expression::{LicenseExpression, parse_expression};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
 use crate::license_detection::query::Query;
 
 pub const MATCH_SPDX_ID: MatcherKind = MatcherKind::SpdxId;
@@ -344,6 +344,8 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
             let referenced_filenames = None;
             let score = 100.0;
 
+            let qspan = PositionSpan::range(*start_token, *end_token);
+
             let license_match = LicenseMatch {
                 license_expression,
                 license_expression_spdx: Some(spdx_expression.clone()),
@@ -366,9 +368,7 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
                 rule_kind: crate::license_detection::models::RuleKind::Tag,
                 is_from_license: false,
                 rule_start_token: 0,
-                qspan: PositionSpan::empty(),
-                ispan: PositionSpan::empty(),
-                hispan: PositionSpan::empty(),
+                coordinates: MatchCoordinates::query_region(qspan),
                 candidate_resemblance: 0.0,
                 candidate_containment: 0.0,
             };

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use std::sync::Once;
 
-use crate::license_detection::models::position_span::PositionSpan;
+use crate::license_detection::models::{MatchCoordinates, position_span::PositionSpan};
 
 static TEST_ENGINE: Lazy<LicenseDetectionEngine> = Lazy::new(|| {
     LicenseDetectionEngine::from_embedded().expect("Should initialize from embedded artifact")
@@ -46,7 +46,7 @@ fn make_test_match(
         matched_length,
         rule_length: matched_length,
         match_coverage: 100.0,
-        qspan,
+        coordinates: MatchCoordinates::query_region(qspan),
         ..Default::default()
     }
 }

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -8,7 +8,7 @@ use sha1::{Digest, Sha1};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
 use crate::license_detection::tokenize::STOPWORDS;
@@ -120,7 +120,7 @@ pub fn unknown_match(
 fn compute_covered_positions(_query: &Query, known_matches: &[LicenseMatch]) -> PositionSet {
     let mut covered = PositionSet::new();
     for m in known_matches {
-        covered.extend_from_span(&m.effective_span());
+        covered.extend_from_span(m.query_span());
     }
     covered
 }
@@ -254,6 +254,8 @@ fn create_unknown_match_from_qspan(query: &Query, qspan: &PositionSet) -> Option
 
     let score = calculate_score(ngram_count, match_len);
 
+    let qspan_span = qspan.to_position_span();
+
     LicenseMatch {
         rid: 0,
         license_expression: "unknown".to_string(),
@@ -276,9 +278,7 @@ fn create_unknown_match_from_qspan(query: &Query, qspan: &PositionSet) -> Option
         rule_kind: crate::license_detection::models::RuleKind::None,
         is_from_license: false,
         rule_start_token: 0,
-        qspan: qspan.to_position_span(),
-        ispan: PositionSpan::empty(),
-        hispan: PositionSpan::empty(),
+        coordinates: MatchCoordinates::query_region(qspan_span),
         candidate_resemblance: 0.0,
         candidate_containment: 0.0,
     }
@@ -826,9 +826,9 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::from_positions(vec![0, 1, 2, 7, 8, 9]),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::from_positions(vec![
+                0, 1, 2, 7, 8, 9,
+            ])),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }];
@@ -875,9 +875,7 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 10)),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }];
@@ -925,9 +923,9 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::from_positions(vec![0, 1, 2, 3, 11, 12, 13, 14]),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::from_positions(vec![
+                0, 1, 2, 3, 11, 12, 13, 14,
+            ])),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }];
@@ -976,7 +974,7 @@ mod tests {
         let m = match_result.unwrap();
         assert_eq!(m.license_expression, "unknown");
         assert_eq!(m.matcher, MATCH_UNKNOWN);
-        assert!(!m.qspan.is_empty());
+        assert!(!m.coordinates.query_span().is_empty());
     }
 
     #[test]
@@ -1008,9 +1006,7 @@ mod tests {
             rule_kind: crate::license_detection::models::RuleKind::None,
             is_from_license: false,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 5)),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }];

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -17,7 +17,6 @@ use crate::license_detection::expression::{
     simplify_expression,
 };
 use crate::license_detection::index::LicenseIndex;
-use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::spdx_mapping::build_spdx_mapping;
 use crate::models::{
     DatasourceId, ExtraData, FacetTallies, FileInfo, FileType, Header, LicenseClarityScore,
@@ -1172,9 +1171,9 @@ fn public_match_to_internal(
         rule_kind: crate::license_detection::models::RuleKind::None,
         is_from_license: false,
         rule_start_token: 0,
-        qspan: PositionSpan::empty(),
-        ispan: PositionSpan::empty(),
-        hispan: PositionSpan::empty(),
+        coordinates: crate::license_detection::models::MatchCoordinates::query_region(
+            crate::license_detection::models::PositionSpan::empty(),
+        ),
         candidate_resemblance: 0.0,
         candidate_containment: 0.0,
     }

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -963,7 +963,7 @@ fn compute_percentage_of_license_text(
     let matched_positions: std::collections::HashSet<usize> = detections
         .iter()
         .flat_map(|detection| detection.matches.iter())
-        .flat_map(|m| m.qspan.iter())
+        .flat_map(|m| m.query_span().iter())
         .collect();
 
     let query_tokens_length = query.tokens.len() + query.unknowns_by_pos.values().sum::<usize>();
@@ -979,7 +979,7 @@ fn matched_text_diagnostics_from_match(
     query: &Query<'_>,
     license_match: &InternalLicenseMatch,
 ) -> String {
-    let matched_positions: PositionSet = license_match.qspan.iter().collect();
+    let matched_positions: PositionSet = license_match.query_span().iter().collect();
     let Some(start_pos) = matched_positions.iter().min() else {
         return crate::license_detection::query::matched_text_from_text(
             &query.text,
@@ -1120,7 +1120,7 @@ mod tests {
     use crate::license_detection::index::LicenseIndex;
     use crate::license_detection::index::dictionary::TokenDictionary;
     use crate::license_detection::models::position_span::PositionSpan;
-    use crate::license_detection::models::{LicenseMatch, MatcherKind, RuleKind};
+    use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleKind};
     use crate::license_detection::query::Query;
     use crate::scanner::LicenseScanOptions;
     use std::fs;
@@ -1149,9 +1149,7 @@ mod tests {
             rule_kind: RuleKind::Text,
             is_from_license: true,
             rule_start_token: 0,
-            qspan: PositionSpan::empty(),
-            ispan: PositionSpan::empty(),
-            hispan: PositionSpan::empty(),
+            coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
             candidate_resemblance: 0.0,
             candidate_containment: 0.0,
         }
@@ -1300,14 +1298,15 @@ mod tests {
         detection.matches[0].end_line = 3;
         detection.matches[0].start_token = 0;
         detection.matches[0].end_token = query.tokens.len();
-        detection.matches[0].qspan = PositionSpan::from_positions(
-            query
-                .tokens
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, _)| (idx != 9).then_some(idx))
-                .collect::<Vec<_>>(),
-        );
+        detection.matches[0].coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(
+                query
+                    .tokens
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, _)| (idx != 9).then_some(idx))
+                    .collect::<Vec<_>>(),
+            ));
         detection.identifier = Some("fsf_ap-test".to_string());
 
         let (converted, clues) = convert_detection_to_model(
@@ -1345,7 +1344,8 @@ mod tests {
         let text = "alpha MIT omega";
         let query = Query::from_extracted_text(text, &index, false).expect("query should build");
         let mut detection = make_detection("");
-        detection.matches[0].qspan = PositionSpan::from_positions(vec![1]);
+        detection.matches[0].coordinates =
+            MatchCoordinates::query_region(PositionSpan::from_positions(vec![1]));
         detection.matches[0].start_token = 1;
         detection.matches[0].end_token = 2;
 


### PR DESCRIPTION
## Summary
- introduce `MatchCoordinates` to separate rule-aligned matches from query-region matches, and update match constructors to populate explicit coordinates consistently
- remove the remaining query-span fallback shim so query geometry comes only from explicit coordinate data, while keeping the unknown-specific synthetic rule-span behavior where refinement still depends on it
- update merge, overlap, refinement, scanner, and detection code to preserve the new semantics, add regression coverage

## Verification
- cargo test --lib license_detection::models::mod_tests::tests::test_qspan_bounds_use_explicit_query_span -- --exact
- cargo test --lib license_detection::models::mod_tests::tests::test_query_region_matches_do_not_synthesize_ispan_bounds -- --exact
- cargo test --lib license_detection::models::mod_tests::tests::test_unknown_query_region_uses_synthetic_ispan_bounds -- --exact
- cargo test --lib license_detection::match_refine::merge::tests::test_merge_adjacent_unknown_matches_preserve_query_region_coordinates -- --exact
- cargo test --lib license_detection::match_refine::merge::tests::test_do_not_merge_adjacent_spdx_query_region_matches -- --exact
- cargo test --release --features golden-tests --lib license_detection::golden_test::golden_tests::test_golden_unknown -- --exact
- cargo test --release --features golden-tests --lib license_detection::golden_test::golden_tests::test_golden_external_part9 -- --exact
- cargo clippy --all-targets --all-features