### PR TITLE
feat(models): add PackageUid and DependencyUid newtypes

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -2748,25 +2748,28 @@ mod tests {
 
     #[test]
     fn test_build_package_uid_format() {
-        use crate::models::build_package_uid;
+        use crate::models::PackageUid;
 
         let purl = "pkg:npm/test@1.0.0";
-        let uid = build_package_uid(purl);
+        let uid = PackageUid::new(purl);
 
         assert!(
-            uid.starts_with("pkg:npm/test@1.0.0?uuid="),
+            uid.as_str().starts_with("pkg:npm/test@1.0.0?uuid="),
             "Expected UUID to be added as qualifier"
         );
-        assert!(uid.contains("uuid="), "Expected uuid qualifier");
+        assert!(uid.as_str().contains("uuid="), "Expected uuid qualifier");
 
         let purl_with_qualifier = "pkg:npm/test@1.0.0?arch=x64";
-        let uid2 = build_package_uid(purl_with_qualifier);
+        let uid2 = PackageUid::new(purl_with_qualifier);
 
         assert!(
-            uid2.contains("&uuid="),
+            uid2.as_str().contains("&uuid="),
             "Expected UUID to be appended with & when qualifiers exist"
         );
-        assert!(uid2.starts_with("pkg:npm/test@1.0.0?arch=x64&uuid="));
+        assert!(
+            uid2.as_str()
+                .starts_with("pkg:npm/test@1.0.0?arch=x64&uuid=")
+        );
     }
 
     #[test]

--- a/src/assembly/bazel_prune.rs
+++ b/src/assembly/bazel_prune.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::models::{FileInfo, Package, PackageType, TopLevelDependency};
+use crate::models::{FileInfo, Package, PackageType, PackageUid, TopLevelDependency};
 
 pub(super) fn prune_unused_bazel_packages(
     files: &[FileInfo],
@@ -9,10 +9,10 @@ pub(super) fn prune_unused_bazel_packages(
 ) {
     let used_package_uids: HashSet<&str> = files
         .iter()
-        .flat_map(|file| file.for_packages.iter().map(String::as_str))
+        .flat_map(|file| file.for_packages.iter().map(|uid| uid.as_str()))
         .collect();
 
-    let removed_package_uids: HashSet<String> = packages
+    let removed_package_uids: HashSet<PackageUid> = packages
         .iter()
         .filter(|package| package.package_type == Some(PackageType::Bazel))
         .filter(|package| !used_package_uids.contains(package.package_uid.as_str()))

--- a/src/assembly/cargo_resource_assign.rs
+++ b/src/assembly/cargo_resource_assign.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use crate::models::{FileInfo, Package, PackageType};
+use crate::models::{FileInfo, Package, PackageType, PackageUid};
 
 pub fn assign_cargo_package_resources(files: &mut [FileInfo], packages: &[Package]) {
-    let cargo_roots: Vec<(PathBuf, String)> = packages
+    let cargo_roots: Vec<(PathBuf, PackageUid)> = packages
         .iter()
         .filter(|package| package.package_type == Some(PackageType::Cargo))
         .filter_map(|package| {

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use log::debug;
 
-use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
 pub(super) struct CargoWorkspaceRootHint {
     pub(super) root_dir: PathBuf,
@@ -192,7 +192,7 @@ pub(super) fn apply_cargo_workspace_domain(
         &workspace_root.workspace_data,
     );
 
-    let member_uids: Vec<String> = member_packages
+    let member_uids: Vec<PackageUid> = member_packages
         .iter()
         .map(|(pkg, _deps)| pkg.package_uid.clone())
         .collect();
@@ -318,7 +318,7 @@ fn remove_member_packages(
         .map(|&idx| files[idx].path.as_str())
         .collect();
 
-    let removed_uids: Vec<String> = packages
+    let removed_uids: Vec<PackageUid> = packages
         .iter()
         .filter(|pkg| {
             pkg.datafile_paths
@@ -538,7 +538,7 @@ fn extract_cargo_dep_name(purl: &str) -> Option<String> {
 fn assign_for_packages(
     files: &mut [FileInfo],
     workspace_root: &CargoWorkspaceDomain,
-    member_uids: &[String],
+    member_uids: &[PackageUid],
 ) {
     let mut member_dirs: Vec<PathBuf> = Vec::new();
     member_dirs.extend(

--- a/src/assembly/composer_resource_assign.rs
+++ b/src/assembly/composer_resource_assign.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use crate::cache::DEFAULT_CACHE_DIR_NAME;
-use crate::models::{FileInfo, Package, PackageType};
+use crate::models::{FileInfo, Package, PackageType, PackageUid};
 
 pub fn assign_composer_package_resources(files: &mut [FileInfo], packages: &[Package]) {
-    let composer_roots: Vec<(PathBuf, String)> = packages
+    let composer_roots: Vec<(PathBuf, PackageUid)> = packages
         .iter()
         .filter(|package| package.package_type == Some(PackageType::Composer))
         .filter_map(|package| {

--- a/src/assembly/conda_rootfs_merge.rs
+++ b/src/assembly/conda_rootfs_merge.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
 pub fn merge_conda_rootfs_metadata(
     files: &mut [FileInfo],
@@ -32,7 +32,7 @@ pub fn merge_conda_rootfs_metadata(
         })
         .collect();
 
-    let json_package_uids: HashMap<Option<String>, String> = packages
+    let json_package_uids: HashMap<Option<String>, PackageUid> = packages
         .iter()
         .filter(|package| {
             package
@@ -83,7 +83,7 @@ pub fn merge_conda_rootfs_metadata(
             }
 
             for dep in dependencies.iter_mut() {
-                if dep.for_package_uid.as_deref() == Some(old_uid.as_str()) {
+                if dep.for_package_uid.as_ref() == Some(&old_uid) {
                     dep.for_package_uid = Some(new_uid.clone());
                 }
             }

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -950,19 +950,6 @@ fn resolve_rpm_namespace(
     None
 }
 
-fn replace_uid_base(old_uid: &str, new_purl: &str) -> String {
-    if let Some((_, suffix)) = old_uid.split_once("?uuid=") {
-        return format!("{}?uuid={}", new_purl, suffix);
-    }
-
-    if let Some((_, suffix)) = old_uid.split_once("&uuid=") {
-        let separator = if new_purl.contains('?') { '&' } else { '?' };
-        return format!("{}{separator}uuid={suffix}", new_purl);
-    }
-
-    old_uid.to_string()
-}
-
 fn rewrite_purl_namespace(existing_purl: &str, namespace: &str) -> Option<String> {
     let parsed = PackageUrl::from_str(existing_purl).ok()?;
     let mut updated = PackageUrl::new(parsed.ty(), parsed.name()).ok()?;
@@ -1000,7 +987,7 @@ fn apply_rpm_namespace(
         && let Some(updated_purl) = rewrite_purl_namespace(current_purl, namespace)
     {
         package.purl = Some(updated_purl.clone());
-        package.package_uid = replace_uid_base(&old_package_uid, &updated_purl);
+        package.package_uid = old_package_uid.replace_base(&updated_purl);
     }
 
     for file in files.iter_mut() {
@@ -1012,18 +999,18 @@ fn apply_rpm_namespace(
     }
 
     for dep in dependencies.iter_mut() {
-        if dep.for_package_uid.as_deref() == Some(old_package_uid.as_str()) {
+        if dep.for_package_uid.as_ref() == Some(&old_package_uid) {
             dep.for_package_uid = Some(package.package_uid.clone());
         }
 
-        if dep.for_package_uid.as_deref() == Some(package.package_uid.as_str()) {
+        if dep.for_package_uid.as_ref() == Some(&package.package_uid) {
             dep.namespace = Some(namespace.to_string());
 
             if let Some(current_purl) = dep.purl.as_deref()
                 && let Some(updated_purl) = rewrite_purl_namespace(current_purl, namespace)
             {
                 dep.purl = Some(updated_purl.clone());
-                dep.dependency_uid = replace_uid_base(&dep.dependency_uid, &updated_purl);
+                dep.dependency_uid = dep.dependency_uid.replace_base(&updated_purl);
             }
         }
     }

--- a/src/assembly/file_ref_resolve_test.rs
+++ b/src/assembly/file_ref_resolve_test.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::models::{FileReference, FileType, Md5Digest, PackageData, PackageType};
+use crate::models::{
+    DependencyUid, FileReference, FileType, Md5Digest, PackageData, PackageType, PackageUid,
+};
 use strum::IntoEnumIterator;
 
 #[test]
@@ -253,7 +255,9 @@ fn test_resolve_rpm_sqlite_file_references_from_legacy_var_lib_path() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:rpm/fedora/libgcc@13.1.1-2.fc38?arch=x86_64".to_string()),
-        package_uid: "pkg:rpm/fedora/libgcc@13.1.1-2.fc38?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw(
+            "pkg:rpm/fedora/libgcc@13.1.1-2.fc38?uuid=test-uuid".to_string(),
+        ),
         datafile_paths: vec!["rootfs/var/lib/rpm/rpmdb.sqlite".to_string()],
         datasource_ids: vec![DatasourceId::RpmInstalledDatabaseSqlite],
     }];
@@ -263,7 +267,9 @@ fn test_resolve_rpm_sqlite_file_references_from_legacy_var_lib_path() {
 
     assert_eq!(
         files[1].for_packages,
-        vec!["pkg:rpm/fedora/libgcc@13.1.1-2.fc38?uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:rpm/fedora/libgcc@13.1.1-2.fc38?uuid=test-uuid".to_string()
+        )]
     );
 }
 
@@ -481,7 +487,7 @@ fn test_resolve_basic_alpine() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:alpine/musl@1.2.3".to_string()),
-        package_uid: "pkg:alpine/musl@1.2.3?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:alpine/musl@1.2.3?uuid=test-uuid".to_string()),
         datafile_paths: vec!["lib/apk/db/installed".to_string()],
         datasource_ids: vec![DatasourceId::AlpineInstalledDb],
     }];
@@ -493,12 +499,12 @@ fn test_resolve_basic_alpine() {
     assert_eq!(files[1].for_packages.len(), 1);
     assert_eq!(
         files[1].for_packages[0],
-        "pkg:alpine/musl@1.2.3?uuid=test-uuid"
+        PackageUid::from_raw("pkg:alpine/musl@1.2.3?uuid=test-uuid".to_string())
     );
     assert_eq!(files[2].for_packages.len(), 1);
     assert_eq!(
         files[2].for_packages[0],
-        "pkg:alpine/musl@1.2.3?uuid=test-uuid"
+        PackageUid::from_raw("pkg:alpine/musl@1.2.3?uuid=test-uuid".to_string())
     );
 }
 
@@ -618,7 +624,7 @@ fn test_resolve_missing_refs() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:alpine/test@1.0".to_string()),
-        package_uid: "pkg:alpine/test@1.0?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:alpine/test@1.0?uuid=test-uuid".to_string()),
         datafile_paths: vec!["lib/apk/db/installed".to_string()],
         datasource_ids: vec![DatasourceId::AlpineInstalledDb],
     }];
@@ -791,7 +797,7 @@ fn test_resolve_rpm_namespace() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:rpm/bash@5.0".to_string()),
-        package_uid: "pkg:rpm/bash@5.0?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:rpm/bash@5.0?uuid=test-uuid".to_string()),
         datafile_paths: vec!["rootfs/var/lib/rpm/Packages".to_string()],
         datasource_ids: vec![DatasourceId::RpmInstalledDatabaseBdb],
     }];
@@ -806,8 +812,10 @@ fn test_resolve_rpm_namespace() {
         is_direct: None,
         resolved_package: None,
         extra_data: None,
-        dependency_uid: "pkg:rpm/readline@8.0?uuid=dep-uuid".to_string(),
-        for_package_uid: Some("pkg:rpm/bash@5.0?uuid=test-uuid".to_string()),
+        dependency_uid: DependencyUid::from_raw("pkg:rpm/readline@8.0?uuid=dep-uuid".to_string()),
+        for_package_uid: Some(PackageUid::from_raw(
+            "pkg:rpm/bash@5.0?uuid=test-uuid".to_string(),
+        )),
         datafile_path: "rootfs/var/lib/rpm/Packages".to_string(),
         datasource_id: DatasourceId::RpmInstalledDatabaseBdb,
         namespace: None,
@@ -860,7 +868,9 @@ fn test_merge_rpm_yumdb_metadata() {
             authors: vec![],
             emails: vec![],
             urls: vec![],
-            for_packages: vec!["pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string()],
+            for_packages: vec![PackageUid::from_raw(
+                "pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string(),
+            )],
             scan_errors: vec![],
             license_policy: None,
             is_source: None,
@@ -908,7 +918,9 @@ fn test_merge_rpm_yumdb_metadata() {
             authors: vec![],
             emails: vec![],
             urls: vec![],
-            for_packages: vec!["pkg:rpm/bash@5.0-1.el8?uuid=yumdb-uuid".to_string()],
+            for_packages: vec![PackageUid::from_raw(
+                "pkg:rpm/bash@5.0-1.el8?uuid=yumdb-uuid".to_string(),
+            )],
             scan_errors: vec![],
             license_policy: None,
             is_source: None,
@@ -975,7 +987,7 @@ fn test_merge_rpm_yumdb_metadata() {
             repository_download_url: None,
             api_data_url: None,
             purl: Some("pkg:rpm/bash@5.0-1.el8?arch=x86_64".to_string()),
-            package_uid: "pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string(),
+            package_uid: PackageUid::from_raw("pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string()),
             datafile_paths: vec!["rootfs/var/lib/rpm/Packages".to_string()],
             datasource_ids: vec![DatasourceId::RpmInstalledDatabaseBdb],
         },
@@ -1032,7 +1044,7 @@ fn test_merge_rpm_yumdb_metadata() {
             repository_download_url: None,
             api_data_url: None,
             purl: Some("pkg:rpm/bash@5.0-1.el8?arch=x86_64".to_string()),
-            package_uid: "pkg:rpm/bash@5.0-1.el8?uuid=yumdb-uuid".to_string(),
+            package_uid: PackageUid::from_raw("pkg:rpm/bash@5.0-1.el8?uuid=yumdb-uuid".to_string()),
             datafile_paths: vec![
                 "rootfs/var/lib/yum/yumdb/p/abc123-bash-5.0-1.el8.x86_64/from_repo".to_string(),
             ],
@@ -1060,7 +1072,9 @@ fn test_merge_rpm_yumdb_metadata() {
     assert_eq!(yumdb["releasever"], "8");
     assert_eq!(
         files[1].for_packages,
-        vec!["pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:rpm/bash@5.0-1.el8?uuid=rpm-uuid".to_string()
+        )]
     );
 }
 
@@ -1219,7 +1233,7 @@ fn test_strip_leading_slash() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:alpine/test@1.0".to_string()),
-        package_uid: "pkg:alpine/test@1.0?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:alpine/test@1.0?uuid=test-uuid".to_string()),
         datafile_paths: vec!["lib/apk/db/installed".to_string()],
         datasource_ids: vec![DatasourceId::AlpineInstalledDb],
     }];
@@ -1231,7 +1245,7 @@ fn test_strip_leading_slash() {
     assert_eq!(files[1].for_packages.len(), 1);
     assert_eq!(
         files[1].for_packages[0],
-        "pkg:alpine/test@1.0?uuid=test-uuid"
+        PackageUid::from_raw("pkg:alpine/test@1.0?uuid=test-uuid".to_string())
     );
 }
 
@@ -1507,7 +1521,7 @@ fn test_resolve_python_metadata_file_references() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:pypi/click@8.0.4".to_string()),
-        package_uid: "pkg:pypi/click@8.0.4?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:pypi/click@8.0.4?uuid=test-uuid".to_string()),
         datafile_paths: vec![
             "venv/lib/python3.11/site-packages/click-8.0.4.dist-info/METADATA".to_string(),
         ],
@@ -1523,7 +1537,7 @@ fn test_resolve_python_metadata_file_references() {
     assert_eq!(files[3].for_packages.len(), 1);
     assert_eq!(
         files[2].for_packages[0],
-        "pkg:pypi/click@8.0.4?uuid=test-uuid"
+        PackageUid::from_raw("pkg:pypi/click@8.0.4?uuid=test-uuid".to_string())
     );
 }
 
@@ -1683,7 +1697,7 @@ fn test_resolve_python_pkg_info_installed_files_references() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:pypi/examplepkg@1.0.0".to_string()),
-        package_uid: "pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string()),
         datafile_paths: vec![
             "venv/lib/python3.11/site-packages/examplepkg.egg-info/PKG-INFO".to_string(),
         ],
@@ -1696,7 +1710,9 @@ fn test_resolve_python_pkg_info_installed_files_references() {
 
     assert_eq!(
         files[1].for_packages,
-        vec!["pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string()
+        )]
     );
 }
 
@@ -1856,7 +1872,7 @@ fn test_resolve_python_metadata_file_references_in_dist_packages() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:pypi/click@8.0.4".to_string()),
-        package_uid: "pkg:pypi/click@8.0.4?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:pypi/click@8.0.4?uuid=test-uuid".to_string()),
         datafile_paths: vec![
             "usr/lib/python3/dist-packages/click-8.0.4.dist-info/METADATA".to_string(),
         ],
@@ -1869,7 +1885,9 @@ fn test_resolve_python_metadata_file_references_in_dist_packages() {
 
     assert_eq!(
         files[1].for_packages,
-        vec!["pkg:pypi/click@8.0.4?uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:pypi/click@8.0.4?uuid=test-uuid".to_string()
+        )]
     );
 }
 
@@ -2029,7 +2047,7 @@ fn test_python_metadata_file_references_do_not_assign_outside_packages_dirs() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:pypi/examplepkg@1.0.0".to_string()),
-        package_uid: "pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:pypi/examplepkg@1.0.0?uuid=test-uuid".to_string()),
         datafile_paths: vec!["project/metadata/METADATA".to_string()],
         datasource_ids: vec![DatasourceId::PypiWheelMetadata],
     }];
@@ -2197,7 +2215,7 @@ fn test_python_sources_file_references_do_not_escape_project_root() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:pypi/PyJPString@0.0.3".to_string()),
-        package_uid: "pkg:pypi/PyJPString@0.0.3?uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw("pkg:pypi/PyJPString@0.0.3?uuid=test-uuid".to_string()),
         datafile_paths: vec!["project/PyJPString.egg-info/PKG-INFO".to_string()],
         datasource_ids: vec![DatasourceId::PypiEditableEggPkginfo],
     }];
@@ -2552,7 +2570,9 @@ fn test_resolve_debian_installed_file_references_from_status_db() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:deb/debian/bash@5.2-1?arch=amd64".to_string()),
-        package_uid: "pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw(
+            "pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string(),
+        ),
         datafile_paths: vec!["rootfs/var/lib/dpkg/status".to_string()],
         datasource_ids: vec![DatasourceId::DebianInstalledStatusDb],
     }];
@@ -2562,11 +2582,15 @@ fn test_resolve_debian_installed_file_references_from_status_db() {
 
     assert_eq!(
         files[3].for_packages,
-        vec!["pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string()
+        )]
     );
     assert_eq!(
         files[4].for_packages,
-        vec!["pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:deb/debian/bash@5.2-1?arch=amd64&uuid=test-uuid".to_string()
+        )]
     );
 }
 
@@ -2783,7 +2807,9 @@ fn test_resolve_debian_installed_file_references_matches_ubuntu_package_namespac
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:deb/ubuntu/bash@5.2-1ubuntu1?arch=amd64".to_string()),
-        package_uid: "pkg:deb/ubuntu/bash@5.2-1ubuntu1?arch=amd64&uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw(
+            "pkg:deb/ubuntu/bash@5.2-1ubuntu1?arch=amd64&uuid=test-uuid".to_string(),
+        ),
         datafile_paths: vec!["rootfs/var/lib/dpkg/status".to_string()],
         datasource_ids: vec![DatasourceId::DebianInstalledStatusDb],
     }];
@@ -2793,7 +2819,9 @@ fn test_resolve_debian_installed_file_references_matches_ubuntu_package_namespac
 
     assert_eq!(
         files[2].for_packages,
-        vec!["pkg:deb/ubuntu/bash@5.2-1ubuntu1?arch=amd64&uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:deb/ubuntu/bash@5.2-1ubuntu1?arch=amd64&uuid=test-uuid".to_string()
+        )]
     );
 }
 
@@ -3125,7 +3153,9 @@ fn test_resolve_debian_installed_file_references_respects_arch_qualifier() {
         repository_download_url: None,
         api_data_url: None,
         purl: Some("pkg:deb/debian/libc6@2.36-1?arch=amd64".to_string()),
-        package_uid: "pkg:deb/debian/libc6@2.36-1?arch=amd64&uuid=test-uuid".to_string(),
+        package_uid: PackageUid::from_raw(
+            "pkg:deb/debian/libc6@2.36-1?arch=amd64&uuid=test-uuid".to_string(),
+        ),
         datafile_paths: vec!["rootfs/var/lib/dpkg/status".to_string()],
         datasource_ids: vec![DatasourceId::DebianInstalledStatusDb],
     }];
@@ -3135,7 +3165,9 @@ fn test_resolve_debian_installed_file_references_respects_arch_qualifier() {
 
     assert_eq!(
         files[3].for_packages,
-        vec!["pkg:deb/debian/libc6@2.36-1?arch=amd64&uuid=test-uuid".to_string()]
+        vec![PackageUid::from_raw(
+            "pkg:deb/debian/libc6@2.36-1?arch=amd64&uuid=test-uuid".to_string()
+        )]
     );
     assert!(files[4].for_packages.is_empty());
 }

--- a/src/assembly/hackage_merge.rs
+++ b/src/assembly/hackage_merge.rs
@@ -1,4 +1,4 @@
-use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
 struct HackageSource<'a> {
     file_index: usize,
@@ -95,7 +95,7 @@ pub fn assemble_hackage_packages(
 
 fn hoist_sources_with_package<'a>(
     sources: impl Iterator<Item = &'a HackageSource<'a>>,
-    for_package_uid: Option<String>,
+    for_package_uid: Option<PackageUid>,
 ) -> Vec<TopLevelDependency> {
     sources
         .flat_map(|source| {
@@ -122,7 +122,7 @@ fn hoist_sources_with_package<'a>(
 
 fn hoist_sources_without_package<'a>(
     sources: &'a [HackageSource<'a>],
-    for_package_uid: Option<String>,
+    for_package_uid: Option<PackageUid>,
 ) -> Vec<TopLevelDependency> {
     hoist_sources_with_package(sources.iter(), for_package_uid)
 }

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -25,7 +25,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use crate::models::{DatasourceId, FileInfo, Package, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageUid, TopLevelDependency};
 
 pub use assemblers::ASSEMBLERS;
 
@@ -155,7 +155,7 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
         {
             let package_uid = pkg.package_uid.clone();
             let purl = pkg.purl.clone();
-            let removed_package_uids: Vec<String> = packages
+            let removed_package_uids: Vec<PackageUid> = packages
                 .iter()
                 .filter(|p| p.purl == purl)
                 .map(|p| p.package_uid.clone())
@@ -191,7 +191,7 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
 
     for file in files.iter_mut() {
         file.for_packages
-            .sort_by(|left, right| stable_uid_key(left).cmp(stable_uid_key(right)));
+            .sort_by(|left, right| left.stable_key().cmp(right.stable_key()));
         file.for_packages.dedup();
     }
 
@@ -215,9 +215,9 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
             })
             .then_with(|| {
                 left.for_package_uid
-                    .as_deref()
-                    .map(stable_uid_key)
-                    .cmp(&right.for_package_uid.as_deref().map(stable_uid_key))
+                    .as_ref()
+                    .map(|uid| uid.stable_key())
+                    .cmp(&right.for_package_uid.as_ref().map(|uid| uid.stable_key()))
             })
     });
 
@@ -298,13 +298,6 @@ fn stable_package_sort_key(package: &Package) -> (Option<&str>, Option<&str>, Op
             .map(String::as_str)
             .unwrap_or(""),
     )
-}
-
-fn stable_uid_key(uid: &str) -> &str {
-    uid.split_once("?uuid=")
-        .map(|(prefix, _)| prefix)
-        .or_else(|| uid.split_once("&uuid=").map(|(prefix, _)| prefix))
-        .unwrap_or(uid)
 }
 
 fn assemble_one_per_package_data(

--- a/src/assembly/npm_resource_assign.rs
+++ b/src/assembly/npm_resource_assign.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::models::{FileInfo, Package, PackageType};
+use crate::models::{FileInfo, Package, PackageType, PackageUid};
 use crate::utils::path::parent_dir_for_lookup;
 
 pub fn assign_npm_package_resources(files: &mut [FileInfo], packages: &[Package]) {
-    let package_roots: HashMap<String, String> = packages
+    let package_roots: HashMap<String, PackageUid> = packages
         .iter()
         .filter(|package| package.package_type == Some(PackageType::Npm))
         .filter_map(|package| {
@@ -32,8 +32,8 @@ pub fn assign_npm_package_resources(files: &mut [FileInfo], packages: &[Package]
 
 fn find_nearest_package_owner(
     path: &str,
-    package_roots: &HashMap<String, String>,
-) -> Option<String> {
+    package_roots: &HashMap<String, PackageUid>,
+) -> Option<PackageUid> {
     let mut current = Some(path);
 
     while let Some(candidate) = current {

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use log::debug;
 
 use super::{ASSEMBLERS, AssemblerConfig, sibling_merge};
-use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 use crate::utils::path::{parent_dir, parent_dir_for_lookup};
 
 /// File-local topology hint emitted by npm-family workspace root files.
@@ -298,7 +298,7 @@ pub(super) fn apply_npm_workspace_domain(
     }
 
     // Collect member UIDs for for_packages assignment
-    let member_uids: Vec<String> = member_packages
+    let member_uids: Vec<PackageUid> = member_packages
         .iter()
         .map(|(pkg, _deps)| pkg.package_uid.clone())
         .collect();
@@ -329,7 +329,7 @@ pub(super) fn apply_npm_workspace_domain(
         files,
         workspace_domain,
         &member_uids,
-        root_package_uid.as_deref(),
+        root_package_uid.as_ref(),
     );
 
     // Step 7: Resolve workspace: versions in all dependencies
@@ -457,7 +457,7 @@ fn remove_member_packages(
         .map(|&idx| files[idx].path.as_str())
         .collect();
 
-    let removed_uids: Vec<String> = packages
+    let removed_uids: Vec<PackageUid> = packages
         .iter()
         .filter(|pkg| {
             pkg.datafile_paths
@@ -591,7 +591,7 @@ fn hoist_root_dependencies(
     root_dir: &Path,
     dependencies: &mut Vec<TopLevelDependency>,
     member_versions: &HashMap<String, String>,
-    for_package_uid: Option<&str>,
+    for_package_uid: Option<PackageUid>,
 ) {
     let root_file = &files[root_idx];
 
@@ -612,7 +612,7 @@ fn hoist_root_dependencies(
                 dep,
                 root_file.path.clone(),
                 DatasourceId::NpmPackageJson,
-                for_package_uid.map(|s| s.to_string()),
+                for_package_uid.clone(),
             );
 
             // Resolve workspace: version immediately
@@ -672,7 +672,7 @@ fn hoist_root_dependencies(
                         dep,
                         file.path.clone(),
                         dsid,
-                        for_package_uid.map(|s| s.to_string()),
+                        for_package_uid.clone(),
                     );
 
                     // Resolve workspace: version
@@ -699,11 +699,11 @@ fn hoist_root_dependencies(
 fn assign_for_packages(
     files: &mut [FileInfo],
     workspace_root: &NpmWorkspaceDomain,
-    member_uids: &[String],
-    root_package_uid: Option<&str>,
+    member_uids: &[PackageUid],
+    root_package_uid: Option<&PackageUid>,
 ) {
     let workspace_root_str = workspace_root.root_dir.to_string_lossy().into_owned();
-    let mut member_dirs: HashMap<String, String> = HashMap::new();
+    let mut member_dirs: HashMap<String, PackageUid> = HashMap::new();
     for (member, uid) in workspace_root.members.iter().zip(member_uids.iter()) {
         if let Some(relative_path) =
             strip_root_prefix(&files[member.manifest_idx].path, &workspace_root_str)
@@ -737,7 +737,7 @@ fn assign_for_packages(
 
         // Shared file: assign to root package (pnpm) or all members (npm/yarn)
         if let Some(root_uid) = root_package_uid {
-            file.for_packages.push(root_uid.to_string());
+            file.for_packages.push(root_uid.clone());
         } else {
             for uid in member_uids {
                 file.for_packages.push(uid.clone());
@@ -746,7 +746,10 @@ fn assign_for_packages(
     }
 }
 
-fn find_nearest_member_dir(path: &str, member_dirs: &HashMap<String, String>) -> Option<String> {
+fn find_nearest_member_dir(
+    path: &str,
+    member_dirs: &HashMap<String, PackageUid>,
+) -> Option<PackageUid> {
     let mut current = Some(path);
 
     while let Some(candidate) = current {

--- a/src/assembly/python_requirements_assign.rs
+++ b/src/assembly/python_requirements_assign.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::models::{DatasourceId, FileInfo, Package, PackageType, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageType, PackageUid, TopLevelDependency};
 
 const PYTHON_PROJECT_ROOT_FILENAMES: &[&str] = &[
     "pyproject.toml",
@@ -16,7 +16,7 @@ const PYTHON_PROJECT_ROOT_FILENAMES: &[&str] = &[
 struct PythonProjectRoot {
     root: PathBuf,
     package_index: usize,
-    package_uid: String,
+    package_uid: PackageUid,
 }
 
 pub fn assign_python_requirements_to_projects(

--- a/src/assembly/ruby_resource_assign.rs
+++ b/src/assembly/ruby_resource_assign.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use crate::cache::DEFAULT_CACHE_DIR_NAME;
-use crate::models::{FileInfo, Package, PackageType};
+use crate::models::{FileInfo, Package, PackageType, PackageUid};
 
 pub fn assign_ruby_package_resources(files: &mut [FileInfo], packages: &[Package]) {
-    let ruby_roots: Vec<(PathBuf, String)> = packages
+    let ruby_roots: Vec<(PathBuf, PackageUid)> = packages
         .iter()
         .filter(|package| package.package_type == Some(PackageType::Gem))
         .filter_map(|package| {

--- a/src/assembly/swift_merge.rs
+++ b/src/assembly/swift_merge.rs
@@ -3,11 +3,11 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use packageurl::PackageUrl;
-use uuid::Uuid;
 
 use crate::cache::DEFAULT_CACHE_DIR_NAME;
 use crate::models::{
-    DatasourceId, Dependency, FileInfo, Package, PackageData, PackageType, TopLevelDependency,
+    DatasourceId, Dependency, FileInfo, Package, PackageData, PackageType, PackageUid,
+    TopLevelDependency,
 };
 
 pub fn assemble_swift_packages(
@@ -66,7 +66,7 @@ pub fn assemble_swift_packages(
             continue;
         };
 
-        let package_uids: Vec<String> = created_packages
+        let package_uids: Vec<PackageUid> = created_packages
             .iter()
             .map(|package| package.package_uid.clone())
             .collect();
@@ -188,7 +188,7 @@ fn hoist_dependencies(
     dependencies: &[Dependency],
     datafile_path: &str,
     datasource_id: DatasourceId,
-    package_uid: Option<String>,
+    package_uid: Option<PackageUid>,
 ) -> Vec<TopLevelDependency> {
     dependencies
         .iter()
@@ -293,7 +293,7 @@ fn build_package_from_resolved_dependency(
         repository_download_url: None,
         api_data_url: None,
         purl: Some(purl.to_string()),
-        package_uid: build_package_uid(purl),
+        package_uid: PackageUid::new(purl),
         datafile_paths: vec![datafile_path.to_string()],
         datasource_ids: vec![DatasourceId::SwiftPackageResolved],
     })
@@ -309,7 +309,7 @@ fn dependency_name(dependency: &Dependency) -> Option<String> {
 fn assign_swift_resources(
     files: &mut [FileInfo],
     root: &Path,
-    package_uids: &[String],
+    package_uids: &[PackageUid],
     inputs: &SwiftDirectoryInputs,
     swift_roots: &[PathBuf],
 ) {
@@ -361,15 +361,6 @@ fn is_internal_cache_path(path: &Path, root: &Path) -> bool {
         .ok()
         .and_then(|relative| relative.components().next())
         .is_some_and(|component| component.as_os_str() == DEFAULT_CACHE_DIR_NAME)
-}
-
-fn build_package_uid(purl: &str) -> String {
-    let uuid = Uuid::new_v4();
-    if purl.contains('?') {
-        format!("{}&uuid={}", purl, uuid)
-    } else {
-        format!("{}?uuid={}", purl, uuid)
-    }
 }
 
 #[cfg(test)]
@@ -554,7 +545,9 @@ mod tests {
         assign_swift_resources(
             &mut files,
             Path::new(""),
-            &["pkg:swift/RootPkg?uuid=root".to_string()],
+            &[PackageUid::from_raw(
+                "pkg:swift/RootPkg?uuid=root".to_string(),
+            )],
             &SwiftDirectoryInputs {
                 manifest: Some(SwiftSource {
                     file_index: 0,
@@ -570,8 +563,18 @@ mod tests {
             &[PathBuf::new(), PathBuf::from("examples/demo")],
         );
 
-        assert_eq!(files[0].for_packages, vec!["pkg:swift/RootPkg?uuid=root"]);
-        assert_eq!(files[1].for_packages, vec!["pkg:swift/RootPkg?uuid=root"]);
+        assert_eq!(
+            files[0].for_packages,
+            vec![PackageUid::from_raw(
+                "pkg:swift/RootPkg?uuid=root".to_string()
+            )]
+        );
+        assert_eq!(
+            files[1].for_packages,
+            vec![PackageUid::from_raw(
+                "pkg:swift/RootPkg?uuid=root".to_string()
+            )]
+        );
         assert!(files[2].for_packages.is_empty());
         assert!(files[3].for_packages.is_empty());
     }

--- a/src/models/dependency_uid.rs
+++ b/src/models/dependency_uid.rs
@@ -1,0 +1,73 @@
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct DependencyUid(String);
+
+impl DependencyUid {
+    /// Creates a new `DependencyUid` by appending a UUID to the given purl.
+    pub fn new(purl: &str) -> Self {
+        let uuid = Uuid::new_v4();
+        if purl.contains('?') {
+            DependencyUid(format!("{}&uuid={}", purl, uuid))
+        } else {
+            DependencyUid(format!("{}?uuid={}", purl, uuid))
+        }
+    }
+
+    /// Wraps an existing UID string without validation or UUID generation.
+    ///
+    /// Use this for deserialization boundaries and round-trip conversions
+    /// where the UID string is already well-formed.
+    pub fn from_raw(s: String) -> Self {
+        DependencyUid(s)
+    }
+
+    /// Returns the empty-string sentinel representing "no purl".
+    pub fn empty() -> Self {
+        DependencyUid(String::new())
+    }
+
+    /// Returns a new `DependencyUid` with the purl base replaced, preserving the UUID suffix.
+    pub fn replace_base(&self, new_purl: &str) -> Self {
+        if let Some((_, suffix)) = self.0.split_once("?uuid=") {
+            return DependencyUid(format!("{}?uuid={}", new_purl, suffix));
+        }
+        if let Some((_, suffix)) = self.0.split_once("&uuid=") {
+            let separator = if new_purl.contains('?') { '&' } else { '?' };
+            return DependencyUid(format!("{}{separator}uuid={suffix}", new_purl));
+        }
+        DependencyUid(self.0.clone())
+    }
+}
+
+impl fmt::Display for DependencyUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for DependencyUid {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for DependencyUid {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for DependencyUid {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1,17 +1,17 @@
 use derive_builder::Builder;
 use packageurl::PackageUrl;
 use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use std::str::FromStr;
-use uuid::Uuid;
-
-use sha1::{Digest, Sha1};
 
 use super::DatasourceId;
+use super::DependencyUid;
 use super::GitSha1;
 use super::LineNumber;
 use super::Md5Digest;
 use super::PackageType;
+use super::PackageUid;
 use super::Sha1Digest;
 use super::Sha256Digest;
 use super::Sha512Digest;
@@ -86,7 +86,7 @@ pub struct FileInfo {
     pub urls: Vec<OutputURL>,
     #[builder(default)]
     #[serde(default)]
-    pub for_packages: Vec<String>,
+    pub for_packages: Vec<PackageUid>,
     #[builder(default)]
     #[serde(default)]
     pub scan_errors: Vec<String>,
@@ -221,7 +221,7 @@ impl FileInfo {
         authors: Vec<Author>,
         emails: Vec<OutputEmail>,
         urls: Vec<OutputURL>,
-        for_packages: Vec<String>,
+        for_packages: Vec<PackageUid>,
         scan_errors: Vec<String>,
     ) -> Self {
         let mut package_data = package_data;
@@ -832,7 +832,7 @@ pub struct Package {
     pub api_data_url: Option<String>,
     pub purl: Option<String>,
     /// Unique identifier for this package instance (PURL with UUID qualifier).
-    pub package_uid: String,
+    pub package_uid: PackageUid,
     /// Paths to all datafiles that contributed to this package.
     pub datafile_paths: Vec<String>,
     /// Datasource identifiers for all parsers that contributed to this package.
@@ -851,8 +851,8 @@ impl Package {
         let package_uid = package_data
             .purl
             .as_ref()
-            .map(|p| build_package_uid(p))
-            .unwrap_or_default();
+            .map(|p| PackageUid::new(p))
+            .unwrap_or_else(PackageUid::empty);
 
         Package {
             package_type: package_data.package_type,
@@ -1027,7 +1027,7 @@ impl Package {
         };
 
         if self.purl.as_deref() != Some(next_purl.as_str()) || self.package_uid.is_empty() {
-            self.package_uid = build_package_uid(&next_purl);
+            self.package_uid = PackageUid::new(&next_purl);
         }
 
         self.purl = Some(next_purl);
@@ -1238,9 +1238,9 @@ pub struct TopLevelDependency {
     #[serde(default)]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
     /// Unique identifier for this dependency instance (PURL with UUID qualifier).
-    pub dependency_uid: String,
+    pub dependency_uid: DependencyUid,
     /// The `package_uid` of the package this dependency belongs to.
-    pub for_package_uid: Option<String>,
+    pub for_package_uid: Option<PackageUid>,
     /// Path to the datafile where this dependency was declared.
     pub datafile_path: String,
     /// Datasource identifier for the parser that extracted this dependency.
@@ -1255,13 +1255,13 @@ impl TopLevelDependency {
         dep: &Dependency,
         datafile_path: String,
         datasource_id: DatasourceId,
-        for_package_uid: Option<String>,
+        for_package_uid: Option<PackageUid>,
     ) -> Self {
         let dependency_uid = dep
             .purl
             .as_ref()
-            .map(|p| build_package_uid(p))
-            .unwrap_or_default();
+            .map(|p| DependencyUid::new(p))
+            .unwrap_or_else(DependencyUid::empty);
 
         TopLevelDependency {
             purl: dep.purl.clone(),
@@ -1279,18 +1279,6 @@ impl TopLevelDependency {
             datasource_id,
             namespace: None,
         }
-    }
-}
-
-/// Generate a unique package identifier by appending a UUID v4 qualifier to a PURL.
-///
-/// The format matches Python ScanCode: `pkg:type/name@version?uuid=<uuid-v4>`
-pub fn build_package_uid(purl: &str) -> String {
-    let uuid = Uuid::new_v4();
-    if purl.contains('?') {
-        format!("{}&uuid={}", purl, uuid)
-    } else {
-        format!("{}?uuid={}", purl, uuid)
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,11 +1,14 @@
 mod datasource_id;
+mod dependency_uid;
 mod digest;
 pub(crate) mod file_info;
 mod line_number;
 mod output;
 mod package_type;
+mod package_uid;
 
 pub use datasource_id::DatasourceId;
+pub use dependency_uid::DependencyUid;
 pub use digest::{GitSha1, Md5Digest, Sha1Digest, Sha256Digest, Sha512Digest};
 pub use file_info::{
     Author, Copyright, Dependency, FileInfo, FileInfoBuilder, FileReference, FileType, Holder,
@@ -14,9 +17,8 @@ pub use file_info::{
 };
 pub use line_number::LineNumber;
 pub use package_type::PackageType;
+pub use package_uid::PackageUid;
 
-#[cfg(test)]
-pub use file_info::build_package_uid;
 pub use output::{
     ExtraData, FacetTallies, Header, LicenseClarityScore, LicenseReference, LicenseRuleReference,
     OUTPUT_FORMAT_VERSION, Output, Summary, SystemEnvironment, Tallies, TallyEntry,

--- a/src/models/package_uid.rs
+++ b/src/models/package_uid.rs
@@ -1,0 +1,92 @@
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct PackageUid(String);
+
+impl PackageUid {
+    /// Creates a new `PackageUid` by appending a UUID to the given purl.
+    pub fn new(purl: &str) -> Self {
+        let uuid = Uuid::new_v4();
+        if purl.contains('?') {
+            PackageUid(format!("{}&uuid={}", purl, uuid))
+        } else {
+            PackageUid(format!("{}?uuid={}", purl, uuid))
+        }
+    }
+
+    /// Wraps an existing UID string without validation or UUID generation.
+    ///
+    /// Use this for deserialization boundaries and round-trip conversions
+    /// where the UID string is already well-formed.
+    pub fn from_raw(s: String) -> Self {
+        PackageUid(s)
+    }
+
+    /// Returns the empty-string sentinel representing "no purl".
+    pub fn empty() -> Self {
+        PackageUid(String::new())
+    }
+
+    /// Returns the purl portion by stripping the UUID suffix.
+    pub fn stable_key(&self) -> &str {
+        self.0
+            .split_once("?uuid=")
+            .map(|(prefix, _)| prefix)
+            .or_else(|| self.0.split_once("&uuid=").map(|(prefix, _)| prefix))
+            .unwrap_or(&self.0)
+    }
+
+    /// Returns a new `PackageUid` with the purl base replaced, preserving the UUID suffix.
+    pub fn replace_base(&self, new_purl: &str) -> Self {
+        if let Some((_, suffix)) = self.0.split_once("?uuid=") {
+            return PackageUid(format!("{}?uuid={}", new_purl, suffix));
+        }
+        if let Some((_, suffix)) = self.0.split_once("&uuid=") {
+            let separator = if new_purl.contains('?') { '&' } else { '?' };
+            return PackageUid(format!("{}{separator}uuid={suffix}", new_purl));
+        }
+        PackageUid(self.0.clone())
+    }
+
+    /// Returns the inner string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns `true` if this is the empty-string sentinel.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Display for PackageUid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for PackageUid {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for PackageUid {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for PackageUid {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -116,7 +116,7 @@ mod tests {
     use crate::models::{
         Author, Copyright, ExtraData, FileInfo, FileType, GitSha1, Header, Holder,
         LicenseDetection, LineNumber, Match, Md5Digest, OutputEmail, OutputURL, PackageData,
-        Sha1Digest, Sha256Digest, SystemEnvironment,
+        PackageUid, Sha1Digest, Sha256Digest, SystemEnvironment,
     };
     use crate::output_schema::OutputFileInfo;
 
@@ -1057,7 +1057,9 @@ mod tests {
             api_data_url: None,
             datasource_ids: vec![],
             purl: Some("pkg:maven/example/gradle-project@1.0.0".to_string()),
-            package_uid: "pkg:maven/example/gradle-project@1.0.0?uuid=test".to_string(),
+            package_uid: PackageUid::from_raw(
+                "pkg:maven/example/gradle-project@1.0.0?uuid=test".to_string(),
+            ),
             datafile_paths: vec![],
         }];
         let output = Output::from(&internal);

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -236,7 +236,11 @@ impl From<&crate::models::FileInfo> for OutputFileInfo {
             authors: value.authors.iter().map(OutputAuthor::from).collect(),
             emails: value.emails.iter().map(OutputEmail::from).collect(),
             urls: value.urls.iter().map(OutputURL::from).collect(),
-            for_packages: value.for_packages.clone(),
+            for_packages: value
+                .for_packages
+                .iter()
+                .map(|uid| uid.to_string())
+                .collect(),
             scan_errors: value.scan_errors.clone(),
             license_policy: value
                 .license_policy
@@ -354,7 +358,11 @@ impl TryFrom<&OutputFileInfo> for crate::models::FileInfo {
             authors,
             emails,
             urls,
-            for_packages: value.for_packages.clone(),
+            for_packages: value
+                .for_packages
+                .iter()
+                .map(|s| crate::models::PackageUid::from_raw(s.clone()))
+                .collect(),
             scan_errors: value.scan_errors.clone(),
             license_policy,
             is_generated: value.is_generated,

--- a/src/output_schema/package.rs
+++ b/src/output_schema/package.rs
@@ -115,7 +115,7 @@ impl From<&crate::models::Package> for OutputPackage {
             repository_download_url: value.repository_download_url.clone(),
             api_data_url: value.api_data_url.clone(),
             purl: value.purl.clone(),
-            package_uid: value.package_uid.clone(),
+            package_uid: value.package_uid.to_string(),
             datafile_paths: value.datafile_paths.clone(),
             datasource_ids: value.datasource_ids.clone(),
         }
@@ -197,7 +197,7 @@ impl TryFrom<&OutputPackage> for crate::models::Package {
             repository_download_url: value.repository_download_url.clone(),
             api_data_url: value.api_data_url.clone(),
             purl: value.purl.clone(),
-            package_uid: value.package_uid.clone(),
+            package_uid: crate::models::PackageUid::from_raw(value.package_uid.clone()),
             datafile_paths: value.datafile_paths.clone(),
             datasource_ids: value.datasource_ids.clone(),
         })

--- a/src/output_schema/top_level_dependency.rs
+++ b/src/output_schema/top_level_dependency.rs
@@ -38,8 +38,8 @@ impl From<&crate::models::TopLevelDependency> for OutputTopLevelDependency {
                 .as_ref()
                 .map(|rp| Box::new(OutputResolvedPackage::from(rp.as_ref()))),
             extra_data: value.extra_data.clone(),
-            dependency_uid: value.dependency_uid.clone(),
-            for_package_uid: value.for_package_uid.clone(),
+            dependency_uid: value.dependency_uid.to_string(),
+            for_package_uid: value.for_package_uid.as_ref().map(|uid| uid.to_string()),
             datafile_path: value.datafile_path.clone(),
             datasource_id: value.datasource_id,
             namespace: value.namespace.clone(),
@@ -65,8 +65,11 @@ impl TryFrom<&OutputTopLevelDependency> for crate::models::TopLevelDependency {
             is_direct: value.is_direct,
             resolved_package,
             extra_data: value.extra_data.clone(),
-            dependency_uid: value.dependency_uid.clone(),
-            for_package_uid: value.for_package_uid.clone(),
+            dependency_uid: crate::models::DependencyUid::from_raw(value.dependency_uid.clone()),
+            for_package_uid: value
+                .for_package_uid
+                .as_ref()
+                .map(|s| crate::models::PackageUid::from_raw(s.clone())),
             datafile_path: value.datafile_path.clone(),
             datasource_id: value.datasource_id,
             namespace: value.namespace.clone(),

--- a/src/parsers/scan_test_utils.rs
+++ b/src/parsers/scan_test_utils.rs
@@ -107,7 +107,11 @@ pub(crate) fn assert_file_links_to_package(
         .find(|file| file.path.ends_with(suffix))
         .unwrap_or_else(|| panic!("{suffix} should be scanned"));
 
-    assert!(file.for_packages.iter().any(|uid| uid == package_uid));
+    assert!(
+        file.for_packages
+            .iter()
+            .any(|uid| uid.as_str() == package_uid)
+    );
     assert!(
         file.package_data
             .iter()

--- a/src/post_processing/classify_test.rs
+++ b/src/post_processing/classify_test.rs
@@ -4,13 +4,16 @@ use super::test_utils::{dir, file, package, scan_and_assemble_with_keyfiles};
 use super::*;
 use crate::models::{
     Copyright, DatasourceId, FileReference, Holder, LineNumber, Match, Package, PackageType,
+    PackageUid,
 };
 
 #[test]
 fn classify_key_files_marks_nested_ruby_license_from_file_references() {
     let uid = "pkg:gem/inspec-bin@6.8.2?uuid=test";
     let mut metadata_file = file("inspec-6.8.2/metadata.gz-extract");
-    metadata_file.for_packages.push(uid.to_string());
+    metadata_file
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     metadata_file.package_data = vec![crate::models::PackageData {
         package_type: Some(PackageType::Gem),
         datasource_id: Some(DatasourceId::GemArchiveExtracted),
@@ -27,7 +30,9 @@ fn classify_key_files_marks_nested_ruby_license_from_file_references() {
     }];
 
     let mut license_file = file("inspec-6.8.2/inspec-bin/LICENSE");
-    license_file.for_packages.push(uid.to_string());
+    license_file
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     license_file.license_expression = Some("Apache-2.0".to_string());
     license_file.copyrights = vec![Copyright {
         copyright: "Copyright (c) 2019 Chef Software Inc.".to_string(),
@@ -81,7 +86,9 @@ fn classify_key_files_marks_nested_ruby_license_from_file_references() {
 fn classify_key_files_does_not_tag_unreferenced_nested_legal_file() {
     let uid = "pkg:gem/demo@1.0.0?uuid=test";
     let mut gemspec = file("demo/demo.gemspec");
-    gemspec.for_packages.push(uid.to_string());
+    gemspec
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     gemspec.package_data = vec![crate::models::PackageData {
         package_type: Some(PackageType::Gem),
         datasource_id: Some(DatasourceId::Gemspec),
@@ -89,7 +96,9 @@ fn classify_key_files_does_not_tag_unreferenced_nested_legal_file() {
     }];
 
     let mut nested_license = file("demo/subdir/LICENSE");
-    nested_license.for_packages.push(uid.to_string());
+    nested_license
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
 
     let mut files = vec![gemspec, nested_license];
     let packages = vec![package(uid, "demo/demo.gemspec")];
@@ -178,23 +187,33 @@ fn classify_key_files_marks_package_data_ancestry_like_with_package_data_fixture
     let uid = "pkg:maven/org.jboss.logging/jboss-logging@3.4.2.Final?uuid=test";
 
     let mut manifest_mf = file("jar/META-INF/MANIFEST.MF");
-    manifest_mf.for_packages.push(uid.to_string());
+    manifest_mf
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     manifest_mf.package_data = vec![crate::models::PackageData::default()];
 
     let mut license = file("jar/META-INF/LICENSE.txt");
-    license.for_packages.push(uid.to_string());
+    license
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
 
     let mut pom_properties =
         file("jar/META-INF/maven/org.jboss.logging/jboss-logging/pom.properties");
-    pom_properties.for_packages.push(uid.to_string());
+    pom_properties
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     pom_properties.package_data = vec![crate::models::PackageData::default()];
 
     let mut pom_xml = file("jar/META-INF/maven/org.jboss.logging/jboss-logging/pom.xml");
-    pom_xml.for_packages.push(uid.to_string());
+    pom_xml
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     pom_xml.package_data = vec![crate::models::PackageData::default()];
 
     let mut source = file("jar/org/jboss/logging/AbstractLoggerProvider.java");
-    source.for_packages.push(uid.to_string());
+    source
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
 
     let mut files = vec![
         dir("jar"),
@@ -213,7 +232,7 @@ fn classify_key_files_marks_package_data_ancestry_like_with_package_data_fixture
     ];
 
     let package = Package {
-        package_uid: uid.to_string(),
+        package_uid: PackageUid::from_raw(uid.to_string()),
         datafile_paths: vec![
             "jar/META-INF/maven/org.jboss.logging/jboss-logging/pom.xml".to_string(),
         ],

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -7,7 +7,7 @@ use crate::assembly;
 use crate::license_detection::index::{IndexedRuleMetadata, LicenseIndex};
 use crate::license_detection::models::{License as RuntimeLicense, Rule, RuleKind};
 use crate::models::{
-    Copyright, Holder, LineNumber, Match, Package, PackageData, PackageType, Tallies,
+    Copyright, Holder, LineNumber, Match, Package, PackageData, PackageType, PackageUid, Tallies,
 };
 use crate::scan_result_shaping::normalize_paths;
 use serde_json::json;
@@ -1029,7 +1029,7 @@ fn apply_local_file_reference_following_resolves_files_beside_manifest() {
     }];
 
     let mut source = file("project/demo/__init__.py");
-    source.for_packages = vec![package_uid.clone()];
+    source.for_packages = vec![PackageUid::from_raw(package_uid.clone())];
     source.license_expression = Some("unknown-license-reference".to_string());
     source.license_detections = vec![crate::models::LicenseDetection {
         license_expression: "unknown-license-reference".to_string(),
@@ -1100,7 +1100,7 @@ fn apply_package_reference_following_resolves_manifest_origin_local_file() {
     }];
 
     let mut manifest = file("project/Cargo.toml");
-    manifest.for_packages = vec![package_uid.clone()];
+    manifest.for_packages = vec![PackageUid::from_raw(package_uid.clone())];
     manifest.package_data = vec![PackageData {
         package_type: Some(PackageType::Cargo),
         license_detections: package.license_detections.clone(),
@@ -1434,7 +1434,7 @@ fn apply_package_reference_following_inherits_license_from_package_context() {
     }];
 
     let mut source = file("project/locale/django.po");
-    source.for_packages = vec![package_uid.clone()];
+    source.for_packages = vec![PackageUid::from_raw(package_uid.clone())];
     source.license_expression = Some("free-unknown".to_string());
     source.license_detections = vec![crate::models::LicenseDetection {
         license_expression: "free-unknown".to_string(),
@@ -1611,7 +1611,10 @@ fn apply_package_reference_following_leaves_ambiguous_multi_package_file_unresol
     }];
 
     let mut shared_file = file("project/shared/locale.po");
-    shared_file.for_packages = vec![first_uid, second_uid];
+    shared_file.for_packages = vec![
+        PackageUid::from_raw(first_uid),
+        PackageUid::from_raw(second_uid),
+    ];
     shared_file.license_expression = Some("free-unknown".to_string());
     shared_file.license_detections = vec![crate::models::LicenseDetection {
         license_expression: "free-unknown".to_string(),
@@ -2846,7 +2849,7 @@ fn create_output_promotes_package_metadata_without_summary_flags() {
     let end = start;
     let package_uid = "pkg:npm/demo?uuid=test".to_string();
     let mut license = file("project/LICENSE");
-    license.for_packages = vec![package_uid.clone()];
+    license.for_packages = vec![PackageUid::from_raw(package_uid.clone())];
     license.copyrights = vec![Copyright {
         copyright: "Copyright Example Corp.".to_string(),
         start_line: LineNumber::ONE,
@@ -2858,7 +2861,7 @@ fn create_output_promotes_package_metadata_without_summary_flags() {
         end_line: LineNumber::ONE,
     }];
     let package = Package {
-        package_uid,
+        package_uid: PackageUid::from_raw(package_uid),
         datafile_paths: vec!["project/package.json".to_string()],
         ..super::test_utils::package("pkg:npm/demo?uuid=test", "project/package.json")
     };

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -8,7 +8,7 @@ use crate::license_detection::detection::{
 };
 use crate::license_detection::expression::parse_expression;
 use crate::models::{
-    FileInfo, FileType, LicenseDetection, Match, Package, TopLevelLicenseDetection,
+    FileInfo, FileType, LicenseDetection, Match, Package, PackageUid, TopLevelLicenseDetection,
 };
 use crate::utils::spdx::combine_license_expressions;
 
@@ -33,8 +33,8 @@ pub(super) struct ResolvedReferenceTarget {
 pub(super) struct ReferenceFollowSnapshot {
     all_file_paths: HashSet<String>,
     files_by_path: HashMap<String, ResolvedReferenceTarget>,
-    package_targets_by_uid: HashMap<String, ResolvedReferenceTarget>,
-    package_manifest_dirs_by_uid: HashMap<String, Vec<String>>,
+    package_targets_by_uid: HashMap<PackageUid, ResolvedReferenceTarget>,
+    package_manifest_dirs_by_uid: HashMap<PackageUid, Vec<String>>,
     same_directory_legal_targets_by_dir: HashMap<String, Vec<ResolvedReferenceTarget>>,
     root_license_targets_by_root: HashMap<String, Vec<ResolvedReferenceTarget>>,
     root_paths: Vec<String>,
@@ -224,7 +224,7 @@ pub(super) fn build_reference_follow_snapshot(
                 .datafile_paths
                 .first()
                 .cloned()
-                .unwrap_or_else(|| package.package_uid.clone());
+                .unwrap_or_else(|| package.package_uid.to_string());
 
             Some((
                 package.package_uid.clone(),
@@ -696,7 +696,7 @@ fn sync_packages_from_followed_package_data(
 fn apply_reference_following_to_detection(
     detection: &mut LicenseDetection,
     current_path: &str,
-    package_uids: &[String],
+    package_uids: &[PackageUid],
     snapshot: &ReferenceFollowSnapshot,
 ) -> bool {
     if has_resolved_referenced_file(detection, current_path) {
@@ -919,7 +919,7 @@ fn sanitize_referenced_filename(name: &str) -> String {
 pub(super) fn resolve_referenced_resource(
     referenced_filename: &str,
     current_path: &str,
-    package_uids: &[String],
+    package_uids: &[PackageUid],
     snapshot: &ReferenceFollowSnapshot,
 ) -> Option<ResolvedReferenceTarget> {
     let is_absolute = referenced_filename.trim_start().starts_with('/');
@@ -975,7 +975,7 @@ fn explicit_reference_root(snapshot: &ReferenceFollowSnapshot) -> Option<&str> {
 
 fn resolve_package_reference_targets(
     current_path: &str,
-    package_uids: &[String],
+    package_uids: &[PackageUid],
     snapshot: &ReferenceFollowSnapshot,
 ) -> Option<(Vec<ResolvedReferenceTarget>, &'static str)> {
     if let Some(targets) = resolve_package_context_target(package_uids, snapshot) {
@@ -991,7 +991,7 @@ fn resolve_package_reference_targets(
 }
 
 fn resolve_package_context_target(
-    package_uids: &[String],
+    package_uids: &[PackageUid],
     snapshot: &ReferenceFollowSnapshot,
 ) -> Option<Vec<ResolvedReferenceTarget>> {
     let mut targets = Vec::new();

--- a/src/post_processing/summary/test.rs
+++ b/src/post_processing/summary/test.rs
@@ -6,14 +6,16 @@ use super::super::test_utils::{dir, file, package};
 use super::*;
 use crate::models::{
     Copyright, DatasourceId, FileReference, Holder, LineNumber, Match, Package, PackageType,
-    TallyEntry,
+    PackageUid, TallyEntry,
 };
 
 #[test]
 fn key_file_license_clues_feed_summary_without_mutating_package_license_provenance() {
     let uid = "pkg:gem/inspec-bin@6.8.2?uuid=test";
     let mut metadata_file = file("inspec-6.8.2/metadata.gz-extract");
-    metadata_file.for_packages.push(uid.to_string());
+    metadata_file
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     metadata_file.package_data = vec![crate::models::PackageData {
         package_type: Some(PackageType::Gem),
         datasource_id: Some(DatasourceId::GemArchiveExtracted),
@@ -30,7 +32,9 @@ fn key_file_license_clues_feed_summary_without_mutating_package_license_provenan
     }];
 
     let mut license_file = file("inspec-6.8.2/inspec-bin/LICENSE");
-    license_file.for_packages.push(uid.to_string());
+    license_file
+        .for_packages
+        .push(PackageUid::from_raw(uid.to_string()));
     license_file.license_expression = Some("Apache-2.0".to_string());
     license_file.license_detections = vec![crate::models::LicenseDetection {
         license_expression: "apache-2.0".to_string(),

--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -24,7 +24,7 @@ use crate::assembly;
 use crate::cache::{DEFAULT_CACHE_DIR_NAME, build_collection_exclude_patterns};
 #[cfg(feature = "golden-tests")]
 use crate::license_detection::LicenseDetectionEngine;
-use crate::models::{FileInfo, FileType, Package, PackageType};
+use crate::models::{FileInfo, FileType, Package, PackageType, PackageUid};
 use crate::progress::{ProgressMode, ScanProgress};
 #[cfg(feature = "golden-tests")]
 use crate::scan_result_shaping::normalize_paths;
@@ -150,7 +150,7 @@ pub(crate) fn package(uid: &str, path: &str) -> Package {
         api_data_url: None,
         datasource_ids: vec![DatasourceId::GemArchiveExtracted],
         purl: Some("pkg:gem/inspec-bin@6.8.2".to_string()),
-        package_uid: uid.to_string(),
+        package_uid: PackageUid::from_raw(uid.to_string()),
         datafile_paths: vec![path.to_string()],
     }
 }

--- a/src/scan_result_shaping/core_test.rs
+++ b/src/scan_result_shaping/core_test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::models::{
     Author, Copyright, DatasourceId, Dependency, FileReference, LineNumber, OutputEmail, OutputURL,
-    Package, PackageData, TopLevelDependency,
+    Package, PackageData, PackageUid, TopLevelDependency,
 };
 use crate::scan_result_shaping::test_fixtures::{dir, file};
 use regex::Regex;
@@ -809,8 +809,8 @@ fn trim_preloaded_assembly_to_files_drops_unreferenced_packages_and_dependencies
             "project/drop-package.json".to_string(),
         ),
     ];
-    packages[0].package_uid = "pkg:npm/keep@1.0.0?uuid=keep".to_string();
-    packages[1].package_uid = "pkg:npm/drop@1.0.0?uuid=drop".to_string();
+    packages[0].package_uid = PackageUid::from_raw("pkg:npm/keep@1.0.0?uuid=keep".to_string());
+    packages[1].package_uid = PackageUid::from_raw("pkg:npm/drop@1.0.0?uuid=drop".to_string());
 
     let mut dependencies = vec![
         TopLevelDependency::from_dependency(
@@ -827,7 +827,9 @@ fn trim_preloaded_assembly_to_files_drops_unreferenced_packages_and_dependencies
             },
             "project/keep-package.json".to_string(),
             DatasourceId::NpmPackageJson,
-            Some("pkg:npm/keep@1.0.0?uuid=keep".to_string()),
+            Some(PackageUid::from_raw(
+                "pkg:npm/keep@1.0.0?uuid=keep".to_string(),
+            )),
         ),
         TopLevelDependency::from_dependency(
             &Dependency {
@@ -843,7 +845,9 @@ fn trim_preloaded_assembly_to_files_drops_unreferenced_packages_and_dependencies
             },
             "project/drop-package.json".to_string(),
             DatasourceId::NpmPackageJson,
-            Some("pkg:npm/drop@1.0.0?uuid=drop".to_string()),
+            Some(PackageUid::from_raw(
+                "pkg:npm/drop@1.0.0?uuid=drop".to_string(),
+            )),
         ),
     ];
 
@@ -881,7 +885,9 @@ fn normalize_top_level_output_paths_only_applies_strip_root() {
         },
         "/tmp/project/package.json".to_string(),
         DatasourceId::NpmPackageJson,
-        Some("pkg:npm/demo@1.0.0?uuid=demo".to_string()),
+        Some(PackageUid::from_raw(
+            "pkg:npm/demo@1.0.0?uuid=demo".to_string(),
+        )),
     )];
 
     normalize_top_level_output_paths(&mut packages, &mut dependencies, "/tmp/project", true);

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -1,7 +1,7 @@
 use provenant::models::{
-    Copyright, DatasourceId, ExtraData, FacetTallies, FileInfo, FileType, Header, Holder,
-    LineNumber, Md5Digest, Output, Package, PackageData, PackageType, Party, ResolvedPackage,
-    Sha1Digest, SystemEnvironment, Tallies, TallyEntry, TopLevelDependency,
+    Copyright, DatasourceId, DependencyUid, ExtraData, FacetTallies, FileInfo, FileType, Header,
+    Holder, LineNumber, Md5Digest, Output, Package, PackageData, PackageType, PackageUid, Party,
+    ResolvedPackage, Sha1Digest, SystemEnvironment, Tallies, TallyEntry, TopLevelDependency,
 };
 use provenant::output_schema::Output as OutputSchemaOutput;
 use provenant::{OutputFormat, OutputWriteConfig, OutputWriter, writer_for_format};
@@ -1738,10 +1738,12 @@ fn sample_cyclonedx_dependency_output() -> Output {
             )
         })),
         extra_data: None,
-        dependency_uid: "pkg:npm/root@1.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
-        for_package_uid: Some(
-            "pkg:npm/root-package@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
+        dependency_uid: DependencyUid::from_raw(
+            "pkg:npm/root@1.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
         ),
+        for_package_uid: Some(PackageUid::from_raw(
+            "pkg:npm/root-package@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
+        )),
         datafile_path: "scan/package-lock.json".to_string(),
         datasource_id: DatasourceId::NpmPackageLockJson,
         namespace: None,
@@ -1757,10 +1759,10 @@ fn sample_cyclonedx_dependency_output() -> Output {
         is_direct: Some(true),
         resolved_package: None,
         extra_data: None,
-        dependency_uid: String::new(),
-        for_package_uid: Some(
+        dependency_uid: DependencyUid::empty(),
+        for_package_uid: Some(PackageUid::from_raw(
             "pkg:npm/root-package@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
-        ),
+        )),
         datafile_path: "scan/package-lock.json".to_string(),
         datasource_id: DatasourceId::NpmPackageLockJson,
         namespace: None,


### PR DESCRIPTION
## Summary

- Introduce `PackageUid(String)` and `DependencyUid(String)` newtypes with `#[serde(transparent)]` for type-safe package and dependency identifiers across internal models, assembly, and output schema
- Deduplicate `build_package_uid` (was in both `file_info.rs` and `swift_merge.rs`) into `PackageUid::new()`, `stable_uid_key` into `PackageUid::stable_key()`, and `replace_uid_base` into `PackageUid::replace_base()` / `DependencyUid::replace_base()`
- Migrate `Package::package_uid`, `TopLevelDependency::dependency_uid`, `TopLevelDependency::for_package_uid`, `FileInfo::for_packages`, and all assembly HashMap/HashSet/Vec key types from bare `String` to the new newtypes
- Update `docs/NEWTYPE_OPPORTUNITIES.md` to reflect current implementation status; `Purl` newtype deferred as a separate item

## Changes

### New files
- `src/models/package_uid.rs` — `PackageUid` newtype with `new()`, `from_raw()`, `empty()`, `stable_key()`, `replace_base()`, `Display`, `Deref<Target=str>`, `AsRef<str>`, `Borrow<str>`, `Hash`, `Eq`
- `src/models/dependency_uid.rs` — `DependencyUid` newtype with `new()`, `from_raw()`, `empty()`, `replace_base()`, same trait impls

### Deduplicated functions removed
- `build_package_uid` removed from `models/file_info.rs` and `assembly/swift_merge.rs` → `PackageUid::new()`
- `stable_uid_key` removed from `assembly/mod.rs` → `PackageUid::stable_key()`
- `replace_uid_base` removed from `assembly/file_ref_resolve.rs` → `.replace_base()` methods

### Internal type migrations
- `Package::package_uid: String` → `PackageUid`
- `TopLevelDependency::dependency_uid: String` → `DependencyUid`
- `TopLevelDependency::for_package_uid: Option<String>` → `Option<PackageUid>`
- `FileInfo::for_packages: Vec<String>` → `Vec<PackageUid>`
- Assembly HashMap keys: `HashMap<String, ...>` → `HashMap<PackageUid, ...>` in `package_file_index.rs`, `reference_following.rs`, `conda_rootfs_merge.rs`, `npm_resource_assign.rs`
- `HashSet<String>` → `HashSet<PackageUid>` in `bazel_prune.rs`
- Output schema conversions: `From` uses `.to_string()`, `TryFrom` uses `::from_raw()`

## Not included

- `Purl` newtype on `Option<String>` fields — deferred due to high surface area across all parsers; to be done as a separate PR

## Testing

- `cargo fmt --all -- --check` passes
- `cargo clippy --all-targets --all-features` passes with zero warnings
- `cargo check --lib --tests` passes