### PR TITLE
feat(skills): add opencode AI agent skills

### DIFF
--- a/.opencode/skills/add-parser/SKILL.md
+++ b/.opencode/skills/add-parser/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: add-parser
+description: Implement a new package parser in Provenant, following the full workflow from research through registration, testing, assembly wiring, and validation.
+---
+
+# Add a Package Parser
+
+This skill implements a new package parser in Provenant following the canonical workflow from `docs/HOW_TO_ADD_A_PARSER.md`.
+
+## Workflow
+
+### Step 1: Research the parser surface
+
+Before writing code, determine:
+
+- Which concrete filenames or file patterns does this parser own?
+- Is this one datasource or several distinct datasources handled by one parser?
+- Does the format carry package identity, dependencies, declared-license metadata, or file references?
+- Does the ecosystem fit default sibling/nested assembly, or does it need topology-driven assembly?
+- If a Python ScanCode parser exists under `reference/scancode-toolkit/src/packagedcode/`, use it as a **behavioral specification** — learn what the Rust parser must do, not how to write it.
+
+Collect representative fixtures covering:
+
+- Basic success case
+- Malformed or partially missing input
+- Dependency scope variations (if the format has them)
+- Declared-license variations (if the format exposes them)
+- Manifest/lockfile or file-reference cases (if downstream assembly depends on them)
+- If you need upstream ScanCode fixtures, copy them into Provenant-owned `testdata/` first; do not make tests depend directly on `reference/scancode-toolkit/` paths.
+
+### Step 2: Implement the parser
+
+Create `src/parsers/<ecosystem>.rs` and implement `PackageParser`.
+
+Use the current parser contract from `src/parsers/mod.rs`. Template:
+
+```rust
+use std::path::Path;
+
+use crate::models::{DatasourceId, PackageData, PackageType};
+use crate::parser_warn as warn;
+
+use super::PackageParser;
+
+pub struct MyParser;
+
+impl PackageParser for MyParser {
+    const PACKAGE_TYPE: PackageType = PackageType::Npm;
+
+    fn is_match(path: &Path) -> bool {
+        path.file_name().is_some_and(|name| name == "package.json")
+    }
+
+    fn extract_packages(path: &Path) -> Vec<PackageData> {
+        match std::fs::read_to_string(path) {
+            Ok(_content) => vec![PackageData {
+                package_type: Some(Self::PACKAGE_TYPE),
+                datasource_id: Some(DatasourceId::NpmPackageJson),
+                ..Default::default()
+            }],
+            Err(error) => {
+                warn!("Failed to read {:?}: {}", path, error);
+                vec![PackageData {
+                    package_type: Some(Self::PACKAGE_TYPE),
+                    datasource_id: Some(DatasourceId::NpmPackageJson),
+                    ..Default::default()
+                }]
+            }
+        }
+    }
+}
+```
+
+Add `register_parser!` near the end of the file:
+
+```rust
+crate::register_parser!(
+    "npm package.json manifest",
+    &["**/package.json"],
+    "npm",
+    "JavaScript",
+    Some("https://docs.npmjs.com/cli/v10/configuring-npm/package-json"),
+);
+```
+
+**Assembly and topology hints**:
+
+- Parsers stay file-local extractors: emit facts for the current file, not repository-wide assembly.
+- If a format declares project structure such as workspace members or root/member roles, preserve that structural intent in parser output so topology-aware assembly can consume it.
+- New parser work should treat topology-aware assembly as a first-class downstream consumer rather than assuming every ecosystem fits plain sibling merge.
+- If the format has no cross-file topology, prefer the default local assembly path and avoid topology-specific wiring without a concrete need.
+
+**Parser invariants** (non-negotiable):
+
+- Set `datasource_id` on **every production path**, including error and fallback returns.
+- Use `crate::parser_warn!` (imported as `warn`) for parser failures — never plain `log::warn!()`.
+- Do not execute package-manager code or shell commands from parser logic.
+- Do not do broad file-content license detection, copyright detection, or backfilling from sibling files inside the parser by default.
+- Preserve raw dependency and license input when the source format is ambiguous.
+
+**Rare exceptions stay rare, bounded, and documented**:
+
+- `python.rs` has bounded sibling enrichment for a few adjacent metadata sidecars; new parsers should not copy that pattern unless an explicit assembly pass is genuinely infeasible.
+- Some content-aware package surfaces are scanner-owned exceptions rather than `PackageParser`s. The current example is compiled-binary package extraction behind `--package-in-compiled`; do not force those surfaces through path-based parser registration.
+
+**Declared-license contract**:
+
+- If the format exposes a trustworthy declared-license surface, populate `extracted_license_statement`, `declared_license_expression`, `declared_license_expression_spdx`, and parser-side `license_detections`.
+- Use the shared helper in `src/parsers/license_normalization.rs` — never write parser-specific normalization logic.
+- If the license surface is weak or ambiguous, keep the parser raw-only: preserve `extracted_license_statement`, leave declared-license fields empty, do not emit guessed or partial expressions.
+
+**Dependency contract**:
+
+- Populate `dependencies` whenever the format actually carries dependency data.
+- Preserve the ecosystem's native scope terminology unless an existing parser pattern says otherwise.
+- Treat parser tests and parser goldens as interface-contract checks for dependency fields, not just smoke tests.
+
+**Multi-format ecosystems**: When an ecosystem has both a manifest and a lockfile, put all `PackageParser` impls in a single `src/parsers/<ecosystem>.rs` file with separate `register_parser!` invocations for each. Example: `src/parsers/julia.rs` contains both `JuliaProjectTomlParser` and `JuliaManifestTomlParser`.
+
+**Use existing parsers as templates**:
+
+- `src/parsers/cargo.rs` — manifest parser with declared-license normalization and dependencies
+- `src/parsers/about.rs` — file-reference handling
+- `src/parsers/npm.rs` or `src/parsers/python.rs` — complex multi-surface ecosystems
+
+### Step 3: Register the parser in `src/parsers/mod.rs`
+
+**Module wiring**:
+
+```rust
+mod my_ecosystem;
+#[cfg(test)]
+mod my_ecosystem_test;
+#[cfg(test)]
+mod my_ecosystem_scan_test;
+
+pub use self::my_ecosystem::MyEcosystemParser;
+```
+
+Do **not** add per-parser golden modules directly to `src/parsers/mod.rs`; golden wiring is centralized in `src/parsers/golden_test.rs`.
+
+**Scanner registration**: Add the parser to the `parsers:` list inside `register_package_handlers!`. If the parser is not listed there, it will never be called by scanner dispatch.
+
+Verify registration:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin update-parser-golden -- --list
+```
+
+The parser should appear in the output.
+
+### Step 4: Add tests
+
+**Unit tests** — `src/parsers/<ecosystem>_test.rs`:
+
+- `is_match()`
+- Basic extraction of package identity
+- Malformed or partial input
+- Dependency extraction and scope handling
+- Declared-license behavior when the format has a trustworthy license field
+- Any parser-specific edge case the reference implementation already handles
+
+**Parser golden tests** — `src/parsers/<ecosystem>_golden_test.rs`:
+
+- Follow the feature-gating pattern used by neighboring golden tests.
+- Add representative fixtures under `testdata/<ecosystem>-golden/`.
+- Register in `src/parsers/golden_test.rs`:
+
+```rust
+#[path = "my_ecosystem_golden_test.rs"]
+mod my_ecosystem_golden_test;
+```
+
+- Generate expected output:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin update-parser-golden -- <ParserType> <input_file> <output_file>
+```
+
+- If fixture filenames don't end in `.json`, run `npx prettier --write --parser json <files>` explicitly.
+- Commit golden `.expected` files alongside test fixtures — CI checks that they exist and match.
+
+**Parser-adjacent scan tests** — `src/parsers/<ecosystem>_scan_test.rs`:
+
+- Required when parser correctness depends on scanner wiring, assembly, topology planning, or file/package linkage.
+- Effectively required when the parser emits: `for_packages` links, `datafile_paths`, dependency hoisting or manifest/lockfile interaction, `PackageData.file_references`.
+- See `src/parsers/cargo_scan_test.rs` for a minimal example.
+
+**Keep local verification scoped**:
+
+- Prefer the smallest owning unit, golden, scan, or assembly target that proves the parser work.
+- Avoid broad local commands like `cargo test` or unfiltered golden suites unless there is no narrower way to validate the change.
+
+### Step 5: Wire `DatasourceId` and assembly accounting
+
+**Add `PackageType` variant** in `src/models/package_type.rs` and its `as_str()` match arm. Use one variant per ecosystem (not per file format).
+
+**Add `DatasourceId` variant(s)** in `src/models/datasource_id.rs`. Use one variant per concrete file format.
+
+**Classify every datasource** in `src/assembly/assemblers.rs`:
+
+- Add to an `AssemblerConfig` when it participates in assembly.
+- Add to `UNASSEMBLED_DATASOURCE_IDS` when it is intentionally standalone.
+- If you skip this, `test_every_datasource_id_is_accounted_for` will fail.
+
+**Add assembly config when needed**: If the ecosystem has related manifest/lockfile or sibling metadata surfaces, add an `AssemblerConfig` with the exact datasource IDs your parser emits. Keep `sibling_file_patterns` aligned with real filenames.
+
+**File-reference resolution**: If the parser emits `PackageData.file_references`, register the datasource in `src/assembly/file_ref_resolve.rs` and add a scan test proving files link back to the package.
+
+**Assembly goldens**: If the ecosystem assembles multiple files into one logical package, add assembly fixtures under `testdata/assembly-golden/<ecosystem>-basic/` and a matching test in `src/assembly/assembly_golden_test.rs`.
+
+### Step 6: Validate behavior
+
+Compare against the Python ScanCode reference (if it exists) or the authoritative format spec. Validate at least:
+
+- Package identity fields
+- Dependency presence and scope
+- Declared-license output and raw statement preservation
+- PURL shape
+- Datasource IDs and assembly behavior
+- File-reference linkage when applicable
+
+For implemented parser families, the main end-to-end parity workflow is `compare-outputs`, not ad hoc manual scanner runs:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/org/repo.git --repo-ref <ref> --profile common
+```
+
+Record representative `compare-outputs` references in `docs/BENCHMARKS.md`.
+
+If the Rust parser intentionally improves on Python behavior, document the improvement in `docs/improvements/<ecosystem>-parser.md`.
+
+Add a scorecard row to `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md`.
+
+Regenerate supported formats and verify:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin generate-supported-formats -- --check
+```
+
+## Done checklist
+
+Before considering a parser complete, verify ALL of the following:
+
+- [ ] Implementation exists in `src/parsers/<ecosystem>.rs`
+- [ ] `PackageType` variant exists in `src/models/package_type.rs`
+- [ ] `datasource_id` is correct on every production path
+- [ ] Parser is exported and registered in `src/parsers/mod.rs`
+- [ ] `register_parser!` metadata is present
+- [ ] Parser unit tests exist
+- [ ] Parser goldens exist (default expectation)
+- [ ] Golden `.expected` files are committed alongside test fixtures
+- [ ] Parser-adjacent scan tests exist when downstream package or file-link behavior matters
+- [ ] Every new datasource is classified in `src/assembly/assemblers.rs`
+- [ ] File-reference ownership is wired when the parser emits `PackageData.file_references`
+- [ ] `docs/SUPPORTED_FORMATS.md` is regenerated and staged
+- [ ] Representative `compare-outputs` references are recorded in `docs/BENCHMARKS.md`
+- [ ] Scorecard row added to `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md`
+- [ ] Behavior has been validated against the Python reference or authoritative spec
+
+## Common failure modes
+
+- Parser compiles but never runs because it was not added to `register_package_handlers!`.
+- `datasource_id` set on happy path but forgotten on parse-error or fallback returns.
+- Parser uses `log::warn!()` instead of `parser_warn!()`.
+- Parser guesses declared-license expressions from weak metadata instead of preserving raw input.
+- Parser-only tests pass but real scanner output is wrong because `*_scan_test.rs` was skipped.
+- Parser emits `file_references` but no resolver ownership was added in assembly.
+- `register_parser!` was skipped, so supported-formats docs never pick up the parser.
+- `docs/SUPPORTED_FORMATS.md` was not regenerated, so the pre-commit hook or CI docs checks fail.
+- Golden `.expected` files were not generated or committed.
+
+## Reference documents
+
+- `docs/HOW_TO_ADD_A_PARSER.md` — full canonical guide
+- `docs/ARCHITECTURE.md` — parser/assembly subsystem rationale
+- `docs/TESTING_STRATEGY.md` — test-layer definitions and command guidance
+- `xtask/README.md` — xtask command CLI reference
+- `AGENTS.md` — contributor guardrails and repo conventions

--- a/.opencode/skills/provenant-cli/SKILL.md
+++ b/.opencode/skills/provenant-cli/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: provenant-cli
+description: Quick reference for Provenant CLI flags, output formats, detection modes, and common scan workflows.
+---
+
+# Provenant CLI Quick Reference
+
+## Synopsis
+
+```text
+provenant [OPTIONS] <OUTPUT_FLAG> [DETECTION_FLAGS] [DIR_PATH]...
+```
+
+At least one output flag is required. Detection flags are opt-in.
+
+## Output Formats (at least one required)
+
+| Flag                     | Format              | Notes                                           |
+| ------------------------ | ------------------- | ----------------------------------------------- |
+| `--json <FILE>`          | Compact JSON        | Machine-readable                                |
+| `--json-pp <FILE>`       | Pretty-printed JSON | Human inspection, debugging                     |
+| `--json-lines <FILE>`    | JSON Lines          | Streaming pipelines                             |
+| `--yaml <FILE>`          | YAML                | Human-readable structured                       |
+| `--html <FILE>`          | HTML report         | Browsable                                       |
+| `--spdx-tv <FILE>`       | SPDX tag/value      | Compliance exchange                             |
+| `--spdx-rdf <FILE>`      | SPDX RDF/XML        | Compliance exchange                             |
+| `--cyclonedx <FILE>`     | CycloneDX JSON      | SBOM pipelines                                  |
+| `--cyclonedx-xml <FILE>` | CycloneDX XML       | SBOM pipelines                                  |
+| `--debian <FILE>`        | Debian copyright    | Requires `--license --copyright --license-text` |
+| `--custom-output <FILE>` | Custom template     | Requires `--custom-template <FILE>`             |
+| `--show-attribution`     | Attribution notices | No file output                                  |
+
+Use `-` as the file path to write to stdout. Multiple output formats can be combined in one run.
+
+## Detection Flags (opt-in)
+
+| Flag                    | Short | What it adds                                                    |
+| ----------------------- | ----- | --------------------------------------------------------------- |
+| `--license`             | `-l`  | License detections, expressions, diagnostics/text               |
+| `--copyright`           | `-c`  | Copyright statements, holders, authors                          |
+| `--package`             | `-p`  | Application packages and dependencies from manifests/lockfiles  |
+| `--system-package`      |       | Installed system package databases (RPM, dpkg, apk)             |
+| `--package-in-compiled` |       | Embedded package metadata in compiled Go/Rust binaries          |
+| `--package-only`        |       | Package data only (no license/copyright, no top-level assembly) |
+| `--info`                | `-i`  | File metadata: checksums, type hints, source/script flags       |
+| `--email`               | `-e`  | Extracted email addresses                                       |
+| `--url`                 | `-u`  | Extracted URLs                                                  |
+| `--generated`           |       | Generated code detection                                        |
+
+## License Sub-flags
+
+| Flag                          | Requires         | What it does                                  |
+| ----------------------------- | ---------------- | --------------------------------------------- |
+| `--license-text`              | `--license`      | Include matched text in detection output      |
+| `--license-text-diagnostics`  | `--license-text` | Diagnostics for matched text                  |
+| `--license-diagnostics`       | `--license`      | License detection diagnostics                 |
+| `--license-references`        | `--license`      | Top-level license/rule reference blocks       |
+| `--unknown-licenses`          | `--license`      | Surface unmatched license-like text           |
+| `--license-score <N>`         | `--license`      | Minimum match score threshold (default: 0)    |
+| `--license-url-template <T>`  | `--license`      | Customize top-level license reference URLs    |
+| `--license-policy <FILE>`     | `--license`      | Evaluate against YAML policy file             |
+| `--license-rules-path <PATH>` | `--license`      | Override embedded rules with custom directory |
+| `--reindex`                   | `--license`      | Force rebuild license index cache             |
+| `--license-cache-dir <PATH>`  | `--license`      | Override cache directory                      |
+
+## Post-processing Flags
+
+| Flag                      | Requires                  | What it does                           |
+| ------------------------- | ------------------------- | -------------------------------------- |
+| `--classify`              |                           | Enable classification output           |
+| `--summary`               | `--classify`              | Codebase-level summary                 |
+| `--tallies`               |                           | Count-oriented tallies                 |
+| `--tallies-key-files`     | `--tallies`, `--classify` | Key-file-focused tallies               |
+| `--tallies-with-details`  |                           | File/directory-level tallies           |
+| `--facet <K>=<P>`         |                           | Define facet rule (e.g. `core=src/**`) |
+| `--tallies-by-facet`      | `--facet`, `--tallies`    | Split tallies by facet                 |
+| `--license-clarity-score` | `--classify`              | Project-level clarity scoring          |
+| `--filter-clues`          |                           | Remove redundant clue output           |
+| `--only-findings`         |                           | Only findings in output                |
+| `--mark-source`           | `--info`                  | Mark source files                      |
+| `--no-assemble`           |                           | Disable package assembly               |
+
+## Filtering & Control
+
+| Flag                                         | What it does                                                               |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `--exclude <PATTERN>` / `--ignore <PATTERN>` | Exclude paths matching glob pattern                                        |
+| `--include <PATTERN>`                        | Include only matching paths                                                |
+| `--max-depth <N>`                            | Recursion depth limit (0 = unlimited, default: 0)                          |
+| `--timeout <SECS>`                           | Timeout per file (default: 120)                                            |
+| `-n, --processes <N>`                        | Parallel processes (default: 11)                                           |
+| `--max-in-memory <N>`                        | Max file details in memory (default: 10000, 0 = unlimited, -1 = disk-only) |
+| `--strip-root`                               | Strip root prefix from paths                                               |
+| `--full-root`                                | Keep full root prefix                                                      |
+| `-q, --quiet`                                | Suppress progress output                                                   |
+| `-v, --verbose`                              | Verbose output                                                             |
+
+## Incremental & Cache
+
+| Flag                 | What it does                                            |
+| -------------------- | ------------------------------------------------------- |
+| `--incremental`      | Reuse previous scan results for unchanged files         |
+| `--cache-dir <PATH>` | Override cache directory (also `PROVENANT_CACHE` env)   |
+| `--cache-clear`      | Clear cache before running                              |
+| `--from-json`        | Reshape one or more existing ScanCode-style JSON inputs |
+
+`--incremental`, `--cache-dir`, and `--cache-clear` apply only to native scans, not `--from-json`. In `--from-json` mode, fresh scan flags such as `--package`, `--copyright`, `--email`, `--url`, `--generated`, and package scan variants are intentionally not allowed.
+
+## Ignore/Filter by Content
+
+| Flag                                  | What it does                                      |
+| ------------------------------------- | ------------------------------------------------- |
+| `--ignore-author <PATTERN>`           | Ignore files where author matches regex           |
+| `--ignore-copyright-holder <PATTERN>` | Ignore files where copyright holder matches regex |
+| `--max-email <N>`                     | Max emails per file (default: 50, 0 = unlimited)  |
+| `--max-url <N>`                       | Max URLs per file (default: 50, 0 = unlimited)    |
+
+## Common Workflows
+
+### Strong default scan
+
+```sh
+provenant --json-pp scan.json --license --package /path/to/project
+```
+
+### Full inventory (licenses + copyright + packages)
+
+```sh
+provenant --json-pp scan.json --license --copyright --package /path/to/project
+```
+
+### License-only scan
+
+```sh
+provenant --json-pp licenses.json --license /path/to/project
+```
+
+### Assembled packages and dependencies
+
+```sh
+provenant --json-pp packages.json --package /path/to/project
+```
+
+### File-level package data only (no normal top-level assembly)
+
+```sh
+provenant --json-pp packages.json --package-only /path/to/project
+```
+
+### System packages (container/rootfs)
+
+```sh
+provenant --json-pp syspkg.json --system-package /path/to/rootfs
+```
+
+### Compiled binary packages
+
+```sh
+provenant --json-pp compiled.json --package-in-compiled /path/to/project
+```
+
+### HTML report
+
+```sh
+provenant --html report.html --license --copyright /path/to/project
+```
+
+### SBOM (CycloneDX)
+
+```sh
+provenant --cyclonedx bom.json --package /path/to/project
+```
+
+### Debian copyright
+
+```sh
+provenant --debian debian.copyright --license --copyright --license-text /path/to/project
+```
+
+### Summary with tallies
+
+```sh
+provenant --json-pp summary.json --license --package --classify --summary --tallies /path/to/project
+```
+
+### Incremental reuse
+
+```sh
+provenant --json-pp scan.json --license --package --incremental /path/to/project
+```
+
+### Reshape existing scan
+
+```sh
+provenant --json-pp reshaped.json --from-json scan.json --only-findings
+```
+
+### Policy-aware license review
+
+```sh
+provenant --json-pp policy.json --license --license-references --filter-clues --license-policy policy.yml /path/to/project
+```
+
+### Ignore noise
+
+```sh
+provenant --json-pp scan.json --license --package --ignore "*.min.js" --ignore "node_modules/*" /path/to/project
+```
+
+### Multiple input paths
+
+```sh
+provenant --json-pp scan.json --license dir-a dir-b
+```
+
+## xtask profile shorthands
+
+These are used by xtask commands (`benchmark-target`, `compare-outputs`), not directly by `provenant`:
+
+| Profile                | Expands to                                                   |
+| ---------------------- | ------------------------------------------------------------ |
+| `common`               | `-clupe --system-package --strip-root`                       |
+| `common-with-compiled` | `-clupe --system-package --package-in-compiled --strip-root` |
+| `licenses`             | `-l --strip-root`                                            |
+| `packages`             | `-p --strip-root`                                            |
+
+## Reference
+
+- `docs/CLI_GUIDE.md` — full workflow guide with explanations
+- `provenant --help` — complete flag reference

--- a/.opencode/skills/verify-parser/SKILL.md
+++ b/.opencode/skills/verify-parser/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: verify-parser
+description: Verify a package parser ecosystem against ScanCode using compare-outputs, fix regressions, record benchmarks, and update the scorecard.
+---
+
+# Verify a Parser Ecosystem
+
+This skill drives the end-to-end verification workflow for a package parser ecosystem listed in the PARSER_VERIFICATION_SCORECARD. It runs `compare-outputs` against candidate repositories, triages and fixes regressions, records results in BENCHMARKS.md, and updates the scorecard.
+
+If a scorecard row explicitly says there is no ScanCode parity target or calls for a different verification shape, follow that row-specific note instead of forcing the default `compare-outputs` workflow.
+
+## Source documents
+
+- **Scorecard**: `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md` — the verification backlog with candidate targets and methodology rules
+- **Benchmarks**: `docs/BENCHMARKS.md` — the maintained reference for recorded compare-outputs runs, timing, and end-state advantages
+- **xtask commands**: `xtask/README.md` — CLI reference for `compare-outputs`, `update-parser-golden`, `update-copyright-golden`, `update-license-golden`
+- **AGENTS.md**: repo-level contributor guardrails
+
+## Workflow
+
+### Step 1: Read the scorecard row
+
+Identify the scorecard row for the target ecosystem. Note:
+
+- Priority number and ecosystem name
+- Status (`⚪ Planned` or `🟢 Verified`)
+- All candidate targets (repos, artifact paths, compiled-binary lanes)
+- Priority and scope notes — these contain stable guidance about what to watch for
+
+Do **not** rewrite the notes column during verification. Only the Status cell should change.
+
+### Step 2: Run compare-outputs for each candidate target, in sequence
+
+Unless the scorecard row explicitly says to use a different verification method:
+
+For repository-backed targets:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
+  --repo-url https://github.com/org/repo.git --repo-ref <ref> --profile common
+```
+
+For artifact/rootfs-backed targets:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
+  --target-path /path/to/local/target --profile common
+```
+
+For compiled-binary artifact targets:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
+  --target-path /path/to/local/target --profile common-with-compiled
+```
+
+**Always use `--profile common`** (not `--profile packages`) so package extraction is evaluated alongside license, copyright, author, email, URL, and other common-profile detection behavior. Use `--profile common-with-compiled` only when the scorecard row explicitly calls for compiled-binary verification.
+
+Find a recent commit SHA or tag for `--repo-ref`. Do not use branch names — they are not stable.
+
+### Step 3: Triage the comparison output
+
+After each compare-outputs run, inspect the artifacts under `.provenant/compare-runs/<run-id>/`:
+
+- `comparison/summary.json` — high-level delta counts and `comparison_status`
+- `comparison/summary.tsv` — tab-separated per-file summary
+- `comparison/samples/*.json` — detailed per-field diff samples
+- `raw/provenant.json` and `raw/scancode.json` — full scanner outputs
+
+**Triage rules** (from the scorecard methodology):
+
+1. Treat `comparison_status: potential_regressions_detected` as a triage-required signal, not an automatic failure.
+2. Treat any "more output" from either scanner as a claim to verify — not proof by itself.
+3. When scanners disagree, inspect the underlying file text to decide whether the extra or missing finding is justified.
+4. Apply the same rigor to license-expression and file-level license-detection deltas as to package, dependency, author, email, or URL deltas.
+5. Treat top-level license-expression deltas and repeated file-level license mismatches as first-class regression signals.
+6. Do **not** mark a row `🟢 Verified` while any ScanCode-better deltas remain unresolved.
+
+**Classification categories**:
+
+| Category                                            | Action                                          |
+| --------------------------------------------------- | ----------------------------------------------- |
+| Provenant is better                                 | Document in BENCHMARKS.md advantages column     |
+| ScanCode is better                                  | Fix in Provenant (see Step 4)                   |
+| Both wrong / cosmetic difference                    | Accept, do not fix, do not regress              |
+| Provenant more correct (e.g. Unicode normalization) | Accept as advantage, do not treat as regression |
+
+Do **not** treat normalization improvements as regressions when Provenant is more correct (e.g. preserving `René` instead of degrading to `Rene`).
+
+### Step 4: Fix regressions
+
+When ScanCode produces better output than Provenant:
+
+1. **Identify the root cause** — is it a parser bug, a missing feature, a license-detection gap, a copyright-detection issue, or an assembly problem?
+2. **Make generic scanner improvements** — fixes must improve general scan quality, not just tune one benchmark target. Reject target-specific workarounds.
+3. **Add focused tests** — every fixed regression or accepted behavior change should gain adequate automated coverage (parser tests, parser-local scanner/assembly contract tests when applicable, integration tests, and golden tests as appropriate).
+4. **Rerun affected regression suites** when a fix touches shared detection logic. Keep local validation tightly scoped and prefer the narrowest owning test target/filter:
+   - Copyright-detection changes → rerun copyright goldens
+   - License-detection changes → rerun license goldens
+   - Parser behavior fixes → rerun narrow parser tests, owning scanner/assembly contract tests where applicable, and relevant integration coverage
+5. **Rerun the compare-outputs** for the target to confirm the fix.
+
+### Step 5: Record the benchmark row
+
+For each verified target, add a row to `docs/BENCHMARKS.md`:
+
+**Repository-backed targets** go in the "Repository-backed targets" section.
+**Artifact/rootfs-backed targets** go in the "Artifact/rootfs-backed targets" section.
+
+Within each section, sort rows **alphabetically by target label**.
+
+**Row format**:
+
+| Column                   | Content                                                                 |
+| ------------------------ | ----------------------------------------------------------------------- |
+| Target snapshot          | `[org/repo @ short_sha](link)` `<br>` `N files`                         |
+| Run context              | `YYYY-MM-DD · <run-id suffix> · <os> · <cpu> · <ram> · <arch> · <proc>` |
+| Timing snapshot          | `Provenant: Xs` `<br>` `ScanCode: Ys` `<br>` `N× faster (±N%)`          |
+| Advantages over ScanCode | Present-tense end-state comparison (see writing rules below)            |
+
+**Run context**: Copy the `run_id` suffix from `.provenant/compare-runs/<run-id>/run-manifest.json` — it is the portion after the leading UTC timestamp (e.g. `airflow-44518`). Get the date from the same manifest. Record machine information (OS, CPU, RAM, arch, process count).
+
+**Timing**: Record same-host wall-clock timings for Provenant and ScanCode from the compare-outputs run. Compute relative speedup. If `run-manifest.json` reports `scancode.cache_hit: true`, use the cached ScanCode raw timing.
+
+**Advantages column writing rules**:
+
+- Write as a **present-tense end-state comparison**, not implementation history.
+- Lead with what Provenant does better today: broader coverage, richer identity, safer handling, cleaner normalization, more correct classification, or faster runtime.
+- Do **not** use process/history wording: `fixed`, `restored`, `aligned`, `added support`, `after`, `now that`, `triaged`, `reviewed tail`, `remaining deltas`.
+- If a reviewed non-regression difference matters, rewrite it as a **user-visible advantage**.
+- When claiming much broader package/dependency counts, include a **short causal explanation** naming the main surfaces driving the gap.
+- Preferred sentence shape: **"Broader/richer/safer/more correct X ..., plus Y ..., with Z ..."**.
+
+### Step 6: Update the scorecard
+
+When all candidate targets for the row have been verified:
+
+1. Change the Status cell from `⚪ Planned` to `🟢 Verified`.
+2. Do **not** modify the notes column unless the planned scope of the row genuinely changed.
+3. Do **not** narrate the implementation path or verification outcome in the table.
+
+### Step 7: Check for golden changes
+
+After all fixes and compare runs are complete:
+
+Keep validation tightly scoped. Prefer the narrowest useful owning test target/filter over broad local golden suites.
+
+1. If fixes touched license detection, run the narrowest relevant license golden coverage and check whether expected files need updating.
+
+   ```bash
+   cargo test --features golden-tests <narrow_license_filter>
+   ```
+
+2. If fixes touched copyright detection, run the narrowest relevant copyright golden coverage and check whether expected files need updating:
+
+   ```bash
+   cargo test --features golden-tests <narrow_copyright_filter>
+   ```
+
+3. If fixes touched a specific parser, rerun the parser golden tests and any owning scanner/assembly contract tests for that ecosystem.
+
+4. Only update golden expected files when the new output is genuinely better and the change is documented.
+
+   For license golden YAML fixtures, first do a parity precheck, then choose the update mode that matches the intent:
+
+   ```bash
+   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --sync-actual --filter <pattern> --write
+   ```
+
+   Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.
+
+   For copyright golden YAML fixtures, use the same precheck-then-update flow:
+
+   ```bash
+   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
+   ```
+
+   Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.
+
+   For parser golden JSON fixtures, regenerate them directly from current Rust output:
+
+   ```bash
+   cargo run --manifest-path xtask/Cargo.toml --bin update-parser-golden -- <ParserType> <input> <output>
+   ```
+
+### Step 8: Open a PR
+
+1. Create a branch: `verify/<ecosystem>-parser`
+2. Commit with an appropriate Conventional Commits type that matches the actual change (`fix`, `test`, `docs`, etc.), optionally scoped to the ecosystem.
+3. Use `.github/pull_request_template.md` for the PR body.
+4. Include the compare-run artifact paths and a summary of what was fixed or accepted.
+5. List any golden test changes with justification.
+
+## Common failure modes
+
+- Using `--profile packages` instead of `--profile common` — misses license/copyright/author/email/URL regressions.
+- Using a branch name instead of a commit SHA for `--repo-ref` — not reproducible.
+- Treating ScanCode-better output as "acceptable noise" without inspecting the underlying file text.
+- Making target-specific fixes that only improve one benchmark without addressing the general root cause.
+- Rewriting the scorecard notes column to capture verification narrative instead of keeping it stable.
+- Forgetting to run regression suites after fixing shared detection logic.
+- Writing BENCHMARKS.md advantages as implementation history instead of present-tense end-state comparison.
+- Updating golden expected files just to make tests pass without documenting why the new output is correct.
+
+## Per-ecosystem watch points
+
+The scorecard notes column contains stable guidance per row. Common cross-ecosystem patterns to watch:
+
+- **Package count deltas**: Verify whether extra/missing packages are real parser regressions or just fixture noise.
+- **License-expression deltas**: ScanCode often collapses compound expressions; Provenant may be more specific.
+- **Copyright/author noise**: Large doc/test trees generate many weak detections. Focus on genuine regressions.
+- **Dependency scope**: Lockfile vs manifest precedence differences are ecosystem-specific.
+- **Vendored/generated files**: Exclude from triage unless they expose a real parser bug.
+- **Compiled-binary lanes**: Only used when the scorecard row explicitly calls for them (`common-with-compiled`).


### PR DESCRIPTION
## Summary

- Add four opencode AI agent skills under `.opencode/skills/` to provide structured, loadable workflows for common Provenant maintainer and contributor tasks
- `add-parser`: full parser implementation workflow from research through registration, testing, assembly wiring, and validation (derived from `docs/HOW_TO_ADD_A_PARSER.md`)
- `release-provenant`: maintainer release flow including preflight checks, dry run, execution, and post-release verification (derived from `docs/RELEASING.md`)
- `golden-test-maintenance`: golden fixture maintenance across parser, copyright, and license domains with xtask commands and parity-vs-Rust-actuals workflows (derived from `docs/TESTING_STRATEGY.md` and `xtask/README.md`)
- `provenant-cli`: quick reference for all CLI flags, output formats, detection modes, flag dependencies, and common scan workflows (derived from `docs/CLI_GUIDE.md` and `provenant --help`)

## Testing

- All four SKILL.md files pass markdown-lint and prettier via lefthook pre-commit hooks