### PR TITLE
perf(license-detection): add rkyv-based license index cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2076,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mutate_once"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,8 +2891,10 @@ dependencies = [
  "pdf_oxide",
  "pep508_rs",
  "quick-xml",
+ "rancor",
  "rayon",
  "regex",
+ "rkyv",
  "rmp-serde",
  "rpm",
  "rusqlite",
@@ -2894,6 +2939,26 @@ dependencies = [
  "url",
  "yaml_serde",
  "zstd",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2959,6 +3024,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3084,6 +3158,46 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "smallvec",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "rle-decode-fast"
@@ -3437,6 +3551,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,10 @@ packageurl = "0.6.0"
 pdf_oxide = "0.3.23"
 pep508_rs = "0.9.2"
 quick-xml = "0.39.2"
+rancor = "0.1.1"
 rayon = { workspace = true }
 regex = { workspace = true }
+rkyv = { version = "0.8.15", features = ["smallvec-1"] }
 rmp-serde = { workspace = true }
 rpm = { version = "0.20.0", default-features = false, features = ["gzip-compression", "xz-compression", "zstd-compression", "bzip2-compression"] }
 ruff_python_ast = { version = "0.15.8", package = "rustpython-ruff_python_ast" }

--- a/src/license_detection/automaton.rs
+++ b/src/license_detection/automaton.rs
@@ -109,6 +109,11 @@ impl Automaton {
     pub fn heap_bytes(&self) -> usize {
         self.inner.heap_bytes()
     }
+
+    /// Serialize the automaton to a byte vector.
+    pub fn serialize_bytes(&self) -> Vec<u8> {
+        self.inner.serialize()
+    }
 }
 
 impl Default for Automaton {

--- a/src/license_detection/index/dictionary.rs
+++ b/src/license_detection/index/dictionary.rs
@@ -5,9 +5,25 @@
 
 use std::collections::HashMap;
 
+use rkyv::Archive;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[rkyv(derive(Hash, Eq, PartialEq, PartialOrd, Ord))]
 pub struct TokenId(u16);
 
 impl TokenId {
@@ -69,13 +85,37 @@ impl PartialOrd<TokenId> for u16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub enum TokenKind {
     Legalese,
     Regular,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub struct KnownToken {
     pub id: TokenId,
     pub kind: TokenKind,
@@ -83,14 +123,28 @@ pub struct KnownToken {
     pub is_short_or_digit: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub enum QueryToken {
     Known(KnownToken),
     Unknown,
     Stopword,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, Archive, rkyv::Serialize, rkyv::Deserialize,
+)]
 pub struct TokenMetadata {
     pub kind: TokenKind,
     pub is_digit_only: bool,
@@ -108,7 +162,7 @@ pub struct TokenMetadata {
 ///
 /// Based on the Python ScanCode Toolkit implementation at:
 /// reference/scancode-toolkit/src/licensedcode/index.py
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TokenDictionary {
     /// Mapping from token string to token ID
     tokens_to_ids: HashMap<String, TokenId>,

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -14,13 +14,94 @@ pub use builder::{
 use crate::license_detection::automaton::Automaton;
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId};
 use crate::license_detection::{TokenMultiset, TokenSet};
+use rkyv::Archive;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct IndexedRuleMetadata {
     pub license_expression_spdx: Option<String>,
     pub skip_for_required_phrase_generation: bool,
     pub replaced_by: Vec<String>,
+}
+
+/// Rkyv-compatible cache representation of LicenseIndex.
+///
+/// Automaton fields and complex model types are stored as serialized byte
+/// vectors since they have custom serde logic that isn't compatible with
+/// rkyv's derive macros.
+#[derive(Debug, Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct CachedLicenseIndex {
+    pub dictionary: TokenDictionary,
+    pub len_legalese: usize,
+    pub rid_by_hash: HashMap<[u8; 20], usize>,
+    pub rules_by_rid_bytes: Vec<u8>,
+    pub tids_by_rid: Vec<Vec<TokenId>>,
+    pub rules_automaton_bytes: Vec<u8>,
+    pub unknown_automaton_bytes: Vec<u8>,
+    pub sets_by_rid: HashMap<usize, TokenSet>,
+    pub rule_metadata_by_identifier: HashMap<String, IndexedRuleMetadata>,
+    pub msets_by_rid: HashMap<usize, TokenMultiset>,
+    pub high_sets_by_rid: HashMap<usize, TokenSet>,
+    pub high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>>,
+    pub false_positive_rids: HashSet<usize>,
+    pub approx_matchable_rids: HashSet<usize>,
+    pub licenses_by_key_bytes: Vec<u8>,
+    pub pattern_id_to_rid: Vec<Vec<usize>>,
+    pub rid_by_spdx_key: HashMap<String, usize>,
+    pub unknown_spdx_rid: Option<usize>,
+    pub rids_by_high_tid: HashMap<TokenId, HashSet<usize>>,
+}
+
+impl From<LicenseIndex> for CachedLicenseIndex {
+    fn from(index: LicenseIndex) -> Self {
+        Self {
+            dictionary: index.dictionary,
+            len_legalese: index.len_legalese,
+            rid_by_hash: index.rid_by_hash,
+            rules_by_rid_bytes: rmp_serde::to_vec(&index.rules_by_rid).unwrap(),
+            tids_by_rid: index.tids_by_rid,
+            rules_automaton_bytes: index.rules_automaton.serialize_bytes(),
+            unknown_automaton_bytes: index.unknown_automaton.serialize_bytes(),
+            sets_by_rid: index.sets_by_rid,
+            rule_metadata_by_identifier: index.rule_metadata_by_identifier,
+            msets_by_rid: index.msets_by_rid,
+            high_sets_by_rid: index.high_sets_by_rid,
+            high_postings_by_rid: index.high_postings_by_rid,
+            false_positive_rids: index.false_positive_rids,
+            approx_matchable_rids: index.approx_matchable_rids,
+            licenses_by_key_bytes: rmp_serde::to_vec(&index.licenses_by_key).unwrap(),
+            pattern_id_to_rid: index.pattern_id_to_rid,
+            rid_by_spdx_key: index.rid_by_spdx_key,
+            unknown_spdx_rid: index.unknown_spdx_rid,
+            rids_by_high_tid: index.rids_by_high_tid,
+        }
+    }
+}
+
+impl From<CachedLicenseIndex> for LicenseIndex {
+    fn from(cached: CachedLicenseIndex) -> Self {
+        Self {
+            dictionary: cached.dictionary,
+            len_legalese: cached.len_legalese,
+            rid_by_hash: cached.rid_by_hash,
+            rules_by_rid: rmp_serde::from_slice(&cached.rules_by_rid_bytes).unwrap(),
+            tids_by_rid: cached.tids_by_rid,
+            rules_automaton: Automaton::deserialize_unchecked(&cached.rules_automaton_bytes),
+            unknown_automaton: Automaton::deserialize_unchecked(&cached.unknown_automaton_bytes),
+            sets_by_rid: cached.sets_by_rid,
+            rule_metadata_by_identifier: cached.rule_metadata_by_identifier,
+            msets_by_rid: cached.msets_by_rid,
+            high_sets_by_rid: cached.high_sets_by_rid,
+            high_postings_by_rid: cached.high_postings_by_rid,
+            false_positive_rids: cached.false_positive_rids,
+            approx_matchable_rids: cached.approx_matchable_rids,
+            licenses_by_key: rmp_serde::from_slice(&cached.licenses_by_key_bytes).unwrap(),
+            pattern_id_to_rid: cached.pattern_id_to_rid,
+            rid_by_spdx_key: cached.rid_by_spdx_key,
+            unknown_spdx_rid: cached.unknown_spdx_rid,
+            rids_by_high_tid: cached.rids_by_high_tid,
+        }
+    }
 }
 
 /// License index containing all data structures for efficient license detection.

--- a/src/license_detection/license_cache.rs
+++ b/src/license_detection/license_cache.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rancor::{Panic, ResultExt};
+
+use crate::license_detection::index::CachedLicenseIndex;
+
+const SCHEMA_VERSION: u32 = 1;
+
+pub struct LicenseCacheConfig {
+    cache_dir: PathBuf,
+}
+
+impl LicenseCacheConfig {
+    pub fn from_default_dir() -> Self {
+        let cache_dir = directories::ProjectDirs::from("", "", "provenant")
+            .map(|dirs| dirs.cache_dir().join("license_index"))
+            .unwrap_or_else(|| PathBuf::from("/tmp/provenant/license_index"));
+        Self { cache_dir }
+    }
+
+    fn cache_file_path(&self) -> PathBuf {
+        self.cache_dir.join("index_cache.rkyv")
+    }
+
+    fn version_file_path(&self) -> PathBuf {
+        self.cache_dir.join("version")
+    }
+}
+
+pub fn load_cached_index(config: &LicenseCacheConfig) -> Result<Option<CachedLicenseIndex>> {
+    let version_path = config.version_file_path();
+    let cache_path = config.cache_file_path();
+
+    if !cache_path.exists() || !version_path.exists() {
+        return Ok(None);
+    }
+
+    let stored_version: u32 = fs::read_to_string(&version_path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+
+    if stored_version != SCHEMA_VERSION {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&cache_path).context("Failed to read license index cache file")?;
+
+    let archived =
+        match rkyv::access::<rkyv::Archived<CachedLicenseIndex>, rkyv::rancor::Error>(&bytes) {
+            Ok(archived) => archived,
+            Err(_) => return Ok(None),
+        };
+
+    let cached: CachedLicenseIndex =
+        rkyv::deserialize::<CachedLicenseIndex, Panic>(archived).always_ok();
+
+    Ok(Some(cached))
+}
+
+pub fn save_cached_index(config: &LicenseCacheConfig, cached: &CachedLicenseIndex) -> Result<()> {
+    fs::create_dir_all(&config.cache_dir)
+        .context("Failed to create license index cache directory")?;
+
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(cached)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize license index cache: {}", e))?;
+
+    let cache_path = config.cache_file_path();
+    let mut file =
+        fs::File::create(&cache_path).context("Failed to create license index cache file")?;
+    file.write_all(&bytes)
+        .context("Failed to write license index cache file")?;
+
+    let version_path = config.version_file_path();
+    fs::write(&version_path, SCHEMA_VERSION.to_string())
+        .context("Failed to write cache version file")?;
+
+    Ok(())
+}
+
+pub fn cache_file_size(config: &LicenseCacheConfig) -> Option<u64> {
+    fs::metadata(config.cache_file_path()).ok().map(|m| m.len())
+}

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -4,6 +4,7 @@ pub mod aho_match;
 pub mod automaton;
 pub(crate) mod detection;
 pub mod embedded;
+mod license_cache;
 mod position_set;
 mod token_multiset;
 mod token_set;
@@ -34,13 +35,18 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 
 use crate::license_detection::embedded::index::{
     load_embedded_artifact_metadata_from_bytes, load_embedded_license_index_from_bytes,
 };
+use crate::license_detection::index::CachedLicenseIndex;
 use crate::license_detection::index::build_index_from_loaded;
+use crate::license_detection::license_cache::{
+    LicenseCacheConfig, cache_file_size, load_cached_index, save_cached_index,
+};
 use crate::license_detection::query::Query;
 use crate::license_detection::rules::{
     load_loaded_licenses_from_directory, load_loaded_rules_from_directory,
@@ -463,13 +469,41 @@ impl LicenseDetectionEngine {
     /// # Returns
     /// A Result containing the engine or an error
     pub fn from_embedded() -> Result<Self> {
+        let cache_config = LicenseCacheConfig::from_default_dir();
+
+        if let Some(cached) = load_cached_index(&cache_config)? {
+            let start = Instant::now();
+            let index = index::LicenseIndex::from(cached);
+            eprintln!(
+                "License index loaded from rkyv cache in {:.2}s",
+                start.elapsed().as_secs_f64()
+            );
+            return Self::from_index(index, Self::embedded_spdx_license_list_version().ok());
+        }
+
+        let start = Instant::now();
         let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         let loaded = load_embedded_license_index_from_bytes(artifact_bytes)
             .map_err(|e| anyhow::anyhow!("Failed to load embedded license index: {}", e))?;
-        Self::from_index(
-            loaded.index,
-            Some(loaded.metadata.spdx_license_list_version),
-        )
+        eprintln!(
+            "License index built from embedded artifact in {:.2}s",
+            start.elapsed().as_secs_f64()
+        );
+
+        let index = loaded.index;
+        let spdx_version = Some(loaded.metadata.spdx_license_list_version);
+
+        let cached = CachedLicenseIndex::from(index.clone());
+        if let Err(e) = save_cached_index(&cache_config, &cached) {
+            eprintln!("Warning: failed to save license index cache: {}", e);
+        } else if let Some(size) = cache_file_size(&cache_config) {
+            eprintln!(
+                "License index cache saved ({:.1} MB)",
+                size as f64 / 1_048_576.0
+            );
+        }
+
+        Self::from_index(index, spdx_version)
     }
 
     /// Create a new license detection engine from a directory of license rules.

--- a/src/license_detection/token_multiset.rs
+++ b/src/license_detection/token_multiset.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use rkyv::Archive;
+
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId, TokenKind};
 
 /// A multiset of token IDs stored as token -> occurrence count.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TokenMultiset(HashMap<TokenId, usize>);
 
 impl TokenMultiset {

--- a/src/license_detection/token_set.rs
+++ b/src/license_detection/token_set.rs
@@ -2,6 +2,8 @@ use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::ops::Deref;
 
+use rkyv::Archive;
+
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId, TokenKind};
 
 /// A set of token IDs stored as a sorted SmallVec.
@@ -9,7 +11,7 @@ use crate::license_detection::index::dictionary::{TokenDictionary, TokenId, Toke
 /// Invariant: elements are always sorted and deduplicated.
 /// Construct via `TokenSet::from_token_ids()`, `TokenSet::from_u16_iter()`,
 /// or `.collect()` from an iterator of u16.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TokenSet(SmallVec<[u16; 64]>);
 
 impl TokenSet {


### PR DESCRIPTION
## Summary

- Add rkyv-based license index cache that persists the built license index to disk, enabling ~0.14s warm starts (down from ~10s cold starts)
- On first run, the index is built from the embedded artifact and saved to `~/.cache/provenant/license_index/`; subsequent runs load the cached index via rkyv zero-copy deserialization
- Automaton fields are stored as daachorse serialized byte blobs; Rule and License fields are stored as rmp_serde byte blobs (avoiding cascading rkyv derive requirements on those complex types)

### Evaluated alternatives

| Approach | Cache Size | Warm Start | Cold Start |
|----------|-----------|------------|------------|
| No caching (baseline) | 0 | ~10.0s | ~10.0s |
| Skip automatons + zstd + rmp_serde | 36 MB | ~5.3s | ~11.5s |
| Full automata + zstd + rmp_serde | 128 MB | ~1.5s | ~13.3s |
| Full automata + rmp_serde (no zstd) | 358 MB | ~1.15s | ~11.1s |
| Full automata + bincode (no zstd) | 340 MB | ~0.57s | ~10.5s |
| **rkyv (this PR)** | **340 MB** | **~0.14s** | **~10.0s** |
| ScanCode Toolkit (Python pickle) | 395 MB | — | — |

rkyv is ~4x faster than bincode and ~8x faster than rmp_serde for warm starts, at the same cache size.

## Scope and exclusions

- Included: rkyv cache serialization/deserialization, cache directory management, `CachedLicenseIndex` struct with byte-blob fields for Automaton/Rule/License, rkyv Archive derives on TokenId/TokenDictionary/TokenSet/TokenMultiset/IndexedRuleMetadata
- Explicit exclusions: cache invalidation beyond schema versioning (e.g., no embedded artifact hash check yet), no CLI flags for cache control

## Intentional differences from Python

- Python ScanCode Toolkit uses pickle for its license index cache (395 MB). This implementation uses rkyv for significantly faster deserialization with a smaller cache footprint.

## Follow-up work

- Add embedded artifact hash to cache validation (invalidate cache when the embedded artifact changes)
- Consider rkyv + zstd compression for a smaller cache at the cost of slightly slower warm starts
- Add `--reindex` and `--license-cache-dir` CLI flags for cache control

Closes #612 