### PR TITLE
fix(output): preserve declared license rule identifiers

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -178,7 +178,7 @@ pub fn aho_match_with_extra_matchables(
                 rule_relevance: rule.relevance,
                 rid,
                 rule_identifier: rule.identifier.clone(),
-                rule_url: String::new(),
+                rule_url: rule.rule_url().unwrap_or_default(),
                 matched_text: None,
                 referenced_filenames: rule.referenced_filenames.clone(),
                 rule_kind: rule.kind(),
@@ -339,6 +339,7 @@ mod tests {
         assert_eq!(matches[0].matcher, MATCH_AHO);
         assert_eq!(matches[0].score, MatchScore::MAX);
         assert_eq!(matches[0].match_coverage, 100.0);
+        assert!(!matches[0].rule_url.is_empty());
     }
 
     #[test]

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -8,8 +8,8 @@ mod tests {
     };
     use crate::license_detection::position_set::PositionSet;
     use crate::models::LineNumber;
-    use crate::models::Match as OutputMatch;
     use crate::models::MatchScore;
+    use crate::output_schema::{OutputLicenseDetection, OutputMatch};
     use std::collections::HashMap;
 
     fn create_test_index() -> LicenseIndex {
@@ -597,8 +597,8 @@ mod tests {
             license_expression: "mit".to_string(),
             license_expression_spdx: "MIT".to_string(),
             from_file: None,
-            start_line: LineNumber::ONE,
-            end_line: LineNumber::ONE,
+            start_line: 1,
+            end_line: 1,
             matcher: Some("1-hash".to_string()),
             score: MatchScore::MAX,
             matched_length: Some(3),
@@ -615,6 +615,48 @@ mod tests {
 
         assert!(json.get("rule_url").is_some());
         assert!(json["rule_url"].is_null());
+    }
+
+    #[test]
+    fn test_output_match_serializes_null_from_file() {
+        let output_match = OutputMatch {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: None,
+            start_line: 1,
+            end_line: 1,
+            matcher: Some("1-hash".to_string()),
+            score: MatchScore::MAX,
+            matched_length: Some(3),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("mit.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: Some("MIT".to_string()),
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        };
+
+        let json = serde_json::to_value(&output_match).unwrap();
+
+        assert!(json.get("from_file").is_some());
+        assert!(json["from_file"].is_null());
+    }
+
+    #[test]
+    fn test_output_license_detection_serializes_null_identifier() {
+        let output_detection = OutputLicenseDetection {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            matches: vec![],
+            detection_log: vec![],
+            identifier: None,
+        };
+
+        let json = serde_json::to_value(&output_detection).unwrap();
+
+        assert!(json.get("identifier").is_some());
+        assert!(json["identifier"].is_null());
     }
 
     #[test]

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -415,6 +415,10 @@ fn from_json_loaded_manifest_detections_can_be_recomputed_into_top_level_uniques
         top_level[0].reference_matches[0].from_file.as_deref(),
         Some("project/package.json")
     );
+    assert_eq!(
+        top_level[0].reference_matches[0].rule_identifier.as_deref(),
+        Some("parser-declared-license")
+    );
 }
 
 #[test]
@@ -458,6 +462,10 @@ fn from_json_recomputes_top_level_uniques_even_without_shaping_flags() {
     assert_eq!(top_level.len(), 1);
     assert_eq!(top_level[0].license_expression, "gpl-2.0-only");
     assert_ne!(top_level[0].identifier, "stale-id");
+    assert_eq!(
+        top_level[0].reference_matches[0].rule_identifier.as_deref(),
+        Some("parser-declared-license")
+    );
 }
 
 #[test]

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -330,6 +330,10 @@ pub(crate) fn enrich_license_detection_provenance(detection: &mut LicenseDetecti
         if detection_match.from_file.is_none() {
             detection_match.from_file = Some(path.to_string());
         }
+
+        if detection_match.rule_identifier.is_none() {
+            detection_match.rule_identifier = detection_match.matcher.clone();
+        }
     }
 
     if detection.identifier.is_none() {
@@ -1173,6 +1177,12 @@ mod tests {
                 .as_deref(),
             Some("project/package.json")
         );
+        assert_eq!(
+            file_info.package_data[0].license_detections[0].matches[0]
+                .rule_identifier
+                .as_deref(),
+            Some("parser-declared-license")
+        );
         assert!(
             file_info.package_data[0].license_detections[0]
                 .identifier
@@ -1217,6 +1227,12 @@ mod tests {
                 .from_file
                 .as_deref(),
             Some("project/package.json")
+        );
+        assert_eq!(
+            package.license_detections[0].matches[0]
+                .rule_identifier
+                .as_deref(),
+            Some("parser-declared-license")
         );
         assert!(package.license_detections[0].identifier.is_some());
     }

--- a/src/output_schema/license_detection.rs
+++ b/src/output_schema/license_detection.rs
@@ -9,7 +9,6 @@ pub struct OutputLicenseDetection {
     pub matches: Vec<OutputMatch>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub detection_log: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 }
 

--- a/src/output_schema/license_match.rs
+++ b/src/output_schema/license_match.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct OutputMatch {
     pub license_expression: String,
     pub license_expression_spdx: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub from_file: Option<String>,
     pub start_line: u64,
     pub end_line: u64,

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -254,6 +254,10 @@ pub(crate) fn build_declared_license_detection(
     normalized: &NormalizedDeclaredLicense,
     metadata: DeclaredLicenseMatchMetadata<'_>,
 ) -> LicenseDetection {
+    let (rule_identifier, rule_url) =
+        derive_declared_rule_metadata(normalized, metadata.matched_text)
+            .unwrap_or_else(|| (PARSER_DECLARED_MATCHER.to_string(), None));
+
     LicenseDetection {
         license_expression: normalized.declared_license_expression.clone(),
         license_expression_spdx: normalized.declared_license_expression_spdx.clone(),
@@ -268,8 +272,8 @@ pub(crate) fn build_declared_license_detection(
             matched_length: Some(metadata.matched_text.split_whitespace().count()),
             match_coverage: Some(100.0),
             rule_relevance: Some(100),
-            rule_identifier: None,
-            rule_url: None,
+            rule_identifier: Some(rule_identifier),
+            rule_url,
             matched_text: Some(metadata.matched_text.to_string()),
             referenced_filenames: metadata
                 .referenced_filenames
@@ -279,6 +283,39 @@ pub(crate) fn build_declared_license_detection(
         detection_log: vec![],
         identifier: None,
     }
+}
+
+fn derive_declared_rule_metadata(
+    normalized: &NormalizedDeclaredLicense,
+    matched_text: &str,
+) -> Option<(String, Option<String>)> {
+    let matched_text = matched_text.trim();
+    if matched_text.is_empty() {
+        return None;
+    }
+
+    let engine = PARSER_LICENSE_ENGINE.as_ref()?;
+    let detections = engine.detect_with_kind(matched_text, false, false).ok()?;
+    let license_match = detections
+        .into_iter()
+        .find(|detection| detection_matches_normalized_expression(detection, normalized))?
+        .matches
+        .into_iter()
+        .next()?;
+
+    Some((
+        license_match.rule_identifier,
+        (!license_match.rule_url.is_empty()).then_some(license_match.rule_url),
+    ))
+}
+
+fn detection_matches_normalized_expression(
+    detection: &crate::license_detection::LicenseDetection,
+    normalized: &NormalizedDeclaredLicense,
+) -> bool {
+    detection.license_expression.as_deref() == Some(normalized.declared_license_expression.as_str())
+        || detection.license_expression_spdx.as_deref()
+            == Some(normalized.declared_license_expression_spdx.as_str())
 }
 
 pub(crate) fn finalize_package_declared_license_references(package_data: &mut PackageData) {
@@ -339,30 +376,14 @@ pub(crate) fn finalize_package_declared_license_references(package_data: &mut Pa
         package_data.declared_license_expression = Some("unknown-license-reference".to_string());
         package_data.declared_license_expression_spdx =
             Some("LicenseRef-scancode-unknown-license-reference".to_string());
-        package_data.license_detections = vec![LicenseDetection {
-            license_expression: "unknown-license-reference".to_string(),
-            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
-            matches: vec![Match {
-                license_expression: "unknown-license-reference".to_string(),
-                license_expression_spdx: "LicenseRef-scancode-unknown-license-reference"
-                    .to_string(),
-                from_file: None,
-                start_line: LineNumber::ONE,
-                end_line: LineNumber::ONE,
-                matcher: Some(PARSER_DECLARED_MATCHER.to_string()),
-                score: MatchScore::MAX,
-                matched_length: Some(statement.split_whitespace().count()),
-                match_coverage: Some(100.0),
-                rule_relevance: Some(100),
-                rule_identifier: None,
-                rule_url: None,
-                matched_text: Some(statement.to_string()),
-                referenced_filenames: Some(referenced_filenames),
-                matched_text_diagnostics: None,
-            }],
-            detection_log: vec![],
-            identifier: None,
-        }];
+        package_data.license_detections = vec![build_declared_license_detection(
+            &NormalizedDeclaredLicense::new(
+                "unknown-license-reference",
+                "LicenseRef-scancode-unknown-license-reference",
+            ),
+            DeclaredLicenseMatchMetadata::single_line(statement)
+                .with_referenced_filenames(&referenced_filename_slices),
+        )];
     }
 }
 
@@ -708,5 +729,39 @@ mod tests {
             LineNumber::new(4).expect("valid")
         );
         assert_eq!(detection.matches[0].matched_text.as_deref(), Some("MIT"));
+        assert!(
+            detection.matches[0]
+                .rule_identifier
+                .as_deref()
+                .is_some_and(|identifier| !identifier.is_empty())
+        );
+    }
+
+    #[test]
+    fn test_build_declared_license_detection_preserves_engine_rule_metadata() {
+        let mit_license_text = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/testdata/license-golden/single-license/mit.txt"
+        ));
+        let normalized = NormalizedDeclaredLicense::new("mit", "MIT");
+        let (expected_rule_identifier, expected_rule_url) =
+            derive_declared_rule_metadata(&normalized, mit_license_text)
+                .expect("full MIT license text should derive rule metadata");
+
+        let detection = build_declared_license_detection(
+            &normalized,
+            DeclaredLicenseMatchMetadata::new(
+                mit_license_text,
+                LineNumber::new(10).unwrap(),
+                LineNumber::new(31).unwrap(),
+            ),
+        );
+
+        assert_ne!(expected_rule_identifier, PARSER_DECLARED_MATCHER);
+        assert_eq!(
+            detection.matches[0].rule_identifier.as_deref(),
+            Some(expected_rule_identifier.as_str())
+        );
+        assert_eq!(detection.matches[0].rule_url, expected_rule_url);
     }
 }

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1968,6 +1968,12 @@ fn collect_top_level_license_detections_includes_package_origin_detections() {
         detections[1].reference_matches[0].from_file.as_deref(),
         Some("project/package.json")
     );
+    assert_eq!(
+        detections[1].reference_matches[0]
+            .rule_identifier
+            .as_deref(),
+        Some("parser-declared-license")
+    );
 }
 
 #[test]

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1173,7 +1173,11 @@ fn public_match_to_internal(
         rule_length: detection_match.matched_length.unwrap_or_default(),
         match_coverage: detection_match.match_coverage.unwrap_or_default() as f32,
         rule_relevance: detection_match.rule_relevance.unwrap_or_default(),
-        rule_identifier: detection_match.rule_identifier.clone().unwrap_or_default(),
+        rule_identifier: detection_match
+            .rule_identifier
+            .clone()
+            .or_else(|| detection_match.matcher.clone())
+            .unwrap_or_default(),
         rule_url: detection_match.rule_url.clone().unwrap_or_default(),
         matched_text: detection_match.matched_text.clone(),
         referenced_filenames: detection_match.referenced_filenames.clone(),
@@ -1205,7 +1209,8 @@ fn internal_match_to_public(
         matched_length: Some(detection_match.matched_length),
         match_coverage: Some(match_coverage),
         rule_relevance: Some(detection_match.rule_relevance),
-        rule_identifier: Some(detection_match.rule_identifier),
+        rule_identifier: (!detection_match.rule_identifier.is_empty())
+            .then_some(detection_match.rule_identifier),
         rule_url: (!detection_match.rule_url.is_empty()).then_some(detection_match.rule_url),
         matched_text: detection_match.matched_text,
         referenced_filenames: detection_match.referenced_filenames,

--- a/testdata/assembly-golden/alpine-file-refs/expected.json
+++ b/testdata/assembly-golden/alpine-file-refs/expected.json
@@ -67,11 +67,12 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
-              "rule_url": null,
+              "rule_identifier": "spdx_license_id_gpl-2.0-only_for_gpl-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_gpl-2.0-only_for_gpl-2.0.RULE",
               "matched_text": "GPL-2.0-only"
             }
           ],
-          "identifier": "gpl_2_0_only-920081c7-a6eb-e2f0-a084-26baabd935ef"
+          "identifier": "gpl_2_0_only-e6dc0f78-f9bd-2b91-5dff-1cf257f19a41"
         }
       ],
       "extracted_license_statement": "GPL-2.0-only",
@@ -124,6 +125,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/maven-meta-inf-basic/expected.json
+++ b/testdata/assembly-golden/maven-meta-inf-basic/expected.json
@@ -53,11 +53,12 @@
               "matched_length": 4,
               "match_coverage": 100.0,
               "rule_relevance": 100,
-              "rule_url": null,
+              "rule_identifier": "apache-2.0_required_phrase_11.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_required_phrase_11.RULE",
               "matched_text": "- license:\n    name: Apache-2.0\n"
             }
           ],
-          "identifier": "apache_2_0-38d5b5b4-7e7c-d58a-f1b5-97251c83146b"
+          "identifier": "apache_2_0-c9592a9d-b153-f7b2-cbba-e67364394224"
         }
       ],
       "extracted_license_statement": "- license:\n    name: Apache-2.0\n",

--- a/testdata/assembly-golden/npm-workspace/expected.json
+++ b/testdata/assembly-golden/npm-workspace/expected.json
@@ -117,6 +117,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }
@@ -168,6 +169,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/nuget-basic/expected.json
+++ b/testdata/assembly-golden/nuget-basic/expected.json
@@ -32,6 +32,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/nuget-cpm-imported-parent/expected.json
+++ b/testdata/assembly-golden/nuget-cpm-imported-parent/expected.json
@@ -32,6 +32,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/nuget-cpm-nearest-ancestor/expected.json
+++ b/testdata/assembly-golden/nuget-cpm-nearest-ancestor/expected.json
@@ -32,6 +32,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/nuget-cpm-version-override/expected.json
+++ b/testdata/assembly-golden/nuget-cpm-version-override/expected.json
@@ -32,6 +32,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/assembly-golden/pnpm-workspace/expected.json
+++ b/testdata/assembly-golden/pnpm-workspace/expected.json
@@ -73,6 +73,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }
@@ -115,11 +116,12 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
-              "rule_url": null,
+              "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
               "matched_text": "Apache-2.0"
             }
           ],
-          "identifier": "apache_2_0-b8ac833d-1634-db39-3e2b-365472f52214"
+          "identifier": "apache_2_0-e4602d8c-0914-7fcd-bb51-6018f5c21d97"
         }
       ],
       "extracted_license_statement": "- Apache-2.0\n",

--- a/testdata/assembly-golden/ruby-extracted-basic/expected.json
+++ b/testdata/assembly-golden/ruby-extracted-basic/expected.json
@@ -55,6 +55,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }
@@ -76,6 +77,7 @@
               "matched_length": 1,
               "match_coverage": 100.0,
               "rule_relevance": 100,
+              "rule_identifier": "parser-declared-license",
               "rule_url": null,
               "matched_text": "MIT"
             }

--- a/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
+++ b/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
@@ -73,6 +73,33 @@
       ]
     },
     {
+      "identifier": "mit-6914bd3d-93be-35a5-ddad-8a441ad0ed45",
+      "license_expression": "mit",
+      "license_expression_spdx": "MIT",
+      "detection_count": 1,
+      "detection_log": ["unknown-reference-to-local-file"],
+      "reference_matches": [
+        {
+          "from_file": "codebase/demo-1.0.dist-info/METADATA",
+          "license_expression": "unknown-license-reference",
+          "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+          "rule_identifier": "parser-declared-license"
+        },
+        {
+          "from_file": "codebase/demo-1.0.dist-info/LICENSE",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "rule_identifier": "mit_14.RULE"
+        },
+        {
+          "from_file": "codebase/demo-1.0.dist-info/LICENSE",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "rule_identifier": "mit.LICENSE"
+        }
+      ]
+    },
+    {
       "identifier": "mit-79774d50-708a-392c-de7f-ef6d29bbf18c",
       "license_expression": "mit",
       "license_expression_spdx": "MIT",
@@ -90,33 +117,6 @@
           "license_expression": "unknown-license-reference",
           "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
           "rule_identifier": "unknown-license-reference_see_license_at_manifest_1.RULE"
-        },
-        {
-          "from_file": "codebase/demo-1.0.dist-info/LICENSE",
-          "license_expression": "mit",
-          "license_expression_spdx": "MIT",
-          "rule_identifier": "mit_14.RULE"
-        },
-        {
-          "from_file": "codebase/demo-1.0.dist-info/LICENSE",
-          "license_expression": "mit",
-          "license_expression_spdx": "MIT",
-          "rule_identifier": "mit.LICENSE"
-        }
-      ]
-    },
-    {
-      "identifier": "mit-946d5424-f316-1245-80ab-ef6c198972d8",
-      "license_expression": "mit",
-      "license_expression_spdx": "MIT",
-      "detection_count": 1,
-      "detection_log": ["unknown-reference-to-local-file"],
-      "reference_matches": [
-        {
-          "from_file": "codebase/demo-1.0.dist-info/METADATA",
-          "license_expression": "unknown-license-reference",
-          "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
-          "rule_identifier": ""
         },
         {
           "from_file": "codebase/demo-1.0.dist-info/LICENSE",
@@ -231,14 +231,14 @@
           "license_expression": "mit",
           "license_expression_spdx": "MIT",
           "detection_log": ["unknown-reference-to-local-file"],
-          "identifier": "mit-946d5424-f316-1245-80ab-ef6c198972d8",
+          "identifier": "mit-6914bd3d-93be-35a5-ddad-8a441ad0ed45",
           "matches": [
             {
               "from_file": "codebase/demo-1.0.dist-info/METADATA",
               "matched_text": "license: MIT\n",
               "license_expression": "unknown-license-reference",
               "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
-              "rule_identifier": "",
+              "rule_identifier": "parser-declared-license",
               "referenced_filenames": ["LICENSE"]
             },
             {


### PR DESCRIPTION
## Summary

- preserve declared-license `rule_identifier` metadata by deriving engine metadata when available and falling back to `parser-declared-license`
- backfill missing public match rule identifiers and keep top-level recomputation from degrading them to empty values in native and `--from-json` outputs
- add focused regression coverage for both the fallback path and the engine-derived declared-license metadata path

## Scope and exclusions

- Included:
  - declared-license normalization
  - public provenance backfill for package/file-origin detections
  - top-level `reference_matches` round-trip preservation
  - targeted regression tests for package-origin and recomputed outputs
- Explicit exclusions:
  - no change to the existing `rule_url` nullability contract
  - no broader output-schema audit beyond the confirmed `rule_identifier` parity gap

## Intentional differences from Python

- None; this narrows an observed ScanCode-compatibility gap.

## Follow-up work

- Created or intentionally deferred:
  - none