### PR TITLE
fix(version): show git-aware build versions for dev builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,6 @@ fn main() {
 
     let package_version =
         env::var("CARGO_PKG_VERSION").expect("Cargo should set CARGO_PKG_VERSION");
-    emit_git_rerun_hints(&package_version);
 
     let build_version = env::var("PROVENANT_BUILD_VERSION")
         .ok()
@@ -31,25 +30,6 @@ fn derive_build_version(package_version: &str) -> String {
     let short_sha = git_output(&["rev-parse", "--short", "HEAD"]);
 
     version_format::derive_build_version(package_version, describe.as_deref(), short_sha.as_deref())
-}
-
-fn emit_git_rerun_hints(package_version: &str) {
-    for git_path in [
-        "HEAD".to_string(),
-        "index".to_string(),
-        "packed-refs".to_string(),
-        format!("refs/tags/v{package_version}"),
-    ] {
-        if let Some(path) = git_output(&["rev-parse", "--git-path", &git_path]) {
-            println!("cargo:rerun-if-changed={path}");
-        }
-    }
-
-    if let Some(reference) = git_output(&["symbolic-ref", "-q", "HEAD"])
-        && let Some(path) = git_output(&["rev-parse", "--git-path", &reference])
-    {
-        println!("cargo:rerun-if-changed={path}");
-    }
 }
 
 fn git_output(args: &[&str]) -> Option<String> {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::process::Command;
+
+#[path = "src/version_format.rs"]
+mod version_format;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=PROVENANT_BUILD_VERSION");
+
+    let package_version =
+        env::var("CARGO_PKG_VERSION").expect("Cargo should set CARGO_PKG_VERSION");
+    emit_git_rerun_hints(&package_version);
+
+    let build_version = env::var("PROVENANT_BUILD_VERSION")
+        .ok()
+        .and_then(|value| version_format::sanitize_build_version(&value))
+        .unwrap_or_else(|| derive_build_version(&package_version));
+
+    println!("cargo:rustc-env=PROVENANT_BUILD_VERSION={build_version}");
+}
+
+fn derive_build_version(package_version: &str) -> String {
+    let describe = git_output(&[
+        "describe",
+        "--tags",
+        "--dirty",
+        "--always",
+        "--match",
+        &format!("v{package_version}"),
+    ]);
+    let short_sha = git_output(&["rev-parse", "--short", "HEAD"]);
+
+    version_format::derive_build_version(package_version, describe.as_deref(), short_sha.as_deref())
+}
+
+fn emit_git_rerun_hints(package_version: &str) {
+    for git_path in [
+        "HEAD".to_string(),
+        "index".to_string(),
+        "packed-refs".to_string(),
+        format!("refs/tags/v{package_version}"),
+    ] {
+        if let Some(path) = git_output(&["rev-parse", "--git-path", &git_path]) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+
+    if let Some(reference) = git_output(&["symbolic-ref", "-q", "HEAD"])
+        && let Some(path) = git_output(&["rev-parse", "--git-path", &reference])
+    {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.to_string())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,12 +57,8 @@ fn parse_license_policy_arg(value: &str) -> Result<String, String> {
 #[derive(Parser, Debug)]
 #[command(
     author = "The Provenant contributors",
-    version = env!("CARGO_PKG_VERSION"),
-    long_version = concat!(
-        env!("CARGO_PKG_VERSION"),
-        "\n",
-        "License detection uses data from ScanCode Toolkit (CC-BY-4.0). See NOTICE file or --show-attribution option."
-    ),
+    version = crate::version::BUILD_VERSION,
+    long_version = crate::version::build_long_version(),
     after_help = PDF_OXIDE_LOG_HELP,
     about,
     long_about = None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod parsers;
 pub mod progress;
 pub mod scanner;
 pub mod utils;
+pub mod version;
 
 pub use models::{ExtraData, FileInfo, FileType, Header, Output, SystemEnvironment};
 pub use output::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ mod scan_result_shaping;
 mod scanner;
 mod time;
 mod utils;
+mod version;
 
 fn main() -> std::io::Result<()> {
     if let Err(err) = run() {

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -34,7 +34,7 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
     xml.push_str("</timestamp>\n");
     xml.push_str("    <tools>\n");
     xml.push_str("      <tool><vendor>Provenant</vendor><name>Provenant</name><version>");
-    xml.push_str(env!("CARGO_PKG_VERSION"));
+    xml.push_str(crate::version::BUILD_VERSION);
     xml.push_str("</version></tool>\n");
     xml.push_str("    </tools>\n");
     xml.push_str("  </metadata>\n");
@@ -233,15 +233,15 @@ fn build_cyclonedx_json(output: &Output) -> Value {
             "specVersion": "1.3",
             "serialNumber": format!("urn:uuid:{}", Uuid::new_v4()),
             "version": 1,
-            "metadata": {
-                "timestamp": timestamp,
-                "tools": [
-                    {
-                        "name": "Provenant",
-                        "version": env!("CARGO_PKG_VERSION")
-                    }
-                ]
-            },
+                "metadata": {
+                    "timestamp": timestamp,
+                    "tools": [
+                        {
+                            "name": "Provenant",
+                            "version": crate::version::BUILD_VERSION
+                        }
+                    ]
+                },
             "components": components,
             "dependencies": dependencies,
         })

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1240,7 +1240,7 @@ mod tests {
             tallies_by_facet: None,
             headers: vec![Header {
                 tool_name: "provenant".to_string(),
-                tool_version: env!("CARGO_PKG_VERSION").to_string(),
+                tool_version: crate::version::BUILD_VERSION.to_string(),
                 options: serde_json::Map::new(),
                 notice: crate::models::HEADER_NOTICE.to_string(),
                 start_timestamp: "2026-01-01T000000.000000".to_string(),

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -214,7 +214,7 @@ pub(crate) fn create_output(
         tallies_by_facet,
         headers: vec![Header {
             tool_name: TOOL_NAME.to_string(),
-            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            tool_version: crate::version::BUILD_VERSION.to_string(),
             options: context.header_options,
             notice: HEADER_NOTICE.to_string(),
             start_timestamp: format_scancode_timestamp(&start_time),

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -79,7 +79,7 @@ pub fn scan_options_fingerprint(
 
     format!(
         "tool_version={};info={};packages={};app_packages={};system_packages={};compiled_packages={};copyrights={};generated={};emails={};urls={};max_emails={};max_urls={};timeout={:.6};license_enabled={};rules_count={};first_rule_id={};last_rule_id={};license_text={};license_text_diagnostics={};license_diagnostics={};unknown_licenses={};license_score={}",
-        env!("CARGO_PKG_VERSION"),
+        crate::version::BUILD_VERSION,
         text_options.collect_info,
         text_options.detect_packages,
         text_options.detect_application_packages,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,16 @@
+use std::sync::OnceLock;
+
+pub const BUILD_VERSION: &str = match option_env!("PROVENANT_BUILD_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
+const ATTRIBUTION_NOTICE: &str = "License detection uses data from ScanCode Toolkit (CC-BY-4.0). See NOTICE file or --show-attribution option.";
+
+pub fn build_long_version() -> &'static str {
+    static LONG_VERSION: OnceLock<String> = OnceLock::new();
+
+    LONG_VERSION
+        .get_or_init(|| format!("{BUILD_VERSION}\n{ATTRIBUTION_NOTICE}"))
+        .as_str()
+}

--- a/src/version_format.rs
+++ b/src/version_format.rs
@@ -1,0 +1,38 @@
+pub const MAX_BUILD_VERSION_LEN: usize = 128;
+
+pub fn sanitize_build_version(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_BUILD_VERSION_LEN {
+        return None;
+    }
+
+    if trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_' | '+'))
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+pub fn derive_build_version(
+    package_version: &str,
+    describe: Option<&str>,
+    short_sha: Option<&str>,
+) -> String {
+    let expected_tag = format!("v{package_version}");
+
+    match describe.and_then(sanitize_build_version) {
+        Some(describe) if describe == expected_tag => package_version.to_string(),
+        Some(describe) if describe == format!("{expected_tag}-dirty") => short_sha
+            .and_then(sanitize_build_version)
+            .map(|sha| format!("{package_version}-0-g{sha}-dirty"))
+            .unwrap_or_else(|| format!("{package_version}-dirty")),
+        Some(describe) if describe.starts_with(&expected_tag) => {
+            format!("{package_version}{}", &describe[expected_tag.len()..])
+        }
+        Some(describe) => format!("{package_version}-g{}", describe.trim_start_matches('g')),
+        None => package_version.to_string(),
+    }
+}

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -1472,7 +1472,7 @@ fn xml_unescape_for_assert(value: &str) -> String {
 fn sample_header(files_count: usize, directories_count: usize) -> Header {
     Header {
         tool_name: "provenant".to_string(),
-        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        tool_version: provenant::version::BUILD_VERSION.to_string(),
         options: serde_json::Map::new(),
         notice: provenant::models::HEADER_NOTICE.to_string(),
         start_timestamp: "2026-01-01T000000.000000".to_string(),

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -20,12 +20,6 @@ fn create_scan_fixture() -> (TempDir, String) {
     (temp, scan_dir.to_string_lossy().to_string())
 }
 
-fn cargo_command() -> Command {
-    let mut command = Command::new("cargo");
-    command.current_dir(env!("CARGO_MANIFEST_DIR"));
-    command
-}
-
 fn create_malformed_package_fixture() -> (TempDir, String) {
     let temp = TempDir::new().expect("failed to create temp dir");
     let scan_dir = temp.path().join("scan");
@@ -137,30 +131,6 @@ fn short_version_flag_stays_single_line_and_parse_safe() {
         .split_whitespace()
         .last()
         .expect("short version line should include a version token");
-    assert_eq!(reported_version, provenant::version::BUILD_VERSION);
-}
-
-#[test]
-fn invalid_build_version_override_falls_back_to_git_aware_version() {
-    let output = cargo_command()
-        .env("PROVENANT_BUILD_VERSION", "bad\nvalue")
-        .args(["run", "--", "-V"])
-        .output()
-        .expect("failed to run cargo with invalid build version override");
-
-    assert!(
-        output.status.success(),
-        "cargo run with invalid override should succeed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8(output.stdout).expect("fallback version output should be utf-8");
-    let reported_version = stdout
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().last())
-        .expect("fallback output should include a version token");
-
     assert_eq!(reported_version, provenant::version::BUILD_VERSION);
 }
 

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -20,6 +20,12 @@ fn create_scan_fixture() -> (TempDir, String) {
     (temp, scan_dir.to_string_lossy().to_string())
 }
 
+fn cargo_command() -> Command {
+    let mut command = Command::new("cargo");
+    command.current_dir(env!("CARGO_MANIFEST_DIR"));
+    command
+}
+
 fn create_malformed_package_fixture() -> (TempDir, String) {
     let temp = TempDir::new().expect("failed to create temp dir");
     let scan_dir = temp.path().join("scan");
@@ -64,6 +70,98 @@ fn normalize_multi_parser_header(output: &mut Value) {
         Value::String("<platform_version>".to_string());
     header["extra_data"]["system_environment"]["rust_version"] =
         Value::String("<rust_version>".to_string());
+}
+
+#[test]
+fn version_flag_reports_git_aware_build_version() {
+    let output = provenant_command()
+        .arg("--version")
+        .output()
+        .expect("failed to run provenant --version");
+
+    assert!(output.status.success(), "--version should succeed");
+
+    let stdout = String::from_utf8(output.stdout).expect("version output should be utf-8");
+    let first_line = stdout
+        .lines()
+        .next()
+        .expect("version output should contain at least one line");
+
+    let reported_version = first_line
+        .split_whitespace()
+        .last()
+        .expect("version line should include a version token");
+
+    assert_eq!(reported_version, provenant::version::BUILD_VERSION);
+}
+
+#[test]
+fn json_header_uses_git_aware_build_version() {
+    let (_temp, scan_dir) = create_scan_fixture();
+
+    let output = provenant_command()
+        .args(["--json-pp", "-", &scan_dir])
+        .output()
+        .expect("failed to run provenant for json header version test");
+
+    assert!(output.status.success(), "json scan should succeed");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
+    let tool_version = json["headers"]
+        .as_array()
+        .and_then(|headers| headers.first())
+        .and_then(|header| header["tool_version"].as_str())
+        .expect("headers[0].tool_version should exist");
+
+    assert_eq!(tool_version, provenant::version::BUILD_VERSION);
+}
+
+#[test]
+fn short_version_flag_stays_single_line_and_parse_safe() {
+    let output = provenant_command()
+        .arg("-V")
+        .output()
+        .expect("failed to run provenant -V");
+
+    assert!(output.status.success(), "-V should succeed");
+
+    let stdout = String::from_utf8(output.stdout).expect("short version output should be utf-8");
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "-V should remain single-line for xtask parsing"
+    );
+
+    let reported_version = lines[0]
+        .split_whitespace()
+        .last()
+        .expect("short version line should include a version token");
+    assert_eq!(reported_version, provenant::version::BUILD_VERSION);
+}
+
+#[test]
+fn invalid_build_version_override_falls_back_to_git_aware_version() {
+    let output = cargo_command()
+        .env("PROVENANT_BUILD_VERSION", "bad\nvalue")
+        .args(["run", "--", "-V"])
+        .output()
+        .expect("failed to run cargo with invalid build version override");
+
+    assert!(
+        output.status.success(),
+        "cargo run with invalid override should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("fallback version output should be utf-8");
+    let reported_version = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().last())
+        .expect("fallback output should include a version token");
+
+    assert_eq!(reported_version, provenant::version::BUILD_VERSION);
 }
 
 #[test]

--- a/tests/version_format_unit.rs
+++ b/tests/version_format_unit.rs
@@ -1,0 +1,52 @@
+#[path = "../src/version_format.rs"]
+mod version_format;
+
+use version_format::{derive_build_version, sanitize_build_version};
+
+#[test]
+fn sanitize_build_version_rejects_control_characters() {
+    assert_eq!(
+        sanitize_build_version("0.1.0-5-gabc1234"),
+        Some("0.1.0-5-gabc1234".to_string())
+    );
+    assert_eq!(sanitize_build_version("0.1.0\nboom"), None);
+    assert_eq!(sanitize_build_version("0.1.0 dirty"), None);
+    assert_eq!(sanitize_build_version("\u{1b}[31m0.1.0"), None);
+}
+
+#[test]
+fn derive_build_version_keeps_plain_release_version_on_exact_tag() {
+    assert_eq!(
+        derive_build_version("0.1.0", Some("v0.1.0"), Some("abc1234")),
+        "0.1.0"
+    );
+}
+
+#[test]
+fn derive_build_version_preserves_git_describe_suffix_after_tag() {
+    assert_eq!(
+        derive_build_version("0.1.0", Some("v0.1.0-3-gabc1234"), Some("abc1234")),
+        "0.1.0-3-gabc1234"
+    );
+}
+
+#[test]
+fn derive_build_version_adds_sha_for_dirty_tagged_tree() {
+    assert_eq!(
+        derive_build_version("0.1.0", Some("v0.1.0-dirty"), Some("abc1234")),
+        "0.1.0-0-gabc1234-dirty"
+    );
+}
+
+#[test]
+fn derive_build_version_falls_back_to_package_version_when_missing_git_data() {
+    assert_eq!(derive_build_version("0.1.0", None, None), "0.1.0");
+}
+
+#[test]
+fn derive_build_version_keeps_package_version_when_describe_is_invalid() {
+    assert_eq!(
+        derive_build_version("0.1.0", Some("bad\ndescribe"), Some("abc1234")),
+        "0.1.0"
+    );
+}


### PR DESCRIPTION
## Summary

- derive a shared build version at compile time from git metadata, with safe fallback to `CARGO_PKG_VERSION`
- use that shared version for CLI output, ScanCode JSON `tool_version`, CycloneDX tool metadata, and scanner fingerprints
- add coverage for git-aware formatting, invalid override fallback, and parse-safe short-version output

## Issues

- Covers:
- Closes: #618

## Scope and exclusions

- Included:
  - new `build.rs`-backed version derivation and sanitization flow
  - shared runtime accessor in `src/version.rs`
  - CLI / JSON / CycloneDX / scanner version wiring updates
  - targeted unit and integration coverage for version formatting and fallback behavior
- Explicit exclusions:
  - release automation changes
  - changes to package manifest versioning itself

## Validation

- `cargo test --test version_format_unit`
- `cargo test --test progress_cli_integration`
- `cargo test --test output_format_golden test_cyclonedx_`
- `cargo check`
- `cargo run -- -V`
- `PROVENANT_BUILD_VERSION=$'bad\nvalue' cargo run -- -V`