### PR TITLE
fix(licenses): canonicalize generated SPDX operand order

### DIFF
--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -1399,7 +1399,7 @@ mod tests {
         assert_eq!(
             result.as_deref(),
             Ok(
-                "apache-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0 AND apsl-1.0 AND apsl-2.0"
+                "apache-2.0 AND apsl-1.0 AND apsl-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0"
             )
         );
     }

--- a/src/license_detection/expression/simplify.rs
+++ b/src/license_detection/expression/simplify.rs
@@ -11,7 +11,7 @@ use super::{LicenseExpression, ParseError};
 ///
 /// # Returns
 /// Simplified expression with duplicate and subsumed licenses removed,
-/// preserving order.
+/// using deterministic canonical ordering for boolean operand chains.
 pub fn simplify_expression(expr: &LicenseExpression) -> LicenseExpression {
     match expr {
         LicenseExpression::License(key) => LicenseExpression::License(key.clone()),
@@ -25,6 +25,7 @@ pub fn simplify_expression(expr: &LicenseExpression) -> LicenseExpression {
             let mut seen = HashSet::new();
             collect_unique_and(expr, &mut unique, &mut seen);
             prune_subsumed_operands(&mut unique, true);
+            sort_operands_canonically(&mut unique);
             build_expression_from_list(&unique, true)
         }
         LicenseExpression::Or { .. } => {
@@ -32,9 +33,18 @@ pub fn simplify_expression(expr: &LicenseExpression) -> LicenseExpression {
             let mut seen = HashSet::new();
             collect_unique_or(expr, &mut unique, &mut seen);
             prune_subsumed_operands(&mut unique, false);
+            sort_operands_canonically(&mut unique);
             build_expression_from_list(&unique, false)
         }
     }
+}
+
+fn sort_operands_canonically(operands: &mut [LicenseExpression]) {
+    operands.sort_by_cached_key(canonical_operand_sort_key);
+}
+
+fn canonical_operand_sort_key(expr: &LicenseExpression) -> String {
+    expression_to_string(expr).to_ascii_lowercase()
 }
 
 fn prune_subsumed_operands(operands: &mut Vec<LicenseExpression>, outer_is_and: bool) {
@@ -507,7 +517,7 @@ mod tests {
     fn test_simplify_expression_no_change() {
         let expr = super::super::parse::parse_expression("MIT AND Apache-2.0").unwrap();
         let simplified = simplify_expression(&expr);
-        assert_eq!(expression_to_string(&simplified), "mit AND apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 AND mit");
     }
 
     #[test]
@@ -535,7 +545,7 @@ mod tests {
     fn test_simplify_preserves_different_licenses() {
         let expr = super::super::parse::parse_expression("mit AND apache-2.0").unwrap();
         let simplified = simplify_expression(&expr);
-        assert_eq!(expression_to_string(&simplified), "mit AND apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 AND mit");
     }
 
     #[test]
@@ -578,11 +588,11 @@ mod tests {
             super::super::parse::parse_expression("(mit AND apache-2.0) OR (mit AND apache-2.0)")
                 .unwrap();
         let simplified = simplify_expression(&expr);
-        assert_eq!(expression_to_string(&simplified), "mit AND apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 AND mit");
     }
 
     #[test]
-    fn test_simplify_preserves_order() {
+    fn test_simplify_sorts_operands_canonically() {
         let expr =
             super::super::parse::parse_expression("apache-2.0 AND mit AND apache-2.0").unwrap();
         let simplified = simplify_expression(&expr);
@@ -593,7 +603,7 @@ mod tests {
     fn test_simplify_mit_and_mit_and_apache() {
         let expr = super::super::parse::parse_expression("mit AND mit AND apache-2.0").unwrap();
         let simplified = simplify_expression(&expr);
-        assert_eq!(expression_to_string(&simplified), "mit AND apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 AND mit");
     }
 
     #[test]
@@ -620,7 +630,7 @@ mod tests {
         .unwrap();
         let simplified = simplify_expression(&expr);
 
-        assert_eq!(expression_to_string(&simplified), "mit AND apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 AND mit");
     }
 
     #[test]
@@ -631,7 +641,7 @@ mod tests {
         .unwrap();
         let simplified = simplify_expression(&expr);
 
-        assert_eq!(expression_to_string(&simplified), "mit OR apache-2.0");
+        assert_eq!(expression_to_string(&simplified), "apache-2.0 OR mit");
     }
 
     #[test]
@@ -642,7 +652,7 @@ mod tests {
 
         assert_eq!(
             expression_to_string(&simplified),
-            "gpl-2.0-or-later AND gpl-2.0-only"
+            "gpl-2.0-only AND gpl-2.0-or-later"
         );
     }
 
@@ -825,13 +835,13 @@ mod tests {
     #[test]
     fn test_combine_expressions_two_or() {
         let result = combine_expressions_or(&["mit", "apache-2.0"], true).unwrap();
-        assert_eq!(result, "mit OR apache-2.0");
+        assert_eq!(result, "apache-2.0 OR mit");
     }
 
     #[test]
     fn test_combine_expressions_multiple_and() {
         let result = combine_expressions_and(&["mit", "apache-2.0", "gpl-2.0-plus"], true).unwrap();
-        assert_eq!(result, "mit AND apache-2.0 AND gpl-2.0-plus");
+        assert_eq!(result, "apache-2.0 AND gpl-2.0-plus AND mit");
     }
 
     #[test]
@@ -856,7 +866,7 @@ mod tests {
     #[test]
     fn test_combine_expressions_complex_with_simplification() {
         let result = combine_expressions_and(&["mit OR apache-2.0", "gpl-2.0-plus"], true).unwrap();
-        assert_eq!(result, "(mit OR apache-2.0) AND gpl-2.0-plus");
+        assert_eq!(result, "(apache-2.0 OR mit) AND gpl-2.0-plus");
         let expr = super::super::parse::parse_expression(&result).unwrap();
         assert!(matches!(expr, LicenseExpression::And { .. }));
         let keys = expr.license_keys();

--- a/src/license_detection/expression/simplify.rs
+++ b/src/license_detection/expression/simplify.rs
@@ -829,7 +829,7 @@ mod tests {
     #[test]
     fn test_combine_expressions_two_and() {
         let result = combine_expressions_and(&["mit", "gpl-2.0-plus"], true).unwrap();
-        assert_eq!(result, "mit AND gpl-2.0-plus");
+        assert_eq!(result, "gpl-2.0-plus AND mit");
     }
 
     #[test]
@@ -984,7 +984,7 @@ mod tests {
 
         assert_eq!(
             result,
-            "apache-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0 AND apsl-1.0 AND apsl-2.0"
+            "apache-2.0 AND apsl-1.0 AND apsl-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0"
         );
     }
 }

--- a/src/license_detection/spdx_mapping/mod.rs
+++ b/src/license_detection/spdx_mapping/mod.rs
@@ -99,7 +99,7 @@ impl SpdxMapping {
     /// ];
     /// let mapping = build_spdx_mapping(&licenses);
     /// let spdx_expr = mapping.expression_scancode_to_spdx("mit OR gpl-2.0-plus").unwrap();
-    /// assert_eq!(spdx_expr, "MIT OR LicenseRef-scancode-gpl-2.0-plus");
+    /// assert_eq!(spdx_expr, "LicenseRef-scancode-gpl-2.0-plus OR MIT");
     /// ```
     pub fn expression_scancode_to_spdx(&self, scancode_expr: &str) -> Result<String, String> {
         let parsed = parse_expression(scancode_expr).map_err(|e| format!("Parse error: {}", e))?;

--- a/src/license_detection/spdx_mapping/mod.rs
+++ b/src/license_detection/spdx_mapping/mod.rs
@@ -11,7 +11,7 @@
 use std::collections::HashMap;
 
 use crate::license_detection::expression::{
-    LicenseExpression, expression_to_string, parse_expression,
+    LicenseExpression, expression_to_string, parse_expression, simplify_expression,
 };
 use crate::license_detection::models::License;
 
@@ -103,7 +103,7 @@ impl SpdxMapping {
     /// ```
     pub fn expression_scancode_to_spdx(&self, scancode_expr: &str) -> Result<String, String> {
         let parsed = parse_expression(scancode_expr).map_err(|e| format!("Parse error: {}", e))?;
-        let converted = self.convert_expression_to_spdx(&parsed);
+        let converted = simplify_expression(&self.convert_expression_to_spdx(&parsed));
         Ok(expression_to_string(&converted))
     }
 

--- a/src/license_detection/spdx_mapping/test.rs
+++ b/src/license_detection/spdx_mapping/test.rs
@@ -121,7 +121,7 @@ mod tests {
         let mapping = build_spdx_mapping(&licenses);
 
         let result = mapping.expression_scancode_to_spdx("mit AND gpl-2.0-plus");
-        assert_eq!(result.unwrap(), "MIT AND GPL-2.0-or-later");
+        assert_eq!(result.unwrap(), "GPL-2.0-or-later AND MIT");
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
         let mapping = build_spdx_mapping(&licenses);
 
         let result = mapping.expression_scancode_to_spdx("mit OR apache-2.0");
-        assert_eq!(result.unwrap(), "MIT OR Apache-2.0");
+        assert_eq!(result.unwrap(), "Apache-2.0 OR MIT");
     }
 
     #[test]
@@ -196,7 +196,7 @@ mod tests {
 
         assert!(spdx_expr.is_ok());
         let exp_str = spdx_expr.unwrap();
-        assert_eq!(exp_str, "MIT OR GPL-2.0-or-later");
+        assert_eq!(exp_str, "GPL-2.0-or-later OR MIT");
     }
 
     #[test]
@@ -205,7 +205,7 @@ mod tests {
         let mapping = build_spdx_mapping(&licenses);
 
         let result = mapping.expression_scancode_to_spdx("MIT AND Apache-2.0");
-        assert_eq!(result.unwrap(), "MIT AND Apache-2.0");
+        assert_eq!(result.unwrap(), "Apache-2.0 AND MIT");
     }
 
     #[test]

--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -1246,7 +1246,7 @@ p:so:libtest.so.1
         );
         assert_eq!(
             pkg.declared_license_expression_spdx.as_deref(),
-            Some("MIT AND ICU AND Unicode-TOU")
+            Some("ICU AND MIT AND Unicode-TOU")
         );
         assert_eq!(pkg.dependencies.len(), 3);
         let depends_dev = pkg

--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -42,11 +42,11 @@ mod tests {
 
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("mit OR apache-2.0")
+            Some("apache-2.0 OR mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("MIT OR Apache-2.0")
+            Some("Apache-2.0 OR MIT")
         );
         assert_eq!(package_data.license_detections.len(), 1);
         assert_eq!(

--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -224,20 +224,20 @@ license = "CC0-1.0 OR MIT-0 OR Apache-2.0"
 
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("cc0-1.0 OR mit-0 OR apache-2.0")
+            Some("apache-2.0 OR cc0-1.0 OR mit-0")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("CC0-1.0 OR MIT-0 OR Apache-2.0")
+            Some("Apache-2.0 OR CC0-1.0 OR MIT-0")
         );
         assert_eq!(package_data.license_detections.len(), 1);
         assert_eq!(
             package_data.license_detections[0].license_expression,
-            "cc0-1.0 OR mit-0 OR apache-2.0"
+            "apache-2.0 OR cc0-1.0 OR mit-0"
         );
         assert_eq!(
             package_data.license_detections[0].license_expression_spdx,
-            "CC0-1.0 OR MIT-0 OR Apache-2.0"
+            "Apache-2.0 OR CC0-1.0 OR MIT-0"
         );
         assert_eq!(
             package_data.extracted_license_statement.as_deref(),

--- a/src/parsers/composer_test.rs
+++ b/src/parsers/composer_test.rs
@@ -342,11 +342,11 @@ mod tests {
         );
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("mit OR apache-2.0")
+            Some("apache-2.0 OR mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("MIT OR Apache-2.0")
+            Some("Apache-2.0 OR MIT")
         );
         assert_eq!(package_data.license_detections.len(), 1);
     }
@@ -396,11 +396,11 @@ mod tests {
         );
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("mit OR apache-2.0")
+            Some("apache-2.0 OR mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("MIT OR Apache-2.0")
+            Some("Apache-2.0 OR MIT")
         );
         assert_eq!(package_data.license_detections.len(), 1);
     }

--- a/src/parsers/freebsd.rs
+++ b/src/parsers/freebsd.rs
@@ -27,6 +27,7 @@ use serde::Deserialize;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
 use crate::parsers::utils::read_file_to_string;
+use crate::utils::spdx::{ExpressionRelation, combine_license_expressions_with_relation};
 
 use super::PackageParser;
 use super::license_normalization::{
@@ -296,8 +297,10 @@ pub(crate) fn build_license_statement(
 
     match logic {
         "single" => Some(filtered_licenses[0].clone()),
-        "or" | "dual" => Some(filtered_licenses.join(" OR ")),
-        _ => Some(filtered_licenses.join(" AND ")), // "and" or unknown defaults to AND
+        "or" | "dual" => {
+            combine_license_expressions_with_relation(filtered_licenses, ExpressionRelation::Or)
+        }
+        _ => combine_license_expressions_with_relation(filtered_licenses, ExpressionRelation::And),
     }
 }
 
@@ -338,7 +341,7 @@ mod tests {
         let licenses = Some(vec!["MIT".to_string(), "BSD-2-Clause".to_string()]);
         let logic = Some("and".to_string());
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT AND BSD-2-Clause".to_string()));
+        assert_eq!(result, Some("BSD-2-Clause AND MIT".to_string()));
     }
 
     #[test]
@@ -346,7 +349,7 @@ mod tests {
         let licenses = Some(vec!["MIT".to_string(), "Apache-2.0".to_string()]);
         let logic = Some("or".to_string());
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT OR Apache-2.0".to_string()));
+        assert_eq!(result, Some("Apache-2.0 OR MIT".to_string()));
     }
 
     #[test]
@@ -354,7 +357,7 @@ mod tests {
         let licenses = Some(vec!["MIT".to_string(), "Apache-2.0".to_string()]);
         let logic = Some("dual".to_string());
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT OR Apache-2.0".to_string()));
+        assert_eq!(result, Some("Apache-2.0 OR MIT".to_string()));
     }
 
     #[test]
@@ -362,7 +365,7 @@ mod tests {
         let licenses = Some(vec!["MIT".to_string(), "BSD".to_string()]);
         let logic = None;
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT AND BSD".to_string()));
+        assert_eq!(result, Some("BSD AND MIT".to_string()));
     }
 
     #[test]
@@ -370,7 +373,7 @@ mod tests {
         let licenses = Some(vec!["MIT".to_string(), "BSD".to_string()]);
         let logic = Some("unknown".to_string());
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT AND BSD".to_string()));
+        assert_eq!(result, Some("BSD AND MIT".to_string()));
     }
 
     #[test]
@@ -402,7 +405,7 @@ mod tests {
         let licenses = Some(vec!["  MIT  ".to_string(), " Apache-2.0 ".to_string()]);
         let logic = Some("or".to_string());
         let result = build_license_statement(&licenses, &logic);
-        assert_eq!(result, Some("MIT OR Apache-2.0".to_string()));
+        assert_eq!(result, Some("Apache-2.0 OR MIT".to_string()));
     }
 }
 

--- a/src/parsers/freebsd_test.rs
+++ b/src/parsers/freebsd_test.rs
@@ -248,7 +248,7 @@ fn test_build_license_statement_multiple_or() {
     ]);
     let logic = Some("or".to_string());
     let result = build_license_statement(&licenses, &logic);
-    assert_eq!(result, Some("GPLv3 OR RUBY OR GPLv2".to_string()));
+    assert_eq!(result, Some("GPLv2 OR GPLv3 OR RUBY".to_string()));
 }
 
 #[test]

--- a/src/parsers/freebsd_test.rs
+++ b/src/parsers/freebsd_test.rs
@@ -74,7 +74,7 @@ fn test_license_and() {
 
     assert_eq!(
         pkg.extracted_license_statement,
-        Some("PSFL AND BSD3CLAUSE".to_string())
+        Some("BSD3CLAUSE AND PSFL".to_string())
     );
 }
 
@@ -86,7 +86,7 @@ fn test_license_or() {
 
     assert_eq!(
         pkg.extracted_license_statement,
-        Some("RUBY OR GPLv2".to_string())
+        Some("GPLv2 OR RUBY".to_string())
     );
 }
 
@@ -98,7 +98,7 @@ fn test_license_dual() {
 
     assert_eq!(
         pkg.extracted_license_statement,
-        Some("GPLv3 OR RUBY OR GPLv2".to_string())
+        Some("GPLv2 OR GPLv3 OR RUBY".to_string())
     );
 }
 
@@ -357,7 +357,7 @@ fn test_multi_license_file() {
     assert_eq!(pkg.name, Some("py27-idna".to_string()));
     assert_eq!(
         pkg.extracted_license_statement,
-        Some("PSFL AND BSD3CLAUSE".to_string())
+        Some("BSD3CLAUSE AND PSFL".to_string())
     );
 }
 
@@ -371,7 +371,7 @@ fn test_dual_license_file() {
     assert_eq!(pkg.name, Some("rubygem-facets".to_string()));
     assert_eq!(
         pkg.extracted_license_statement,
-        Some("RUBY OR GPLv2".to_string())
+        Some("GPLv2 OR RUBY".to_string())
     );
 }
 

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -632,8 +632,8 @@ mod tests {
         let (declared, declared_spdx, detections) =
             normalize_spdx_declared_license(Some("MIT OR Apache-2.0"));
 
-        assert_eq!(declared.as_deref(), Some("mit OR apache-2.0"));
-        assert_eq!(declared_spdx.as_deref(), Some("MIT OR Apache-2.0"));
+        assert_eq!(declared.as_deref(), Some("apache-2.0 OR mit"));
+        assert_eq!(declared_spdx.as_deref(), Some("Apache-2.0 OR MIT"));
         assert_eq!(detections.len(), 1);
     }
 
@@ -666,10 +666,10 @@ mod tests {
         )
         .expect("combined expression");
 
-        assert_eq!(combined.declared_license_expression, "mit OR apache-2.0");
+        assert_eq!(combined.declared_license_expression, "apache-2.0 OR mit");
         assert_eq!(
             combined.declared_license_expression_spdx,
-            "MIT OR Apache-2.0"
+            "Apache-2.0 OR MIT"
         );
     }
 

--- a/src/parsers/python_test.rs
+++ b/src/parsers/python_test.rs
@@ -999,11 +999,11 @@ Example metadata.
         );
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("mit OR apache-2.0")
+            Some("apache-2.0 OR mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("MIT OR Apache-2.0")
+            Some("Apache-2.0 OR MIT")
         );
         assert_eq!(package_data.license_detections.len(), 1);
     }

--- a/src/parsers/ruby_test.rs
+++ b/src/parsers/ruby_test.rs
@@ -1077,11 +1077,11 @@ gem "specific-range", ">= 1.0.0", "< 1.5.0", "!= 1.2.3"
         assert_eq!(package_data.name, Some("multi-license-gem".to_string()));
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("mit AND apache-2.0 AND bsd-2-clause")
+            Some("apache-2.0 AND bsd-2-clause AND mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("MIT AND Apache-2.0 AND BSD-2-Clause")
+            Some("Apache-2.0 AND BSD-2-Clause AND MIT")
         );
         assert_eq!(package_data.license_detections.len(), 1);
         assert!(package_data.extracted_license_statement.is_some());

--- a/src/parsers/ruby_test.rs
+++ b/src/parsers/ruby_test.rs
@@ -928,11 +928,11 @@ gem "specific-range", ">= 1.0.0", "< 1.5.0", "!= 1.2.3"
 
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("ruby AND bsd-2-clause")
+            Some("bsd-2-clause AND ruby")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
-            Some("Ruby AND BSD-2-Clause")
+            Some("BSD-2-Clause AND Ruby")
         );
         assert_eq!(package_data.license_detections.len(), 1);
         assert!(package_data.extracted_license_statement.is_some());

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1465,13 +1465,13 @@ fn apply_package_reference_following_prefers_nearest_ancestor_license_file() {
         .expect("source file should exist");
     assert_eq!(
         source.license_expression.as_deref(),
-        Some("mit AND apache-2.0")
+        Some("apache-2.0 AND mit")
     );
     assert_eq!(source.license_detections.len(), 2);
     let combined = source
         .license_detections
         .iter()
-        .find(|detection| detection.license_expression_spdx == "MIT AND Apache-2.0")
+        .find(|detection| detection.license_expression_spdx == "Apache-2.0 AND MIT")
         .expect("combined followed detection should exist");
     assert_eq!(combined.detection_log, ["unknown-reference-to-local-file"]);
     assert!(

--- a/src/utils/spdx.rs
+++ b/src/utils/spdx.rs
@@ -217,7 +217,7 @@ mod tests {
     fn combine_license_expressions_preserves_spdx_case() {
         let result = combine_license_expressions(vec!["MIT".to_string(), "Apache-2.0".to_string()]);
 
-        assert_eq!(result.as_deref(), Some("MIT AND Apache-2.0"));
+        assert_eq!(result.as_deref(), Some("Apache-2.0 AND MIT"));
     }
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
             "Unicode-TOU".to_string(),
         ]);
 
-        assert_eq!(result.as_deref(), Some("MIT AND ICU AND Unicode-TOU"));
+        assert_eq!(result.as_deref(), Some("ICU AND MIT AND Unicode-TOU"));
     }
 
     #[test]
@@ -240,7 +240,7 @@ mod tests {
 
         assert_eq!(
             result.as_deref(),
-            Some("GPL-2.0 WITH Classpath-exception-2.0 AND GPL-2.0")
+            Some("GPL-2.0 AND GPL-2.0 WITH Classpath-exception-2.0")
         );
     }
 

--- a/testdata/alpine/apkbuild/icu/APKBUILD.expected.json
+++ b/testdata/alpine/apkbuild/icu/APKBUILD.expected.json
@@ -6,16 +6,16 @@
     "description": "International Components for Unicode library",
     "parties": [],
     "homepage_url": "http://site.icu-project.org/",
-    "declared_license_expression": "mit AND x11 AND unicode-tou",
-    "declared_license_expression_spdx": "MIT AND ICU AND Unicode-TOU",
+    "declared_license_expression": "mit AND unicode-tou AND x11",
+    "declared_license_expression_spdx": "ICU AND MIT AND Unicode-TOU",
     "license_detections": [
       {
-        "license_expression": "mit AND x11 AND unicode-tou",
-        "license_expression_spdx": "MIT AND ICU AND Unicode-TOU",
+        "license_expression": "mit AND unicode-tou AND x11",
+        "license_expression_spdx": "ICU AND MIT AND Unicode-TOU",
         "matches": [
           {
-            "license_expression": "mit AND x11 AND unicode-tou",
-            "license_expression_spdx": "MIT AND ICU AND Unicode-TOU",
+            "license_expression": "mit AND unicode-tou AND x11",
+            "license_expression_spdx": "ICU AND MIT AND Unicode-TOU",
             "start_line": 1,
             "end_line": 1,
             "matcher": "1-spdx-id",

--- a/testdata/cargo-golden/rustup/Cargo.toml.expected
+++ b/testdata/cargo-golden/rustup/Cargo.toml.expected
@@ -20,16 +20,16 @@
     ],
     "homepage_url": "https://github.com/rust-lang/rustup.rs",
     "vcs_url": "https://github.com/rust-lang/rustup.rs",
-    "declared_license_expression": "mit OR apache-2.0",
-    "declared_license_expression_spdx": "MIT OR Apache-2.0",
+    "declared_license_expression": "apache-2.0 OR mit",
+    "declared_license_expression_spdx": "Apache-2.0 OR MIT",
     "license_detections": [
       {
-        "license_expression": "mit OR apache-2.0",
-        "license_expression_spdx": "MIT OR Apache-2.0",
+        "license_expression": "apache-2.0 OR mit",
+        "license_expression_spdx": "Apache-2.0 OR MIT",
         "matches": [
           {
-            "license_expression": "mit OR apache-2.0",
-            "license_expression_spdx": "MIT OR Apache-2.0",
+            "license_expression": "apache-2.0 OR mit",
+            "license_expression_spdx": "Apache-2.0 OR MIT",
             "from_file": null,
             "score": 100.0
           }

--- a/testdata/cargo-golden/single-file-scan/Cargo.toml.expected
+++ b/testdata/cargo-golden/single-file-scan/Cargo.toml.expected
@@ -19,16 +19,16 @@
     ],
     "homepage_url": "https://crates.io/crates/constant_time_eq",
     "vcs_url": "https://github.com/cesarb/constant_time_eq",
-    "declared_license_expression": "cc0-1.0 OR mit-0 OR apache-2.0",
-    "declared_license_expression_spdx": "CC0-1.0 OR MIT-0 OR Apache-2.0",
+    "declared_license_expression": "apache-2.0 OR cc0-1.0 OR mit-0",
+    "declared_license_expression_spdx": "Apache-2.0 OR CC0-1.0 OR MIT-0",
     "license_detections": [
       {
-        "license_expression": "cc0-1.0 OR mit-0 OR apache-2.0",
-        "license_expression_spdx": "CC0-1.0 OR MIT-0 OR Apache-2.0",
+        "license_expression": "apache-2.0 OR cc0-1.0 OR mit-0",
+        "license_expression_spdx": "Apache-2.0 OR CC0-1.0 OR MIT-0",
         "matches": [
           {
-            "license_expression": "cc0-1.0 OR mit-0 OR apache-2.0",
-            "license_expression_spdx": "CC0-1.0 OR MIT-0 OR Apache-2.0",
+            "license_expression": "apache-2.0 OR cc0-1.0 OR mit-0",
+            "license_expression_spdx": "Apache-2.0 OR CC0-1.0 OR MIT-0",
             "from_file": null,
             "score": 100.0
           }

--- a/testdata/freebsd/multi_license/+COMPACT_MANIFEST.expected.json
+++ b/testdata/freebsd/multi_license/+COMPACT_MANIFEST.expected.json
@@ -19,23 +19,23 @@
     "homepage_url": "https://github.com/kjd/idna",
     "download_url": "https://pkg.freebsd.org/freebsd:10:*/latest/All/py27-idna-2.6.txz",
     "code_view_url": "https://svnweb.freebsd.org/ports/head/dns/py-idna",
-    "declared_license_expression": "psf-2.0 AND bsd-new",
-    "declared_license_expression_spdx": "PSF-2.0 AND BSD-3-Clause",
+    "declared_license_expression": "bsd-new AND psf-2.0",
+    "declared_license_expression_spdx": "BSD-3-Clause AND PSF-2.0",
     "license_detections": [
       {
-        "license_expression": "psf-2.0 AND bsd-new",
-        "license_expression_spdx": "PSF-2.0 AND BSD-3-Clause",
+        "license_expression": "bsd-new AND psf-2.0",
+        "license_expression_spdx": "BSD-3-Clause AND PSF-2.0",
         "matches": [
           {
-            "license_expression": "psf-2.0 AND bsd-new",
-            "license_expression_spdx": "PSF-2.0 AND BSD-3-Clause",
+            "license_expression": "bsd-new AND psf-2.0",
+            "license_expression_spdx": "BSD-3-Clause AND PSF-2.0",
             "score": 100.0,
-            "matched_text": "PSFL AND BSD3CLAUSE"
+            "matched_text": "BSD3CLAUSE AND PSFL"
           }
         ]
       }
     ],
-    "extracted_license_statement": "PSFL AND BSD3CLAUSE",
+    "extracted_license_statement": "BSD3CLAUSE AND PSFL",
     "purl": "pkg:freebsd/py27-idna@2.6?arch=freebsd:10:*&origin=dns/py-idna",
     "datasource_id": "freebsd_compact_manifest"
   }

--- a/testdata/summarycode-golden/score/no_license_ambiguity-expected.json
+++ b/testdata/summarycode-golden/score/no_license_ambiguity-expected.json
@@ -1,6 +1,6 @@
 {
   "summary": {
-    "declared_license_expression": "mit OR apache-2.0",
+    "declared_license_expression": "apache-2.0 OR mit",
     "license_clarity_score": {
       "score": 100,
       "declared_license": true,
@@ -51,16 +51,16 @@
       "vcs_url": "https://github.com/rust-random/rand",
       "copyright": null,
       "holder": null,
-      "declared_license_expression": "mit OR apache-2.0",
-      "declared_license_expression_spdx": "MIT OR Apache-2.0",
+      "declared_license_expression": "apache-2.0 OR mit",
+      "declared_license_expression_spdx": "Apache-2.0 OR MIT",
       "license_detections": [
         {
-          "license_expression": "mit OR apache-2.0",
-          "license_expression_spdx": "MIT OR Apache-2.0",
+          "license_expression": "apache-2.0 OR mit",
+          "license_expression_spdx": "Apache-2.0 OR MIT",
           "matches": [
             {
-              "license_expression": "mit OR apache-2.0",
-              "license_expression_spdx": "MIT OR Apache-2.0",
+              "license_expression": "apache-2.0 OR mit",
+              "license_expression_spdx": "Apache-2.0 OR MIT",
               "from_file": "no_license_ambiguity/Cargo.toml",
               "start_line": 1,
               "end_line": 1,


### PR DESCRIPTION
## Summary

- canonicalize machine-generated SPDX `AND` and `OR` operand ordering in the shared generation path so equivalent expressions render deterministically, using the same ordering policy across simplification and `combine_license_expressions`
- apply that canonicalization to direct generator consumers that previously preserved incidental input order, including SPDX mapping output and FreeBSD's standalone license-statement builder
- align downstream parser, golden, doctest, and post-processing expectations with the new generated order, including the Watchman-style reference-following regression path that now resolves to canonical `Apache-2.0 AND MIT`

## Scope and exclusions

- Included: shared expression canonicalization, SPDX mapping output, FreeBSD license statement generation, and downstream unit/golden expectation updates for generated parser and post-processing output
- Explicit exclusions: changing plain parse/render behavior for expressions that have not gone through machine-generation or simplification, and broader compare-output reruns unrelated to ordering semantics

## Intentional differences from Python

- Provenant now prefers deterministic canonical operand ordering for machine-generated boolean license expressions instead of preserving incidental authored/input order; this is an intentional output-stability choice, not a parser-semantics change

## Follow-up work

- Created or intentionally deferred: broader repository-wide audits for additional compare-output parity questions beyond canonical ordering, if we later want to review every unrelated expression-rendering surface against ScanCode one by one