### PR TITLE
fix(output): update ScanCode repository URLs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -28,7 +28,7 @@ ScanCode data is licensed under CC-BY-4.0.
 See https://www.apache.org/licenses/LICENSE-2.0 for the Apache-2.0 license text.
 See https://creativecommons.org/licenses/by/4.0/legalcode for the CC-BY-4.0 license text.
 
-See https://github.com/nexB/scancode-toolkit for support or download.
+See https://github.com/aboutcode-org/scancode-toolkit for support or download.
 See https://aboutcode.org for more information about nexB OSS projects
 
 
@@ -44,5 +44,5 @@ The preferred attribution for use of ScanCode data is:
     ScanCode is a trademark of nexB Inc.
     SPDX-License-Identifier: CC-BY-4.0
     See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
-    See https://github.com/nexB/scancode-toolkit for support or download.
+    See https://github.com/aboutcode-org/scancode-toolkit for support or download.
     See https://aboutcode.org for more information about nexB OSS projects.

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -273,7 +273,7 @@ mod tests {
         assert_eq!(
             rule.rule_url(),
             Some(
-                "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_123.RULE"
+                "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_123.RULE"
                     .to_string()
             )
         );
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(
             rule.rule_url(),
             Some(
-                "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+                "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
                     .to_string()
             )
         );
@@ -303,7 +303,7 @@ mod tests {
         assert_eq!(
             rule.rule_url(),
             Some(
-                "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit.LICENSE"
+                "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit.LICENSE"
                     .to_string()
             )
         );

--- a/src/license_detection/models/rule.rs
+++ b/src/license_detection/models/rule.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 use crate::license_detection::index::dictionary::TokenId;
 
 const SCANCODE_LICENSE_URL_BASE: &str =
-    "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses";
+    "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses";
 const SCANCODE_RULE_URL_BASE: &str =
-    "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules";
+    "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules";
 
 mod range_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/post_processing/license_references.rs
+++ b/src/post_processing/license_references.rs
@@ -9,7 +9,7 @@ use crate::models::{
 };
 
 const SCANCODE_LICENSE_URL_BASE: &str =
-    "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses";
+    "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses";
 const SPDX_LICENSE_URL_BASE: &str = "https://spdx.org/licenses";
 
 pub(crate) fn collect_top_level_license_references(

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -381,7 +381,7 @@ fn collect_top_level_license_references_applies_custom_license_url_template() {
     assert_eq!(
         license_references[0].scancode_url.as_deref(),
         Some(
-            "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+            "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         )
     );
 }

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -1621,7 +1621,7 @@ mod tests {
     #[test]
     fn test_convert_detection_to_model_preserves_rule_url() {
         let detection = make_detection(
-            "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+            "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
         );
 
         let (converted, clues) =
@@ -1631,7 +1631,7 @@ mod tests {
         assert_eq!(
             converted.matches[0].rule_url.as_deref(),
             Some(
-                "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+                "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             )
         );
         assert!(clues.is_empty());
@@ -1670,7 +1670,7 @@ mod tests {
     #[test]
     fn test_convert_detection_to_model_routes_expressionless_detection_to_license_clues() {
         let mut detection = make_detection(
-            "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-clue_1.RULE",
+            "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-clue_1.RULE",
         );
         detection.license_expression = None;
         detection.license_expression_spdx = None;
@@ -1779,7 +1779,7 @@ mod tests {
         );
         let query = Query::from_extracted_text(text, &index, false).expect("query should build");
         let mut detection = make_detection(
-            "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/fsf-ap.LICENSE",
+            "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/fsf-ap.LICENSE",
         );
         detection.detection_log = vec!["imperfect-match-coverage".to_string()];
         detection.matches[0].license_expression = "fsf-ap".to_string();

--- a/testdata/bower/author-objects/expected.json
+++ b/testdata/bower/author-objects/expected.json
@@ -79,7 +79,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0"
           }
         ],
@@ -101,7 +101,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "bsd-new_10.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
             "matched_text": "BSD-3-Clause"
           }
         ],

--- a/testdata/bower/list-of-licenses/expected.json
+++ b/testdata/bower/list-of-licenses/expected.json
@@ -72,7 +72,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0"
           }
         ],
@@ -94,7 +94,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "bsd-new_10.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
             "matched_text": "BSD-3-Clause"
           }
         ],

--- a/testdata/bower/scan-expected.json
+++ b/testdata/bower/scan-expected.json
@@ -80,7 +80,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "Apache 2.0"
             }
           ],
@@ -102,7 +102,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "BSD-3-Clause"
             }
           ],
@@ -266,7 +266,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "Apache 2.0"
                 }
               ],
@@ -288,7 +288,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "bsd-new_10.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
                   "matched_text": "BSD-3-Clause"
                 }
               ],

--- a/testdata/chef/basic/test_package.json.expected
+++ b/testdata/chef/basic/test_package.json.expected
@@ -41,7 +41,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 70,
           "rule_identifier": "public-domain_bare_words.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
           "matched_text": "public-domain"
         }
       ],

--- a/testdata/chef/basic/test_package_code_view_url_and_bug_tracking_url.json.expected
+++ b/testdata/chef/basic/test_package_code_view_url_and_bug_tracking_url.json.expected
@@ -41,7 +41,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 70,
           "rule_identifier": "public-domain_bare_words.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
           "matched_text": "public-domain"
         }
       ],

--- a/testdata/chef/basic/test_package_dependencies.json.expected
+++ b/testdata/chef/basic/test_package_dependencies.json.expected
@@ -41,7 +41,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 70,
           "rule_identifier": "public-domain_bare_words.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
           "matched_text": "public-domain"
         }
       ],

--- a/testdata/chef/basic/test_package_parties.json.expected
+++ b/testdata/chef/basic/test_package_parties.json.expected
@@ -49,7 +49,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 70,
           "rule_identifier": "public-domain_bare_words.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
           "matched_text": "public-domain"
         }
       ],

--- a/testdata/cocoapods-golden/assemble/many-podspecs-expected.json
+++ b/testdata/cocoapods-golden/assemble/many-podspecs-expected.json
@@ -51,7 +51,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -126,7 +126,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -201,7 +201,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -276,7 +276,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -351,7 +351,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -426,7 +426,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -1032,7 +1032,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1117,7 +1117,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1202,7 +1202,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1287,7 +1287,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1372,7 +1372,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1457,7 +1457,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],

--- a/testdata/cocoapods-golden/assemble/many-podspecs-with-license-expected.json
+++ b/testdata/cocoapods-golden/assemble/many-podspecs-with-license-expected.json
@@ -51,7 +51,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -126,7 +126,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -201,7 +201,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -276,7 +276,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -351,7 +351,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -426,7 +426,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
               "matched_text": "Apache License, Version 2.0"
             }
           ],
@@ -988,7 +988,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_48.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE"
         }
       ]
     },
@@ -1010,7 +1010,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_68.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
         }
       ]
     },
@@ -1032,7 +1032,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_70.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
         }
       ]
     }
@@ -1105,7 +1105,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1152,7 +1152,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1217,7 +1217,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1264,7 +1264,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1329,7 +1329,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1376,7 +1376,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1441,7 +1441,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1488,7 +1488,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1553,7 +1553,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1600,7 +1600,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1665,7 +1665,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
                   "matched_text": "Apache License, Version 2.0"
                 }
               ],
@@ -1712,7 +1712,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_68.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_68.RULE"
             }
           ],
           "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f"
@@ -1769,7 +1769,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_70.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
                 }
               ],
               "identifier": "apache_2_0-08479bef-4de5-8be8-0987-1bec0c232b20"
@@ -1850,7 +1850,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_70.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
                 }
               ],
               "identifier": "apache_2_0-08479bef-4de5-8be8-0987-1bec0c232b20"
@@ -2396,7 +2396,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_70.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_70.RULE"
             }
           ],
           "identifier": "apache_2_0-08479bef-4de5-8be8-0987-1bec0c232b20"

--- a/testdata/cocoapods-golden/podspec/LoadingShimmer.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/LoadingShimmer.podspec.expected.json
@@ -50,7 +50,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "mit_in_manifest.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
             "matched_text": ":type = MIT, :file = LICENSE"
           }
         ],

--- a/testdata/cocoapods-golden/podspec/Starscream.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/Starscream.podspec.expected.json
@@ -57,7 +57,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "apache-2.0_48.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_48.RULE",
             "matched_text": "Apache License, Version 2.0"
           }
         ],

--- a/testdata/cocoapods-golden/podspec/SwiftLib.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/SwiftLib.podspec.expected.json
@@ -50,7 +50,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "mit_in_manifest.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
             "matched_text": ":type = MIT, :file = LICENSE"
           }
         ],

--- a/testdata/cocoapods-golden/podspec/flutter_paytabs_bridge.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/flutter_paytabs_bridge.podspec.expected.json
@@ -50,7 +50,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "unknown-license-reference_see_license_at_manifest_1.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
             "matched_text": "license :file = ../LICENSE"
           }
         ],

--- a/testdata/cocoapods-golden/podspec/kmmWebSocket.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/kmmWebSocket.podspec.expected.json
@@ -50,7 +50,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "mit_in_manifest.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_in_manifest.RULE",
             "matched_text": ":type = MIT, :file = LICENSE"
           }
         ],

--- a/testdata/conan/recipes/boost/conan-boost-package-expected.json
+++ b/testdata/conan/recipes/boost/conan-boost-package-expected.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -110,7 +110,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -177,7 +177,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -244,7 +244,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -311,7 +311,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -378,7 +378,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -445,7 +445,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -512,7 +512,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -579,7 +579,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -646,7 +646,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -713,7 +713,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -780,7 +780,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -847,7 +847,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -914,7 +914,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "- BSL-1.0"
             }
           ],
@@ -981,7 +981,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "boost-1.0_48.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
               "matched_text": "BSL-1.0"
             }
           ],
@@ -1800,7 +1800,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 50,
                   "rule_identifier": "boost-1.0_48.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
                   "matched_text": "BSL-1.0"
                 }
               ],

--- a/testdata/conan/recipes/boost/conanfile.py-expected.json
+++ b/testdata/conan/recipes/boost/conanfile.py-expected.json
@@ -42,7 +42,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 50,
             "rule_identifier": "boost-1.0_48.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_48.RULE",
             "matched_text": "BSL-1.0"
           }
         ],

--- a/testdata/conan/recipes/libgettext/conan-libgettext-package-expected.json
+++ b/testdata/conan/recipes/libgettext/conan-libgettext-package-expected.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
               "matched_text": "- LGPL-2.1-or-later"
             }
           ],
@@ -110,7 +110,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
               "matched_text": "- LGPL-2.1-or-later"
             }
           ],
@@ -177,7 +177,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
               "matched_text": "- LGPL-2.1-or-later"
             }
           ],
@@ -244,7 +244,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
               "matched_text": "LGPL-2.1-or-later"
             }
           ],
@@ -478,7 +478,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 50,
                   "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
                   "matched_text": "LGPL-2.1-or-later"
                 }
               ],

--- a/testdata/conan/recipes/libgettext/conanfile.py-expected.json
+++ b/testdata/conan/recipes/libgettext/conanfile.py-expected.json
@@ -42,7 +42,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 50,
             "rule_identifier": "spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_lgpl-2.1-or-later_for_lgpl-2.1-plus.RULE",
             "matched_text": "LGPL-2.1-or-later"
           }
         ],

--- a/testdata/conan/recipes/libzip/conan-libzip-package-expected.json
+++ b/testdata/conan/recipes/libzip/conan-libzip-package-expected.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "- BSD-3-Clause"
             }
           ],
@@ -110,7 +110,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "- BSD-3-Clause"
             }
           ],
@@ -177,7 +177,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "- BSD-3-Clause"
             }
           ],
@@ -244,7 +244,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "- BSD-3-Clause"
             }
           ],
@@ -311,7 +311,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_10.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
               "matched_text": "BSD-3-Clause"
             }
           ],
@@ -665,7 +665,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "bsd-new_10.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
                   "matched_text": "BSD-3-Clause"
                 }
               ],

--- a/testdata/conan/recipes/libzip/conanfile.py-expected.json
+++ b/testdata/conan/recipes/libzip/conanfile.py-expected.json
@@ -42,7 +42,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "bsd-new_10.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
             "matched_text": "BSD-3-Clause"
           }
         ],

--- a/testdata/conda/assembly-conda-scan.json
+++ b/testdata/conda/assembly-conda-scan.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "Apache-2.0"
             }
           ],
@@ -65,7 +65,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "Apache-2.0"
             }
           ],
@@ -158,7 +158,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "Apache-2.0"
             }
           ],
@@ -326,7 +326,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "Apache-2.0"
                 }
               ],
@@ -466,7 +466,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "Apache-2.0"
                 }
               ],
@@ -594,7 +594,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "Apache-2.0"
                 }
               ],

--- a/testdata/conda/meta-yaml/gcnvkernel/meta.yaml-expected.json
+++ b/testdata/conda/meta-yaml/gcnvkernel/meta.yaml-expected.json
@@ -42,7 +42,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "bsd-new_10.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
             "matched_text": "BSD-3-Clause"
           }
         ],

--- a/testdata/cran/codetools/package.json.expected
+++ b/testdata/cran/codetools/package.json.expected
@@ -57,7 +57,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 50,
             "rule_identifier": "gpl_bare_word_only.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_bare_word_only.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_bare_word_only.RULE",
             "matched_text": "GPL"
           }
         ],

--- a/testdata/cran/geometry/package.json.expected
+++ b/testdata/cran/geometry/package.json.expected
@@ -99,7 +99,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-3.0_25.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_25.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_25.RULE",
             "matched_text": "GPL (>= 3)"
           }
         ],

--- a/testdata/freebsd/basic/+COMPACT_MANIFEST.expected
+++ b/testdata/freebsd/basic/+COMPACT_MANIFEST.expected
@@ -55,7 +55,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-2.0_bare_single_word.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
             "matched_text": "GPLv2"
           }
         ],

--- a/testdata/freebsd/basic2/+COMPACT_MANIFEST.expected
+++ b/testdata/freebsd/basic2/+COMPACT_MANIFEST.expected
@@ -55,7 +55,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-3.0_32.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_32.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_32.RULE",
             "matched_text": "GPLv3"
           }
         ],

--- a/testdata/freebsd/dual_license/+COMPACT_MANIFEST.expected
+++ b/testdata/freebsd/dual_license/+COMPACT_MANIFEST.expected
@@ -78,7 +78,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-2.0_bare_single_word.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
             "matched_text": "GPLv2"
           }
         ],

--- a/testdata/freebsd/dual_license2/+COMPACT_MANIFEST.expected
+++ b/testdata/freebsd/dual_license2/+COMPACT_MANIFEST.expected
@@ -56,7 +56,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-3.0_32.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_32.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_32.RULE",
             "matched_text": "GPLv3"
           }
         ],
@@ -100,7 +100,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-2.0_bare_single_word.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
             "matched_text": "GPLv2"
           }
         ],

--- a/testdata/freebsd/multi_license/+COMPACT_MANIFEST.expected
+++ b/testdata/freebsd/multi_license/+COMPACT_MANIFEST.expected
@@ -56,7 +56,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 80,
             "rule_identifier": "python_10.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/python_10.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/python_10.RULE",
             "matched_text": "PSFL"
           }
         ],
@@ -78,7 +78,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 99,
             "rule_identifier": "bsd-new_416.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_416.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_416.RULE",
             "matched_text": "BSD3CLAUSE"
           }
         ],

--- a/testdata/license-golden/datadriven/external/fossology-tests/LGPL/License.rtf.yml
+++ b/testdata/license-golden/datadriven/external/fossology-tests/LGPL/License.rtf.yml
@@ -1,3 +1,3 @@
 license_expressions:
   - lgpl-2.1
-notes: failing pending https://github.com/nexB/scancode-toolkit/issues/1548
+notes: failing pending https://github.com/aboutcode-org/scancode-toolkit/issues/1548

--- a/testdata/license-golden/datadriven/lic1/cloudinit.license.yml
+++ b/testdata/license-golden/datadriven/lic1/cloudinit.license.yml
@@ -1,3 +1,3 @@
 license_expressions:
   - gpl-3.0 OR apache-2.0
-notes: found in https://github.com/nexB/scancode-toolkit/issues/508 cloudinit
+notes: found in https://github.com/aboutcode-org/scancode-toolkit/issues/508 cloudinit

--- a/testdata/license-golden/datadriven/lic1/flat.de.po.yml
+++ b/testdata/license-golden/datadriven/lic1/flat.de.po.yml
@@ -1,5 +1,5 @@
 license_expressions:
   - free-unknown
 notes:
-  this is a reference to some "package" license common in gettext .po files. See https://github.com/nexB/scancode-toolkit/issues/1379  and
+  this is a reference to some "package" license common in gettext .po files. See https://github.com/aboutcode-org/scancode-toolkit/issues/1379  and
   https://savannah.gnu.org/bugs/index.php?55733

--- a/testdata/license-golden/datadriven/lic3/libgcj.so.10.0.0.strings.txt.yml
+++ b/testdata/license-golden/datadriven/lic3/libgcj.so.10.0.0.strings.txt.yml
@@ -15,4 +15,4 @@ notes: |
   this is a subset of the strings extracted from libgcj.so.10.0.0
   originally from http://vault.centos.org/6.4/cr/x86_64/Packages/libgcj-4.4.7-4.el6.i686.rpm
   /usr/lib/libgcj.so.10.0.0
-  This a test for https://github.com/nexB/scancode-toolkit/issues/99
+  This a test for https://github.com/aboutcode-org/scancode-toolkit/issues/99

--- a/testdata/opam/sample3/output.opam.expected
+++ b/testdata/opam/sample3/output.opam.expected
@@ -71,7 +71,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 50,
             "rule_identifier": "spdx_license_id_gpl-3.0-only_for_gpl-3.0.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-3.0-only_for_gpl-3.0.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-3.0-only_for_gpl-3.0.RULE",
             "matched_text": "GPL-3.0-only"
           }
         ],

--- a/testdata/opam/sample6/output.opam.expected
+++ b/testdata/opam/sample6/output.opam.expected
@@ -57,7 +57,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-2.0_52.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_52.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_52.RULE",
             "matched_text": "GPL-2.0"
           }
         ],

--- a/testdata/summarycode-golden/classify/with_package_data.expected.json
+++ b/testdata/summarycode-golden/classify/with_package_data.expected.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1379.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
               "matched_text": "name: Apache License, version 2.0\nurl: http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
           ],
@@ -688,7 +688,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_1379.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
                   "matched_text": "name: Apache License, version 2.0\nurl: http://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
               ],

--- a/testdata/summarycode-golden/reference_following-expected/root_license_preferred_over_top_level_sibling.expected.json
+++ b/testdata/summarycode-golden/reference_following-expected/root_license_preferred_over_top_level_sibling.expected.json
@@ -169,7 +169,7 @@
       "identifier": "bsd-new_1145.RULE",
       "license_expression": "bsd-new",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_1145.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_1145.RULE",
       "is_synthetic": false,
       "length": 230,
       "referenced_filenames": []
@@ -178,7 +178,7 @@
       "identifier": "mit.LICENSE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
       "is_synthetic": false,
       "length": 161,
       "referenced_filenames": []
@@ -187,7 +187,7 @@
       "identifier": "mit_14.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
       "is_synthetic": false,
       "length": 2,
       "referenced_filenames": []
@@ -196,7 +196,7 @@
       "identifier": "mit_1471.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_1471.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_1471.RULE",
       "is_synthetic": false,
       "length": 14,
       "referenced_filenames": ["LICENSE"]

--- a/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
+++ b/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
@@ -139,7 +139,7 @@
       "identifier": "bsd-new_195.RULE",
       "license_expression": "bsd-new",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_195.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_195.RULE",
       "is_synthetic": false,
       "length": 4,
       "referenced_filenames": []
@@ -148,7 +148,7 @@
       "identifier": "free-unknown-package_1.RULE",
       "license_expression": "free-unknown",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/free-unknown-package_1.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/free-unknown-package_1.RULE",
       "is_synthetic": false,
       "length": 11,
       "referenced_filenames": ["INHERIT_LICENSE_FROM_PACKAGE"]

--- a/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
+++ b/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
@@ -184,7 +184,7 @@
       "identifier": "mit.LICENSE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
       "is_synthetic": false,
       "length": 161,
       "referenced_filenames": []
@@ -193,7 +193,7 @@
       "identifier": "mit_14.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
       "is_synthetic": false,
       "length": 2,
       "referenced_filenames": []
@@ -202,7 +202,7 @@
       "identifier": "mit_31.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_31.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_31.RULE",
       "is_synthetic": false,
       "length": 3,
       "referenced_filenames": []
@@ -211,7 +211,7 @@
       "identifier": "unknown-license-reference_see_license_at_manifest_1.RULE",
       "license_expression": "unknown-license-reference",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
       "is_synthetic": false,
       "length": 3,
       "referenced_filenames": ["LICENSE"]

--- a/testdata/summarycode-golden/reference_following/manifest_origin_local_file/expected.json
+++ b/testdata/summarycode-golden/reference_following/manifest_origin_local_file/expected.json
@@ -141,7 +141,7 @@
       "identifier": "mit.LICENSE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
       "is_synthetic": false,
       "length": 161,
       "referenced_filenames": []
@@ -150,7 +150,7 @@
       "identifier": "mit_14.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
       "is_synthetic": false,
       "length": 2,
       "referenced_filenames": []
@@ -159,7 +159,7 @@
       "identifier": "unknown-license-reference_see_license_at_manifest_1.RULE",
       "license_expression": "unknown-license-reference",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
       "is_synthetic": false,
       "length": 3,
       "referenced_filenames": ["LICENSE"]

--- a/testdata/summarycode-golden/reference_following/readme_mit_see_license/expected.json
+++ b/testdata/summarycode-golden/reference_following/readme_mit_see_license/expected.json
@@ -121,7 +121,7 @@
       "identifier": "mit.LICENSE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
       "is_synthetic": false,
       "length": 161,
       "referenced_filenames": []
@@ -130,7 +130,7 @@
       "identifier": "mit_14.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
       "is_synthetic": false,
       "length": 2,
       "referenced_filenames": []
@@ -139,7 +139,7 @@
       "identifier": "mit_1471.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_1471.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_1471.RULE",
       "is_synthetic": false,
       "length": 14,
       "referenced_filenames": ["LICENSE"]

--- a/testdata/summarycode-golden/reference_following/root_fallback_no_package/expected.json
+++ b/testdata/summarycode-golden/reference_following/root_fallback_no_package/expected.json
@@ -141,7 +141,7 @@
       "identifier": "free-unknown-package_1.RULE",
       "license_expression": "free-unknown",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/free-unknown-package_1.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/free-unknown-package_1.RULE",
       "is_synthetic": false,
       "length": 11,
       "referenced_filenames": ["INHERIT_LICENSE_FROM_PACKAGE"]
@@ -150,7 +150,7 @@
       "identifier": "mit.LICENSE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
       "is_synthetic": false,
       "length": 161,
       "referenced_filenames": []
@@ -159,7 +159,7 @@
       "identifier": "mit_14.RULE",
       "license_expression": "mit",
       "language": null,
-      "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
       "is_synthetic": false,
       "length": 2,
       "referenced_filenames": []

--- a/testdata/summarycode-golden/score/basic-expected.json
+++ b/testdata/summarycode-golden/score/basic-expected.json
@@ -304,7 +304,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     },
@@ -326,7 +326,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         }
       ]
     },
@@ -444,7 +444,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -521,7 +521,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -818,7 +818,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             }
           ],
           "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee"

--- a/testdata/summarycode-golden/score/inconsistent_licenses_copyleft-expected.json
+++ b/testdata/summarycode-golden/score/inconsistent_licenses_copyleft-expected.json
@@ -326,7 +326,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     },
@@ -348,7 +348,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         }
       ]
     },
@@ -466,7 +466,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -543,7 +543,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -840,7 +840,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             }
           ],
           "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee"

--- a/testdata/summarycode-golden/score/jar-expected.json
+++ b/testdata/summarycode-golden/score/jar-expected.json
@@ -55,7 +55,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1379.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
               "matched_text": "name: Apache License, version 2.0\nurl: http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
           ],
@@ -238,7 +238,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
         }
       ]
     },
@@ -260,7 +260,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_7.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
         }
       ]
     },
@@ -282,7 +282,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1379.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE"
         }
       ]
     },
@@ -304,7 +304,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1227.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1227.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1227.RULE"
         }
       ]
     }
@@ -488,7 +488,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
             }
           ],
           "identifier": "apache_2_0-ab23f79b-ec38-9a8a-9b23-85059407f34d"
@@ -579,7 +579,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0.LICENSE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE"
                 }
               ],
               "identifier": "apache_2_0-ab23f79b-ec38-9a8a-9b23-85059407f34d"
@@ -906,7 +906,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_1379.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1379.RULE",
                   "matched_text": "name: Apache License, version 2.0\nurl: http://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
               ],
@@ -1055,7 +1055,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1227.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1227.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1227.RULE"
             }
           ],
           "identifier": "apache_2_0-4800df2e-4a56-bac0-cac1-9fd31da23344"
@@ -1249,7 +1249,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_7.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
             }
           ],
           "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d"
@@ -1326,7 +1326,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_7.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
             }
           ],
           "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d"

--- a/testdata/summarycode-golden/score/no_license_ambiguity-expected.json
+++ b/testdata/summarycode-golden/score/no_license_ambiguity-expected.json
@@ -70,7 +70,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_or_apache-2.0_15.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
               "matched_text": "MIT OR Apache-2.0"
             }
           ],
@@ -246,7 +246,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_875.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_875.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_875.RULE"
         }
       ]
     },
@@ -268,7 +268,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     },
@@ -290,7 +290,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_or_apache-2.0_15.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE"
         }
       ]
     },
@@ -312,7 +312,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_or_apache-2.0_14.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_14.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_14.RULE"
         }
       ]
     },
@@ -334,7 +334,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_or_apache-2.0_38.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_38.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_38.RULE"
         }
       ]
     },
@@ -356,7 +356,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_or_apache-2.0_33.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_33.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_33.RULE"
         }
       ]
     }
@@ -491,7 +491,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_or_apache-2.0_38.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_38.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_38.RULE"
             }
           ],
           "identifier": "mit_or_apache_2_0-a43a1e15-1968-4de7-fe27-2129ebf57d54"
@@ -592,7 +592,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "mit_or_apache-2.0_15.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
                   "matched_text": "MIT OR Apache-2.0"
                 }
               ],
@@ -740,7 +740,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_or_apache-2.0_14.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_14.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_14.RULE"
             }
           ],
           "identifier": "mit_or_apache_2_0-719f8427-422e-8023-c20e-9f8dd0af13b9"
@@ -821,7 +821,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_875.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_875.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_875.RULE"
             }
           ],
           "identifier": "apache_2_0-e3938c59-cc73-037c-3372-e20c26c25f48"
@@ -884,7 +884,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -969,7 +969,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_or_apache-2.0_33.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_33.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_33.RULE"
             }
           ],
           "identifier": "mit_or_apache_2_0-d9d84ae7-113e-249f-5302-6054bdbcdadb"

--- a/testdata/summarycode-golden/score/no_license_text-expected.json
+++ b/testdata/summarycode-golden/score/no_license_text-expected.json
@@ -304,7 +304,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         }
       ]
     },
@@ -740,7 +740,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             }
           ],
           "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee"

--- a/testdata/summarycode-golden/summary/conflicting_license_categories/conflicting_license_categories.expected.json
+++ b/testdata/summarycode-golden/summary/conflicting_license_categories/conflicting_license_categories.expected.json
@@ -63,7 +63,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -85,7 +85,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -99,7 +99,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -121,7 +121,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl_208.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_208.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_208.RULE"
         },
         {
           "license_expression": "gpl-2.0",
@@ -135,7 +135,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0_840.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_840.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_840.RULE"
         },
         {
           "license_expression": "gpl-2.0-plus",
@@ -149,7 +149,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 50,
           "rule_identifier": "spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE"
         }
       ]
     },
@@ -171,7 +171,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -318,7 +318,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -381,7 +381,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -485,7 +485,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -499,7 +499,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -625,7 +625,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl_208.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_208.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl_208.RULE"
             },
             {
               "license_expression": "gpl-2.0",
@@ -639,7 +639,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0_840.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_840.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_840.RULE"
             },
             {
               "license_expression": "gpl-2.0-plus",
@@ -653,7 +653,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-2.0-or-later_for_gpl-2.0-plus.RULE"
             }
           ],
           "identifier": "gpl_1_0_plus_and_gpl_2_0_and_gpl_2_0_plus-d3814696-f4d1-6a85-1134-6baea31b797a"

--- a/testdata/summarycode-golden/summary/embedded_packages/bunkerweb.expected.json
+++ b/testdata/summarycode-golden/summary/embedded_packages/bunkerweb.expected.json
@@ -82,7 +82,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -126,7 +126,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 99,
           "rule_identifier": "pypi_bsd_license.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE"
         }
       ]
     },
@@ -148,7 +148,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 99,
           "rule_identifier": "bsd-new_26.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_26.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_26.RULE"
         },
         {
           "license_expression": "unknown-license-reference",
@@ -162,7 +162,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "unknown-license-reference_98.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_98.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_98.RULE"
         },
         {
           "license_expression": "bsd-new",
@@ -176,7 +176,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "bsd-new_105.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
         },
         {
           "license_expression": "bsd-new",
@@ -190,7 +190,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "bsd-new_226.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
         }
       ]
     },
@@ -212,7 +212,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "bsd-new_105.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
         },
         {
           "license_expression": "bsd-new",
@@ -226,7 +226,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "bsd-new_226.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
         }
       ]
     },
@@ -248,7 +248,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -342,7 +342,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -499,7 +499,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_105.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
             },
             {
               "license_expression": "bsd-new",
@@ -513,7 +513,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_226.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
             }
           ],
           "identifier": "bsd_new-99f77058-447d-ca1d-7b17-8e92d1a664e4"
@@ -627,7 +627,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 99,
                   "rule_identifier": "pypi_bsd_license.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE",
                   "matched_text": "- 'License :: OSI Approved :: BSD License'"
                 }
               ],
@@ -672,7 +672,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 99,
               "rule_identifier": "bsd-new_26.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_26.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_26.RULE"
             },
             {
               "license_expression": "unknown-license-reference",
@@ -686,7 +686,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "unknown-license-reference_98.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_98.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_98.RULE"
             },
             {
               "license_expression": "bsd-new",
@@ -700,7 +700,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_105.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_105.RULE"
             },
             {
               "license_expression": "bsd-new",
@@ -714,7 +714,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "bsd-new_226.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_226.RULE"
             }
           ],
           "identifier": "bsd_new-90c8b089-2f85-4a93-d0c8-a411247c6395",
@@ -736,7 +736,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 99,
               "rule_identifier": "pypi_bsd_license.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_bsd_license.RULE"
             }
           ],
           "identifier": "bsd_new-f4e99f86-00ab-18d9-a65d-a3a12767dcf5"
@@ -848,7 +848,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "mit.LICENSE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
                 }
               ],
               "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"

--- a/testdata/summarycode-golden/summary/end-2-end/bug-1141.expected.json
+++ b/testdata/summarycode-golden/summary/end-2-end/bug-1141.expected.json
@@ -55,7 +55,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_119.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
         }
       ]
     },
@@ -77,7 +77,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-3.0-plus_29.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
         }
       ]
     }
@@ -294,7 +294,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-3.0-plus_29.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
             }
           ],
           "identifier": "gpl_3_0_plus-ab631a6e-10ac-69e1-8910-f809c0735e6d"
@@ -521,7 +521,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_119.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603"

--- a/testdata/summarycode-golden/summary/holders/clear_holder.expected.json
+++ b/testdata/summarycode-golden/summary/holders/clear_holder.expected.json
@@ -55,7 +55,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -77,7 +77,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -91,7 +91,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -113,7 +113,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -207,7 +207,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -221,7 +221,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -306,7 +306,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -369,7 +369,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -473,7 +473,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -487,7 +487,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -603,7 +603,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -617,7 +617,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"

--- a/testdata/summarycode-golden/summary/holders/combined_holders.expected.json
+++ b/testdata/summarycode-golden/summary/holders/combined_holders.expected.json
@@ -51,7 +51,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -73,7 +73,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -87,7 +87,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -109,7 +109,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -203,7 +203,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -217,7 +217,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -302,7 +302,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -365,7 +365,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -469,7 +469,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -483,7 +483,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -587,7 +587,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -601,7 +601,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"

--- a/testdata/summarycode-golden/summary/license_ambiguity/ambiguous.expected.json
+++ b/testdata/summarycode-golden/summary/license_ambiguity/ambiguous.expected.json
@@ -55,7 +55,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -77,7 +77,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -224,7 +224,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -287,7 +287,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"

--- a/testdata/summarycode-golden/summary/license_ambiguity/unambiguous.expected.json
+++ b/testdata/summarycode-golden/summary/license_ambiguity/unambiguous.expected.json
@@ -51,7 +51,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -73,7 +73,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -87,7 +87,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -109,7 +109,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -203,7 +203,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -217,7 +217,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -292,7 +292,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -355,7 +355,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"

--- a/testdata/summarycode-golden/summary/multiple_package_data/multiple_package_data.expected.json
+++ b/testdata/summarycode-golden/summary/multiple_package_data/multiple_package_data.expected.json
@@ -157,7 +157,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "apache-2.0"
             }
           ],
@@ -202,7 +202,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -224,7 +224,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE"
         }
       ]
     },
@@ -246,7 +246,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_65.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
         }
       ]
     },
@@ -268,7 +268,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -282,7 +282,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -304,7 +304,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         }
       ]
     },
@@ -348,7 +348,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -442,7 +442,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -456,7 +456,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -531,7 +531,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -673,7 +673,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             }
           ],
           "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee"
@@ -742,7 +742,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -836,7 +836,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "apache-2.0"
                 }
               ],
@@ -881,7 +881,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_65.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
             }
           ],
           "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0"

--- a/testdata/summarycode-golden/summary/single_file/single_file.expected.json
+++ b/testdata/summarycode-golden/summary/single_file/single_file.expected.json
@@ -37,7 +37,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "jetty.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/jetty.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/jetty.LICENSE"
         }
       ]
     }
@@ -131,7 +131,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "jetty.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/jetty.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/jetty.LICENSE"
             }
           ],
           "identifier": "jetty-a0130d29-e7f1-bc37-111a-fccd6b1c6b58"

--- a/testdata/summarycode-golden/summary/summary_without_holder/summary-without-holder-pypi.expected.json
+++ b/testdata/summarycode-golden/summary/summary_without_holder/summary-without-holder-pypi.expected.json
@@ -100,7 +100,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "pypi_mit_license.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
               "matched_text": "- 'License :: OSI Approved :: MIT License'"
             }
           ],
@@ -149,7 +149,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "pypi_mit_license.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
         }
       ]
     },
@@ -171,7 +171,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "unknown-license-reference_see_license_at_manifest_2.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
         },
         {
           "license_expression": "mit",
@@ -185,7 +185,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     },
@@ -229,7 +229,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         }
       ]
     },
@@ -251,7 +251,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit_30.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
         },
         {
           "license_expression": "mit",
@@ -265,7 +265,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "pypi_mit_license.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
         }
       ]
     },
@@ -287,7 +287,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -359,7 +359,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -493,7 +493,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "pypi_mit_license.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
                   "matched_text": "- 'License :: OSI Approved :: MIT License'"
                 }
               ],
@@ -542,7 +542,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             }
           ],
           "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee"
@@ -563,7 +563,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "pypi_mit_license.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
             }
           ],
           "identifier": "mit-24a5293c-14d7-5403-efac-1a8b7532c0e8"
@@ -584,7 +584,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "unknown-license-reference_see_license_at_manifest_2.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
             },
             {
               "license_expression": "mit",
@@ -598,7 +598,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
@@ -956,7 +956,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "unknown-license-reference_see_license_at_manifest_2.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
                 },
                 {
                   "license_expression": "mit",
@@ -970,7 +970,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "mit.LICENSE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
                 }
               ],
               "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
@@ -1015,7 +1015,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "unknown-license-reference_see_license_at_manifest_2.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_2.RULE"
             },
             {
               "license_expression": "mit",
@@ -1029,7 +1029,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
@@ -1128,7 +1128,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "pypi_mit_license.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE",
                   "matched_text": "- 'License :: OSI Approved :: MIT License'"
                 }
               ],
@@ -1177,7 +1177,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit_30.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE"
             },
             {
               "license_expression": "mit",
@@ -1191,7 +1191,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "pypi_mit_license.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/pypi_mit_license.RULE"
             }
           ],
           "identifier": "mit-6e6256c5-00ca-dcb6-8033-2fc4b6ff86be"

--- a/testdata/summarycode-golden/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
+++ b/testdata/summarycode-golden/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
@@ -78,7 +78,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_7.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
             }
           ],
           "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d"
@@ -138,7 +138,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_7.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
         }
       ]
     }
@@ -316,7 +316,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "apache-2.0_7.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
                 }
               ],
               "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d"
@@ -372,7 +372,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_7.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_7.RULE"
             }
           ],
           "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d"

--- a/testdata/summarycode-golden/summary/with_package_data/with_package_data.expected.json
+++ b/testdata/summarycode-golden/summary/with_package_data/with_package_data.expected.json
@@ -78,7 +78,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "apache-2.0"
             }
           ],
@@ -123,7 +123,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -145,7 +145,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE"
         }
       ]
     },
@@ -167,7 +167,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_65.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
         }
       ]
     },
@@ -189,7 +189,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -203,7 +203,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -225,7 +225,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -319,7 +319,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -333,7 +333,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -408,7 +408,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -471,7 +471,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"
@@ -565,7 +565,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
                   "matched_text": "apache-2.0"
                 }
               ],
@@ -610,7 +610,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_65.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_65.RULE"
             }
           ],
           "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0"

--- a/testdata/summarycode-golden/summary/without_package_data/without_package_data.expected.json
+++ b/testdata/summarycode-golden/summary/without_package_data/without_package_data.expected.json
@@ -51,7 +51,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_93.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
         }
       ]
     },
@@ -73,7 +73,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_1109.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
         },
         {
           "license_expression": "apache-2.0 OR mit",
@@ -87,7 +87,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "apache-2.0_or_mit_36.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
         }
       ]
     },
@@ -109,7 +109,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
         }
       ]
     }
@@ -203,7 +203,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_1109.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1109.RULE"
             },
             {
               "license_expression": "apache-2.0 OR mit",
@@ -217,7 +217,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_or_mit_36.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_or_mit_36.RULE"
             }
           ],
           "identifier": "apache_2_0_and__apache_2_0_or_mit-ab5115d2-1eff-af76-1473-34378a32b2bb"
@@ -292,7 +292,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_93.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_93.RULE"
             }
           ],
           "identifier": "apache_2_0-9804422e-94ac-ad40-b53a-ee6f8ddb7a3b"
@@ -355,7 +355,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE"
             }
           ],
           "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a"

--- a/testdata/summarycode-golden/tallies/end-2-end/bug-1141.expected.json
+++ b/testdata/summarycode-golden/tallies/end-2-end/bug-1141.expected.json
@@ -20,7 +20,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_119.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
         }
       ]
     },
@@ -42,7 +42,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-3.0-plus_29.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
         }
       ]
     }
@@ -327,7 +327,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-3.0-plus_29.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_29.RULE"
             }
           ],
           "identifier": "gpl_3_0_plus-ab631a6e-10ac-69e1-8910-f809c0735e6d"
@@ -559,7 +559,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_119.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_119.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603"

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies.expected.json
@@ -2221,7 +2221,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
               "matched_text": "Artistic-2.0"
             }
           ],
@@ -3422,7 +3422,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 50,
           "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
         }
       ]
     },
@@ -3444,7 +3444,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "artistic-2.0_46.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
         }
       ]
     },
@@ -3466,7 +3466,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "boost-1.0_21.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
         }
       ]
     },
@@ -3488,7 +3488,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "cc-by-2.5_4.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
         }
       ]
     },
@@ -3510,7 +3510,7 @@
           "match_coverage": 99.69,
           "rule_relevance": 100,
           "rule_identifier": "cc0-1.0_155.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
         }
       ]
     },
@@ -3532,7 +3532,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
         }
       ]
     },
@@ -3554,7 +3554,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "lgpl-2.1-plus_59.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
         }
       ]
     },
@@ -3576,7 +3576,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
         }
       ]
     },
@@ -3598,7 +3598,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         },
         {
           "license_expression": "zlib",
@@ -3612,7 +3612,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3634,7 +3634,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         }
       ]
     },
@@ -3656,7 +3656,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3678,7 +3678,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
         }
       ]
     }
@@ -4010,7 +4010,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4079,7 +4079,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "cc-by-2.5_4.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
             }
           ],
           "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae"
@@ -4154,7 +4154,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4305,7 +4305,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4485,7 +4485,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -4499,7 +4499,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -4569,7 +4569,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -4638,7 +4638,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -4652,7 +4652,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -4722,7 +4722,7 @@
               "match_coverage": 99.69,
               "rule_relevance": 100,
               "rule_identifier": "cc0-1.0_155.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
             }
           ],
           "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963"
@@ -6980,7 +6980,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 50,
                   "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
                   "matched_text": "Artistic-2.0"
                 }
               ],
@@ -7873,7 +7873,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "artistic-2.0_46.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
             }
           ],
           "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732"
@@ -8006,7 +8006,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e"
@@ -8075,7 +8075,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8089,7 +8089,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -8159,7 +8159,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8173,7 +8173,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -8243,7 +8243,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8257,7 +8257,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -8409,7 +8409,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "boost-1.0_21.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
             }
           ],
           "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5"
@@ -8513,7 +8513,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
             }
           ],
           "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8"
@@ -8623,7 +8623,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -8692,7 +8692,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -8796,7 +8796,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
             }
           ],
           "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0"
@@ -8865,7 +8865,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -8934,7 +8934,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8948,7 +8948,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9018,7 +9018,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9032,7 +9032,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_by_facet.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_by_facet.expected.json
@@ -2221,7 +2221,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
               "matched_text": "Artistic-2.0"
             }
           ],
@@ -3422,7 +3422,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 50,
           "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
         }
       ]
     },
@@ -3444,7 +3444,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "artistic-2.0_46.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
         }
       ]
     },
@@ -3466,7 +3466,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "boost-1.0_21.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
         }
       ]
     },
@@ -3488,7 +3488,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "cc-by-2.5_4.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
         }
       ]
     },
@@ -3510,7 +3510,7 @@
           "match_coverage": 99.69,
           "rule_relevance": 100,
           "rule_identifier": "cc0-1.0_155.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
         }
       ]
     },
@@ -3532,7 +3532,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
         }
       ]
     },
@@ -3554,7 +3554,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "lgpl-2.1-plus_59.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
         }
       ]
     },
@@ -3576,7 +3576,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
         }
       ]
     },
@@ -3598,7 +3598,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         },
         {
           "license_expression": "zlib",
@@ -3612,7 +3612,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3634,7 +3634,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         }
       ]
     },
@@ -3656,7 +3656,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3678,7 +3678,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
         }
       ]
     }
@@ -4272,7 +4272,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4350,7 +4350,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "cc-by-2.5_4.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
             }
           ],
           "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae"
@@ -4439,7 +4439,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4605,7 +4605,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4814,7 +4814,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -4828,7 +4828,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -4901,7 +4901,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -4990,7 +4990,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -5004,7 +5004,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -5077,7 +5077,7 @@
               "match_coverage": 99.69,
               "rule_relevance": 100,
               "rule_identifier": "cc0-1.0_155.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
             }
           ],
           "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963"
@@ -7338,7 +7338,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 50,
                   "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
                   "matched_text": "Artistic-2.0"
                 }
               ],
@@ -8231,7 +8231,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "artistic-2.0_46.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
             }
           ],
           "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732"
@@ -8655,7 +8655,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e"
@@ -8727,7 +8727,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8741,7 +8741,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -8814,7 +8814,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8828,7 +8828,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -8901,7 +8901,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -8915,7 +8915,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9076,7 +9076,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "boost-1.0_21.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
             }
           ],
           "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5"
@@ -9192,7 +9192,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
             }
           ],
           "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8"
@@ -9324,7 +9324,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -9396,7 +9396,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -9506,7 +9506,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
             }
           ],
           "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0"
@@ -9584,7 +9584,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -9667,7 +9667,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9681,7 +9681,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9754,7 +9754,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9768,7 +9768,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_details.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_details.expected.json
@@ -2221,7 +2221,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 50,
               "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
               "matched_text": "Artistic-2.0"
             }
           ],
@@ -3422,7 +3422,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 50,
           "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE"
         }
       ]
     },
@@ -3444,7 +3444,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "artistic-2.0_46.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
         }
       ]
     },
@@ -3466,7 +3466,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "boost-1.0_21.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
         }
       ]
     },
@@ -3488,7 +3488,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "cc-by-2.5_4.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
         }
       ]
     },
@@ -3510,7 +3510,7 @@
           "match_coverage": 99.69,
           "rule_relevance": 100,
           "rule_identifier": "cc0-1.0_155.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
         }
       ]
     },
@@ -3532,7 +3532,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
         }
       ]
     },
@@ -3554,7 +3554,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "lgpl-2.1-plus_59.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
         }
       ]
     },
@@ -3576,7 +3576,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
         }
       ]
     },
@@ -3598,7 +3598,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         },
         {
           "license_expression": "zlib",
@@ -3612,7 +3612,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3634,7 +3634,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         }
       ]
     },
@@ -3656,7 +3656,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -3678,7 +3678,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
         }
       ]
     }
@@ -4342,7 +4342,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4443,7 +4443,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "cc-by-2.5_4.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
             }
           ],
           "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae"
@@ -4550,7 +4550,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -4797,7 +4797,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -5121,7 +5121,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -5135,7 +5135,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -5237,7 +5237,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -5338,7 +5338,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -5352,7 +5352,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -5454,7 +5454,7 @@
               "match_coverage": 99.69,
               "rule_relevance": 100,
               "rule_identifier": "cc0-1.0_155.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
             }
           ],
           "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963"
@@ -7744,7 +7744,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 50,
                   "rule_identifier": "spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_artistic-2.0_for_artistic-2.0.RULE",
                   "matched_text": "Artistic-2.0"
                 }
               ],
@@ -8637,7 +8637,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "artistic-2.0_46.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
             }
           ],
           "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732"
@@ -8941,7 +8941,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e"
@@ -9042,7 +9042,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9056,7 +9056,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9158,7 +9158,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9172,7 +9172,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9274,7 +9274,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -9288,7 +9288,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -9544,7 +9544,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "boost-1.0_21.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
             }
           ],
           "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5"
@@ -9712,7 +9712,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
             }
           ],
           "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8"
@@ -9886,7 +9886,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -9987,7 +9987,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -10155,7 +10155,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
             }
           ],
           "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0"
@@ -10256,7 +10256,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -10357,7 +10357,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -10371,7 +10371,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -10473,7 +10473,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -10487,7 +10487,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files-details.expected.json-lines
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files-details.expected.json-lines
@@ -2,7 +2,7 @@
   {
     "headers": [
       {
-        "tool_name": "scancode-toolkit",
+        "tool_name": "provenant",
         "options": {
           "input": "<path>",
           "--classify": true,
@@ -14,7 +14,7 @@
           "--tallies": true,
           "--tallies-key-files": true
         },
-        "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+        "notice": "Generated with Provenant and provided on an \"AS IS\" basis, without warranties or conditions of any kind, either express or implied. Provenant and its authors/providers do not provide legal advice, and are not responsible for how this output is used. Consult qualified legal counsel for legal advice.",
         "output_format_version": "4.1.0",
         "message": null,
         "errors": [],
@@ -53,7 +53,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "artistic-2.0_46.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
           }
         ]
       },
@@ -75,7 +75,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "boost-1.0_21.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
           }
         ]
       },
@@ -97,7 +97,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "cc-by-2.5_4.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
           }
         ]
       },
@@ -119,7 +119,7 @@
             "match_coverage": 99.69,
             "rule_relevance": 100,
             "rule_identifier": "cc0-1.0_155.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
           }
         ]
       },
@@ -141,7 +141,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
           }
         ]
       },
@@ -163,7 +163,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "lgpl-2.1-plus_59.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
           }
         ]
       },
@@ -185,7 +185,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
           }
         ]
       },
@@ -207,7 +207,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "zlib_5.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
           },
           {
             "license_expression": "zlib",
@@ -221,7 +221,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "zlib_17.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
           }
         ]
       },
@@ -243,7 +243,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "zlib_5.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
           }
         ]
       },
@@ -265,7 +265,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "zlib_17.RULE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
           }
         ]
       },
@@ -287,7 +287,7 @@
             "match_coverage": 100.0,
             "rule_relevance": 100,
             "rule_identifier": "zlib.LICENSE",
-            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
           }
         ]
       }
@@ -588,7 +588,7 @@
                 "match_coverage": 99.69,
                 "rule_relevance": 100,
                 "rule_identifier": "cc0-1.0_155.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
               }
             ],
             "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963"
@@ -653,7 +653,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "artistic-2.0_46.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
               }
             ],
             "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732"
@@ -810,7 +810,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -824,7 +824,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -904,7 +904,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -981,7 +981,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -995,7 +995,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1161,7 +1161,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "lgpl-2.1-plus_59.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
               }
             ],
             "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -1238,7 +1238,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "cc-by-2.5_4.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
               }
             ],
             "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae"
@@ -1321,7 +1321,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "lgpl-2.1-plus_59.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
               }
             ],
             "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -1496,7 +1496,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "lgpl-2.1-plus_59.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
               }
             ],
             "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -1665,7 +1665,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -1679,7 +1679,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1759,7 +1759,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -1773,7 +1773,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1853,7 +1853,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -1867,7 +1867,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1947,7 +1947,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -2024,7 +2024,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -2038,7 +2038,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -2118,7 +2118,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               },
               {
                 "license_expression": "zlib",
@@ -2132,7 +2132,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_17.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
               }
             ],
             "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -2255,7 +2255,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
               }
             ],
             "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e"
@@ -2430,7 +2430,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "boost-1.0_21.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
               }
             ],
             "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5"
@@ -2550,7 +2550,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib.LICENSE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
               }
             ],
             "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8"
@@ -2676,7 +2676,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               }
             ],
             "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -2753,7 +2753,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "zlib_5.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
               }
             ],
             "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -2873,7 +2873,7 @@
                 "match_coverage": 100.0,
                 "rule_relevance": 100,
                 "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-                "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+                "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
               }
             ],
             "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0"

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files.expected.json
@@ -18,7 +18,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "artistic-2.0_46.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
         }
       ]
     },
@@ -40,7 +40,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "boost-1.0_21.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
         }
       ]
     },
@@ -62,7 +62,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "cc-by-2.5_4.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
         }
       ]
     },
@@ -84,7 +84,7 @@
           "match_coverage": 99.69,
           "rule_relevance": 100,
           "rule_identifier": "cc0-1.0_155.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
         }
       ]
     },
@@ -106,7 +106,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
         }
       ]
     },
@@ -128,7 +128,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "lgpl-2.1-plus_59.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
         }
       ]
     },
@@ -150,7 +150,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
         }
       ]
     },
@@ -172,7 +172,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         },
         {
           "license_expression": "zlib",
@@ -186,7 +186,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -208,7 +208,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_5.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
         }
       ]
     },
@@ -230,7 +230,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib_17.RULE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
         }
       ]
     },
@@ -252,7 +252,7 @@
           "match_coverage": 100.0,
           "rule_relevance": 100,
           "rule_identifier": "zlib.LICENSE",
-          "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+          "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
         }
       ]
     }
@@ -621,7 +621,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -694,7 +694,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "cc-by-2.5_4.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc-by-2.5_4.RULE"
             }
           ],
           "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae"
@@ -773,7 +773,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -936,7 +936,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "lgpl-2.1-plus_59.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_59.RULE"
             }
           ],
           "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1"
@@ -1132,7 +1132,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -1146,7 +1146,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1220,7 +1220,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -1293,7 +1293,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -1307,7 +1307,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1381,7 +1381,7 @@
               "match_coverage": 99.69,
               "rule_relevance": 100,
               "rule_identifier": "cc0-1.0_155.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/cc0-1.0_155.RULE"
             }
           ],
           "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963"
@@ -1442,7 +1442,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "artistic-2.0_46.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/artistic-2.0_46.RULE"
             }
           ],
           "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732"
@@ -1587,7 +1587,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0-plus_with_ada-linking-exception_1.RULE"
             }
           ],
           "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e"
@@ -1660,7 +1660,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -1674,7 +1674,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1748,7 +1748,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -1762,7 +1762,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -1836,7 +1836,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -1850,7 +1850,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -2014,7 +2014,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "boost-1.0_21.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/boost-1.0_21.RULE"
             }
           ],
           "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5"
@@ -2126,7 +2126,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib.LICENSE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/zlib.LICENSE"
             }
           ],
           "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8"
@@ -2244,7 +2244,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -2317,7 +2317,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             }
           ],
           "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296"
@@ -2429,7 +2429,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "mit-old-style_cmr-no_1.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit-old-style_cmr-no_1.RULE"
             }
           ],
           "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0"
@@ -2502,7 +2502,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c"
@@ -2575,7 +2575,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -2589,7 +2589,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
@@ -2663,7 +2663,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_5.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_5.RULE"
             },
             {
               "license_expression": "zlib",
@@ -2677,7 +2677,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "zlib_17.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/zlib_17.RULE"
             }
           ],
           "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",

--- a/testdata/summarycode-golden/tallies/packages/expected.json
+++ b/testdata/summarycode-golden/tallies/packages/expected.json
@@ -43,7 +43,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 70,
               "rule_identifier": "public-domain_bare_words.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
               "matched_text": "name: Public Domain"
             }
           ],
@@ -121,7 +121,7 @@
               "match_coverage": 100.0,
               "rule_relevance": 100,
               "rule_identifier": "gpl-2.0_bare_single_word.RULE",
-              "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
               "matched_text": "GPLv2"
             }
           ],
@@ -1217,7 +1217,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 70,
                   "rule_identifier": "public-domain_bare_words.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/public-domain_bare_words.RULE",
                   "matched_text": "name: Public Domain"
                 }
               ],
@@ -1319,7 +1319,7 @@
                   "match_coverage": 100.0,
                   "rule_relevance": 100,
                   "rule_identifier": "gpl-2.0_bare_single_word.RULE",
-                  "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-2.0_bare_single_word.RULE",
                   "matched_text": "GPLv2"
                 }
               ],


### PR DESCRIPTION
## Summary

- migrate Provenant-controlled ScanCode GitHub URLs from `nexB/scancode-toolkit` to `aboutcode-org/scancode-toolkit` at the runtime source-of-truth for `rule_url` and top-level `scancode_url`
- refresh owned parser and summary golden expectations to match the migrated URLs, and replace the last stale ScanCode header snapshot with Provenant's runtime `HEADER_NOTICE`
- clean up remaining owned metadata references to the old repo while intentionally preserving vendored upstream content and copied source-input fixtures that must keep historical text

## Issues

- Covers: #617
- Closes: #617

## Scope and exclusions

- Included: runtime URL builders in `src/license_detection/models/rule.rs` and `src/post_processing/license_references.rs`, direct assertion tests, owned expected-output fixtures under `testdata/`, license-golden metadata notes, and `NOTICE`
- Explicit exclusions: `reference/scancode-toolkit/**` vendored reference content and copied source-input fixtures such as `testdata/license-golden/datadriven/lic3/NOTICE_scancode.txt` that intentionally preserve historical ScanCode text

## Intentional differences from Python

- owned Provenant output expectations now use Provenant's runtime header notice and `tool_name` where ScanCode-derived snapshots had stale header text, while preserved source-input fixtures remain unchanged

## Follow-up work

- Created or intentionally deferred: none

## Expected-output fixture changes

- Files changed: parser and assembly expectations across bower, chef, cocoapods, conan, conda, cran, freebsd, and opam; summarycode golden expectations for classify, reference following, score, summary, and tallies output; one summarycode JSON-lines header snapshot; four license-golden metadata YAML notes
- Why the new expected output is correct: the output builders now emit `aboutcode-org` URLs for ScanCode references, Provenant runtime headers use `HEADER_NOTICE`, and the updated fixtures match those validated runtime semantics while leaving preserved historical fixture inputs untouched