### PR TITLE
chore(gitmodules): Do not use an SSH URL to ScanCode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "reference/scancode-toolkit"]
 	path = reference/scancode-toolkit
-	url = git@github.com:aboutcode-org/scancode-toolkit.git
+	url = https://github.com/aboutcode-org/scancode-toolkit.git


### PR DESCRIPTION
It is not possible to anonymously clone via SSH, so use HTTPS instead for the ScanCode submodule.