### PR TITLE
fix(parsers): ADR 0004 security compliance batch 1 — npm, cargo, python, ruby, alpine + utils

### DIFF
--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -28,7 +28,13 @@ use crate::models::{
     DatasourceId, Dependency, FileReference, LicenseDetection, PackageData, PackageType, Party,
     Sha1Digest,
 };
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
+
+const MAX_ARCHIVE_SIZE: u64 = 1024 * 1024 * 1024; // 1GB uncompressed
+const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50MB per entry
+const MAX_COMPRESSION_RATIO: f64 = 100.0; // 100:1 ratio
 
 use super::PackageParser;
 use super::license_normalization::{
@@ -62,7 +68,7 @@ impl PackageParser for AlpineInstalledParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Alpine installed db {:?}: {}", path, e);
@@ -82,7 +88,7 @@ impl PackageParser for AlpineApkbuildParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read APKBUILD {:?}: {}", path, e);
@@ -102,7 +108,7 @@ fn parse_alpine_installed_db(content: &str) -> Vec<PackageData> {
 
     let mut all_packages = Vec::new();
 
-    for raw_text in &raw_paragraphs {
+    for raw_text in raw_paragraphs.iter().take(MAX_ITERATION_COUNT) {
         let headers = parse_alpine_headers(raw_text);
         let pkg = parse_alpine_package_paragraph(&headers, raw_text);
         if pkg.name.is_some() {
@@ -125,7 +131,7 @@ fn parse_alpine_installed_db(content: &str) -> Vec<PackageData> {
 fn parse_alpine_headers(content: &str) -> HashMap<String, Vec<String>> {
     let mut headers: HashMap<String, Vec<String>> = HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         if line.is_empty() {
             continue;
         }
@@ -149,7 +155,7 @@ fn get_first(headers: &HashMap<String, Vec<String>>, key: &str) -> Option<String
     headers
         .get(key)
         .and_then(|values| values.first())
-        .map(|v| v.trim().to_string())
+        .map(|v| truncate_field(v.trim().to_string()))
 }
 
 fn get_all(headers: &HashMap<String, Vec<String>>, key: &str) -> Vec<String> {
@@ -202,14 +208,24 @@ fn parse_alpine_package_paragraph(
     } else {
         Vec::new()
     };
-    let vcs_url = get_first(headers, "c")
-        .map(|commit| format!("git+https://git.alpinelinux.org/aports/commit/?id={commit}"));
+    let vcs_url = get_first(headers, "c").map(|commit| {
+        truncate_field(format!(
+            "git+https://git.alpinelinux.org/aports/commit/?id={commit}"
+        ))
+    });
 
     let mut dependencies = Vec::new();
-    for dep in get_all(headers, "D") {
+    let mut dep_count = 0;
+    'dep_loop: for dep in get_all(headers, "D") {
         for dep_str in dep.split_whitespace() {
             if dep_str.starts_with("so:") || dep_str.starts_with("cmd:") {
                 continue;
+            }
+
+            dep_count += 1;
+            if dep_count > MAX_ITERATION_COUNT {
+                warn!("Exceeded MAX_ITERATION_COUNT in dependency parsing, truncating");
+                break 'dep_loop;
             }
 
             dependencies.push(Dependency {
@@ -293,15 +309,15 @@ fn parse_alpine_package_paragraph(
 fn parse_apkbuild(content: &str) -> PackageData {
     let variables = parse_apkbuild_variables(content);
 
-    let name = variables.get("pkgname").cloned();
+    let name = variables.get("pkgname").cloned().map(truncate_field);
     let version = match (variables.get("pkgver"), variables.get("pkgrel")) {
-        (Some(ver), Some(rel)) => Some(format!("{}-r{}", ver, rel)),
-        (Some(ver), None) => Some(ver.clone()),
+        (Some(ver), Some(rel)) => Some(truncate_field(format!("{}-r{}", ver, rel))),
+        (Some(ver), None) => Some(truncate_field(ver.clone())),
         _ => None,
     };
-    let description = variables.get("pkgdesc").cloned();
-    let homepage_url = variables.get("url").cloned();
-    let extracted_license_statement = variables.get("license").cloned();
+    let description = variables.get("pkgdesc").cloned().map(truncate_field);
+    let homepage_url = variables.get("url").cloned().map(truncate_field);
+    let extracted_license_statement = variables.get("license").cloned().map(truncate_field);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         build_alpine_license_data(extracted_license_statement.as_deref());
 
@@ -369,8 +385,14 @@ fn parse_apkbuild_variables(content: &str) -> HashMap<String, String> {
     let mut raw = HashMap::new();
     let mut lines = content.lines().peekable();
     let mut brace_depth = 0usize;
+    let mut line_count = 0usize;
 
     while let Some(line) = lines.next() {
+        line_count += 1;
+        if line_count > MAX_ITERATION_COUNT {
+            warn!("Exceeded MAX_ITERATION_COUNT in parse_apkbuild_variables, truncating");
+            break;
+        }
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -392,7 +414,10 @@ fn parse_apkbuild_variables(content: &str) -> HashMap<String, String> {
             while let Some(next) = lines.peek() {
                 value.push('\n');
                 value.push_str(next);
-                let current = lines.next().unwrap();
+                let current = match lines.next() {
+                    Some(l) => l,
+                    None => break,
+                };
                 if current.trim_end().ends_with('"') {
                     break;
                 }
@@ -564,6 +589,7 @@ fn normalize_alpine_license_token(token: &str) -> Option<NormalizedDeclaredLicen
 
 fn parse_apkbuild_dependencies(variables: &HashMap<String, String>) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
+    let mut dep_count = 0;
 
     for (field, scope, is_runtime, is_optional) in [
         ("depends", "depends", true, false),
@@ -581,6 +607,12 @@ fn parse_apkbuild_dependencies(variables: &HashMap<String, String>) -> Vec<Depen
             let dep_str = dep_str.trim();
             if dep_str.is_empty() {
                 continue;
+            }
+
+            dep_count += 1;
+            if dep_count > MAX_ITERATION_COUNT {
+                warn!("Exceeded MAX_ITERATION_COUNT in parse_apkbuild_dependencies, truncating");
+                return dependencies;
             }
 
             let dep_name = dep_str
@@ -614,7 +646,7 @@ fn extract_file_references(raw_text: &str) -> Vec<FileReference> {
     let mut current_dir = String::new();
     let mut current_file: Option<FileReference> = None;
 
-    for line in raw_text.lines() {
+    for line in raw_text.lines().take(MAX_ITERATION_COUNT) {
         if line.is_empty() {
             continue;
         }
@@ -692,7 +724,7 @@ fn extract_file_references(raw_text: &str) -> Vec<FileReference> {
 fn extract_providers(raw_text: &str) -> Vec<String> {
     let mut providers = Vec::new();
 
-    for line in raw_text.lines() {
+    for line in raw_text.lines().take(MAX_ITERATION_COUNT) {
         if line.is_empty() {
             continue;
         }
@@ -761,12 +793,27 @@ fn apk_contains_pkginfo(path: &Path) -> bool {
         Err(_) => return false,
     };
 
+    let archive_size = match std::fs::metadata(path) {
+        Ok(m) => m.len(),
+        Err(_) => return false,
+    };
+
+    if archive_size > MAX_ARCHIVE_SIZE {
+        warn!(
+            "Archive {:?} exceeds MAX_ARCHIVE_SIZE ({} bytes)",
+            path, archive_size
+        );
+        return false;
+    }
+
     let decoder = GzDecoder::new(file);
     let mut archive = tar::Archive::new(decoder);
     let entries = match archive.entries() {
         Ok(entries) => entries,
         Err(_) => return false,
     };
+
+    let mut total_extracted: u64 = 0;
 
     for entry_result in entries {
         let entry = match entry_result {
@@ -777,6 +824,35 @@ fn apk_contains_pkginfo(path: &Path) -> bool {
             Ok(path) => path,
             Err(_) => return false,
         };
+
+        let entry_str = entry_path.to_string_lossy();
+        if entry_str.contains("..") {
+            warn!("Skipping tar entry with path traversal: {}", entry_str);
+            continue;
+        }
+
+        let uncompressed_size = entry.size();
+        if uncompressed_size > MAX_FILE_SIZE {
+            warn!(
+                "Entry {:?} in {:?} exceeds MAX_FILE_SIZE ({} bytes)",
+                entry_path, path, uncompressed_size
+            );
+            continue;
+        }
+
+        if archive_size > 0 {
+            let ratio = uncompressed_size as f64 / archive_size as f64;
+            if ratio > MAX_COMPRESSION_RATIO {
+                warn!("Suspicious compression ratio in {:?}: {:.2}:1", path, ratio);
+                continue;
+            }
+        }
+
+        total_extracted += uncompressed_size;
+        if total_extracted > MAX_ARCHIVE_SIZE {
+            warn!("Total extracted size exceeds limit for {:?}", path);
+            return false;
+        }
 
         if entry_path.ends_with(".PKGINFO") {
             return true;
@@ -792,8 +868,21 @@ fn extract_apk_archive(path: &Path) -> Result<PackageData, String> {
 
     let file = std::fs::File::open(path).map_err(|e| format!("Failed to open .apk file: {}", e))?;
 
+    let archive_size = std::fs::metadata(path)
+        .map_err(|e| format!("Failed to stat .apk file: {}", e))?
+        .len();
+
+    if archive_size > MAX_ARCHIVE_SIZE {
+        return Err(format!(
+            "Archive {:?} is {} bytes, exceeding MAX_ARCHIVE_SIZE ({} bytes)",
+            path, archive_size, MAX_ARCHIVE_SIZE
+        ));
+    }
+
     let decoder = GzDecoder::new(file);
     let mut archive = tar::Archive::new(decoder);
+
+    let mut total_extracted: u64 = 0;
 
     for entry_result in archive
         .entries()
@@ -804,6 +893,34 @@ fn extract_apk_archive(path: &Path) -> Result<PackageData, String> {
         let entry_path = entry
             .path()
             .map_err(|e| format!("Failed to get entry path: {}", e))?;
+
+        let entry_str = entry_path.to_string_lossy();
+        if entry_str.contains("..") {
+            warn!("Skipping tar entry with path traversal: {}", entry_str);
+            continue;
+        }
+
+        let uncompressed_size = entry.size();
+        if uncompressed_size > MAX_FILE_SIZE {
+            warn!(
+                "Entry {:?} in {:?} exceeds MAX_FILE_SIZE ({} bytes)",
+                entry_path, path, uncompressed_size
+            );
+            continue;
+        }
+
+        if archive_size > 0 {
+            let ratio = uncompressed_size as f64 / archive_size as f64;
+            if ratio > MAX_COMPRESSION_RATIO {
+                warn!("Suspicious compression ratio in {:?}: {:.2}:1", path, ratio);
+                continue;
+            }
+        }
+
+        total_extracted += uncompressed_size;
+        if total_extracted > MAX_ARCHIVE_SIZE {
+            return Err(format!("Total extracted size exceeds limit for {:?}", path));
+        }
 
         if entry_path.ends_with(".PKGINFO") {
             let mut content = String::new();
@@ -821,7 +938,7 @@ fn extract_apk_archive(path: &Path) -> Result<PackageData, String> {
 fn parse_pkginfo(content: &str) -> PackageData {
     let mut fields: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -835,31 +952,31 @@ fn parse_pkginfo(content: &str) -> PackageData {
     let name = fields
         .get("pkgname")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let pkgver = fields.get("pkgver").and_then(|v| v.first());
-    let version = pkgver.map(|s| s.to_string());
+    let version = pkgver.map(|s| truncate_field(s.to_string()));
     let arch = fields
         .get("arch")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let license = fields
         .get("license")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         build_alpine_license_data(license.as_deref());
     let description = fields
         .get("pkgdesc")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let homepage = fields
         .get("url")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let origin = fields
         .get("origin")
         .and_then(|v| v.first())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let maintainer_str = fields.get("maintainer").and_then(|v| v.first());
 
     let mut parties = Vec::new();
@@ -883,7 +1000,11 @@ fn parse_pkginfo(content: &str) -> PackageData {
 
     let mut dependencies = Vec::new();
     if let Some(depends_list) = fields.get("depend") {
-        for dep_str in depends_list {
+        for (i, dep_str) in depends_list.iter().enumerate() {
+            if i >= MAX_ITERATION_COUNT {
+                warn!("Exceeded MAX_ITERATION_COUNT in parse_pkginfo dependencies, truncating");
+                break;
+            }
             let dep_name = dep_str.split_whitespace().next().unwrap_or(dep_str);
             dependencies.push(Dependency {
                 purl: Some(format!("pkg:alpine/{}", dep_name)),

--- a/src/parsers/arch.rs
+++ b/src/parsers/arch.rs
@@ -26,7 +26,7 @@ impl PackageParser for ArchSrcinfoParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read Arch source metadata {:?}: {}", path, e);
@@ -46,7 +46,7 @@ impl PackageParser for ArchPkginfoParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read Arch .PKGINFO {:?}: {}", path, e);

--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -20,10 +20,10 @@
 
 use crate::models::{DatasourceId, Dependency, FileReference, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
-use crate::parsers::utils::split_name_email;
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 use packageurl::PackageUrl;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use toml::Value;
 
@@ -74,17 +74,17 @@ impl PackageParser for CargoParser {
         let name = package
             .and_then(|p| p.get(FIELD_NAME))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let version = package
             .and_then(|p| p.get(FIELD_VERSION))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let raw_license = package
             .and_then(|p| p.get(FIELD_LICENSE))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
         let file_references = extract_file_references(&toml_content);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             raw_license
@@ -117,7 +117,7 @@ impl PackageParser for CargoParser {
         let homepage_url = package
             .and_then(|p| p.get(FIELD_HOMEPAGE))
             .and_then(|v| v.as_str())
-            .map(String::from)
+            .map(|s| truncate_field(s.to_string()))
             .or_else(|| {
                 name.as_ref()
                     .map(|n| format!("https://crates.io/crates/{}", n))
@@ -126,7 +126,7 @@ impl PackageParser for CargoParser {
         let repository_url = package
             .and_then(|p| p.get(FIELD_REPOSITORY))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
         let download_url = None;
 
         let api_data_url = generate_cargo_api_url(&name, &version);
@@ -146,7 +146,7 @@ impl PackageParser for CargoParser {
         let description = package
             .and_then(|p| p.get(FIELD_DESCRIPTION))
             .and_then(|v| v.as_str())
-            .map(|s| s.trim().to_string());
+            .map(|s| truncate_field(s.trim().to_string()));
 
         let keywords = extract_keywords_and_categories(&toml_content);
 
@@ -209,10 +209,8 @@ impl PackageParser for CargoParser {
 
 /// Reads and parses a TOML file
 fn read_cargo_toml(path: &Path) -> Result<Value, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Error reading file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
 
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
@@ -256,7 +254,7 @@ fn extract_parties(toml_content: &Value) -> Vec<Party> {
     if let Some(package) = toml_content.get(FIELD_PACKAGE).and_then(|v| v.as_table())
         && let Some(authors) = package.get(FIELD_AUTHORS).and_then(|v| v.as_array())
     {
-        for author in authors {
+        for author in authors.iter().take(MAX_ITERATION_COUNT) {
             if let Some(author_str) = author.as_str() {
                 let (name, email) = split_name_email(author_str);
                 parties.push(Party {
@@ -270,6 +268,13 @@ fn extract_parties(toml_content: &Value) -> Vec<Party> {
                     timezone: None,
                 });
             }
+        }
+        if authors.len() > MAX_ITERATION_COUNT {
+            warn!(
+                "Authors array has {} entries, capping at MAX_ITERATION_COUNT ({})",
+                authors.len(),
+                MAX_ITERATION_COUNT
+            );
         }
     }
 
@@ -316,7 +321,15 @@ fn extract_dependencies(toml_content: &Value, scope: &str) -> Vec<Dependency> {
     let is_runtime = !scope.ends_with("dev-dependencies") && !scope.ends_with("build-dependencies");
 
     if let Some(deps_table) = toml_content.get(scope).and_then(|v| v.as_table()) {
-        for (name, value) in deps_table {
+        if deps_table.len() > MAX_ITERATION_COUNT {
+            warn!(
+                "Dependency table '{}' has {} entries, capping at MAX_ITERATION_COUNT ({})",
+                scope,
+                deps_table.len(),
+                MAX_ITERATION_COUNT
+            );
+        }
+        for (name, value) in deps_table.iter().take(MAX_ITERATION_COUNT) {
             let (extracted_requirement, is_optional, extra_data_map, is_pinned) = match value {
                 Value::String(version_str) => {
                     // Simple string version: "1.0"
@@ -434,20 +447,32 @@ fn extract_keywords_and_categories(toml_content: &Value) -> Vec<String> {
     let mut keywords = Vec::new();
 
     if let Some(package) = toml_content.get(FIELD_PACKAGE).and_then(|v| v.as_table()) {
-        // Extract keywords array
         if let Some(kw_array) = package.get(FIELD_KEYWORDS).and_then(|v| v.as_array()) {
-            for kw in kw_array {
+            if kw_array.len() > MAX_ITERATION_COUNT {
+                warn!(
+                    "Keywords array has {} entries, capping at MAX_ITERATION_COUNT ({})",
+                    kw_array.len(),
+                    MAX_ITERATION_COUNT
+                );
+            }
+            for kw in kw_array.iter().take(MAX_ITERATION_COUNT) {
                 if let Some(kw_str) = kw.as_str() {
-                    keywords.push(kw_str.to_string());
+                    keywords.push(truncate_field(kw_str.to_string()));
                 }
             }
         }
 
-        // Extract categories array and merge with keywords
         if let Some(cat_array) = package.get(FIELD_CATEGORIES).and_then(|v| v.as_array()) {
-            for cat in cat_array {
+            if cat_array.len() > MAX_ITERATION_COUNT {
+                warn!(
+                    "Categories array has {} entries, capping at MAX_ITERATION_COUNT ({})",
+                    cat_array.len(),
+                    MAX_ITERATION_COUNT
+                );
+            }
+            for cat in cat_array.iter().take(MAX_ITERATION_COUNT) {
                 if let Some(cat_str) = cat.as_str() {
-                    keywords.push(cat_str.to_string());
+                    keywords.push(truncate_field(cat_str.to_string()));
                 }
             }
         }
@@ -494,18 +519,28 @@ fn extract_file_references(toml_content: &Value) -> Vec<FileReference> {
     file_references
 }
 
-/// Converts toml::Value to serde_json::Value recursively
-fn toml_to_json(value: &toml::Value) -> serde_json::Value {
+const MAX_TOML_DEPTH: usize = 50;
+
+fn toml_to_json(value: &toml::Value, depth: usize) -> serde_json::Value {
+    if depth > MAX_TOML_DEPTH {
+        warn!(
+            "TOML nesting depth exceeded {}, returning Null",
+            MAX_TOML_DEPTH
+        );
+        return serde_json::Value::Null;
+    }
     match value {
         toml::Value::String(s) => serde_json::json!(s),
         toml::Value::Integer(i) => serde_json::json!(i),
         toml::Value::Float(f) => serde_json::json!(f),
         toml::Value::Boolean(b) => serde_json::json!(b),
-        toml::Value::Array(a) => serde_json::Value::Array(a.iter().map(toml_to_json).collect()),
+        toml::Value::Array(a) => {
+            serde_json::Value::Array(a.iter().map(|v| toml_to_json(v, depth + 1)).collect())
+        }
         toml::Value::Table(t) => {
             let map: serde_json::Map<String, serde_json::Value> = t
                 .iter()
-                .map(|(k, v)| (k.clone(), toml_to_json(v)))
+                .map(|(k, v)| (k.clone(), toml_to_json(v, depth + 1)))
                 .collect();
             serde_json::Value::Object(map)
         }
@@ -521,7 +556,13 @@ fn extract_extra_data(
     let mut extra_data = std::collections::HashMap::new();
 
     if let Some(package) = toml_content.get(FIELD_PACKAGE).and_then(|v| v.as_table()) {
-        // Extract rust-version (or detect workspace inheritance)
+        if package.len() > MAX_ITERATION_COUNT {
+            warn!(
+                "Package table has {} entries, exceeding MAX_ITERATION_COUNT ({})",
+                package.len(),
+                MAX_ITERATION_COUNT
+            );
+        }
         if let Some(rust_version_value) = package.get(FIELD_RUST_VERSION) {
             if let Some(rust_version_str) = rust_version_value.as_str() {
                 extra_data.insert("rust_version".to_string(), json!(rust_version_str));
@@ -569,7 +610,7 @@ fn extract_extra_data(
         }
 
         if let Some(publish_value) = package.get(FIELD_PUBLISH) {
-            extra_data.insert("publish".to_string(), toml_to_json(publish_value));
+            extra_data.insert("publish".to_string(), toml_to_json(publish_value, 0));
         }
 
         // Check for workspace inheritance markers for other fields
@@ -630,7 +671,7 @@ fn extract_extra_data(
 
     // Extract workspace table if it exists
     if let Some(workspace_value) = toml_content.get("workspace") {
-        extra_data.insert("workspace".to_string(), toml_to_json(workspace_value));
+        extra_data.insert("workspace".to_string(), toml_to_json(workspace_value, 0));
     }
 
     if extra_data.is_empty() {

--- a/src/parsers/debian.rs
+++ b/src/parsers/debian.rs
@@ -173,7 +173,7 @@ impl PackageParser for DebianControlParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read debian/control at {:?}: {}", path, e);
@@ -205,7 +205,7 @@ impl PackageParser for DebianInstalledParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read dpkg/status at {:?}: {}", path, e);
@@ -233,7 +233,7 @@ impl PackageParser for DebianDistrolessInstalledParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read distroless status file at {:?}: {}", path, e);
@@ -881,7 +881,7 @@ impl PackageParser for DebianDscParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .dsc file {:?}: {}", path, e);
@@ -1155,7 +1155,7 @@ impl PackageParser for DebianInstalledListParser {
             }
         };
 
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .list file {:?}: {}", path, e);
@@ -1201,7 +1201,7 @@ impl PackageParser for DebianInstalledMd5sumsParser {
             }
         };
 
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .md5sums file {:?}: {}", path, e);
@@ -1313,7 +1313,7 @@ impl PackageParser for DebianCopyrightParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         let datasource_id = detect_debian_copyright_datasource(path);
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read copyright file {:?}: {}", path, e);
@@ -1933,7 +1933,7 @@ impl PackageParser for DebianControlInExtractedDebParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!(
@@ -1989,7 +1989,7 @@ impl PackageParser for DebianMd5sumInPackageParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read md5sums file {:?}: {}", path, e);

--- a/src/parsers/docker.rs
+++ b/src/parsers/docker.rs
@@ -40,7 +40,7 @@ impl PackageParser for DockerfileParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read Dockerfile {:?}: {}", path, error);

--- a/src/parsers/freebsd.rs
+++ b/src/parsers/freebsd.rs
@@ -59,7 +59,7 @@ impl PackageParser for FreebsdCompactManifestParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read FreeBSD manifest {:?}: {}", path, e);

--- a/src/parsers/gitmodules.rs
+++ b/src/parsers/gitmodules.rs
@@ -47,7 +47,7 @@ impl PackageParser for GitmodulesParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .gitmodules {:?}: {}", path, e);

--- a/src/parsers/maven.rs
+++ b/src/parsers/maven.rs
@@ -776,7 +776,7 @@ impl PackageParser for MavenParser {
             }
         }
 
-        let content = match read_file_to_string(path).map_err(|e| e.to_string()) {
+        let content = match read_file_to_string(path, None).map_err(|e| e.to_string()) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to open pom.xml at {:?}: {}", path, e);
@@ -2050,7 +2050,7 @@ fn normalize_maven_license_name(name: &str) -> Option<NormalizedDeclaredLicense>
 
 /// Parse pom.properties file (Java properties format)
 fn parse_pom_properties(path: &Path) -> PackageData {
-    let content = match read_file_to_string(path).map_err(|e| e.to_string()) {
+    let content = match read_file_to_string(path, None).map_err(|e| e.to_string()) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read pom.properties at {:?}: {}", path, e);
@@ -2135,7 +2135,7 @@ fn parse_pom_properties(path: &Path) -> PackageData {
 /// and extracts OSGi-specific metadata including Import-Package and Require-Bundle
 /// dependencies.
 fn parse_manifest_mf(path: &Path) -> PackageData {
-    let content = match read_file_to_string(path).map_err(|e| e.to_string()) {
+    let content = match read_file_to_string(path, None).map_err(|e| e.to_string()) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read MANIFEST.MF at {:?}: {}", path, e);

--- a/src/parsers/npm.rs
+++ b/src/parsers/npm.rs
@@ -23,10 +23,9 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{npm_purl, parse_sri};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use super::PackageParser;
@@ -231,7 +230,8 @@ impl PackageParser for NpmParser {
 /// Reads and parses a JSON file while tracking line numbers of fields
 fn read_and_parse_json_with_lines(path: &Path) -> Result<(Value, HashMap<String, usize>), String> {
     // Read file once into string
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = crate::parsers::utils::read_file_to_string(path, None)
+        .map_err(|e| format!("Failed to read file: {}", e))?;
 
     // Parse JSON
     let json: Value =
@@ -239,11 +239,10 @@ fn read_and_parse_json_with_lines(path: &Path) -> Result<(Value, HashMap<String,
 
     // Track line numbers for each field by iterating over lines
     let mut field_lines = HashMap::new();
-    for (line_num, line) in content.lines().enumerate() {
+    for (line_num, line) in content.lines().enumerate().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
-        // Look for field names in the format: "field": value
         if let Some(field_name) = extract_field_name(trimmed) {
-            field_lines.insert(field_name, line_num + 1); // 1-based line numbers
+            field_lines.insert(field_name, line_num + 1);
         }
     }
 
@@ -325,7 +324,7 @@ fn extract_license_statement(json: &Value) -> Option<String> {
     }
 
     if let Some(licenses) = json.get(FIELD_LICENSES).and_then(|v| v.as_array()) {
-        for license in licenses {
+        for license in licenses.iter().take(MAX_ITERATION_COUNT) {
             if let Some(license_obj) = license.as_object()
                 && let Some(type_val) = license_obj.get("type").and_then(|v| v.as_str())
             {
@@ -340,7 +339,7 @@ fn extract_license_statement(json: &Value) -> Option<String> {
     if statements.is_empty() {
         None
     } else {
-        Some(format!("{}\n", statements.join("\n")))
+        Some(truncate_field(format!("{}\n", statements.join("\n"))))
     }
 }
 
@@ -349,7 +348,7 @@ fn extract_declared_license_candidate(json: &Value) -> Option<String> {
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .map(|s| truncate_field(s.to_string()))
 }
 
 /// Extracts the repository URL from the repository field.
@@ -416,7 +415,7 @@ fn extract_vcs_url(json: &Value) -> Option<String> {
         vcs_url.push_str(directory);
     }
 
-    Some(vcs_url)
+    Some(truncate_field(vcs_url))
 }
 
 /// Normalizes repository URLs by converting various formats to a standard HTTPS URL.
@@ -526,24 +525,22 @@ fn extract_parties(json: &Value) -> Vec<Party> {
 fn extract_party_from_field(field: &Value) -> Option<Party> {
     match field {
         Value::String(s) => {
-            // Try to extract email from "Name <email>" format
             if let Some(email) = extract_email_from_string(s) {
                 Some(Party {
                     r#type: Some("person".to_string()),
                     role: None,
-                    name: extract_name_from_author_string(s),
-                    email: Some(email),
+                    name: extract_name_from_author_string(s).map(truncate_field),
+                    email: Some(truncate_field(email)),
                     url: None,
                     organization: None,
                     organization_url: None,
                     timezone: None,
                 })
             } else {
-                // Treat the string as name if no email found
                 Some(Party {
                     r#type: Some("person".to_string()),
                     role: None,
-                    name: Some(s.clone()),
+                    name: Some(truncate_field(s.clone())),
                     email: None,
                     url: None,
                     organization: None,
@@ -554,13 +551,23 @@ fn extract_party_from_field(field: &Value) -> Option<Party> {
         }
         Value::Object(obj) => Some(Party {
             r#type: Some("person".to_string()),
-            role: obj.get("role").and_then(|v| v.as_str()).map(String::from),
-            name: obj.get("name").and_then(|v| v.as_str()).map(String::from),
-            email: obj.get("email").and_then(|v| v.as_str()).map(String::from),
+            role: obj
+                .get("role")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_field(s.to_string())),
+            name: obj
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_field(s.to_string())),
+            email: obj
+                .get("email")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_field(s.to_string())),
             url: obj
                 .get("url")
                 .and_then(|v| v.as_str())
-                .and_then(normalize_optional_party_url),
+                .and_then(normalize_optional_party_url)
+                .map(truncate_field),
             organization: None,
             organization_url: None,
             timezone: None,
@@ -574,6 +581,7 @@ fn extract_parties_from_array(array: &Value) -> Option<Vec<Party>> {
     if let Value::Array(items) = array {
         let parties = items
             .iter()
+            .take(MAX_ITERATION_COUNT)
             .filter_map(extract_party_from_field)
             .collect::<Vec<_>>();
         if !parties.is_empty() {
@@ -630,7 +638,7 @@ fn extract_non_empty_string(json: &Value, field: &str) -> Option<String> {
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(String::from)
+        .map(|s| truncate_field(s.to_string()))
 }
 
 fn generate_npm_api_url(
@@ -713,6 +721,7 @@ fn extract_dependency_group(
         .and_then(|deps| deps.as_object())
         .map_or_else(Vec::new, |deps| {
             deps.iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|(name, version)| {
                     let version_str = version.as_str()?;
 
@@ -725,7 +734,7 @@ fn extract_dependency_group(
                         };
                         return Some(Dependency {
                             purl: Some(package_url),
-                            extracted_requirement: Some(version_str.to_string()),
+                            extracted_requirement: Some(truncate_field(version_str.to_string())),
                             scope: Some(scope.to_string()),
                             is_runtime: Some(is_runtime),
                             is_optional: is_opt,
@@ -754,7 +763,7 @@ fn extract_dependency_group(
 
                     Some(Dependency {
                         purl: Some(package_url),
-                        extracted_requirement: Some(version_str.to_string()),
+                        extracted_requirement: Some(truncate_field(version_str.to_string())),
                         scope: Some(scope.to_string()),
                         is_runtime: Some(is_runtime),
                         is_optional: is_opt,
@@ -824,6 +833,7 @@ fn extract_bundled_dependencies(json: &Value) -> Vec<Dependency> {
 fn extract_bundled_list(bundled_array: &[Value]) -> Vec<Dependency> {
     bundled_array
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|value| {
             let name = value.as_str()?;
             // Create PURL without version for bundled dependencies
@@ -865,6 +875,7 @@ fn extract_peer_dependencies_meta(json: &Value) -> HashMap<String, bool> {
         .map_or_else(HashMap::new, |meta_obj| {
             meta_obj
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|(package_name, meta_value)| {
                     meta_value.as_object().and_then(|obj| {
                         obj.get("optional")
@@ -887,12 +898,12 @@ fn extract_overrides(json: &Value) -> Option<serde_json::Value> {
 fn extract_description(json: &Value) -> Option<String> {
     json.get(FIELD_DESCRIPTION)
         .and_then(|v| v.as_str())
-        .map(String::from)
+        .map(|s| truncate_field(s.to_string()))
 }
 
 fn extract_homepage_url(json: &Value) -> Option<String> {
     match json.get(FIELD_HOMEPAGE) {
-        Some(Value::String(homepage)) => normalize_non_empty_string(homepage),
+        Some(Value::String(homepage)) => normalize_non_empty_string(homepage).map(truncate_field),
         _ => None,
     }
 }
@@ -924,8 +935,9 @@ fn extract_keywords_as_vec(json: &Value) -> Vec<String> {
             } else if let Some(arr) = v.as_array() {
                 let keywords: Vec<String> = arr
                     .iter()
+                    .take(MAX_ITERATION_COUNT)
                     .filter_map(|kw| kw.as_str())
-                    .map(String::from)
+                    .map(|s| truncate_field(s.to_string()))
                     .collect();
                 if keywords.is_empty() {
                     None
@@ -950,7 +962,7 @@ fn extract_raw_extra_data_field(json: &Value, field: &str) -> Option<serde_json:
 fn extract_package_manager(json: &Value) -> Option<String> {
     json.get(FIELD_PACKAGE_MANAGER)
         .and_then(|v| v.as_str())
-        .map(String::from)
+        .map(|s| truncate_field(s.to_string()))
 }
 
 fn extract_workspaces(json: &Value) -> Option<serde_json::Value> {
@@ -965,11 +977,12 @@ fn extract_bugs(json: &Value) -> Option<String> {
     match json.get(FIELD_BUGS) {
         Some(bugs) => {
             if let Some(url) = bugs.as_str() {
-                normalize_non_empty_string(url)
+                normalize_non_empty_string(url).map(truncate_field)
             } else if let Some(obj) = bugs.as_object() {
                 obj.get("url")
                     .and_then(|v| v.as_str())
                     .and_then(normalize_non_empty_string)
+                    .map(truncate_field)
             } else {
                 None
             }
@@ -1009,6 +1022,7 @@ fn extract_dist_tarball(dist: &Value) -> Option<String> {
         .or_else(|| dist.get("dnl_url"))
         .and_then(|v| v.as_str())
         .map(normalize_npm_registry_tarball_url)
+        .map(truncate_field)
 }
 
 fn normalize_npm_registry_tarball_url(url: &str) -> String {

--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -69,7 +69,7 @@ impl PackageParser for PixiLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read pixi.lock at {:?}: {}", path, error);

--- a/src/parsers/python.rs
+++ b/src/parsers/python.rs
@@ -35,7 +35,9 @@ use crate::models::{
     DatasourceId, Dependency, FileReference, PackageData, PackageType, Party, Sha256Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bzip2::read::BzDecoder;
@@ -231,7 +233,7 @@ fn merge_sibling_wheel_metadata(path: &Path, package_data: &mut PackageData) {
         return;
     }
 
-    let Ok(content) = read_file_to_string(&wheel_path) else {
+    let Ok(content) = read_file_to_string(&wheel_path, None) else {
         warn!("Failed to read sibling WHEEL file at {:?}", wheel_path);
         return;
     };
@@ -370,7 +372,7 @@ fn is_pip_cache_origin_json(path: &Path) -> bool {
 }
 
 fn extract_from_pip_origin_json(path: &Path) -> PackageData {
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read pip cache origin.json at {:?}: {}", path, e);
@@ -416,10 +418,10 @@ fn extract_from_pip_origin_json(path: &Path) -> PackageData {
     PackageData {
         package_type: Some(PythonParser::PACKAGE_TYPE),
         primary_language: Some("Python".to_string()),
-        name: Some(name),
+        name: Some(truncate_field(name)),
         version: Some(version),
         datasource_id: Some(DatasourceId::PypiPipOriginJson),
-        download_url: Some(download_url.to_string()),
+        download_url: Some(truncate_field(download_url.to_string())),
         sha256: extract_sha256_from_origin_json(&root)
             .and_then(|h| Sha256Digest::from_hex(&h).ok()),
         repository_homepage_url,
@@ -496,7 +498,7 @@ fn normalize_origin_hash(hash: &str) -> Option<String> {
 }
 
 fn extract_from_rfc822_metadata(path: &Path, datasource_id: DatasourceId) -> PackageData {
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read metadata at {:?}: {}", path, e);
@@ -520,7 +522,7 @@ fn merge_sibling_metadata_dependencies(path: &Path, package_data: &mut PackageDa
     if let Some(parent) = path.parent() {
         let direct_requires = parent.join("requires.txt");
         if direct_requires.exists()
-            && let Ok(content) = read_file_to_string(&direct_requires)
+            && let Ok(content) = read_file_to_string(&direct_requires, None)
         {
             extra_dependencies.extend(parse_requires_txt(&content));
         }
@@ -547,7 +549,7 @@ fn merge_sibling_metadata_dependencies(path: &Path, package_data: &mut PackageDa
             });
 
         if let Some(requires_path) = sibling_egg_info_requires
-            && let Ok(content) = read_file_to_string(&requires_path)
+            && let Ok(content) = read_file_to_string(&requires_path, None)
         {
             extra_dependencies.extend(parse_requires_txt(&content));
         }
@@ -571,21 +573,21 @@ fn merge_sibling_metadata_file_references(path: &Path, package_data: &mut Packag
     if let Some(parent) = path.parent() {
         let record_path = parent.join("RECORD");
         if record_path.exists()
-            && let Ok(content) = read_file_to_string(&record_path)
+            && let Ok(content) = read_file_to_string(&record_path, None)
         {
             extra_refs.extend(parse_record_csv(&content));
         }
 
         let installed_files_path = parent.join("installed-files.txt");
         if installed_files_path.exists()
-            && let Ok(content) = read_file_to_string(&installed_files_path)
+            && let Ok(content) = read_file_to_string(&installed_files_path, None)
         {
             extra_refs.extend(parse_installed_files_txt(&content));
         }
 
         let sources_path = parent.join("SOURCES.txt");
         if sources_path.exists()
-            && let Ok(content) = read_file_to_string(&sources_path)
+            && let Ok(content) = read_file_to_string(&sources_path, None)
         {
             extra_refs.extend(parse_sources_txt(&content));
         }
@@ -609,8 +611,17 @@ fn collect_validated_zip_entries<R: Read + std::io::Seek>(
 ) -> Result<Vec<ValidatedZipEntry>, String> {
     let mut total_extracted = 0u64;
     let mut entries = Vec::new();
+    let mut entry_count = 0usize;
 
     for i in 0..archive.len() {
+        entry_count += 1;
+        if entry_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded max entry count in {} {:?}; stopping at {} entries",
+                archive_type, path, MAX_ITERATION_COUNT
+            );
+            break;
+        }
         if let Ok(file) = archive.by_index_raw(i) {
             let compressed_size = file.compressed_size();
             let uncompressed_size = file.size();
@@ -934,8 +945,18 @@ fn collect_tar_sdist_entries<R: Read>(
 
     let mut total_extracted = 0u64;
     let mut entries = Vec::new();
+    let mut entry_count = 0usize;
 
     for entry_result in archive_entries {
+        entry_count += 1;
+        if entry_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded max entry count in {} sdist {:?}; stopping at {} entries",
+                archive_type, path, MAX_ITERATION_COUNT
+            );
+            break;
+        }
+
         let mut entry = match entry_result {
             Ok(entry) => entry,
             Err(e) => {
@@ -1586,7 +1607,14 @@ fn read_limited_utf8<R: Read>(
         ));
     }
 
-    String::from_utf8(bytes).map_err(|e| format!("{} is not valid UTF-8: {}", context, e))
+    match String::from_utf8(bytes) {
+        Ok(s) => Ok(s),
+        Err(err) => {
+            let bytes = err.into_bytes();
+            warn!("Invalid UTF-8 in archive entry; using lossy conversion");
+            Ok(String::from_utf8_lossy(&bytes).into_owned())
+        }
+    }
 }
 
 fn normalize_archive_entry_path(entry_path: &str) -> Option<String> {
@@ -1621,8 +1649,17 @@ pub fn parse_record_csv(content: &str) -> Vec<FileReference> {
         .from_reader(content.as_bytes());
 
     let mut file_references = Vec::new();
+    let mut record_count = 0usize;
 
     for result in reader.records() {
+        record_count += 1;
+        if record_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded max record count in RECORD CSV; stopping at {} records",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         match result {
             Ok(record) => {
                 if record.len() < 3 {
@@ -1816,13 +1853,13 @@ fn build_package_data_from_rfc822(
 ) -> PackageData {
     use super::rfc822::{get_header_all, get_header_first};
 
-    let name = get_header_first(&metadata.headers, "name");
-    let version = get_header_first(&metadata.headers, "version");
-    let summary = get_header_first(&metadata.headers, "summary");
-    let mut homepage_url = get_header_first(&metadata.headers, "home-page");
-    let author = get_header_first(&metadata.headers, "author");
-    let author_email = get_header_first(&metadata.headers, "author-email");
-    let license = get_header_first(&metadata.headers, "license");
+    let name = get_header_first(&metadata.headers, "name").map(truncate_field);
+    let version = get_header_first(&metadata.headers, "version").map(truncate_field);
+    let summary = get_header_first(&metadata.headers, "summary").map(truncate_field);
+    let mut homepage_url = get_header_first(&metadata.headers, "home-page").map(truncate_field);
+    let author = get_header_first(&metadata.headers, "author").map(truncate_field);
+    let author_email = get_header_first(&metadata.headers, "author-email").map(truncate_field);
+    let license = get_header_first(&metadata.headers, "license").map(truncate_field);
     let license_expression = get_header_first(&metadata.headers, "license-expression");
     let download_url = get_header_first(&metadata.headers, "download-url");
     let platform = get_header_first(&metadata.headers, "platform");
@@ -1836,7 +1873,7 @@ fn build_package_data_from_rfc822(
         metadata.body.clone()
     };
 
-    let description = build_description(summary.as_deref(), &description_body);
+    let description = build_description(summary.as_deref(), &description_body).map(truncate_field);
 
     let mut parties = Vec::new();
     if author.is_some() || author_email.is_some() {
@@ -2214,7 +2251,7 @@ fn extract_from_pyproject_toml(path: &Path) -> PackageData {
     let name = project_table
         .get(FIELD_NAME)
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|v| truncate_field(v.to_string()));
 
     let version = project_table
         .get(FIELD_VERSION)
@@ -2239,7 +2276,7 @@ fn extract_from_pyproject_toml(path: &Path) -> PackageData {
     let description = project_table
         .get(FIELD_DESCRIPTION)
         .and_then(|value| value.as_str())
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
     let mut keywords = project_table
         .get(FIELD_KEYWORDS)
         .and_then(|value| value.as_array())
@@ -3096,7 +3133,7 @@ fn extract_setup_py_packages(path: &Path) -> Vec<PackageData> {
 }
 
 fn extract_from_setup_py(path: &Path) -> Option<PackageData> {
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read setup.py at {:?}: {}", path, e);
@@ -3242,7 +3279,7 @@ fn collect_sibling_dunder_metadata(root: &Path, content: &str) -> DunderMetadata
             continue;
         }
 
-        let Ok(module_content) = read_file_to_string(&path) else {
+        let Ok(module_content) = read_file_to_string(&path, None) else {
             continue;
         };
 
@@ -3699,17 +3736,19 @@ fn extract_setup_keywords(
 }
 
 fn build_setup_py_package_data(values: &HashMap<String, Value>) -> PackageData {
-    let name = get_value_string(values, "name");
-    let version = get_value_string(values, "version");
-    let description =
-        get_value_string(values, "description").or_else(|| get_value_string(values, "summary"));
-    let homepage_url =
-        get_value_string(values, "url").or_else(|| get_value_string(values, "home_page"));
-    let author = get_value_string(values, "author");
+    let name = get_value_string(values, "name").map(truncate_field);
+    let version = get_value_string(values, "version").map(truncate_field);
+    let description = get_value_string(values, "description")
+        .or_else(|| get_value_string(values, "summary"))
+        .map(truncate_field);
+    let homepage_url = get_value_string(values, "url")
+        .or_else(|| get_value_string(values, "home_page"))
+        .map(truncate_field);
+    let author = get_value_string(values, "author").map(truncate_field);
     let author_email = get_value_string(values, "author_email");
-    let maintainer = get_value_string(values, "maintainer");
+    let maintainer = get_value_string(values, "maintainer").map(truncate_field);
     let maintainer_email = get_value_string(values, "maintainer_email");
-    let license = get_value_string(values, "license");
+    let license = get_value_string(values, "license").map(truncate_field);
     let classifiers = values
         .get("classifiers")
         .and_then(value_to_string_list)
@@ -4094,8 +4133,17 @@ fn parse_requires_txt(content: &str) -> Vec<Dependency> {
     let mut current_scope = "install".to_string();
     let mut current_optional = false;
     let mut current_marker: Option<String> = None;
+    let mut line_count = 0usize;
 
     for line in content.lines() {
+        line_count += 1;
+        if line_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded max line count in requires.txt; stopping at {} lines",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -4148,16 +4196,16 @@ fn build_setup_py_purl(name: Option<&str>, version: Option<&str>) -> Option<Stri
 }
 
 fn extract_from_setup_py_regex(content: &str) -> PackageData {
-    let name = extract_setup_value(content, "name");
-    let version = extract_setup_value(content, "version");
-    let license_expression = extract_setup_value(content, "license");
+    let name = extract_setup_value(content, "name").map(truncate_field);
+    let version = extract_setup_value(content, "version").map(truncate_field);
+    let license_expression = extract_setup_value(content, "license").map(truncate_field);
 
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         normalize_spdx_declared_license(license_expression.as_deref());
     let extracted_license_statement = license_expression.clone();
 
     let dependencies = extract_setup_py_dependencies(content);
-    let homepage_url = extract_setup_value(content, "url");
+    let homepage_url = extract_setup_value(content, "url").map(truncate_field);
     let purl = build_setup_py_purl(name.as_deref(), version.as_deref());
 
     PackageData {
@@ -4217,7 +4265,7 @@ fn extract_from_pypi_json(path: &Path) -> PackageData {
         ..Default::default()
     };
 
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(error) => {
             warn!("Failed to read pypi.json at {:?}: {}", path, error);
@@ -4241,7 +4289,7 @@ fn extract_from_pypi_json(path: &Path) -> PackageData {
     let name = info
         .get("name")
         .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_owned()));
     let version = info
         .get("version")
         .and_then(|value| value.as_str())
@@ -4249,22 +4297,22 @@ fn extract_from_pypi_json(path: &Path) -> PackageData {
     let summary = info
         .get("summary")
         .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_owned()));
     let description = info
         .get("description")
         .and_then(|value| value.as_str())
         .filter(|value| !value.trim().is_empty())
-        .map(ToOwned::to_owned)
+        .map(|v| truncate_field(v.to_owned()))
         .or(summary);
     let mut homepage_url = info
         .get("home_page")
         .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_owned()));
     let author = info
         .get("author")
         .and_then(|value| value.as_str())
         .filter(|value| !value.trim().is_empty())
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_owned()));
     let author_email = info
         .get("author_email")
         .and_then(|value| value.as_str())
@@ -4435,7 +4483,7 @@ fn select_pypi_json_artifact(
 }
 
 fn extract_from_pip_inspect(path: &Path) -> PackageData {
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read pip-inspect.deplock at {:?}: {}", path, e);
@@ -4492,7 +4540,7 @@ fn extract_from_pip_inspect(path: &Path) -> PackageData {
         let name = metadata
             .get("name")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let version = metadata
             .get("version")
             .and_then(|v| v.as_str())
@@ -4500,15 +4548,15 @@ fn extract_from_pip_inspect(path: &Path) -> PackageData {
         let summary = metadata
             .get("summary")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let home_page = metadata
             .get("home_page")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let author = metadata
             .get("author")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let author_email = metadata
             .get("author_email")
             .and_then(|v| v.as_str())
@@ -4516,11 +4564,11 @@ fn extract_from_pip_inspect(path: &Path) -> PackageData {
         let license = metadata
             .get("license")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let description = metadata
             .get("description")
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let keywords = metadata
             .get("keywords")
             .and_then(|v| v.as_array())
@@ -4742,7 +4790,7 @@ fn base_dependency_purl(purl: &str) -> String {
 type IniSections = HashMap<String, HashMap<String, Vec<String>>>;
 
 fn extract_from_setup_cfg(path: &Path) -> PackageData {
-    let content = match read_file_to_string(path) {
+    let content = match read_file_to_string(path, None) {
         Ok(content) => content,
         Err(e) => {
             warn!("Failed to read setup.cfg at {:?}: {}", path, e);
@@ -4751,15 +4799,15 @@ fn extract_from_setup_cfg(path: &Path) -> PackageData {
     };
 
     let sections = parse_setup_cfg(&content);
-    let name = get_ini_value(&sections, "metadata", "name");
-    let version = get_ini_value(&sections, "metadata", "version");
-    let description = get_ini_value(&sections, "metadata", "description");
-    let author = get_ini_value(&sections, "metadata", "author");
+    let name = get_ini_value(&sections, "metadata", "name").map(truncate_field);
+    let version = get_ini_value(&sections, "metadata", "version").map(truncate_field);
+    let description = get_ini_value(&sections, "metadata", "description").map(truncate_field);
+    let author = get_ini_value(&sections, "metadata", "author").map(truncate_field);
     let author_email = get_ini_value(&sections, "metadata", "author_email");
-    let maintainer = get_ini_value(&sections, "metadata", "maintainer");
+    let maintainer = get_ini_value(&sections, "metadata", "maintainer").map(truncate_field);
     let maintainer_email = get_ini_value(&sections, "metadata", "maintainer_email");
-    let license = get_ini_value(&sections, "metadata", "license");
-    let mut homepage_url = get_ini_value(&sections, "metadata", "url");
+    let license = get_ini_value(&sections, "metadata", "license").map(truncate_field);
+    let mut homepage_url = get_ini_value(&sections, "metadata", "url").map(truncate_field);
     let classifiers = get_ini_values(&sections, "metadata", "classifiers");
     let keywords = parse_setup_cfg_keywords(get_ini_value(&sections, "metadata", "keywords"));
     let python_requires = get_ini_value(&sections, "options", "python_requires");
@@ -5234,7 +5282,7 @@ fn parse_setup_py_dep_list(deps_str: &str, scope: &str, is_optional: bool) -> Ve
 
 /// Reads and parses a TOML file
 pub(crate) fn read_toml_file(path: &Path) -> Result<TomlValue, String> {
-    let content = read_file_to_string(path).map_err(|e| e.to_string())?;
+    let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
 

--- a/src/parsers/readme.rs
+++ b/src/parsers/readme.rs
@@ -53,7 +53,7 @@ impl PackageParser for ReadmeParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read README file at {:?}: {}", path, e);

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -56,7 +56,7 @@ impl PackageParser for RpmSpecfileParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read RPM specfile {:?}: {}", path, e);

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -26,7 +26,9 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
-use crate::parsers::utils::split_name_email;
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 use flate2::read::GzDecoder;
 use packageurl::PackageUrl;
 use regex::Regex;
@@ -79,7 +81,7 @@ impl PackageParser for GemfileParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         let datasource_id = gemfile_datasource_id(path);
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Gemfile at {:?}: {}", path, e);
@@ -163,7 +165,7 @@ fn parse_gemfile(content: &str) -> PackageData {
         }
     };
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
 
         // Skip comments and empty lines
@@ -404,7 +406,7 @@ impl PackageParser for GemfileLockParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         let datasource_id = gemfile_lock_datasource_id(path);
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Gemfile.lock at {:?}: {}", path, e);
@@ -533,7 +535,7 @@ fn parse_gemfile_lock(content: &str) -> PackageData {
         }
     };
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim_end();
 
         // Empty line resets state
@@ -988,7 +990,7 @@ impl PackageParser for GemspecParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         let datasource_id = gemspec_datasource_id(path);
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .gemspec at {:?}: {}", path, e);
@@ -1307,17 +1309,20 @@ fn resolve_gemspec_scalar_value(
     base_dir: Option<&Path>,
     contexts: &[String],
 ) -> Option<String> {
-    let cleaned = clean_gemspec_value(raw_value);
+    let cleaned = truncate_field(clean_gemspec_value(raw_value));
     if cleaned.is_empty() {
         return None;
     }
 
     if looks_like_constant_reference(&cleaned) {
-        return resolve_variable_version(&cleaned, contexts).or(Some(cleaned));
+        return resolve_variable_version(&cleaned, contexts)
+            .map(truncate_field)
+            .or(Some(cleaned));
     }
 
     if looks_like_local_variable_reference(&cleaned) {
         return resolve_local_variable_value(&cleaned, content, base_dir, contexts)
+            .map(truncate_field)
             .or(Some(cleaned));
     }
 
@@ -1347,7 +1352,7 @@ fn load_required_ruby_contexts(content: &str, base_dir: Option<&Path>) -> Vec<St
             else {
                 continue;
             };
-            if let Ok(required_content) = fs::read_to_string(&safe_candidate) {
+            if let Ok(required_content) = read_file_to_string(&safe_candidate, None) {
                 contexts.push(required_content);
                 break;
             }
@@ -1442,7 +1447,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
     let mut dependencies: Vec<Dependency> = Vec::new();
 
     // Extract basic fields
-    for caps in field_re.captures_iter(content) {
+    for caps in field_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
         let field_name = match caps.get(1) {
             Some(m) => m.as_str(),
             None => continue,
@@ -1460,24 +1465,24 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
             "summary" => {
                 summary = resolve_gemspec_scalar_value(raw_value, content, base_dir, &contexts)
             }
-            "description" => description = Some(clean_gemspec_value(raw_value)),
+            "description" => description = Some(truncate_field(clean_gemspec_value(raw_value))),
             "homepage" => {
                 homepage = resolve_gemspec_scalar_value(raw_value, content, base_dir, &contexts)
             }
-            "license" => license = Some(clean_gemspec_value(raw_value)),
+            "license" => license = Some(truncate_field(clean_gemspec_value(raw_value))),
             _ => {}
         }
     }
 
     // Extract licenses (plural)
-    for caps in licenses_re.captures_iter(content) {
+    for caps in licenses_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
         if let Some(raw) = caps.get(1) {
             licenses = extract_ruby_array(raw.as_str());
         }
     }
 
     // Extract authors
-    for caps in authors_re.captures_iter(content) {
+    for caps in authors_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
         if let Some(raw) = caps.get(1) {
             let raw_str = raw.as_str().trim();
             if raw_str.starts_with('[') {
@@ -1492,7 +1497,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
     }
 
     // Extract emails
-    for caps in email_re.captures_iter(content) {
+    for caps in email_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
         if let Some(raw) = caps.get(1) {
             let raw_str = raw.as_str().trim();
             if raw_str.starts_with('[') {
@@ -1563,7 +1568,10 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
         }
     }
 
-    for caps in dependency_call_re.captures_iter(content) {
+    for caps in dependency_call_re
+        .captures_iter(content)
+        .take(MAX_ITERATION_COUNT)
+    {
         let method = match caps.get(1) {
             Some(m) => m.as_str(),
             None => continue,
@@ -1573,7 +1581,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
             None => continue,
         };
 
-        let Some(dep_name) = extract_first_ruby_value(args) else {
+        let Some(dep_name) = extract_first_ruby_value(args).map(truncate_field) else {
             continue;
         };
         let version_parts = extract_all_ruby_values(after_first_argument(args));
@@ -1703,14 +1711,29 @@ fn extract_gem_archive(path: &Path) -> Result<PackageData, String> {
     let file = File::open(path).map_err(|e| format!("Failed to open archive: {}", e))?;
     let mut archive = Archive::new(file);
 
+    let mut entry_count: usize = 0;
     for entry_result in archive
         .entries()
         .map_err(|e| format!("Failed to read tar entries: {}", e))?
     {
+        entry_count += 1;
+        if entry_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded max tar entry count ({}) in .gem archive, stopping iteration",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
+
         let entry = entry_result.map_err(|e| format!("Failed to read tar entry: {}", e))?;
         let entry_path = entry
             .path()
             .map_err(|e| format!("Failed to get entry path: {}", e))?;
+        let entry_str = entry_path.to_string_lossy();
+        if entry_str.contains("..") {
+            warn!("Skipping tar entry with path traversal: {}", entry_str);
+            continue;
+        }
 
         if entry_path.to_str() == Some("metadata.gz") {
             let entry_size = entry.size();
@@ -1722,10 +1745,27 @@ fn extract_gem_archive(path: &Path) -> Result<PackageData, String> {
             }
 
             let mut decoder = GzDecoder::new(entry);
-            let mut content = String::new();
-            decoder
-                .read_to_string(&mut content)
+            let mut content = Vec::new();
+            let mut limited = std::io::Read::take(&mut decoder, MAX_FILE_SIZE + 1);
+            limited
+                .read_to_end(&mut content)
                 .map_err(|e| format!("Failed to decompress metadata.gz: {}", e))?;
+
+            if content.len() > MAX_FILE_SIZE as usize {
+                return Err(format!(
+                    "Decompressed metadata too large: exceeds {} byte limit",
+                    MAX_FILE_SIZE
+                ));
+            }
+
+            let content = match String::from_utf8(content) {
+                Ok(s) => s,
+                Err(err) => {
+                    let bytes = err.into_bytes();
+                    warn!("Invalid UTF-8 in gem metadata; using lossy conversion");
+                    String::from_utf8_lossy(&bytes).into_owned()
+                }
+            };
 
             let uncompressed_size = content.len() as u64;
             if entry_size > 0 {
@@ -1736,12 +1776,6 @@ fn extract_gem_archive(path: &Path) -> Result<PackageData, String> {
                         ratio, MAX_COMPRESSION_RATIO
                     ));
                 }
-            }
-            if uncompressed_size > MAX_FILE_SIZE {
-                return Err(format!(
-                    "Decompressed metadata too large: {} bytes (limit: {} bytes)",
-                    uncompressed_size, MAX_FILE_SIZE
-                ));
             }
 
             return parse_gem_metadata_yaml(&content, DatasourceId::GemArchive);
@@ -1763,18 +1797,19 @@ fn parse_gem_metadata_yaml(
     let yaml: yaml_serde::Value =
         yaml_serde::from_str(&cleaned).map_err(|e| format!("Failed to parse YAML: {}", e))?;
 
-    let name = yaml_string(&yaml, "name");
+    let name = yaml_string(&yaml, "name").map(truncate_field);
     let version = yaml.get("version").and_then(|v| {
-        // version can be a simple string or a mapping with a "version" key
         if v.is_string() {
-            v.as_str().map(|s| s.to_string())
+            v.as_str().map(|s| truncate_field(s.to_string()))
         } else {
-            yaml_string(v, "version")
+            yaml_string(v, "version").map(truncate_field)
         }
     });
-    let description = yaml_string(&yaml, "description").or_else(|| yaml_string(&yaml, "summary"));
-    let homepage = yaml_string(&yaml, "homepage");
-    let summary = yaml_string(&yaml, "summary");
+    let description = yaml_string(&yaml, "description")
+        .or_else(|| yaml_string(&yaml, "summary"))
+        .map(truncate_field);
+    let homepage = yaml_string(&yaml, "homepage").map(truncate_field);
+    let summary = yaml_string(&yaml, "summary").map(truncate_field);
 
     // Licenses
     let licenses: Vec<String> = yaml
@@ -1782,7 +1817,7 @@ fn parse_gem_metadata_yaml(
         .and_then(|v| v.as_sequence())
         .map(|seq| {
             seq.iter()
-                .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                 .collect()
         })
         .unwrap_or_default();
@@ -1803,7 +1838,7 @@ fn parse_gem_metadata_yaml(
         .and_then(|v| v.as_sequence())
         .map(|seq| {
             seq.iter()
-                .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                 .collect()
         })
         .unwrap_or_default();
@@ -1813,10 +1848,10 @@ fn parse_gem_metadata_yaml(
         .map(|v| {
             if let Some(seq) = v.as_sequence() {
                 seq.iter()
-                    .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                    .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                     .collect()
             } else if let Some(s) = v.as_str() {
-                vec![s.to_string()]
+                vec![truncate_field(s.to_string())]
             } else {
                 Vec::new()
             }
@@ -1859,13 +1894,19 @@ fn parse_gem_metadata_yaml(
 
     let metadata = yaml.get("metadata");
 
-    let bug_tracking_url = metadata.and_then(|m| yaml_string(m, "bug_tracking_uri"));
+    let bug_tracking_url = metadata
+        .and_then(|m| yaml_string(m, "bug_tracking_uri"))
+        .map(truncate_field);
 
-    let code_view_url = metadata.and_then(|m| yaml_string(m, "source_code_uri"));
+    let code_view_url = metadata
+        .and_then(|m| yaml_string(m, "source_code_uri"))
+        .map(truncate_field);
 
-    let vcs_url = code_view_url
-        .clone()
-        .or_else(|| metadata.and_then(|m| yaml_string(m, "homepage_uri")));
+    let vcs_url = code_view_url.clone().or_else(|| {
+        metadata
+            .and_then(|m| yaml_string(m, "homepage_uri"))
+            .map(truncate_field)
+    });
 
     let file_references = metadata
         .and_then(|m| m.get("files"))
@@ -1899,7 +1940,7 @@ fn parse_gem_metadata_yaml(
         .map(|n| create_gem_purl(n, version.as_deref()))
         .unwrap_or(None);
 
-    let platform = yaml_string(&yaml, "platform");
+    let platform = yaml_string(&yaml, "platform").map(truncate_field);
     let (repository_homepage_url, repository_download_url, api_data_url, download_url) =
         if let Some(n) = name.as_deref() {
             get_rubygems_urls(n, version.as_deref(), platform.as_deref())
@@ -1972,8 +2013,8 @@ fn parse_gem_yaml_dependencies(yaml: &yaml_serde::Value) -> Vec<Dependency> {
         None => return dependencies,
     };
 
-    for dep_value in deps_seq {
-        let dep_name = match yaml_string(dep_value, "name") {
+    for dep_value in deps_seq.iter().take(MAX_ITERATION_COUNT) {
+        let dep_name = match yaml_string(dep_value, "name").map(truncate_field) {
             Some(n) => n,
             None => continue,
         };
@@ -2066,7 +2107,7 @@ impl PackageParser for GemMetadataExtractedParser {
 }
 
 fn extract_gem_metadata_extracted(path: &Path) -> Result<PackageData, String> {
-    let content = fs::read_to_string(path)
+    let content = read_file_to_string(path, None)
         .map_err(|e| format!("Failed to read metadata.gz-extract file: {}", e))?;
 
     parse_gem_metadata_yaml(&content, DatasourceId::GemArchiveExtracted)

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -2,7 +2,7 @@
 ///
 /// This module provides common file I/O and parsing utilities
 /// used across multiple parser implementations.
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;
 
@@ -10,16 +10,47 @@ use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use packageurl::PackageUrl;
 
-/// Reads a file's entire contents into a String.
+/// Default maximum file size for non-archive manifest files (100 MB).
+pub const MAX_MANIFEST_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Default maximum length for individual string field values (10 MB).
+pub const MAX_FIELD_LENGTH: usize = 10 * 1024 * 1024;
+
+/// Default maximum iteration count for loops processing items (100,000).
+pub const MAX_ITERATION_COUNT: usize = 100_000;
+
+/// Truncates a string field value to [`MAX_FIELD_LENGTH`] bytes if it exceeds
+/// the limit, returning the truncated string. Returns the original string if
+/// within limits.
+pub fn truncate_field(value: String) -> String {
+    if value.len() <= MAX_FIELD_LENGTH {
+        return value;
+    }
+    let truncated = &value[..value.floor_char_boundary(MAX_FIELD_LENGTH)];
+    crate::parser_warn!(
+        "Truncated field value from {} bytes to {} bytes (MAX_FIELD_LENGTH)",
+        value.len(),
+        truncated.len()
+    );
+    truncated.to_string()
+}
+
+/// Reads a file's entire contents into a String with ADR 0004 security checks.
+///
+/// Performs the following validations before reading:
+/// 1. **File existence**: checks `fs::metadata()` before opening
+/// 2. **File size**: rejects files exceeding `max_size` (default 100 MB)
+/// 3. **UTF-8 encoding**: on UTF-8 failure, falls back to lossy conversion with a warning
 ///
 /// # Arguments
 ///
 /// * `path` - Path to the file to read
+/// * `max_size` - Maximum allowed file size in bytes (defaults to [`MAX_MANIFEST_SIZE`])
 ///
 /// # Returns
 ///
-/// * `Ok(String)` - File contents as UTF-8 string
-/// * `Err` - I/O error or UTF-8 decoding error
+/// * `Ok(String)` - File contents as UTF-8 string (lossy if non-UTF-8 bytes found)
+/// * `Err` - File doesn't exist, is too large, or cannot be read
 ///
 /// # Examples
 ///
@@ -27,14 +58,39 @@ use packageurl::PackageUrl;
 /// use std::path::Path;
 /// use provenant::parsers::utils::read_file_to_string;
 ///
-/// let content = read_file_to_string(Path::new("path/to/file.txt"))?;
+/// let content = read_file_to_string(Path::new("path/to/file.txt"), None)?;
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub fn read_file_to_string(path: &Path) -> Result<String> {
+pub fn read_file_to_string(path: &Path, max_size: Option<u64>) -> Result<String> {
+    let limit = max_size.unwrap_or(MAX_MANIFEST_SIZE);
+
+    let metadata =
+        fs::metadata(path).map_err(|e| anyhow::anyhow!("Cannot stat file {:?}: {}", path, e))?;
+
+    if metadata.len() > limit {
+        anyhow::bail!(
+            "File {:?} is {} bytes, exceeding the {} byte limit",
+            path,
+            metadata.len(),
+            limit
+        );
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
     let mut file = File::open(path)?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)?;
-    Ok(content)
+    file.read_to_end(&mut bytes)?;
+
+    match String::from_utf8(bytes) {
+        Ok(s) => Ok(s),
+        Err(err) => {
+            let bytes = err.into_bytes();
+            crate::parser_warn!(
+                "File {:?} contains invalid UTF-8; using lossy conversion",
+                path
+            );
+            Ok(String::from_utf8_lossy(&bytes).into_owned())
+        }
+    }
 }
 
 /// Creates a correctly-formatted npm Package URL for scoped or regular packages.
@@ -158,14 +214,14 @@ mod tests {
         let mut file = File::create(&file_path).unwrap();
         file.write_all(b"test content").unwrap();
 
-        let content = read_file_to_string(&file_path).unwrap();
+        let content = read_file_to_string(&file_path, None).unwrap();
         assert_eq!(content, "test content");
     }
 
     #[test]
     fn test_read_file_to_string_nonexistent() {
         let path = Path::new("/nonexistent/file.txt");
-        let result = read_file_to_string(path);
+        let result = read_file_to_string(path, None);
         assert!(result.is_err());
     }
 
@@ -175,7 +231,7 @@ mod tests {
         let file_path = dir.path().join("empty.txt");
         File::create(&file_path).unwrap();
 
-        let content = read_file_to_string(&file_path).unwrap();
+        let content = read_file_to_string(&file_path, None).unwrap();
         assert_eq!(content, "");
     }
 
@@ -312,5 +368,40 @@ mod tests {
         let (name, email) = split_name_email("John Doe email@example.com>");
         assert_eq!(name, Some("John Doe email@example.com>".to_string()));
         assert_eq!(email, None);
+    }
+
+    #[test]
+    fn test_read_file_to_string_oversized() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("big.txt");
+        fs::write(&file_path, "x").unwrap();
+
+        let result = read_file_to_string(&file_path, Some(0));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_file_to_string_lossy_utf8() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("bad_utf8.txt");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(b"hello\xffworld").unwrap();
+
+        let content = read_file_to_string(&file_path, None).unwrap();
+        assert!(content.contains("hello"));
+        assert!(content.contains("world"));
+    }
+
+    #[test]
+    fn test_truncate_field_within_limit() {
+        let s = "short value".to_string();
+        assert_eq!(truncate_field(s.clone()), s);
+    }
+
+    #[test]
+    fn test_truncate_field_exceeds_limit() {
+        let long = "x".repeat(MAX_FIELD_LENGTH + 100);
+        let truncated = truncate_field(long);
+        assert!(truncated.len() <= MAX_FIELD_LENGTH);
     }
 }


### PR DESCRIPTION
## Summary

- Harden shared `utils.rs` foundation and 5 parsers (npm, cargo, python, ruby, alpine) against DoS, archive bombs, and UTF-8 edge cases per ADR 0004
- Fix 29 total findings across the 6 files (utils + 5 parsers)

## Changes by Parser

### `src/parsers/utils.rs` (shared foundation — affects all dependent parsers)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2-FileSize: `read_file_to_string` read entire file without size check | Added `fs::metadata().len()` pre-check with configurable 100MB default limit |
| 2 | P4-UTF8: `read_to_string` failed on invalid UTF-8 without lossy fallback | Changed to `read_to_end` + `String::from_utf8` with lossy fallback path and `parser_warn!` |
| 3 | P4-FileExists: No `fs::metadata()` pre-check before `File::open` | Added `fs::metadata()` check before opening file |
| — | New utility: `truncate_field()` | 10MB per-field truncation with `parser_warn!` |
| — | New constants exported | `MAX_MANIFEST_SIZE`, `MAX_FIELD_LENGTH`, `MAX_ITERATION_COUNT` |
| — | Signature change: `read_file_to_string(path, max_size: Option<u64>)` | All 38 call sites updated to pass `None` |

### `src/parsers/npm.rs` (5 findings)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2-FileSize: No `fs::metadata().len()` before `fs::read_to_string` | Replaced with `utils::read_file_to_string(path, None)` |
| 2 | P2-Iteration: No 100K cap on line/dep/license/keyword loops | Added `.take(MAX_ITERATION_COUNT)` to 7 iteration sites |
| 3 | P2-StringLength: No 10MB per-field truncation | Applied `truncate_field()` to 21 extracted string values |
| 4 | P4-FileExists: No explicit pre-check | Fixed via utils function |
| 5 | P4-UTF8: No lossy UTF-8 fallback | Fixed via utils function |

### `src/parsers/cargo.rs` (6 findings)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2-FileSize: No size check before `File::open`+`read_to_string` | Replaced with `utils::read_file_to_string(path, None)` |
| 2 | P2-Recursion: `toml_to_json` recursed without depth tracking | Added `depth` parameter with `MAX_TOML_DEPTH = 50` limit |
| 3 | P2-Iteration: No 100K cap on dep/keyword/author loops | Added caps to 7 iteration sites |
| 4 | P2-StringLength: No 10MB truncation on string fields | Applied `truncate_field()` to 9 key values |
| 5 | P4-FileExists: Used `File::open` without pre-check | Fixed via utils function |
| 6 | P4-UTF8: No lossy UTF-8 conversion path | Fixed via utils function |

### `src/parsers/python.rs` (5 findings)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2-FileSize: No size check for non-archive file reads | Fixed via updated `utils::read_file_to_string` |
| 2 | P2-Iteration: No 100K cap on archive entries, CSV, lines | Added caps to 9 iteration sites (zip entries, tar entries, CSV records, requires_txt lines) |
| 3 | P2-StringLength: No 10MB per-field truncation | Applied `truncate_field()` to 42 string values across all extraction paths |
| 4 | P4-UTF8: `read_limited_utf8` returned error instead of lossy fallback | Changed to lossy conversion with `parser_warn!` on invalid UTF-8 |

### `src/parsers/ruby.rs` (7 findings)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2-DoS: No file size pre-check for 4 text parsers | Replaced `fs::read_to_string` with `utils::read_file_to_string(path, None)` |
| 2 | P2-DoS: No 100K iteration cap on lines/entries/dependencies | Added `.take(MAX_ITERATION_COUNT)` to 11 iteration sites |
| 3 | P2-DoS: No 10MB string field truncation | Applied `truncate_field()` to 24 extracted values |
| 4 | P3-Archive: No path traversal check on tar entry paths | Added `..` check — entries with path traversal are skipped with `parser_warn!` |
| 5 | P3-Archive: Decompression limit checked post-read (OOM risk) | Replaced with `Read::take()`-bounded reading, size check before conversion |
| 6 | P3-Archive: No explicit 1GB uncompressed limit | Existing 100MB + ratio checks bound this; acceptable as more restrictive than ADR |
| 7 | P4-Input: No lossy UTF-8 fallback | Fixed via utils function + bounded decompression path |

### `src/parsers/alpine.rs` (7 findings)

| # | Violation | Fix |
|---|-----------|-----|
| 1 | P2: No file size check before reading | Fixed via updated `utils::read_file_to_string` |
| 2 | P2: No 100K iteration cap on paragraph/line/dep loops | Added caps to 14 iteration sites |
| 3 | P2: No 10MB string field truncation | Applied `truncate_field()` to 16 extracted values |
| 4 | P3: No archive size/ratio/path-traversal limits on .apk extraction | Added `MAX_ARCHIVE_SIZE` (1GB), `MAX_FILE_SIZE` (50MB), `MAX_COMPRESSION_RATIO` (100:1), path traversal (`..`) check |
| 5 | P4: No explicit fs::metadata() pre-check | Fixed via utils function |
| 6 | P4: No lossy UTF-8 fallback | Fixed via utils function + archive path |
| 7 | Additional: `.unwrap()` in library code | Replaced `lines.next().unwrap()` with safe match pattern |

## Also Updated (signature-only changes)

These parsers only had their `read_file_to_string` call sites updated for the new signature — they gain the file size check, fs::metadata pre-check, and lossy UTF-8 fallback automatically:

- `arch.rs`, `debian.rs`, `docker.rs`, `freebsd.rs`, `gitmodules.rs`, `maven.rs`, `pixi.rs`, `readme.rs`, `rpm_specfile.rs`

## Testing

- `cargo check` — clean
- `cargo clippy --all-targets --all-features` — clean (0 warnings)
- `cargo fmt` — clean
- Pre-commit hooks (clippy, rustfmt, generate-supported-formats) — all pass