### PR TITLE
fix(output): align public export behavior with ScanCode

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -65,7 +65,7 @@ This is the main reason the workflow guide matters: the right command depends on
 
 ## Choose an Output Format First
 
-Every run needs at least one output flag.
+Every run needs at least one output flag, and you can request more than one in the same run.
 
 For most users, the best default is still pretty JSON:
 

--- a/docs/adr/0008-output-schema-separation.md
+++ b/docs/adr/0008-output-schema-separation.md
@@ -10,7 +10,7 @@
 All internal model types in Provenant originally derived both `Serialize` and `Deserialize` from serde and carried output-formatting attributes (`skip_serializing_if`, `rename`, `serialize_with`, custom `Serialize` impls). This conflated two distinct concerns:
 
 1. **Internal domain logic** — scanning, parsing, assembly, and post-processing operate on strongly-typed domain values (`LineNumber`, `Sha1Digest`, `FileType`, `DatasourceId`).
-2. **ScanCode-compatible JSON output** — the public JSON schema requires specific field names (`"type"` for `package_type`), conditional field omission (`skip_serializing_if`), `None` serialized as `{}` for maps, and a hand-rolled `FileInfo` serializer with info-surface gating and controlled field ordering.
+2. **ScanCode-compatible JSON output** — the public JSON schema requires specific field names (`"type"` for `package_type`), conditional field omission (`skip_serializing_if`), package-like optional map normalization in the final public output writers, and a hand-rolled `FileInfo` serializer with info-surface gating and controlled field ordering.
 
 Mixing these concerns in one type meant:
 
@@ -26,7 +26,7 @@ Separate the ScanCode-compatible output schema from internal types:
 1. **Output schema types** (`src/output_schema/`) are dedicated serde-enabled types, one file per type, that define the ScanCode-compatible JSON schema explicitly. They own all output-formatting logic:
    - Field renames (`package_type` → `"type"`, `license_expression` → `"detected_license_expression_spdx"`)
    - Conditional field omission (`skip_serializing_if`)
-   - `None` → `{}` serialization for optional maps
+   - Package-like optional map normalization for the final public output contract
    - The `FileInfo` info-surface gating logic
    - Type widening: `LineNumber` → `u64`, `Sha1Digest` → `Option<String>` (hex)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,7 @@ fn parse_license_policy_arg(value: &str) -> Result<String, String> {
     group(
         ArgGroup::new("output")
             .required(true)
+            .multiple(true)
             .args([
                 "output_json",
                 "output_json_pp",
@@ -350,7 +351,22 @@ pub struct Cli {
     pub max_url: usize,
 
     /// Show attribution notices for embedded license detection data
-    #[arg(long)]
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "output_json",
+            "output_json_pp",
+            "output_json_lines",
+            "output_yaml",
+            "output_debian",
+            "output_html",
+            "output_spdx_tv",
+            "output_spdx_rdf",
+            "output_cyclonedx",
+            "output_cyclonedx_xml",
+            "custom_output"
+        ]
+    )]
     pub show_attribution: bool,
 }
 
@@ -712,6 +728,35 @@ mod tests {
         assert_eq!(parsed.output_json_pp.as_deref(), Some("scan.json"));
         assert_eq!(parsed.output_targets().len(), 1);
         assert_eq!(parsed.output_targets()[0].format, OutputFormat::JsonPretty);
+    }
+
+    #[test]
+    fn test_allows_multiple_output_options_in_one_run() {
+        let parsed = Cli::try_parse_from([
+            "provenant",
+            "--json",
+            "scan.json",
+            "--html",
+            "report.html",
+            "samples",
+        ])
+        .expect("cli parse should allow multiple outputs");
+
+        assert_eq!(parsed.output_targets().len(), 2);
+        assert_eq!(parsed.output_targets()[0].format, OutputFormat::Json);
+        assert_eq!(parsed.output_targets()[1].format, OutputFormat::Html);
+    }
+
+    #[test]
+    fn test_show_attribution_conflicts_with_output_flags() {
+        let parsed = Cli::try_parse_from([
+            "provenant",
+            "--show-attribution",
+            "--json",
+            "scan.json",
+            "samples",
+        ]);
+        assert!(parsed.is_err());
     }
 
     #[test]

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io::{self, Write};
 
 use serde_json::{Map, Value, json};
@@ -288,26 +289,20 @@ fn component_hashes(pkg: &Package) -> Vec<(&'static str, String)> {
 
 fn component_external_references(pkg: &Package) -> Vec<(&'static str, String)> {
     let mut refs = Vec::new();
-    if let Some(url) = &pkg.api_data_url {
-        refs.push(("bom", url.clone()));
-    }
-    if let Some(url) = &pkg.bug_tracking_url {
-        refs.push(("issue-tracker", url.clone()));
-    }
-    if let Some(url) = &pkg.download_url {
-        refs.push(("distribution", url.clone()));
-    }
-    if let Some(url) = &pkg.repository_download_url {
-        refs.push(("distribution", url.clone()));
-    }
-    if let Some(url) = &pkg.homepage_url {
-        refs.push(("website", url.clone()));
-    }
-    if let Some(url) = &pkg.repository_homepage_url {
-        refs.push(("website", url.clone()));
-    }
-    if let Some(url) = &pkg.vcs_url {
-        refs.push(("vcs", url.clone()));
-    }
+    let mut seen = HashSet::new();
+    let mut push_ref = |ref_type: &'static str, url: &Option<String>| {
+        if let Some(url) = url
+            && seen.insert((ref_type, url.clone()))
+        {
+            refs.push((ref_type, url.clone()));
+        }
+    };
+    push_ref("bom", &pkg.api_data_url);
+    push_ref("issue-tracker", &pkg.bug_tracking_url);
+    push_ref("distribution", &pkg.download_url);
+    push_ref("distribution", &pkg.repository_download_url);
+    push_ref("website", &pkg.homepage_url);
+    push_ref("website", &pkg.repository_homepage_url);
+    push_ref("vcs", &pkg.vcs_url);
     refs
 }

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -196,7 +196,7 @@ const HTML_REPORT_TEMPLATE: &str = r#"<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Custom Template</title>
+    <title>Provenant HTML Report</title>
     <style type="text/css">
       table {
         border-collapse: collapse;

--- a/src/output/jsonl.rs
+++ b/src/output/jsonl.rs
@@ -1,71 +1,84 @@
 use std::io::{self, Write};
 
-use serde_json::{Value, json};
-
 use crate::output_schema::Output;
 
+use super::public_serialize::{
+    PublicPackages, PublicTopLevelDependencies, SingleField, SinglePublicFile,
+};
 use super::shared::{io_other, sorted_files};
 
 pub(crate) fn write_json_lines(output: &Output, writer: &mut dyn Write) -> io::Result<()> {
-    write_jsonl_line(writer, &json!({ "headers": output.headers }))?;
+    write_jsonl_line(writer, &SingleField::new("headers", &output.headers))?;
 
     if let Some(summary) = &output.summary {
-        write_jsonl_line(writer, &json!({ "summary": summary }))?;
+        write_jsonl_line(writer, &SingleField::new("summary", summary))?;
     }
 
     if let Some(tallies) = &output.tallies {
-        write_jsonl_line(writer, &json!({ "tallies": tallies }))?;
+        write_jsonl_line(writer, &SingleField::new("tallies", tallies))?;
     }
 
     if let Some(tallies_of_key_files) = &output.tallies_of_key_files {
         write_jsonl_line(
             writer,
-            &json!({ "tallies_of_key_files": tallies_of_key_files }),
+            &SingleField::new("tallies_of_key_files", tallies_of_key_files),
         )?;
     }
 
     if let Some(tallies_by_facet) = &output.tallies_by_facet {
-        write_jsonl_line(writer, &json!({ "tallies_by_facet": tallies_by_facet }))?;
+        write_jsonl_line(
+            writer,
+            &SingleField::new("tallies_by_facet", tallies_by_facet),
+        )?;
     }
 
     if !output.packages.is_empty() {
-        write_jsonl_line(writer, &json!({ "packages": output.packages }))?;
+        write_jsonl_line(
+            writer,
+            &SingleField::new("packages", PublicPackages(&output.packages)),
+        )?;
     }
 
     if !output.dependencies.is_empty() {
-        write_jsonl_line(writer, &json!({ "dependencies": output.dependencies }))?;
-    }
-
-    if !output.license_detections.is_empty() {
         write_jsonl_line(
             writer,
-            &json!({ "license_detections": output.license_detections }),
+            &SingleField::new(
+                "dependencies",
+                PublicTopLevelDependencies(&output.dependencies),
+            ),
         )?;
     }
+
+    write_jsonl_line(
+        writer,
+        &SingleField::new("license_detections", &output.license_detections),
+    )?;
 
     if !output.license_references.is_empty() {
         write_jsonl_line(
             writer,
-            &json!({ "license_references": output.license_references }),
+            &SingleField::new("license_references", &output.license_references),
         )?;
     }
 
     if !output.license_rule_references.is_empty() {
         write_jsonl_line(
             writer,
-            &json!({ "license_rule_references": output.license_rule_references }),
+            &SingleField::new("license_rule_references", &output.license_rule_references),
         )?;
     }
 
     for file in sorted_files(&output.files) {
-        write_jsonl_line(writer, &json!({ "files": [file] }))?;
+        write_jsonl_line(writer, &SingleField::new("files", SinglePublicFile(file)))?;
     }
 
     Ok(())
 }
 
-fn write_jsonl_line(writer: &mut dyn Write, value: &Value) -> io::Result<()> {
-    let line = serde_json::to_string(value).map_err(io_other)?;
-    writer.write_all(line.as_bytes())?;
+fn write_jsonl_line<T>(writer: &mut dyn Write, value: &T) -> io::Result<()>
+where
+    T: serde::Serialize,
+{
+    serde_json::to_writer(&mut *writer, value).map_err(io_other)?;
     writer.write_all(b"\n")
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,7 @@ mod cyclonedx;
 mod debian;
 mod html;
 mod jsonl;
+mod public_serialize;
 mod shared;
 mod spdx;
 mod template;
@@ -63,11 +64,13 @@ impl OutputWriter for FormatWriter {
     ) -> io::Result<()> {
         match self.format {
             OutputFormat::Json => {
-                serde_json::to_writer(&mut *writer, output).map_err(shared::io_other)?;
+                serde_json::to_writer(&mut *writer, &public_serialize::PublicOutput(output))
+                    .map_err(shared::io_other)?;
                 writer.write_all(b"\n")
             }
             OutputFormat::JsonPretty => {
-                serde_json::to_writer_pretty(&mut *writer, output).map_err(shared::io_other)?;
+                serde_json::to_writer_pretty(&mut *writer, &public_serialize::PublicOutput(output))
+                    .map_err(shared::io_other)?;
                 writer.write_all(b"\n")
             }
             OutputFormat::Yaml => write_yaml(output, writer),
@@ -103,7 +106,8 @@ pub fn write_output_file(
 }
 
 fn write_yaml(output: &Output, writer: &mut dyn Write) -> io::Result<()> {
-    yaml_serde::to_writer(&mut *writer, output).map_err(shared::io_other)?;
+    yaml_serde::to_writer(&mut *writer, &public_serialize::PublicOutput(output))
+        .map_err(shared::io_other)?;
     writer.write_all(b"\n")
 }
 
@@ -1050,6 +1054,64 @@ mod tests {
     }
 
     #[test]
+    fn test_json_and_json_lines_writers_keep_empty_top_level_license_detections() {
+        let output = Output::from(&sample_internal_output());
+
+        let mut json_bytes = Vec::new();
+        writer_for_format(OutputFormat::Json)
+            .write(&output, &mut json_bytes, &OutputWriteConfig::default())
+            .expect("json write should succeed");
+        let json_value: Value =
+            serde_json::from_slice(&json_bytes).expect("json output should parse");
+        assert_eq!(json_value["license_detections"], Value::Array(vec![]));
+
+        let mut jsonl_bytes = Vec::new();
+        writer_for_format(OutputFormat::JsonLines)
+            .write(&output, &mut jsonl_bytes, &OutputWriteConfig::default())
+            .expect("json-lines write should succeed");
+        let rendered = String::from_utf8(jsonl_bytes).expect("json-lines should be utf-8");
+        assert!(
+            rendered
+                .lines()
+                .any(|line| line == r#"{"license_detections":[]}"#)
+        );
+    }
+
+    #[test]
+    fn test_public_writer_normalizes_empty_package_maps_without_changing_schema_output() {
+        let mut internal = sample_internal_output();
+        internal.packages.push(Package::from_package_data(
+            &PackageData {
+                package_type: Some(crate::models::PackageType::Npm),
+                name: Some("demo".to_string()),
+                version: Some("1.0.0".to_string()),
+                ..PackageData::default()
+            },
+            "scan/package.json".to_string(),
+        ));
+
+        let output = Output::from(&internal);
+        let raw_schema = serde_json::to_value(&output).expect("schema output should serialize");
+        assert_eq!(
+            raw_schema["packages"][0]["qualifiers"],
+            serde_json::json!({})
+        );
+        assert_eq!(
+            raw_schema["packages"][0]["extra_data"],
+            serde_json::json!({})
+        );
+
+        let mut bytes = Vec::new();
+        writer_for_format(OutputFormat::Json)
+            .write(&output, &mut bytes, &OutputWriteConfig::default())
+            .expect("json write should succeed");
+        let public_value: Value = serde_json::from_slice(&bytes).expect("public json should parse");
+
+        assert!(public_value["packages"][0]["qualifiers"].is_null());
+        assert!(public_value["packages"][0]["extra_data"].is_null());
+    }
+
+    #[test]
     fn test_cyclonedx_xml_writer_outputs_xml() {
         let output = Output::from(&sample_internal_output());
         let mut bytes = Vec::new();
@@ -1128,6 +1190,89 @@ mod tests {
     }
 
     #[test]
+    fn test_cyclonedx_external_references_are_deduplicated() {
+        let mut internal = sample_internal_output();
+        internal.packages = vec![Package::from_package_data(
+            &PackageData {
+                package_type: Some(crate::models::PackageType::Npm),
+                name: Some("demo".to_string()),
+                version: Some("1.0.0".to_string()),
+                download_url: Some("https://example.com/download.tgz".to_string()),
+                repository_download_url: Some("https://example.com/download.tgz".to_string()),
+                homepage_url: Some("https://example.com".to_string()),
+                repository_homepage_url: Some("https://example.com".to_string()),
+                ..PackageData::default()
+            },
+            "scan/package.json".to_string(),
+        )];
+        let output = Output::from(&internal);
+
+        let mut json_bytes = Vec::new();
+        writer_for_format(OutputFormat::CycloneDxJson)
+            .write(&output, &mut json_bytes, &OutputWriteConfig::default())
+            .expect("cyclonedx json write should succeed");
+        let value: Value = serde_json::from_slice(&json_bytes).expect("valid cyclonedx json");
+        let refs = value["components"][0]["externalReferences"]
+            .as_array()
+            .expect("external references should be an array");
+        assert_eq!(refs.len(), 2);
+
+        let mut xml_bytes = Vec::new();
+        writer_for_format(OutputFormat::CycloneDxXml)
+            .write(&output, &mut xml_bytes, &OutputWriteConfig::default())
+            .expect("cyclonedx xml write should succeed");
+        let xml = String::from_utf8(xml_bytes).expect("cyclonedx xml should be utf-8");
+        assert_eq!(xml.matches("https://example.com/download.tgz").count(), 1);
+        assert_eq!(xml.matches("https://example.com</url>").count(), 1);
+    }
+
+    #[test]
+    fn test_spdx_prefers_single_detected_package_name_over_scan_root() {
+        let mut internal = sample_internal_output();
+        internal.packages = vec![Package::from_package_data(
+            &PackageData {
+                package_type: Some(crate::models::PackageType::Npm),
+                name: Some("detected-package".to_string()),
+                version: Some("1.0.0".to_string()),
+                ..PackageData::default()
+            },
+            "scan/package.json".to_string(),
+        )];
+        let output = Output::from(&internal);
+
+        let mut tv_bytes = Vec::new();
+        writer_for_format(OutputFormat::SpdxTv)
+            .write(
+                &output,
+                &mut tv_bytes,
+                &OutputWriteConfig {
+                    format: OutputFormat::SpdxTv,
+                    custom_template: None,
+                    scanned_path: Some("scan-root".to_string()),
+                },
+            )
+            .expect("spdx tv write should succeed");
+        let tv = String::from_utf8(tv_bytes).expect("spdx tv should be utf-8");
+        assert!(tv.contains("PackageName: detected-package"));
+        assert!(tv.contains("DocumentNamespace: http://spdx.org/spdxdocs/detected-package"));
+
+        let mut rdf_bytes = Vec::new();
+        writer_for_format(OutputFormat::SpdxRdf)
+            .write(
+                &output,
+                &mut rdf_bytes,
+                &OutputWriteConfig {
+                    format: OutputFormat::SpdxRdf,
+                    custom_template: None,
+                    scanned_path: Some("scan-root".to_string()),
+                },
+            )
+            .expect("spdx rdf write should succeed");
+        let rdf = String::from_utf8(rdf_bytes).expect("spdx rdf should be utf-8");
+        assert!(rdf.contains("<spdx:name>detected-package</spdx:name>"));
+    }
+
+    #[test]
     fn test_spdx_empty_scan_tag_value_matches_python_sentinel() {
         let output = Output {
             summary: None,
@@ -1200,7 +1345,7 @@ mod tests {
             .expect("html write should succeed");
         let rendered = String::from_utf8(bytes).expect("html should be utf-8");
         assert!(rendered.contains("<!doctype html>"));
-        assert!(rendered.contains("Custom Template"));
+        assert!(rendered.contains("Provenant HTML Report"));
     }
 
     #[test]

--- a/src/output/public_serialize.rs
+++ b/src/output/public_serialize.rs
@@ -1,0 +1,734 @@
+use std::collections::HashMap;
+
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Serialize, Serializer};
+
+use crate::output_schema::{
+    Output, OutputDependency, OutputFileInfo, OutputFileReference, OutputPackage,
+    OutputPackageData, OutputResolvedPackage, OutputTopLevelDependency,
+};
+
+pub(crate) struct PublicOutput<'a>(pub(crate) &'a Output);
+
+impl Serialize for PublicOutput<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let output = self.0;
+        let mut map = serializer.serialize_map(None)?;
+
+        if let Some(summary) = &output.summary {
+            map.serialize_entry("summary", summary)?;
+        }
+        if let Some(tallies) = &output.tallies {
+            map.serialize_entry("tallies", tallies)?;
+        }
+        if let Some(tallies_of_key_files) = &output.tallies_of_key_files {
+            map.serialize_entry("tallies_of_key_files", tallies_of_key_files)?;
+        }
+        if let Some(tallies_by_facet) = &output.tallies_by_facet {
+            map.serialize_entry("tallies_by_facet", tallies_by_facet)?;
+        }
+
+        map.serialize_entry("headers", &output.headers)?;
+        map.serialize_entry("packages", &PublicPackages(&output.packages))?;
+        map.serialize_entry(
+            "dependencies",
+            &PublicTopLevelDependencies(&output.dependencies),
+        )?;
+        map.serialize_entry("license_detections", &output.license_detections)?;
+        map.serialize_entry("files", &PublicFiles(&output.files))?;
+        map.serialize_entry("license_references", &output.license_references)?;
+        map.serialize_entry("license_rule_references", &output.license_rule_references)?;
+        map.end()
+    }
+}
+
+pub(crate) struct SingleField<T> {
+    key: &'static str,
+    value: T,
+}
+
+impl<T> SingleField<T> {
+    pub(crate) fn new(key: &'static str, value: T) -> Self {
+        Self { key, value }
+    }
+}
+
+impl<T> Serialize for SingleField<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(self.key, &self.value)?;
+        map.end()
+    }
+}
+
+pub(crate) struct SinglePublicFile<'a>(pub(crate) &'a OutputFileInfo);
+
+impl Serialize for SinglePublicFile<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(1))?;
+        seq.serialize_element(&PublicFileInfo(self.0))?;
+        seq.end()
+    }
+}
+
+struct NullableMap<'a, T>(&'a Option<HashMap<String, T>>);
+
+impl<T> Serialize for NullableMap<'_, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0 {
+            Some(map) if !map.is_empty() => map.serialize(serializer),
+            _ => serializer.serialize_none(),
+        }
+    }
+}
+
+struct NullableResolvedPackage<'a>(Option<&'a OutputResolvedPackage>);
+
+impl Serialize for NullableResolvedPackage<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0 {
+            Some(package) => PublicResolvedPackage(package).serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+pub(crate) struct PublicPackages<'a>(pub(crate) &'a [OutputPackage]);
+
+impl Serialize for PublicPackages<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for package in self.0 {
+            seq.serialize_element(&PublicPackage(package))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicPackage<'a>(&'a OutputPackage);
+
+#[derive(Serialize)]
+struct PublicPackageFields<'a> {
+    #[serde(rename = "type")]
+    package_type: &'a Option<crate::models::PackageType>,
+    namespace: &'a Option<String>,
+    name: &'a Option<String>,
+    version: &'a Option<String>,
+    qualifiers: NullableMap<'a, String>,
+    subpath: &'a Option<String>,
+    primary_language: &'a Option<String>,
+    description: &'a Option<String>,
+    release_date: &'a Option<String>,
+    parties: &'a [crate::output_schema::OutputParty],
+    keywords: &'a [String],
+    homepage_url: &'a Option<String>,
+    download_url: &'a Option<String>,
+    size: &'a Option<u64>,
+    sha1: &'a Option<String>,
+    md5: &'a Option<String>,
+    sha256: &'a Option<String>,
+    sha512: &'a Option<String>,
+    bug_tracking_url: &'a Option<String>,
+    code_view_url: &'a Option<String>,
+    vcs_url: &'a Option<String>,
+    copyright: &'a Option<String>,
+    holder: &'a Option<String>,
+    declared_license_expression: &'a Option<String>,
+    declared_license_expression_spdx: &'a Option<String>,
+    license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    other_license_expression: &'a Option<String>,
+    other_license_expression_spdx: &'a Option<String>,
+    other_license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    extracted_license_statement: &'a Option<String>,
+    notice_text: &'a Option<String>,
+    source_packages: &'a [String],
+    is_private: bool,
+    is_virtual: bool,
+    extra_data: NullableMap<'a, serde_json::Value>,
+    repository_homepage_url: &'a Option<String>,
+    repository_download_url: &'a Option<String>,
+    api_data_url: &'a Option<String>,
+    purl: &'a Option<String>,
+    package_uid: &'a str,
+    datafile_paths: &'a [String],
+    datasource_ids: &'a [crate::models::DatasourceId],
+}
+
+impl Serialize for PublicPackage<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let package = self.0;
+        PublicPackageFields {
+            package_type: &package.package_type,
+            namespace: &package.namespace,
+            name: &package.name,
+            version: &package.version,
+            qualifiers: NullableMap(&package.qualifiers),
+            subpath: &package.subpath,
+            primary_language: &package.primary_language,
+            description: &package.description,
+            release_date: &package.release_date,
+            parties: &package.parties,
+            keywords: &package.keywords,
+            homepage_url: &package.homepage_url,
+            download_url: &package.download_url,
+            size: &package.size,
+            sha1: &package.sha1,
+            md5: &package.md5,
+            sha256: &package.sha256,
+            sha512: &package.sha512,
+            bug_tracking_url: &package.bug_tracking_url,
+            code_view_url: &package.code_view_url,
+            vcs_url: &package.vcs_url,
+            copyright: &package.copyright,
+            holder: &package.holder,
+            declared_license_expression: &package.declared_license_expression,
+            declared_license_expression_spdx: &package.declared_license_expression_spdx,
+            license_detections: &package.license_detections,
+            other_license_expression: &package.other_license_expression,
+            other_license_expression_spdx: &package.other_license_expression_spdx,
+            other_license_detections: &package.other_license_detections,
+            extracted_license_statement: &package.extracted_license_statement,
+            notice_text: &package.notice_text,
+            source_packages: &package.source_packages,
+            is_private: package.is_private,
+            is_virtual: package.is_virtual,
+            extra_data: NullableMap(&package.extra_data),
+            repository_homepage_url: &package.repository_homepage_url,
+            repository_download_url: &package.repository_download_url,
+            api_data_url: &package.api_data_url,
+            purl: &package.purl,
+            package_uid: &package.package_uid,
+            datafile_paths: &package.datafile_paths,
+            datasource_ids: &package.datasource_ids,
+        }
+        .serialize(serializer)
+    }
+}
+
+struct PublicPackageDataSeq<'a>(&'a [OutputPackageData]);
+
+impl Serialize for PublicPackageDataSeq<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for package in self.0 {
+            seq.serialize_element(&PublicPackageData(package))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicPackageData<'a>(&'a OutputPackageData);
+
+#[derive(Serialize)]
+struct PublicPackageDataFields<'a> {
+    #[serde(rename = "type")]
+    package_type: &'a Option<crate::models::PackageType>,
+    namespace: &'a Option<String>,
+    name: &'a Option<String>,
+    version: &'a Option<String>,
+    qualifiers: NullableMap<'a, String>,
+    subpath: &'a Option<String>,
+    primary_language: &'a Option<String>,
+    description: &'a Option<String>,
+    release_date: &'a Option<String>,
+    parties: &'a [crate::output_schema::OutputParty],
+    keywords: &'a [String],
+    homepage_url: &'a Option<String>,
+    download_url: &'a Option<String>,
+    size: &'a Option<u64>,
+    sha1: &'a Option<String>,
+    md5: &'a Option<String>,
+    sha256: &'a Option<String>,
+    sha512: &'a Option<String>,
+    bug_tracking_url: &'a Option<String>,
+    code_view_url: &'a Option<String>,
+    vcs_url: &'a Option<String>,
+    copyright: &'a Option<String>,
+    holder: &'a Option<String>,
+    declared_license_expression: &'a Option<String>,
+    declared_license_expression_spdx: &'a Option<String>,
+    license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    other_license_expression: &'a Option<String>,
+    other_license_expression_spdx: &'a Option<String>,
+    other_license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    extracted_license_statement: &'a Option<String>,
+    notice_text: &'a Option<String>,
+    source_packages: &'a [String],
+    file_references: PublicFileReferences<'a>,
+    is_private: bool,
+    is_virtual: bool,
+    extra_data: NullableMap<'a, serde_json::Value>,
+    dependencies: PublicDependencies<'a>,
+    repository_homepage_url: &'a Option<String>,
+    repository_download_url: &'a Option<String>,
+    api_data_url: &'a Option<String>,
+    datasource_id: &'a Option<crate::models::DatasourceId>,
+    purl: &'a Option<String>,
+}
+
+impl Serialize for PublicPackageData<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let package = self.0;
+        PublicPackageDataFields {
+            package_type: &package.package_type,
+            namespace: &package.namespace,
+            name: &package.name,
+            version: &package.version,
+            qualifiers: NullableMap(&package.qualifiers),
+            subpath: &package.subpath,
+            primary_language: &package.primary_language,
+            description: &package.description,
+            release_date: &package.release_date,
+            parties: &package.parties,
+            keywords: &package.keywords,
+            homepage_url: &package.homepage_url,
+            download_url: &package.download_url,
+            size: &package.size,
+            sha1: &package.sha1,
+            md5: &package.md5,
+            sha256: &package.sha256,
+            sha512: &package.sha512,
+            bug_tracking_url: &package.bug_tracking_url,
+            code_view_url: &package.code_view_url,
+            vcs_url: &package.vcs_url,
+            copyright: &package.copyright,
+            holder: &package.holder,
+            declared_license_expression: &package.declared_license_expression,
+            declared_license_expression_spdx: &package.declared_license_expression_spdx,
+            license_detections: &package.license_detections,
+            other_license_expression: &package.other_license_expression,
+            other_license_expression_spdx: &package.other_license_expression_spdx,
+            other_license_detections: &package.other_license_detections,
+            extracted_license_statement: &package.extracted_license_statement,
+            notice_text: &package.notice_text,
+            source_packages: &package.source_packages,
+            file_references: PublicFileReferences(&package.file_references),
+            is_private: package.is_private,
+            is_virtual: package.is_virtual,
+            extra_data: NullableMap(&package.extra_data),
+            dependencies: PublicDependencies(&package.dependencies),
+            repository_homepage_url: &package.repository_homepage_url,
+            repository_download_url: &package.repository_download_url,
+            api_data_url: &package.api_data_url,
+            datasource_id: &package.datasource_id,
+            purl: &package.purl,
+        }
+        .serialize(serializer)
+    }
+}
+
+struct PublicResolvedPackage<'a>(&'a OutputResolvedPackage);
+
+#[derive(Serialize)]
+struct PublicResolvedPackageFields<'a> {
+    #[serde(rename = "type")]
+    package_type: &'a crate::models::PackageType,
+    namespace: &'a String,
+    name: &'a String,
+    version: &'a String,
+    qualifiers: NullableMap<'a, String>,
+    subpath: &'a Option<String>,
+    primary_language: &'a Option<String>,
+    description: &'a Option<String>,
+    release_date: &'a Option<String>,
+    parties: &'a [crate::output_schema::OutputParty],
+    keywords: &'a [String],
+    homepage_url: &'a Option<String>,
+    download_url: &'a Option<String>,
+    size: &'a Option<u64>,
+    sha1: &'a Option<String>,
+    md5: &'a Option<String>,
+    sha256: &'a Option<String>,
+    sha512: &'a Option<String>,
+    bug_tracking_url: &'a Option<String>,
+    code_view_url: &'a Option<String>,
+    vcs_url: &'a Option<String>,
+    copyright: &'a Option<String>,
+    holder: &'a Option<String>,
+    declared_license_expression: &'a Option<String>,
+    declared_license_expression_spdx: &'a Option<String>,
+    license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    other_license_expression: &'a Option<String>,
+    other_license_expression_spdx: &'a Option<String>,
+    other_license_detections: &'a [crate::output_schema::OutputLicenseDetection],
+    extracted_license_statement: &'a Option<String>,
+    notice_text: &'a Option<String>,
+    source_packages: &'a [String],
+    file_references: PublicFileReferences<'a>,
+    is_private: bool,
+    is_virtual: bool,
+    extra_data: NullableMap<'a, serde_json::Value>,
+    dependencies: PublicDependencies<'a>,
+    repository_homepage_url: &'a Option<String>,
+    repository_download_url: &'a Option<String>,
+    api_data_url: &'a Option<String>,
+    datasource_id: &'a Option<crate::models::DatasourceId>,
+    purl: &'a Option<String>,
+}
+
+impl Serialize for PublicResolvedPackage<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let package = self.0;
+        PublicResolvedPackageFields {
+            package_type: &package.package_type,
+            namespace: &package.namespace,
+            name: &package.name,
+            version: &package.version,
+            qualifiers: NullableMap(&package.qualifiers),
+            subpath: &package.subpath,
+            primary_language: &package.primary_language,
+            description: &package.description,
+            release_date: &package.release_date,
+            parties: &package.parties,
+            keywords: &package.keywords,
+            homepage_url: &package.homepage_url,
+            download_url: &package.download_url,
+            size: &package.size,
+            sha1: &package.sha1,
+            md5: &package.md5,
+            sha256: &package.sha256,
+            sha512: &package.sha512,
+            bug_tracking_url: &package.bug_tracking_url,
+            code_view_url: &package.code_view_url,
+            vcs_url: &package.vcs_url,
+            copyright: &package.copyright,
+            holder: &package.holder,
+            declared_license_expression: &package.declared_license_expression,
+            declared_license_expression_spdx: &package.declared_license_expression_spdx,
+            license_detections: &package.license_detections,
+            other_license_expression: &package.other_license_expression,
+            other_license_expression_spdx: &package.other_license_expression_spdx,
+            other_license_detections: &package.other_license_detections,
+            extracted_license_statement: &package.extracted_license_statement,
+            notice_text: &package.notice_text,
+            source_packages: &package.source_packages,
+            file_references: PublicFileReferences(&package.file_references),
+            is_private: package.is_private,
+            is_virtual: package.is_virtual,
+            extra_data: NullableMap(&package.extra_data),
+            dependencies: PublicDependencies(&package.dependencies),
+            repository_homepage_url: &package.repository_homepage_url,
+            repository_download_url: &package.repository_download_url,
+            api_data_url: &package.api_data_url,
+            datasource_id: &package.datasource_id,
+            purl: &package.purl,
+        }
+        .serialize(serializer)
+    }
+}
+
+pub(crate) struct PublicTopLevelDependencies<'a>(pub(crate) &'a [OutputTopLevelDependency]);
+
+impl Serialize for PublicTopLevelDependencies<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for dependency in self.0 {
+            seq.serialize_element(&PublicTopLevelDependency(dependency))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicTopLevelDependency<'a>(&'a OutputTopLevelDependency);
+
+#[derive(Serialize)]
+struct PublicTopLevelDependencyFields<'a> {
+    purl: &'a Option<String>,
+    extracted_requirement: &'a Option<String>,
+    scope: &'a Option<String>,
+    is_runtime: &'a Option<bool>,
+    is_optional: &'a Option<bool>,
+    is_pinned: &'a Option<bool>,
+    is_direct: &'a Option<bool>,
+    resolved_package: NullableResolvedPackage<'a>,
+    extra_data: NullableMap<'a, serde_json::Value>,
+    dependency_uid: &'a str,
+    for_package_uid: &'a Option<String>,
+    datafile_path: &'a str,
+    datasource_id: &'a crate::models::DatasourceId,
+    namespace: &'a Option<String>,
+}
+
+impl Serialize for PublicTopLevelDependency<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let dependency = self.0;
+        PublicTopLevelDependencyFields {
+            purl: &dependency.purl,
+            extracted_requirement: &dependency.extracted_requirement,
+            scope: &dependency.scope,
+            is_runtime: &dependency.is_runtime,
+            is_optional: &dependency.is_optional,
+            is_pinned: &dependency.is_pinned,
+            is_direct: &dependency.is_direct,
+            resolved_package: NullableResolvedPackage(
+                dependency
+                    .resolved_package
+                    .as_ref()
+                    .map(|package| package.as_ref()),
+            ),
+            extra_data: NullableMap(&dependency.extra_data),
+            dependency_uid: &dependency.dependency_uid,
+            for_package_uid: &dependency.for_package_uid,
+            datafile_path: &dependency.datafile_path,
+            datasource_id: &dependency.datasource_id,
+            namespace: &dependency.namespace,
+        }
+        .serialize(serializer)
+    }
+}
+
+struct PublicDependencies<'a>(&'a [OutputDependency]);
+
+impl Serialize for PublicDependencies<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for dependency in self.0 {
+            seq.serialize_element(&PublicDependency(dependency))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicDependency<'a>(&'a OutputDependency);
+
+#[derive(Serialize)]
+struct PublicDependencyFields<'a> {
+    purl: &'a Option<String>,
+    extracted_requirement: &'a Option<String>,
+    scope: &'a Option<String>,
+    is_runtime: &'a Option<bool>,
+    is_optional: &'a Option<bool>,
+    is_pinned: &'a Option<bool>,
+    is_direct: &'a Option<bool>,
+    resolved_package: NullableResolvedPackage<'a>,
+    extra_data: NullableMap<'a, serde_json::Value>,
+}
+
+impl Serialize for PublicDependency<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let dependency = self.0;
+        PublicDependencyFields {
+            purl: &dependency.purl,
+            extracted_requirement: &dependency.extracted_requirement,
+            scope: &dependency.scope,
+            is_runtime: &dependency.is_runtime,
+            is_optional: &dependency.is_optional,
+            is_pinned: &dependency.is_pinned,
+            is_direct: &dependency.is_direct,
+            resolved_package: NullableResolvedPackage(
+                dependency
+                    .resolved_package
+                    .as_ref()
+                    .map(|package| package.as_ref()),
+            ),
+            extra_data: NullableMap(&dependency.extra_data),
+        }
+        .serialize(serializer)
+    }
+}
+
+struct PublicFileReferences<'a>(&'a [OutputFileReference]);
+
+impl Serialize for PublicFileReferences<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for file_reference in self.0 {
+            seq.serialize_element(&PublicFileReference(file_reference))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicFileReference<'a>(&'a OutputFileReference);
+
+#[derive(Serialize)]
+struct PublicFileReferenceFields<'a> {
+    path: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+    sha1: &'a Option<String>,
+    md5: &'a Option<String>,
+    sha256: &'a Option<String>,
+    sha512: &'a Option<String>,
+    extra_data: NullableMap<'a, serde_json::Value>,
+}
+
+impl Serialize for PublicFileReference<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let file_reference = self.0;
+        PublicFileReferenceFields {
+            path: &file_reference.path,
+            size: file_reference.size,
+            sha1: &file_reference.sha1,
+            md5: &file_reference.md5,
+            sha256: &file_reference.sha256,
+            sha512: &file_reference.sha512,
+            extra_data: NullableMap(&file_reference.extra_data),
+        }
+        .serialize(serializer)
+    }
+}
+
+struct PublicFiles<'a>(&'a [OutputFileInfo]);
+
+impl Serialize for PublicFiles<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for file in self.0 {
+            seq.serialize_element(&PublicFileInfo(file))?;
+        }
+        seq.end()
+    }
+}
+
+struct PublicFileInfo<'a>(&'a OutputFileInfo);
+
+impl Serialize for PublicFileInfo<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let file = self.0;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("path", &file.path)?;
+        map.serialize_entry("type", &file.file_type)?;
+        map.serialize_entry("name", &file.name)?;
+        map.serialize_entry("base_name", &file.base_name)?;
+        map.serialize_entry("extension", &file.extension)?;
+        map.serialize_entry("size", &file.size)?;
+
+        if file.should_serialize_info_surface() {
+            map.serialize_entry("date", &file.date)?;
+            map.serialize_entry("sha1", &file.sha1)?;
+            map.serialize_entry("md5", &file.md5)?;
+            map.serialize_entry("sha256", &file.sha256)?;
+            map.serialize_entry("sha1_git", &file.sha1_git)?;
+            map.serialize_entry("mime_type", &file.mime_type)?;
+            map.serialize_entry("file_type", &file.file_type_label)?;
+            map.serialize_entry("programming_language", &file.programming_language)?;
+            map.serialize_entry("is_binary", &file.is_binary)?;
+            map.serialize_entry("is_text", &file.is_text)?;
+            map.serialize_entry("is_archive", &file.is_archive)?;
+            map.serialize_entry("is_media", &file.is_media)?;
+            map.serialize_entry("is_source", &file.is_source)?;
+            map.serialize_entry("is_script", &file.is_script)?;
+            map.serialize_entry("files_count", &file.files_count)?;
+            map.serialize_entry("dirs_count", &file.dirs_count)?;
+            map.serialize_entry("size_count", &file.size_count)?;
+        }
+
+        map.serialize_entry("package_data", &PublicPackageDataSeq(&file.package_data))?;
+        map.serialize_entry("detected_license_expression_spdx", &file.license_expression)?;
+        map.serialize_entry("license_detections", &file.license_detections)?;
+        if file.should_serialize_license_surface() {
+            map.serialize_entry("license_clues", &file.license_clues)?;
+        }
+        if file.percentage_of_license_text.is_some() {
+            map.serialize_entry(
+                "percentage_of_license_text",
+                &file.percentage_of_license_text,
+            )?;
+        }
+        map.serialize_entry("copyrights", &file.copyrights)?;
+        map.serialize_entry("holders", &file.holders)?;
+        map.serialize_entry("authors", &file.authors)?;
+        if !file.emails.is_empty() {
+            map.serialize_entry("emails", &file.emails)?;
+        }
+        map.serialize_entry("urls", &file.urls)?;
+        map.serialize_entry("for_packages", &file.for_packages)?;
+        map.serialize_entry("scan_errors", &file.scan_errors)?;
+        if file.license_policy.is_some() {
+            map.serialize_entry("license_policy", &file.license_policy)?;
+        }
+        if file.is_generated.is_some() {
+            map.serialize_entry("is_generated", &file.is_generated)?;
+        }
+        if file.source_count.is_some() {
+            map.serialize_entry("source_count", &file.source_count)?;
+        }
+        if file.is_legal {
+            map.serialize_entry("is_legal", &file.is_legal)?;
+        }
+        if file.is_manifest {
+            map.serialize_entry("is_manifest", &file.is_manifest)?;
+        }
+        if file.is_readme {
+            map.serialize_entry("is_readme", &file.is_readme)?;
+        }
+        if file.is_top_level {
+            map.serialize_entry("is_top_level", &file.is_top_level)?;
+        }
+        if file.is_key_file {
+            map.serialize_entry("is_key_file", &file.is_key_file)?;
+        }
+        if file.is_community {
+            map.serialize_entry("is_community", &file.is_community)?;
+        }
+        if !file.facets.is_empty() {
+            map.serialize_entry("facets", &file.facets)?;
+        }
+        if file.tallies.is_some() {
+            map.serialize_entry("tallies", &file.tallies)?;
+        }
+
+        map.end()
+    }
+}

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -272,6 +272,12 @@ pub(crate) fn write_spdx_rdf_xml(
 }
 
 fn primary_package_name(output: &Output, config: &OutputWriteConfig) -> String {
+    if output.packages.len() == 1
+        && let Some(name) = output.packages.first().and_then(|p| p.name.clone())
+    {
+        return sanitize_spdx_package_name(&name);
+    }
+
     if let Some(scanned_path) = &config.scanned_path {
         let path = PathBuf::from(scanned_path);
         if let Some(name) = path.file_name().and_then(|n| n.to_str())

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -83,7 +83,7 @@ pub struct OutputFileInfo {
 }
 
 impl OutputFileInfo {
-    fn should_serialize_info_surface(&self) -> bool {
+    pub(crate) fn should_serialize_info_surface(&self) -> bool {
         self.date.is_some()
             || self.sha1.is_some()
             || self.md5.is_some()
@@ -101,6 +101,13 @@ impl OutputFileInfo {
             || self.files_count.is_some()
             || self.dirs_count.is_some()
             || self.size_count.is_some()
+    }
+
+    pub(crate) fn should_serialize_license_surface(&self) -> bool {
+        self.license_expression.is_some()
+            || !self.license_detections.is_empty()
+            || !self.license_clues.is_empty()
+            || self.percentage_of_license_text.is_some()
     }
 }
 
@@ -144,7 +151,7 @@ impl Serialize for OutputFileInfo {
             &self.license_expression,
         )?;
         insert_json(&mut map, "license_detections", &self.license_detections)?;
-        if !self.license_clues.is_empty() {
+        if self.should_serialize_license_surface() {
             insert_json(&mut map, "license_clues", &self.license_clues)?;
         }
         if self.percentage_of_license_text.is_some() {

--- a/src/output_schema/file_reference.rs
+++ b/src/output_schema/file_reference.rs
@@ -8,13 +8,9 @@ pub struct OutputFileReference {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha1: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub md5: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha512: Option<String>,
     #[serde(default, serialize_with = "serialize_optional_map_as_object")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,

--- a/src/output_schema/output.rs
+++ b/src/output_schema/output.rs
@@ -24,7 +24,7 @@ pub struct Output {
     pub headers: Vec<OutputHeader>,
     pub packages: Vec<OutputPackage>,
     pub dependencies: Vec<OutputTopLevelDependency>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub license_detections: Vec<OutputTopLevelLicenseDetection>,
     pub files: Vec<OutputFileInfo>,
     pub license_references: Vec<OutputLicenseReference>,

--- a/src/output_schema/package.rs
+++ b/src/output_schema/package.rs
@@ -25,13 +25,9 @@ pub struct OutputPackage {
     pub homepage_url: Option<String>,
     pub download_url: Option<String>,
     pub size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha1: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub md5: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha512: Option<String>,
     pub bug_tracking_url: Option<String>,
     pub code_view_url: Option<String>,

--- a/src/output_schema/package_data.rs
+++ b/src/output_schema/package_data.rs
@@ -27,13 +27,9 @@ pub struct OutputPackageData {
     pub homepage_url: Option<String>,
     pub download_url: Option<String>,
     pub size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha1: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub md5: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha512: Option<String>,
     pub bug_tracking_url: Option<String>,
     pub code_view_url: Option<String>,

--- a/src/output_schema/resolved_package.rs
+++ b/src/output_schema/resolved_package.rs
@@ -27,13 +27,9 @@ pub struct OutputResolvedPackage {
     pub homepage_url: Option<String>,
     pub download_url: Option<String>,
     pub size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha1: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub md5: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sha512: Option<String>,
     pub bug_tracking_url: Option<String>,
     pub code_view_url: Option<String>,

--- a/testdata/output-formats/cyclonedx-expected.json
+++ b/testdata/output-formats/cyclonedx-expected.json
@@ -47,10 +47,6 @@
           "url": "https://registry.npmjs.org/npm/-/npm-2.13.5.tgz"
         },
         {
-          "type": "distribution",
-          "url": "https://registry.npmjs.org/npm/-/npm-2.13.5.tgz"
-        },
-        {
           "type": "website",
           "url": "https://docs.npmjs.com/"
         },

--- a/testdata/output-formats/html-templated-simple-expected.html
+++ b/testdata/output-formats/html-templated-simple-expected.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Custom Template</title>
+    <title>Provenant HTML Report</title>
     <style type="text/css">
       table {
         border-collapse: collapse;

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -341,6 +341,125 @@ fn test_json_contract_includes_facets_and_tallies_by_facet() {
 }
 
 #[test]
+fn test_json_contract_preserves_scancode_style_nulls_for_package_like_objects() {
+    let package_data = PackageData {
+        package_type: Some(PackageType::Npm),
+        name: Some("left-pad".to_string()),
+        version: Some("1.3.0".to_string()),
+        ..Default::default()
+    };
+    let package = Package::from_package_data(&package_data, "package.json".to_string());
+
+    let file = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "scan/package.json",
+        12,
+        EMPTY_SHA1,
+        vec![package_data.clone()],
+    );
+
+    let dependency = TopLevelDependency {
+        purl: Some("pkg:npm/dep@2.0.0".to_string()),
+        extracted_requirement: None,
+        scope: Some("dependencies".to_string()),
+        is_runtime: Some(true),
+        is_optional: Some(false),
+        is_pinned: Some(true),
+        is_direct: Some(true),
+        resolved_package: Some(Box::new(ResolvedPackage::new(
+            PackageType::Npm,
+            String::new(),
+            "dep".to_string(),
+            "2.0.0".to_string(),
+        ))),
+        extra_data: None,
+        dependency_uid: DependencyUid::from_raw(
+            "pkg:npm/dep@2.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
+        ),
+        for_package_uid: Some(PackageUid::from_raw(
+            "pkg:npm/left-pad@1.3.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
+        )),
+        datafile_path: "scan/package-lock.json".to_string(),
+        datasource_id: DatasourceId::NpmPackageLockJson,
+        namespace: None,
+    };
+
+    let output = sample_output_with_sections(1, 0, vec![package], vec![dependency], vec![file]);
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::Json)
+        .write(&schema_output, &mut bytes, &OutputWriteConfig::default())
+        .expect("json output should be generated");
+
+    let value: Value = serde_json::from_slice(&bytes).expect("json output should parse");
+
+    assert_eq!(value["license_detections"], Value::Array(vec![]));
+
+    let package = &value["packages"][0];
+    assert!(package.get("qualifiers").is_some());
+    assert!(package["qualifiers"].is_null());
+    assert!(package["extra_data"].is_null());
+    assert!(package["sha1"].is_null());
+    assert!(package["md5"].is_null());
+    assert!(package["sha256"].is_null());
+    assert!(package["sha512"].is_null());
+
+    let package_data = &value["files"][0]["package_data"][0];
+    assert!(package_data.get("qualifiers").is_some());
+    assert!(package_data["qualifiers"].is_null());
+    assert!(package_data["extra_data"].is_null());
+    assert!(package_data["sha1"].is_null());
+    assert!(package_data["md5"].is_null());
+    assert!(package_data["sha256"].is_null());
+    assert!(package_data["sha512"].is_null());
+
+    let dependency = &value["dependencies"][0];
+    assert!(dependency["extra_data"].is_null());
+
+    let resolved_package = &dependency["resolved_package"];
+    assert!(resolved_package.get("qualifiers").is_some());
+    assert!(resolved_package["qualifiers"].is_null());
+    assert!(resolved_package["extra_data"].is_null());
+    assert!(resolved_package["sha1"].is_null());
+    assert!(resolved_package["md5"].is_null());
+    assert!(resolved_package["sha256"].is_null());
+    assert!(resolved_package["sha512"].is_null());
+}
+
+#[test]
+fn test_json_contract_keeps_empty_license_clues_when_license_surface_active() {
+    let mut file = sample_plain_text_file(
+        "README",
+        "README",
+        "",
+        "scan/README",
+        10,
+        EMPTY_SHA1,
+        vec![],
+    );
+    file.percentage_of_license_text = Some(0.0);
+    file.license_expression = None;
+    file.license_detections = vec![];
+    file.license_clues = vec![];
+
+    let output = sample_output_with_sections(1, 0, vec![], vec![], vec![file]);
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::Json)
+        .write(&schema_output, &mut bytes, &OutputWriteConfig::default())
+        .expect("json output should be generated");
+
+    let value: Value = serde_json::from_slice(&bytes).expect("json output should parse");
+    assert_eq!(value["files"][0]["license_clues"], Value::Array(vec![]));
+    assert_eq!(
+        value["files"][0]["percentage_of_license_text"],
+        serde_json::json!(0.0)
+    );
+}
+
+#[test]
 fn test_json_lines_matches_local_fixture_file_semantics() {
     let fixture = fs::read_to_string("testdata/output-formats/json-simple-expected.jsonlines")
         .expect("json-lines fixture should be readable");


### PR DESCRIPTION
## Summary

- align the public JSON/YAML/JSONL writer contract with ScanCode-style output while moving the package-map normalization into streaming writer-only serializers
- allow multiple output flags in one CLI invocation and keep `--show-attribution` exclusive, matching both the intended UX and current ScanCode docs
- fix the HTML report title, dedupe duplicate CycloneDX external references, prefer a single detected package name in SPDX output, and refresh the affected regression tests and expected fixtures

## Issues

- Covers: public output UX drift from current ScanCode behavior and format anomalies found during end-to-end output verification

## Scope and exclusions

- Included: CLI output flag parsing, public output writers, HTML/SPDX/CycloneDX exporters, output docs, regression tests, and output-format fixtures
- Explicit exclusions: scanner/package-extraction timeout behavior on `testdata/integration/multi-parser`, which is a separate CLI smoke-target problem rather than an output-writer issue

## Follow-up work

- Created or intentionally deferred: investigate the manifest extraction timeouts seen on the `multi-parser` fixture when it is used as a CLI end-to-end scan target

## Expected-output fixture changes

- Files changed: `testdata/output-formats/cyclonedx-expected.json`, `testdata/output-formats/html-templated-simple-expected.html`
- Why the new expected output is correct: CycloneDX should not emit duplicate external references for the same URL/type pair, and the HTML report title should identify the actual report instead of reusing the custom-template label