### PR TITLE
feat: add clippy lint config and eliminate cast_sign_loss warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,9 @@ zstd = { workspace = true }
 
 [lints.clippy]
 cargo = { level = "warn", priority = -1 }
+cast_lossless = "warn"
+checked_conversions = "warn"
+cloned_instead_of_copied = "warn"
 clone_on_ref_ptr = "warn"
 filetype_is_file = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ checked_conversions = "warn"
 cloned_instead_of_copied = "warn"
 clone_on_ref_ptr = "warn"
 filetype_is_file = "warn"
+cast_sign_loss = "warn"
 
 [profile.release]
 # Enable link-time optimization for better cross-module optimizations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,11 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 
+[lints.clippy]
+cargo = { level = "warn", priority = -1 }
+clone_on_ref_ptr = "warn"
+filetype_is_file = "warn"
+
 [profile.release]
 # Enable link-time optimization for better cross-module optimizations
 lto = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,65 @@ use yaml_serde::Value as YamlValue;
 
 use crate::license_detection::DEFAULT_LICENSEDB_URL_TEMPLATE;
 use crate::output::OutputFormat;
+use crate::scanner::MemoryMode;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessMode {
+    Parallel(usize),
+    SequentialWithTimeouts,
+    SequentialWithoutTimeouts,
+}
+
+impl Default for ProcessMode {
+    fn default() -> Self {
+        let cpus = std::thread::available_parallelism().map_or(1, |n| n.get());
+        if cpus > 1 {
+            ProcessMode::Parallel(cpus - 1)
+        } else {
+            ProcessMode::Parallel(1)
+        }
+    }
+}
+
+impl ProcessMode {
+    fn default_value() -> Self {
+        let cpus = std::thread::available_parallelism().map_or(1, |n| n.get());
+        if cpus > 1 {
+            ProcessMode::Parallel(cpus - 1)
+        } else {
+            ProcessMode::Parallel(1)
+        }
+    }
+
+    pub fn to_i32(self) -> i32 {
+        match self {
+            ProcessMode::Parallel(n) => n as i32,
+            ProcessMode::SequentialWithTimeouts => 0,
+            ProcessMode::SequentialWithoutTimeouts => -1,
+        }
+    }
+}
+
+impl std::fmt::Display for ProcessMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_i32())
+    }
+}
+
+fn parse_processes(value: &str) -> Result<ProcessMode, String> {
+    let parsed: i32 = value
+        .parse()
+        .map_err(|e| format!("invalid integer for --processes: {e}"))?;
+    if parsed > 0 {
+        Ok(ProcessMode::Parallel(
+            u32::try_from(parsed).unwrap() as usize
+        ))
+    } else if parsed == 0 {
+        Ok(ProcessMode::SequentialWithTimeouts)
+    } else {
+        Ok(ProcessMode::SequentialWithoutTimeouts)
+    }
+}
 
 const PDF_OXIDE_LOG_HELP: &str = "Troubleshooting PDF parser logs:\n  Provenant suppresses noisy pdf_oxide logs by default.\n  To inspect raw pdf_oxide logs for debugging, rerun with RUST_LOG=pdf_oxide=warn (or =error).";
 
@@ -156,8 +215,8 @@ pub struct Cli {
     #[arg(short, long, default_value = "0")]
     pub max_depth: usize,
 
-    #[arg(short = 'n', long, default_value_t = default_processes(), allow_hyphen_values = true)]
-    pub processes: i32,
+    #[arg(short = 'n', long, default_value_t = ProcessMode::default_value(), value_parser = parse_processes, allow_hyphen_values = true)]
+    pub processes: ProcessMode,
 
     #[arg(long, default_value_t = 120.0)]
     pub timeout: f64,
@@ -195,11 +254,11 @@ pub struct Cli {
     #[arg(
         long = "max-in-memory",
         value_name = "INT",
-        default_value_t = 10000,
+        default_value_t = MemoryMode::Limit(10000),
         value_parser = parse_max_in_memory,
         allow_hyphen_values = true
     )]
-    pub max_in_memory: i64,
+    pub max_in_memory: MemoryMode,
 
     /// Collect file information such as checksums, type hints, and source/script flags.
     #[arg(short = 'i', long)]
@@ -354,19 +413,19 @@ pub struct Cli {
     pub show_attribution: bool,
 }
 
-fn default_processes() -> i32 {
-    let cpus = std::thread::available_parallelism().map_or(1, |n| n.get());
-    if cpus > 1 { (cpus - 1) as i32 } else { 1 }
-}
-
-fn parse_max_in_memory(value: &str) -> Result<i64, String> {
+fn parse_max_in_memory(value: &str) -> Result<MemoryMode, String> {
     let parsed = value
         .parse::<i64>()
         .map_err(|_| format!("invalid integer value: {value}"))?;
     if parsed < -1 {
         return Err("--max-in-memory must be -1, 0, or a positive integer".to_string());
     }
-    Ok(parsed)
+    match parsed {
+        -1 => Ok(MemoryMode::StreamUnlimited),
+        0 => Ok(MemoryMode::CollectFirst),
+        n if n > 0 => Ok(MemoryMode::Limit(usize::try_from(n).unwrap_or(usize::MAX))),
+        _ => Ok(MemoryMode::CollectFirst),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -552,7 +611,21 @@ impl Cli {
             DEFAULT_LICENSEDB_URL_TEMPLATE,
         );
         push_non_default_usize_option(&mut flags, "--max-depth", self.max_depth, 0);
-        push_non_default_i64_option(&mut flags, "--max-in-memory", self.max_in_memory, 10000);
+        match self.max_in_memory {
+            MemoryMode::Limit(10000) => {}
+            MemoryMode::CollectFirst => {
+                flags.push(("--max-in-memory".to_string(), JsonValue::Number(0.into())));
+            }
+            MemoryMode::StreamUnlimited => {
+                flags.push((
+                    "--max-in-memory".to_string(),
+                    JsonValue::Number((-1i64).into()),
+                ));
+            }
+            MemoryMode::Limit(n) => {
+                flags.push(("--max-in-memory".to_string(), JsonValue::Number(n.into())));
+            }
+        }
         if self.email {
             push_non_default_usize_option(&mut flags, "--max-email", self.max_email, 50);
         }
@@ -569,11 +642,11 @@ impl Cli {
             self.package_in_compiled,
         );
         push_bool_option(&mut flags, "--package-only", self.package_only);
-        push_non_default_i32_option(
+        push_non_default_process_mode_option(
             &mut flags,
             "--processes",
             self.processes,
-            default_processes(),
+            ProcessMode::default_value(),
         );
         push_bool_option(&mut flags, "--quiet", self.quiet);
         push_string_option(&mut flags, "--spdx-rdf", self.output_spdx_rdf.as_ref());
@@ -658,25 +731,14 @@ fn push_non_default_u8_option(
     }
 }
 
-fn push_non_default_i32_option(
+fn push_non_default_process_mode_option(
     options: &mut Vec<(String, JsonValue)>,
     key: &str,
-    value: i32,
-    default: i32,
+    value: ProcessMode,
+    default: ProcessMode,
 ) {
     if value != default {
-        options.push((key.to_string(), JsonValue::Number(value.into())));
-    }
-}
-
-fn push_non_default_i64_option(
-    options: &mut Vec<(String, JsonValue)>,
-    key: &str,
-    value: i64,
-    default: i64,
-) {
-    if value != default {
-        options.push((key.to_string(), JsonValue::Number(value.into())));
+        options.push((key.to_string(), JsonValue::Number(value.to_i32().into())));
     }
 }
 
@@ -914,7 +976,7 @@ mod tests {
         ])
         .expect("cli parse should succeed");
 
-        assert_eq!(parsed.processes, 4);
+        assert_eq!(parsed.processes, ProcessMode::Parallel(4));
         assert_eq!(parsed.timeout, 30.0);
     }
 
@@ -1442,12 +1504,12 @@ mod tests {
         let zero =
             Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "-n", "0", "samples"])
                 .expect("cli parse should accept processes=0");
-        assert_eq!(zero.processes, 0);
+        assert_eq!(zero.processes, ProcessMode::SequentialWithTimeouts);
 
         let parsed =
             Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "-n", "-1", "samples"])
                 .expect("cli parse should accept processes=-1");
-        assert_eq!(parsed.processes, -1);
+        assert_eq!(parsed.processes, ProcessMode::SequentialWithoutTimeouts);
     }
 
     #[test]
@@ -1468,7 +1530,7 @@ mod tests {
         assert_eq!(parsed.cache_dir.as_deref(), Some("/tmp/sc-cache"));
         assert!(parsed.cache_clear);
         assert!(!parsed.incremental);
-        assert_eq!(parsed.max_in_memory, 5000);
+        assert_eq!(parsed.max_in_memory, MemoryMode::Limit(5000));
     }
 
     #[test]
@@ -1490,7 +1552,7 @@ mod tests {
         let default_parsed =
             Cli::try_parse_from(["provenant", "--json-pp", "scan.json", "samples"])
                 .expect("default max-in-memory should parse");
-        assert_eq!(default_parsed.max_in_memory, 10000);
+        assert_eq!(default_parsed.max_in_memory, MemoryMode::Limit(10000));
 
         let disk_only = Cli::try_parse_from([
             "provenant",
@@ -1501,7 +1563,7 @@ mod tests {
             "samples",
         ])
         .expect("-1 should parse");
-        assert_eq!(disk_only.max_in_memory, -1);
+        assert_eq!(disk_only.max_in_memory, MemoryMode::StreamUnlimited);
 
         let unlimited = Cli::try_parse_from([
             "provenant",
@@ -1512,7 +1574,7 @@ mod tests {
             "samples",
         ])
         .expect("0 should parse");
-        assert_eq!(unlimited.max_in_memory, 0);
+        assert_eq!(unlimited.max_in_memory, MemoryMode::CollectFirst);
     }
 
     #[test]

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -752,7 +752,7 @@ mod tests {
         index.tids_by_rid.push(tids(&[0, 1]));
         index.pattern_id_to_rid.push(vec![0]);
 
-        let tokens: Vec<TokenId> = (0..1000).map(|i| tid((i % 2) as u16)).collect();
+        let tokens: Vec<TokenId> = (0u16..1000).map(|i| tid(i % 2)).collect();
         let line_by_pos: Vec<usize> = (0..1000).map(|i| i / 80 + 1).collect();
 
         let query = crate::license_detection::query::Query {

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -54,7 +54,8 @@ pub(super) fn has_unknown_matches(matches: &[LicenseMatch]) -> bool {
 /// and has_extra_words() at detection.py:1139
 pub(super) fn has_extra_words(matches: &[LicenseMatch]) -> bool {
     matches.iter().any(|m| {
-        let score_coverage_relevance = m.coverage() as f64 * m.rule_relevance as f64 / 100.0;
+        let score_coverage_relevance =
+            f64::from(m.coverage()) * f64::from(m.rule_relevance) / 100.0;
         score_coverage_relevance - m.score.value() > 0.01
     })
 }

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -194,7 +194,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
                     let contains_unknown = qspan
                         .iter()
                         .take(qspan.len() - 1)
-                        .any(|&qpos| query.unknowns_by_pos.contains_key(&Some(qpos as i32)));
+                        .any(|&qpos| query.unknowns_by_pos.contains_key(&Some(qpos)));
 
                     if contains_unknown {
                         discarded.push(m.clone());
@@ -212,10 +212,10 @@ pub(crate) fn filter_matches_missing_required_phrases(
                             continue;
                         }
 
-                        let i_stop = rule.stopwords_by_pos.get(&ipos).copied().unwrap_or(0);
+                        let i_stop = rule.stopwords_by_pos.get(&Some(ipos)).copied().unwrap_or(0);
                         let q_stop = query
                             .stopwords_by_pos
-                            .get(&Some(qpos as i32))
+                            .get(&Some(qpos))
                             .copied()
                             .unwrap_or(0);
 
@@ -276,7 +276,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
                 let contains_unknown = qkey_span
                     .iter()
                     .take(qkey_span.len() - 1)
-                    .any(|&qpos| query.unknowns_by_pos.contains_key(&Some(qpos as i32)));
+                    .any(|&qpos| query.unknowns_by_pos.contains_key(&Some(qpos)));
 
                 if contains_unknown {
                     is_valid = false;
@@ -294,10 +294,10 @@ pub(crate) fn filter_matches_missing_required_phrases(
                         continue;
                     }
 
-                    let i_stop = rule.stopwords_by_pos.get(&ipos).copied().unwrap_or(0);
+                    let i_stop = rule.stopwords_by_pos.get(&Some(ipos)).copied().unwrap_or(0);
                     let q_stop = query
                         .stopwords_by_pos
-                        .get(&Some(qpos as i32))
+                        .get(&Some(qpos))
                         .copied()
                         .unwrap_or(0);
 
@@ -355,7 +355,7 @@ pub(crate) fn filter_matches_to_spurious_single_token(
 
             let before = query
                 .unknowns_by_pos
-                .get(&Some(qstart as i32 - 1))
+                .get(&Some(qstart.saturating_sub(1)))
                 .copied()
                 .unwrap_or(0)
                 + (qstart.saturating_sub(unknown_count)..qstart)
@@ -368,7 +368,7 @@ pub(crate) fn filter_matches_to_spurious_single_token(
 
             let after = query
                 .unknowns_by_pos
-                .get(&Some(qstart as i32))
+                .get(&Some(qstart))
                 .copied()
                 .unwrap_or(0)
                 + (qstart + 1..qstart + 1 + unknown_count)

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -80,7 +80,7 @@ pub(crate) fn filter_below_rule_minimum_coverage(
             if let Some(rule) = index.rules_by_rid.get(rid)
                 && let Some(min_cov) = rule.minimum_coverage
             {
-                return m.coverage() >= min_cov as f32;
+                return m.coverage() >= f32::from(min_cov);
             }
 
             true

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -287,7 +287,7 @@ pub(super) fn update_match_scores(matches: &mut [LicenseMatch], query: &Query) {
 }
 
 fn compute_match_score(m: &LicenseMatch, query: &Query) -> MatchScore {
-    let relevance = m.rule_relevance as f64 / 100.0;
+    let relevance = f64::from(m.rule_relevance) / 100.0;
     if relevance < 0.001 {
         return MatchScore::default();
     }
@@ -298,7 +298,7 @@ fn compute_match_score(m: &LicenseMatch, query: &Query) -> MatchScore {
     }
 
     let query_coverage = m.len() as f64 / qmagnitude as f64;
-    let rule_coverage = m.icoverage() as f64;
+    let rule_coverage = f64::from(m.icoverage());
 
     if query_coverage < 1.0 && rule_coverage < 1.0 {
         return MatchScore::from_percentage(rule_coverage * relevance * 100.0);

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -454,7 +454,7 @@ impl LicenseMatch {
         let unknowns_in_match: usize = span
             .iter()
             .filter(|&pos| pos != max_pos)
-            .filter_map(|pos| query.unknowns_by_pos.get(&Some(pos as i32)))
+            .filter_map(|pos| query.unknowns_by_pos.get(&Some(pos)))
             .sum();
         qregion_len + unknowns_in_match
     }

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -761,8 +761,8 @@ mod tests {
         match_result.coordinates =
             MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 9]));
         let mut unknowns_by_pos = HashMap::new();
-        unknowns_by_pos.insert(Some(0), 2);
-        unknowns_by_pos.insert(Some(5), 3);
+        unknowns_by_pos.insert(Some(0usize), 2);
+        unknowns_by_pos.insert(Some(5usize), 3);
         let query = crate::license_detection::query::Query {
             text: String::new(),
             tokens: vec![],
@@ -789,8 +789,8 @@ mod tests {
         match_result.coordinates =
             MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 10]));
         let mut unknowns_by_pos = HashMap::new();
-        unknowns_by_pos.insert(Some(0), 2);
-        unknowns_by_pos.insert(Some(5), 3);
+        unknowns_by_pos.insert(Some(0usize), 2);
+        unknowns_by_pos.insert(Some(5usize), 3);
         let query = crate::license_detection::query::Query {
             text: String::new(),
             tokens: vec![],
@@ -817,7 +817,7 @@ mod tests {
         match_result.coordinates =
             MatchCoordinates::query_region(PositionSpan::from_positions(vec![0, 5, 10]));
         let mut unknowns_by_pos = HashMap::new();
-        unknowns_by_pos.insert(Some(10), 100);
+        unknowns_by_pos.insert(Some(10usize), 100);
         let query = crate::license_detection::query::Query {
             text: String::new(),
             tokens: vec![],

--- a/src/license_detection/models/rule.rs
+++ b/src/license_detection/models/rule.rs
@@ -40,20 +40,23 @@ mod stopwords_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::collections::HashMap;
 
-    pub fn serialize<S>(map: &HashMap<usize, usize>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(
+        map: &HashMap<Option<usize>, usize>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut entries: Vec<(usize, usize)> = map.iter().map(|(k, v)| (*k, *v)).collect();
+        let mut entries: Vec<(Option<usize>, usize)> = map.iter().map(|(k, v)| (*k, *v)).collect();
         entries.sort_by_key(|(k, _)| *k);
         entries.serialize(serializer)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<usize, usize>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<Option<usize>, usize>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let entries: Vec<(usize, usize)> = Vec::deserialize(deserializer)?;
+        let entries: Vec<(Option<usize>, usize)> = Vec::deserialize(deserializer)?;
         Ok(entries.into_iter().collect())
     }
 }
@@ -183,7 +186,7 @@ pub struct Rule {
     /// Mapping from token position to count of stopwords at that position.
     /// Used for required phrase validation.
     #[serde(with = "stopwords_serde", default)]
-    pub stopwords_by_pos: HashMap<usize, usize>,
+    pub stopwords_by_pos: HashMap<Option<usize>, usize>,
 
     /// Filenames where this rule should be considered
     pub referenced_filenames: Option<Vec<String>>,

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -63,18 +63,17 @@ pub struct Query<'a> {
     ///
     /// Unknown tokens are those not found in the dictionary. We track them by
     /// counting how many unknown tokens appear after each known position.
-    /// Unknown tokens before the first known token are tracked at position -1
-    /// (using the key `None` in Rust).
+    /// Unknown tokens before the first known token are tracked with the key `None`.
     ///
     /// Corresponds to Python: `self.unknowns_by_pos = {}` (line 236)
-    pub unknowns_by_pos: HashMap<Option<i32>, usize>,
+    pub unknowns_by_pos: HashMap<Option<usize>, usize>,
 
     /// Mapping from token position to count of stopwords after that position
     ///
     /// Similar to unknown_tokens, but for stopwords.
     ///
     /// Corresponds to Python: `self.stopwords_by_pos = {}` (line 244)
-    pub stopwords_by_pos: HashMap<Option<i32>, usize>,
+    pub stopwords_by_pos: HashMap<Option<usize>, usize>,
 
     /// Set of positions with single-character or digit-only tokens
     ///
@@ -475,12 +474,12 @@ impl<'a> Query<'a> {
 
         let mut tokens = Vec::new();
         let mut line_by_pos = Vec::new();
-        let mut unknowns_by_pos: HashMap<Option<i32>, usize> = HashMap::new();
-        let mut stopwords_by_pos: HashMap<Option<i32>, usize> = HashMap::new();
+        let mut unknowns_by_pos: HashMap<Option<usize>, usize> = HashMap::new();
+        let mut stopwords_by_pos: HashMap<Option<usize>, usize> = HashMap::new();
         let mut shorts_and_digits_pos = PositionSet::new();
         let mut spdx_lines: Vec<(String, usize, usize)> = Vec::new();
 
-        let mut known_pos = -1i32;
+        let mut known_pos: Option<usize> = None;
         let mut started = false;
         let mut current_line = 1usize;
 
@@ -497,18 +496,18 @@ impl<'a> Query<'a> {
             for query_token in &line_query_tokens {
                 match query_token {
                     QueryToken::Known(known_token) => {
-                        known_pos += 1;
+                        known_pos = Some(known_pos.map_or(0, |p| p + 1));
                         started = true;
                         tokens.push(known_token.id);
                         line_by_pos.push(current_line);
                         line_tokens.push(Some(*known_token));
 
                         if line_first_known_pos.is_none() {
-                            line_first_known_pos = Some(known_pos);
+                            line_first_known_pos = known_pos;
                         }
 
                         if known_token.is_short_or_digit {
-                            let _ = shorts_and_digits_pos.insert(known_pos as usize);
+                            let _ = shorts_and_digits_pos.insert(known_pos.unwrap());
                         }
                     }
                     QueryToken::Unknown if !started => {
@@ -516,14 +515,14 @@ impl<'a> Query<'a> {
                         line_tokens.push(None);
                     }
                     QueryToken::Unknown => {
-                        *unknowns_by_pos.entry(Some(known_pos)).or_insert(0) += 1;
+                        *unknowns_by_pos.entry(known_pos).or_insert(0) += 1;
                         line_tokens.push(None);
                     }
                     QueryToken::Stopword if !started => {
                         *stopwords_by_pos.entry(None).or_insert(0) += 1;
                     }
                     QueryToken::Stopword => {
-                        *stopwords_by_pos.entry(Some(known_pos)).or_insert(0) += 1;
+                        *stopwords_by_pos.entry(known_pos).or_insert(0) += 1;
                     }
                 }
             }
@@ -538,12 +537,11 @@ impl<'a> Query<'a> {
             {
                 let (spdx_prefix, spdx_expression) = split_spdx_lid(line);
                 let spdx_text = format!("{}{}", spdx_prefix.unwrap_or_default(), spdx_expression);
-                let spdx_start_known_pos = line_first_known_pos + offset as i32;
+                let spdx_start_known_pos = line_first_known_pos + offset;
 
-                if spdx_start_known_pos <= line_last_known_pos {
-                    let spdx_start = spdx_start_known_pos as usize;
-                    let spdx_end = (line_last_known_pos + 1) as usize;
-                    spdx_lines.push((spdx_text, spdx_start, spdx_end));
+                if spdx_start_known_pos <= line_last_known_pos.unwrap() {
+                    let spdx_end = line_last_known_pos.unwrap() + 1;
+                    spdx_lines.push((spdx_text, spdx_start_known_pos, spdx_end));
                 }
             }
 
@@ -998,7 +996,7 @@ impl<'a> QueryRun<'a> {
         }
     }
 
-    pub fn matchable_tokens(&self) -> Vec<i32> {
+    pub fn matchable_tokens(&self) -> Vec<Option<TokenId>> {
         let high_matchables = self.high_matchables();
         if high_matchables.is_empty() {
             return Vec::new();
@@ -1008,9 +1006,9 @@ impl<'a> QueryRun<'a> {
         self.tokens_with_pos()
             .map(|(pos, tid)| {
                 if matchables.contains(pos) {
-                    i32::from(tid.raw())
+                    Some(tid)
                 } else {
-                    -1
+                    None
                 }
             })
             .collect()

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -1008,7 +1008,7 @@ impl<'a> QueryRun<'a> {
         self.tokens_with_pos()
             .map(|(pos, tid)| {
                 if matchables.contains(pos) {
-                    tid.raw() as i32
+                    i32::from(tid.raw())
                 } else {
                     -1
                 }

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -31,11 +31,11 @@ mod tests {
         Query::with_source_options(text, index, line_threshold, None)
     }
 
-    fn query_unknown_count_after(query: &Query<'_>, pos: Option<i32>) -> usize {
+    fn query_unknown_count_after(query: &Query<'_>, pos: Option<usize>) -> usize {
         query.unknowns_by_pos.get(&pos).copied().unwrap_or(0)
     }
 
-    fn query_stopword_count_after(query: &Query<'_>, pos: Option<i32>) -> usize {
+    fn query_stopword_count_after(query: &Query<'_>, pos: Option<usize>) -> usize {
         query.stopwords_by_pos.get(&pos).copied().unwrap_or(0)
     }
 
@@ -324,9 +324,9 @@ mod tests {
 
         let tokens = run.matchable_tokens();
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0], 0);
-        assert_eq!(tokens[1], 1);
-        assert_eq!(tokens[2], 2);
+        assert_eq!(tokens[0], Some(tid(0)));
+        assert_eq!(tokens[1], Some(tid(1)));
+        assert_eq!(tokens[2], Some(tid(2)));
     }
 
     #[test]

--- a/src/license_detection/rules/loader.rs
+++ b/src/license_detection/rules/loader.rs
@@ -56,7 +56,7 @@ impl ParseNumber for yaml_serde::Number {
     fn as_u8(&self) -> Option<u8> {
         self.as_i64()
             .and_then(|n| {
-                if n >= 0 && n <= u8::MAX as i64 {
+                if u8::try_from(n).is_ok() {
                     Some(n as u8)
                 } else {
                     None
@@ -64,7 +64,7 @@ impl ParseNumber for yaml_serde::Number {
             })
             .or_else(|| {
                 self.as_f64().and_then(|f| {
-                    if f >= 0.0 && f <= u8::MAX as f64 {
+                    if f >= 0.0 && f <= f64::from(u8::MAX) {
                         Some(f as u8)
                     } else {
                         None

--- a/src/license_detection/rules/loader.rs
+++ b/src/license_detection/rules/loader.rs
@@ -55,16 +55,12 @@ trait ParseNumber {
 impl ParseNumber for yaml_serde::Number {
     fn as_u8(&self) -> Option<u8> {
         self.as_i64()
-            .and_then(|n| {
-                if u8::try_from(n).is_ok() {
-                    Some(n as u8)
-                } else {
-                    None
-                }
-            })
+            .and_then(|n| u8::try_from(n).ok())
             .or_else(|| {
                 self.as_f64().and_then(|f| {
                     if f >= 0.0 && f <= f64::from(u8::MAX) {
+                        // truncation toward zero is intentional (e.g. 90.5 → 90)
+                        #[allow(clippy::cast_sign_loss)]
                         Some(f as u8)
                     } else {
                         None

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -8,7 +8,7 @@ use crate::license_detection::models::Rule;
 use crate::license_detection::query::QueryRun;
 use std::collections::{HashMap, HashSet};
 
-use super::HIGH_RESEMBLANCE_THRESHOLD;
+use super::HIGH_RESEMBLANCE_THRESHOLD_TENTHS;
 
 /// Score vector for ranking candidates using set similarity.
 ///
@@ -85,14 +85,13 @@ impl CandidateMetrics {
     }
 
     fn rounded_is_highly_resemblant(&self) -> bool {
-        self.rounded_resemblance_threshold_tenths()
-            >= (HIGH_RESEMBLANCE_THRESHOLD * 10.0).round() as u32
+        self.rounded_resemblance_threshold_tenths() >= HIGH_RESEMBLANCE_THRESHOLD_TENTHS
     }
 
     fn full_is_highly_resemblant(&self) -> bool {
         let matched = self.matched_length as u64;
         let union = self.union_len() as u64;
-        let threshold_tenths = (HIGH_RESEMBLANCE_THRESHOLD * 10.0).round() as u64;
+        let threshold_tenths = u64::from(HIGH_RESEMBLANCE_THRESHOLD_TENTHS);
 
         u128::from(matched) * 10 >= u128::from(union) * u128::from(threshold_tenths)
     }
@@ -214,11 +213,7 @@ impl QueryData {
             return None;
         }
 
-        let query_token_ids: Vec<TokenId> = query_tokens
-            .iter()
-            .filter(|&&tid| tid >= 0)
-            .map(|&tid| TokenId::new(tid as u16))
-            .collect();
+        let query_token_ids: Vec<TokenId> = query_tokens.iter().filter_map(|tid| *tid).collect();
 
         if query_token_ids.is_empty() {
             return None;

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -59,8 +59,8 @@ impl PartialOrd for OrderingKey {
 
 impl Ord for OrderingKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        ((self.numerator as u128) * (other.denominator as u128))
-            .cmp(&((other.numerator as u128) * (self.denominator as u128)))
+        (u128::from(self.numerator) * u128::from(other.denominator))
+            .cmp(&(u128::from(other.numerator) * u128::from(self.denominator)))
     }
 }
 
@@ -94,7 +94,7 @@ impl CandidateMetrics {
         let union = self.union_len() as u64;
         let threshold_tenths = (HIGH_RESEMBLANCE_THRESHOLD * 10.0).round() as u64;
 
-        (matched as u128) * 10 >= (union as u128) * (threshold_tenths as u128)
+        u128::from(matched) * 10 >= u128::from(union) * u128::from(threshold_tenths)
     }
 
     pub(super) fn containment_f32(&self) -> f32 {
@@ -293,12 +293,12 @@ fn compare_candidate_rank(
 }
 
 fn quantize_ratio_tenths(numerator: u64, denominator: u64) -> u32 {
-    quantize_ratio_tenths_wide(numerator as u128, denominator as u128)
+    quantize_ratio_tenths_wide(u128::from(numerator), u128::from(denominator))
 }
 
 fn quantize_squared_ratio_tenths(numerator: u64, denominator: u64) -> u32 {
-    let numerator = numerator as u128;
-    let denominator = denominator as u128;
+    let numerator = u128::from(numerator);
+    let denominator = u128::from(denominator);
 
     quantize_ratio_tenths_wide(numerator * numerator, denominator * denominator)
 }
@@ -327,9 +327,9 @@ fn passes_minimum_containment(rule: &Rule, metrics: CandidateMetrics) -> bool {
     rule.minimum_coverage.is_none_or(|min_cont| {
         let matched = metrics.matched_length as u64;
         let rule_len = metrics.rule_len as u64;
-        let min_cont = min_cont as u64;
+        let min_cont = u64::from(min_cont);
 
-        (matched as u128) * 100 >= (rule_len as u128) * (min_cont as u128)
+        u128::from(matched) * 100 >= u128::from(rule_len) * u128::from(min_cont)
     })
 }
 

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -311,7 +311,7 @@ pub(crate) fn seq_match_with_candidates(
                     let match_coverage = LicenseMatch::round_metric(rule_coverage * 100.0);
 
                     let score = MatchScore::from_percentage(
-                        match_coverage as f64 * candidate.rule.relevance as f64 / 100.0,
+                        f64::from(match_coverage) * f64::from(candidate.rule.relevance) / 100.0,
                     );
 
                     let license_match = LicenseMatch {

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -29,8 +29,10 @@ use crate::license_detection::models::MatcherKind;
 
 pub const MATCH_SEQ: MatcherKind = MatcherKind::Seq;
 
-/// Default threshold for high resemblance (0.8 = 80% similarity).
-pub const HIGH_RESEMBLANCE_THRESHOLD: f32 = 0.8;
+pub const HIGH_RESEMBLANCE_THRESHOLD_TENTHS: u32 = 8;
+
+#[cfg(test)]
+pub const HIGH_RESEMBLANCE_THRESHOLD: f32 = HIGH_RESEMBLANCE_THRESHOLD_TENTHS as f32 / 10.0;
 
 /// Default number of top near-duplicate candidates to consider.
 pub const MAX_NEAR_DUPE_CANDIDATES: usize = 10;

--- a/src/license_detection/tokenize.rs
+++ b/src/license_detection/tokenize.rs
@@ -368,7 +368,7 @@ static REQUIRED_PHRASE_PATTERN: Lazy<Regex> = Lazy::new(|| {
 /// Based on Python: `index_tokenizer_with_stopwords()` in tokenize.py:247-306
 pub fn tokenize_with_stopwords(
     text: &str,
-) -> (Vec<String>, std::collections::HashMap<usize, usize>) {
+) -> (Vec<String>, std::collections::HashMap<Option<usize>, usize>) {
     if text.is_empty() {
         return (Vec::new(), std::collections::HashMap::new());
     }
@@ -376,7 +376,7 @@ pub fn tokenize_with_stopwords(
     let mut tokens = Vec::new();
     let mut stopwords_by_pos = std::collections::HashMap::new();
 
-    let mut pos: i64 = -1;
+    let mut pos: Option<usize> = None;
     let lowercase_text = text.to_lowercase();
 
     for cap in QUERY_PATTERN.find_iter(&lowercase_text) {
@@ -386,9 +386,9 @@ pub fn tokenize_with_stopwords(
         }
 
         if STOPWORDS.contains(token) {
-            *stopwords_by_pos.entry(pos as usize).or_insert(0) += 1;
+            *stopwords_by_pos.entry(pos).or_insert(0) += 1;
         } else {
-            pos += 1;
+            pos = Some(pos.map_or(0, |p| p + 1));
             tokens.push(token.to_string());
         }
     }
@@ -722,8 +722,8 @@ mod tests {
         let (tokens, stopwords) = tokenize_with_stopwords(text);
         assert_eq!(tokens, vec!["hello", "world", "test"]);
         // "div" is stopword after "hello" (pos 0), "p" is stopword after "world" (pos 1)
-        assert_eq!(stopwords.get(&0), Some(&1));
-        assert_eq!(stopwords.get(&1), Some(&1));
+        assert_eq!(stopwords.get(&Some(0)), Some(&1));
+        assert_eq!(stopwords.get(&Some(1)), Some(&1));
     }
 
     #[test]

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -685,9 +685,8 @@ mod tests {
     #[test]
     fn test_compute_hispan_from_qspan() {
         let mut index = LicenseIndex::with_legalese_count(0);
-        let legalese_entries: Vec<(String, u16)> = (0..15)
-            .map(|i| (format!("legalese-{i}"), i as u16))
-            .collect();
+        let legalese_entries: Vec<(String, u16)> =
+            (0u16..15).map(|i| (format!("legalese-{i}"), i)).collect();
         index.dictionary =
             crate::license_detection::index::dictionary::TokenDictionary::new_with_legalese(
                 &legalese_entries

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -609,7 +609,7 @@ mod tests {
         let query_len = 20;
         let covered_positions: PositionSet = [0, 1, 2, 12, 13, 14, 15, 16, 17, 18, 19]
             .iter()
-            .cloned()
+            .copied()
             .collect();
 
         let regions = find_unmatched_regions(query_len, &covered_positions);
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn test_find_unmatched_regions_trailing_unmatched() {
         let query_len = 20;
-        let covered_positions: PositionSet = [0, 1, 2, 3, 4, 5].iter().cloned().collect();
+        let covered_positions: PositionSet = [0, 1, 2, 3, 4, 5].iter().copied().collect();
 
         let regions = find_unmatched_regions(query_len, &covered_positions);
 
@@ -782,7 +782,7 @@ mod tests {
         let query_len = 20;
         let covered_positions: PositionSet = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
             .iter()
-            .cloned()
+            .copied()
             .collect();
 
         let regions = find_unmatched_regions(query_len, &covered_positions);
@@ -797,7 +797,7 @@ mod tests {
         let covered_positions: PositionSet =
             [0, 1, 2, 3, 4, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
                 .iter()
-                .cloned()
+                .copied()
                 .collect();
 
         let regions = find_unmatched_regions(query_len, &covered_positions);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use crate::cache::{
     build_collection_exclude_patterns, incremental_manifest_path, load_incremental_manifest,
     manifest_entry_matches_path, metadata_fingerprint, write_incremental_manifest,
 };
-use crate::cli::Cli;
+use crate::cli::{Cli, ProcessMode};
 use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{FileInfo, FileType, Sha256Digest};
 use crate::output::{OutputWriteConfig, write_output_file};
@@ -197,7 +197,7 @@ fn run() -> Result<()> {
         } else {
             (cli.copyright, cli.email, cli.url, cli.generated)
         };
-        let process_mode = resolve_process_mode(cli.processes);
+        let process_mode = cli.processes;
 
         let text_options = TextDetectionOptions {
             collect_info: cli.info,
@@ -790,23 +790,6 @@ fn compile_regex_patterns(option_name: &str, patterns: &[String]) -> Result<Vec<
             })
         })
         .collect()
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProcessMode {
-    Parallel(usize),
-    SequentialWithTimeouts,
-    SequentialWithoutTimeouts,
-}
-
-fn resolve_process_mode(processes: i32) -> ProcessMode {
-    if processes > 0 {
-        ProcessMode::Parallel(processes as usize)
-    } else if processes == 0 {
-        ProcessMode::SequentialWithTimeouts
-    } else {
-        ProcessMode::SequentialWithoutTimeouts
-    }
 }
 
 fn effective_timeout_seconds(process_mode: ProcessMode, timeout_seconds: f64) -> f64 {

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cli::ProcessMode;
 use crate::models::{LineNumber, MatchScore};
 use clap::Parser;
 use serde_json::json;
@@ -17,13 +18,10 @@ use crate::scan_result_shaping::json_input::{
 use crate::scanner::collect_paths;
 
 #[test]
-fn resolve_process_mode_supports_reference_compat_values() {
-    assert_eq!(
-        resolve_process_mode(-1),
-        ProcessMode::SequentialWithoutTimeouts
-    );
-    assert_eq!(resolve_process_mode(0), ProcessMode::SequentialWithTimeouts);
-    assert_eq!(resolve_process_mode(4), ProcessMode::Parallel(4));
+fn process_mode_to_i32_supports_reference_compat_values() {
+    assert_eq!(ProcessMode::SequentialWithoutTimeouts.to_i32(), -1);
+    assert_eq!(ProcessMode::SequentialWithTimeouts.to_i32(), 0);
+    assert_eq!(ProcessMode::Parallel(4).to_i32(), 4);
     assert_eq!(
         effective_timeout_seconds(ProcessMode::SequentialWithoutTimeouts, 30.0),
         0.0

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -297,7 +297,7 @@ fn build_package_data_from_lockb(
     let extra_data = package_data.extra_data.get_or_insert_with(HashMap::new);
     extra_data.insert(
         "lockfileVersion".to_string(),
-        JsonValue::from(format_version as i64),
+        JsonValue::from(i64::from(format_version)),
     );
     extra_data.insert(
         "meta_hash".to_string(),

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -71,7 +71,7 @@ struct RpmQueryPackage {
     source_rpm: Option<String>,
     requires: Vec<String>,
     file_names: Vec<Option<String>>,
-    dir_indexes: Vec<i32>,
+    dir_indexes: Vec<u32>,
     base_names: Vec<Option<String>>,
     dir_names: Vec<String>,
 }
@@ -209,7 +209,7 @@ fn native_package_to_query_package(package: InstalledRpmPackage) -> RpmQueryPack
         distribution: normalize_optional_string(Some(package.distribution)),
         arch: normalize_optional_string(Some(package.arch)),
         platform: normalize_optional_string(Some(package.platform)),
-        size: (package.size > 0).then_some(package.size as u64),
+        size: (package.size > 0).then_some(u64::from(package.size)),
         license: normalize_optional_string(Some(package.license)),
         source_rpm: normalize_optional_string(Some(package.source_rpm)),
         requires: package.requires,
@@ -220,7 +220,7 @@ fn native_package_to_query_package(package: InstalledRpmPackage) -> RpmQueryPack
     }
 }
 
-fn build_evr_version(epoch: i32, version: &str, release: &str) -> Option<String> {
+fn build_evr_version(epoch: u32, version: &str, release: &str) -> Option<String> {
     if version.is_empty() {
         return None;
     }
@@ -243,7 +243,7 @@ fn build_evr_version(epoch: i32, version: &str, release: &str) -> Option<String>
 
 fn build_file_references(
     base_names: &[Option<String>],
-    dir_indexes: &[i32],
+    dir_indexes: &[u32],
     dir_names: &[String],
 ) -> Vec<FileReference> {
     if base_names.is_empty() || dir_names.is_empty() {
@@ -573,9 +573,9 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
     })
 }
 
-fn parse_epoch(value: Option<String>) -> i32 {
+fn parse_epoch(value: Option<String>) -> u32 {
     normalize_optional_string(value)
-        .and_then(|value| value.parse::<i32>().ok())
+        .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(0)
 }
 
@@ -717,7 +717,7 @@ mod tests {
                 Some("".to_string()),
                 Some("ignored".to_string()),
             ],
-            &[0, 0, -1],
+            &[0, 0, u32::MAX],
             &["/usr/bin/".to_string()],
         );
 

--- a/src/parsers/rpm_db_native/entry.rs
+++ b/src/parsers/rpm_db_native/entry.rs
@@ -11,16 +11,33 @@ use super::tags::{
     RPMTAG_HEADERSIGNATURES,
 };
 
-const REGION_TAG_COUNT: i32 = mem::size_of::<EntryInfo>() as i32;
+const REGION_TAG_COUNT: u32 = mem::size_of::<EntryInfo>() as u32;
 const REGION_TAG_TYPE: u32 = 7;
 const HEADER_MAX_BYTES: usize = 256 * 1024 * 1024;
 
-const TYPE_SIZES: [i32; 16] = [1, 1, 1, 2, 4, 8, -1, 1, -1, -1, 0, 0, 0, 0, 0, 0];
-const TYPE_ALIGN: [i32; 16] = [1, 1, 1, 2, 4, 8, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0];
+const TYPE_SIZES: [Option<u32>; 16] = [
+    Some(1),
+    Some(1),
+    Some(1),
+    Some(2),
+    Some(4),
+    Some(8),
+    None,
+    Some(1),
+    None,
+    None,
+    Some(0),
+    Some(0),
+    Some(0),
+    Some(0),
+    Some(0),
+    Some(0),
+];
+const TYPE_ALIGN: [u32; 16] = [1, 1, 1, 2, 4, 8, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0];
 
 #[derive(Clone, Debug)]
 pub(crate) struct EntryInfo {
-    pub(crate) tag: i32,
+    pub(crate) tag: u32,
     pub(crate) kind: u32,
     pub(crate) offset: i32,
     pub(crate) count: u32,
@@ -29,7 +46,7 @@ pub(crate) struct EntryInfo {
 impl EntryInfo {
     fn swap_be(&self) -> EntryInfo {
         EntryInfo {
-            tag: i32::from_be(self.tag),
+            tag: u32::from_be(self.tag),
             kind: u32::from_be(self.kind),
             offset: i32::from_be(self.offset),
             count: u32::from_be(self.count),
@@ -44,14 +61,14 @@ pub(crate) struct IndexEntry {
 }
 
 impl IndexEntry {
-    pub(crate) fn read_i32(&self) -> Result<i32> {
+    pub(crate) fn read_u32(&self) -> Result<u32> {
         let bytes: [u8; 4] = self
             .data
             .get(..4)
-            .context("expected 4 bytes for int32 entry")?
+            .context("expected 4 bytes for uint32 entry")?
             .try_into()
-            .map_err(|_| anyhow!("failed to read int32 entry bytes"))?;
-        Ok(i32::from_be_bytes(bytes))
+            .map_err(|_| anyhow!("failed to read uint32 entry bytes"))?;
+        Ok(u32::from_be_bytes(bytes))
     }
 
     pub(crate) fn read_string(&self) -> Result<String> {
@@ -60,13 +77,13 @@ impl IndexEntry {
             .to_string())
     }
 
-    pub(crate) fn read_i32_array(&self) -> Result<Vec<i32>> {
+    pub(crate) fn read_u32_array(&self) -> Result<Vec<u32>> {
         let mut values = Vec::new();
         for chunk in self.data.chunks_exact(4).take(self.info.count as usize) {
-            values.push(i32::from_be_bytes(
+            values.push(u32::from_be_bytes(
                 chunk
                     .try_into()
-                    .map_err(|_| anyhow!("failed to parse int32 array chunk"))?,
+                    .map_err(|_| anyhow!("failed to parse uint32 array chunk"))?,
             ));
         }
         Ok(values)
@@ -98,28 +115,28 @@ impl Eq for IndexEntry {}
 
 pub(crate) struct HeaderBlob {
     entry_infos: Vec<EntryInfo>,
-    index_length: i32,
-    data_length: i32,
-    data_start: i32,
-    data_end: i32,
-    region_tag: i32,
-    region_index_length: i32,
-    region_data_length: i32,
+    index_length: u32,
+    data_length: u32,
+    data_start: u32,
+    data_end: u32,
+    region_tag: u32,
+    region_index_length: u32,
+    region_data_length: u32,
 }
 
 impl HeaderBlob {
     pub(crate) fn parse(data: &[u8]) -> Result<HeaderBlob> {
         let mut cursor = Cursor::new(data);
-        let index_length = read_be_i32(&mut cursor)?;
-        let data_length = read_be_i32(&mut cursor)?;
-        let entry_info_size = mem::size_of::<EntryInfo>() as i32;
+        let index_length = read_be_u32(&mut cursor)?;
+        let data_length = read_be_u32(&mut cursor)?;
+        let entry_info_size = mem::size_of::<EntryInfo>() as u32;
         let data_start = 8 + index_length * entry_info_size;
         let total_length = data_start + data_length;
         let data_end = data_start + data_length;
         if index_length < 1 {
             return Err(anyhow!("RPM header blob has no index entries"));
         }
-        if total_length >= HEADER_MAX_BYTES as i32 {
+        if total_length >= HEADER_MAX_BYTES as u32 {
             return Err(anyhow!(
                 "RPM header blob too large: total={} index_length={} data_length={}",
                 total_length,
@@ -176,10 +193,7 @@ impl HeaderBlob {
                 self.data_start,
                 self.data_end,
             )?;
-            if computed_length < 0 {
-                return Err(anyhow!("RPM region length became negative"));
-            }
-            if self.region_index_length < self.entry_infos.len() as i32 - 1 {
+            if self.region_index_length < self.entry_infos.len() as u32 - 1 {
                 let (extra_entries, dribble_length) = swab_region(
                     data,
                     self.entry_infos[region_index_length as usize..].to_vec(),
@@ -187,9 +201,6 @@ impl HeaderBlob {
                     self.data_start,
                     self.data_end,
                 )?;
-                if dribble_length < 0 {
-                    return Err(anyhow!("RPM dribble region length became negative"));
-                }
                 entries.extend(extra_entries);
                 entries = entries
                     .into_iter()
@@ -198,7 +209,7 @@ impl HeaderBlob {
                     .collect();
                 computed_length = dribble_length;
             }
-            computed_length += mem::size_of::<EntryInfo>() as i32;
+            computed_length += mem::size_of::<EntryInfo>() as u32;
             (entries, computed_length)
         };
 
@@ -234,14 +245,19 @@ impl HeaderBlob {
         if entry.tag != region_tag {
             return Ok(());
         }
-        if !(entry.kind == REGION_TAG_TYPE && entry.count == REGION_TAG_COUNT as u32) {
+        if !(entry.kind == REGION_TAG_TYPE && entry.count == REGION_TAG_COUNT) {
             return Err(anyhow!("invalid RPM region tag header"));
         }
-        if is_out_of_range(self.data_length, entry.offset + REGION_TAG_COUNT) {
+        if entry.offset < 0
+            || is_out_of_range(
+                self.data_length,
+                u32::try_from(entry.offset + REGION_TAG_COUNT as i32)?,
+            )
+        {
             return Err(anyhow!("invalid RPM region tag offset"));
         }
 
-        let region_end = self.data_start + entry.offset;
+        let region_end = self.data_start + positive_offset(entry.offset)?;
         let trailer = parse_entry_info_le(
             data.get(region_end as usize..(region_end + REGION_TAG_COUNT) as usize)
                 .context("invalid RPM region trailer slice")?,
@@ -253,15 +269,15 @@ impl HeaderBlob {
         }
         if !(entry.tag == region_tag
             && entry.kind == REGION_TAG_TYPE
-            && entry.count == REGION_TAG_COUNT as u32)
+            && entry.count == REGION_TAG_COUNT)
         {
             return Err(anyhow!("invalid RPM region trailer header"));
         }
 
         let mut trailer = trailer.swap_be();
         trailer.offset = -trailer.offset;
-        self.region_index_length = trailer.offset / REGION_TAG_COUNT;
-        if trailer.offset % REGION_TAG_COUNT != 0
+        self.region_index_length = positive_offset(trailer.offset)? / REGION_TAG_COUNT;
+        if trailer.offset % REGION_TAG_COUNT as i32 != 0
             || is_out_of_range(self.index_length, self.region_index_length)
             || is_out_of_range(self.data_length, self.region_data_length)
         {
@@ -272,11 +288,13 @@ impl HeaderBlob {
     }
 
     fn verify_entries(&self, data: &[u8]) -> Result<()> {
-        let mut end = 0;
+        let mut end: u32 = 0;
         let entry_offset = usize::from(self.region_tag != 0);
         for entry in &self.entry_infos[entry_offset..] {
             let info = entry.swap_be();
-            if end > info.offset {
+            let offset_u32 = positive_offset(info.offset)
+                .map_err(|_| anyhow!("RPM header entry offset out of range"))?;
+            if end > offset_u32 {
                 return Err(anyhow!("RPM header entry offsets are not sorted"));
             }
             if is_reserved_tag(info.tag) {
@@ -291,7 +309,7 @@ impl HeaderBlob {
                     info.offset
                 ));
             }
-            if is_out_of_range(self.data_length, info.offset) {
+            if is_out_of_range(self.data_length, offset_u32) {
                 return Err(anyhow!("RPM header entry offset out of range"));
             }
 
@@ -299,11 +317,15 @@ impl HeaderBlob {
                 data,
                 info.kind,
                 info.count,
-                self.data_start + info.offset,
+                self.data_start + offset_u32,
                 self.data_end,
             );
-            end = info.offset + length as i32;
-            if is_out_of_range(self.data_length, end) || length <= 0 {
+            let length = match length {
+                Some(l) => l,
+                None => return Err(anyhow!("invalid RPM header entry length")),
+            };
+            end = offset_u32 + length as u32;
+            if is_out_of_range(self.data_length, end) {
                 return Err(anyhow!("invalid RPM header entry length"));
             }
         }
@@ -315,97 +337,107 @@ impl HeaderBlob {
 fn swab_region(
     data: &[u8],
     entry_infos: Vec<EntryInfo>,
-    mut running_length: i32,
-    data_start: i32,
-    data_end: i32,
-) -> Result<(Vec<IndexEntry>, i32)> {
+    mut running_length: u32,
+    data_start: u32,
+    data_end: u32,
+) -> Result<(Vec<IndexEntry>, u32)> {
     let mut entries = Vec::new();
     for (index, entry_info) in entry_infos.iter().enumerate() {
         let info = entry_info.swap_be();
-        let start = data_start + info.offset;
+        let start = data_start + positive_offset(info.offset)?;
         if start >= data_end {
             return Err(anyhow!("RPM entry data offset is outside payload"));
         }
 
         let length =
-            if index < entry_infos.len() - 1 && TYPE_SIZES.get(info.kind as usize) == Some(&-1) {
+            if index < entry_infos.len() - 1 && TYPE_SIZES.get(info.kind as usize) == Some(&None) {
                 let next_offset = entry_infos[index + 1].swap_be().offset;
-                (next_offset - info.offset) as isize
+                positive_offset(next_offset - info.offset)? as usize
             } else {
                 compute_data_length(data, info.kind, info.count, start, data_end)
+                    .ok_or_else(|| anyhow!("RPM entry data length is invalid"))?
             };
-        if length < 0 {
-            return Err(anyhow!("RPM entry data length is invalid"));
-        }
 
-        let end = start as isize + length;
+        let end = start as usize + length;
         entries.push(IndexEntry {
             info: info.clone(),
-            data: data[start as usize..end as usize].to_vec(),
+            data: data[start as usize..end].to_vec(),
         });
-        running_length += length as i32 + alignment_padding(info.kind, running_length as u32);
+        running_length += length as u32 + alignment_padding(info.kind, running_length);
     }
 
     Ok((entries, running_length))
 }
 
-fn compute_data_length(data: &[u8], kind: u32, count: u32, start: i32, data_end: i32) -> isize {
+fn compute_data_length(
+    data: &[u8],
+    kind: u32,
+    count: u32,
+    start: u32,
+    data_end: u32,
+) -> Option<usize> {
     match kind {
-        RPM_STRING_TYPE if count != 1 => -1,
+        RPM_STRING_TYPE if count != 1 => None,
         RPM_STRING_TYPE => string_tag_length(data, 1, start, data_end),
         RPM_STRING_ARRAY_TYPE | RPM_I18NSTRING_TYPE => {
             string_tag_length(data, count, start, data_end)
         }
         _ => {
-            if TYPE_SIZES.get(kind as usize) == Some(&-1) {
-                return -1;
+            if TYPE_SIZES.get(kind as usize) == Some(&None) {
+                return None;
             }
-            let size = TYPE_SIZES.get((kind & 0xf) as usize).copied().unwrap_or(0) * count as i32;
-            if size < 0 || (data_end > 0 && start + size > data_end) {
-                -1
+            let size = TYPE_SIZES
+                .get((kind & 0xf) as usize)
+                .copied()
+                .flatten()
+                .unwrap_or(0)
+                * count;
+            if start + size > data_end {
+                None
             } else {
-                size as isize
+                Some(size as usize)
             }
         }
     }
 }
 
-fn string_tag_length(data: &[u8], count: u32, start: i32, data_end: i32) -> isize {
+fn string_tag_length(data: &[u8], count: u32, start: u32, data_end: u32) -> Option<usize> {
     if start >= data_end {
-        return -1;
+        return None;
     }
-    let mut length = 0isize;
+    let mut length: usize = 0;
     for _ in 0..count {
-        let offset = start + length as i32;
-        if offset > data.len() as i32 {
-            return -1;
+        let offset = start as usize + length;
+        if offset > data.len() {
+            return None;
         }
-        let Some(position) = data[offset as usize..data_end as usize]
+        let position = data[offset..data_end as usize]
             .iter()
-            .position(|&byte| byte == 0)
-        else {
-            return -1;
-        };
-        length += position as isize + 1;
+            .position(|&byte| byte == 0)?;
+        length += position + 1;
     }
-    length
+    Some(length)
 }
 
-fn alignment_padding(kind: u32, current_length: u32) -> i32 {
-    match TYPE_SIZES.get(kind as usize) {
-        Some(&size) if size > 1 => {
-            let diff = size - (current_length as i32 % size);
+fn alignment_padding(kind: u32, current_length: u32) -> u32 {
+    match TYPE_SIZES.get(kind as usize).and_then(|opt| *opt) {
+        Some(size) if size > 1 => {
+            let diff = size - (current_length % size);
             if diff == size { 0 } else { diff }
         }
         _ => 0,
     }
 }
 
-fn is_out_of_range(length: i32, offset: i32) -> bool {
-    offset < 0 || offset > length
+fn is_out_of_range(length: u32, offset: u32) -> bool {
+    offset > length
 }
 
-fn is_reserved_tag(tag: i32) -> bool {
+fn positive_offset(offset: i32) -> Result<u32> {
+    u32::try_from(offset).map_err(|_| anyhow!("RPM header offset is negative: {offset}"))
+}
+
+fn is_reserved_tag(tag: u32) -> bool {
     tag < HEADER_I18NTABLE
 }
 
@@ -415,13 +447,13 @@ fn is_invalid_type(kind: u32) -> bool {
 
 fn is_misaligned(kind: u32, offset: i32) -> bool {
     let align = TYPE_ALIGN.get(kind as usize).copied().unwrap_or(0);
-    offset & (align - 1) != 0
+    offset & (align as i32 - 1) != 0
 }
 
-fn read_be_i32(cursor: &mut Cursor<&[u8]>) -> Result<i32> {
+fn read_be_u32(cursor: &mut Cursor<&[u8]>) -> Result<u32> {
     let mut bytes = [0_u8; 4];
     std::io::Read::read_exact(cursor, &mut bytes)?;
-    Ok(i32::from_be_bytes(bytes))
+    Ok(u32::from_be_bytes(bytes))
 }
 
 fn read_entry_info_le(cursor: &mut Cursor<&[u8]>) -> Result<EntryInfo> {
@@ -433,7 +465,7 @@ fn read_entry_info_le(cursor: &mut Cursor<&[u8]>) -> Result<EntryInfo> {
 fn parse_entry_info_le(data: &[u8]) -> Result<EntryInfo> {
     let mut offset = 0;
     Ok(EntryInfo {
-        tag: read_i32_le(data, &mut offset)?,
+        tag: read_u32_le(data, &mut offset)?,
         kind: read_u32_le(data, &mut offset)?,
         offset: read_i32_le(data, &mut offset)?,
         count: read_u32_le(data, &mut offset)?,

--- a/src/parsers/rpm_db_native/entry.rs
+++ b/src/parsers/rpm_db_native/entry.rs
@@ -1,57 +1,43 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::io::Cursor;
-use std::mem;
 
 use anyhow::{Context, Result, anyhow};
 
 use super::tags::{
-    HEADER_I18NTABLE, RPM_I18NSTRING_TYPE, RPM_MAX_TYPE, RPM_MIN_TYPE, RPM_STRING_ARRAY_TYPE,
-    RPM_STRING_TYPE, RPMTAG_HEADERI18NTABLE, RPMTAG_HEADERIMAGE, RPMTAG_HEADERIMMUTABLE,
-    RPMTAG_HEADERSIGNATURES,
+    HEADER_I18NTABLE, RPMTAG_HEADERI18NTABLE, RPMTAG_HEADERIMAGE, RPMTAG_HEADERIMMUTABLE,
+    RPMTAG_HEADERSIGNATURES, TagType,
 };
 
-const REGION_TAG_COUNT: u32 = mem::size_of::<EntryInfo>() as u32;
-const REGION_TAG_TYPE: u32 = 7;
+const ENTRY_INFO_DISK_SIZE: u32 = 16;
+const REGION_TAG_COUNT: u32 = ENTRY_INFO_DISK_SIZE;
 const HEADER_MAX_BYTES: usize = 256 * 1024 * 1024;
 
-const TYPE_SIZES: [Option<u32>; 16] = [
-    Some(1),
-    Some(1),
-    Some(1),
-    Some(2),
-    Some(4),
-    Some(8),
-    None,
-    Some(1),
-    None,
-    None,
-    Some(0),
-    Some(0),
-    Some(0),
-    Some(0),
-    Some(0),
-    Some(0),
-];
-const TYPE_ALIGN: [u32; 16] = [1, 1, 1, 2, 4, 8, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0];
+#[derive(Clone, Debug)]
+struct RawEntryInfo {
+    tag: u32,
+    kind: u32,
+    offset: i32,
+    count: u32,
+}
+
+impl RawEntryInfo {
+    fn to_native(&self) -> Result<EntryInfo> {
+        Ok(EntryInfo {
+            tag: u32::from_be(self.tag),
+            kind: TagType::from_raw(u32::from_be(self.kind))?,
+            offset: i32::from_be(self.offset),
+            count: u32::from_be(self.count),
+        })
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct EntryInfo {
     pub(crate) tag: u32,
-    pub(crate) kind: u32,
+    pub(crate) kind: TagType,
     pub(crate) offset: i32,
     pub(crate) count: u32,
-}
-
-impl EntryInfo {
-    fn swap_be(&self) -> EntryInfo {
-        EntryInfo {
-            tag: u32::from_be(self.tag),
-            kind: u32::from_be(self.kind),
-            offset: i32::from_be(self.offset),
-            count: u32::from_be(self.count),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -114,7 +100,7 @@ impl PartialEq for IndexEntry {
 impl Eq for IndexEntry {}
 
 pub(crate) struct HeaderBlob {
-    entry_infos: Vec<EntryInfo>,
+    entry_infos: Vec<RawEntryInfo>,
     index_length: u32,
     data_length: u32,
     data_start: u32,
@@ -129,8 +115,7 @@ impl HeaderBlob {
         let mut cursor = Cursor::new(data);
         let index_length = read_be_u32(&mut cursor)?;
         let data_length = read_be_u32(&mut cursor)?;
-        let entry_info_size = mem::size_of::<EntryInfo>() as u32;
-        let data_start = 8 + index_length * entry_info_size;
+        let data_start = 8 + index_length * ENTRY_INFO_DISK_SIZE;
         let total_length = data_start + data_length;
         let data_end = data_start + data_length;
         if index_length < 1 {
@@ -170,7 +155,7 @@ impl HeaderBlob {
             .entry_infos
             .first()
             .context("missing RPM header entry")?
-            .swap_be();
+            .to_native()?;
 
         let (mut entries, computed_length) = if first.tag >= RPMTAG_HEADERI18NTABLE {
             swab_region(
@@ -209,7 +194,7 @@ impl HeaderBlob {
                     .collect();
                 computed_length = dribble_length;
             }
-            computed_length += mem::size_of::<EntryInfo>() as u32;
+            computed_length += ENTRY_INFO_DISK_SIZE;
             (entries, computed_length)
         };
 
@@ -229,7 +214,7 @@ impl HeaderBlob {
             .entry_infos
             .first()
             .context("missing RPM header region entry")?
-            .swap_be();
+            .to_native()?;
         let region_tag = if [
             RPMTAG_HEADERIMAGE,
             RPMTAG_HEADERSIGNATURES,
@@ -245,13 +230,13 @@ impl HeaderBlob {
         if entry.tag != region_tag {
             return Ok(());
         }
-        if !(entry.kind == REGION_TAG_TYPE && entry.count == REGION_TAG_COUNT) {
+        if !(entry.kind == TagType::Bin && entry.count == REGION_TAG_COUNT) {
             return Err(anyhow!("invalid RPM region tag header"));
         }
         if entry.offset < 0
             || is_out_of_range(
                 self.data_length,
-                u32::try_from(entry.offset + REGION_TAG_COUNT as i32)?,
+                u32::try_from(entry.offset + ENTRY_INFO_DISK_SIZE as i32)?,
             )
         {
             return Err(anyhow!("invalid RPM region tag offset"));
@@ -259,22 +244,22 @@ impl HeaderBlob {
 
         let region_end = self.data_start + positive_offset(entry.offset)?;
         let trailer = parse_entry_info_le(
-            data.get(region_end as usize..(region_end + REGION_TAG_COUNT) as usize)
+            data.get(region_end as usize..(region_end + ENTRY_INFO_DISK_SIZE) as usize)
                 .context("invalid RPM region trailer slice")?,
         )?;
 
-        self.region_data_length = region_end + REGION_TAG_COUNT - self.data_start;
+        self.region_data_length = region_end + ENTRY_INFO_DISK_SIZE - self.data_start;
         if region_tag == RPMTAG_HEADERSIGNATURES && entry.tag == RPMTAG_HEADERIMAGE {
             entry.tag = RPMTAG_HEADERSIGNATURES;
         }
         if !(entry.tag == region_tag
-            && entry.kind == REGION_TAG_TYPE
+            && entry.kind == TagType::Bin
             && entry.count == REGION_TAG_COUNT)
         {
             return Err(anyhow!("invalid RPM region trailer header"));
         }
 
-        let mut trailer = trailer.swap_be();
+        let mut trailer = trailer.to_native()?;
         trailer.offset = -trailer.offset;
         self.region_index_length = positive_offset(trailer.offset)? / REGION_TAG_COUNT;
         if trailer.offset % REGION_TAG_COUNT as i32 != 0
@@ -291,7 +276,8 @@ impl HeaderBlob {
         let mut end: u32 = 0;
         let entry_offset = usize::from(self.region_tag != 0);
         for entry in &self.entry_infos[entry_offset..] {
-            let info = entry.swap_be();
+            let info = entry.to_native()?;
+            let kind = info.kind;
             let offset_u32 = positive_offset(info.offset)
                 .map_err(|_| anyhow!("RPM header entry offset out of range"))?;
             if end > offset_u32 {
@@ -300,10 +286,7 @@ impl HeaderBlob {
             if is_reserved_tag(info.tag) {
                 return Err(anyhow!("invalid RPM header tag {}", info.tag));
             }
-            if is_invalid_type(info.kind) {
-                return Err(anyhow!("invalid RPM header type {}", info.kind));
-            }
-            if is_misaligned(info.kind, info.offset) {
+            if is_misaligned(kind, info.offset) {
                 return Err(anyhow!(
                     "misaligned RPM header entry offset {}",
                     info.offset
@@ -315,7 +298,7 @@ impl HeaderBlob {
 
             let length = compute_data_length(
                 data,
-                info.kind,
+                kind,
                 info.count,
                 self.data_start + offset_u32,
                 self.data_end,
@@ -336,34 +319,34 @@ impl HeaderBlob {
 
 fn swab_region(
     data: &[u8],
-    entry_infos: Vec<EntryInfo>,
+    entry_infos: Vec<RawEntryInfo>,
     mut running_length: u32,
     data_start: u32,
     data_end: u32,
 ) -> Result<(Vec<IndexEntry>, u32)> {
     let mut entries = Vec::new();
     for (index, entry_info) in entry_infos.iter().enumerate() {
-        let info = entry_info.swap_be();
+        let info = entry_info.to_native()?;
+        let kind = info.kind;
         let start = data_start + positive_offset(info.offset)?;
         if start >= data_end {
             return Err(anyhow!("RPM entry data offset is outside payload"));
         }
 
-        let length =
-            if index < entry_infos.len() - 1 && TYPE_SIZES.get(info.kind as usize) == Some(&None) {
-                let next_offset = entry_infos[index + 1].swap_be().offset;
-                positive_offset(next_offset - info.offset)? as usize
-            } else {
-                compute_data_length(data, info.kind, info.count, start, data_end)
-                    .ok_or_else(|| anyhow!("RPM entry data length is invalid"))?
-            };
+        let length = if index < entry_infos.len() - 1 && kind.is_variable_length() {
+            let next_offset = entry_infos[index + 1].to_native()?.offset;
+            positive_offset(next_offset - info.offset)? as usize
+        } else {
+            compute_data_length(data, kind, info.count, start, data_end)
+                .ok_or_else(|| anyhow!("RPM entry data length is invalid"))?
+        };
 
         let end = start as usize + length;
         entries.push(IndexEntry {
             info: info.clone(),
             data: data[start as usize..end].to_vec(),
         });
-        running_length += length as u32 + alignment_padding(info.kind, running_length);
+        running_length += length as u32 + alignment_padding(kind, running_length);
     }
 
     Ok((entries, running_length))
@@ -371,27 +354,19 @@ fn swab_region(
 
 fn compute_data_length(
     data: &[u8],
-    kind: u32,
+    kind: TagType,
     count: u32,
     start: u32,
     data_end: u32,
 ) -> Option<usize> {
     match kind {
-        RPM_STRING_TYPE if count != 1 => None,
-        RPM_STRING_TYPE => string_tag_length(data, 1, start, data_end),
-        RPM_STRING_ARRAY_TYPE | RPM_I18NSTRING_TYPE => {
+        TagType::String if count != 1 => None,
+        TagType::String => string_tag_length(data, 1, start, data_end),
+        TagType::StringArray | TagType::I18nString => {
             string_tag_length(data, count, start, data_end)
         }
         _ => {
-            if TYPE_SIZES.get(kind as usize) == Some(&None) {
-                return None;
-            }
-            let size = TYPE_SIZES
-                .get((kind & 0xf) as usize)
-                .copied()
-                .flatten()
-                .unwrap_or(0)
-                * count;
+            let size = kind.element_size().unwrap_or(0) * count;
             if start + size > data_end {
                 None
             } else {
@@ -419,14 +394,13 @@ fn string_tag_length(data: &[u8], count: u32, start: u32, data_end: u32) -> Opti
     Some(length)
 }
 
-fn alignment_padding(kind: u32, current_length: u32) -> u32 {
-    match TYPE_SIZES.get(kind as usize).and_then(|opt| *opt) {
-        Some(size) if size > 1 => {
-            let diff = size - (current_length % size);
-            if diff == size { 0 } else { diff }
-        }
-        _ => 0,
+fn alignment_padding(kind: TagType, current_length: u32) -> u32 {
+    let align = kind.alignment();
+    if align <= 1 {
+        return 0;
     }
+    let diff = align - (current_length % align);
+    if diff == align { 0 } else { diff }
 }
 
 fn is_out_of_range(length: u32, offset: u32) -> bool {
@@ -441,13 +415,9 @@ fn is_reserved_tag(tag: u32) -> bool {
     tag < HEADER_I18NTABLE
 }
 
-fn is_invalid_type(kind: u32) -> bool {
-    !(RPM_MIN_TYPE..=RPM_MAX_TYPE).contains(&kind)
-}
-
-fn is_misaligned(kind: u32, offset: i32) -> bool {
-    let align = TYPE_ALIGN.get(kind as usize).copied().unwrap_or(0);
-    offset & (align as i32 - 1) != 0
+fn is_misaligned(kind: TagType, offset: i32) -> bool {
+    let align = kind.alignment() as i32;
+    offset & (align - 1) != 0
 }
 
 fn read_be_u32(cursor: &mut Cursor<&[u8]>) -> Result<u32> {
@@ -456,15 +426,15 @@ fn read_be_u32(cursor: &mut Cursor<&[u8]>) -> Result<u32> {
     Ok(u32::from_be_bytes(bytes))
 }
 
-fn read_entry_info_le(cursor: &mut Cursor<&[u8]>) -> Result<EntryInfo> {
-    let mut bytes = [0_u8; mem::size_of::<EntryInfo>()];
+fn read_entry_info_le(cursor: &mut Cursor<&[u8]>) -> Result<RawEntryInfo> {
+    let mut bytes = [0_u8; ENTRY_INFO_DISK_SIZE as usize];
     std::io::Read::read_exact(cursor, &mut bytes)?;
     parse_entry_info_le(&bytes)
 }
 
-fn parse_entry_info_le(data: &[u8]) -> Result<EntryInfo> {
+fn parse_entry_info_le(data: &[u8]) -> Result<RawEntryInfo> {
     let mut offset = 0;
-    Ok(EntryInfo {
+    Ok(RawEntryInfo {
         tag: read_u32_le(data, &mut offset)?,
         kind: read_u32_le(data, &mut offset)?,
         offset: read_i32_le(data, &mut offset)?,

--- a/src/parsers/rpm_db_native/ndb.rs
+++ b/src/parsers/rpm_db_native/ndb.rs
@@ -123,7 +123,7 @@ impl BlobReader for NdbDatabase {
                 continue;
             }
 
-            let offset = (slot.block_offset * BLOB_BLOCK_SIZE) as u64;
+            let offset = u64::from(slot.block_offset * BLOB_BLOCK_SIZE);
             self.reader.seek(SeekFrom::Start(offset))?;
 
             let blob_header = NdbBlobHeader::read(&mut self.reader)?;

--- a/src/parsers/rpm_db_native/package.rs
+++ b/src/parsers/rpm_db_native/package.rs
@@ -2,10 +2,10 @@ use anyhow::{Result, anyhow};
 
 use super::entry::IndexEntry;
 use super::tags::{
-    RPM_INT32_TYPE, RPM_STRING_ARRAY_TYPE, RPM_STRING_TYPE, RPMTAG_ARCH, RPMTAG_BASENAMES,
-    RPMTAG_DIRINDEXES, RPMTAG_DIRNAMES, RPMTAG_DISTRIBUTION, RPMTAG_EPOCH, RPMTAG_FILENAMES,
-    RPMTAG_LICENSE, RPMTAG_NAME, RPMTAG_PLATFORM, RPMTAG_PROVIDENAME, RPMTAG_RELEASE,
-    RPMTAG_REQUIRENAME, RPMTAG_SIZE, RPMTAG_SOURCERPM, RPMTAG_VENDOR, RPMTAG_VERSION,
+    RPMTAG_ARCH, RPMTAG_BASENAMES, RPMTAG_DIRINDEXES, RPMTAG_DIRNAMES, RPMTAG_DISTRIBUTION,
+    RPMTAG_EPOCH, RPMTAG_FILENAMES, RPMTAG_LICENSE, RPMTAG_NAME, RPMTAG_PLATFORM,
+    RPMTAG_PROVIDENAME, RPMTAG_RELEASE, RPMTAG_REQUIRENAME, RPMTAG_SIZE, RPMTAG_SOURCERPM,
+    RPMTAG_VENDOR, RPMTAG_VERSION, TagType,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -34,71 +34,71 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
     for entry in entries {
         match entry.info.tag {
             RPMTAG_DIRINDEXES => {
-                ensure_kind(&entry, RPM_INT32_TYPE, "dir indexes")?;
+                ensure_kind(&entry, TagType::Int32, "dir indexes")?;
                 package.dir_indexes = entry.read_u32_array()?;
             }
             RPMTAG_DIRNAMES => {
-                ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "dir names")?;
+                ensure_kind(&entry, TagType::StringArray, "dir names")?;
                 package.dir_names = entry.read_string_array()?;
             }
             RPMTAG_BASENAMES => {
-                ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "base names")?;
+                ensure_kind(&entry, TagType::StringArray, "base names")?;
                 package.base_names = entry.read_string_array()?;
             }
             RPMTAG_FILENAMES => {
-                ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "file names")?;
+                ensure_kind(&entry, TagType::StringArray, "file names")?;
                 package.file_names = entry.read_string_array()?;
             }
             RPMTAG_NAME => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "name")?;
+                ensure_kind(&entry, TagType::String, "name")?;
                 package.name = entry.read_string()?;
             }
             RPMTAG_EPOCH => {
-                ensure_kind(&entry, RPM_INT32_TYPE, "epoch")?;
+                ensure_kind(&entry, TagType::Int32, "epoch")?;
                 package.epoch = entry.read_u32()?;
             }
             RPMTAG_VERSION => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "version")?;
+                ensure_kind(&entry, TagType::String, "version")?;
                 package.version = entry.read_string()?;
             }
             RPMTAG_RELEASE => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "release")?;
+                ensure_kind(&entry, TagType::String, "release")?;
                 package.release = entry.read_string()?;
             }
             RPMTAG_ARCH => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "arch")?;
+                ensure_kind(&entry, TagType::String, "arch")?;
                 package.arch = entry.read_string()?;
             }
             RPMTAG_SOURCERPM => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "source rpm")?;
+                ensure_kind(&entry, TagType::String, "source rpm")?;
                 package.source_rpm = normalize_none(entry.read_string()?);
             }
             RPMTAG_LICENSE => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "license")?;
+                ensure_kind(&entry, TagType::String, "license")?;
                 package.license = normalize_none(entry.read_string()?);
             }
             RPMTAG_VENDOR => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "vendor")?;
+                ensure_kind(&entry, TagType::String, "vendor")?;
                 package.vendor = normalize_none(entry.read_string()?);
             }
             RPMTAG_DISTRIBUTION => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "distribution")?;
+                ensure_kind(&entry, TagType::String, "distribution")?;
                 package.distribution = normalize_none(entry.read_string()?);
             }
             RPMTAG_PLATFORM => {
-                ensure_kind(&entry, RPM_STRING_TYPE, "platform")?;
+                ensure_kind(&entry, TagType::String, "platform")?;
                 package.platform = normalize_none(entry.read_string()?);
             }
             RPMTAG_SIZE => {
-                ensure_kind(&entry, RPM_INT32_TYPE, "size")?;
+                ensure_kind(&entry, TagType::Int32, "size")?;
                 package.size = entry.read_u32()?;
             }
             RPMTAG_PROVIDENAME => {
-                ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "provide names")?;
+                ensure_kind(&entry, TagType::StringArray, "provide names")?;
                 package.provides = entry.read_string_array()?;
             }
             RPMTAG_REQUIRENAME => {
-                ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "require names")?;
+                ensure_kind(&entry, TagType::StringArray, "require names")?;
                 package.requires = entry.read_string_array()?;
             }
             _ => {}
@@ -108,10 +108,10 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
     Ok(package)
 }
 
-fn ensure_kind(entry: &IndexEntry, expected: u32, label: &str) -> Result<()> {
+fn ensure_kind(entry: &IndexEntry, expected: TagType, label: &str) -> Result<()> {
     if entry.info.kind != expected {
         return Err(anyhow!(
-            "invalid RPM tag type for {}: expected={}, actual={}",
+            "invalid RPM tag type for {}: expected={:?}, actual={:?}",
             label,
             expected,
             entry.info.kind

--- a/src/parsers/rpm_db_native/package.rs
+++ b/src/parsers/rpm_db_native/package.rs
@@ -10,19 +10,19 @@ use super::tags::{
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct InstalledRpmPackage {
-    pub(crate) epoch: i32,
+    pub(crate) epoch: u32,
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) release: String,
     pub(crate) arch: String,
     pub(crate) source_rpm: String,
-    pub(crate) size: i32,
+    pub(crate) size: u32,
     pub(crate) license: String,
     pub(crate) vendor: String,
     pub(crate) distribution: String,
     pub(crate) platform: String,
     pub(crate) base_names: Vec<String>,
-    pub(crate) dir_indexes: Vec<i32>,
+    pub(crate) dir_indexes: Vec<u32>,
     pub(crate) dir_names: Vec<String>,
     pub(crate) file_names: Vec<String>,
     pub(crate) provides: Vec<String>,
@@ -32,10 +32,10 @@ pub(crate) struct InstalledRpmPackage {
 pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<InstalledRpmPackage> {
     let mut package = InstalledRpmPackage::default();
     for entry in entries {
-        match entry.info.tag as u32 {
+        match entry.info.tag {
             RPMTAG_DIRINDEXES => {
                 ensure_kind(&entry, RPM_INT32_TYPE, "dir indexes")?;
-                package.dir_indexes = entry.read_i32_array()?;
+                package.dir_indexes = entry.read_u32_array()?;
             }
             RPMTAG_DIRNAMES => {
                 ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "dir names")?;
@@ -55,7 +55,7 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
             }
             RPMTAG_EPOCH => {
                 ensure_kind(&entry, RPM_INT32_TYPE, "epoch")?;
-                package.epoch = entry.read_i32()?;
+                package.epoch = entry.read_u32()?;
             }
             RPMTAG_VERSION => {
                 ensure_kind(&entry, RPM_STRING_TYPE, "version")?;
@@ -91,7 +91,7 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
             }
             RPMTAG_SIZE => {
                 ensure_kind(&entry, RPM_INT32_TYPE, "size")?;
-                package.size = entry.read_i32()?;
+                package.size = entry.read_u32()?;
             }
             RPMTAG_PROVIDENAME => {
                 ensure_kind(&entry, RPM_STRING_ARRAY_TYPE, "provide names")?;

--- a/src/parsers/rpm_db_native/tags.rs
+++ b/src/parsers/rpm_db_native/tags.rs
@@ -1,8 +1,8 @@
-pub(crate) const RPMTAG_HEADERIMAGE: i32 = 61;
-pub(crate) const RPMTAG_HEADERSIGNATURES: i32 = 62;
-pub(crate) const RPMTAG_HEADERIMMUTABLE: i32 = 63;
-pub(crate) const HEADER_I18NTABLE: i32 = 100;
-pub(crate) const RPMTAG_HEADERI18NTABLE: i32 = HEADER_I18NTABLE;
+pub(crate) const RPMTAG_HEADERIMAGE: u32 = 61;
+pub(crate) const RPMTAG_HEADERSIGNATURES: u32 = 62;
+pub(crate) const RPMTAG_HEADERIMMUTABLE: u32 = 63;
+pub(crate) const HEADER_I18NTABLE: u32 = 100;
+pub(crate) const RPMTAG_HEADERI18NTABLE: u32 = HEADER_I18NTABLE;
 
 pub(crate) const RPMTAG_NAME: u32 = 1000;
 pub(crate) const RPMTAG_VERSION: u32 = 1001;

--- a/src/parsers/rpm_db_native/tags.rs
+++ b/src/parsers/rpm_db_native/tags.rs
@@ -22,9 +22,57 @@ pub(crate) const RPMTAG_PLATFORM: u32 = 1132;
 pub(crate) const RPMTAG_SIZE: u32 = 1009;
 pub(crate) const RPMTAG_FILENAMES: u32 = 5000;
 
-pub(crate) const RPM_MIN_TYPE: u32 = 0;
-pub(crate) const RPM_MAX_TYPE: u32 = 9;
-pub(crate) const RPM_INT32_TYPE: u32 = 4;
-pub(crate) const RPM_STRING_TYPE: u32 = 6;
-pub(crate) const RPM_STRING_ARRAY_TYPE: u32 = 8;
-pub(crate) const RPM_I18NSTRING_TYPE: u32 = 9;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TagType {
+    Null,
+    Char,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Bin,
+    StringArray,
+    I18nString,
+}
+
+impl TagType {
+    pub(crate) fn from_raw(code: u32) -> anyhow::Result<Self> {
+        match code {
+            0 => Ok(Self::Null),
+            1 => Ok(Self::Char),
+            2 => Ok(Self::Int8),
+            3 => Ok(Self::Int16),
+            4 => Ok(Self::Int32),
+            5 => Ok(Self::Int64),
+            6 => Ok(Self::String),
+            7 => Ok(Self::Bin),
+            8 => Ok(Self::StringArray),
+            9 => Ok(Self::I18nString),
+            _ => Err(anyhow::anyhow!("invalid RPM tag type: {code}")),
+        }
+    }
+
+    pub(crate) fn element_size(&self) -> Option<u32> {
+        match self {
+            Self::Null | Self::Char | Self::Int8 | Self::Bin => Some(1),
+            Self::Int16 => Some(2),
+            Self::Int32 => Some(4),
+            Self::Int64 => Some(8),
+            Self::String | Self::StringArray | Self::I18nString => None,
+        }
+    }
+
+    pub(crate) fn alignment(&self) -> u32 {
+        match self {
+            Self::Int16 => 2,
+            Self::Int32 => 4,
+            Self::Int64 => 8,
+            _ => 1,
+        }
+    }
+
+    pub(crate) fn is_variable_length(&self) -> bool {
+        self.element_size().is_none()
+    }
+}

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1192,7 +1192,7 @@ fn internal_match_to_public(
     detection_match: crate::license_detection::models::LicenseMatch,
 ) -> Match {
     let score = detection_match.score;
-    let match_coverage = ((detection_match.coverage() as f64) * 100.0).round() / 100.0;
+    let match_coverage = (f64::from(detection_match.coverage()) * 100.0).round() / 100.0;
 
     Match {
         license_expression: detection_match.license_expression,

--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -158,14 +158,12 @@ pub(crate) fn package(uid: &str, path: &str) -> Package {
 #[cfg(feature = "golden-tests")]
 pub(crate) fn test_license_engine() -> Arc<LicenseDetectionEngine> {
     static ENGINE: OnceLock<Arc<LicenseDetectionEngine>> = OnceLock::new();
-    ENGINE
-        .get_or_init(|| {
-            Arc::new(
-                LicenseDetectionEngine::from_embedded()
-                    .expect("embedded license engine should initialize"),
-            )
-        })
-        .clone()
+    Arc::clone(ENGINE.get_or_init(|| {
+        Arc::new(
+            LicenseDetectionEngine::from_embedded()
+                .expect("embedded license engine should initialize"),
+        )
+    }))
 }
 
 #[cfg(feature = "golden-tests")]

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -10,6 +10,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use indicatif_log_bridge::LogWrapper;
 use log::LevelFilter;
 
+use crate::cli::ProcessMode;
 use crate::models::{FileInfo, FileType};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -21,7 +22,7 @@ pub enum ProgressMode {
 
 #[derive(Debug, Default, Clone)]
 pub struct ScanStats {
-    pub processes: i32,
+    pub processes: ProcessMode,
     pub scan_names: String,
     pub initial_files: usize,
     pub initial_dirs: usize,
@@ -97,7 +98,7 @@ impl ScanProgress {
         self.finish_top_level_phase("setup");
     }
 
-    pub fn set_processes(&self, processes: i32) {
+    pub fn set_processes(&self, processes: ProcessMode) {
         let mut stats = self.stats.lock().expect("stats lock poisoned");
         stats.processes = processes;
     }
@@ -602,27 +603,27 @@ fn build_summary_messages(stats: &ScanStats, scan_start: &str, scan_end: &str) -
     let mut lines = vec![
         format!(
             "Summary:        {scan_names} with {} process(es)",
-            stats.processes
+            stats.processes.to_i32()
         ),
         format!("Errors count:   {}", stats.error_count),
         format!("Warnings count: {}", stats.warning_count),
         format!(
             "Scan Speed:     {speed_files:.2} files/sec. {}/sec.",
-            format_size(speed_bytes as u64)
+            format_size(speed_bytes)
         ),
         format!(
             "Initial counts: {} resource(s): {} file(s) and {} directorie(s) for {}",
             stats.initial_files + stats.initial_dirs,
             stats.initial_files,
             stats.initial_dirs,
-            format_size(stats.initial_size)
+            format_size(stats.initial_size as f64)
         ),
         format!(
             "Final counts:   {} resource(s): {} file(s) and {} directorie(s) for {}",
             stats.final_files + stats.final_dirs,
             stats.final_files,
             stats.final_dirs,
-            format_size(stats.final_size)
+            format_size(stats.final_size as f64)
         ),
         format!("Excluded count: {}", stats.excluded_count),
         format!(
@@ -683,15 +684,15 @@ fn detail_parent_phase(detail_name: &str) -> Option<&'static str> {
     }
 }
 
-pub fn format_size(bytes: u64) -> String {
-    if bytes == 0 {
+pub fn format_size(bytes: f64) -> String {
+    if bytes < 1.0 {
         return "0 Bytes".to_string();
     }
-    if bytes == 1 {
+    if bytes == 1.0 {
         return "1 Byte".to_string();
     }
 
-    let mut size = bytes as f64;
+    let mut size = bytes;
     let units = ["Bytes", "KB", "MB", "GB", "TB"];
     let mut idx = 0;
     while size >= 1024.0 && idx < units.len() - 1 {
@@ -700,7 +701,7 @@ pub fn format_size(bytes: u64) -> String {
     }
 
     if idx == 0 {
-        format!("{} {}", bytes, units[idx])
+        format!("{:.0} {}", size, units[idx])
     } else {
         format!("{size:.2} {}", units[idx])
     }
@@ -714,6 +715,7 @@ mod tests {
         format_size, pdf_oxide_default_log_filter_from, pluralize_files,
         should_filter_pdf_oxide_default_warnings_from,
     };
+    use crate::cli::ProcessMode;
 
     use std::path::Path;
 
@@ -721,16 +723,16 @@ mod tests {
 
     #[test]
     fn format_size_matches_expected_shape() {
-        assert_eq!(format_size(0), "0 Bytes");
-        assert_eq!(format_size(1), "1 Byte");
-        assert_eq!(format_size(1024), "1.00 KB");
-        assert_eq!(format_size(2_567_000), "2.45 MB");
+        assert_eq!(format_size(0.0), "0 Bytes");
+        assert_eq!(format_size(1.0), "1 Byte");
+        assert_eq!(format_size(1024.0), "1.00 KB");
+        assert_eq!(format_size(2_567_000.0), "2.45 MB");
     }
 
     #[test]
     fn summary_messages_render_detail_timings_hierarchically() {
         let stats = ScanStats {
-            processes: 4,
+            processes: ProcessMode::Parallel(4),
             scan_names: "licenses, packages".to_string(),
             initial_files: 10,
             initial_dirs: 2,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -107,8 +107,8 @@ pub fn scan_options_fingerprint(
 pub use self::collect::{CollectedPaths, collect_paths};
 #[allow(unused_imports)]
 pub use self::process::{
-    process_collected, process_collected_sequential, process_collected_with_memory_limit,
-    process_collected_with_memory_limit_sequential,
+    MemoryMode, process_collected, process_collected_sequential,
+    process_collected_with_memory_limit, process_collected_with_memory_limit_sequential,
 };
 
 #[cfg(test)]
@@ -123,7 +123,7 @@ mod tests {
     use crate::progress::{ProgressMode, ScanProgress};
 
     use super::{
-        LicenseScanOptions, TextDetectionOptions, collect_paths, process_collected,
+        LicenseScanOptions, MemoryMode, TextDetectionOptions, collect_paths, process_collected,
         process_collected_with_memory_limit,
     };
 
@@ -1554,7 +1554,7 @@ mod tests {
                 max_urls: 50,
                 timeout_seconds: 120.0,
             },
-            1,
+            MemoryMode::Limit(1),
         );
 
         assert_eq!(result.files.len(), 3);
@@ -1585,7 +1585,7 @@ mod tests {
                 max_urls: 50,
                 timeout_seconds: 120.0,
             },
-            -1,
+            MemoryMode::StreamUnlimited,
         );
 
         assert_eq!(result.files.len(), 2);

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -4,6 +4,7 @@ use crate::parsers::compiled_binary::{
 };
 use crate::parsers::try_parse_file;
 use crate::parsers::windows_executable::try_parse_windows_executable_bytes;
+
 use crate::utils::hash::{calculate_md5, calculate_sha1, calculate_sha1_git, calculate_sha256};
 use crate::utils::text::{
     remove_verbatim_escape_sequences, should_remove_verbatim_escape_sequences,
@@ -38,6 +39,23 @@ use crate::utils::file::{
 };
 use crate::utils::generated::generated_code_hints_from_bytes;
 use tempfile::TempDir;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryMode {
+    CollectFirst,
+    StreamUnlimited,
+    Limit(usize),
+}
+
+impl std::fmt::Display for MemoryMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoryMode::CollectFirst => write!(f, "0"),
+            MemoryMode::StreamUnlimited => write!(f, "-1"),
+            MemoryMode::Limit(n) => write!(f, "{n}"),
+        }
+    }
+}
 
 const PEM_CERTIFICATE_HEADERS: &[(&str, &str)] = &[
     ("-----BEGIN CERTIFICATE-----", "-----END CERTIFICATE-----"),
@@ -130,27 +148,26 @@ pub fn process_collected_with_memory_limit(
     license_engine: Option<Arc<LicenseDetectionEngine>>,
     license_options: LicenseScanOptions,
     text_options: &TextDetectionOptions,
-    max_in_memory: i64,
+    max_in_memory: MemoryMode,
 ) -> ProcessResult {
-    if max_in_memory == 0 {
-        return process_collected(
-            collected,
-            progress,
-            license_engine,
-            license_options,
-            text_options,
-        );
+    match max_in_memory {
+        MemoryMode::CollectFirst => {
+            return process_collected(
+                collected,
+                progress,
+                license_engine,
+                license_options,
+                text_options,
+            );
+        }
+        MemoryMode::StreamUnlimited => {}
+        MemoryMode::Limit(_) => {}
     }
 
-    let memory_limit = if max_in_memory < 0 {
-        0
-    } else {
-        max_in_memory as usize
-    };
-    let chunk_size = if max_in_memory < 0 {
-        256
-    } else {
-        memory_limit.max(1)
+    let (memory_limit, chunk_size) = match max_in_memory {
+        MemoryMode::CollectFirst => unreachable!(),
+        MemoryMode::StreamUnlimited => (0, 256),
+        MemoryMode::Limit(n) => (n, n.max(1)),
     };
 
     let mut retained_files = Vec::new();
@@ -212,27 +229,26 @@ pub fn process_collected_with_memory_limit_sequential(
     license_engine: Option<Arc<LicenseDetectionEngine>>,
     license_options: LicenseScanOptions,
     text_options: &TextDetectionOptions,
-    max_in_memory: i64,
+    max_in_memory: MemoryMode,
 ) -> ProcessResult {
-    if max_in_memory == 0 {
-        return process_collected_sequential(
-            collected,
-            progress,
-            license_engine,
-            license_options,
-            text_options,
-        );
+    match max_in_memory {
+        MemoryMode::CollectFirst => {
+            return process_collected_sequential(
+                collected,
+                progress,
+                license_engine,
+                license_options,
+                text_options,
+            );
+        }
+        MemoryMode::StreamUnlimited => {}
+        MemoryMode::Limit(_) => {}
     }
 
-    let memory_limit = if max_in_memory < 0 {
-        0
-    } else {
-        max_in_memory as usize
-    };
-    let chunk_size = if max_in_memory < 0 {
-        256
-    } else {
-        memory_limit.max(1)
+    let (memory_limit, chunk_size) = match max_in_memory {
+        MemoryMode::CollectFirst => unreachable!(),
+        MemoryMode::StreamUnlimited => (0, 256),
+        MemoryMode::Limit(n) => (n, n.max(1)),
     };
 
     let mut retained_files = Vec::new();

--- a/src/scanner/process.rs
+++ b/src/scanner/process.rs
@@ -1249,7 +1249,7 @@ fn extract_license_information(
             license_options.unknown_licenses,
             from_binary_strings,
             &path.to_string_lossy(),
-            license_options.min_score as f32,
+            f32::from(license_options.min_score),
         )
     };
 
@@ -1377,7 +1377,7 @@ fn convert_match_to_model(
         matcher: Some(m.matcher.to_string()),
         score: m.score,
         matched_length: Some(m.matched_length),
-        match_coverage: Some(((m.coverage() as f64) * 100.0).round() / 100.0),
+        match_coverage: Some((f64::from(m.coverage()) * 100.0).round() / 100.0),
         rule_relevance: Some(m.rule_relevance),
         rule_identifier: Some(m.rule_identifier.clone()),
         rule_url,


### PR DESCRIPTION
## Summary

- Add `[lints.clippy]` section to Cargo.toml enforcing: `cargo` group, `cast_lossless`, `cast_sign_loss`, `checked_conversions`, `cloned_instead_of_copied`, `clone_on_ref_ptr`, `filetype_is_file`
- Eliminate all 25 `cast_sign_loss` warnings through proper type refactoring and idiomatic Rust patterns
- Auto-fix `cast_lossless`, `checked_conversions`, and `cloned_instead_of_copied` warnings via `cargo clippy --fix`

## Issues

- Covers: Clippy lint enforcement for the project

## Scope and exclusions

- Included:
  - Clippy lint config in Cargo.toml (6 active lints, all clean)
  - RPM parser type improvements: `EntryInfo.tag`, `InstalledRpmPackage` fields (`epoch`/`size`/`dir_indexes`) changed from `i32` to `u32`; `compute_data_length`/`string_tag_length` return `Option<usize>` instead of `isize` with `-1` sentinel; `TYPE_SIZES` uses `Option<u32>` with `None` for variable-length types; `TagType` enum replaces raw `u32` tag type encoding
  - `MemoryMode` enum replaces `max_in_memory: i64` sentinel pattern in scanner
  - `ProcessMode` enum replaces `processes: i32` in CLI
  - License detection: `known_pos`/`pos` refactored from signed sentinels to `Option<usize>`; `matchable_tokens()` returns `Vec<Option<TokenId>>` instead of `Vec<i32>` with `-1` sentinels; `HIGH_RESEMBLANCE_THRESHOLD_TENTHS` const eliminates float→int cast
  - `format_size(f64)` in progress reporting eliminates unnecessary f64→u64→f64 round-trip
- Explicit exclusions:
  - `cast_possible_truncation`, `cast_possible_wrap`, `cast_precision_loss` lints NOT added (107 warnings, deferred)
  - No output format or behavior changes

## Intentional differences from Python

- RPM parser fields now use unsigned types matching the RPM binary format spec (tags, epochs, sizes, indexes were always unsigned)
- `MemoryMode`/`ProcessMode` enums replace sentinel-based signed integers — same behavior, more type-safe
- License detection position tracking uses `Option<usize>` instead of `-1` sentinels — same semantics, no latent `usize::MAX` key bug

## Follow-up work

- Created or intentionally deferred:
  - `cast_possible_truncation` (37 warnings), `cast_possible_wrap` (8 warnings), `cast_precision_loss` (62 warnings) — can be addressed incrementally in future PRs

## Expected-output fixture changes

- Files changed: None
- Why the new expected output is correct: No output changes; all changes are internal type refinements with identical behavior