### PR TITLE
docs(cli): Fix spelling of `--show-attribution`

### DIFF
--- a/docs/implementation-plans/infrastructure/CLI_PLAN.md
+++ b/docs/implementation-plans/infrastructure/CLI_PLAN.md
@@ -172,7 +172,7 @@ Confirmed remaining gaps:
 | `--no-assemble`      | Skips package assembly after manifest detection     | `Rust-specific` | Provenant-only convenience; Python ScanCode always assembles.                                                                                                                                                                                                                         |
 | `--no-cache`         | Disables Provenant caching                          | `Won't do`      | No longer needed because incremental reuse is opt-in by default.                                                                                                                                                                                                                      |
 | `--incremental`      | Enables unchanged-file reuse on repeated scans      | `Rust-specific` | Beyond-parity feature; kept as the sole repeated-run reuse mechanism.                                                                                                                                                                                                                 |
-| `--show_attribution` | Prints embedded-data attribution notices            | `Rust-specific` | Provenant-only convenience for bundled license-detection data notices.                                                                                                                                                                                                                |
+| `--show-attribution` | Prints embedded-data attribution notices            | `Rust-specific` | Provenant-only convenience for bundled license-detection data notices.                                                                                                                                                                                                                |
 
 ## Key Design Decisions
 
@@ -194,7 +194,7 @@ Confirmed remaining gaps:
 - Thread pool via rayon instead of multiprocessing
 - JSON output structure matches Python (`OUTPUT_FORMAT_VERSION`)
 - `--no-cache` is not a parity requirement (upstream removed it); if retained, it is Rust-specific
-- `--show_attribution` is a Rust-specific convenience flag for printing embedded-data notices
+- `--show-attribution` is a Rust-specific convenience flag for printing embedded-data notices
 
 ## References
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ fn parse_license_policy_arg(value: &str) -> Result<String, String> {
     long_version = concat!(
         env!("CARGO_PKG_VERSION"),
         "\n",
-        "License detection uses data from ScanCode Toolkit (CC-BY-4.0). See NOTICE or --show_attribution."
+        "License detection uses data from ScanCode Toolkit (CC-BY-4.0). See NOTICE file or --show-attribution option."
     ),
     after_help = PDF_OXIDE_LOG_HELP,
     about,


### PR DESCRIPTION
While at it, slightly improve the wording shown as part of `--version`.