### PR TITLE
fix(parsers): interpolate package name in opam repository_homepage_url

### DIFF
--- a/src/parsers/opam.rs
+++ b/src/parsers/opam.rs
@@ -188,7 +188,7 @@ fn build_opam_urls(
 ) -> (Option<String>, Option<String>, Option<String>) {
     let repository_homepage_url = name
         .as_ref()
-        .map(|_| "{https://opam.ocaml.org/packages}/{name}".to_string());
+        .map(|n| format!("https://opam.ocaml.org/packages/{}", n));
 
     let api_data_url = match (name, version) {
         (Some(n), Some(v)) => Some(format!(

--- a/testdata/opam/sample2/output.opam.expected
+++ b/testdata/opam/sample2/output.opam.expected
@@ -119,7 +119,7 @@
         "extra_data": {}
       }
     ],
-    "repository_homepage_url": "{https://opam.ocaml.org/packages}/{name}",
+    "repository_homepage_url": "https://opam.ocaml.org/packages/js_of_ocaml",
     "repository_download_url": null,
     "api_data_url": null,
     "datasource_id": "opam_file",

--- a/testdata/opam/sample5/output.opam.expected
+++ b/testdata/opam/sample5/output.opam.expected
@@ -131,7 +131,7 @@
         "extra_data": {}
       }
     ],
-    "repository_homepage_url": "{https://opam.ocaml.org/packages}/{name}",
+    "repository_homepage_url": "https://opam.ocaml.org/packages/bap-elf",
     "repository_download_url": null,
     "api_data_url": "https://github.com/ocaml/opam-repository/blob/master/packages/bap-elf/bap-elf.1.0.0/opam",
     "datasource_id": "opam_file",


### PR DESCRIPTION
## Summary

- Fix bug in `build_opam_urls()` where `repository_homepage_url` produced the literal string `"{https://opam.ocaml.org/packages}/{name}"` instead of interpolating the package name via `format!()`.

## Issues

- Closes:

## Scope and exclusions

- Included: `src/parsers/opam.rs` fix and golden expected file updates for sample2 and sample5
- Explicit exclusions: URL newtype (item #6 in newtype doc) — deferred; this fix is independent

## Intentional differences from Python

- The Python reference also produces the same broken URL string, so this is a bug fix beyond parity.

## Follow-up work

- Created or intentionally deferred: URL newtype (#6) deferred per investigation — ~40 fields, overwhelmingly passthrough, moderate category-error risk, high migration cost

## Expected-output fixture changes

- Files changed: `testdata/opam/sample2/output.opam.expected`, `testdata/opam/sample5/output.opam.expected`
- Why the new expected output is correct: The previous expected values contained the broken literal string `"{https://opam.ocaml.org/packages}/{name}"`. The fix interpolates the package name correctly, producing `"https://opam.ocaml.org/packages/js_of_ocaml"` and `"https://opam.ocaml.org/packages/bap-elf"` respectively.