### PR TITLE
perf(post-processing): parallelize file-local output preparation

### DIFF
--- a/src/post_processing/classification.rs
+++ b/src/post_processing/classification.rs
@@ -1,3 +1,5 @@
+use rayon::prelude::*;
+
 use crate::models::FileInfo;
 #[cfg(test)]
 use crate::models::Package;
@@ -71,9 +73,13 @@ pub(crate) fn apply_file_classification(
     files: &mut [FileInfo],
     package_file_index: &PackageFileIndex,
 ) {
-    for idx in 0..files.len() {
-        let classification = package_file_index.classify_file(files, FileIx(idx));
-        let file = &mut files[idx];
+    let classifications: Vec<_> = files
+        .par_iter()
+        .enumerate()
+        .map(|(idx, _)| package_file_index.classify_file(files, FileIx(idx)))
+        .collect();
+
+    for (file, classification) in files.iter_mut().zip(classifications) {
         file.is_legal = classification.is_legal;
         file.is_manifest = classification.is_manifest;
         file.is_readme = classification.is_readme;

--- a/src/post_processing/license_references.rs
+++ b/src/post_processing/license_references.rs
@@ -1,4 +1,6 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use rayon::prelude::*;
 
 use crate::license_detection::expression::parse_expression;
 use crate::license_detection::index::LicenseIndex;
@@ -20,39 +22,77 @@ pub(crate) fn collect_top_level_license_references(
 ) -> (Vec<LicenseReference>, Vec<LicenseRuleReference>) {
     let licenses: Vec<_> = license_index.licenses_by_key.values().cloned().collect();
     let spdx_mapping = build_spdx_mapping(&licenses);
-    let mut license_keys = BTreeSet::new();
-    let mut rule_identifiers = BTreeSet::new();
+    let (mut license_keys, mut rule_identifiers) = files
+        .par_iter()
+        .map(|file| {
+            let mut license_keys = HashSet::new();
+            let mut rule_identifiers = HashSet::new();
 
-    for file in files {
-        collect_license_keys_from_expression(file.license_expression.as_deref(), &mut license_keys);
-        collect_rule_identifiers_from_detections(&file.license_detections, &mut rule_identifiers);
-        collect_rule_identifiers_from_matches(&file.license_clues, &mut rule_identifiers);
+            collect_license_keys_from_expression(
+                file.license_expression.as_deref(),
+                &mut license_keys,
+            );
+            collect_rule_identifiers_from_detections(
+                &file.license_detections,
+                &mut rule_identifiers,
+            );
+            collect_rule_identifiers_from_matches(&file.license_clues, &mut rule_identifiers);
+            for package_data in &file.package_data {
+                collect_license_keys_from_package_data(package_data, &mut license_keys);
+            }
 
-        for package_data in &file.package_data {
-            collect_license_keys_from_package_data(package_data, &mut license_keys);
-        }
-    }
+            (license_keys, rule_identifiers)
+        })
+        .reduce(
+            || (HashSet::new(), HashSet::new()),
+            |mut left, right| {
+                left.0.extend(right.0);
+                left.1.extend(right.1);
+                left
+            },
+        );
 
-    for package in packages {
-        collect_license_keys_from_expression(
-            package.declared_license_expression.as_deref(),
-            &mut license_keys,
+    let (package_license_keys, package_rule_identifiers) = packages
+        .par_iter()
+        .map(|package| {
+            let mut license_keys = HashSet::new();
+            let mut rule_identifiers = HashSet::new();
+
+            collect_license_keys_from_expression(
+                package.declared_license_expression.as_deref(),
+                &mut license_keys,
+            );
+            collect_license_keys_from_expression(
+                package.other_license_expression.as_deref(),
+                &mut license_keys,
+            );
+            collect_license_keys_from_detections(&package.license_detections, &mut license_keys);
+            collect_license_keys_from_detections(
+                &package.other_license_detections,
+                &mut license_keys,
+            );
+            collect_rule_identifiers_from_detections(
+                &package.license_detections,
+                &mut rule_identifiers,
+            );
+            collect_rule_identifiers_from_detections(
+                &package.other_license_detections,
+                &mut rule_identifiers,
+            );
+
+            (license_keys, rule_identifiers)
+        })
+        .reduce(
+            || (HashSet::new(), HashSet::new()),
+            |mut left, right| {
+                left.0.extend(right.0);
+                left.1.extend(right.1);
+                left
+            },
         );
-        collect_license_keys_from_expression(
-            package.other_license_expression.as_deref(),
-            &mut license_keys,
-        );
-        collect_license_keys_from_detections(&package.license_detections, &mut license_keys);
-        collect_license_keys_from_detections(&package.other_license_detections, &mut license_keys);
-        collect_rule_identifiers_from_detections(
-            &package.license_detections,
-            &mut rule_identifiers,
-        );
-        collect_rule_identifiers_from_detections(
-            &package.other_license_detections,
-            &mut rule_identifiers,
-        );
-    }
+
+    license_keys.extend(package_license_keys);
+    rule_identifiers.extend(package_rule_identifiers);
 
     let rules_by_identifier: HashMap<&str, &Rule> = license_index
         .rules_by_rid
@@ -65,6 +105,9 @@ pub(crate) fn collect_top_level_license_references(
             collect_license_keys_from_expression(Some(&rule.license_expression), &mut license_keys);
         }
     }
+
+    let license_keys: BTreeSet<_> = license_keys.into_iter().collect();
+    let rule_identifiers: BTreeSet<_> = rule_identifiers.into_iter().collect();
 
     let license_references = license_keys
         .into_iter()
@@ -178,7 +221,7 @@ fn format_license_reference_url(template: &str, license_key: &str) -> String {
 
 fn collect_license_keys_from_package_data(
     package_data: &PackageData,
-    license_keys: &mut BTreeSet<String>,
+    license_keys: &mut std::collections::HashSet<String>,
 ) {
     collect_license_keys_from_expression(
         package_data.declared_license_expression.as_deref(),
@@ -194,7 +237,7 @@ fn collect_license_keys_from_package_data(
 
 fn collect_license_keys_from_detections(
     detections: &[LicenseDetection],
-    license_keys: &mut BTreeSet<String>,
+    license_keys: &mut std::collections::HashSet<String>,
 ) {
     for detection in detections {
         collect_license_keys_from_expression(Some(&detection.license_expression), license_keys);
@@ -203,7 +246,7 @@ fn collect_license_keys_from_detections(
 
 fn collect_license_keys_from_expression(
     expression: Option<&str>,
-    license_keys: &mut BTreeSet<String>,
+    license_keys: &mut std::collections::HashSet<String>,
 ) {
     let Some(expression) = expression else {
         return;
@@ -218,7 +261,7 @@ fn collect_license_keys_from_expression(
 
 fn collect_rule_identifiers_from_detections(
     detections: &[LicenseDetection],
-    rule_identifiers: &mut BTreeSet<String>,
+    rule_identifiers: &mut HashSet<String>,
 ) {
     for detection in detections {
         collect_rule_identifiers_from_matches(&detection.matches, rule_identifiers);
@@ -227,7 +270,7 @@ fn collect_rule_identifiers_from_detections(
 
 fn collect_rule_identifiers_from_matches(
     matches: &[Match],
-    rule_identifiers: &mut BTreeSet<String>,
+    rule_identifiers: &mut HashSet<String>,
 ) {
     for license_match in matches {
         if let Some(rule_identifier) = license_match.rule_identifier.as_ref() {

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 use glob::Pattern;
+use rayon::prelude::*;
 
 use self::classification::apply_file_classification;
 pub(crate) use self::license_references::collect_top_level_license_references;
@@ -434,10 +435,10 @@ fn assign_facets(files: &mut [FileInfo], facet_rules: &[FacetRule]) {
         return;
     }
 
-    for file in files.iter_mut() {
+    files.par_iter_mut().for_each(|file| {
         if file.file_type != FileType::File {
             file.facets.clear();
-            continue;
+            return;
         }
 
         const FACET_SORT_ORDER: [usize; FACETS.len()] = [0, 4, 1, 3, 5, 2];
@@ -466,20 +467,20 @@ fn assign_facets(files: &mut [FileInfo], facet_rules: &[FacetRule]) {
         } else {
             facets
         };
-    }
+    });
 }
 
 fn materialize_generated_flags(files: &mut [FileInfo]) {
-    for file in files.iter_mut() {
+    files.par_iter_mut().for_each(|file| {
         if file.file_type != FileType::File {
             file.is_generated = Some(false);
-            continue;
+            return;
         }
 
         if file.is_generated.is_none() {
             file.is_generated = Some(false);
         }
-    }
+    });
 }
 
 #[cfg(test)]
@@ -498,15 +499,15 @@ fn mark_generated_files(files: &mut [FileInfo], scanned_root: Option<&Path>) {
 }
 
 fn clear_generated_flags(files: &mut [FileInfo]) {
-    for file in files {
+    files.par_iter_mut().for_each(|file| {
         file.is_generated = None;
-    }
+    });
 }
 
 fn clear_resource_tallies(files: &mut [FileInfo]) {
-    for file in files {
+    files.par_iter_mut().for_each(|file| {
         file.tallies = None;
-    }
+    });
 }
 
 #[cfg(test)]

--- a/src/post_processing/output_indexes.rs
+++ b/src/post_processing/output_indexes.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use rayon::prelude::*;
+
 use crate::models::FileInfo;
 
 use super::package_file_index::{FileIx, PackageFileIndex, PackageIx};
@@ -29,34 +31,62 @@ impl OutputIndexes {
         use_fallback_key_classification: bool,
         mode: OutputIndexMode,
     ) -> Self {
-        let mut indexes = Self::default();
+        let mut indexes = files
+            .par_iter()
+            .enumerate()
+            .fold(Self::default, |mut indexes, (idx, file)| {
+                let file_ix = FileIx(idx);
 
-        for (idx, file) in files.iter().enumerate() {
-            let file_ix = FileIx(idx);
+                if mode.includes_path_index() {
+                    indexes
+                        .first_file_index_by_path
+                        .entry(file.path.clone())
+                        .or_insert(file_ix);
+                }
 
-            if mode.includes_path_index() {
+                let is_key_file = package_file_index.is_some_and(|index| {
+                    index.is_key_file(files, file_ix, use_fallback_key_classification)
+                });
+
+                if is_key_file {
+                    for package_ix in package_file_index
+                        .into_iter()
+                        .flat_map(|index| index.package_ixs_for_file(file_ix))
+                    {
+                        indexes
+                            .key_file_indices_by_package_ix
+                            .entry(*package_ix)
+                            .or_default()
+                            .push(file_ix);
+                    }
+                }
+
                 indexes
-                    .first_file_index_by_path
-                    .entry(file.path.clone())
-                    .or_insert(file_ix);
-            }
+            })
+            .reduce(Self::default, |mut left, mut right| {
+                for (path, file_ix) in right.first_file_index_by_path.drain() {
+                    left.first_file_index_by_path
+                        .entry(path)
+                        .and_modify(|existing| {
+                            if file_ix.0 < existing.0 {
+                                *existing = file_ix;
+                            }
+                        })
+                        .or_insert(file_ix);
+                }
 
-            let is_key_file = package_file_index.is_some_and(|index| {
-                index.is_key_file(files, file_ix, use_fallback_key_classification)
+                for (package_ix, mut file_indices) in right.key_file_indices_by_package_ix.drain() {
+                    left.key_file_indices_by_package_ix
+                        .entry(package_ix)
+                        .or_default()
+                        .append(&mut file_indices);
+                }
+
+                left
             });
 
-            if is_key_file {
-                for package_ix in package_file_index
-                    .into_iter()
-                    .flat_map(|index| index.package_ixs_for_file(file_ix))
-                {
-                    indexes
-                        .key_file_indices_by_package_ix
-                        .entry(*package_ix)
-                        .or_default()
-                        .push(file_ix);
-                }
-            }
+        for file_indices in indexes.key_file_indices_by_package_ix.values_mut() {
+            file_indices.sort_by_key(|file_ix| file_ix.0);
         }
 
         indexes

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use rayon::prelude::*;
+
 use crate::license_detection::detection::identifier::compute_detection_identifier;
 use crate::license_detection::detection::{
     FileRegion as InternalFileRegion, determine_license_expression, determine_spdx_expression,
@@ -42,16 +44,11 @@ pub(crate) fn apply_package_reference_following(files: &mut [FileInfo], packages
     for _ in 0..5 {
         let snapshot = build_reference_follow_snapshot(files, packages);
         let package_file_index = PackageFileIndex::build(files, packages);
-        let mut modified = false;
-
-        for file in files
-            .iter_mut()
+        let mut modified = files
+            .par_iter_mut()
             .filter(|file| file.file_type == FileType::File)
-        {
-            if follow_references_for_file(file, &snapshot) {
-                modified = true;
-            }
-        }
+            .map(|file| follow_references_for_file(file, &snapshot))
+            .reduce(|| false, |left, right| left || right);
 
         if sync_packages_from_followed_package_data(files, packages, &package_file_index) {
             modified = true;
@@ -66,19 +63,32 @@ pub(crate) fn apply_package_reference_following(files: &mut [FileInfo], packages
 pub(crate) fn collect_top_level_license_detections(
     files: &[FileInfo],
 ) -> Vec<TopLevelLicenseDetection> {
-    let mut internal_detections = Vec::new();
-
-    for file in files {
-        let mut file_detections = file.license_detections.iter().collect::<Vec<_>>();
-        for package_data in &file.package_data {
-            file_detections.extend(package_data.license_detections.iter());
-            file_detections.extend(package_data.other_license_detections.iter());
-        }
-
-        for detection in file_detections {
-            internal_detections.push(public_detection_to_internal(detection, &file.path));
-        }
-    }
+    let internal_detections: Vec<_> = files
+        .par_iter()
+        .flat_map_iter(|file| {
+            let mut detections = Vec::new();
+            detections.extend(
+                file.license_detections
+                    .iter()
+                    .map(|detection| public_detection_to_internal(detection, &file.path)),
+            );
+            for package_data in &file.package_data {
+                detections.extend(
+                    package_data
+                        .license_detections
+                        .iter()
+                        .map(|detection| public_detection_to_internal(detection, &file.path)),
+                );
+                detections.extend(
+                    package_data
+                        .other_license_detections
+                        .iter()
+                        .map(|detection| public_detection_to_internal(detection, &file.path)),
+                );
+            }
+            detections.into_iter()
+        })
+        .collect();
 
     let representative_detections: HashMap<_, _> =
         internal_detections

--- a/src/post_processing/tallies.rs
+++ b/src/post_processing/tallies.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use rayon::prelude::*;
+
 use crate::models::{FacetTallies, FileInfo, FileType, Tallies, TallyEntry};
 
 use super::FACETS;
@@ -63,38 +65,46 @@ pub(crate) fn compute_key_file_tallies(files: &[FileInfo]) -> Option<Tallies> {
 }
 
 pub(crate) fn compute_tallies_by_facet(files: &[FileInfo]) -> Option<Vec<FacetTallies>> {
-    let mut buckets: HashMap<&'static str, TallyAccumulator> = FACETS
-        .iter()
-        .map(|facet| (*facet, TallyAccumulator::default()))
-        .collect();
+    let mut buckets = files
+        .par_iter()
+        .filter(|file| file.file_type == FileType::File)
+        .fold(facet_buckets, |mut buckets, file| {
+            if file.facets.is_empty() {
+                return buckets;
+            }
 
-    for file in files.iter().filter(|file| file.file_type == FileType::File) {
-        if file.facets.is_empty() {
-            continue;
-        }
-
-        let Some(file_tallies) = file.tallies.as_ref() else {
-            continue;
-        };
-
-        for facet in &file.facets {
-            let Some(bucket) = buckets.get_mut(facet.as_str()) else {
-                continue;
+            let Some(file_tallies) = file.tallies.as_ref() else {
+                return buckets;
             };
-            bucket.merge_license_expressions(&file_tallies.detected_license_expression);
-            bucket.merge_copyrights(&file_tallies.copyrights);
-            bucket.merge_holders(&file_tallies.holders);
-            bucket.merge_authors(&file_tallies.authors);
-            bucket.merge_programming_languages(&file_tallies.programming_language);
-        }
-    }
+
+            for facet in &file.facets {
+                let Some(index) = facet_index(facet) else {
+                    continue;
+                };
+                let bucket = &mut buckets[index];
+                bucket.merge_license_expressions(&file_tallies.detected_license_expression);
+                bucket.merge_copyrights(&file_tallies.copyrights);
+                bucket.merge_holders(&file_tallies.holders);
+                bucket.merge_authors(&file_tallies.authors);
+                bucket.merge_programming_languages(&file_tallies.programming_language);
+            }
+
+            buckets
+        })
+        .reduce(facet_buckets, |mut left, right| {
+            for (left_bucket, right_bucket) in left.iter_mut().zip(right) {
+                left_bucket.merge_from(right_bucket);
+            }
+            left
+        });
 
     Some(
         FACETS
             .iter()
-            .map(|facet| FacetTallies {
+            .enumerate()
+            .map(|(idx, facet)| FacetTallies {
                 facet: (*facet).to_string(),
-                tallies: buckets.remove(facet).unwrap_or_default().into_tallies(),
+                tallies: std::mem::take(&mut buckets[idx]).into_tallies(),
             })
             .collect(),
     )
@@ -133,13 +143,13 @@ pub(crate) fn compute_detailed_tallies(files: &mut [FileInfo]) {
 }
 
 pub(crate) fn compute_file_tallies(files: &mut [FileInfo]) {
-    for file in files.iter_mut() {
+    files.par_iter_mut().for_each(|file| {
         if file.file_type == FileType::File {
             file.tallies = Some(compute_direct_file_tallies(file));
         } else {
             file.tallies = None;
         }
-    }
+    });
 }
 
 pub(super) fn author_values(file: &FileInfo) -> Vec<String> {
@@ -224,7 +234,7 @@ pub(super) fn tally_file_values<F>(
     count_missing_files: bool,
 ) -> Vec<TallyEntry>
 where
-    F: Fn(&FileInfo) -> Vec<String>,
+    F: Fn(&FileInfo) -> Vec<String> + Sync + Send,
 {
     tally_file_values_filtered(files, |_| true, values_for_file, count_missing_files)
 }
@@ -236,27 +246,31 @@ pub(super) fn tally_file_values_filtered<P, F>(
     count_missing_files: bool,
 ) -> Vec<TallyEntry>
 where
-    P: Fn(&FileInfo) -> bool,
-    F: Fn(&FileInfo) -> Vec<String>,
+    P: Fn(&FileInfo) -> bool + Sync + Send,
+    F: Fn(&FileInfo) -> Vec<String> + Sync + Send,
 {
-    let mut counts: HashMap<Option<String>, usize> = HashMap::new();
-
-    for file in files
-        .iter()
+    let counts = files
+        .par_iter()
         .filter(|file| file.file_type == FileType::File && predicate(file))
-    {
-        let values = values_for_file(file);
-        if values.is_empty() {
-            if count_missing_files {
-                *counts.entry(None).or_insert(0) += 1;
+        .fold(HashMap::new, |mut counts, file| {
+            let values = values_for_file(file);
+            if values.is_empty() {
+                if count_missing_files {
+                    *counts.entry(None).or_insert(0) += 1;
+                }
+                return counts;
             }
-            continue;
-        }
 
-        for value in values {
-            *counts.entry(Some(value)).or_insert(0) += 1;
-        }
-    }
+            for value in values {
+                *counts.entry(Some(value)).or_insert(0) += 1;
+            }
+
+            counts
+        })
+        .reduce(HashMap::new, |mut left, right| {
+            merge_count_maps(&mut left, right);
+            left
+        });
 
     build_tally_entries(counts)
 }
@@ -314,6 +328,36 @@ impl TallyAccumulator {
             authors: build_tally_entries(self.authors),
             programming_language: build_tally_entries(self.programming_language),
         }
+    }
+
+    fn merge_from(&mut self, other: Self) {
+        merge_count_maps(
+            &mut self.detected_license_expression,
+            other.detected_license_expression,
+        );
+        merge_count_maps(&mut self.copyrights, other.copyrights);
+        merge_count_maps(&mut self.holders, other.holders);
+        merge_count_maps(&mut self.authors, other.authors);
+        merge_count_maps(&mut self.programming_language, other.programming_language);
+    }
+}
+
+fn facet_buckets() -> Vec<TallyAccumulator> {
+    (0..FACETS.len())
+        .map(|_| TallyAccumulator::default())
+        .collect()
+}
+
+fn facet_index(facet: &str) -> Option<usize> {
+    FACETS.iter().position(|candidate| *candidate == facet)
+}
+
+fn merge_count_maps(
+    destination: &mut HashMap<Option<String>, usize>,
+    source: HashMap<Option<String>, usize>,
+) {
+    for (key, count) in source {
+        *destination.entry(key).or_insert(0) += count;
     }
 }
 


### PR DESCRIPTION
## Summary

- Parallelize the embarrassingly parallel file-local post-scan and finalize work in post-processing using Rayon instead of leaving those loops entirely serial.
- Cover the quick-win passes that only read shared immutable state and write independent per-file or per-thread local results: per-round file reference following, file classification, output index construction, tally collection, facet assignment, generated/tally flag maintenance, and top-level license reference/detection gathering.
- Keep the stateful aggregation paths such as directory tally rollups and package sync sequential so the change stays focused on low-risk wins.

## Scope and exclusions

- Included:
  - `src/post_processing/reference_following.rs`
  - `src/post_processing/classification.rs`
  - `src/post_processing/output_indexes.rs`
  - `src/post_processing/tallies.rs`
  - `src/post_processing/license_references.rs`
  - `src/post_processing/mod.rs`
- Explicit exclusions:
  - no assembly parallelization yet
  - no output writer parallelization
  - no changes to expected semantics or fixture outputs
  - no attempt to parallelize directory-dependent tally rollups

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- focused post-processing regressions:
  - `collect_top_level_license_references_includes_clues_packages_and_sorted_deduped_refs`
  - `key_file_license_clues_feed_summary_without_mutating_package_license_provenance`
  - `classify_key_files_marks_nested_ruby_license_from_file_references`
  - `compute_tallies`
  - `compute_key_file_tallies`
  - `compute_tallies_by_facet`
  - `collect_top_level_license_detections`
- focused `golden-tests` regressions:
  - `post_processing::golden_test::tests::test_golden_reference_follow_file_to_package_inheritance`
  - `post_processing::golden_test::tests::test_golden_reference_follow_root_fallback_no_package`
- focused topology assembly regressions:
  - `test_assembly_npm_workspace`
  - `test_assembly_cargo_workspace`
  - `test_assembly_go_workspace_basic`
  - `test_assembly_pixi_basic`
  - `test_assembly_hackage_basic`

## Benchmarks

- Synthetic benchmark target: `/tmp/provenant-workspace-storm-33000`
- Command: `target/release/provenant --json /dev/null -c -l -u -p -e /tmp/provenant-workspace-storm-33000`
- Warmed comparison versus current `origin/main`:
  - `origin/main`
    - scan `6.32s`
    - post-scan `2.67s`
    - assembly `3.28s`
    - finalize `3.92s`
    - output `8.25s`
    - total `35.95s`
  - this branch
    - scan `6.12s`
    - post-scan `2.07s`
    - assembly `3.39s`
    - finalize `3.54s`
    - output `7.50s`
    - total `34.12s`
- Relative improvement on the warmed run:
  - post-scan about `-22%`
  - finalize about `-10%`
  - total about `-5%`

## Follow-up work

- Created or intentionally deferred:
  - assembly parallelization after we decide whether the remaining serial assembly work is worth the added complexity
  - output serialization parallelization, which likely needs a more structural redesign than these quick wins
  - profiling after merge to see whether output or setup becomes the dominant next target on large synthetic runs