### PR TITLE
ci: split library tests out of code quality

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,9 +77,6 @@ jobs:
       - name: Check compilation
         run: cargo check --all --verbose
 
-      - name: Run library tests except scanner/assembly contract layer
-        run: "cargo test --lib --release --verbose -- --skip _scan_test::"
-
       - name: Run doctests
         run: cargo test --doc --release --verbose
 
@@ -88,6 +85,28 @@ jobs:
 
       - name: Check for unused dependencies
         run: ./scripts/check_unused_deps.sh
+
+  rust-library-tests:
+    name: Rust Library Tests
+    runs-on: ubuntu-latest
+    if: |
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          submodules: recursive
+          lfs: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-library-tests-release
+
+      - name: Run library tests except scanner/assembly contract layer
+        run: "cargo test --lib --release --verbose -- --skip _scan_test::"
 
   windows-build-smoke:
     name: Windows Build Smoke Test

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -476,16 +476,17 @@ Quality gates run automatically on:
 - Every push to main
 - Every pull request
 
-The full test suites run in CI on pushes and pull requests. All tests must pass before merging. CI uses a minimal split so the scanner-wired tests no longer sit
-on the same critical path as the main Rust quality job, without introducing lots of tiny shards.
+The full test suites run in CI on pushes and pull requests. All tests must pass before merging. CI uses a minimal split so the heaviest Rust test layers no
+longer sit on the same critical path as the main Rust quality job, without introducing lots of tiny shards.
 Commands:
 
 - **Rust Quality**
   - `cargo fmt --all -- --check`
   - `cargo clippy --all-targets --all-features -- -D warnings`
   - `cargo check --all --verbose`
-  - `cargo test --lib --release --verbose -- --skip _scan_test::`
   - `cargo test --doc --release --verbose`
+- **Rust Library Tests**
+  - `cargo test --lib --release --verbose -- --skip _scan_test::`
 - **Rust Scan/Integration Tests**
   - `cargo test --lib --release --verbose _scan_test::`
   - `cargo test --test scanner_integration --release --verbose`


### PR DESCRIPTION
## Summary

- move `cargo test --lib --release --verbose -- --skip _scan_test::` into a dedicated parallel `Rust Library Tests` job
- keep `cargo test --doc --release --verbose` in `Code Quality` so only the slowest test phase leaves that critical path
- update `docs/TESTING_STRATEGY.md` to match the new CI layout

## Scope and exclusions

- Included: the Code Quality workflow split for non-`_scan_test` library tests and the corresponding testing-strategy documentation update
- Explicit exclusions: no changes to doctest placement, scanner/integration shards, or golden-test sharding

## Follow-up work

- Created or intentionally deferred: monitor CI timings after merge to confirm the Code Quality job drops by the expected several minutes