### PR TITLE
ci: shorten sharded test check labels

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -203,8 +203,6 @@ jobs:
             shared_key: rust-scan-integration-tests-release-contracts
           - shard: integration
             shared_key: rust-scan-integration-tests-release-integration
-          - shard: cli
-            shared_key: rust-scan-integration-tests-release-cli
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -235,11 +233,11 @@ jobs:
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite
-        if: matrix.shard == 'cli'
+        if: matrix.shard == 'integration'
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'cli'
+        if: matrix.shard == 'integration'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -237,7 +237,7 @@ jobs:
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'integration'
+        if: matrix.shard == 'contracts'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,8 +190,8 @@ jobs:
       - name: Build and run Intel macOS CLI smoke check
         run: cargo run --quiet --locked --bin provenant -- --show-attribution > /dev/null
 
-  rust-scan-integration-tests:
-    name: Scan and Integration Tests (${{ matrix.shard }})
+  rust-contract-integration-tests:
+    name: Contract and Integration Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
@@ -199,10 +199,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: parser-scan-contracts
-            shared_key: rust-scan-integration-tests-release-parser-scan-contracts
-          - shard: integration-suites
-            shared_key: rust-scan-integration-tests-release-integration-suites
+          - shard: contracts
+            shared_key: rust-scan-integration-tests-release-contracts
+          - shard: system-integration
+            shared_key: rust-scan-integration-tests-release-system-integration
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -221,23 +221,23 @@ jobs:
           shared-key: ${{ matrix.shared_key }}
 
       - name: Run parser-local scanner/assembly contract tests
-        if: matrix.shard == 'parser-scan-contracts'
+        if: matrix.shard == 'contracts'
         run: "cargo test --lib --release --verbose _scan_test::"
 
       - name: Run scanner integration suite
-        if: matrix.shard == 'integration-suites'
+        if: matrix.shard == 'system-integration'
         run: cargo test --test scanner_integration --release --verbose
 
       - name: Run scanner copyright/credits integration suite
-        if: matrix.shard == 'integration-suites'
+        if: matrix.shard == 'system-integration'
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite
-        if: matrix.shard == 'integration-suites'
+        if: matrix.shard == 'contracts'
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'integration-suites'
+        if: matrix.shard == 'contracts'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,9 +200,9 @@ jobs:
       matrix:
         include:
           - shard: contracts
-            shared_key: rust-scan-integration-tests-release-parser-scan-contracts
+            shared_key: rust-scan-integration-tests-release-contracts
           - shard: integration
-            shared_key: rust-scan-integration-tests-release-integration-suites
+            shared_key: rust-scan-integration-tests-release-integration
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,9 +200,9 @@ jobs:
       matrix:
         include:
           - shard: contracts
-            shared_key: rust-scan-integration-tests-release-contracts
+            shared_key: rust-scan-integration-tests-release-parser-scan-contracts
           - shard: integration
-            shared_key: rust-scan-integration-tests-release-integration
+            shared_key: rust-scan-integration-tests-release-integration-suites
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -233,11 +233,11 @@ jobs:
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite
-        if: matrix.shard == 'contracts'
+        if: matrix.shard == 'integration'
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'contracts'
+        if: matrix.shard == 'integration'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Quality Checks
+name: CI
 
 on:
   push:
@@ -190,8 +190,8 @@ jobs:
       - name: Build and run Intel macOS CLI smoke check
         run: cargo run --quiet --locked --bin provenant -- --show-attribution > /dev/null
 
-  rust-contract-integration-tests:
-    name: Contract and Integration Tests (${{ matrix.shard }})
+  rust-sharded-tests:
+    name: Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
@@ -201,8 +201,8 @@ jobs:
         include:
           - shard: contracts
             shared_key: rust-scan-integration-tests-release-contracts
-          - shard: system-integration
-            shared_key: rust-scan-integration-tests-release-system-integration
+          - shard: integration
+            shared_key: rust-scan-integration-tests-release-integration
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -225,11 +225,11 @@ jobs:
         run: "cargo test --lib --release --verbose _scan_test::"
 
       - name: Run scanner integration suite
-        if: matrix.shard == 'system-integration'
+        if: matrix.shard == 'integration'
         run: cargo test --test scanner_integration --release --verbose
 
       - name: Run scanner copyright/credits integration suite
-        if: matrix.shard == 'system-integration'
+        if: matrix.shard == 'integration'
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -203,6 +203,8 @@ jobs:
             shared_key: rust-scan-integration-tests-release-contracts
           - shard: integration
             shared_key: rust-scan-integration-tests-release-integration
+          - shard: cli
+            shared_key: rust-scan-integration-tests-release-cli
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -233,11 +235,11 @@ jobs:
         run: cargo test --test scanner_copyright_credits --release --verbose
 
       - name: Run progress CLI integration suite
-        if: matrix.shard == 'integration'
+        if: matrix.shard == 'cli'
         run: cargo test --test progress_cli_integration --release --verbose
 
       - name: Run output contract fixture suite
-        if: matrix.shard == 'contracts'
+        if: matrix.shard == 'cli'
         run: cargo test --test output_format_golden --release --verbose
 
   golden-tests:


### PR DESCRIPTION
## Summary

- shorten the GitHub checks UI labels by renaming the workflow to `CI`, the sharded test job to `Tests (${{ matrix.shard }})`, and the shard identifiers to `contracts` and `integration`
- rename the workflow job id to `rust-sharded-tests` so the internal identifier matches the shorter check labeling scheme
- keep the original two-lane runtime grouping after timing validation showed that splitting out the CLI and output suites only relocated the same compile wall instead of reducing the longest lane

## Scope and exclusions

- Included: `.github/workflows/check.yml` naming cleanup for the workflow, sharded test job, job id, shard identifiers, and aligned cache-key names
- Explicit exclusions: no Rust test code changed, and no effective runtime reshuffle remains versus `main`; the integration shard still runs the same four top-level suites together

## Follow-up work

- Created or intentionally deferred: if we want a real CI runtime reduction later, the next investigation should target compile-reuse and binary test build cost rather than more shard reshuffling