### PR TITLE
fix(parsers): ADR 0004 batch 2 — swift_show_dependencies, sbt, pylock_toml, pnpm_lock, npm_lock

### DIFF
--- a/docs/NEWTYPE_OPPORTUNITIES.md
+++ b/docs/NEWTYPE_OPPORTUNITIES.md
@@ -1,0 +1,524 @@
+# Newtype Opportunities for Provenant
+
+This document catalogs raw types across the codebase that represent domain concepts and would benefit from newtype wrappers for improved type safety and semantics. Each opportunity includes the current state, the proposed change, and the benefits.
+
+---
+
+## Tier 1: Highest Impact — Prevents Real Bugs
+
+### 1. Cryptographic Digests — **DONE** (PR #590)
+
+**Implemented in `src/models/digest.rs`.** Fixed-size `[u8; N]` byte arrays with serde hex-string serialization. ~15% scan performance improvement from eliminating heap allocations. `EMPTY_SHA1_DIGEST` const replaces string literal.
+
+**Current State:** Hash strings are `Option<String>` across ~20 fields in 5 structs (`FileInfo`, `PackageData`, `ResolvedPackage`, `Package`, `FileReference`) plus `cache/incremental.rs`. A SHA-1 value silently accepted where SHA-256 is expected is an undetectable data integrity bug.
+
+**Fields Affected:**
+
+- `FileInfo`: `sha1`, `md5`, `sha256`, `sha1_git`
+- `PackageData`: `sha1`, `md5`, `sha256`, `sha512`
+- `ResolvedPackage`: `sha1`, `md5`, `sha256`, `sha512`
+- `Package`: `sha1`, `md5`, `sha256`, `sha512`
+- `FileReference`: `sha1`, `md5`, `sha256`, `sha512`
+- `cache::FileStateFingerprint`: `content_sha256`
+
+**Proposed Newtypes:**
+
+```rust
+/// SHA-1 digest as raw 20 bytes (40 hex chars when displayed).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Sha1Digest([u8; 20]);
+
+/// MD5 digest as raw 16 bytes (32 hex chars when displayed).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Md5Digest([u8; 16]);
+
+/// SHA-256 digest as raw 32 bytes (64 hex chars when displayed).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Sha256Digest([u8; 32]);
+
+/// SHA-512 digest as raw 64 bytes (128 hex chars when displayed).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Sha512Digest([u8; 64]);
+
+/// Git object SHA-1 (blob format, 20 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GitSha1([u8; 20]);
+```
+
+**Benefits:**
+
+- Compile-time guarantee: `Sha1Digest` cannot be assigned to `Sha256Digest` field
+- Fixed-size: `[u8; N]` is stack-allocated, no heap allocation
+- Validation at construction: malformed hex strings rejected early
+- Serde serialization to lowercase hex string (JSON-compatible)
+- Enables `Sha1Digest::EMPTY` constant to replace `EMPTY_SHA1` string literal
+- Enables `HashAlgorithm` enum for CycloneDX output (`"SHA-1"`, `"SHA-256"`, etc.)
+
+**Implementation Notes:**
+
+- Store as raw bytes (`[u8; N]`), serialize/deserialize as hex string
+- `Display` and `Debug` impls show hex representation
+- Constructor from hex string: `Sha256Digest::from_hex("abc123...")`
+- Constructor from bytes: `Sha256Digest::from_bytes([u8; 32])`
+- Serde with `#[serde(try_from = "String", into = "String")]` for JSON compatibility
+
+---
+
+### 2. Line Numbers and Spans — **PARTIALLY DONE** (PR #596)
+
+**Implemented in `src/models/line_number.rs`.** `LineNumber(NonZeroUsize)` enforces 1-based invariant at the type level. All `start_line`/`end_line` fields across output, detection, and internal types migrated from `usize` to `LineNumber`. Eliminated runtime `start_line > 0` guards. `serde(transparent)` preserves JSON backward compatibility.
+
+**Deferred: `LineSpan`** — Not implemented because it is not a simple newtype migration. All current structs use separate `start_line`/`end_line` fields rather than a combined span, so adopting `LineSpan` would require restructuring output structs (replacing two fields with one), changing JSON serialization shape, and updating all construction/deconstruction sites. This is a deeper refactoring than a newtype wrapper and should be evaluated as a separate effort when the output schema is open to structural changes.
+
+**Current State:** `start_line`/`end_line` are raw `usize` across 12+ fields in 6+ structs. Nothing prevents 0-based indexing bugs or swapping start/end.
+
+**Fields Affected:**
+
+- `Match`: `start_line`, `end_line`
+- `Copyright`: `start_line`, `end_line`
+- `Holder`: `start_line`, `end_line`
+- `Author`: `start_line`, `end_line`
+- `OutputEmail`: `start_line`, `end_line`
+- `OutputURL`: `start_line`, `end_line`
+- `copyright::CopyrightDetection`: `start_line`, `end_line`
+- `copyright::HolderDetection`: `start_line`, `end_line`
+- `copyright::AuthorDetection`: `start_line`, `end_line`
+- `finder::UrlDetection`: `start_line`, `end_line`
+- `finder::EmailDetection`: `start_line`, `end_line`
+
+**Proposed Newtypes:**
+
+```rust
+/// 1-based line number in a source file. Invariant: value >= 1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LineNumber(usize);
+
+/// Contiguous span of 1-based source lines (inclusive on both ends).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineSpan {
+    pub start: LineNumber,
+    pub end: LineNumber,
+}
+```
+
+**Benefits:**
+
+- Enforces 1-based invariant at construction
+- Prevents swapping start/end (struct with named fields)
+- Self-documenting: always clear it's a line number, not a count or byte offset
+- Can add `len()` and `is_empty()` methods to `LineSpan`
+
+---
+
+### 3. Package and Dependency Identifiers — **PARTIALLY DONE**
+
+**Implemented in `src/models/package_uid.rs` and `src/models/dependency_uid.rs`.** `PackageUid(String)` and `DependencyUid(String)` newtypes with `#[serde(transparent)]`, `Display`, `Deref<Target=str>`, `AsRef<str>`, `Borrow<str>`, `Clone`, `PartialEq`, `Eq`, `Hash`. Key methods: `new(purl)` appends UUID, `from_raw(s)` wraps without validation, `empty()` returns empty sentinel, `replace_base(new_purl)` preserves UUID suffix. `PackageUid` also has `stable_key()` for deterministic sorting. Deduplicated `build_package_uid` (was in both `file_info.rs` and `swift_merge.rs`) into `PackageUid::new()`. Deduplicated `replace_uid_base` into `.replace_base()` methods. Deduplicated `stable_uid_key` into `.stable_key()`.
+
+**Migrated fields:**
+
+- `Package::package_uid: String` → `PackageUid`
+- `TopLevelDependency::dependency_uid: String` → `DependencyUid`
+- `TopLevelDependency::for_package_uid: Option<String>` → `Option<PackageUid>`
+- `FileInfo::for_packages: Vec<String>` → `Vec<PackageUid>`
+- Assembly HashMap keys: `HashMap<String, ...>` → `HashMap<PackageUid, ...>` in `package_file_index.rs`, `reference_following.rs`, `conda_rootfs_merge.rs`, `npm_resource_assign.rs`
+- `HashSet<String>` → `HashSet<PackageUid>` in `bazel_prune.rs`
+- `Vec<String>` → `Vec<PackageUid>` in `npm_workspace_merge.rs`, `cargo_workspace_merge.rs`, `swift_merge.rs`
+- Output schema conversions use `.to_string()` for `From` and `::from_raw()` for `TryFrom`
+
+**Deferred: `Purl` newtype** — Not yet implemented. The `purl` field is `Option<String>` on `PackageData`, `Package`, `Dependency`, and `TopLevelDependency`. There are many construction sites across all parsers that set `purl` directly from parsed strings. Migrating to a `Purl` newtype would require updating every parser's purl construction, which is high surface area with moderate benefit (purl strings come from trusted parser output, not arbitrary user input). Should be evaluated as a separate effort.
+
+**Current State (for Purl):** `purl` is `Option<String>` across 4 structs. Nothing validates the `pkg:` prefix or purl-spec format at construction.
+
+**Fields Affected (for Purl):**
+
+- `PackageData::purl`, `Package::purl`, `Dependency::purl`, `TopLevelDependency::purl`
+
+**Proposed Newtype (for Purl):**
+
+```rust
+/// Package URL (purl) per the purl-spec. Format: pkg:type/namespace/name@version?qualifiers#subpath
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Purl(String);
+```
+
+**Benefits (for Purl):**
+
+- Validation at construction: `Purl::new("pkg:npm/lodash@4.17.0")` validates format
+- Type system prevents confusing PURL with URL or arbitrary string
+- Can add accessors for type, namespace, name, version, qualifiers
+
+---
+
+### 4. License Expression Strings — **DEFERRED**
+
+**Decision:** Not worth implementing. The existing `_spdx` suffix naming convention already distinguishes ScanCode and SPDX expressions clearly. Expressions are constructed from trusted sources (detection, normalization) that already produce correct output, so validation would add complexity for no real payoff. Only ~2-3 call sites use sentinel string comparisons (not enough to justify helper methods). The cost is high (~50+ field instances, 15+ structs, 20+ test files) for marginal benefit. The existing `LicenseExpression` AST enum in `src/license_detection/expression/mod.rs` also makes naming awkward — a string newtype would need a distinct name like `ScancodeExpression`, adding further indirection. `extracted_license_statement` is pure passthrough (never used in logic) and does not need a newtype either.
+
+---
+
+## Tier 2: High Impact — Prevents Category Errors
+
+### 5. Match Scores and Percentages — **PARTIALLY DONE**
+
+**Implemented in `src/models/match_score.rs`.** `MatchScore(f64)` with sealed API: no `From<f64>`/`Into<f64>`, only semantic constructors (`from_percentage()`, `MAX` constant, `GOOD_THRESHOLD`). Widened `LicenseMatch::score` from `f32` to `MatchScore` so the same type spans the entire detection→model→output pipeline, eliminating f32/f64 boundary conversions. Also fixed `Match::rule_relevance` from `Option<usize>` to `Option<u8>`.
+
+**Bug fixes included:** Normalized `LicenseMatch::score` range inconsistency where aho_match and unknown_match produced 0.0–1.0 scores while hash/spdx/seq matchers produced 0.0–100.0. Fixed doc comment from "0.0-1.0" to "0.0-100.0".
+
+**Deferred newtypes:**
+
+- `MatchCoverage(f64)` — same 0.0–100.0 domain as MatchScore; would require same full migration across detection+model+output layers. Lower priority since coverage is less semantically overloaded than score.
+- `Percentage(f64)` — for `FileInfo::percentage_of_license_text`; single-field newtype with low reuse.
+- `Score100(u8)` / `RuleRelevance(u8)` / `MinCoverage(u8)` — integer 0–100 domain; `Rule::relevance` is already `u8`, `Rule::minimum_coverage` is `Option<u8>`. The `usize`→`u8` fix for `Match::rule_relevance` already addressed the main type confusion here.
+- `LicenseClarityScore::score` uses `usize` but is naturally bounded 0–100 by construction; low risk of misuse.
+
+**Fields still using raw types:**
+
+- `Match::match_coverage: Option<f64>` (0.0–100.0)
+- `FileInfo::percentage_of_license_text: Option<f64>` (0.0–100.0)
+- `LicenseClarityScore::score: usize` (0–100)
+- `LicenseRuleReference::relevance: Option<u8>` (0–100)
+- `LicenseReference::minimum_coverage: Option<u8>` (0–100)
+- `LicenseRuleReference::minimum_coverage: Option<u8>` (0–100)
+- `LicenseScanOptions::min_score: u8` (0–100)
+
+---
+
+### 6. URLs — **DEFERRED**
+
+**Decision:** Not worth implementing as a newtype at this time. The ~40 URL fields across model + output_schema layers are overwhelmingly passthrough (constructed once, cloned between structs, serialized). Only ~6 sites consume URLs in logic. The category-error risk is concentrated in 2-3 parsers (Python `apply_project_url_mappings` label-based routing, `download_url` fallback from VCS URL) and is low-frequency. The `TryFrom` cascade from making URL fields fallible (affecting `--from-json` workflows) is high cost for moderate benefit. License index URLs are all from trusted constants; `ignorable_urls` fields are pattern-matching strings (not navigable URLs) and must stay `Vec<String>`. A `url::Url` wrapper would normalize URLs and break ScanCode output parity.
+
+**Bug fix included:** Fixed `src/parsers/opam.rs:191` where `repository_homepage_url` produced the literal string `"{https://opam.ocaml.org/packages}/{name}"` instead of interpolating the package name via `format!()`. Updated golden expected files for sample2 and sample5.
+
+**Current State:** 18+ URL fields are `Option<String>`. No validation, easily confused with paths or PURLs.
+
+**Fields Affected:**
+
+- `PackageData`: `homepage_url`, `download_url`, `bug_tracking_url`, `code_view_url`, `vcs_url`, `repository_homepage_url`, `repository_download_url`, `api_data_url`
+- `Match::rule_url`
+- `Party::url`, `organization_url`
+- `LicenseReference`: `homepage_url`, `text_urls`, `osi_url`, `faq_url`, `other_urls`, `scancode_url`, `licensedb_url`, `spdx_url`
+- `LicenseRuleReference::rule_url`
+
+**Proposed Newtype:**
+
+```rust
+/// A validated URL string.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Url(String);
+```
+
+**Benefits:**
+
+- Validates scheme (http/https/git+https/etc.) at construction
+- Prevents storing a file path or PURL in a URL field
+- Display/Debug impls always show the URL scheme
+
+---
+
+### 7. File Paths
+
+**Current State:** The most ubiquitous string in the codebase. No distinction between scan-root-relative paths, file names, and extensions.
+
+**Fields Affected:**
+
+- `FileInfo::path`, `FileInfo::name`, `FileInfo::base_name`, `FileInfo::extension`
+- `FileReference::path`
+- `Package::datafile_paths`
+- `Match::from_file`
+- `TopLevelDependency::datafile_path`
+- `PackageData::subpath`
+
+**Proposed Newtypes:**
+
+```rust
+/// File path relative to the scan root (forward-slash separated).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScanPath(String);
+
+/// File name component (last segment of a path).
+pub struct FileName(String);
+
+/// Base name without extension.
+pub struct BaseName(String);
+
+/// File extension (with or without leading dot).
+pub struct FileExtension(String);
+```
+
+**Benefits:**
+
+- Self-documenting: type tells you it's scan-root-relative
+- Can add `is_absolute()`, `parent()`, `join()` methods
+- Prevents confusion with URLs, PURLs, license expressions
+
+---
+
+### 8. Rule and Detection Identifiers
+
+**Current State:** `RuleId` is `usize` used as HashMap key throughout license detection. `RuleIdentifier` and `DetectionId` are both `String` but represent different concepts.
+
+**Fields Affected:**
+
+- `license_detection::LicenseMatch::rid` — internal rule index
+- `license_detection::index` — 10+ HashMaps keyed by `usize` rule ID
+- `Match::rule_identifier` — string ID like "mit.LICENSE"
+- `LicenseRuleReference::identifier`
+- `LicenseDetection::identifier` — format: `<expr>-<uuid>`
+- `TopLevelLicenseDetection::identifier`
+
+**Proposed Newtypes:**
+
+```rust
+/// Internal rule index ID (used as HashMap/HashSet key in license index).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RuleId(usize);
+
+/// Unique rule identifier string (e.g., "mit.LICENSE", "gpl-2.0-plus_4.RULE").
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RuleIdentifier(String);
+
+/// Unique detection instance identifier (format: "<expression>-<uuid>").
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DetectionId(String);
+```
+
+**Benefits:**
+
+- `RuleId` cannot be confused with `PatternId` (Aho-Corasich) or `LineNumber`
+- `RuleIdentifier` vs `DetectionId` distinction enforced by type system
+- Better `Debug`/`Display` output for logs
+
+---
+
+### 9. Package Domain Identifiers
+
+**Current State:** Package names, versions, namespaces, and version requirements are all `Option<String>` or `String`. `extracted_requirement` (constraint) and `version` (resolved) are both `Option<String>`.
+
+**Fields Affected:**
+
+- `PackageData::name`, `PackageData::version`, `PackageData::namespace`
+- `ResolvedPackage::name`, `ResolvedPackage::version`, `ResolvedPackage::namespace`
+- `Package::name`, `Package::version`, `Package::namespace`
+- `Dependency::extracted_requirement`, `Dependency::scope`
+
+**Proposed Newtypes:**
+
+```rust
+pub struct PackageName(String);
+pub struct PackageVersion(String);
+pub struct PackageNamespace(String);
+pub struct VersionRequirement(String); // Constraint, not resolved version
+pub struct DependencyScope(String);    // Ecosystem-specific, not a closed enum
+```
+
+**Benefits:**
+
+- `PackageName` cannot be passed where `PackageVersion` expected
+- `VersionRequirement` distinct from `PackageVersion` (constraint vs resolved)
+- `DependencyScope` signals "not an arbitrary string" even though it's open-ended
+
+---
+
+### 10. Tristate for Optional Booleans
+
+**Current State:** `Dependency::is_runtime`, `is_optional`, `is_pinned`, `is_direct` are `Option<bool>`. The three states (unknown/true/false) are implicit.
+
+**Fields Affected:**
+
+- `Dependency::is_runtime`, `is_optional`, `is_pinned`, `is_direct`
+
+**Proposed Newtype:**
+
+```rust
+/// Three-valued logic for optional boolean fields.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Tristate {
+    Unknown,
+    True,
+    False,
+}
+```
+
+**Benefits:**
+
+- Explicit `Unknown` variant instead of `None` semantics
+- Prevents boolean logic errors (`unwrap_or(false)` vs `== Some(true)`)
+- Self-documenting in struct definitions
+
+---
+
+## Tier 3: Medium Impact — Improves Semantics
+
+### 11. Stringly-Typed Enums
+
+| Field                            | Current Type     | Proposed Type                         |
+| -------------------------------- | ---------------- | ------------------------------------- |
+| `Match::matcher`                 | `Option<String>` | `Option<MatcherKind>` enum            |
+| `Party::r#type`                  | `Option<String>` | `Option<PartyType>` enum              |
+| `Party::role`                    | `Option<String>` | `Option<PartyRole>` enum              |
+| `LicenseReference::category`     | `Option<String>` | `Option<LicenseCategory>` enum        |
+| `FileInfo::mime_type`            | `Option<String>` | `Option<MimeType>` newtype            |
+| `FileInfo::programming_language` | `Option<String>` | `Option<ProgrammingLanguage>` newtype |
+| `PackageData::primary_language`  | `Option<String>` | `Option<ProgrammingLanguage>`         |
+
+**Detection Log Constants** (in `license_detection/detection/mod.rs`):
+
+```rust
+// Current: 9 string constants
+const DETECTION_LOG_LICENSE_CLUES: &str = "license-clues";
+const DETECTION_LOG_FALSE_POSITIVE: &str = "false-positive";
+// ... etc
+
+// Proposed: single enum
+pub enum DetectionLogCategory {
+    LicenseClues,
+    FalsePositive,
+    LowQualityMatchFragments,
+    NotLicenseCluesAsMoreDetectionsPresent,
+    ImperfectCoverage,
+    UnknownMatch,
+    ExtraWords,
+    UndetectedLicense,
+    UnknownIntroFollowedByMatch,
+}
+```
+
+---
+
+### 12. File Size and Count Types
+
+**Fields Affected:**
+
+- `FileInfo::size`, `FileReference::size`, `PackageData::size`
+- `FileInfo::files_count`, `ExtraData::files_count`
+- `FileInfo::dirs_count`, `ExtraData::directories_count`
+- `FileInfo::size_count`
+- `FileInfo::source_count`
+- `ExtraData::excluded_count`
+- `TopLevelLicenseDetection::detection_count`
+- `TallyEntry::count`
+
+**Proposed Newtypes:**
+
+```rust
+pub struct FileSize(u64);       // Bytes
+pub struct FileCount(usize);
+pub struct DirCount(usize);
+pub struct SourceCount(usize);
+pub struct ExcludedCount(usize);
+pub struct DetectionCount(usize);
+```
+
+---
+
+### 13. Email Addresses
+
+**Fields Affected:**
+
+- `Party::email`
+- `OutputEmail::email`
+- `finder::EmailDetection::email`
+
+**Proposed Newtype:**
+
+```rust
+pub struct EmailAddress(String);  // Validates @ presence
+```
+
+---
+
+### 14. Timestamps
+
+**Fields Affected:**
+
+- `FileInfo::date`
+- `PackageData::release_date`, `ResolvedPackage::release_date`
+- `Header::start_timestamp`, `Header::end_timestamp`
+
+**Proposed Newtype:**
+
+```rust
+pub struct Timestamp(String);  // ISO 8601 format, could validate
+```
+
+---
+
+### 15. Token Positions (0-indexed)
+
+**Fields Affected** (in `license_detection/models/license_match.rs`):
+
+- `start_token`, `end_token`, `rule_start_token`
+- Aho-Corasich `Match::start`, `end` (byte positions)
+
+**Proposed Newtypes:**
+
+```rust
+pub struct TokenPosition(usize);  // 0-indexed, distinct from LineNumber
+pub struct PatternId(usize);      // Aho-Corasick pattern ID
+```
+
+---
+
+## Tier 4: Lower Priority
+
+### 16. Type Alias Replacements
+
+| Current Alias                                                                                        | Proposed Struct                                                           |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `NumberedLine = (usize, String)` in `copyright/candidates.rs`                                        | `struct NumberedLine { line: usize, text: String }`                       |
+| `DirectoryMergeOutput = (Option<Package>, Vec<TopLevelDependency>, Vec<usize>)` in `assembly/mod.rs` | `struct DirectoryMergeOutput { package, dependencies, affected_indices }` |
+
+---
+
+### 17. Other String Newtypes
+
+- `LicenseKey(String)` — ScanCode license key, used as HashMap key
+- `SpdxLicenseKey(String)` — SPDX identifier
+- `HashAlgorithm` enum — replaces `"SHA-1"`, `"SHA-256"`, etc. in CycloneDX output
+- `NpmLockfileVersion` enum — replaces raw `i64` (values 1, 2, 3)
+
+---
+
+## Summary Statistics
+
+| Metric                                 | Count |
+| -------------------------------------- | ----- |
+| Distinct newtype definitions suggested | ~30   |
+| Raw `Option<String>` fields covered    | ~70   |
+| Raw `usize`/`u64` fields covered       | ~35   |
+| Raw `f64`/`f32` fields covered         | ~8    |
+| Stringly-typed enums suggested         | ~6    |
+| Type aliases to replace                | 2     |
+| Detection log constants → enum         | 9     |
+
+---
+
+## Implementation Priority
+
+1. **Digests** — DONE (PR #590)
+2. **Line numbers** — PARTIALLY DONE (PR #596, `LineSpan` deferred)
+3. **Package identifiers** — PARTIALLY DONE (`PackageUid`/`DependencyUid` implemented; `Purl` deferred)
+4. **Match scores** — PARTIALLY DONE (`MatchScore` implemented on `LicenseMatch::score` and `Match::score`; `MatchCoverage`, `Percentage`, `Score100`, `RuleRelevance`, `MinCoverage` deferred)
+5. **Scores and percentages** — Remaining: `MatchCoverage`, `Percentage`, `Score100`, `RuleRelevance`, `MinCoverage`
+6. **URLs** — DEFERRED (bug fix only: opam `repository_homepage_url`)
+7. Everything else in order of diminishing returns
+
+---
+
+## Deferred and Rejected
+
+| Item                                                               | Decision | Rationale                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LineSpan` (from #2)                                               | Deferred | Not a simple newtype migration — requires replacing two separate `start_line`/`end_line` fields with one combined struct, changing JSON serialization shape. Evaluate when output schema is open to structural changes.                                                                                      |
+| `Purl` (from #3)                                                   | Deferred | High surface area across all parsers with moderate benefit. Purl strings come from trusted parser output. Evaluate as separate effort.                                                                                                                                                                       |
+| License expression strings (#4)                                    | Rejected | `_spdx` suffix naming convention sufficient. Expressions from trusted sources. Only 2-3 sentinel comparison sites. High cost (~50+ fields, 15+ structs, 20+ test files) for marginal benefit. Naming collision with existing `LicenseExpression` AST enum.                                                   |
+| `MatchCoverage(f64)` (from #5)                                     | Deferred | Same 0.0–100.0 domain as MatchScore but lower semantic urgency. Coverage is less overloaded than score. Full migration across detection+model+output layers required.                                                                                                                                        |
+| `Percentage(f64)` (from #5)                                        | Deferred | Single-field newtype (`FileInfo::percentage_of_license_text`) with low reuse.                                                                                                                                                                                                                                |
+| `Score100(u8)` / `RuleRelevance(u8)` / `MinCoverage(u8)` (from #5) | Deferred | Integer 0–100 fields already use `u8` internally; `Match::rule_relevance` fixed from `usize` to `u8`. Low risk of remaining type confusion.                                                                                                                                                                  |
+| URLs (#6)                                                          | Deferred | ~40 fields but overwhelmingly passthrough. Only ~6 logic consumption sites. Category-error risk concentrated in 2-3 parsers, low-frequency. `TryFrom` cascade makes `--from-json` fallible. `ignorable_urls` must stay `Vec<String>`. `url::Url` normalizes and breaks parity. Opam bug fixed independently. |

--- a/docs/parser-audit/about.md
+++ b/docs/parser-audit/about.md
@@ -1,0 +1,95 @@
+# ADR 0004 Security Audit: about
+
+**File**: `src/parsers/about.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `yaml_serde` for static YAML parsing. Uses `packageurl` crate for purl parsing. Uses `url` crate for URL parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` called at line 291 via `read_and_parse_yaml` without size pre-check.
+
+### Recursion Depth
+
+No recursive functions found. All processing is iterative over YAML fields. — PASS
+
+### Iteration Count
+
+- `extract_file_references` (line 345): Small fixed iteration (3 items) — PASS
+- `build_extra_data` (line 449): Small fixed iteration (3 keys) — PASS
+- No unbounded iteration loops
+
+### String Length
+
+No field-level truncation at 10MB. YAML values are used as-is.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+YAML files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 291 fails on missing files, error propagated and handled in `extract_packages` (line 72). — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+YAML parse error at line 294 is handled, returns error string caught in `extract_packages` (line 72). Non-mapping root returns error (line 298). — PASS
+
+### Required Fields
+
+Missing name/version/purl result in `None` values with fallback chains (lines 143-157). — PASS
+
+### URL Format
+
+URLs parsed via `Url::parse` in `infer_about_from_download_url` (line 399). Invalid URLs return `None`. — PASS
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 291     | No file size check before reading |
+| 2   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 3   | P4 UTF-8         | LOW      | 291     | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB

--- a/docs/parser-audit/alpine.md
+++ b/docs/parser-audit/alpine.md
@@ -1,0 +1,127 @@
+# ADR 0004 Security Audit: alpine
+
+**File**: `src/parsers/alpine.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. The APKBUILD parser (`parse_apkbuild_variables()`) performs static text parsing of shell-like variable assignments — it does NOT execute shell code. It handles brace depth tracking for function bodies (lines 371-386) to skip them, and performs string replacement for variable expansion (lines 430-457) purely via `String::replace()`, not shell execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file_to_string()` at lines 65, 85 reads entire files without size validation.
+
+### Recursion Depth
+
+- `resolve_apkbuild_value()` line 430: Not recursive itself, but performs up to 8 iterations of variable substitution (line 432: `for _ in 0..8`). This is bounded and acceptable.
+- `resolve_apkbuild_value_no_recursion()` line 460: Single-pass, not recursive.
+- No unbounded recursion found. PASS for recursion depth.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_alpine_installed_db()` line 105: iterates all paragraphs without limit
+- `parse_alpine_headers()` line 128: iterates all lines without limit
+- `parse_alpine_package_paragraph()` line 209: iterates `D` dependency field entries without limit
+- `extract_file_references()` line 617: iterates all lines without limit
+- `extract_providers()` line 695: iterates all lines without limit
+- `parse_pkginfo()` line 824: iterates all lines without limit
+- `parse_apkbuild_dependencies()` line 580: iterates dependency fields without limit
+
+### String Length
+
+No 10MB truncation on field values. APKBUILD variable values are stored without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: FAIL
+
+### .apk Archive Extraction (AlpineApkParser)
+
+- `apk_contains_pkginfo()` line 756: Opens gzip+tar archive, iterates all entries without size/ratio limits
+- `extract_apk_archive()` line 789: Opens gzip+tar archive, reads `.PKGINFO` content without:
+  - Uncompressed size limit (1 GB)
+  - Compression ratio check (100:1 max)
+  - Path traversal check (`../` patterns)
+  - Decompression limit (1 GB)
+- `entry.read_to_string(&mut content)` at line 810 reads unbounded content from tar entry
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+Uses `read_file_to_string()` which returns error on missing files (handled at lines 67-70, 88-90), but no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`read_file_to_string()` uses `file.read_to_string()` which errors on invalid UTF-8. No lossy conversion fallback. In `extract_apk_archive()` line 810, `entry.read_to_string()` will also error on invalid UTF-8.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`parse_alpine_package_paragraph()` line 108: Package is only pushed if `pkg.name.is_some()` — missing name causes the package to be silently skipped, which is acceptable. Missing version results in `None`.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution; only parsing declared dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 395: `.unwrap()` in `parse_apkbuild_variables()` — `lines.next().unwrap()` when consuming multi-line quoted values. Could panic if the iterator is exhausted unexpectedly (though `peek()` suggested content exists).
+- Line 481: `.unwrap_or(value)` — acceptable defensive pattern.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s)                     | Description                                                     |
+| --- | ---------- | -------- | --------------------------- | --------------------------------------------------------------- |
+| 1   | P2         | HIGH     | 65,85                       | No file size check before reading (100MB limit)                 |
+| 2   | P2         | MEDIUM   | 105,128,209,580,617,695,824 | No iteration count cap (100K items)                             |
+| 3   | P2         | MEDIUM   | —                           | No string length truncation (10MB per field)                    |
+| 4   | P3         | HIGH     | 756,789,810                 | No archive size/ratio/path-traversal limits on .apk extraction  |
+| 5   | P4         | LOW      | 65,85                       | No explicit fs::metadata() pre-check                            |
+| 6   | P4         | MEDIUM   | 65,85,810                   | No lossy UTF-8 fallback; invalid UTF-8 causes error not warning |
+| 7   | Additional | LOW      | 395                         | .unwrap() in library code (lines.next().unwrap())               |
+
+## Remediation Priority
+
+1. Add archive safety limits to .apk extraction (uncompressed size 1GB, compression ratio 100:1, path traversal blocking)
+2. Add fs::metadata().len() check before read_file_to_string with 100MB limit
+3. Add iteration count caps on paragraph/line/dependency loops
+4. Add String::from_utf8_lossy() fallback for UTF-8 handling
+5. Replace .unwrap() at line 395 with proper error handling
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/arch.md
+++ b/docs/parser-audit/arch.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: arch
+
+**File**: `src/parsers/arch.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. All parsing is static text-based key-value parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file_to_string()` at lines 29, 49 reads entire files without size validation.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_key_value_lines()` line 82: iterates all lines without limit
+- `parse_srcinfo_like()` line 108: iterates all lines without limit
+- `build_dependencies()` line 351: iterates all keys and values without limit
+- `build_extra_data()` line 408: iterates all fields without limit
+
+### String Length
+
+No 10MB truncation on field values. Values from key-value parsing stored without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+Uses `read_file_to_string()` which returns error on missing files (handled at lines 31-34, 51-54), but no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`read_file_to_string()` errors on invalid UTF-8. No lossy conversion fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`parse_srcinfo_like()` line 157: Package is only included if `pkg.name.is_some()`. Missing name is handled gracefully. Missing version results in `None`.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. `unwrap_or_default()` and `unwrap_or(false)` patterns are used (lines 159, 391, 450), which are safe.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s)        | Description                                                     |
+| --- | --------- | -------- | -------------- | --------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 29,49          | No file size check before reading (100MB limit)                 |
+| 2   | P2        | MEDIUM   | 82,108,351,408 | No iteration count cap (100K items)                             |
+| 3   | P2        | MEDIUM   | —              | No string length truncation (10MB per field)                    |
+| 4   | P4        | LOW      | 29,49          | No explicit fs::metadata() pre-check                            |
+| 5   | P4        | MEDIUM   | 29,49          | No lossy UTF-8 fallback; invalid UTF-8 causes error not warning |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before read_file_to_string with 100MB limit
+2. Add iteration count caps on line/field loops
+3. Add String::from_utf8_lossy() fallback for UTF-8 handling

--- a/docs/parser-audit/autotools.md
+++ b/docs/parser-audit/autotools.md
@@ -1,0 +1,92 @@
+# ADR 0004 Security Audit: autotools
+
+**File**: `src/parsers/autotools.rs`
+**Date**: 2026-04-14
+**Status**: COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Does not parse file contents at all. Extracts package name from the parent directory path only (line 41-50). No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism.
+
+## Principle 2: DoS Protection
+
+**Status**: PASS
+
+### File Size
+
+N/A — the parser does not read file contents. No file I/O beyond path manipulation.
+
+### Recursion Depth
+
+No recursive functions. **PASS**.
+
+### Iteration Count
+
+No iteration over file contents or collections. **PASS**.
+
+### String Length
+
+The only string extracted is the parent directory name (line 41-50), which is bounded by filesystem path limits. **PASS**.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Autotools parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PASS
+
+### File Exists
+
+N/A — the parser does not read file contents. The `extract_packages` function only uses `path.parent()` and `path.file_name()` for path manipulation. No file I/O is performed, so no file existence check is needed.
+
+### UTF-8 Encoding
+
+N/A — no file content is read. Path components are accessed via `to_str()` which returns `None` for non-UTF-8 paths, handled at line 44.
+
+### JSON/YAML Validity
+
+N/A — no JSON/YAML parsing.
+
+### Required Fields
+
+Missing parent directory name is handled with a fallback to `"input"` (line 47-49). **PASS**.
+
+### URL Format
+
+N/A — no URL fields.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description |
+| --- | --------- | -------- | ------- | ----------- |
+
+No findings. The parser does not read file contents, does not recurse, does not iterate over collections, and has no code execution vectors.
+
+## Remediation Priority
+
+No remediation needed. This parser is fully compliant with ADR 0004 by virtue of not reading or parsing file contents.

--- a/docs/parser-audit/bazel.md
+++ b/docs/parser-audit/bazel.md
@@ -1,0 +1,105 @@
+# ADR 0004 Security Audit: bazel
+
+**File**: `src/parsers/bazel.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses `starlark_syntax::AstModule::parse` (line 325) for AST-based parsing. This is a compile-time parsing library that produces an AST without executing Starlark code. No `Command::new`, `subprocess`, `eval()`, or code execution. The `starlark_syntax` crate is a parser-only dependency — it does not evaluate Starlark expressions.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Both `parse_bazel_build` (line 64) and `parse_bazel_module` (line 250) read the entire file into memory via `std::fs::read_to_string(path)` without a size check.
+
+### Recursion Depth
+
+No explicit recursion depth tracking. The Starlark AST parser handles nesting internally. The `extract_call` and `extract_call_expr` functions (lines 335, 343) are not recursive. The `expr_to_json` function (line 456) recursively converts AST expressions but is bounded by the AST depth from the parser. The `starlark_syntax` parser may have its own depth limits. **Partial** — relies on external parser limits.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `top_level_statements` (line 328): Returns slice of all statements
+- `extract_packages` / `parse_bazel_build` (line 63-79): Iterates over all statements without cap
+- `parse_bazel_module` (line 259): Iterates over all statements
+- `extract_string_list_kwarg` (line 371): No cap on list items
+
+### String Length
+
+No 10 MB truncation with warning on any field value. `extract_string_kwarg` (line 367) and `expr_as_string` (line 431) return string values without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Bazel parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `std::fs::read_to_string(path)` at lines 64 and 250 with error handling that returns error/fallback on failure. Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`std::fs::read_to_string` returns an error for non-UTF-8 files. The `starlark_syntax` parser works on `String` (UTF-8 validated). No explicit lossy conversion path — invalid UTF-8 causes the parser to return error/fallback data. No `String::from_utf8()` + warning + lossy conversion pattern.
+
+### JSON/YAML Validity
+
+Returns fallback/default `PackageData` on parse failure (lines 53-58, 240-245). **PASS**.
+
+### Required Fields
+
+Missing `name` in Bazel BUILD rules causes `extract_package_from_statement` to return `None` (line 90). Missing `name` in MODULE.bazel causes `parse_bazel_module` to return default data (line 307-308). **PASS**.
+
+### URL Format
+
+N/A — no URL fields directly parsed from user input.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in `#[cfg(test)]` blocks.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)      | Description                                                                           |
+| --- | ------------------- | -------- | ------------ | ------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 64, 250      | No `fs::metadata().len()` check before reading; entire file loaded into memory        |
+| 2   | P2: Iteration Count | Low      | 71, 259, 371 | No 100K iteration cap on statement processing or list extraction                      |
+| 3   | P2: String Length   | Low      | 367, 431     | No 10 MB truncation with warning on string values                                     |
+| 4   | P4: File Exists     | Low      | 64, 250      | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                       |
+| 5   | P4: UTF-8 Encoding  | Low      | 64, 250      | No lossy UTF-8 conversion path; invalid UTF-8 causes parser to return fallback data   |
+| 6   | P2: Recursion Depth | Low      | 456          | `expr_to_json` is recursive; relies on starlark_syntax parser's internal depth limits |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 64, 250)
+2. Add iteration count cap (100K) on statement/dependency processing
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/bower.md
+++ b/docs/parser-audit/bower.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: bower
+
+**File**: `src/parsers/bower.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `serde_json` for JSON parsing (static). All processing is data extraction from parsed JSON values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 158 (inside `read_and_parse_json`) reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `licenses.iter()` at line 176 (in `extract_license_statement`): no iteration cap on license array.
+- `authors` iteration at line 246: no 100K cap.
+- `deps.iter()` at line 372: no 100K cap on dependencies.
+- `keywords` iteration at line 232: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 158 will fail if the file doesn't exist, but error is handled gracefully via `read_and_parse_json` returning `Err`, which is handled in `extract_packages` at line 58.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 158 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`serde_json::from_str(&content)` at line 159 handles parse failure gracefully, returning an error that is handled in `extract_packages` at line 58, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing `name` and `version` are handled via `.and_then(|v| v.as_str()).map(String::from)` (lines 65-68, 79-82) resulting in `None` values. When `name` is `None`, the package is marked as private (line 71). PASS.
+
+### URL Format
+
+URLs (homepage, VCS) are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. Only `.unwrap_or()` and `.unwrap_or_default()` are used.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                        |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 158                | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 176, 246, 372, 232 | No 100K iteration cap on license/author/dependency/keyword loops   |
+| 3   | P2: String Length   | Low      | Various            | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 158                | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 158                | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 158)
+2. Add 100K iteration cap to license/author/dependency/keyword loops
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/buck.md
+++ b/docs/parser-audit/buck.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: buck
+
+**File**: `src/parsers/buck.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses `starlark_syntax::AstModule::parse` (line 132) for AST-based parsing. Same approach as `bazel.rs` — the `starlark_syntax` crate produces an AST without executing Starlark code. No `Command::new`, `subprocess`, `eval()`, or code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Both `parse_buck_build` (line 91) and `parse_metadata_bzl` (line 108) read the entire file into memory via `std::fs::read_to_string(path)` without a size check.
+
+### Recursion Depth
+
+No explicit recursion depth tracking. The Starlark AST parser handles nesting internally. The `extract_call` and `extract_call_expr` functions (lines 484, 492) are not recursive. The `expr_to_json` function from bazel.rs is not duplicated here; this file uses `metadata_value_from_expr` (line 431) which is not recursive. **PASS** for this file's code; relies on starlark_syntax parser's internal limits.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `top_level_statements` (line 135): Returns slice of all statements
+- `parse_buck_build` (line 97): Iterates over all statements without cap
+- `parse_metadata_bzl` (line 113): Iterates over statements
+- `extract_named_kwarg_string_list` (line 513): No cap on list items
+
+### String Length
+
+No 10 MB truncation with warning on any field value. `expr_as_string` (line 523) and `extract_named_kwarg_string` (line 509) return string values without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Buck parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `std::fs::read_to_string(path)` at lines 91 and 108 with error handling that returns fallback data on failure (lines 53-58, 75-86). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`std::fs::read_to_string` returns an error for non-UTF-8 files. The `starlark_syntax` parser works on `String` (UTF-8 validated). No explicit lossy conversion path — invalid UTF-8 causes the parser to return fallback data. No `String::from_utf8()` + warning + lossy conversion pattern.
+
+### JSON/YAML Validity
+
+Returns fallback/default `PackageData` on parse failure (lines 53-58, 75-86, 119-124). **PASS**.
+
+### Required Fields
+
+Missing `name` in BUCK build rules causes `extract_build_package_from_statement` to return `None` (line 459). Falls back to parent directory name (line 536). Missing name in METADATA.bzl results in partial `PackageData` with available fields. **PASS**.
+
+### URL Format
+
+URLs accepted as-is. **PASS** per ADR spec.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in `#[cfg(test)]` blocks.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)      | Description                                                                         |
+| --- | ------------------- | -------- | ------------ | ----------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 91, 108      | No `fs::metadata().len()` check before reading; entire file loaded into memory      |
+| 2   | P2: Iteration Count | Low      | 97, 113, 513 | No 100K iteration cap on statement processing or list extraction                    |
+| 3   | P2: String Length   | Low      | 509, 523     | No 10 MB truncation with warning on string values                                   |
+| 4   | P4: File Exists     | Low      | 91, 108      | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                     |
+| 5   | P4: UTF-8 Encoding  | Low      | 91, 108      | No lossy UTF-8 conversion path; invalid UTF-8 causes parser to return fallback data |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 91, 108)
+2. Add iteration count cap (100K) on statement/dependency processing
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/bun_lock.md
+++ b/docs/parser-audit/bun_lock.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: bun_lock
+
+**File**: `src/parsers/bun_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `json5::from_str` for JSON5 parsing (static). All processing is data extraction from parsed JSON values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 43 reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `packages` iteration at line 115: iterates all package entries without a 100K cap.
+- `workspaces.values()` iterations at lines 156, 168: no iteration cap.
+- `deps.iter()` at line 462: no iteration cap on nested dependencies.
+- `map.keys()` at line 221: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 43 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 43 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`json5::from_str(&content)` at line 51 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing package name/version result in `None` or skipped entries (e.g., `split_locator` at line 303 returns `Option`). PASS.
+
+### URL Format
+
+URLs (resolved download URLs) are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependency graphs.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                        |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 43                 | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 115, 156, 168, 462 | No 100K iteration cap on package/workspace/dependency loops        |
+| 3   | P2: String Length   | Low      | Various            | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 43                 | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 43                 | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 43)
+2. Add 100K iteration cap to package/workspace/dependency loops
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/bun_lockb.md
+++ b/docs/parser-audit/bun_lockb.md
@@ -1,0 +1,116 @@
+# ADR 0004 Security Audit: bun_lockb
+
+**File**: `src/parsers/bun_lockb.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Performs custom binary parsing of the bun.lockb format using `LockbCursor` (lines 60-693) — all static analysis of binary data. No code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `std::fs::read(path)` at line 76 reads entire file into memory as bytes without size validation. A very large `.lockb` file would be loaded entirely.
+
+### Recursion Depth
+
+`build_dependencies_for_package` at line 353 is indirectly recursive — it calls `build_resolved_package` at line 427, which calls `build_dependencies_for_package` at line 427 again. There is **no depth tracking** and **no cycle detection** in this recursion. A circular package reference in the lockb data would cause infinite recursion and stack overflow.
+
+### Iteration Count
+
+- `packages` iteration at line 191: iterates all packages without a 100K cap. The `list_len` value comes directly from the binary file at line 122 with no upper bound check.
+- `dep_slice.iter().zip(res_slice.iter())` at line 369: no iteration cap on dependency entries.
+- `bytes.chunks_exact()` at lines 331, 347: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Decoded strings from `decode_bun_string` at line 524 are stored as-is without length checks. The `len` value at line 538 comes from the binary data.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives (bun.lockb is a binary lockfile, not an archive format).
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `std::fs::read(path)` at line 76 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`decode_bun_string` at line 524 uses `std::str::from_utf8` and returns `Err` on invalid UTF-8 (line 531, 543). There is no lossy fallback — invalid UTF-8 causes the entire parse to fail.
+
+### JSON/YAML Validity
+
+Not applicable — this is a binary format parser. The `serde_json` usage at line 751 is only in the `yaml_value_to_json` helper, not for input parsing.
+
+### Required Fields
+
+Missing package data is handled via `Result<..., String>` error propagation. The root package is required (line 289). PASS.
+
+### URL Format
+
+URLs (resolved URLs) are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: FAIL
+
+`build_dependencies_for_package` (line 353) calls `build_resolved_package` (line 405), which calls `build_dependencies_for_package` (line 427) recursively. There is **no visited tracking** and **no cycle detection**. A circular reference between packages in the lockb data would cause infinite recursion.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+Seven bare `.unwrap()` calls in library code (non-test):
+
+- Line 349: `chunk.try_into().unwrap()` — in `parse_resolution_ids`, converting 4-byte chunks to `u32`
+- Line 453: `bytes[0..4].try_into().unwrap()` — in `parse_slice_ref`, converting to `u32`
+- Line 454: `bytes[4..8].try_into().unwrap()` — in `parse_slice_ref`, converting to `u32`
+- Line 471: `bytes[16..20].try_into().unwrap()` — in `parse_resolution`, converting to `u32`
+- Line 472: `bytes[20..24].try_into().unwrap()` — in `parse_resolution`, converting to `u32`
+- Line 473: `bytes[24..28].try_into().unwrap()` — in `parse_resolution`, converting to `u32`
+- Line 536: `bytes[0..4].try_into().unwrap()` — in `decode_bun_string`, converting to `u32`
+- Line 537: `bytes[4..8].try_into().unwrap()` — in `decode_bun_string`, converting to `u32`
+
+Note: These `.unwrap()` calls are on fixed-size slice-to-array conversions where the slice length is guaranteed by prior bounds checks. They are safe in practice but technically violate the ADR 0004 rule against `.unwrap()` in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle               | Severity | Line(s)                                | Description                                                                                                 |
+| --- | ----------------------- | -------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | P5: Circular Dependency | High     | 353, 405, 427                          | `build_dependencies_for_package` ↔ `build_resolved_package` recursion has no cycle detection or depth limit |
+| 2   | P2: File Size           | Medium   | 76                                     | No `fs::metadata().len()` check before `std::fs::read()`                                                    |
+| 3   | P2: Iteration Count     | Low      | 191, 369                               | No 100K iteration cap; `list_len` from binary is unbounded                                                  |
+| 4   | P2: String Length       | Low      | 524, 538                               | No 10 MB per-field truncation on decoded strings                                                            |
+| 5   | Additional: .unwrap()   | Low      | 349, 453, 454, 471, 472, 473, 536, 537 | 8 `.unwrap()` calls in library code on fixed-size array conversions                                         |
+| 6   | P4: File Exists         | Low      | 76                                     | No explicit `fs::metadata()` pre-check before reading                                                       |
+| 7   | P4: UTF-8 Encoding      | Low      | 531, 543                               | No lossy UTF-8 fallback; invalid UTF-8 causes total parse failure                                           |
+
+## Remediation Priority
+
+1. Add cycle detection (visited set or depth limit of 50) to `build_dependencies_for_package` ↔ `build_resolved_package` recursion
+2. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 76)
+3. Add upper bound check on `list_len` (line 122) and 100K iteration cap
+4. Replace `.unwrap()` calls with proper error handling (lines 349, 453, 454, 471-473, 536, 537)
+5. Add 10 MB string length truncation with warning in `decode_bun_string`
+6. Add `fs::metadata()` pre-check for file existence
+7. Add lossy UTF-8 fallback for string decoding

--- a/docs/parser-audit/cargo.md
+++ b/docs/parser-audit/cargo.md
@@ -1,0 +1,113 @@
+# ADR 0004 Security Audit: cargo
+
+**File**: `src/parsers/cargo.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses `toml::from_str` (line 212) for static TOML parsing. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism. All parsing is AST/structured-data based.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_cargo_toml` (line 206) opens and reads the entire file via `File::open` + `read_to_string` without a size check.
+
+### Recursion Depth
+
+`toml_to_json` (line 486) is recursive — it recurses into `toml::Value::Array` and `toml::Value::Table` variants. No depth tracking or limit. Bounded implicitly by the TOML parser's own nesting limits.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `extract_dependencies` (line 305): iterates over all keys in a TOML table without cap
+- `extract_keywords_and_categories` (line 421): iterates over keywords and categories arrays without cap
+- `extract_parties` (line 248): iterates over authors array without cap
+- `extract_extra_data` (line 505): iterates over multiple package fields without cap
+
+### String Length
+
+No 10 MB truncation with warning on any field value. String fields like `name`, `version`, `description`, `raw_license` are extracted from TOML values without size limits (lines 75-88, 141-144).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Cargo.toml parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `read_cargo_toml` (line 207) uses `File::open(path)` with error handling that returns error string on failure. Returns fallback `default_package_data()` on error (line 69). Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`file.read_to_string(&mut content)` (line 209) returns an error for non-UTF-8 files. The error is propagated and fallback data is returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+`toml::from_str(&content)` (line 212) returns an error on invalid TOML, which is propagated as `Err(String)` and caught at line 65-70, returning `default_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing `name` and `version` are handled as `Option<String>` (lines 75-83). When `None`, fields are populated as `None` in `PackageData`. PURL generation handles `None` gracefully (line 220). **PASS**.
+
+### URL Format
+
+URLs from `repository` and `homepage` fields are accepted as-is (lines 121-124, 112-119). Per ADR 0004, accept as-is is correct. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from manifest declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)        | Description                                                                    |
+| --- | ------------------- | -------- | -------------- | ------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 206-210        | No `fs::metadata().len()` check before reading; entire file loaded into memory |
+| 2   | P2: Recursion Depth | Low      | 486-502        | `toml_to_json` recurses into nested TOML values without depth tracking         |
+| 3   | P2: Iteration Count | Low      | 305, 421, 248  | No 100K iteration cap on dependency/keyword/author processing                  |
+| 4   | P2: String Length   | Low      | 75-88, 141-144 | No 10 MB truncation with warning on string field values                        |
+| 5   | P4: File Exists     | Low      | 207            | Uses `File::open` instead of `fs::metadata()` pre-check                        |
+| 6   | P4: UTF-8 Encoding  | Low      | 209            | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return      |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 206)
+2. Add depth tracking to `toml_to_json` recursion (line 486)
+3. Add iteration count cap (100K) on dependency/keyword processing loops
+4. Add 10 MB string field truncation with warning
+5. Add `fs::metadata()` pre-check before file read
+6. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/cargo_lock.md
+++ b/docs/parser-audit/cargo_lock.md
@@ -1,0 +1,103 @@
+# ADR 0004 Security Audit: cargo_lock
+
+**File**: `src/parsers/cargo_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses `toml::from_str` (line 161) for static TOML parsing. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_cargo_lock` (line 156) opens and reads the entire file via `File::open` + `read_to_string` without a size check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative — `extract_all_dependencies` (line 172) iterates over packages, `build_package_versions` (line 291) and `build_package_provenance` (line 307) use `fold`. **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `extract_all_dependencies` (line 182): iterates over all packages and their dependencies without cap
+- Inner loop at line 189: iterates over all dependencies in each package without cap
+- `build_package_versions` (line 291): processes all packages without cap
+
+### String Length
+
+No 10 MB truncation with warning on any field value. String fields like `name`, `version`, `checksum` are extracted from TOML values without size limits (lines 66-79).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Cargo.lock parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `read_cargo_lock` (line 157) uses `File::open(path)` with error handling. Returns fallback `default_package_data()` on error (line 51). Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`file.read_to_string(&mut content)` (line 159) returns an error for non-UTF-8 files. Error is propagated and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+`toml::from_str(&content)` (line 161) returns an error on invalid TOML, caught at line 48-53, returning `default_package_data()`. Also handles missing `package` array at line 56-62. **PASS**.
+
+### Required Fields
+
+Missing `name` and `version` are handled as `Option<String>` (lines 66-74). When `None`, fields are populated as `None` in `PackageData`. PURL generation handles missing values gracefully (lines 95-101). **PASS**.
+
+### URL Format
+
+URLs are constructed programmatically (lines 103-107), not parsed from user input. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from lockfile declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)       | Description                                                                    |
+| --- | ------------------- | -------- | ------------- | ------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 156-160       | No `fs::metadata().len()` check before reading; entire file loaded into memory |
+| 2   | P2: Iteration Count | Low      | 182, 189, 291 | No 100K iteration cap on package/dependency processing                         |
+| 3   | P2: String Length   | Low      | 66-79         | No 10 MB truncation with warning on string field values                        |
+| 4   | P4: File Exists     | Low      | 157           | Uses `File::open` instead of `fs::metadata()` pre-check                        |
+| 5   | P4: UTF-8 Encoding  | Low      | 159           | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return      |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 156)
+2. Add iteration count cap (100K) on package/dependency processing loops
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/chef.md
+++ b/docs/parser-audit/chef.md
@@ -1,0 +1,109 @@
+# ADR 0004 Security Audit: chef
+
+**File**: `src/parsers/chef.rs`
+**Date**: 2026-04-14
+**Status**: NON-COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. The Ruby DSL parser (ChefMetadataRbParser) uses regex-based line extraction (line 233-235) rather than executing Ruby code. `IO.read(...)` expressions are explicitly skipped (line 236, 250). Uses `serde_json` for static JSON parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading.
+
+- JSON parser: `File::open` + `read_to_string` at lines 179-183
+- Ruby parser: `File::open` at line 221 with `BufReader` — reads line by line, which is more memory-efficient but still no size cap
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative. — PASS
+
+### Iteration Count
+
+- Ruby parser `for line in reader.lines()` (line 238): No 100K cap on lines processed
+- JSON parser `deps_obj` iteration (lines 144-150): No 100K cap on dependencies
+- JSON parser `depends_obj` iteration (lines 153-159): No 100K cap
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+JSON/Ruby text files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open` fails on missing files, errors handled via `match` (line 221 for Ruby, line 179 for JSON). — Acceptable.
+
+### UTF-8 Encoding
+
+- JSON parser: `file.read_to_string` at line 182 will fail on non-UTF-8. No lossy conversion.
+- Ruby parser: `BufReader::lines()` at line 238 will produce errors on non-UTF-8 lines, which are skipped via `Err(_) => continue` (line 241). This silently drops non-UTF-8 lines without logging a warning. — Should log warning per ADR.
+
+### JSON/YAML Validity
+
+JSON parse error at line 183 is handled, returns error string caught in `extract_packages` (line 89). — PASS
+
+### Required Fields
+
+Missing name/version result in `None` values with filtering for empty strings (lines 94-98, 100-104). — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 233: `Regex::new(r#"^\s*(\w+)\s+['"](.+?)['"]"#).unwrap()` — `.unwrap()` on regex compilation in library code. This is a static regex that will always compile, but violates the ADR rule.
+- Line 235: `Regex::new(r#"^\s*depends\s+['"](.+?)['"](?:\s*,\s*['"](.+?)['"])?"#).unwrap()` — same issue
+- Line 236: `Regex::new(r"IO\.read\(").unwrap()` — same issue
+- Line 255: `caps.get(1).map(|m| m.as_str().to_string()).unwrap()` — `.unwrap()` on regex capture group that is guaranteed to exist by the pattern, but still `.unwrap()` in library code
+- Line 262: Same `.unwrap()` pattern for regex captures
+- Line 263: Same `.unwrap()` pattern for regex captures
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s)       | Description                                                                                            |
+| --- | ---------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| 1   | Additional       | MEDIUM   | 233, 235, 236 | `.unwrap()` on `Regex::new()` in library code — should use `expect()` with justification or `LazyLock` |
+| 2   | Additional       | MEDIUM   | 255, 262, 263 | `.unwrap()` on regex capture groups in library code — should use `?` or `expect()`                     |
+| 3   | P2 File Size     | MEDIUM   | 179-183, 221  | No file size check before reading                                                                      |
+| 4   | P4 UTF-8         | LOW      | 241           | Non-UTF-8 lines silently skipped without logging warning                                               |
+| 5   | P2 String Length | LOW      | —             | No field-level 10MB truncation                                                                         |
+
+## Remediation Priority
+
+1. Replace `Regex::new(...).unwrap()` with `LazyLock` + `expect("documented reason")` or use `once_cell::sync::Lazy`
+2. Replace `.unwrap()` on regex captures with `?` operator or proper error handling
+3. Add `fs::metadata().len()` check before reading, reject >100MB
+4. Log warning when non-UTF-8 lines are skipped in Ruby parser

--- a/docs/parser-audit/citation.md
+++ b/docs/parser-audit/citation.md
@@ -1,0 +1,94 @@
+# ADR 0004 Security Audit: citation
+
+**File**: `src/parsers/citation.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `yaml_serde` for static YAML parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` at line 20 without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative over YAML fields. — PASS
+
+### Iteration Count
+
+- `extract_author_parties` (line 93): Iterates over authors sequence — no 100K cap
+- Small expected iteration (authors are typically few)
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+YAML files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 20 fails on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+YAML parse error at line 28 is handled, returns `default_package_data()`. — PASS
+
+### Required Fields
+
+Missing `cff-version` returns `default_package_data()` (line 49-55). Missing name/version result in `None`. — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 20      | No file size check before reading |
+| 2   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 3   | P4 UTF-8         | LOW      | 20      | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB

--- a/docs/parser-audit/clojure.md
+++ b/docs/parser-audit/clojure.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: clojure
+
+**File**: `src/parsers/clojure.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, or code execution. Uses a custom EDN reader (`Reader` struct, line 115) that parses Clojure data structures as static data. Notably, the `parse_dispatch_form` method (line 181) explicitly rejects `#=` reader eval (line 189: returns `Err("unsupported reader eval dispatch")`). Reader conditionals, tagged literals, and function literals are tolerated but parsed as inert data without evaluation. This is a textbook ADR 0004-compliant approach.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Both parsers (`ClojureDepsEdnParser` line 23, `ClojureProjectCljParser` line 59) read the entire file into memory via `fs::read_to_string(path)` without a size check.
+
+### Recursion Depth
+
+The `Reader::parse_form` method (line 157) is recursive:
+
+- `parse_collection` calls `parse_form` for each element (line 277)
+- `parse_map` calls `parse_form` for keys and values (lines 293, 298)
+- `parse_dispatch_form` calls `parse_form` (lines 167, 172, 187, 201, 209-210, 215-216)
+- Prefixed forms call `parse_form` (line 172)
+
+**No depth tracking or limit exists.** A deeply nested EDN structure (e.g., 1000 levels of nested vectors) would cause stack overflow. The ADR requires 50 levels with tracking in parser state.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `Reader::parse_all` (line 128): Iterates over all top-level forms
+- `parse_collection` (line 265): No cap on collection elements
+- `parse_map` (line 281): No cap on map entries
+- `extract_deps_map` (line 478): No cap on dependency entries
+- `extract_project_dependencies` (line 537): No cap on project dependency entries
+
+### String Length
+
+No 10 MB truncation with warning on any field value. The `parse_string` method (line 223) builds strings without size limits. The `parse_atom` method (line 303) builds symbol strings without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Clojure parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Both parsers use `fs::read_to_string(path)` (lines 23, 59) with error handling that returns `default_package_data()` on failure (lines 27, 63). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. The `Reader` works on `&str` (UTF-8 validated by Rust). No explicit lossy conversion path — invalid UTF-8 causes the parser to return default data. No `String::from_utf8()` + warning + lossy conversion pattern.
+
+### JSON/YAML/EDN Validity
+
+Both parsers return `default_package_data()` on parse failure (lines 42-43, 77-79). The `parse_forms` function returns `Result<Vec<Form>, String>`, and parse errors are caught and logged. **PASS**.
+
+### Required Fields
+
+Missing name/version in `deps.edn` are left as `None` — deps.edn format doesn't have a top-level name/version. For `project.clj`, missing project identifier or version returns an error (lines 410-415) and falls back to default. **PASS**.
+
+### URL Format
+
+URLs accepted as-is. **PASS** per ADR spec.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from EDN map declarations.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in any code (library or test).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                 | Description                                                                                                      |
+| --- | ------------------- | -------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: Recursion Depth | High     | 157, 265, 281           | Recursive EDN parsing with no depth tracking; deeply nested input causes stack overflow. ADR requires 50 levels. |
+| 2   | P2: File Size       | Medium   | 23, 59                  | No `fs::metadata().len()` check before reading; entire file loaded into memory                                   |
+| 3   | P2: Iteration Count | Medium   | 128, 265, 281, 478, 537 | No 100K iteration cap on form parsing, collection/map entries, or dependency extraction                          |
+| 4   | P2: String Length   | Low      | 223, 303                | No 10 MB truncation with warning on parsed string/atom values                                                    |
+| 5   | P4: File Exists     | Low      | 23, 59                  | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                                                  |
+| 6   | P4: UTF-8 Encoding  | Low      | 23, 59                  | No lossy UTF-8 conversion path; invalid UTF-8 causes parser to return default data                               |
+
+## Remediation Priority
+
+1. Add depth tracking to `Reader::parse_form` with 50-level limit (line 157) — **highest priority**, stack overflow risk
+2. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 23, 59)
+3. Add iteration count cap (100K) on collection/map parsing and dependency extraction
+4. Add 10 MB string field truncation with warning
+5. Add `fs::metadata()` pre-check before file read
+6. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/compiled_binary.md
+++ b/docs/parser-audit/compiled_binary.md
@@ -1,0 +1,107 @@
+# ADR 0004 Security Audit: compiled_binary
+
+**File**: `src/parsers/compiled_binary.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `object` crate for static binary format parsing. Uses `serde_json` for JSON deserialization of audit data. Uses `flate2` for zlib decompression — all static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+The parser operates on `bytes: &[u8]` received from the scanner. File size checking is the caller's responsibility. However, there IS a size limit for decompressed Rust audit data:
+
+- `MAX_RUST_AUDIT_JSON_SIZE` = 8MB (line 50), enforced at line 120-121 via `decoder.take()` + length check — PASS for Rust audit data
+- Go binary parsing: No size limit on `bytes` input or `modinfo` string processing
+- `read_sibling_license_text` is in `windows_executable.rs`, not this module
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative. — PASS
+
+### Iteration Count
+
+- `audit_data.packages.iter()` (line 110): No 100K cap on Rust audit packages
+- `package.dependencies.iter()` (line 133): No 100K cap on per-package dependencies
+- `parse_go_modinfo_packages` (line 282): Iterates over `modinfo.lines()` — no 100K cap
+- `find_aligned_magic` (line 224): Scans entire binary for magic bytes — no size cap on scan window
+
+### String Length
+
+No field-level truncation at 10MB.
+
+### Decompression Limits
+
+- `decode_rust_audit_data` (line 117): Uses `decoder.take(MAX_RUST_AUDIT_JSON_SIZE + 1)` at line 120, then checks decoded length at line 121 — PASS (8MB limit). This satisfies ADR Principle 3 decompression limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Binary files are not archives in the traditional sense. The decompression of Rust audit data has a size limit (8MB).
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+The function signature accepts `bytes: &[u8]` — file existence and reading is the caller's responsibility.
+
+### UTF-8 Encoding
+
+- `decode_varint_string` (line 247): Uses `std::str::from_utf8(bytes.get(start..end)?).ok()?` — silently drops invalid UTF-8 rather than using lossy conversion
+- `decode_go_build_info_inline` (line 233): Uses `String::from_utf8(modinfo[...].to_vec()).ok()?` — same issue
+- `decode_utf16_bytes` is in `windows_executable.rs`, not this module
+
+### JSON/YAML Validity
+
+`serde_json::from_slice` at line 125 returns `Option` via `.ok()`. Parse failure results in `None`, which is handled by returning no packages. — PASS
+
+### Required Fields
+
+Missing name/version in Rust audit packages are required by the struct definition (`String`, not `Option<String>`). — PASS (serde deserialization would fail on missing fields)
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with cycle tracking. Rust audit data has dependency indices but these are just used for lookup, not cycle detection.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. Test code at lines 406, 408, 859, etc. uses `.expect()` which is acceptable per ADR.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle    | Severity | Line(s)       | Description                                                                  |
+| --- | ------------ | -------- | ------------- | ---------------------------------------------------------------------------- |
+| 1   | P2 Iteration | MEDIUM   | 110, 133, 282 | No 100K cap on packages, dependencies, or modinfo lines                      |
+| 2   | P4 UTF-8     | LOW      | 247, 239      | `from_utf8().ok()` silently drops invalid UTF-8; should use lossy conversion |
+| 3   | P2 File Size | LOW      | —             | No file size check in this module (caller's responsibility)                  |
+
+## Remediation Priority
+
+1. Add iteration caps (100K) on package/dependency/modinfo line processing
+2. Replace `from_utf8().ok()` with `from_utf8_lossy()` or log warnings for invalid UTF-8

--- a/docs/parser-audit/composer.md
+++ b/docs/parser-audit/composer.md
@@ -1,0 +1,97 @@
+# ADR 0004 Security Audit: composer
+
+**File**: `src/parsers/composer.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `serde_json` for JSON parsing (line 239) and manual field extraction. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_json_file` at line 234 uses `File::open` then `file.read_to_string()` — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+Loops over dependencies (`deps.iter()` at line 253, `for package in packages` at line 320, `for author in authors` at line 621) have no 100K iteration cap. A composer.lock with >100K packages would process all entries.
+
+### String Length
+
+No field value truncation at 10MB. JSON string values are stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open(path)` at line 235 returns an error on failure, handled correctly. No explicit pre-check.
+
+### UTF-8 Encoding
+
+Uses `file.read_to_string()` at line 237 which fails on invalid UTF-8 without lossy fallback. No `String::from_utf8_lossy()` usage.
+
+### JSON/YAML Validity
+
+JSON parse failure at line 239 returns `Err`, handled by returning `default_package_data()` at lines 73-75 and 203-205. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. `full_name` being `None` results in `name: None` (line 135). Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. Uses `unwrap_or_default()` (lines 293, 611) which are acceptable.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)       | Description                                                         |
+| --- | ------------------- | -------- | ------------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 234-238       | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 253, 320, 621 | No 100K iteration cap on dependency/author loops                    |
+| 3   | P2: String Length   | LOW      | various       | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 237           | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add lossy UTF-8 fallback on read failure
+3. Add 100K iteration cap in dependency/author extraction loops
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/conan.md
+++ b/docs/parser-audit/conan.md
@@ -1,0 +1,115 @@
+# ADR 0004 Security Audit: conan
+
+**File**: `src/parsers/conan.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- `conanfile.py` parsed via `ruff_python_parser::parse_module` at line 62 — AST only
+- `extract_conanfile_data` traverses AST nodes at line 97 — no code execution
+- `collect_self_method_calls` recursively traverses AST at line 245 — no execution
+- `conanfile.txt` parsed as plain text at line 336 — no code execution
+- `conan.lock` parsed as JSON via `serde_json::from_str` at line 370 — no code execution
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `fs::read_to_string` at lines 54, 328, 362
+- **GAP**: Entire files read into memory without size limit
+
+### Recursion Depth
+
+- `collect_self_method_calls` at line 245 recurses through AST nodes (if/with/while/for/try/match)
+- **GAP**: No recursion depth limit — a deeply nested AST could cause stack overflow
+- Unlike `python.rs` which has `MAX_SETUP_PY_AST_DEPTH` = 50 and `MAX_SETUP_PY_AST_NODES` = 10,000, this parser has no such limits
+
+### Iteration Count
+
+- `parse_conanfile_txt` iterates lines without cap at line 438
+- `parse_conan_lock` iterates JSON object entries without cap at line 476
+- `extract_conanfile_data` iterates class body statements without cap at line 109
+- **GAP**: No 100,000 item cap on lines, dependencies, or JSON nodes
+
+### String Length
+
+- No 10MB per-field truncation for parsed values (name, version, license)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check
+- `fs::read_to_string` failures handled with `warn!` and default return at lines 56-58, 330-332, 364-366
+
+### UTF-8 Encoding
+
+- `fs::read_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- `parse_module` failure returns `default_package_data` at lines 63-67
+- `serde_json::from_str` failure returns `default_package_data` at lines 371-375
+- PASS — graceful degradation
+
+### Required Fields
+
+- Missing name/version handled with `None` — continues parsing
+- `parse_conan_reference` returns `None` for invalid references at line 390
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- No `.unwrap()` calls in library code
+- All `Option`/`Result` values handled with `?`, `match`, or safe combinators
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s)       | Description                                                          |
+| --- | --------------- | -------- | ------------- | -------------------------------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | 54, 328, 362  | No file size check before `fs::read_to_string`                       |
+| 2   | P2-Recursion    | HIGH     | 245           | `collect_self_method_calls` recurses through AST without depth limit |
+| 3   | P2-Iteration    | LOW      | 109, 438, 476 | No 100K iteration cap on statements, lines, or JSON nodes            |
+| 4   | P2-StringLength | LOW      | N/A           | No 10MB per-field truncation                                         |
+| 5   | P4-UTF8         | LOW      | N/A           | No lossy UTF-8 fallback                                              |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading conanfile.py/conanfile.txt/conan.lock
+2. Add AST node count and recursion depth limits to `collect_self_method_calls` (like python.rs: `MAX_SETUP_PY_AST_DEPTH`=50, `MAX_SETUP_PY_AST_NODES`=10,000)
+3. Add 100K iteration caps on line/entry iteration
+4. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/conan_data.md
+++ b/docs/parser-audit/conan_data.md
@@ -1,0 +1,107 @@
+# ADR 0004 Security Audit: conan_data
+
+**File**: `src/parsers/conan_data.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- YAML parsing via `yaml_serde::from_str` at line 102 — static deserialization
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `fs::read_to_string` at line 89
+- Entire file read into memory without size limit
+
+### Recursion Depth
+
+- No recursive functions in this parser
+- PASS
+
+### Iteration Count
+
+- `parse_conandata_yml` iterates `sources` HashMap entries without cap at line 116
+- **GAP**: No 100,000 item cap on source entries
+
+### String Length
+
+- No 10MB per-field truncation for parsed URL strings, SHA256 hashes, or patch descriptions
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check
+- `fs::read_to_string` failure handled with `warn!` and default return at lines 90-94
+
+### UTF-8 Encoding
+
+- `fs::read_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- YAML parse failure returns `vec![default_package_data()]` at lines 103-107
+- Missing `sources` field returns default at lines 110-112
+- PASS — graceful degradation
+
+### Required Fields
+
+- No name field extracted from conandata.yml (format doesn't include it)
+- Version extracted from HashMap key at line 116 — always present if in sources
+- Empty sources results in default package data at lines 171-173
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- No `.unwrap()` calls in library code
+- All `Option`/`Result` values handled with `match` or `?`
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s) | Description                                    |
+| --- | --------------- | -------- | ------- | ---------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | 89      | No file size check before `fs::read_to_string` |
+| 2   | P2-Iteration    | LOW      | 116     | No 100K iteration cap on source entries        |
+| 3   | P2-StringLength | LOW      | N/A     | No 10MB per-field truncation                   |
+| 4   | P4-UTF8         | LOW      | N/A     | No lossy UTF-8 fallback                        |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading conandata.yml
+2. Add 100K iteration caps on source entries
+3. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/conda.md
+++ b/docs/parser-audit/conda.md
@@ -1,0 +1,97 @@
+# ADR 0004 Security Audit: conda
+
+**File**: `src/parsers/conda.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `yaml_serde::from_str()` for YAML parsing, `regex::Regex` for pattern matching, and `pep508_rs::Requirement` for dependency parsing. The Jinja2 handling at lines 398-458 is strictly text substitution — it finds `{% set %}` patterns and replaces `{{ variable }}` references with string values. No Jinja2 engine or template evaluation is performed. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at lines 149 and 323 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+Loops over requirements (`for req in reqs` at line 228), dependencies (`for dep_value in dependencies` at line 562), Jinja2 variable processing (`for line in content.lines()` at line 401), and YAML dependency iteration have no 100K iteration cap.
+
+### String Length
+
+No field value truncation at 10MB. String values from YAML fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at lines 149, 323 returns an error on failure, handled correctly with `warn!()` and default return.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+YAML parse failure at lines 162-167, 331-336 returns `default_package_data()`. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. Uses `unwrap_or()` and `unwrap_or_default()` where needed.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)       | Description                                                         |
+| --- | ------------------- | -------- | ------------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 149, 323      | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 228, 401, 562 | No 100K iteration cap on requirement/line/dependency loops          |
+| 3   | P2: String Length   | LOW      | various       | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 149, 323      | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in requirement/line/dependency processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/conda_meta_json.md
+++ b/docs/parser-audit/conda_meta_json.md
@@ -1,0 +1,98 @@
+# ADR 0004 Security Audit: conda_meta_json
+
+**File**: `src/parsers/conda_meta_json.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `serde_json::from_str()` for JSON parsing (line 96) and `fs::read_to_string()` for file reading. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 79 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+- `build_conda_file_references` (lines 213-224): `for file in files` iterates over the `files` array from JSON with no cap. A JSON with >100K file entries would process all of them.
+- No 100K iteration cap anywhere.
+
+### String Length
+
+No field value truncation at 10MB. JSON string values (name, version, license, url, etc.) stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 79 returns an error on failure, handled correctly with `warn!()` and default return at lines 80-84.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+JSON parse failure at line 96-101 returns `default_package_data()`. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>` in the `CondaMetaJson` struct. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s) | Description                                                         |
+| --- | ------------------- | -------- | ------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 79      | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 213-224 | No 100K iteration cap on file references loop                       |
+| 3   | P2: String Length   | LOW      | various | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 79      | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in file references loop
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/cpan.md
+++ b/docs/parser-audit/cpan.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: cpan
+
+**File**: `src/parsers/cpan.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `serde_json::from_str()` for JSON parsing (line 248), `yaml_serde::from_str()` for YAML parsing (line 257), and `fs::read_to_string()` for MANIFEST reading (line 199). Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at lines 199, 246, 255 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+- MANIFEST parser (line 207): `content.lines()` with no cap on line count
+- Dependency extraction (lines 543-583, 585-635): iterates over JSON/YAML prereq objects with no cap
+- Party extraction (lines 399-422, 424-447): iterates over author arrays with no cap
+- No 100K iteration cap anywhere
+
+### String Length
+
+No field value truncation at 10MB. String values from JSON/YAML fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` returns an error on failure, handled correctly with `warn!()` and default return at lines 70-73, 137-139, 199-205.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+- JSON parse failure at line 248 returns `Err`, handled at lines 70-73. **PASS**
+- YAML parse failure at line 257 returns `Err`, handled at lines 137-139. **PASS**
+- Non-object root at lines 249-251, 258-260 returns `Err`. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)               | Description                                                         |
+| --- | ------------------- | -------- | --------------------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 199, 246, 255         | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 207, 543-583, 585-635 | No 100K iteration cap on line/dependency/author loops               |
+| 3   | P2: String Length   | LOW      | various               | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 199, 246, 255         | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in line/dependency/author processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/cpan_dist_ini.md
+++ b/docs/parser-audit/cpan_dist_ini.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: cpan_dist_ini
+
+**File**: `src/parsers/cpan_dist_ini.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses custom INI-style text parsing (`parse_ini_structure` at line 124) with `line.split_once('=')` for key-value extraction. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 41 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+- `parse_ini_structure` (line 134): `for line in content.lines()` — no cap on line count
+- `parse_dependencies` (line 212): iterates over sections and fields with no cap
+- No 100K iteration cap anywhere
+
+### String Length
+
+No field value truncation at 10MB. String values from INI fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 41 returns an error on failure, handled correctly at lines 42-51.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. INI format is custom text. **N/A**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)  | Description                                                         |
+| --- | ------------------- | -------- | -------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 41       | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 134, 212 | No 100K iteration cap on line/dependency loops                      |
+| 3   | P2: String Length   | LOW      | various  | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 41       | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in line/dependency processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/cpan_makefile_pl.md
+++ b/docs/parser-audit/cpan_makefile_pl.md
@@ -1,0 +1,120 @@
+# ADR 0004 Security Audit: cpan_makefile_pl
+
+**File**: `src/parsers/cpan_makefile_pl.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses regex-based extraction from Perl source code (`RE_WRITEMAKEFILE`, `RE_SIMPLE_KV`, etc. at lines 33-53) — no Perl interpreter or eval is used. The regex patterns extract key-value pairs from `WriteMakefile()` calls without executing any Perl code. Fully static analysis. This is explicitly noted in the file's documentation (line 13): "Uses regex-based extraction (no Perl code execution for security)".
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+- **Main file**: No `fs::metadata().len()` check before reading `Makefile.PL`. `fs::read_to_string(path)` at line 68 — no size pre-check. **FAIL**
+- **Referenced metadata files**: `read_safe_metadata_file` at line 241 DOES check `fs::metadata(&canonical_candidate).len()` at line 254, and enforces `MAX_METADATA_FILE_SIZE` (1MB, line 56) at line 255. **PASS** for referenced files only.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+- `extract_writemakefile_block` (line 300): iterates over `chars` with no cap — a very long line could iterate millions of characters
+- `parse_hash_fields` (line 335): `RE_SIMPLE_KV.captures_iter(content)` — no cap on number of captures
+- `extract_deps_from_hash` (line 490): `RE_DEP_PAIR.captures_iter(hash_content)` — no cap on dependency count
+- No 100K iteration cap anywhere
+
+### String Length
+
+No field value truncation at 10MB. String values from regex captures stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- **Main file**: No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 68 returns an error, handled at lines 69-78. **PARTIAL**
+- **Referenced files**: `read_safe_metadata_file` at line 241 performs comprehensive path traversal protection:
+  - Rejects absolute paths (line 243)
+  - Canonicalizes base directory (line 247)
+  - Canonicalizes candidate path (line 249)
+  - Verifies candidate starts with base directory (line 250)
+  - Checks `is_file()` and `len() <= MAX_METADATA_FILE_SIZE` (lines 254-255)
+    **PASS** for referenced files — excellent path traversal protection.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback. No lossy conversion for either main file or referenced metadata files.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. Makefile.PL format is custom text parsed via regex. **N/A**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 34: `Regex::new(r"...").unwrap()` in `LazyLock` — compile-time constant, acceptable.
+- Lines 36-37: `Regex::new(r"...").unwrap()` in `LazyLock` — compile-time constant, acceptable.
+- Lines 40-47: `Regex::new(r"...").unwrap()` in `LazyLock` — compile-time constant, acceptable.
+- Line 339: `cap.get(1).expect("group 1 always exists")` — uses `expect()` with justification. Technically `.expect()` is equivalent to `.unwrap()` with a message. Low risk since the regex guarantees the group exists.
+- Line 341: `cap.get(2).or_else(|| cap.get(3)).or_else(|| cap.get(4)).or_else(|| cap.get(5))` — safe fallback chain.
+- Line 367: `cap.get(1).expect("group 1 always exists")` — same pattern.
+- Line 368: `cap.get(2).expect("group 2 always exists")` — same pattern.
+- Line 383: `cap.get(1).expect("group 1 always exists")` — same pattern.
+- Line 494: `cap.get(1).expect("group 1 always exists")` — same pattern.
+
+The `expect()` calls are on regex capture groups after successful match where the group is guaranteed to exist by the regex pattern. Low risk but technically uses panic-on-failure semantics.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle             | Severity | Line(s)                 | Description                                                                        |
+| --- | --------------------- | -------- | ----------------------- | ---------------------------------------------------------------------------------- |
+| 1   | P2: File Size         | HIGH     | 68                      | No `fs::metadata().len()` check before reading Makefile.PL; unbounded file read    |
+| 2   | P2: Iteration Count   | MEDIUM   | 300, 335, 490           | No 100K iteration cap on character/capture/dependency loops                        |
+| 3   | P2: String Length     | LOW      | various                 | No 10MB field value truncation                                                     |
+| 4   | P4: UTF-8 Encoding    | MEDIUM   | 68                      | No lossy UTF-8 fallback on read failure                                            |
+| 5   | Additional: .expect() | LOW      | 339, 367, 368, 383, 494 | `.expect()` on regex capture groups — low risk but uses panic-on-failure semantics |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading Makefile.PL (100MB default limit, similar to `MAX_METADATA_FILE_SIZE` pattern already used for referenced files)
+2. Add 100K iteration cap in character/capture processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning
+5. Consider replacing `.expect()` with safer alternatives or documenting why panic is acceptable

--- a/docs/parser-audit/cran.md
+++ b/docs/parser-audit/cran.md
@@ -1,0 +1,105 @@
+# ADR 0004 Security Audit: cran
+
+**File**: `src/parsers/cran.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses custom DCF (Debian Control File) text parsing (`parse_dcf` at line 181), `regex::Regex` for version constraint parsing (line 290-291), and `packageurl::PackageUrl` for PURL generation. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `File::open(path)` at line 166 then `file.read_to_string()` at line 169 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative.
+
+### Iteration Count
+
+- `parse_dcf` (line 186): `for line in content.lines()` — no cap on line count
+- `parse_dependencies` (line 225): `for dep in deps_str.split(',')` — no cap on dependency count
+- `split_author_entries` (line 337): iterates over characters — no cap
+- No 100K iteration cap anywhere
+
+### String Length
+
+No field value truncation at 10MB. String values from DCF fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open(path)` at line 166 returns an error on failure, handled correctly with `warn!()` and default return at lines 52-56.
+
+### UTF-8 Encoding
+
+Uses `file.read_to_string()` at line 169 which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. DCF format is custom text. **N/A**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 291: `Regex::new(r"...").unwrap()` in `lazy_static!` — compile-time constant, acceptable.
+- Line 300: `captures.get(1).unwrap().as_str()` — this is after `VERSION_CONSTRAINT_RE.captures(dep)` succeeded, so group 1 is guaranteed to exist. However, this is a raw `.unwrap()` without a safer alternative. Low risk but violates the rule.
+- Line 301: `captures.get(2).unwrap().as_str()` — same pattern as above.
+- Line 302: `captures.get(3).unwrap().as_str()` — same pattern as above.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle             | Severity | Line(s)       | Description                                                                                       |
+| --- | --------------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size         | HIGH     | 166-170       | No `fs::metadata().len()` check before reading; unbounded file read                               |
+| 2   | P2: Iteration Count   | MEDIUM   | 186, 225, 337 | No 100K iteration cap on line/dependency/character processing loops                               |
+| 3   | P2: String Length     | LOW      | various       | No 10MB field value truncation                                                                    |
+| 4   | P4: UTF-8 Encoding    | MEDIUM   | 169           | No lossy UTF-8 fallback on read failure                                                           |
+| 5   | Additional: .unwrap() | LOW      | 300-302       | `.unwrap()` on regex capture groups after successful match — low risk but violates no-unwrap rule |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in line/dependency processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Replace `.unwrap()` on regex captures with safer alternatives (e.g., `expect()` with message or `if let`)
+5. Add 10MB field value truncation with warning

--- a/docs/parser-audit/dart.md
+++ b/docs/parser-audit/dart.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: dart
+
+**File**: `src/parsers/dart.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `yaml_serde::from_str()` for YAML parsing (line 119) and manual field extraction. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_yaml_file` at line 117 uses `fs::read_to_string(path)` — no size pre-check.
+
+### Recursion Depth
+
+`format_dependency_mapping` at line 511 has a recursive call at line 526 (`format_dependency_mapping(nested)?`). No depth tracking — a deeply nested YAML mapping could cause deep recursion. However, in practice YAML parsers limit nesting.
+
+### Iteration Count
+
+Loops over dependencies (`dep_map` at lines 454-482, lock packages at lines 301-349, SDKs at lines 262-277) have no 100K iteration cap. The `reachable_lock_packages` function (line 772) uses a BFS queue with no iteration cap.
+
+### String Length
+
+No field value truncation at 10MB. String values from YAML fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 118 returns an error, handled correctly at lines 73-81, 98-106.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+YAML parse failure at line 119 returns `Err`, handled by returning `default_package_data()` at lines 75-81, 99-106. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PASS
+
+`reachable_lock_packages` at line 772 uses a `HashSet<String>` (`reachable`) to track visited nodes. At line 790, `reachable.insert(current.clone())` returns `false` for already-visited nodes, and the `if !reachable.insert(...)` check at line 790 causes the loop to `continue`, breaking cycles. **PASS**
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                   | Description                                                                  |
+| --- | ------------------- | -------- | ------------------------- | ---------------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 118                       | No `fs::metadata().len()` check before reading; unbounded file read          |
+| 2   | P2: Recursion Depth | MEDIUM   | 526                       | `format_dependency_mapping` has unbounded recursion for nested YAML mappings |
+| 3   | P2: Iteration Count | MEDIUM   | 301-349, 454-482, 772-808 | No 100K iteration cap on dependency/BFS loops                                |
+| 4   | P2: String Length   | LOW      | various                   | No 10MB field value truncation                                               |
+| 5   | P4: UTF-8 Encoding  | MEDIUM   | 118                       | No lossy UTF-8 fallback on read failure                                      |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add depth tracking to `format_dependency_mapping` recursion (50-level max)
+3. Add 100K iteration cap in dependency extraction and BFS traversal loops
+4. Add lossy UTF-8 fallback on read failure
+5. Add 10MB field value truncation with warning

--- a/docs/parser-audit/debian.md
+++ b/docs/parser-audit/debian.md
@@ -1,0 +1,123 @@
+# ADR 0004 Security Audit: debian
+
+**File**: `src/parsers/debian.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, subprocess calls, or shell execution found. All parsing is static: RFC 822 text parsing, regex-based dependency parsing, filename parsing, and tar/ar archive reading via Rust libraries.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file_to_string()` at line 176 (and similar calls at lines 208, 236, 884, 1158, 1204, 1316, 1936, 1992) reads the entire file into memory without size validation. The shared utility `read_file_to_string` (src/parsers/utils.rs:33) also lacks a size check.
+
+### Recursion Depth
+
+No recursive functions found. Parsing is iterative. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops over lines/paragraphs/dependencies:
+
+- `parse_dpkg_status()` line 322: iterates all paragraphs without limit
+- `parse_debian_control()` line 294: iterates all paragraphs without limit
+- `parse_dependency_field()` line 741: iterates comma-separated deps without limit
+- `parse_copyright_file()` line 1386: iterates all paragraphs without limit
+- `parse_debian_file_list()` line 1245: iterates all lines without limit
+- `extract_file_references()` line 617 in alpine.rs (not this file, but pattern applies)
+- `parse_copyright_holders()` line 1626: iterates all lines without limit
+
+### String Length
+
+No 10MB truncation on individual field values. Header values from RFC 822 parsing (e.g., dependency strings, description fields) are stored without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: FAIL
+
+### debian.rs Archive Extraction
+
+- `extract_deb_archive()` line 1719: Opens `.deb` ar archives and extracts control.tar.gz/xz and data.tar.gz/xz without:
+  - Uncompressed size limit (1 GB required)
+  - Compression ratio check (100:1 max required)
+  - Path traversal check (`../` patterns)
+  - Decompression limit (1 GB required)
+- `apk_contains_pkginfo()` is in alpine.rs, not here, but `apk_contains_pkginfo` at line 756 in alpine.rs reads tar entries without limits
+- `parse_control_tar_archive()` line 1776: Reads tar entries without size/ratio limits
+- `merge_deb_data_archive()` line 1816: Reads data tar entries without size/ratio limits
+- `control_data` read via `read_to_end()` at line 1739 without size limit
+- `data` read via `read_to_end()` at line 1755 without size limit
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+Uses `read_file_to_string()` which returns an error on missing files (handled at lines 177-181, 208-213, etc.), but does NOT perform an explicit `fs::metadata()` pre-check. Returns default PackageData on error rather than error type.
+
+### UTF-8 Encoding
+
+`read_file_to_string()` at utils.rs:33 uses `file.read_to_string()` which will error on invalid UTF-8 rather than falling back to lossy conversion. In `extract_deb_archive()` line 1732, `std::str::from_utf8()` is used for entry names which returns an error on invalid UTF-8. `String::from_utf8_lossy()` is NOT used as a fallback anywhere.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing in this file. N/A.
+
+### Required Fields
+
+`build_package_from_paragraph()` line 433: `name` is extracted with `?` (returns None if missing, causing the whole package to be skipped). `version` is `Option<String>` — missing version results in `None`, which is acceptable per ADR (populate with None, continue).
+
+### URL Format
+
+URLs are accepted as-is (lines 405-413 for homepage, VCS URLs). PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution; only parsing declared dependencies from metadata.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 739: `.unwrap()` on `Regex::new()` in `parse_dependency_field()` — this is a compile-time-constant regex, so it will never fail at runtime, but it is technically `.unwrap()` in library code.
+- Line 1598: `.unwrap()` on `LineNumber::new(line_no)` in `build_primary_license_detection()` — could theoretically fail if line_no is 0.
+- Line 1038: `.unwrap_or(false)` on is_match — acceptable defensive pattern, not a bare unwrap.
+- Line 1074: `.unwrap_or(false)` — acceptable defensive pattern.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s)                        | Description                                                     |
+| --- | ---------- | -------- | ------------------------------ | --------------------------------------------------------------- |
+| 1   | P2         | HIGH     | 176,208,236,884,1158,1204,1316 | No file size check before reading (100MB limit)                 |
+| 2   | P2         | MEDIUM   | 322,294,741,1245,1386          | No iteration count cap (100K items)                             |
+| 3   | P2         | MEDIUM   | —                              | No string length truncation (10MB per field)                    |
+| 4   | P3         | HIGH     | 1719,1776,1816                 | No archive size/ratio/path-traversal limits on .deb extraction  |
+| 5   | P4         | LOW      | 176,208,etc.                   | No explicit fs::metadata() pre-check; relies on read error      |
+| 6   | P4         | MEDIUM   | 1732,utils.rs:36               | No lossy UTF-8 fallback; invalid UTF-8 causes error not warning |
+| 7   | Additional | LOW      | 739,1598                       | .unwrap() in library code (regex and LineNumber)                |
+
+## Remediation Priority
+
+1. Add archive safety limits to .deb extraction (uncompressed size 1GB, compression ratio 100:1, path traversal blocking)
+2. Add fs::metadata().len() check before read_file_to_string with 100MB limit
+3. Add iteration count caps on paragraph/line/dependency loops
+4. Add String::from_utf8_lossy() fallback for UTF-8 handling
+5. Replace .unwrap() calls with proper error handling

--- a/docs/parser-audit/deno.md
+++ b/docs/parser-audit/deno.md
@@ -1,0 +1,100 @@
+# ADR 0004 Security Audit: deno
+
+**File**: `src/parsers/deno.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `json5::from_str` for JSON/JSONC parsing (static). All processing is data extraction from parsed JSON values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 37 reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `json.get(FIELD_IMPORTS)...into_iter().flatten().filter_map()` at line 124: iterates all import entries without a 100K cap.
+- `extra_data` field insertion loop at line 202: iterates a fixed set of 8 fields, so no concern.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 37 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 37 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`json5::from_str(&content)` at line 45 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing `name` and `version` are handled via `extract_non_empty_string` (line 219) which returns `Option<String>`, resulting in `None` values. PASS.
+
+### URL Format
+
+URLs (import specifiers) are parsed via `Url::parse` at line 258, which validates URL format. Other specifiers are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. All `.unwrap()` usage is in test files (`deno_test.rs`, `deno_lock_test.rs`) which is acceptable per ADR 0004.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s) | Description                                                        |
+| --- | ------------------- | -------- | ------- | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 37      | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 124     | No 100K iteration cap on import entries                            |
+| 3   | P2: String Length   | Low      | Various | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 37      | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 37      | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 37)
+2. Add 100K iteration cap to import entries loop (line 124)
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/deno_lock.md
+++ b/docs/parser-audit/deno_lock.md
@@ -1,0 +1,106 @@
+# ADR 0004 Security Audit: deno_lock
+
+**File**: `src/parsers/deno_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `serde_json` for JSON parsing (static). All processing is data extraction from parsed JSON values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 36 reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `workspace_direct` iteration at line 74: no iteration cap.
+- `jsr_map.keys()` iteration at line 96: no 100K cap on JSR entries.
+- `npm_map.keys()` iteration at line 107: no 100K cap on npm entries.
+- `redirects` iteration at line 118: no iteration cap.
+- `filter_map(Value::as_str)` at line 308: no iteration cap on npm dependency arrays.
+- `filter_map(Value::as_str)` at line 348: no iteration cap on JSR dependency arrays.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 36 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 36 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`serde_json::from_str(&content)` at line 44 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+Lockfile version validation at line 58 checks for version "5" and warns on unsupported versions. PASS.
+
+### Required Fields
+
+Missing package data results in `None` values or skipped entries. PASS.
+
+### URL Format
+
+URLs (redirect targets, remote URLs) are parsed via `Url::parse` at line 466, which validates URL format. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependency graphs.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                    | Description                                                        |
+| --- | ------------------- | -------- | -------------------------- | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 36                         | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 74, 96, 107, 118, 308, 348 | No 100K iteration cap on JSR/npm/redirect/dependency loops         |
+| 3   | P2: String Length   | Low      | Various                    | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 36                         | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 36                         | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 36)
+2. Add 100K iteration cap to JSR/npm/redirect/dependency loops
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/docker.md
+++ b/docs/parser-audit/docker.md
@@ -1,0 +1,97 @@
+# ADR 0004 Security Audit: docker
+
+**File**: `src/parsers/docker.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `subprocess`, `Command::new`, or any code execution mechanism. Uses line-by-line text parsing with manual tokenization (`tokenize_label_arguments` at line 182) and string matching. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Uses `read_file_to_string(path)` (line 43) which delegates to `utils::read_file_to_string` — no size pre-check. A 10GB Dockerfile would be read entirely into memory.
+
+### Recursion Depth
+
+No recursive functions present. Parsing is iterative (`logical_lines` at line 98, `tokenize_label_arguments` at line 182). No recursion depth tracking needed.
+
+### Iteration Count
+
+`logical_lines()` (line 98) iterates over `content.lines()` with no cap. A file with >100K lines would process all of them. `tokenize_label_arguments()` (line 182) iterates over chars with no cap. The `for token in tokens` loop at line 163 has no iteration limit. No 100K cap anywhere.
+
+### String Length
+
+No field value truncation at 10MB. String values from label parsing (e.g., line 169 `labels.insert(key.to_string(), value.trim().to_string())`) are stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Relies on `read_file_to_string(path)` which returns an error on failure (line 43-48). Error handling returns a default `PackageData` — acceptable but no explicit existence check.
+
+### UTF-8 Encoding
+
+Uses `read_file_to_string` from utils which calls `file.read_to_string()`. This will fail on invalid UTF-8 rather than falling back to lossy conversion. No `String::from_utf8()` or `String::from_utf8_lossy()` usage. A binary Dockerfile would cause a parse failure with no lossy fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing in this file. N/A.
+
+### Required Fields
+
+Missing `name` and `version` are handled via `Option<String>` — `None` is populated if OCI labels are absent (lines 67-73). This is correct.
+
+### URL Format
+
+URLs extracted from OCI labels (e.g., `homepage_url`, `vcs_url`) are accepted as-is (lines 68-72). No URL validation. This is ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)      | Description                                                                          |
+| --- | ------------------- | -------- | ------------ | ------------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | HIGH     | 43           | No `fs::metadata().len()` check before reading file; unbounded file read into memory |
+| 2   | P2: Iteration Count | MEDIUM   | 98, 102, 163 | No 100K iteration cap on line/token processing loops                                 |
+| 3   | P2: String Length   | LOW      | 169          | No 10MB field value truncation                                                       |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 43           | No lossy UTF-8 fallback; binary files cause hard failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit) — line 43
+2. Add lossy UTF-8 fallback on read failure — line 43
+3. Add 100K iteration cap in `logical_lines()` and `tokenize_label_arguments()`
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/freebsd.md
+++ b/docs/parser-audit/freebsd.md
@@ -1,0 +1,96 @@
+# ADR 0004 Security Audit: freebsd
+
+**File**: `src/parsers/freebsd.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `yaml_serde::from_str()` for parsing, which is a safe Rust deserializer.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file_to_string()` at line 61 reads entire files without size validation.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops. However, parsing is delegated to `yaml_serde::from_str()` which has its own internal limits. The license normalization loops are bounded by the number of licenses in the manifest. LOW risk.
+
+### String Length
+
+No 10MB truncation on field values from deserialized manifest.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`read_file_to_string()` returns error on missing files (handled at lines 62-66), but no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`read_file_to_string()` errors on invalid UTF-8. No lossy conversion fallback.
+
+### JSON/YAML Validity
+
+`yaml_serde::from_str()` at line 89 returns error on invalid YAML/JSON (handled at lines 90-94). Returns `default_package_data()` on failure. PASS per ADR.
+
+### Required Fields
+
+`parse_freebsd_manifest()` line 97: `name` and `version` are `Option<String>` from deserialized struct. Missing values result in `None`. Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code (excluding test module at line 304).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                     |
+| --- | --------- | -------- | ------- | --------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 61      | No file size check before reading (100MB limit)                 |
+| 2   | P2        | MEDIUM   | —       | No string length truncation (10MB per field)                    |
+| 3   | P4        | LOW      | 61      | No explicit fs::metadata() pre-check                            |
+| 4   | P4        | MEDIUM   | 61      | No lossy UTF-8 fallback; invalid UTF-8 causes error not warning |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before read_file_to_string with 100MB limit
+2. Add String::from_utf8_lossy() fallback for UTF-8 handling
+3. Add string length truncation on deserialized field values

--- a/docs/parser-audit/gitmodules.md
+++ b/docs/parser-audit/gitmodules.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: gitmodules
+
+**File**: `src/parsers/gitmodules.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Simple line-based INI-style parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Uses `read_file_to_string(path)` at line 50 without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative over lines. — PASS
+
+### Iteration Count
+
+- `parse_gitmodules` (line 93): Iterates over `content.lines()` — no 100K cap on lines
+- `submodules.into_iter().map()` (line 63): No 100K cap on number of submodules
+
+### String Length
+
+No field-level truncation at 10MB. URL and path values used as-is.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+INI-style text files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `read_file_to_string` at line 50 returns error on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`read_file_to_string` fails on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+N/A — .gitmodules is INI-format text, not JSON/YAML.
+
+### Required Fields
+
+Missing path/url in submodule section results in empty strings, checked at line 141-143. — PASS
+
+### URL Format
+
+URLs parsed via `parse_github_url`/`parse_gitlab_url` (lines 166-192) with simple string matching. Non-matching URLs result in `None` purl. — PASS
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 138: `.unwrap_or_default()` — safe
+- Line 139: `.unwrap_or_default()` — safe
+- Line 195: `.unwrap_or(path)` — safe
+- No problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 50      | No file size check before reading |
+| 2   | P2 Iteration     | LOW      | 93, 63  | No 100K cap on lines/submodules   |
+| 3   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 4   | P4 UTF-8         | LOW      | 50      | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB
+2. Add iteration cap (100K) on line parsing

--- a/docs/parser-audit/go.md
+++ b/docs/parser-audit/go.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: go
+
+**File**: `src/parsers/go.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses line-by-line text parsing and `serde_json::from_str` for static analysis. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism. All four parsers (GoMod, GoSum, GoWork, Godeps) use static parsing only.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. All four `extract_packages` methods use `fs::read_to_string(path)` without a size check:
+
+- GoModParser: line 46
+- GoSumParser: line 539
+- GoWorkParser: line 656
+- GodepsParser: line 1037
+
+Additionally, `resolve_workspace_use_dependencies` (line 848) reads additional `go.mod` files via `fs::read_to_string` without size checks.
+
+### Recursion Depth
+
+No recursive functions in any parser. All parsing is iterative over `content.lines()`. The `parse_go_tokens` function (line 975) uses a simple loop. **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `parse_go_mod` (line 82): iterates over all lines without cap
+- `parse_go_sum` (line 559): iterates over all lines without cap
+- `parse_go_work` (line 680): iterates over all lines without cap
+- `parse_godeps_json` (line 1086): iterates over all Deps array entries without cap
+- `resolve_workspace_use_dependencies` (line 846): iterates over all use_paths without cap
+
+### String Length
+
+No 10 MB truncation with warning on any field value. Module paths, versions, and other string fields are extracted without size limits throughout all four parsers.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Go parsers do not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. All parsers use `fs::read_to_string(path)` with error handling that returns fallback data. Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. Error is caught and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` (line 1054) for Godeps.json returns an error on invalid JSON, caught at line 1056-1059, returning `default_godeps_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing module name/version handled gracefully throughout. `parse_go_mod` returns `None` for missing namespace/name (lines 72-73). PURL construction handles `None` values. **PASS**.
+
+### URL Format
+
+URLs are constructed programmatically (lines 211-215, 1115-1119), not parsed from user input. Per ADR 0004, accept as-is is correct. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from file declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 573: `raw_version.strip_suffix("/go.mod").unwrap_or(raw_version)` — this is `unwrap_or`, which is a safe fallback, not a panic-risk `unwrap()`. **Actually PASS** — `unwrap_or` is the safe variant.
+
+No unsafe `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                 | Description                                                                     |
+| --- | ------------------- | -------- | ----------------------- | ------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 46, 539, 656, 848, 1037 | No `fs::metadata().len()` check before reading; entire files loaded into memory |
+| 2   | P2: Iteration Count | Low      | 82, 559, 680, 846, 1086 | No 100K iteration cap on line/dependency processing                             |
+| 3   | P2: String Length   | Low      | Multiple                | No 10 MB truncation with warning on string field values                         |
+| 4   | P4: File Exists     | Low      | 46, 539, 656, 1037      | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                 |
+| 5   | P4: UTF-8 Encoding  | Low      | 46, 539, 656, 1037      | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return       |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 46, 539, 656, 848, 1037)
+2. Add iteration count cap (100K) on line/dependency processing loops
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/go_mod_graph.md
+++ b/docs/parser-audit/go_mod_graph.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: go_mod_graph
+
+**File**: `src/parsers/go_mod_graph.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses line-by-line text parsing with `split_whitespace` and `rsplit_once` for static analysis. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `extract_packages` (line 35) uses `fs::read_to_string(path)` without a size check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative over `content.lines()`. **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `parse_go_mod_graph` (line 57): iterates over all lines without cap
+- Lines are inserted into `dependency_map` (BTreeMap) without cap on total entries
+
+### String Length
+
+No 10 MB truncation with warning on any field value. Module paths and versions are extracted without size limits (lines 74-75, 137-148).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Go mod graph parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` (line 35) with error handling that returns `default_package_data()` (lines 37-40). Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. Error is caught and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+N/A — parser does not parse JSON/YAML. Input is plain text.
+
+### Required Fields
+
+Missing module name handled gracefully. `root_module` defaults to `None` (line 54). When name is empty, it's filtered out at line 127: `(!name.is_empty()).then_some(name)`. **PASS**.
+
+### URL Format
+
+URLs are constructed programmatically (lines 112-116), not parsed from user input. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from graph lines only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. Test code uses `.unwrap()` at lines 183, 189, 207, 213 which is acceptable.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)        | Description                                                                    |
+| --- | ------------------- | -------- | -------------- | ------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 35             | No `fs::metadata().len()` check before reading; entire file loaded into memory |
+| 2   | P2: Iteration Count | Low      | 57             | No 100K iteration cap on line processing                                       |
+| 3   | P2: String Length   | Low      | 74-75, 137-148 | No 10 MB truncation with warning on string field values                        |
+| 4   | P4: File Exists     | Low      | 35             | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                |
+| 5   | P4: UTF-8 Encoding  | Low      | 35             | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return      |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 35)
+2. Add iteration count cap (100K) on line processing
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/gradle.md
+++ b/docs/parser-audit/gradle.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: gradle
+
+**File**: `src/parsers/gradle.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses a custom token-based lexer (`lex()` function, line 174) and recursive descent parser. No Groovy engine, no `Command::new`, no `eval()`, no subprocess calls. The lexer is a hand-written ~120-line scanner that produces `Tok` tokens. This is exactly the approach ADR 0004 mandates: static analysis / token-based lexing rather than code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. The file is read entirely into memory at line 81 (`fs::read_to_string(path)`) without a size check. A large file would be fully loaded.
+
+### Recursion Depth
+
+No explicit recursion depth tracking in the parser. The `parse_block` function (line 373) iterates linearly with a `while` loop — not recursive. The `find_matching_paren`/`find_matching_bracket`/`find_matching_brace` functions (lines 796, 816, 1166) are iterative with depth counters. The `lex()` function (line 174) is iterative. No stack overflow risk from recursion. **PASS** for recursion depth.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `lex()` function (line 174): Iterates over all input characters without limit. Token count is unbounded.
+- `parse_block()` (line 373): No cap on number of dependencies extracted
+- `extract_dependencies()` (line 355): No cap on total dependencies across blocks
+- `parse_gradle_version_catalog()` (line 961): No cap on catalog entries
+
+### String Length
+
+No 10 MB truncation with warning on any field value. String tokens from the lexer are stored without size limits. Catalog entry values are not truncated.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Gradle parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` at line 81 with error handling that returns `default_package_data()` on failure (line 85). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files (line 81-86). No explicit lossy conversion path — invalid UTF-8 causes the parser to return default data. No `String::from_utf8()` + warning + lossy conversion pattern.
+
+### JSON/YAML Validity
+
+Returns default `PackageData` on read failure (line 85). The version catalog TOML parser (line 961) returns `None` on read failure. **PASS**.
+
+### Required Fields
+
+Missing name/version are handled as empty strings in `RawDep` and filtered out at line 361 (`if rd.name.is_empty() { continue }`). **PASS**.
+
+### URL Format
+
+URLs accepted as-is. **PASS** per ADR spec.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from build file declarations.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in `#[cfg(test)]` blocks.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                                        |
+| --- | ------------------- | -------- | ------------------ | ---------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 81                 | No `fs::metadata().len()` check before reading; entire file loaded into memory     |
+| 2   | P2: Iteration Count | Medium   | 174, 373, 355, 961 | No 100K iteration cap on lexer, dependency extraction, or catalog parsing          |
+| 3   | P2: String Length   | Low      | 210, 230, 282      | No 10 MB truncation with warning on string token values                            |
+| 4   | P4: File Exists     | Low      | 81                 | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                    |
+| 5   | P4: UTF-8 Encoding  | Low      | 81                 | No lossy UTF-8 conversion path; invalid UTF-8 causes parser to return default data |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 81)
+2. Add iteration count cap (100K) on lexer token production and dependency extraction
+3. Add 10 MB string field truncation with warning on string token values
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for non-UTF-8 files

--- a/docs/parser-audit/gradle_lock.md
+++ b/docs/parser-audit/gradle_lock.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: gradle_lock
+
+**File**: `src/parsers/gradle_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, or code execution. Uses `BufReader` line-by-line text parsing. All parsing is static string splitting.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Opens file via `File::open` at line 46 without size pre-check. `BufReader` provides streaming, but no limit on total lines or file size.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative (`for line in reader.lines()` at line 108). **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on the line-reading loop at line 108. A lockfile with >100K dependency lines would be processed without early termination.
+
+### String Length
+
+No 10 MB truncation with warning on any field value. Group, artifact, version strings from parsed lines (lines 158-160) are stored without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Gradle lockfile parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `File::open` at line 46 with error handling that returns `default_package_data()` on failure (line 50). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`reader.lines()` (line 108) returns `io::Result<String>` which handles UTF-8. Invalid UTF-8 lines produce an `Err` which is logged and skipped (line 111-114). No explicit lossy conversion — invalid lines are silently skipped without a warning about encoding issues.
+
+### JSON/YAML Validity
+
+Returns default `PackageData` on file open failure (line 50). Malformed lines are silently skipped via `parse_dependency_line` returning `None`. **PASS**.
+
+### Required Fields
+
+Missing group/artifact/version (wrong number of colon-separated parts) causes `parse_dependency_line` to return `None` (line 154-156). **PASS**.
+
+### URL Format
+
+N/A — no URL fields parsed.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in `#[cfg(test)]` blocks (lines 267, 271, 275, 279, 290, 294, 298, 309, 313, 336-338, 348-349, 378, 389, 402, 416-417).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s) | Description                                                               |
+| --- | ------------------- | -------- | ------- | ------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 46      | No `fs::metadata().len()` check before reading; 100 MB limit not enforced |
+| 2   | P2: Iteration Count | Low      | 108     | No 100K iteration cap on line-reading loop                                |
+| 3   | P2: String Length   | Low      | 158-160 | No 10 MB truncation with warning on parsed field values                   |
+| 4   | P4: File Exists     | Low      | 46      | Uses `File::open` instead of `fs::metadata()` pre-check                   |
+| 5   | P4: UTF-8 Encoding  | Low      | 108-114 | Invalid UTF-8 lines skipped without explicit lossy conversion warning     |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 46)
+2. Add iteration count cap (100K) on line-reading loop
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before `File::open`
+5. Add explicit lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/gradle_module.md
+++ b/docs/parser-audit/gradle_module.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: gradle_module
+
+**File**: `src/parsers/gradle_module.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, or code execution. Uses `serde_json::from_reader` for JSON parsing. All parsing is static JSON deserialization.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Opens file via `File::open` at line 76 (`extract_packages`) and line 64 (`is_match`) without size pre-check. `serde_json::from_reader` with `BufReader` provides streaming deserialization, but no limit on total JSON size.
+
+### Recursion Depth
+
+No recursive parsing functions. All data extraction is iterative over JSON arrays/objects. `serde_json` handles deeply nested JSON internally, but there's no explicit depth cap in this parser's code. **Partial** — relies on serde_json's internal limits which may not enforce 50 levels.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- Variant processing loop (line 240): `variants.into_iter().flatten().filter_map(Value::as_object)`
+- Dependency extraction loop (line 319): iterates over all dependencies in each variant
+- File reference extraction loop (line 287): iterates over all files in each variant
+- No cap on `seen_dependencies` HashMap or `file_references` Vec
+
+### String Length
+
+No 10 MB truncation with warning on any field value. JSON string values from component fields (lines 121-132) and dependency fields are stored without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Gradle module parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `File::open` at lines 64 and 76. `is_match` silently returns `false` on open failure (line 64-65). `extract_packages` returns `default_package_data()` on open failure (line 79-80). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+JSON parsing via `serde_json::from_reader` handles UTF-8 validation internally. No explicit lossy conversion path — invalid JSON causes parser to return default data (line 87-89). No warning about encoding issues specifically.
+
+### JSON/YAML Validity
+
+Returns default `PackageData` on JSON parse failure (lines 84-89). Checks `is_gradle_module_json` for structural validity (lines 92-94). **PASS**.
+
+### Required Fields
+
+Missing component fields (group, module, version) are handled as `None` (lines 121-132). The `is_gradle_module_json` check requires group, module, and version for `is_match` (lines 108-111) but `extract_packages` handles their absence gracefully. **PASS**.
+
+### URL Format
+
+N/A — no URL fields directly parsed from user input.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in test files (`gradle_module_test.rs`).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)       | Description                                                                |
+| --- | ------------------- | -------- | ------------- | -------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 64, 76        | No `fs::metadata().len()` check before reading; 100 MB limit not enforced  |
+| 2   | P2: Iteration Count | Medium   | 240, 287, 319 | No 100K iteration cap on variant, file reference, or dependency processing |
+| 3   | P2: String Length   | Low      | 121-132       | No 10 MB truncation with warning on JSON string field values               |
+| 4   | P4: File Exists     | Low      | 64, 76        | Uses `File::open` instead of `fs::metadata()` pre-check                    |
+| 5   | P2: Recursion Depth | Low      | N/A           | No explicit JSON nesting depth cap; relies on serde_json internal limits   |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 64, 76)
+2. Add iteration count cap (100K) on variant/dependency/file processing loops
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before `File::open`
+5. Consider adding explicit JSON nesting depth tracking beyond serde_json's defaults

--- a/docs/parser-audit/hackage.md
+++ b/docs/parser-audit/hackage.md
@@ -1,0 +1,112 @@
+# ADR 0004 Security Audit: hackage
+
+**File**: `src/parsers/hackage.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses line-by-line text parsing for `.cabal` and `cabal.project` files, and `yaml_serde::from_str` (line 80) for `stack.yaml`. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism. Regex usage (line 658, 964) is for pattern matching only, not code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. All three `extract_packages` methods use `fs::read_to_string(path)` without a size check:
+
+- HackageCabalParser: line 32
+- HackageCabalProjectParser: line 52
+- HackageStackYamlParser: line 72
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative via `while index < lines.len()` loops (lines 193, 333). `collect_indented_field` (line 742) uses a forward scan, not recursion. **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `parse_cabal_data` (line 333): iterates over all lines without cap
+- `parse_cabal_project` (line 193): iterates over all lines without cap
+- `parse_stack_yaml` (line 299-306): iterates over packages and extra-deps arrays without cap
+- `split_dependency_entries` (line 769): iterates over all characters in dependency strings without cap
+- `parse_hackage_spec_dependency` (line 617): called per dependency entry without cap on total calls
+
+### String Length
+
+No 10 MB truncation with warning on any field value. Fields like `name`, `version`, `description`, `synopsis`, `license` are extracted without size limits (lines 356-362, 826-841).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Hackage parsers do not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. All three parsers use `fs::read_to_string(path)` with error handling that returns `default_package_data()`. Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. Error is caught and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+`yaml_serde::from_str` (line 80) returns an error on invalid YAML, caught at lines 82-85, returning `default_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing `name` and `version` handled as `Option<String>` (lines 356-357). When `None`, fields are populated as `None` in `PackageData`. PURL handles missing values via `build_hackage_purl` (line 919-924). **PASS**.
+
+### URL Format
+
+URLs from `homepage` and `bug-reports` fields are accepted as-is (lines 363-364). Per ADR 0004, accept as-is is correct. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from file declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 534: `parse_hackage_spec_dependency(package_spec, Some("extra-deps"), None, None).unwrap_or(...)` — this is `unwrap_or`, which is a safe fallback. **Not a violation**.
+- Line 811: `line.strip_prefix("-").unwrap_or(line)` — this is `unwrap_or`, which is a safe fallback. **Not a violation**.
+
+No unsafe `.unwrap()` calls in library code. All uses are the safe `unwrap_or` variant. **PASS**.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                                     |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 32, 52, 72         | No `fs::metadata().len()` check before reading; entire files loaded into memory |
+| 2   | P2: Iteration Count | Low      | 193, 333, 299, 769 | No 100K iteration cap on line/dependency processing                             |
+| 3   | P2: String Length   | Low      | 356-362, 826-841   | No 10 MB truncation with warning on string field values                         |
+| 4   | P4: File Exists     | Low      | 32, 52, 72         | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                 |
+| 5   | P4: UTF-8 Encoding  | Low      | 32, 52, 72         | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return       |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 32, 52, 72)
+2. Add iteration count cap (100K) on line/dependency processing loops
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/haxe.md
+++ b/docs/parser-audit/haxe.md
@@ -1,0 +1,95 @@
+# ADR 0004 Security Audit: haxe
+
+**File**: `src/parsers/haxe.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `serde_json` for static JSON deserialization.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_haxelib_json` (line 185) uses `File::open` + `read_to_string` without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative. — PASS
+
+### Iteration Count
+
+- `deps_list` iteration (line 84): Iterates over dependencies HashMap — no 100K cap
+- `json_content.contributors` iteration (line 103): Iterates over contributors — no 100K cap
+- Both are expected to be small in practice
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+JSON files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open` at line 186 fails on missing files, error propagated and handled in `extract_packages` (line 51). — Acceptable.
+
+### UTF-8 Encoding
+
+`file.read_to_string` at line 189 will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` error at line 192 is handled, returns error string caught in `extract_packages` (line 51). — PASS
+
+### Required Fields
+
+Missing name/version from serde deserialization are `Option<String>` with `#[serde(default)]` (lines 166-169). — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 186-190 | No file size check before reading |
+| 2   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 3   | P4 UTF-8         | LOW      | 189     | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB

--- a/docs/parser-audit/helm.md
+++ b/docs/parser-audit/helm.md
@@ -1,0 +1,97 @@
+# ADR 0004 Security Audit: helm
+
+**File**: `src/parsers/helm.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `yaml_serde::from_str()` for YAML parsing (line 61) and manual field extraction. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Uses `fs::read_to_string(path)` at line 59. A very large Chart.yaml/Chart.lock would be read entirely into memory.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative over YAML value structures.
+
+### Iteration Count
+
+Loops over dependencies (`entries.iter()` at lines 126-131, 190-195), maintainers (lines 250-269), and `extract_string_values` (line 285) have no 100K iteration cap. A Chart.yaml with >100K dependencies would process all entries.
+
+### String Length
+
+No field value truncation at 10MB. String values extracted via `extract_string_field` (line 271) are stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` which returns an error (line 59). Error handling returns default `PackageData` — acceptable but no explicit pre-check.
+
+### UTF-8 Encoding
+
+Uses `fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback. No `String::from_utf8_lossy()` usage.
+
+### JSON/YAML Validity
+
+YAML parse failure at line 61 returns `Err`, which is handled by returning `default_package_data()` at lines 28-29 and 48-50. Correct behavior.
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>` — `None` populated when fields absent. Correct.
+
+### URL Format
+
+URLs accepted as-is from YAML fields. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                   | Description                                                         |
+| --- | ------------------- | -------- | ------------------------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 59                        | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 126-131, 190-195, 250-269 | No 100K iteration cap on dependency/maintainer loops                |
+| 3   | P2: String Length   | LOW      | 271                       | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 59                        | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit) — line 59
+2. Add lossy UTF-8 fallback on read failure — line 59
+3. Add 100K iteration cap in dependency extraction loops
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/hex_lock.md
+++ b/docs/parser-audit/hex_lock.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: hex_lock
+
+**File**: `src/parsers/hex_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Implements a custom recursive-descent parser (lines 324-579) for Elixir term syntax. This is static analysis — no `Command::new`, `subprocess`, `eval()`, or code execution. The parser tokenizes and parses character-by-character without executing any code.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `extract_packages` (line 43) uses `fs::read_to_string(path)` without a size check.
+
+### Recursion Depth
+
+**CRITICAL**: `parse_term` (line 333) is mutually recursive with `parse_map`, `parse_tuple`, `parse_list`, and `parse_string`/`parse_atom`/`parse_integer`/`parse_bool`:
+
+- `parse_term()` (line 333) dispatches to `parse_map()`, `parse_tuple()`, `parse_list()`
+- `parse_map()` (line 348) calls `parse_term()` at lines 358 and 365
+- `parse_tuple()` (line 375) calls `parse_term()` at line 384
+- `parse_list()` (line 393) calls `parse_term()` at lines 408 and 411
+
+These form mutual recursion: `parse_term → parse_map/parse_tuple/parse_list → parse_term`. There is **no depth tracking** in the `Parser` struct and **no recursion limit**. A deeply nested input (e.g., `%{%{%{...} => ...} => ...} => ...}`) could cause a stack overflow.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `parse_map` (line 352): loops over map entries without cap
+- `parse_tuple` (line 378): loops over tuple items without cap
+- `parse_list` (line 399): loops over list items without cap
+- `parse_mix_lock` (line 84): iterates over all map entries without cap
+- `term_to_dependency_tuples` (line 222): iterates over all list items without cap
+
+### String Length
+
+No 10 MB truncation with warning on any field value. `parse_string` (line 455) reads string content character-by-character into `out` without size limits. `parse_atom` (line 482) reads atom names without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Hex lock parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` (line 43) with error handling that returns `default_package_data()` (lines 45-48). Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. The custom parser operates on `Vec<char>` derived from a valid UTF-8 string. No explicit `String::from_utf8()` + warning + lossy conversion path for the file read.
+
+### JSON/YAML Validity
+
+N/A — parser uses custom term parsing, not JSON/YAML. Parse failures return `Err(String)` which is caught at line 51-57, returning `default_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing fields in lock entries cause `build_dependency_from_lock_entry` to return `Ok(None)` (lines 103, 107, 113). These are skipped in `parse_mix_lock` (line 85). Package-level name/version default to `None`. **PASS**.
+
+### URL Format
+
+URLs are constructed programmatically (lines 284-297), not parsed from user input. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from lockfile declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                                                                                                |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | P2: Recursion Depth | High     | 333, 348, 375, 393 | Mutual recursion (`parse_term` ↔ `parse_map`/`parse_tuple`/`parse_list`) with no depth limit; deeply nested input can cause stack overflow |
+| 2   | P2: File Size       | Medium   | 43                 | No `fs::metadata().len()` check before reading; entire file loaded into memory                                                             |
+| 3   | P2: Iteration Count | Low      | 352, 378, 399, 84  | No 100K iteration cap on map/tuple/list entry processing                                                                                   |
+| 4   | P2: String Length   | Low      | 455, 482           | No 10 MB truncation with warning on string/atom values                                                                                     |
+| 5   | P4: File Exists     | Low      | 43                 | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                                                                            |
+| 6   | P4: UTF-8 Encoding  | Low      | 43                 | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return                                                                  |
+
+## Remediation Priority
+
+1. **CRITICAL**: Add recursion depth tracking to `Parser` struct with 50-level limit; check depth on each `parse_term` entry (lines 333, 348, 375, 393)
+2. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 43)
+3. Add iteration count cap (100K) on map/tuple/list entry processing loops
+4. Add 10 MB string/atom field truncation with warning
+5. Add `fs::metadata()` pre-check before file read
+6. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/julia.md
+++ b/docs/parser-audit/julia.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: julia
+
+**File**: `src/parsers/julia.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses `toml::from_str()` for TOML parsing (line 199) and manual field extraction. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_julia_toml` at line 194 uses `File::open` then `file.read_to_string()` — no size pre-check.
+
+### Recursion Depth
+
+`toml_to_json` at line 451 has recursive calls for `Value::Array` (line 457) and `Value::Table` (line 458). No depth tracking — a deeply nested TOML table could cause deep recursion. However, the `toml` crate itself limits nesting.
+
+### Iteration Count
+
+Loops over dependencies (`deps_table` at line 262, `dep_entries` at line 324, `authors` at line 232) have no 100K iteration cap. `extract_manifest_packages` iterates over all deps entries (line 318) without cap.
+
+### String Length
+
+No field value truncation at 10MB. TOML string values stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open(path)` at line 195 returns an error, handled correctly at lines 55-58, 177-179.
+
+### UTF-8 Encoding
+
+Uses `file.read_to_string()` at line 197 which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+TOML parse failure at line 199 returns `Err`, handled by returning `default_project_package_data()` at lines 56-58 or empty vec at line 179. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                         |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 195-198            | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Recursion Depth | MEDIUM   | 451-466            | `toml_to_json` has unbounded recursion for nested TOML values       |
+| 3   | P2: Iteration Count | MEDIUM   | 232, 262, 318, 324 | No 100K iteration cap on dependency/author loops                    |
+| 4   | P2: String Length   | LOW      | various            | No 10MB field value truncation                                      |
+| 5   | P4: UTF-8 Encoding  | MEDIUM   | 197                | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add depth tracking to `toml_to_json` recursion (50-level max)
+3. Add 100K iteration cap in dependency extraction loops
+4. Add lossy UTF-8 fallback on read failure
+5. Add 10MB field value truncation with warning

--- a/docs/parser-audit/license_normalization.md
+++ b/docs/parser-audit/license_normalization.md
@@ -1,0 +1,102 @@
+# ADR 0004 Security Audit: license_normalization
+
+**File**: `src/parsers/license_normalization.rs`
+**Date**: 2026-04-14
+**Status**: NON-COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `LicenseDetectionEngine` for static license expression parsing and normalization.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+N/A — This module does not read files directly. It operates on already-parsed strings.
+
+### Recursion Depth
+
+**CRITICAL**: `normalize_expression_ast` (line 426) is recursive with **NO depth tracking**. It recurses on `LicenseExpression::And`, `Or`, and `With` variants (lines 442-486), calling itself for both `left` and `right` sub-expressions. A deeply nested license expression like `((((A AND B) AND C) AND D)...))` with depth >50 would cause stack overflow.
+
+`collect_boolean_chain` (line 581) is also recursive (lines 589-590) without depth tracking, though this is on the already-processed AST and follows the same tree structure.
+
+### Iteration Count
+
+- `combine_license_expressions` calls into external functions — no caps visible here
+- `collect_reference_strings` (line 404): Iterates over JSON arrays — no 100K cap
+- `collect_declared_license_reference_filenames` (line 387): Iterates over extra_data — no 100K cap
+
+### String Length
+
+No field-level truncation at 10MB. License expressions are used as-is.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not applicable — this module processes license strings, not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+N/A — This module does not read files directly.
+
+### UTF-8 Encoding
+
+N/A — Operates on Rust `String` values which are already valid UTF-8.
+
+### JSON/YAML Validity
+
+N/A — Does not parse JSON/YAML directly. Uses `serde_json::Value` for extra_data access.
+
+### Required Fields
+
+Missing/empty license statements return `None` from `normalize_spdx_expression` (line 147-149) and `empty_declared_license_data` (line 76). — PASS
+
+### URL Format
+
+N/A — No URL handling.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution. License expression trees are data structures, not dependency graphs.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 508: `.unwrap_or_else(|| normalized_key.to_string())` — safe fallback
+- Line 521: `.unwrap_or(canonical_spdx_key)` — safe fallback
+- Line 535: `.unwrap_or_else(|| format!("LicenseRef-scancode-{}", ...))` — safe fallback
+- No truly problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle    | Severity | Line(s) | Description                                                                                                          |
+| --- | ------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2 Recursion | HIGH     | 426-486 | `normalize_expression_ast` recursive without depth tracking — deeply nested license expressions cause stack overflow |
+| 2   | P2 Recursion | MEDIUM   | 581-590 | `collect_boolean_chain` recursive without depth tracking                                                             |
+| 3   | P2 Iteration | LOW      | 404     | No 100K cap on reference string iteration                                                                            |
+
+## Remediation Priority
+
+1. Add depth parameter (max 50) to `normalize_expression_ast`, return `None` on overflow
+2. Add depth parameter to `collect_boolean_chain`, or convert to iterative approach
+3. Add iteration cap (100K) on reference string collection

--- a/docs/parser-audit/maven.md
+++ b/docs/parser-audit/maven.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: maven
+
+**File**: `src/parsers/maven.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism found. Uses `quick-xml` for XML parsing (static AST-based), and string-based property resolution via custom byte-level parser. All parsing is static.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. The pom.xml path opens the file via `File::open` at line 748 without size pre-check. The pom.properties path uses `read_file_to_string` at line 2021 without size pre-check. The MANIFEST.MF path uses `read_file_to_string` at line 2106 without size pre-check.
+
+### Recursion Depth
+
+The `PropertyResolver` enforces `max_depth: 10` (line 94) for property resolution. The `resolve_key` method checks `depth >= self.max_depth` at line 106 and returns `None` with a warning. The `resolve_text` method checks depth at line 158. This is well below the 50-level ADR requirement and is appropriate for property resolution. **PASS** for property resolution specifically.
+
+However, the main XML parsing loop at line 840 (`loop { match reader.read_event_into(&mut buf)`) has no recursion depth tracking. While quick-xml is a streaming parser and doesn't recurse, deeply nested XML elements could cause the `current_element` stack (line 765) to grow without bound.
+
+### Iteration Count
+
+No iteration count cap on:
+
+- XML event loop (line 840): No 100K item limit on parsed elements, dependencies, or properties
+- `dependency_data` accumulation (line 768)
+- `licenses` accumulation (line 771)
+- `properties` HashMap (line 832)
+- OSGi dependency parsing: `parse_osgi_package_list` (line 2309) and `parse_osgi_bundle_list` (line 2354) iterate without caps
+
+### String Length
+
+No 10 MB truncation with warning on any field value. XML text content, property values, and other string fields are stored without size limits. The `PropertyResolver` has `max_output_len: 100_000` (line 95) for property resolution output, but this only applies within the resolver, not to the raw XML text content.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Maven parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `File::open` at line 748 and returns a default `PackageData` on failure (line 752). The `read_file_to_string` helper used for pom.properties and MANIFEST.MF handles errors similarly. **Partial** — returns error rather than panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+XML text decoding uses `e.decode().unwrap_or_default()` (line 935, 1268), which silently replaces invalid bytes. The `PropertyResolver` uses `String::from_utf8(output).unwrap_or_else(|_| text.to_string())` (line 218) as a lossy fallback. No explicit `String::from_utf8()` + log warning + lossy conversion pattern as specified.
+
+### JSON/YAML Validity
+
+Returns default `PackageData` on parse failure for pom.xml (line 1424 error path), pom.properties (line 2024), and MANIFEST.MF (line 2109). **PASS**.
+
+### Required Fields
+
+Missing name/version are left as `None` and the parser continues. For pom.xml, if namespace is missing it falls back to parent_group_id (line 1540). **PASS**.
+
+### URL Format
+
+URLs (homepage_url, scm_url, etc.) are accepted as-is without validation. **PASS** per ADR spec.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PASS
+
+The `PropertyResolver` explicitly tracks circular references:
+
+- `resolving_set: HashSet<String>` (line 78) for O(1) cycle detection
+- `resolving_stack: Vec<String>` (line 79) for error reporting
+- `resolve_key` checks `resolving_set.contains(key)` at line 115 and warns + returns `None` on cycle
+- Cache (`HashMap<String, String>`) at line 102 prevents redundant work
+
+Note: This is property reference cycle detection, not dependency graph cycle detection. ADR 0004 Principle 5 applies to dependency resolution, which this parser doesn't perform.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All instances are in `#[cfg(test)]` blocks (lines 2467, 2482, 2490, 2507, 2526, 2551, 2567, 2602, 2638, 2655, 2665, 2674, 2691, 2697, 2712, 2745, 2755, 2766, 2768, 2790, 2792, 2816, 2818).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)         | Description                                                                            |
+| --- | ------------------- | -------- | --------------- | -------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 748, 2021, 2106 | No `fs::metadata().len()` check before reading file; 100 MB limit not enforced         |
+| 2   | P2: Iteration Count | Medium   | 840, 2309, 2354 | No 100K iteration cap on XML event loop or OSGi dependency list parsing                |
+| 3   | P2: String Length   | Low      | 935, 1268       | No 10 MB truncation with warning on XML text field values                              |
+| 4   | P4: File Exists     | Low      | 748             | Uses `File::open` instead of `fs::metadata()` pre-check as specified                   |
+| 5   | P4: UTF-8 Encoding  | Low      | 935, 1268       | Uses `unwrap_or_default()` instead of `String::from_utf8()` + warning + lossy fallback |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 748, 2021, 2106)
+2. Add iteration count cap (100K) on XML event loop and dependency accumulation
+3. Add 10 MB string field truncation with warning on parsed text content
+4. Add `fs::metadata()` pre-check before `File::open`
+5. Replace `unwrap_or_default()` on text decode with explicit UTF-8 validation + warning + lossy conversion

--- a/docs/parser-audit/meson.md
+++ b/docs/parser-audit/meson.md
@@ -1,0 +1,117 @@
+# ADR 0004 Security Audit: meson
+
+**File**: `src/parsers/meson.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Implements a custom tokenizer (line 455) and recursive-descent parser (lines 551-672) for Meson build syntax. This is static analysis — no `Command::new`, `subprocess`, `eval()`, or code execution. The parser tokenizes and parses without executing any Meson code.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `extract_packages` (line 24) uses `fs::read_to_string(path)` without a size check. Additionally, the parser materializes the entire input as `Vec<char>` in `strip_comments` (line 298) and `tokenize` (line 456), doubling memory usage.
+
+### Recursion Depth
+
+**CRITICAL**: `parse_expr` (line 561) is mutually recursive with `parse_array` and `parse_identifier_or_call`:
+
+- `parse_expr()` (line 561) dispatches to `parse_array()` (line 571) and `parse_identifier_or_call()` (line 572)
+- `parse_array()` (line 578) calls `parse_expr()` at line 582
+- `parse_identifier_or_call()` (line 593) calls `parse_expr()` at lines 617 and 620
+
+These form mutual recursion: `parse_expr → parse_array/parse_identifier_or_call → parse_expr`. There is **no depth tracking** in the `Parser` struct and **no recursion limit**. A deeply nested input (e.g., `[[[[[...]]]]]`) could cause a stack overflow.
+
+Additionally, `parse_statement` (line 435) calls `parse_expr` at lines 443 and 450.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `strip_comments` (line 297): iterates over all characters without cap
+- `split_statements` (line 348): iterates over all characters without cap
+- `tokenize` (line 455): iterates over all characters without cap
+- `parse_meson_build` (line 48): iterates over all statements without cap
+- `parse_array` (line 580): iterates over all array elements without cap
+- `parse_identifier_or_call` (line 610): iterates over all call arguments without cap
+- `extract_dependencies_from_call` (line 177): processes dependency names without cap
+
+### String Length
+
+No 10 MB truncation with warning on any field value. `tokenize` extracts string tokens (lines 496-520) without size limits. The `strip_comments` output string (line 299) and `split_statements` output strings have no size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Meson parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` (line 24) with error handling that returns `default_package_data()` (lines 26-29). Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. Error is caught and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+N/A — parser uses custom Meson syntax parsing, not JSON/YAML. Parse failures return `Err(String)` which is caught at line 32-35, returning `default_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing project name causes `apply_project_call` to return early (line 113). Package-level `name` defaults to `None`. PURL is only generated when name is present (lines 83-86). **PASS**.
+
+### URL Format
+
+N/A — no URL fields directly parsed from user input.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from build file declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                     | Description                                                                                                                                  |
+| --- | ------------------- | -------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: Recursion Depth | High     | 561, 578, 593               | Mutual recursion (`parse_expr` ↔ `parse_array`/`parse_identifier_or_call`) with no depth limit; deeply nested input can cause stack overflow |
+| 2   | P2: File Size       | Medium   | 24, 298, 456                | No `fs::metadata().len()` check before reading; entire file loaded into memory and materialized as `Vec<char>`                               |
+| 3   | P2: Iteration Count | Low      | 297, 348, 455, 48, 580, 610 | No 100K iteration cap on character/statement/argument processing                                                                             |
+| 4   | P2: String Length   | Low      | 496-520                     | No 10 MB truncation with warning on string token values                                                                                      |
+| 5   | P4: File Exists     | Low      | 24                          | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                                                                              |
+| 6   | P4: UTF-8 Encoding  | Low      | 24                          | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return                                                                    |
+
+## Remediation Priority
+
+1. **CRITICAL**: Add recursion depth tracking to `Parser` struct with 50-level limit; check depth on each `parse_expr` entry (lines 561, 578, 593)
+2. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 24)
+3. Add iteration count cap (100K) on character/statement/argument processing loops
+4. Add 10 MB string token truncation with warning
+5. Add `fs::metadata()` pre-check before file read
+6. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/metadata.md
+++ b/docs/parser-audit/metadata.md
@@ -1,0 +1,74 @@
+# ADR 0004 Security Audit: metadata
+
+**File**: `src/parsers/metadata.rs`
+**Date**: 2026-04-14
+**Status**: COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. This module defines `ParserMetadata` struct and `register_parser!` macro for documentation generation only.
+
+## Principle 2: DoS Protection
+
+**Status**: PASS
+
+### File Size
+
+No files are read. — PASS
+
+### Recursion Depth
+
+No functions with logic. — PASS
+
+### Iteration Count
+
+No iteration loops. — PASS
+
+### String Length
+
+No string processing. — PASS
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No file operations.
+
+## Principle 4: Input Validation
+
+**Status**: N/A
+
+No input processing.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description |
+| --- | --------- | -------- | ------- | ----------- |
+
+No findings. This module is purely a data structure definition and macro for documentation generation.
+
+## Remediation Priority
+
+None required.

--- a/docs/parser-audit/microsoft_update_manifest.md
+++ b/docs/parser-audit/microsoft_update_manifest.md
@@ -1,0 +1,96 @@
+# ADR 0004 Security Audit: microsoft_update_manifest
+
+**File**: `src/parsers/microsoft_update_manifest.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `quick_xml` for streaming XML parsing — static analysis only.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` at line 36 without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. `quick_xml::Reader` is used iteratively with a loop (line 64). — PASS
+
+### Iteration Count
+
+- XML parsing loop (line 64-105): No iteration cap on XML events processed. A file with millions of XML events would be fully processed.
+- `e.attributes().filter_map(|a| a.ok())` (lines 68, 79): No cap on number of attributes
+
+### String Length
+
+No field-level truncation at 10MB. XML attribute values used as-is.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+XML files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 36 fails on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap. XML attribute values are decoded via `String::from_utf8().ok()` (lines 70-71, 82-86) which silently drops invalid UTF-8 rather than using lossy conversion.
+
+### JSON/YAML Validity
+
+N/A — XML format. XML parse errors (line 94-101) are handled by logging warning and breaking. — PASS
+
+### Required Fields
+
+Missing name/version result in `None` values. — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s)      | Description                                                                                  |
+| --- | ---------------- | -------- | ------------ | -------------------------------------------------------------------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 36           | No file size check before reading                                                            |
+| 2   | P2 Iteration     | LOW      | 64           | No iteration cap on XML events                                                               |
+| 3   | P2 String Length | LOW      | —            | No field-level 10MB truncation                                                               |
+| 4   | P4 UTF-8         | LOW      | 70-71, 82-86 | `String::from_utf8().ok()` silently drops invalid UTF-8; should use lossy conversion per ADR |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB
+2. Replace `String::from_utf8().ok()` with `String::from_utf8_lossy()` for XML attribute values

--- a/docs/parser-audit/misc.md
+++ b/docs/parser-audit/misc.md
@@ -1,0 +1,92 @@
+# ADR 0004 Security Audit: misc
+
+**File**: `src/parsers/misc.rs`
+**Date**: 2026-04-14
+**Status**: COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. All recognizers use simple file extension/path matching and optional magic byte detection via `magic::is_squashfs`, `magic::is_zip`, `magic::is_nsis_installer`.
+
+## Principle 2: DoS Protection
+
+**Status**: PASS
+
+### File Size
+
+No files are read. All recognizers return minimal `PackageData` with only `package_type` and `datasource_id` set (line 45-49). The `extract_packages` function discards the `path` parameter entirely (line 44: `let _ = path;`). — PASS (no file reading = no DoS via file size).
+
+### Recursion Depth
+
+No recursive functions. — PASS
+
+### Iteration Count
+
+No iteration loops. — PASS
+
+### String Length
+
+No string fields are populated. — PASS
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archives are extracted. Recognizers only identify file types.
+
+## Principle 4: Input Validation
+
+**Status**: PASS
+
+### File Exists
+
+No file reading occurs. File existence is not checked because it's not needed — the `is_match` function only inspects the path string. — PASS
+
+### UTF-8 Encoding
+
+No file content is read. — PASS
+
+### JSON/YAML Validity
+
+N/A — No parsing occurs.
+
+### Required Fields
+
+Minimal `PackageData` is returned with `package_type` and `datasource_id`. — PASS (by design)
+
+### URL Format
+
+N/A — No URLs are handled.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in this module.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description |
+| --- | --------- | -------- | ------- | ----------- |
+
+No findings. This module is data-only — it identifies file types by extension/path/magic bytes and returns minimal metadata without reading file contents.
+
+## Remediation Priority
+
+None required.

--- a/docs/parser-audit/mod.md
+++ b/docs/parser-audit/mod.md
@@ -1,0 +1,96 @@
+# ADR 0004 Security Audit: mod
+
+**File**: `src/parsers/mod.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. The module defines parser infrastructure, trait, and dispatch macros.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No direct file reading. `capture_parser_diagnostics` (line 346) wraps parser `extract` closures — file reading happens in the individual parsers, not here. — N/A
+
+### Recursion Depth
+
+No recursive functions. — PASS
+
+### Iteration Count
+
+- `packages.into_iter().map(...)` (line 364-369): No cap on number of packages returned by a parser
+- `register_package_handlers!` macro generates iteration over all registered parsers (line 599-618) — this is a fixed, compile-time list
+
+### String Length
+
+No string processing beyond diagnostic messages. — PASS
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No file operations.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No file existence checks in this module. Delegated to individual parsers. — N/A
+
+### UTF-8 Encoding
+
+N/A — No file reading.
+
+### JSON/YAML Validity
+
+N/A — No parsing.
+
+### Required Fields
+
+`finalize_package_declared_license_references` (line 284) is called on every extracted package to ensure license references are properly attached. This is post-processing, not validation. — PASS
+
+### URL Format
+
+N/A — No URL handling.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 360: `stack.borrow_mut().pop().unwrap_or_default()` — safe, uses `unwrap_or_default()`
+- Line 483: `.unwrap_or_default()` — safe, used for `extract_first_package` fallback
+- No truly problematic `.unwrap()` calls.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle    | Severity | Line(s) | Description                                                                         |
+| --- | ------------ | -------- | ------- | ----------------------------------------------------------------------------------- |
+| 1   | P2 Iteration | LOW      | 364     | No cap on number of packages returned by a parser (delegated to individual parsers) |
+
+No significant findings. This module is infrastructure code that delegates to individual parsers.
+
+## Remediation Priority
+
+None required. Individual parsers are responsible for their own DoS protections.

--- a/docs/parser-audit/nix.md
+++ b/docs/parser-audit/nix.md
@@ -1,0 +1,126 @@
+# ADR 0004 Security Audit: nix
+
+**File**: `src/parsers/nix.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. The Nix parser implements a custom lexer/tokenizer and recursive-descent parser (lines 144-773) for static AST analysis. The `try_follow_local_nix_application` function (line 1541) reads local `.nix` files via `fs::read_to_string` and parses them statically — no execution occurs.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Files are read directly via `fs::read_to_string` at lines 23, 59, 84, and 1560 without size pre-check. A 5GB file would be fully loaded into memory.
+
+### Recursion Depth
+
+The parser has multiple recursive functions with varying depth limits:
+
+- `extract_default_nix_package` (line 1424): depth limit of 2 (line 1430) — PASS
+- `extract_flake_compat_package_from_expr` (line 1585): depth limit of 2 (line 1591) — PASS
+- `resolve_flake_compat_source_root` (line 1668): depth limit of 8 (line 1674) — PASS
+- `resolve_symbol` (line 1336): depth limit of 8 (line 1341) — PASS
+- `resolve_select` (line 1360): depth limit of 8 (line 1366) — PASS
+- **`parse_expr`** (line 450): **NO depth limit** — calls `parse_term` which calls `parse_expr` recursively for lambda bodies, `with` expressions, and parenthesized expressions
+- **`parse_let_in_expr`** (line 529): **NO depth limit** — recursive via `parse_expr`
+- **`parse_attrset`** (line 557): **NO depth limit** — recursive via `parse_expr`
+- **`parse_list`** (line 622): **NO depth limit** — recursive via `parse_expr`
+- **`expr_to_dependency_symbols_with_scopes`** (line 1117): **NO depth limit** — recursive on `Expr::Symbol` via `resolve_symbol` then back to itself
+- **`expr_as_symbol_with_scopes`** (line 1192): **NO depth limit** — recursive on resolved symbols
+- **`expr_as_bool_with_scopes`** (line 1215): **NO depth limit** — recursive
+- **`expr_as_string_with_scopes`** (line 1230): **NO depth limit** — recursive
+- **`list_items_with_scopes`** (line 1167): **NO depth limit** — recursive
+- **`interpolate_string`** (line 1390): **NO depth limit** on `${...}` interpolation chains
+- **`root_attrset_with_scopes`** (line 1315): **NO depth limit** — recursive on `Expr::Let`
+- **`find_attr`** (line 1261): **NO depth limit** — recursive on nested `AttrSet`
+
+### Iteration Count
+
+- `Lexer::tokenize` (line 157): No cap on number of tokens produced from input
+- `parse_let_in_expr` (line 529): No cap on number of bindings
+- `parse_attrset` (line 557): No cap on number of entries
+- `parse_list` (line 622): No cap on number of items
+- `parse_inherit_entries` (line 591): No cap on number of entries
+- `root_inputs.iter()` (line 836): No 100K cap on dependencies
+- `build_list_dependencies` (line 1084): No 100K cap on dependencies
+
+### String Length
+
+No field-level truncation at 10MB. String values extracted from the AST are used as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Nix files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` is called directly (lines 23, 59, 84). Errors are handled gracefully via `match` and logged with `warn!`, returning default `PackageData`. — Acceptable fallback.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8 content, which is handled by returning default data. However, there is no lossy conversion fallback (no `String::from_utf8_lossy`). — Minor gap.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` errors at line 31 are handled by returning `default_flake_lock_package_data()`. — PASS
+
+### Required Fields
+
+Missing name/version fields result in `None` values with `fallback_name(path)` as fallback (lines 782-783, 1530-1531). — PASS
+
+### URL Format
+
+URLs are accepted as-is without validation. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular detection. The Nix parser extracts declared dependencies, not resolved dependency graphs.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 255: `terms.pop().expect("single term")` — `.expect()` in library code
+- Line 475: `terms.pop().expect("single term")` — `.expect()` in library code
+- Line 750: `extract_local_flake_compat_src_value(content).unwrap_or("./.".to_string())` — `.unwrap_or()` is safe, not a concern
+- Line 754: `conda_name_from_locator` uses `.unwrap_or(file_name)` — safe
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s)                                  | Description                                                                                                                |
+| --- | ---------------- | -------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2 Recursion     | HIGH     | 450, 529, 557, 622                       | No depth tracking in Nix expression parser — deeply nested input causes stack overflow                                     |
+| 2   | P2 Recursion     | MEDIUM   | 1117, 1192, 1215, 1230, 1167, 1261, 1315 | Recursive AST evaluation functions have no depth limit (resolve_symbol/resolve_select are capped at 8, but callers aren't) |
+| 3   | P2 File Size     | MEDIUM   | 23, 59, 84, 1560                         | No file size check before reading — oversized files loaded entirely into memory                                            |
+| 4   | P2 Iteration     | MEDIUM   | 157, 529, 557, 622, 836                  | No iteration caps on tokens, bindings, entries, or dependencies                                                            |
+| 5   | P2 String Length | LOW      | —                                        | No field-level 10MB truncation                                                                                             |
+| 6   | P4 UTF-8         | LOW      | 23, 59, 84                               | No lossy UTF-8 fallback on non-UTF-8 content                                                                               |
+| 7   | Additional       | LOW      | 475                                      | `.expect("single term")` in library code                                                                                   |
+
+## Remediation Priority
+
+1. Add recursion depth tracking (max 50) to `parse_expr`/`parse_term` and all recursive AST evaluation functions
+2. Add `fs::metadata().len()` check before reading files, reject >100MB
+3. Add iteration caps (100K) on token count, binding count, dependency count

--- a/docs/parser-audit/npm.md
+++ b/docs/parser-audit/npm.md
@@ -1,0 +1,110 @@
+# ADR 0004 Security Audit: npm
+
+**File**: `src/parsers/npm.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, subprocess calls, or dynamic code execution found. Uses `serde_json` for parsing (AST-level), regex-free field name extraction via character iteration (`extract_field_name` at line 254). All parsing is static.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 234 reads entire file without size validation. A 100 MB+ file would be loaded into memory without warning.
+
+### Recursion Depth
+
+No recursive functions in this parser. `extract_field_name` (line 254) uses a simple loop. No recursion depth concern.
+
+### Iteration Count
+
+- `content.lines().enumerate()` at line 242: iterates all lines without a 100K cap. A malicious file with >100K lines would iterate without limit.
+- `deps.iter()` at line 715: iterates dependency entries without iteration cap.
+- `bundled_array.iter()` at line 825: no iteration cap.
+- `licenses.iter()` at line 328: no iteration cap.
+- `keywords` iteration at line 927: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON (e.g., `json.get(field).and_then(|v| v.as_str())`) are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 234 will fail with an error if the file doesn't exist, but the ADR requires an explicit `fs::metadata()` check before reading. The error is handled gracefully via `map_err` and returns `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 234 will fail on invalid UTF-8, returning an error. There is no `String::from_utf8()` with lossy fallback — the parser simply fails and returns default data. No warning about encoding issues is logged for partial recovery.
+
+### JSON/YAML Validity
+
+`serde_json::from_str(&content)` at line 238 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing `name` and `version` are handled via `extract_non_empty_string` (line 628) which returns `Option<String>`, resulting in `None` values. Fields are populated with `None` and parsing continues. PASS.
+
+### URL Format
+
+URLs (homepage, repository, download URLs) are accepted as-is without aggressive parsing. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. Only `.unwrap_or()`, `.unwrap_or_default()`, and `.unwrap_or_else()` are used (lines 207, 293, 368, 376, 939, 1026).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                 | Description                                                        |
+| --- | ------------------- | -------- | ----------------------- | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 234                     | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 242, 715, 825, 328, 927 | No 100K iteration cap on line/entry/dependency loops               |
+| 3   | P2: String Length   | Low      | Various                 | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 234                     | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 234                     | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 234)
+2. Add 100K iteration cap to `content.lines()` loop (line 242) and dependency iteration loops
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence before reading
+5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/npm_lock.md
+++ b/docs/parser-audit/npm_lock.md
@@ -1,0 +1,107 @@
+# ADR 0004 Security Audit: npm_lock
+
+**File**: `src/parsers/npm_lock.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `serde_json` for JSON parsing (static). All processing is data extraction from parsed JSON values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 69 reads entire file without size validation.
+
+### Recursion Depth
+
+`parse_dependencies_v1_with_depth` at line 365 is recursive and tracks `depth` parameter, but **no maximum depth limit is enforced**. The function recurses at line 397 with `depth + 1` but never checks if `depth > 50`. A deeply nested v1 lockfile could cause stack overflow.
+
+### Iteration Count
+
+- `packages` iteration at line 160: iterates all package entries without a 100K cap.
+- `dependencies_obj` iteration at line 371: iterates all dependencies without cap.
+- `root_deps_obj.keys()` at lines 143, 148: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. JSON field values are extracted as-is without length checks (e.g., `version.as_str()` at line 183, `resolved` at line 198).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 69 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 69 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without warning about encoding.
+
+### JSON/YAML Validity
+
+`serde_json::from_str(&content)` at line 77 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing `name` and `version` are handled via `.unwrap_or("")` (lines 93, 100) or `Option<String>` (lines 183). The `normalize_root_package_metadata` function (line 483) converts empty strings to `None`. PASS.
+
+### URL Format
+
+URLs (resolved URLs) are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependency graphs (v2+ is flat structure; v1 is nested but within the lockfile's own tree, not a resolution engine).
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. All uses are `.unwrap_or()`, `.unwrap_or_default()`, or `.unwrap_or_else()`.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)  | Description                                                                            |
+| --- | ------------------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| 1   | P2: Recursion Depth | High     | 365, 397 | Recursive `parse_dependencies_v1_with_depth` has no depth limit (50-level cap missing) |
+| 2   | P2: File Size       | Medium   | 69       | No `fs::metadata().len()` check before `fs::read_to_string()`                          |
+| 3   | P2: Iteration Count | Low      | 160, 371 | No 100K iteration cap on package/dependency loops                                      |
+| 4   | P2: String Length   | Low      | Various  | No 10 MB per-field truncation                                                          |
+| 5   | P4: File Exists     | Low      | 69       | No explicit `fs::metadata()` pre-check before reading                                  |
+| 6   | P4: UTF-8 Encoding  | Low      | 69       | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure                     |
+
+## Remediation Priority
+
+1. Add 50-level depth cap to `parse_dependencies_v1_with_depth` at line 365 — break early with warning when `depth >= 50`
+2. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 69)
+3. Add 100K iteration cap to package and dependency loops
+4. Add 10 MB field value truncation with warning
+5. Add `fs::metadata()` pre-check for file existence
+6. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+All 6 findings addressed. Added MAX_RECURSION_DEPTH=50 to parse_dependencies_v1_with_depth, replaced fs::read_to_string with utils version, added iteration caps to all package/dependency loops, applied truncate_field to all string values.

--- a/docs/parser-audit/npm_workspace.md
+++ b/docs/parser-audit/npm_workspace.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: npm_workspace
+
+**File**: `src/parsers/npm_workspace.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `yaml_serde` for YAML parsing (static). All processing is data extraction from parsed YAML values.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 43 reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `workspace_patterns` iteration at line 79: iterates all workspace patterns without a 100K cap. A YAML file with >100K workspace entries would iterate without limit.
+
+### String Length
+
+No 10 MB per-field truncation. Workspace pattern strings are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 43 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 43 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`yaml_serde::from_str(&content)` at line 51 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+The parser does not extract `name` or `version` fields from workspace YAML — it only extracts workspace patterns. Missing fields result in `None` or empty data. PASS.
+
+### URL Format
+
+No URLs are extracted from workspace files. N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code. All `.unwrap()` usage is in `#[cfg(test)]` block (lines 148, 153, 155, 158, 172, 175, 176, etc.) which is acceptable per ADR 0004.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s) | Description                                                        |
+| --- | ------------------- | -------- | ------- | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 43      | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 79      | No 100K iteration cap on workspace patterns                        |
+| 3   | P2: String Length   | Low      | 79      | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 43      | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 43      | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 43)
+2. Add 100K iteration cap to workspace patterns loop (line 79)
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/nuget.md
+++ b/docs/parser-audit/nuget.md
@@ -1,0 +1,125 @@
+# ADR 0004 Security Audit: nuget
+
+**File**: `src/parsers/nuget.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `subprocess`, `Command::new`, or any code execution mechanism. Uses `quick_xml` for XML parsing, `serde_json` for JSON parsing, and `zip::ZipArchive` for archive extraction. All static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+- **NupkgParser**: Has `fs::metadata().len()` check at line 2484 (`file_metadata.len()`) and enforces `MAX_ARCHIVE_SIZE` (100MB, line 547) at line 2487. **PASS**
+- **All other parsers** (PackagesConfigParser line 199, NuspecParser line 257, PackagesLockParser line 564, DotNetDepsJsonParser line 669, ProjectJsonParser line 969, ProjectLockJsonParser line 1001, PackageReferenceProjectParser line 1041): Use `File::open(path)` without `fs::metadata().len()` pre-check. **FAIL**
+
+### Recursion Depth
+
+- `resolve_directory_packages_props` (line 1668) and `resolve_directory_build_props` (line 1732) are recursive functions that follow `Import` project references. They use a `visited: &mut HashSet<PathBuf>` (lines 1671, 1734) to detect cycles — the `canonical` path is checked at lines 1672-1674 and 1736-1738. However, there is no explicit **depth counter** — a deeply nested chain of imports (within the 100-entry cycle set) would recurse up to 100+ levels before a cycle is detected. The recursion depth is implicitly bounded by the `visited` set, but not explicitly tracked at 50 levels. **PARTIAL**
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- XML event loops (lines 216-233, 290-389, 1081-1244, 1798-1943, 1962-2036, 2618-2714)
+- JSON dependency iteration (lines 582-646, 708-782, 1385-1417, 1503-1521)
+- Archive entry iteration (lines 2498-2551, 2562-2591)
+- `replace_matching_dependency_group` (line 2194) iterates without cap
+
+### String Length
+
+No 10MB field value truncation. XML text events (e.g., line 340-366), JSON string values (e.g., line 589-590), and archive content (line 2528-2531) are stored without length limits. However, `MAX_FILE_SIZE` (50MB, line 548) limits individual archive entries.
+
+## Principle 3: Archive Safety
+
+**Status**: PASS
+
+The `NupkgParser` (lines 2457-2477) extracts `.nupkg` (ZIP) archives with comprehensive safety checks:
+
+- **Size Limits**: `MAX_ARCHIVE_SIZE` (100MB, line 547) checked at line 2487. `MAX_FILE_SIZE` (50MB, line 548) checked at lines 2510 and 2574. Note: 100MB is below the ADR's 1GB uncompressed limit — more conservative.
+- **Compression Ratio**: `MAX_COMPRESSION_RATIO` (100:1, line 549) checked at lines 2518-2526.
+- **Path Traversal**: The archive extraction only reads `.nuspec` and license files by name — it does NOT extract to disk or construct file paths from archive entries. No path traversal risk since no filesystem writes occur.
+- **Decompression Limits**: The per-entry `MAX_FILE_SIZE` (50MB) and `read_to_string`/`read_to_end` calls limit decompression.
+
+Note: The archive size limits are more conservative than ADR requirements (100MB vs 1GB for archives, 50MB vs 100MB for files), which is acceptable.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- **NupkgParser**: `fs::metadata(path)` at line 2484 before opening. **PASS**
+- **All other parsers**: Use `File::open(path)` which returns an error if file doesn't exist, handled with `warn!()` and default return. No explicit `fs::metadata()` pre-check. **PARTIAL** — functionally correct but no explicit pre-check.
+
+### UTF-8 Encoding
+
+- XML text: `e.decode()` at lines 340, 1171, 1887, 1994, 2668 — `quick_xml` handles encoding internally.
+- JSON: `serde_json` handles encoding internally.
+- Archive license file: `String::from_utf8_lossy(&content)` at line 2587. **PASS** — uses lossy conversion.
+- Non-archive parsers: No explicit lossy UTF-8 fallback for file reads.
+
+### JSON/YAML Validity
+
+- JSON parse failures at lines 572-577, 677-682, 977-982, 1011-1018 return `default_package_data()`. **PASS**
+- XML parse failures at lines 224-229, 382-385, 1236-1239 return `default_package_data()`. **PASS**
+- `parse_nuspec_content` at line 2593 returns `Err` on XML failure, propagated correctly. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PARTIAL
+
+- `resolve_directory_packages_props` (line 1668) and `resolve_directory_build_props` (line 1732) use `visited: &mut HashSet<PathBuf>` for cycle detection. This prevents infinite loops from circular imports. **PASS for cycle detection**
+- However, no explicit depth counter (50-level limit). The `visited` set provides implicit depth bounding but not at the ADR-specified 50-level granularity.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 1672: `path.canonicalize().unwrap_or_else(|_| path.to_path_buf())` — uses `unwrap_or_else`, acceptable.
+- Line 1736: Same pattern, acceptable.
+- Line 785: `split_library_key(&root_key).unwrap_or(("", ""))` — acceptable fallback.
+- Line 705: `.cloned().unwrap_or_default()` — acceptable.
+- Line 293: `unwrap_or(&[])` — acceptable.
+
+No raw `.unwrap()` without fallback in library code. All uses are `unwrap_or`, `unwrap_or_default`, or `unwrap_or_else`. **PASS on closer inspection**
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                             | Description                                                                                             |
+| --- | ------------------- | -------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 199, 257, 564, 669, 969, 1001, 1041 | No `fs::metadata().len()` pre-check for non-archive parsers                                             |
+| 2   | P2: Recursion Depth | MEDIUM   | 1668, 1732                          | Recursive import resolution lacks explicit 50-level depth counter; only cycle detection via visited set |
+| 3   | P2: Iteration Count | MEDIUM   | 216, 290, 582, 1081, 1798, 2498     | No 100K iteration cap on XML/JSON/archive processing loops                                              |
+| 4   | P2: String Length   | LOW      | 340-366, 589                        | No 10MB field value truncation                                                                          |
+| 5   | P4: UTF-8 Encoding  | LOW      | 199, 257, etc.                      | No lossy UTF-8 fallback for non-archive file reads                                                      |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` pre-check (100MB limit) for all non-archive parsers
+2. Add explicit 50-level depth counter to `resolve_directory_packages_props` and `resolve_directory_build_props`
+3. Add 100K iteration cap on primary parsing loops
+4. Add 10MB field value truncation with warning
+5. Add lossy UTF-8 fallback for file reads

--- a/docs/parser-audit/opam.md
+++ b/docs/parser-audit/opam.md
@@ -1,0 +1,105 @@
+# ADR 0004 Security Audit: opam
+
+**File**: `src/parsers/opam.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No code execution mechanisms. Uses custom regex-based text parsing and manual line-by-line extraction. The `Regex::new()` calls at lines 388, 406, 471 are static pattern compilation, not code execution. Fully static analysis.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `std::fs::read_to_string(path)` at line 55 — no size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative using `while` loops with index manipulation (e.g., `parse_opam_data` at line 211, `parse_multiline_string` at line 295, `parse_string_array` at line 324).
+
+### Iteration Count
+
+- `parse_opam_data` (line 216): `while i < lines.len()` — no cap on line count
+- `parse_multiline_string` (line 304): `while *i < lines.len()` — no cap
+- `parse_string_array` (line 332): `while *i < lines.len()` — no cap
+- `parse_dependency_array` (line 363): `while *i < lines.len()` — no cap
+- `parse_checksums` (line 446): `while *i < lines.len()` — no cap
+- No 100K iteration cap anywhere
+
+### String Length
+
+No field value truncation at 10MB. String values from parsed fields stored without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction performed.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `std::fs::read_to_string(path)` at line 55 returns an error on failure, handled at lines 56-59 with `warn!()` and default return. No explicit pre-check.
+
+### UTF-8 Encoding
+
+Uses `std::fs::read_to_string()` which fails on invalid UTF-8 without lossy fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. OPAM format is custom text. Regex parsing failures at lines 388, 406, 471 are handled gracefully via `.ok()?` which returns `None`. **PASS**
+
+### Required Fields
+
+Missing `name`/`version` handled via `Option<String>` in `OpamData`. Correct.
+
+### URL Format
+
+URLs accepted as-is. ADR-compliant.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 410: `caps.get(1).map(|m| m.as_str()).unwrap_or("")` — acceptable (fallback)
+- Line 411: `caps.get(2).map(|m| m.as_str()).unwrap_or("")` — acceptable (fallback)
+- Lines 291: `VERSION_CONSTRAINT_RE` uses `.unwrap()` in `lazy_static!` block — this is a compile-time constant regex, acceptable.
+- No raw `.unwrap()` without fallback in runtime library code. **Actually PASS on closer inspection**
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+None.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)                 | Description                                                         |
+| --- | ------------------- | -------- | ----------------------- | ------------------------------------------------------------------- |
+| 1   | P2: File Size       | HIGH     | 55                      | No `fs::metadata().len()` check before reading; unbounded file read |
+| 2   | P2: Iteration Count | MEDIUM   | 216, 304, 332, 363, 446 | No 100K iteration cap on line processing loops                      |
+| 3   | P2: String Length   | LOW      | various                 | No 10MB field value truncation                                      |
+| 4   | P4: UTF-8 Encoding  | MEDIUM   | 55                      | No lossy UTF-8 fallback on read failure                             |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading (100MB default limit)
+2. Add 100K iteration cap in line processing loops
+3. Add lossy UTF-8 fallback on read failure
+4. Add 10MB field value truncation with warning

--- a/docs/parser-audit/os_release.md
+++ b/docs/parser-audit/os_release.md
@@ -1,0 +1,94 @@
+# ADR 0004 Security Audit: os_release
+
+**File**: `src/parsers/os_release.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Simple line-based key=value parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` at line 47 without size pre-check. Note: OS release files are typically very small (<1KB), making this low risk in practice.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative. — PASS
+
+### Iteration Count
+
+- `parse_key_value_pairs` (line 121): Iterates over `content.lines()` — no 100K cap. OS release files have few lines in practice.
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Text files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 47 fails on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+N/A — plain text format.
+
+### Required Fields
+
+Missing `ID` field defaults to empty string (line 66). Name is always set via `determine_namespace_and_name`. — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 71: `.unwrap_or_default()` — safe
+- No problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                                                                        |
+| --- | ---------------- | -------- | ------- | ---------------------------------------------------------------------------------- |
+| 1   | P2 File Size     | LOW      | 47      | No file size check before reading (low risk — OS release files are typically tiny) |
+| 2   | P2 String Length | LOW      | —       | No field-level 10MB truncation                                                     |
+| 3   | P4 UTF-8         | LOW      | 47      | No lossy UTF-8 fallback                                                            |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading for defense-in-depth (low priority due to small expected file size)

--- a/docs/parser-audit/pep508.md
+++ b/docs/parser-audit/pep508.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: pep508
+
+**File**: `src/parsers/pep508.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- Pure string parsing — no AST, no code execution, no regex (manual character iteration)
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+- N/A — this module receives string input, not files
+
+### Recursion Depth
+
+- No recursive functions — all parsing is iterative
+- PASS
+
+### Iteration Count
+
+- `parse_name_and_extras` iterates characters at line 81 — O(n) on input length
+- `extras_str.split(',')` at line 101 — no cap on number of extras
+- `normalize_specifiers` iterates characters at line 119 — O(n)
+- **GAP**: No iteration cap on extras or character processing
+
+### String Length
+
+- Input strings are passed from callers — no 10MB truncation at this level
+- **GAP**: No input string length validation (relies on callers to enforce limits)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- N/A — this module processes strings, not files
+
+### UTF-8 Encoding
+
+- N/A — input is already a Rust `&str` (valid UTF-8 guaranteed by type system)
+
+### JSON/YAML Validity
+
+- N/A — no JSON/YAML parsing
+
+### Required Fields
+
+- Empty input returns `None` at line 13
+- Empty `requirement_part` returns `None` at line 24
+- Empty name returns `None` at lines 89, 350
+- PASS — invalid input gracefully returns `None`
+
+### URL Format
+
+- URLs extracted from `@` syntax at line 53 — accepted as-is
+- Compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 18: `.unwrap_or_default()` — safe, uses `unwrap_or_default`
+- No dangerous bare `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s) | Description                                                |
+| --- | --------------- | -------- | ------- | ---------------------------------------------------------- |
+| 1   | P2-Iteration    | LOW      | 81, 101 | No iteration cap on character scanning or extras splitting |
+| 2   | P2-StringLength | LOW      | N/A     | No input string length validation (relies on callers)      |
+
+## Remediation Priority
+
+1. Add input string length validation (e.g., reject inputs > 10MB) at the entry point `parse_pep508_requirement`
+2. Add cap on number of extras parsed from bracket syntax

--- a/docs/parser-audit/pip_inspect_deplock.md
+++ b/docs/parser-audit/pip_inspect_deplock.md
@@ -1,0 +1,106 @@
+# ADR 0004 Security Audit: pip_inspect_deplock
+
+**File**: `src/parsers/pip_inspect_deplock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- `extract_packages` delegates to `PythonParser::extract_first_package` at line 89 — no code execution
+- Test-only `parse_pip_inspect_deplock` uses `serde_json::from_str` — static deserialization
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before reading
+- `PythonParser::extract_first_package` handles reading internally — delegates to python.rs which also lacks pre-check for this format
+
+### Recursion Depth
+
+- No recursive functions
+- PASS
+
+### Iteration Count
+
+- Test-only `parse_pip_inspect_deplock` iterates `installed_packages` without cap at line 108
+- **GAP**: No 100,000 item cap (though actual parsing is delegated to PythonParser)
+
+### String Length
+
+- No 10MB per-field truncation for parsed metadata values
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check — file reading handled by PythonParser
+
+### UTF-8 Encoding
+
+- No explicit UTF-8 handling in this module — delegated to PythonParser
+- Test-only function has no lossy fallback
+
+### JSON/YAML Validity
+
+- Test-only `parse_pip_inspect_deplock` returns `default_package_data` on JSON parse failure at lines 95-99
+- Actual production path delegates to PythonParser which handles errors
+
+### Required Fields
+
+- Missing name/version handled with `None` — continues parsing
+- `default_package_data` returned when no main package found at line 121
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 151: `.unwrap_or_default()` — safe
+- Line 158: `.unwrap_or_default()` — safe
+- No dangerous `.unwrap()` calls in library code (all `.unwrap_or_*` variants)
+- Test code uses `.unwrap()` which is acceptable per ADR 0004
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s) | Description                                                               |
+| --- | --------------- | -------- | ------- | ------------------------------------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | N/A     | No file size check — reading delegated to PythonParser without size limit |
+| 2   | P2-Iteration    | LOW      | 108     | No 100K iteration cap on installed packages (test-only code)              |
+| 3   | P2-StringLength | LOW      | N/A     | No 10MB per-field truncation                                              |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading (may need to coordinate with PythonParser delegation)
+2. Add 100K iteration caps on installed packages list
+3. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/pipfile_lock.md
+++ b/docs/parser-audit/pipfile_lock.md
@@ -1,0 +1,111 @@
+# ADR 0004 Security Audit: pipfile_lock
+
+**File**: `src/parsers/pipfile_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- JSON parsing via `serde_json::from_str` at line 85 — static deserialization
+- TOML parsing via `read_toml_file` at line 217 — static deserialization
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `fs::read_to_string` at line 77 (Pipfile.lock)
+- `read_toml_file` (via `python::read_toml_file`) uses `read_file_to_string` without size check
+- **GAP**: Entire file read into memory without size limit
+
+### Recursion Depth
+
+- No recursive functions in this parser
+- PASS
+
+### Iteration Count
+
+- `extract_lockfile_dependencies` iterates `section_map` entries without cap at line 136
+- `extract_pipfile_dependencies` iterates package entries without cap at line 259
+- `parse_pipfile_sources` iterates sources array without cap at line 353
+- **GAP**: No 100,000 item cap on dependencies or sources
+
+### String Length
+
+- No 10MB per-field truncation for parsed values (name, version, requirement strings)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check — `fs::read_to_string` at line 77 returns error
+- Error handled gracefully with `warn!` and default return at lines 79-82
+
+### UTF-8 Encoding
+
+- `fs::read_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- JSON parse failure returns `default_package_data` at lines 87-90
+- TOML parse failure returns `default_package_data` at lines 219-222
+- PASS — graceful degradation
+
+### Required Fields
+
+- Missing name/version results in `None` — continues parsing
+- `build_lockfile_dependency` returns `None` if requirement extraction fails at line 153
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- No `.unwrap()` calls in library code
+- All `Option`/`Result` values handled with `?`, `match`, or `unwrap_or` patterns
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s)  | Description                                                     |
+| --- | --------------- | -------- | -------- | --------------------------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | 77       | No file size check before `fs::read_to_string` for Pipfile.lock |
+| 2   | P2-FileSize     | HIGH     | 217      | No file size check before `read_toml_file` for Pipfile          |
+| 3   | P2-Iteration    | LOW      | 136, 259 | No 100K iteration cap on dependencies                           |
+| 4   | P2-StringLength | LOW      | N/A      | No 10MB per-field truncation                                    |
+| 5   | P4-UTF8         | LOW      | 77       | No lossy UTF-8 fallback                                         |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading Pipfile.lock and Pipfile
+2. Add 100K iteration caps on dependency/package iteration
+3. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/pixi.md
+++ b/docs/parser-audit/pixi.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: pixi
+
+**File**: `src/parsers/pixi.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `serde` for JSON/TOML deserialization and `yaml_serde` for YAML — all static parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Files are read via `read_toml_file(path)` (line 50) and `read_file_to_string(path)` (line 72) — both read entire content without size pre-check.
+
+### Recursion Depth
+
+No recursive functions found in pixi.rs. All processing is iterative. — PASS
+
+### Iteration Count
+
+- `extract_manifest_dependencies` (line 250): Iterates over feature table entries — no 100K cap
+- `extract_conda_dependencies` (line 292): Iterates over dependency table — no 100K cap
+- `extract_pypi_dependencies` (line 346): Iterates over dependency table — no 100K cap
+- `extract_v6_lock_dependencies` (line 462): Iterates over packages array — no 100K cap
+- `collect_v6_package_refs` (line 475): Nested iteration over environments → platforms → entries — no 100K cap
+- `extract_v4_lock_dependencies` (line 615): Iterates over packages array — no 100K cap
+- `extract_authors` (line 182): Iterates over authors array — no 100K cap
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Pixi files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `read_toml_file` and `read_file_to_string` which return errors on missing files, handled gracefully via `match`. — Acceptable fallback.
+
+### UTF-8 Encoding
+
+`read_file_to_string` (from utils.rs line 33) uses `File::open` + `read_to_string`, which will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+- TOML parse errors (line 141): Handled, falls back to YAML parsing attempt
+- YAML parse errors (line 145): Handled, returns error string
+- Both return `default_package_data` on failure — PASS
+
+### Required Fields
+
+Missing name/version fields result in `None` values — PASS (line 102-108)
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with cycle tracking.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 754: `conda_name_from_locator` uses `.unwrap_or(file_name)` — this is safe, not a concern
+- No problematic `.unwrap()` calls found in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s)                      | Description                                                                     |
+| --- | ---------------- | -------- | ---------------------------- | ------------------------------------------------------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 50, 72                       | No file size check before reading — oversized files loaded entirely into memory |
+| 2   | P2 Iteration     | LOW      | 250, 292, 346, 462, 475, 615 | No 100K iteration cap on dependency/table entries                               |
+| 3   | P2 String Length | LOW      | —                            | No field-level 10MB truncation                                                  |
+| 4   | P4 UTF-8         | LOW      | 50, 72                       | No lossy UTF-8 fallback on non-UTF-8 content                                    |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading files, reject >100MB
+2. Add iteration caps (100K) on dependency extraction loops

--- a/docs/parser-audit/pnpm_lock.md
+++ b/docs/parser-audit/pnpm_lock.md
@@ -1,0 +1,109 @@
+# ADR 0004 Security Audit: pnpm_lock
+
+**File**: `src/parsers/pnpm_lock.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `yaml_serde` for YAML parsing (static). All processing is data extraction from parsed YAML values. The `compute_dev_only_packages_v9` function at line 88 performs BFS graph traversal but does not execute any code.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 51 reads entire file without size validation.
+
+### Recursion Depth
+
+No recursive functions. `compute_dev_only_packages_v9` uses BFS (line 167), not DFS, so no stack overflow risk from depth. No recursion depth concern.
+
+### Iteration Count
+
+- `packages_map` iteration at line 213: iterates all packages without a 100K cap.
+- `importers` iteration at line 96: no iteration cap.
+- `snapshots` iteration at line 129: no iteration cap.
+- `graph` BFS queue at line 167: no iteration cap on BFS traversal.
+- Dependency iteration in `parse_nested_dependencies` at lines 379, 387, 397, 407: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from YAML are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 51 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 51 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`yaml_serde::from_str(&content)` at line 59 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+
+### Required Fields
+
+Missing package name/version result in `None` via `parse_purl_fields` returning `Option`. PASS.
+
+### URL Format
+
+URLs are not directly extracted from pnpm lockfiles. N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PARTIAL
+
+The `compute_dev_only_packages_v9` function at line 88 performs BFS with a `prod_reachable` `HashSet` at line 159 that prevents revisiting nodes. This is implicit cycle detection — the BFS will not infinite-loop on circular dependencies. However, the cycle detection is not explicit (no warning is logged when a cycle is detected) and the traversal has no depth limit. The BFS is bounded by the graph size, which itself is unbounded (no iteration cap).
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. All 7 `.unwrap()` calls are within `#[cfg(test)]` module (lines 701, 708, 715, 754, 763, 772, 780) which is acceptable per ADR 0004.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle               | Severity | Line(s)           | Description                                                                              |
+| --- | ----------------------- | -------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| 1   | P2: File Size           | Medium   | 51                | No `fs::metadata().len()` check before `fs::read_to_string()`                            |
+| 2   | P2: Iteration Count     | Low      | 213, 96, 129, 167 | No 100K iteration cap on package/importer/snapshot/BFS loops                             |
+| 3   | P2: String Length       | Low      | Various           | No 10 MB per-field truncation                                                            |
+| 4   | P5: Circular Dependency | Low      | 167               | BFS has implicit cycle protection via `HashSet` but no explicit cycle break with warning |
+| 5   | P4: File Exists         | Low      | 51                | No explicit `fs::metadata()` pre-check before reading                                    |
+| 6   | P4: UTF-8 Encoding      | Low      | 51                | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure                       |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 51)
+2. Add 100K iteration cap to package/snapshot/BFS loops
+3. Add 10 MB field value truncation with warning
+4. Add explicit cycle detection with warning in BFS traversal
+5. Add `fs::metadata()` pre-check for file existence
+6. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+All 6 findings addressed. Replaced fs::read_to_string with utils version, added iteration caps to all package/dependency/BFS loops, applied truncate_field to all string values. BFS cycle detection already sufficient (HashSet).

--- a/docs/parser-audit/podfile.md
+++ b/docs/parser-audit/podfile.md
@@ -1,0 +1,106 @@
+# ADR 0004 Security Audit: podfile
+
+**File**: `src/parsers/podfile.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, `exec()`, or code execution primitives found. Parsing uses regex-based Ruby DSL pattern matching (`Regex::new`, `POD_PATTERN.captures`) — no Ruby AST or runtime evaluation.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- Line 54: `fs::read_to_string(path)` called directly with **no** `fs::metadata().len()` pre-check. A 10GB Podfile would be fully read into memory before any parsing begins.
+
+### Recursion Depth
+
+- No recursive functions in this parser. `extract_dependencies` (line 127) iterates `content.lines()` linearly. **PASS**.
+
+### Iteration Count
+
+- Line 130: `for line in content.lines()` iterates without any 100K cap. A Podfile with millions of lines would be processed indefinitely.
+- No cap on number of dependencies collected in `dependencies` vector (line 128).
+
+### String Length
+
+- No field values are truncated at 10MB. `name`, `version_req`, `git_url`, `local_path` extracted from regex captures (lines 133-136) are stored as-is regardless of length.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archive files.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- Line 54-59: `fs::read_to_string` error is caught and returns `default_package_data()`. No explicit `fs::metadata()` pre-check, but the error is handled gracefully. Functionally acceptable, though ADR prescribes `fs::metadata()` check.
+
+### UTF-8 Encoding
+
+- Line 54: `fs::read_to_string` fails on non-UTF-8 content, returning default PackageData. **No** lossy fallback (`String::from_utf8_lossy`) is attempted. **FAIL** — non-UTF-8 files silently return default data.
+
+### JSON/YAML Validity
+
+- N/A — this parser does not parse JSON or YAML.
+
+### Required Fields
+
+- The Podfile parser does not extract name/version for the package itself (lines 64-107: `name: None, version: None`). Dependencies with empty names are filtered (line 154: `if name.is_empty() { return None; }`). **PASS**.
+
+### URL Format
+
+- URLs (git_url, local_path) extracted from regex captures and stored as-is. Per ADR: "Accept as-is". **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not perform dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 123: `POD_PATTERN` initialization uses `.unwrap()` in `lazy_static!` block:
+
+  ```rust
+  static ref POD_PATTERN: Regex = Regex::new(...).unwrap();
+  ```
+
+  This will panic at program startup if the regex fails to compile. While this is in a `lazy_static!` (one-time init), it is technically `.unwrap()` in non-test library code. The regex is a compile-time constant, so this is low-risk in practice but violates the no-unwrap rule.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new`, `std::process::Command`, or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s) | Description                                                                 |
+| --- | ---------- | -------- | ------- | --------------------------------------------------------------------------- |
+| 1   | P2: DoS    | Medium   | 54      | No file size pre-check (`fs::metadata().len()`) before `fs::read_to_string` |
+| 2   | P2: DoS    | Medium   | 130     | No iteration count cap (100K) on line processing loop                       |
+| 3   | P2: DoS    | Low      | 133-136 | No string field truncation at 10MB limit                                    |
+| 4   | P4: Input  | Medium   | 54      | No lossy UTF-8 fallback — non-UTF-8 files cause silent default return       |
+| 5   | Additional | Low      | 123     | `.unwrap()` in `lazy_static!` regex initialization (non-test library code)  |
+
+## Remediation Priority
+
+1. **[P2: DoS] Add file size pre-check** using `fs::metadata().len()` with 100MB limit before reading
+2. **[P4: Input] Add lossy UTF-8 fallback** — use `fs::read()` + `String::from_utf8_lossy()` instead of `fs::read_to_string()`
+3. **[P2: DoS] Add iteration count cap** (100K) to line processing loop with early-break and warning
+4. **[P2: DoS] Add string field truncation** at 10MB with warning log
+5. **[Additional] Replace `.unwrap()`** in `lazy_static!` with `expect()` or `Regex::new(...).expect("POD_PATTERN regex is valid")` for explicit panics with context

--- a/docs/parser-audit/podfile_lock.md
+++ b/docs/parser-audit/podfile_lock.md
@@ -1,0 +1,103 @@
+# ADR 0004 Security Audit: podfile_lock
+
+**File**: `src/parsers/podfile_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, `exec()`, or code execution primitives found. Parsing uses `yaml_serde` for YAML deserialization and structured data traversal — no code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- Line 63: `fs::read_to_string(path)` called directly with **no** `fs::metadata().len()` pre-check. A multi-GB Podfile.lock would be fully loaded into memory.
+
+### Recursion Depth
+
+- No recursive functions. All parsing iterates over YAML sequences and mappings linearly (lines 101-187, 194-218). **PASS**.
+
+### Iteration Count
+
+- Line 101: `for pod in pods` — iterates over PODS sequence with **no** 100K cap.
+- Line 117: `for dep in deps` — iterates over DEPENDENCIES sequence with **no** 100K cap.
+- Line 132: `for package in packages` — iterates over SPEC REPOS packages with **no** 100K cap.
+- Line 145: `for (name_key, checksum_val) in checksums` — iterates over CHECKSUMS with **no** 100K cap.
+- Line 194: `for pod in pods` — second iteration over PODS with **no** 100K cap.
+- Line 198: `for (main_pod_key, dep_pods_val) in m` — iterates over mapping entries with **no** 100K cap.
+- No cap on number of dependencies collected (line 192).
+
+### String Length
+
+- No field values are truncated at 10MB. Values extracted from YAML (e.g., `dep.as_str()`, `checksum_val.as_str()`) are stored as-is regardless of length.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archive files.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- Line 63-68: `fs::read_to_string` error is caught and returns `default_package_data()`. No explicit `fs::metadata()` pre-check. Functionally acceptable but doesn't match ADR prescription.
+
+### UTF-8 Encoding
+
+- Line 63: `fs::read_to_string` fails on non-UTF-8 content, returning default PackageData. **No** lossy fallback is attempted. **FAIL** — non-UTF-8 files silently return default data.
+
+### JSON/YAML Validity
+
+- Line 71-76: YAML parse failure (`yaml_serde::from_str`) is caught with `warn!()` and returns `default_package_data()`. **PASS** — graceful handling on invalid YAML.
+
+### Required Fields
+
+- Missing name/version in dependency entries result in empty strings or `None` values. The code continues processing. **PASS**.
+
+### URL Format
+
+- URLs from external sources (git, path) are extracted from YAML mappings and stored as-is. Per ADR: "Accept as-is". **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not perform dependency resolution. It reads resolved dependency data from a lockfile — no traversal or resolution logic.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls found in library code. The only `unwrap_or_default()` usage (line 203) is safe.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new`, `std::process::Command`, or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s)                      | Description                                                                 |
+| --- | --------- | -------- | ---------------------------- | --------------------------------------------------------------------------- |
+| 1   | P2: DoS   | Medium   | 63                           | No file size pre-check (`fs::metadata().len()`) before `fs::read_to_string` |
+| 2   | P2: DoS   | Medium   | 101, 117, 132, 145, 194, 198 | No iteration count cap (100K) on YAML sequence/mapping iteration loops      |
+| 3   | P2: DoS   | Low      | Various                      | No string field truncation at 10MB limit                                    |
+| 4   | P4: Input | Medium   | 63                           | No lossy UTF-8 fallback — non-UTF-8 files cause silent default return       |
+
+## Remediation Priority
+
+1. **[P2: DoS] Add file size pre-check** using `fs::metadata().len()` with 100MB limit before reading
+2. **[P4: Input] Add lossy UTF-8 fallback** — use `fs::read()` + `String::from_utf8_lossy()` instead of `fs::read_to_string()`
+3. **[P2: DoS] Add iteration count caps** (100K) to all YAML sequence/mapping loops with early-break and warning
+4. **[P2: DoS] Add string field truncation** at 10MB with warning log

--- a/docs/parser-audit/podspec.md
+++ b/docs/parser-audit/podspec.md
@@ -1,0 +1,121 @@
+# ADR 0004 Security Audit: podspec
+
+**File**: `src/parsers/podspec.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, `exec()`, or code execution primitives found. All parsing uses regex-based Ruby DSL pattern matching (`Regex::new`, `captures`, `captures_iter`). The `md5` crate usage (line 29) is for hash computation only, not execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- Line 64: `fs::read_to_string(path)` called directly with **no** `fs::metadata().len()` pre-check. A multi-GB .podspec would be fully loaded into memory.
+
+### Recursion Depth
+
+- No recursive functions. `extract_multiline_description` (line 335) iterates `lines.iter().skip(start_index)` linearly. All other functions iterate `content.lines()` linearly. **PASS**.
+
+### Iteration Count
+
+- Line 288: `for line in content.lines()` in `extract_field` — **no** 100K cap.
+- Line 301: `for (i, line) in lines.iter().enumerate()` in `extract_description` — **no** 100K cap.
+- Line 348: `for line in lines.iter().skip(start_index)` in `extract_multiline_description` — **no** 100K cap.
+- Line 374: `for line in content.lines()` in `extract_authors` — **no** 100K cap.
+- Line 400: `for line in content.lines()` in `extract_source_url` — **no** 100K cap.
+- Line 462: `for line in content.lines()` in `extract_dependencies` — **no** 100K cap.
+- No cap on number of dependencies or authors collected.
+
+### String Length
+
+- No field values are truncated at 10MB. `clean_string` (line 525) and `extract_field` return full strings regardless of length.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archive files.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- Line 64-69: `fs::read_to_string` error is caught and returns `default_package_data()`. No explicit `fs::metadata()` pre-check. Functionally acceptable but doesn't match ADR prescription.
+
+### UTF-8 Encoding
+
+- Line 64: `fs::read_to_string` fails on non-UTF-8 content, returning default PackageData. **No** lossy fallback is attempted. **FAIL** — non-UTF-8 files silently return default data.
+
+### JSON/YAML Validity
+
+- N/A — this parser uses regex-based text parsing, not JSON/YAML deserialization.
+
+### Required Fields
+
+- Missing name/version result in `None` values, the parser continues. Line 480: empty names are filtered (`if name.is_empty() { return None; }`). **PASS**.
+
+### URL Format
+
+- URLs (homepage, source, vcs_url) are extracted from content or constructed programmatically and stored as-is. Per ADR: "Accept as-is". **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not perform dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 137: `.unwrap_or_else(|_| PackageUrl::new("generic", name_str).unwrap())` — nested `.unwrap()` that will panic if both `PackageUrl::new("cocoapods", ...)` and `PackageUrl::new("generic", ...)` fail. The "generic" fallback should always succeed, but the bare `.unwrap()` violates the no-unwrap rule.
+- Lines 204-213: Multiple `.unwrap()` calls in `lazy_static!` regex initializations:
+  - Line 204: `Regex::new(r"\.name\s*=\s*(.+)").unwrap()`
+  - Line 205: `Regex::new(r"\.version\s*=\s*(.+)").unwrap()`
+  - Line 206: `Regex::new(r"\.summary\s*=\s*(.+)").unwrap()`
+  - Line 207: `Regex::new(r"\.description\s*=\s*(.+)").unwrap()`
+  - Line 208: `Regex::new(r"\.homepage\s*=\s*(.+)").unwrap()`
+  - Line 209: `Regex::new(r"\.license\s*=\s*(.+)").unwrap()`
+  - Line 210: `Regex::new(r"\.source\s*=\s*(.+)").unwrap()`
+  - Line 211: `Regex::new(r"\.authors?\s*=\s*(.+)").unwrap()`
+  - Line 212: `Regex::new(r#":git\s*=>\s*['\"]([^'\"]+)['\"]"#).unwrap()`
+  - Line 213: `Regex::new(r#":http\s*=>\s*['\"]([^'\"]+)['\"]"#).unwrap()`
+  - Line 218: `DEPENDENCY_PATTERN` regex `.unwrap()`
+
+  These will panic at first access if regex compilation fails. While the patterns are compile-time constants and unlikely to fail, they are bare `.unwrap()` in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new`, `std::process::Command`, or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s)                      | Description                                                                 |
+| --- | ---------- | -------- | ---------------------------- | --------------------------------------------------------------------------- |
+| 1   | P2: DoS    | Medium   | 64                           | No file size pre-check (`fs::metadata().len()`) before `fs::read_to_string` |
+| 2   | P2: DoS    | Medium   | 288, 301, 348, 374, 400, 462 | No iteration count cap (100K) on line processing loops                      |
+| 3   | P2: DoS    | Low      | 525                          | No string field truncation at 10MB limit                                    |
+| 4   | P4: Input  | Medium   | 64                           | No lossy UTF-8 fallback — non-UTF-8 files cause silent default return       |
+| 5   | Additional | Medium   | 137                          | `.unwrap()` in PURL creation fallback — can panic on invalid input          |
+| 6   | Additional | Low      | 204-213, 218                 | `.unwrap()` in `lazy_static!` regex initializations (11 instances)          |
+
+## Remediation Priority
+
+1. **[P2: DoS] Add file size pre-check** using `fs::metadata().len()` with 100MB limit before reading
+2. **[P4: Input] Add lossy UTF-8 fallback** — use `fs::read()` + `String::from_utf8_lossy()` instead of `fs::read_to_string()`
+3. **[Additional] Replace `.unwrap()`** at line 137 with `match`/`map_err` or `expect("generic PURL creation should not fail")`
+4. **[P2: DoS] Add iteration count caps** (100K) to all line processing loops with early-break and warning
+5. **[Additional] Replace `.unwrap()`** in `lazy_static!` blocks with `expect("regex is valid")` for explicit panics with context
+6. **[P2: DoS] Add string field truncation** at 10MB with warning log

--- a/docs/parser-audit/podspec_json.md
+++ b/docs/parser-audit/podspec_json.md
@@ -1,0 +1,106 @@
+# ADR 0004 Security Audit: podspec_json
+
+**File**: `src/parsers/podspec_json.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, `exec()`, or code execution primitives found. Parsing uses `serde_json` for JSON deserialization and structured data traversal. The `md5` crate usage (line 485) is for hash computation only, not execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- Line 262: `read_json_file` opens the file with `File::open(path)` and reads with `file.read_to_string(&mut contents)` — **no** `fs::metadata().len()` pre-check. A multi-GB .podspec.json would be fully loaded into memory.
+- The `serde_json::from_str` at line 266 then parses the entire string, potentially consuming significant memory for deeply nested JSON structures.
+
+### Recursion Depth
+
+- No recursive functions in this parser. All extraction iterates over JSON object key-value pairs linearly. **PASS**.
+
+### Iteration Count
+
+- Line 383: `for (name, value) in authors_obj` — iterates over authors object with **no** 100K cap.
+- Line 438: `for (name, requirement) in deps_obj` — iterates over dependencies object with **no** 100K cap.
+- No cap on number of dependencies or parties collected.
+
+### String Length
+
+- No field values are truncated at 10MB. Values extracted from JSON (`.as_str()`, `.trim()`) are stored as-is regardless of length.
+- The entire JSON content is cloned into `extra_data["podspec.json"]` at line 147 without size check.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archive files.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- Line 262: `File::open(path)` returns error on missing file, propagated via `Result<Value, String>`. At line 58-63, the error is caught and `default_package_data()` is returned. No explicit `fs::metadata()` pre-check. Functionally acceptable but doesn't match ADR prescription.
+
+### UTF-8 Encoding
+
+- Line 264: `file.read_to_string(&mut contents)` fails on non-UTF-8 content. The error is propagated up to line 58-63 which returns `default_package_data()`. **No** lossy fallback is attempted. **FAIL** — non-UTF-8 files silently return default data.
+
+### JSON/YAML Validity
+
+- Line 266: `serde_json::from_str(&contents)` parse failure returns `Err(String)`, which propagates to line 58-63 and returns `default_package_data()`. **PASS** — graceful handling on invalid JSON.
+
+### Required Fields
+
+- Missing name/version are handled via `.filter(|s| !s.is_empty())` (lines 70, 76) which results in `None`. The parser continues with `None` values. **PASS**.
+- Empty dependency names are skipped (line 440: `if name_str.is_empty() { continue; }`). **PASS**.
+
+### URL Format
+
+- URLs (homepage, git, http) are extracted from JSON fields and stored as-is. Per ADR: "Accept as-is". **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not perform dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 198: `.unwrap_or_else(|_| PackageUrl::new("generic", name_str).unwrap())` — nested `.unwrap()` that will panic if both `PackageUrl::new("cocoapods", ...)` and `PackageUrl::new("generic", ...)` fail. The "generic" fallback should always succeed for non-empty strings, but the bare `.unwrap()` violates the no-unwrap rule.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new`, `std::process::Command`, or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s)  | Description                                                                  |
+| --- | ---------- | -------- | -------- | ---------------------------------------------------------------------------- |
+| 1   | P2: DoS    | Medium   | 262-264  | No file size pre-check (`fs::metadata().len()`) before reading file          |
+| 2   | P2: DoS    | Medium   | 383, 438 | No iteration count cap (100K) on authors/dependencies object iteration loops |
+| 3   | P2: DoS    | Low      | 147      | Entire JSON content cloned into `extra_data` without size check              |
+| 4   | P2: DoS    | Low      | Various  | No string field truncation at 10MB limit                                     |
+| 5   | P4: Input  | Medium   | 264      | No lossy UTF-8 fallback — non-UTF-8 files cause silent default return        |
+| 6   | Additional | Medium   | 198      | `.unwrap()` in PURL creation fallback — can panic on invalid input           |
+
+## Remediation Priority
+
+1. **[P2: DoS] Add file size pre-check** using `fs::metadata().len()` with 100MB limit before reading
+2. **[P4: Input] Add lossy UTF-8 fallback** — use `fs::read()` + `String::from_utf8_lossy()` instead of `read_to_string()`
+3. **[Additional] Replace `.unwrap()`** at line 198 with `match`/`map_err` or `expect("generic PURL creation should not fail")`
+4. **[P2: DoS] Add iteration count caps** (100K) to authors/dependencies iteration loops with early-break and warning
+5. **[P2: DoS] Add size check** before cloning full JSON into `extra_data["podspec.json"]` at line 147
+6. **[P2: DoS] Add string field truncation** at 10MB with warning log

--- a/docs/parser-audit/poetry_lock.md
+++ b/docs/parser-audit/poetry_lock.md
@@ -1,0 +1,109 @@
+# ADR 0004 Security Audit: poetry_lock
+
+**File**: `src/parsers/poetry_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- TOML parsing via `read_toml_file` at line 62 — static deserialization
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `read_toml_file` at line 62
+- `read_toml_file` delegates to `read_file_to_string` without size check
+- **GAP**: Entire file read into memory without size limit
+
+### Recursion Depth
+
+- No recursive functions in this parser
+- PASS
+
+### Iteration Count
+
+- `parse_poetry_lock` iterates `packages` array without cap at line 86
+- `extract_package_dependencies` iterates dependency tables without cap at lines 263, 276
+- **GAP**: No 100,000 item cap on packages or dependencies
+
+### String Length
+
+- No 10MB per-field truncation for parsed values (name, version, requirement)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check
+- `read_toml_file` failure handled gracefully at lines 63-68
+
+### UTF-8 Encoding
+
+- `read_file_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- TOML parse failure returns `default_package_data` at lines 64-68
+- PASS — graceful degradation
+
+### Required Fields
+
+- `build_dependency_from_package` returns `None` if name or version missing at lines 182-190
+- Missing fields result in `None` — continues parsing
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 79: `.unwrap_or_default()` on `packages` — safe, uses `unwrap_or_default`
+- Line 199: `.unwrap_or(false)` on `poetry_optional` — safe, uses `unwrap_or`
+- Line 301: `.unwrap_or(false)` on `is_optional` — safe, uses `unwrap_or`
+- No dangerous bare `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s) | Description                                |
+| --- | --------------- | -------- | ------- | ------------------------------------------ |
+| 1   | P2-FileSize     | HIGH     | 62      | No file size check before `read_toml_file` |
+| 2   | P2-Iteration    | LOW      | 86      | No 100K iteration cap on packages array    |
+| 3   | P2-StringLength | LOW      | N/A     | No 10MB per-field truncation               |
+| 4   | P4-UTF8         | LOW      | N/A     | No lossy UTF-8 fallback                    |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading poetry.lock
+2. Add 100K iteration caps on package/dependency iteration
+3. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/publiccode.md
+++ b/docs/parser-audit/publiccode.md
@@ -1,0 +1,94 @@
+# ADR 0004 Security Audit: publiccode
+
+**File**: `src/parsers/publiccode.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `yaml_serde` for static YAML parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` at line 23 without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative over YAML fields. — PASS
+
+### Iteration Count
+
+- `extract_contact_parties` (line 129): Iterates over contacts sequence — no 100K cap
+- `extract_localized_string` (line 115): Iterates over mapping values — small iteration expected
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+YAML files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 23 fails on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+YAML parse error at line 34 is handled, returns `default_package_data()`. — PASS
+
+### Required Fields
+
+Missing `publiccodeYmlVersion` returns `default_package_data()` (line 58-64). Missing name/version result in `None`. — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 23      | No file size check before reading |
+| 2   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 3   | P4 UTF-8         | LOW      | 23      | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB

--- a/docs/parser-audit/pylock_toml.md
+++ b/docs/parser-audit/pylock_toml.md
@@ -1,0 +1,122 @@
+# ADR 0004 Security Audit: pylock_toml
+
+**File**: `src/parsers/pylock_toml.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- TOML parsing via `read_toml_file` at line 77 — static deserialization
+- Regex-based marker parsing at line 446 — no code execution
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `read_toml_file` at line 77
+- Entire file read into memory without size limit
+
+### Recursion Depth
+
+- `toml_values_match` recursively compares TOML values at line 355 — no depth limit
+- `collect_reachable_indices` uses BFS (VecDeque) at line 391 — no depth issue but no cycle protection needed (BFS)
+- **GAP**: `toml_values_match` has no recursion depth limit for deeply nested TOML values
+
+### Iteration Count
+
+- `package_values.iter()` at line 117 iterates packages without cap
+- `build_dependency_indices` iterates packages with O(n\*m) matching at line 307 — could be quadratic
+- `collect_reachable_indices` BFS has no node count limit
+- **GAP**: No 100,000 item cap on packages, dependencies, or BFS nodes
+
+### String Length
+
+- No 10MB per-field truncation for parsed values (name, version, marker strings)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check
+- `read_toml_file` failure handled gracefully at lines 78-82
+
+### UTF-8 Encoding
+
+- `read_file_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- TOML parse failure returns `default_package_data` at lines 79-82
+- Invalid `lock-version` returns default at lines 93-98
+- Missing `created-by` returns default at lines 104-107
+- PASS — graceful degradation with validation
+
+### Required Fields
+
+- Missing `name`/`version` in package tables results in `None` — dependency skipped via `filter_map` at line 192
+- Missing `lock-version` or `created-by` returns default package data
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PASS
+
+- `collect_reachable_indices` at line 391 uses `HashSet<usize>` visited set to prevent revisiting
+- BFS naturally handles cycles via `visited.insert(index)` check at line 396
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 212: `.unwrap_or_default()` — safe
+- Line 219: `.unwrap_or_default()` — safe
+- Line 258: `.unwrap_or_default()` — safe
+- Line 259: `.unwrap_or_default()` — safe
+- No dangerous bare `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s) | Description                                                      |
+| --- | --------------- | -------- | ------- | ---------------------------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | 77      | No file size check before `read_toml_file`                       |
+| 2   | P2-Recursion    | MEDIUM   | 355     | `toml_values_match` recurses without depth limit on nested TOML  |
+| 3   | P2-Iteration    | MEDIUM   | 307     | `build_dependency_indices` has O(n\*m) package matching — no cap |
+| 4   | P2-Iteration    | LOW      | 117     | No 100K iteration cap on packages array                          |
+| 5   | P2-StringLength | LOW      | N/A     | No 10MB per-field truncation                                     |
+| 6   | P4-UTF8         | LOW      | N/A     | No lossy UTF-8 fallback                                          |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading pylock.toml
+2. Add recursion depth limit to `toml_values_match` (max 50)
+3. Add 100K iteration caps on package iteration and dependency resolution
+4. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+All 6 findings addressed. read_toml_file already uses read_file_to_string (file size + UTF-8). Added depth limit to toml_values_match (50), iteration caps on package iteration and BFS, applied truncate_field to all string values.

--- a/docs/parser-audit/python.md
+++ b/docs/parser-audit/python.md
@@ -1,0 +1,158 @@
+# ADR 0004 Security Audit: python
+
+**File**: `src/parsers/python.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- setup.py parsed via `ruff_python_parser::parse_module` (AST only) at line 3315
+- `LiteralEvaluator` evaluates only literal values (strings, numbers, lists, dicts) — no exec/eval at lines 2963-3086
+- Regex fallback for large setup.py files at line 4104 (`extract_from_setup_py_regex`) — no code execution
+- No `Command::new`, `subprocess`, `eval()`, or `exec()` anywhere in the file
+- `collect_self_method_calls` in conan.rs traverses AST nodes recursively but never executes code
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+- `MAX_SETUP_PY_BYTES` = 1MB checked at line 3107 before AST parsing
+- `MAX_ARCHIVE_SIZE` = 100MB for wheel/egg/sdist archives checked via `fs::metadata().len()` at lines 833, 1303, 1417
+- `MAX_FILE_SIZE` = 50MB per archive entry at lines 951, 638, 1557
+- `read_limited_utf8` enforces byte limits at line 1571
+- **GAP**: No `fs::metadata().len()` check before reading plain text files (pyproject.toml, setup.cfg, PKG-INFO, METADATA, pypi.json). `read_file_to_string` at line 33 reads entire file without size check.
+
+### Recursion Depth
+
+- `MAX_SETUP_PY_AST_DEPTH` = 50 tracked in `LiteralEvaluator` at line 2978
+- `SetupCallFinder` tracks `nodes_visited` against `MAX_SETUP_PY_AST_NODES` = 10,000 at lines 3504, 3567
+- `dotted_name` respects depth limit at line 3601
+- **GAP**: `collect_self_method_calls` (used by conan parser) recurses without depth tracking — but this is in conan.rs, not python.rs
+
+### Iteration Count
+
+- Archive entries iterated without 100K cap in `collect_validated_zip_entries` (line 613) and `collect_tar_sdist_entries` (line 938)
+- `parse_record_csv` iterates CSV records without cap (line 1625)
+- `parse_requires_txt` iterates lines without cap (line 4052)
+- **GAP**: No 100,000 iteration limit on archive entries, CSV rows, or dependency lists
+
+### String Length
+
+- `read_limited_utf8` truncates at `MAX_FILE_SIZE` (50MB) for archive entries (line 1576)
+- **GAP**: No 10MB per-field truncation for parsed string values (name, version, description, license, etc.)
+- `content.len()` checked against `MAX_SETUP_PY_BYTES` (1MB) at line 3107 but individual field values are not truncated
+
+## Principle 3: Archive Safety
+
+**Status**: PASS
+
+### Size Limits
+
+- `MAX_ARCHIVE_SIZE` = 100MB total uncompressed checked at lines 647, 960 (exceeds ADR 0004's 1GB — more restrictive, acceptable)
+- `MAX_FILE_SIZE` = 50MB per entry at lines 638, 951, 1557
+
+### Compression Ratio
+
+- `MAX_COMPRESSION_RATIO` = 100:1 enforced at lines 629, 969, 1549
+
+### Path Traversal
+
+- `normalize_archive_entry_path` at line 1592 blocks `..`, root dir, and drive letter prefixes
+- Returns `None` for `Component::ParentDir` and `Component::RootDir` at line 1607
+
+### Decompression Limits
+
+- Total extracted size tracked and enforced via `total_extracted` at lines 610, 935
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- Archive paths checked via `fs::metadata()` at lines 833, 1303, 1417
+- **GAP**: Non-archive file reads use `read_file_to_string` which calls `File::open` — returns error but no pre-check with `fs::metadata()`
+- `is_valid_wheel_archive_path` opens and validates at line 671
+
+### UTF-8 Encoding
+
+- `read_limited_utf8` at line 1571 uses `String::from_utf8` with error return (line 1589)
+- **GAP**: No lossy fallback — returns error on invalid UTF-8 rather than logging warning and converting lossy
+- `read_file_to_string` uses `file.read_to_string` which fails on invalid UTF-8 without lossy fallback
+
+### JSON/YAML Validity
+
+- `serde_json::from_str` failures return `default_package_data` at lines 382, 4182, 4400
+- `read_toml_file` failures return error propagated to callers which return default at lines 2172, 61-68
+- PASS — graceful degradation on parse failure
+
+### Required Fields
+
+- Missing `name`/`version` handled with `None` — continue parsing at lines 1819-1820, 2214-2221
+- `apply_sdist_name_version_fallback` populates from archive filename if missing at line 1256
+- PASS
+
+### URL Format
+
+- URLs accepted as-is from parsed content (no validation) — compliant with ADR 0004 ("Accept as-is")
+- PASS
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with circular dependency risk in this parser. The `requirements_txt` module handles circular includes separately.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 130: `path.file_name().unwrap_or_default()` — safe, uses `unwrap_or_default`
+- Line 132: `path.file_name().unwrap_or_default()` — safe
+- Line 136: `path.file_name().unwrap_or_default()` — safe
+- Line 142: `path.file_name().unwrap_or_default()` — safe
+- Line 349: `scope_from_filename` uses `unwrap_or_default()` — safe
+- Line 611: `unwrap_or_default()` on `extract_lockfile_requirement` — safe
+- Line 1632: `record.get(0).unwrap_or("")` — safe, `unwrap_or`
+- Line 1637: `record.get(1).unwrap_or("")` — safe
+- Line 1638: `record.get(2).unwrap_or("")` — safe
+- Line 1834: `get_header_first(...).unwrap_or_default()` — safe
+- Line 3999: `.expect("extra marker regex should compile")` — acceptable, compile-time invariant
+- Line 5191: `.map_err(|e| e.to_string())` — safe
+- No dangerous `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s)              | Description                                                                            |
+| --- | --------------- | -------- | -------------------- | -------------------------------------------------------------------------------------- |
+| 1   | P2-FileSize     | MEDIUM   | 33, 37               | `read_file_to_string` reads entire file without size pre-check for non-archive formats |
+| 2   | P2-Iteration    | LOW      | 613, 938, 1625, 4052 | No 100K iteration cap on archive entries, CSV records, or lines                        |
+| 3   | P2-StringLength | LOW      | N/A                  | No 10MB per-field truncation for parsed string values                                  |
+| 4   | P4-FileExists   | LOW      | 37                   | No `fs::metadata()` pre-check before reading non-archive files                         |
+| 5   | P4-UTF8         | LOW      | 1589                 | `read_limited_utf8` returns error instead of lossy fallback on invalid UTF-8           |
+
+## Remediation Priority
+
+1. Add file size pre-check (`fs::metadata().len()` against 100MB limit) in `read_file_to_string` or before calling it for non-archive files
+2. Add 100K iteration caps to archive entry loops, CSV parsing, and line-based parsers
+3. Add 10MB string field truncation with warning logging for long parsed values
+4. Add lossy UTF-8 fallback with warning in `read_limited_utf8`
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/readme.md
+++ b/docs/parser-audit/readme.md
@@ -1,0 +1,95 @@
+# ADR 0004 Security Audit: readme
+
+**File**: `src/parsers/readme.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Simple line-based key:value parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. Uses `read_file_to_string(path)` at line 56 without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative over lines. — PASS
+
+### Iteration Count
+
+- `content.lines()` iteration (line 67): No 100K cap on number of lines processed. A file with millions of lines would be fully iterated.
+
+### String Length
+
+No field-level truncation at 10MB. Individual line values are used as-is (line 91-107).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Text files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `read_file_to_string` at line 56 returns error on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`read_file_to_string` (utils.rs) uses `read_to_string` which fails on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+N/A — README files are plain text, not JSON/YAML.
+
+### Required Fields
+
+Missing name falls back to parent directory name (lines 115-120). — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 56      | No file size check before reading |
+| 2   | P2 Iteration     | LOW      | 67      | No 100K cap on line iteration     |
+| 3   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 4   | P4 UTF-8         | LOW      | 56      | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB
+2. Add line iteration cap (100K) on README parsing

--- a/docs/parser-audit/requirements_txt.md
+++ b/docs/parser-audit/requirements_txt.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: requirements_txt
+
+**File**: `src/parsers/requirements_txt.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- Pure string/regex parsing via `parse_pep508_requirement` at line 524
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+- No dynamic code execution of any kind
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `fs::read_to_string` at line 193
+- Entire file read into memory without size limit
+
+### Recursion Depth
+
+- `parse_requirements_with_includes` recurses for `-r` and `-c` includes at lines 228, 245
+- Circular include detection via `state.visited` HashSet at lines 186-189 prevents infinite recursion
+- **GAP**: No explicit recursion depth limit (e.g., 50 levels). Malicious file chain could create deep recursion before hitting the visited-set check, though cycles are broken. Non-circular deep chains (A includes B includes C ...) have no depth cap.
+
+### Iteration Count
+
+- `collect_logical_lines` iterates all lines without cap at line 283
+- `for line in collect_logical_lines(&content)` at line 201 has no 100K iteration limit
+- **GAP**: No 100,000 item cap on lines or dependencies
+
+### String Length
+
+- No 10MB per-field truncation for parsed requirement strings
+- `trimmed` at line 203 and dependency lines are used as-is
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- `path.canonicalize()` at line 178 returns early on error — no explicit `fs::metadata()` pre-check
+- `included_path.exists()` checked at lines 227, 244 before processing includes
+
+### UTF-8 Encoding
+
+- `fs::read_to_string` at line 193 — will fail on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- N/A — no JSON/YAML parsing in this module
+
+### Required Fields
+
+- Dependencies without names handled gracefully — `parse_pep508_requirement` returns `None` for invalid specs
+- `build_dependency` returns `None` for empty/invalid input at line 367
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PASS
+
+- `ParseState.visited` HashSet at line 111 tracks visited file paths
+- Circular include detected and logged at lines 186-189
+- Path canonicalized at line 178 for consistent comparison
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 224: `unwrap_or_else(|| Path::new("."))` — safe, `unwrap_or_else`
+- Line 349: `unwrap_or_default()` — safe
+- Line 611: `unwrap_or_else(|| (name_part.to_string(), Vec::new(), None))` — safe
+- No dangerous `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s)  | Description                                                                    |
+| --- | --------------- | -------- | -------- | ------------------------------------------------------------------------------ |
+| 1   | P2-FileSize     | HIGH     | 193      | No file size check before `fs::read_to_string` — unbounded memory read         |
+| 2   | P2-Recursion    | MEDIUM   | 228, 245 | No explicit recursion depth limit for include chains (only circular detection) |
+| 3   | P2-Iteration    | LOW      | 201, 283 | No 100K iteration cap on lines or dependencies                                 |
+| 4   | P2-StringLength | LOW      | N/A      | No 10MB per-field truncation for requirement strings                           |
+| 5   | P4-UTF8         | LOW      | 193      | No lossy UTF-8 fallback on `fs::read_to_string` failure                        |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading requirements.txt files
+2. Add explicit recursion depth counter (max 50) to `parse_requirements_with_includes`
+3. Add 100K iteration cap on lines/dependencies with early break and warning
+4. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/rfc822.md
+++ b/docs/parser-audit/rfc822.md
@@ -1,0 +1,97 @@
+# ADR 0004 Security Audit: rfc822
+
+**File**: `src/parsers/rfc822.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure text parsing with string splitting and HashMap operations.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+This module does not read files directly — it receives `&str` content from callers. File size checks are the responsibility of the calling parser. N/A for this module, but callers (debian.rs, etc.) must enforce limits.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_rfc822_content()` line 75: iterates all lines without limit
+- `parse_rfc822_paragraphs()` line 136: iterates all lines without limit
+- `parse_paragraph_headers()` line 171: iterates all lines without limit
+
+### String Length
+
+No 10MB truncation on header values. Continuation lines (lines 87-91) can append unbounded content to a single header value.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction. No file I/O.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+N/A — module receives `&str` content, does not read files.
+
+### UTF-8 Encoding
+
+N/A — input is already `&str` which is guaranteed valid UTF-8 by Rust's type system.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+Header lookup functions (`get_header_first`, `get_header_all`) return `Option` types. Missing headers result in `None`. PASS per ADR.
+
+### URL Format
+
+URLs accepted as-is. N/A (no URL-specific handling).
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code (excluding test module at line 251). `unwrap_or_default()` at line 243 is a safe pattern.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s)    | Description                                                          |
+| --- | --------- | -------- | ---------- | -------------------------------------------------------------------- |
+| 1   | P2        | MEDIUM   | 75,136,171 | No iteration count cap on line loops (100K items)                    |
+| 2   | P2        | MEDIUM   | 87-91      | No string length truncation on header values with continuation lines |
+
+## Remediation Priority
+
+1. Add iteration count caps on line processing loops
+2. Add string length truncation on accumulated header values

--- a/docs/parser-audit/rpm_db.md
+++ b/docs/parser-audit/rpm_db.md
@@ -1,0 +1,113 @@
+# ADR 0004 Security Audit: rpm_db
+
+**File**: `src/parsers/rpm_db.rs`
+**Date**: 2026-04-14
+**Status**: NON-COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: FAIL
+
+**CRITICAL**: `Command::new("rpm")` is used as a fallback when native parsing fails:
+
+- Line 325: `Command::new("rpm").args(["--dbpath"]).arg(&rpmdb_dir).args(["--query", "--all", "--queryformat", RPM_QUERY_FORMAT]).output()` — executes the `rpm` CLI tool
+- Line 353: `Command::new("rpm").arg("--version").output()` — checks if rpm CLI is available
+
+This is a direct violation of ADR 0004 Principle 1: "FORBIDDEN: subprocess calls, Command::new". The `rpm` CLI is executed with user-controlled database paths.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. The native parser reads the entire database file. `read_installed_rpm_packages()` is called without pre-checking file size.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_rpm_query_output()` line 359: iterates all package blocks without limit
+- `build_package_data()` line 464: iterates all requires without limit
+- `build_file_references()` line 272: iterates all base_names without limit
+- `build_file_references_from_paths()` line 295: iterates all paths without limit
+
+### String Length
+
+No 10MB truncation on field values from rpm query output or native parsing.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction. RPM databases are raw database files, not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+The native parser (`BdbDatabase::open()`, `NdbDatabase::open()`) uses `File::open()` which returns error on missing files. `rpm_command_available()` at line 352 handles missing `rpm` binary. However, no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+- Line 333: `String::from_utf8_lossy(&output.stderr)` — uses lossy conversion for rpm CLI output. PASS for stderr.
+- Line 346: `String::from_utf8(output.stdout)` — uses strict UTF-8 for rpm query output, returns error on invalid UTF-8. Should use lossy conversion.
+- Native parser uses `String::from_utf8_lossy()` in `entry.rs:61` for string reading. PASS.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`build_package_data()` line 443: `name` is optional; missing name results in `None`. `version` is constructed via `build_evr_version()` which returns `None` for empty versions. Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution; only parsing declared dependencies.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code (excluding test module at line 614).
+
+### Command::new / Subprocess Usage
+
+**Status**: FAIL
+
+- Line 325: `Command::new("rpm")` — executes rpm CLI with user-controlled `--dbpath`
+- Line 353: `Command::new("rpm")` — checks rpm CLI availability
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s)         | Description                                                            |
+| --- | --------- | -------- | --------------- | ---------------------------------------------------------------------- |
+| 1   | P1        | CRITICAL | 325,353         | Command::new("rpm") subprocess execution violates ADR 0004 Principle 1 |
+| 2   | P2        | HIGH     | —               | No file size check before reading (100MB limit)                        |
+| 3   | P2        | MEDIUM   | 359,464,272,295 | No iteration count cap (100K items)                                    |
+| 4   | P2        | MEDIUM   | —               | No string length truncation (10MB per field)                           |
+| 5   | P4        | LOW      | —               | No explicit fs::metadata() pre-check                                   |
+| 6   | P4        | LOW      | 346             | String::from_utf8() on rpm stdout should use lossy conversion          |
+
+## Remediation Priority
+
+1. **CRITICAL**: Remove `Command::new("rpm")` subprocess calls; rely solely on native RPM database parsing
+2. Add fs::metadata().len() check before reading with 100MB limit
+3. Add iteration count caps on package/dependency/file loops
+4. Add String::from_utf8_lossy() for rpm query output
+5. Add string length truncation on field values

--- a/docs/parser-audit/rpm_db_native_bdb.md
+++ b/docs/parser-audit/rpm_db_native_bdb.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: rpm_db_native_bdb
+
+**File**: `src/parsers/rpm_db_native/bdb.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure binary parsing of BerkeleyDB format using `File`, `Read`, and `Seek` traits.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before opening. `File::open()` at line 30 reads the file without pre-checking size. The `read_blobs()` method iterates from page 0 to `last_page_number` (line 96), which could be very large for a large database file.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- `read_blobs()` line 96: iterates `0..=self.metadata.generic.last_page_number` — no cap on number of pages. A database claiming millions of pages could cause excessive I/O.
+- `read_overflow_value()` line 57: follows a linked list of overflow pages with no depth limit. A malicious database could create an infinite overflow chain.
+- `hash_page_value_indexes()` line 139: processes index entries based on `entry_count` without limit.
+
+### String Length
+
+No 10MB truncation on blob data. Overflow values are accumulated via `value.extend_from_slice()` without size limit.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction. Raw binary database reading.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`File::open()` at line 30 returns error on missing files. No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+N/A — this module reads raw binary data. String conversion happens in `entry.rs` which uses `String::from_utf8_lossy()`.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+N/A — returns raw blobs.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                     |
+| --- | --------- | -------- | ------- | --------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 30      | No file size check before opening (100MB limit)                 |
+| 2   | P2        | HIGH     | 96      | No cap on page iteration (last_page_number could be very large) |
+| 3   | P2        | HIGH     | 57      | No depth limit on overflow page linked-list traversal           |
+| 4   | P2        | MEDIUM   | 139     | No cap on hash page entry count processing                      |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before opening with 100MB limit
+2. Add iteration cap on page loop (0..=last_page_number)
+3. Add depth limit on overflow page chain traversal
+4. Add size limit on accumulated overflow value data

--- a/docs/parser-audit/rpm_db_native_entry.md
+++ b/docs/parser-audit/rpm_db_native_entry.md
@@ -1,0 +1,101 @@
+# ADR 0004 Security Audit: rpm_db_native_entry
+
+**File**: `src/parsers/rpm_db_native/entry.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure binary data parsing and struct construction.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+N/A — this module receives `&[u8]` slices, does not read files.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- `HeaderBlob::parse()` line 134: iterates `0..index_length` — limited by `HEADER_MAX_BYTES` check at line 124, but `index_length` itself is only bounded indirectly by the 256MB total limit.
+- `verify_entries()` line 278: iterates all entry_infos without limit.
+- `import_entries()` line 153: iterates all entry_infos without limit.
+- `swab_region()` line 328: iterates all entry_infos without limit.
+- `read_u32_array()` line 67: limited by `self.info.count` without explicit cap.
+- `read_string_array()` line 79: splits on null bytes without count limit.
+
+### String Length
+
+- `HEADER_MAX_BYTES` at line 14: 256 MB limit on total header blob size. This exceeds ADR 0004's 100MB file size limit.
+- No 10MB per-field truncation on string values.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+N/A — operates on in-memory data.
+
+### UTF-8 Encoding
+
+- `read_string()` line 60: uses `String::from_utf8_lossy()` — PASS per ADR.
+- `read_string_array()` line 83: uses `String::from_utf8_lossy()` — PASS per ADR.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+N/A — returns parsed entries; callers handle missing fields.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s)     | Description                                                           |
+| --- | --------- | -------- | ----------- | --------------------------------------------------------------------- |
+| 1   | P2        | MEDIUM   | 14          | HEADER_MAX_BYTES is 256MB, exceeding ADR 0004's 100MB file size limit |
+| 2   | P2        | MEDIUM   | 134,278,328 | No explicit iteration count cap on entry processing                   |
+| 3   | P2        | LOW      | 67,79       | No count cap on u32/string array reads                                |
+
+## Remediation Priority
+
+1. Reduce HEADER_MAX_BYTES from 256MB to 100MB or add a separate file-level 100MB check
+2. Add iteration count caps on entry/array processing

--- a/docs/parser-audit/rpm_db_native_mod.md
+++ b/docs/parser-audit/rpm_db_native_mod.md
@@ -1,0 +1,94 @@
+# ADR 0004 Security Audit: rpm_db_native_mod
+
+**File**: `src/parsers/rpm_db_native/mod.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Delegates to BDB/NDB/SQLite parsers which are all native Rust implementations.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before opening database files. `BdbDatabase::open()`, `NdbDatabase::open()`, `SqliteDatabase::open()` all open files without pre-checking size.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- Line 52: `reader.read_blobs()?.into_iter().map(...)` iterates all blobs without limit. A database with >100K packages would violate the 100K iteration cap.
+- Line 54: `.collect()` collects all results without limit.
+
+### String Length
+
+No 10MB truncation on parsed package data fields.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction. RPM database files are read structurally.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+Each sub-parser handles file opening errors via `File::open()` returning `Result`. No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+Delegated to sub-parsers. `entry.rs` uses `String::from_utf8_lossy()` for string reading (line 61-63). PASS for UTF-8 in the entry parsing path.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+Delegated to `parse_installed_rpm_package()` in package.rs. Fields default to empty strings. Acceptable per ADR.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code (excluding test module at line 63).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                    |
+| --- | --------- | -------- | ------- | -------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 36-37   | No file size check before opening database files (100MB limit) |
+| 2   | P2        | MEDIUM   | 52-54   | No iteration count cap on blob/package iteration (100K items)  |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before opening database files with 100MB limit
+2. Add iteration count cap on blob/package iteration

--- a/docs/parser-audit/rpm_db_native_ndb.md
+++ b/docs/parser-audit/rpm_db_native_ndb.md
@@ -1,0 +1,98 @@
+# ADR 0004 Security Audit: rpm_db_native_ndb
+
+**File**: `src/parsers/rpm_db_native/ndb.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure binary parsing of RPM NDB format using `BufReader<File>`, `Read`, and `Seek`.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before opening. `File::open()` at line 88 reads the file without pre-checking size. However, there are some bounds:
+
+- Line 98: `slot_page_count > 2048` is rejected — this limits the number of slot entries.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- `open()` line 107: iterates `0..slot_count` (bounded by `slot_page_count * 4096/16 - 2`). With `slot_page_count <= 2048`, max slots = 2048 \* 256 - 2 = 524286. This exceeds the 100K iteration cap.
+- `read_blobs()` line 118: iterates all slots without limit beyond the slot_page_count cap.
+
+### String Length
+
+No 10MB truncation on blob data. `blob_header.blob_length` at line 144 determines the read size — a malicious NDB could specify a very large `blob_length`, causing a large memory allocation.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`File::open()` at line 88 returns error on missing files. No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+N/A — returns raw blobs. String conversion happens in entry.rs.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+N/A — returns raw blobs.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                                   |
+| --- | --------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 88      | No file size check before opening (100MB limit)                               |
+| 2   | P2        | MEDIUM   | 107     | Slot count can reach 524K, exceeding 100K iteration cap                       |
+| 3   | P2        | MEDIUM   | 144     | No size cap on blob_length; malicious NDB could cause large memory allocation |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before opening with 100MB limit
+2. Reduce slot_page_count limit or add explicit 100K iteration cap on slot processing
+3. Add size cap on individual blob allocation

--- a/docs/parser-audit/rpm_db_native_package.md
+++ b/docs/parser-audit/rpm_db_native_package.md
@@ -1,0 +1,94 @@
+# ADR 0004 Security Audit: rpm_db_native_package
+
+**File**: `src/parsers/rpm_db_native/package.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure struct construction from parsed entries.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+N/A — operates on in-memory parsed entries.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- `parse_installed_rpm_package()` line 34: iterates all entries without limit. However, entries are already bounded by HEADER_MAX_BYTES (256MB) in entry.rs.
+- `read_u32_array()` and `read_string_array()` in entry.rs are bounded by `info.count`.
+
+### String Length
+
+No 10MB truncation on string values from `entry.read_string()` or `entry.read_string_array()`. Large string arrays (e.g., file_names, requires) are stored without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+N/A — operates on in-memory data.
+
+### UTF-8 Encoding
+
+Delegated to `entry.rs` which uses `String::from_utf8_lossy()`. PASS.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+All fields in `InstalledRpmPackage` default to empty strings/vectors. `ensure_kind()` at line 111 validates tag types. Acceptable per ADR.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                               |
+| --- | --------- | -------- | ------- | --------------------------------------------------------- |
+| 1   | P2        | MEDIUM   | 34      | No explicit iteration count cap on entry processing       |
+| 2   | P2        | MEDIUM   | —       | No string length truncation on string/string_array fields |
+
+## Remediation Priority
+
+1. Add iteration count cap on entry processing loop
+2. Add string length truncation on parsed string values

--- a/docs/parser-audit/rpm_db_native_sqlite.md
+++ b/docs/parser-audit/rpm_db_native_sqlite.md
@@ -1,0 +1,93 @@
+# ADR 0004 Security Audit: rpm_db_native_sqlite
+
+**File**: `src/parsers/rpm_db_native/sqlite.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `rusqlite` crate for read-only SQLite database access. The connection is opened with `SQLITE_OPEN_READ_ONLY` flag (line 24), which prevents any write operations or SQL injection-based modifications.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before opening. `File::open()` at line 19 and `Connection::open_with_flags()` at line 24 both operate without pre-checking size.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+- `read_blobs()` line 36: iterates all rows from the `Packages` table without limit. A database with >100K rows would violate the 100K iteration cap.
+
+### String Length
+
+No 10MB truncation on blob data. SQLite blobs could be arbitrarily large.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`File::open()` at line 19 returns error on missing files. `Connection::open_with_flags()` at line 24 also returns error. No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+N/A — returns raw blobs. String conversion happens in entry.rs.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+N/A — returns raw blobs.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                 |
+| --- | --------- | -------- | ------- | ----------------------------------------------------------- |
+| 1   | P2        | HIGH     | 19,24   | No file size check before opening (100MB limit)             |
+| 2   | P2        | MEDIUM   | 36      | No iteration count cap on SQLite row iteration (100K items) |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before opening with 100MB limit
+2. Add iteration count cap on SQLite row iteration (LIMIT clause or early break)

--- a/docs/parser-audit/rpm_db_native_tags.md
+++ b/docs/parser-audit/rpm_db_native_tags.md
@@ -1,0 +1,90 @@
+# ADR 0004 Security Audit: rpm_db_native_tags
+
+**File**: `src/parsers/rpm_db_native/tags.rs`
+**Date**: 2026-04-14
+**Status**: COMPLIANT
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure constant definitions and enum matching.
+
+## Principle 2: DoS Protection
+
+**Status**: PASS
+
+### File Size
+
+N/A — no file I/O.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No loops. PASS.
+
+### String Length
+
+N/A — no string data processing.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PASS
+
+### File Exists
+
+N/A.
+
+### UTF-8 Encoding
+
+N/A.
+
+### JSON/YAML Validity
+
+N/A.
+
+### Required Fields
+
+N/A.
+
+### URL Format
+
+N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description |
+| --- | --------- | -------- | ------- | ----------- |
+
+## Remediation Priority
+
+No issues found. File is fully compliant with ADR 0004.

--- a/docs/parser-audit/rpm_license_files.md
+++ b/docs/parser-audit/rpm_license_files.md
@@ -1,0 +1,91 @@
+# ADR 0004 Security Audit: rpm_license_files
+
+**File**: `src/parsers/rpm_license_files.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Pure path-based name extraction.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check. However, this parser does NOT read file contents — it only extracts the package name from the file path. No file content is read into memory. PASS for file size (content not read).
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No loops that iterate over potentially large datasets. PASS.
+
+### String Length
+
+No 10MB truncation on extracted name/path values, but values come from path components which are inherently bounded by filesystem limits. LOW risk.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No file content reading occurs. The parser only inspects the path string. N/A for file existence check of content.
+
+### UTF-8 Encoding
+
+`path.to_string_lossy()` at line 41 and `path_str.split()` at line 61 use lossy conversion implicitly through `to_string_lossy()`. PASS for UTF-8.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`extract_packages()` line 61: `name` is extracted from path. If path doesn't contain `usr/share/licenses/`, `name` will be `None`. PackageData is still returned with `None` name. Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                         |
+| --- | --------- | -------- | ------- | ------------------------------------------------------------------- |
+| 1   | P2        | LOW      | —       | No string length truncation, but values are filesystem-path-bounded |
+
+## Remediation Priority
+
+1. Consider adding a string length cap on extracted path-based name values (LOW priority — filesystem already limits path component length)

--- a/docs/parser-audit/rpm_mariner_manifest.md
+++ b/docs/parser-audit/rpm_mariner_manifest.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: rpm_mariner_manifest
+
+**File**: `src/parsers/rpm_mariner_manifest.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. All parsing is static text-based line parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string()` at line 52 reads entire files without size validation. Note: this uses `std::fs::read_to_string` directly (not the utility), which also lacks size checks.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_rpm_mariner_manifest()` line 67: iterates all lines without limit
+
+### String Length
+
+No 10MB truncation on field values (name, version, arch, filename from line splits).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`fs::read_to_string()` at line 52 returns error on missing files (handled at lines 53-57), but no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`fs::read_to_string()` errors on invalid UTF-8. No lossy conversion fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`parse_rpm_mariner_manifest()` lines 89-92: `name`, `version`, `arch`, `filename` extracted from tab-split fields. Missing/empty handled by checking `is_empty()` (lines 94, 102, 116, 121). Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                         |
+| --- | --------- | -------- | ------- | ------------------------------------------------------------------- |
+| 1   | P2        | HIGH     | 52      | No file size check before reading (100MB limit)                     |
+| 2   | P2        | MEDIUM   | 67      | No iteration count cap (100K items)                                 |
+| 3   | P2        | MEDIUM   | —       | No string length truncation (10MB per field)                        |
+| 4   | P4        | LOW      | 52      | No explicit fs::metadata() pre-check                                |
+| 5   | P4        | MEDIUM   | 52      | No lossy UTF-8 fallback; fs::read_to_string errors on invalid UTF-8 |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before reading with 100MB limit
+2. Add iteration count cap on line loop
+3. Add String::from_utf8_lossy() fallback for UTF-8 handling

--- a/docs/parser-audit/rpm_parser.md
+++ b/docs/parser-audit/rpm_parser.md
@@ -1,0 +1,101 @@
+# ADR 0004 Security Audit: rpm_parser
+
+**File**: `src/parsers/rpm_parser.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses the `rpm` crate for binary RPM package parsing via `Package::parse()` (line 184), which is a static Rust library — no shell execution.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `File::open()` at line 175 opens the file and `Package::parse()` reads it without pre-checking size. The `is_match()` function at line 166 also opens the file without size checks.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `extract_rpm_dependencies()` line 405: iterates all requires without limit
+- `extract_rpm_relationships()` line 453: iterates all relationships without limit
+
+### String Length
+
+No 10MB truncation on field values from RPM metadata.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+RPM package files are parsed structurally (not extracted as archives in the traditional sense). The `rpm` crate handles decompression internally.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`File::open()` at line 175 returns an error on missing files (handled at lines 176-179). No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+The `rpm` crate's `get_name()`, `get_version()`, etc. return `String` types. The internal `rpm_header_string()` function at line 93 uses `get_entry_data_as_string()` which likely handles UTF-8 internally. No explicit lossy conversion fallback in this file.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`parse_rpm_package()` line 221: `name` from `metadata.get_name()` is `Option<String>`. Missing name results in `None`. `version` from `build_evr_version()` returns `None` if version is missing. Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 574: `.unwrap()` in test code only — acceptable.
+- No `.unwrap()` in non-test library code. PASS for library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                               |
+| --- | --------- | -------- | ------- | --------------------------------------------------------- |
+| 1   | P2        | HIGH     | 175,166 | No file size check before reading RPM files (100MB limit) |
+| 2   | P2        | MEDIUM   | 405,453 | No iteration count cap (100K items)                       |
+| 3   | P2        | MEDIUM   | —       | No string length truncation (10MB per field)              |
+| 4   | P4        | LOW      | 175     | No explicit fs::metadata() pre-check                      |
+| 5   | P4        | LOW      | —       | No explicit lossy UTF-8 fallback for RPM metadata strings |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before opening RPM files with 100MB limit
+2. Add iteration count caps on dependency/relationship loops
+3. Add string length truncation on field values

--- a/docs/parser-audit/rpm_specfile.md
+++ b/docs/parser-audit/rpm_specfile.md
@@ -1,0 +1,107 @@
+# ADR 0004 Security Audit: rpm_specfile
+
+**File**: `src/parsers/rpm_specfile.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. The specfile parser performs static text parsing and simple macro expansion via `String::replace()` (line 374). It does NOT execute shell commands or evaluate RPM macros as code.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file_to_string()` at line 59 reads entire files without size validation.
+
+### Recursion Depth
+
+No recursive functions. Macro expansion in `expand_macros()` is iterative (line 372: iterates over macros map), not recursive. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `parse_specfile()` line 87: `while i < lines.len()` iterates all preamble lines without limit
+- Line 126: iterates comma-separated BuildRequires without limit
+- Line 145: iterates comma-separated Requires without limit
+- Line 153: iterates comma-separated Provides without limit
+- Line 170: while loop for %description section without line count limit
+- Line 267: iterates all build_requires without limit
+- Line 285: iterates all requires without limit
+
+### String Length
+
+No 10MB truncation on field values. Tag values, macro definitions, and expanded strings are stored without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+Uses `read_file_to_string()` which returns error on missing files (handled at lines 60-68), but no explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`read_file_to_string()` errors on invalid UTF-8. No lossy conversion fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`parse_specfile()` lines 211-212: `name` and `version` are extracted from tags as `Option<String>`. Missing values result in `None`, which is acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 42: `.unwrap()` on `Regex::new()` in `LazyLock` static — compile-time constant regex, unlikely to fail, but technically `.unwrap()` in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle  | Severity | Line(s)                    | Description                                                     |
+| --- | ---------- | -------- | -------------------------- | --------------------------------------------------------------- |
+| 1   | P2         | HIGH     | 59                         | No file size check before reading (100MB limit)                 |
+| 2   | P2         | MEDIUM   | 87,126,145,153,170,267,285 | No iteration count cap (100K items)                             |
+| 3   | P2         | MEDIUM   | —                          | No string length truncation (10MB per field)                    |
+| 4   | P4         | LOW      | 59                         | No explicit fs::metadata() pre-check                            |
+| 5   | P4         | MEDIUM   | 59                         | No lossy UTF-8 fallback; invalid UTF-8 causes error not warning |
+| 6   | Additional | LOW      | 42                         | .unwrap() on Regex::new() in LazyLock static                    |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before read_file_to_string with 100MB limit
+2. Add iteration count caps on line/dependency loops
+3. Add String::from_utf8_lossy() fallback for UTF-8 handling
+4. Replace .unwrap() at line 42 with expect() or proper initialization

--- a/docs/parser-audit/rpm_yumdb.md
+++ b/docs/parser-audit/rpm_yumdb.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: rpm_yumdb
+
+**File**: `src/parsers/rpm_yumdb.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. All parsing is static text-based path parsing and filesystem reads.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading individual key files. `fs::read_to_string()` at line 93 reads key files without size validation. While individual key files are typically small, a malicious filesystem could contain large files.
+
+### Recursion Depth
+
+No recursive functions. PASS.
+
+### Iteration Count
+
+No 100K iteration cap on loops:
+
+- `extract_packages()` line 83: iterates all entries in the yumdb package directory without limit
+
+### String Length
+
+No 10MB truncation on key values read from filesystem. Each key file's content is stored in `extra_data` without length limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+No archive extraction.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+`fs::read_dir()` at line 72 returns error on missing directory (handled at lines 73-79). `fs::read_to_string()` at line 93 returns error on missing files (handled at lines 103). No explicit `fs::metadata()` pre-check.
+
+### UTF-8 Encoding
+
+`fs::read_to_string()` at line 93 errors on invalid UTF-8. No lossy conversion fallback.
+
+### JSON/YAML Validity
+
+No JSON/YAML parsing. N/A.
+
+### Required Fields
+
+`extract_packages()` line 63: If `parse_yumdb_dir_name()` returns `None`, returns default package data. Name and version are extracted from directory name; missing values handled. Acceptable per ADR.
+
+### URL Format
+
+URLs accepted as-is. PASS per ADR.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code (excluding test module at line 123).
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle | Severity | Line(s) | Description                                                         |
+| --- | --------- | -------- | ------- | ------------------------------------------------------------------- |
+| 1   | P2        | MEDIUM   | 93      | No file size check before reading key files (100MB limit)           |
+| 2   | P2        | MEDIUM   | 83      | No iteration count cap on directory entries (100K items)            |
+| 3   | P2        | LOW      | —       | No string length truncation (10MB per field)                        |
+| 4   | P4        | LOW      | 72,93   | No explicit fs::metadata() pre-check                                |
+| 5   | P4        | MEDIUM   | 93      | No lossy UTF-8 fallback; fs::read_to_string errors on invalid UTF-8 |
+
+## Remediation Priority
+
+1. Add fs::metadata().len() check before reading key files with 100MB limit
+2. Add iteration count cap on directory entry loop
+3. Add String::from_utf8_lossy() fallback for UTF-8 handling

--- a/docs/parser-audit/ruby.md
+++ b/docs/parser-audit/ruby.md
@@ -1,0 +1,142 @@
+# ADR 0004 Security Audit: ruby
+
+**File**: `src/parsers/ruby.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, `exec()`, or any code execution primitives found. All parsing uses regex-based static analysis (`Regex::new`, `captures_iter`, `captures`) and YAML/structured data parsing via `yaml_serde`. Ruby DSL constructs (Gemfile, gemspec) are parsed via regex tokenization, not Ruby AST or runtime evaluation.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+- **GemfileParser** (line 82): Uses `fs::read_to_string(path)` directly with **no** `fs::metadata().len()` pre-check.
+- **GemfileLockParser** (line 407): Uses `fs::read_to_string(path)` directly with **no** file size pre-check.
+- **GemspecParser** (line 967): Uses `fs::read_to_string(path)` directly with **no** file size pre-check.
+- **GemArchiveParser** (line 1564-1566): **PASS** — Checks `fs::metadata(path).len()` before reading, enforces `MAX_ARCHIVE_SIZE` (100MB, line 1531).
+- **GemMetadataExtractedParser** (line 1941): Uses `fs::read_to_string(path)` with **no** file size pre-check.
+
+### Recursion Depth
+
+- No recursive parsing functions found. The `block_stack` (line 108) and state machine (lines 466-667) are iterative, not recursive. The `load_required_ruby_contexts` function (line 1183) follows `require` statements but does so iteratively with a single level of follow — no depth tracking. However, there is no cycle detection: if a required file itself requires another file, `load_required_ruby_contexts` does not recurse (it only scans the original content for `require` statements), so this is bounded. **PASS** for recursion, but see Principle 5.
+
+### Iteration Count
+
+- `parse_gemfile` (line 166): Iterates `content.lines()` with **no** 100K cap on iterations or dependency count.
+- `parse_gemfile_lock` (line 512): Iterates `content.lines()` with **no** 100K cap.
+- `parse_gemspec_with_context` (line 1294): Iterates `field_re.captures_iter(content)` with **no** 100K cap.
+- `extract_gem_archive` (line 1578): Iterates tar entries with **no** 100K cap on number of entries.
+- `parse_gem_yaml_dependencies` (line 1847): Iterates dependency sequence with **no** 100K cap.
+
+### String Length
+
+- No field values are truncated at 10MB. `clean_gemspec_value` (line 1019) and other extraction functions return full strings regardless of length.
+- `decoder.read_to_string(&mut content)` (line 1599) reads full decompressed metadata into a single `String` with only a 50MB cap on decompressed size (line 1612), which exceeds the 10MB per-field ADR limit.
+
+## Principle 3: Archive Safety
+
+**Status**: PARTIAL
+
+### Size Limits
+
+- `MAX_ARCHIVE_SIZE` = 100MB (line 1531): Checks compressed archive size. **PASS** for archive-level, but ADR requires 1GB uncompressed limit — no explicit uncompressed total check for the full tar archive (only `metadata.gz` entry is size-checked at 50MB, line 1532).
+- `MAX_FILE_SIZE` = 50MB (line 1532): Checks individual entry size. This is reasonable but does not match ADR's 1GB uncompressed limit.
+
+### Compression Ratio
+
+- `MAX_COMPRESSION_RATIO` = 100.0 (line 1533): Checks ratio of decompressed `metadata.gz` size vs compressed entry size (lines 1603-1610). **PASS**.
+
+### Path Traversal
+
+- **FAIL**: No check for `../` patterns in tar entry paths. The `entry_path` at line 1583-1585 is only checked against `"metadata.gz"` — no path traversal validation is performed on tar entry names.
+
+### Decompression Limits
+
+- Decompressed `metadata.gz` is checked against `MAX_FILE_SIZE` (50MB) at line 1612. However, the decompression is done via `read_to_string` (line 1599) which allocates the full decompressed content in memory before the size check, meaning a decompression bomb could OOM before the limit is enforced. **PARTIAL** — limit exists but is checked post-decompression.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- `GemfileParser` (line 82): `fs::read_to_string` returns error on missing file, handled gracefully. **PASS** (returns default PackageData).
+- `GemfileLockParser` (line 407): Same pattern. **PASS**.
+- `GemspecParser` (line 967): Same pattern. **PASS**.
+- `GemArchiveParser` (line 1564-1565): Uses `fs::metadata` before opening. **PASS**.
+- `GemMetadataExtractedParser` (line 1941): `fs::read_to_string` error handled. **PASS**.
+- No explicit `fs::metadata()` pre-check for the text parsers (Gemfile, GemfileLock, Gemspec), relying on `read_to_string` error instead. This is functionally equivalent but doesn't match the ADR's prescriptive `fs::metadata()` check.
+
+### UTF-8 Encoding
+
+- `fs::read_to_string` returns an error on non-UTF-8 content, which is handled by returning default PackageData. **No** lossy fallback (`String::from_utf8_lossy`) is attempted. If the file contains non-UTF-8 bytes, the parser silently returns default data. **FAIL** — no lossy conversion attempted.
+
+### JSON/YAML Validity
+
+- `parse_gem_metadata_yaml` (line 1635-1636): YAML parse failure returns `Err`, which propagates up to `extract_gem_archive` which returns default `PackageData`. **PASS** for graceful handling.
+- `clean_ruby_yaml_tags` (line 1824): Handles regex compilation failure gracefully. **PASS**.
+
+### Required Fields
+
+- Missing `name`/`version` in gemspec results in `None` values — the code continues and returns a `PackageData` with those fields as `None`. **PASS**.
+- Missing `name` in Gemfile dependencies (line 216-218): Skips empty names. **PASS**.
+
+### URL Format
+
+- URLs (homepage, download, API) are constructed programmatically or extracted from content as-is. No URL validation or sanitization is performed. Per ADR: "Accept as-is". **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+These parsers do not perform dependency resolution. The `load_required_ruby_contexts` function (line 1183) follows `require` statements but does so only one level deep (scans original content for requires, loads each found file) — it does not recursively follow requires in loaded files, so cycles are not possible.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls found in library code. All `unwrap_or`, `unwrap_or_default`, and `unwrap_or_else` usages are safe:
+
+- Line 176, 191, 215, 305, 330, 584-585, 595-596, 635, 754, 1029, 1031, 1033, 1035, 1359, 1374, 1495, 1660, 1681, 1696, 1759, 1772, 1869-1870: All `unwrap_or()`/`unwrap_or_default()`/`unwrap_or_else()` — safe defaults.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new`, `std::process::Command`, or subprocess usage found in this file.
+
+## Findings Summary
+
+| #   | Principle   | Severity | Line(s)                    | Description                                                                                                                                    |
+| --- | ----------- | -------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: DoS     | Medium   | 82, 407, 967, 1941         | No file size pre-check (`fs::metadata().len()`) before `fs::read_to_string` for Gemfile, GemfileLock, Gemspec, and metadata.gz-extract parsers |
+| 2   | P2: DoS     | Medium   | 166, 512, 1294, 1578, 1847 | No iteration count cap (100K) on line/entry/dependency loops                                                                                   |
+| 3   | P2: DoS     | Low      | 1019, 1599                 | No string field truncation at 10MB limit                                                                                                       |
+| 4   | P3: Archive | High     | 1578-1621                  | No path traversal check (`../`) on tar entry paths in .gem archive parser                                                                      |
+| 5   | P3: Archive | Medium   | 1599                       | Decompression limit checked post-read; a decompression bomb could OOM before size check executes                                               |
+| 6   | P3: Archive | Low      | 1531                       | MAX_ARCHIVE_SIZE is 100MB; ADR specifies 1GB uncompressed limit for archives                                                                   |
+| 7   | P4: Input   | Medium   | 82, 407, 967, 1941         | No lossy UTF-8 fallback — non-UTF-8 files cause parser to return default data silently                                                         |
+
+## Remediation Priority
+
+1. **[P3: Archive] Add path traversal check for `../` in tar entry paths** (line 1583-1585) — block entries with `..` path components before processing
+2. **[P3: Archive] Use bounded decompression** (line 1596-1600) — read decompressed data in chunks with a size accumulator to enforce limits before full allocation
+3. **[P4: Input] Add lossy UTF-8 fallback** (lines 82, 407, 967, 1941) — use `fs::read()` + `String::from_utf8_lossy()` instead of `fs::read_to_string()` to handle non-UTF-8 content
+4. **[P2: DoS] Add file size pre-checks** before `fs::read_to_string` using `fs::metadata().len()` with 100MB limit
+5. **[P2: DoS] Add iteration count caps** (100K) to all line/entry/dependency loops with early-break and warning
+6. **[P2: DoS] Add string field truncation** at 10MB with warning log for oversized values
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/sbt.md
+++ b/docs/parser-audit/sbt.md
@@ -1,0 +1,118 @@
+# ADR 0004 Security Audit: sbt
+
+**File**: `src/parsers/sbt.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `subprocess`, `eval()`, or code execution. Uses a custom tokenizer (`tokenize()` at line 249) and pattern-matching parser. All parsing is static string/token analysis. No Scala or JVM code execution.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. The entire file is read into memory at line 23 (`fs::read_to_string(path)`) without a size check.
+
+### Recursion Depth
+
+The `resolve_alias_value` function (line 428) is recursive and resolves string alias references. It has cycle detection via `visiting: &mut HashSet<String>` (line 399, 438) — inserting returns `false` if already present, which returns `None` and breaks the cycle. However, there is no explicit depth limit. A chain of 50+ alias references would recurse deeply. The `strip_outer_parens` function (line 830) uses a `loop` construct (not recursion). **Partial** — cycle detection present but no depth limit.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `split_top_level_statements` (line 179): Iterates over all input characters
+- `tokenize` (line 249): Iterates over all characters in each statement
+- `process_statement_tokens` (line 521): Called for each statement without cap
+- `parse_library_dependencies` (line 660): No cap on dependencies extracted
+- `resolve_string_aliases` (line 387): Iterates over all statements
+
+### String Length
+
+No 10 MB truncation with warning on any field value. Token strings, identifier values, and string literals are stored without size limits.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+SBT parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` at line 23 with error handling that returns `default_package_data()` on failure (line 27). Returns error not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files (line 23-28). No explicit lossy conversion path — invalid UTF-8 causes the parser to return default data. No `String::from_utf8()` + warning + lossy conversion pattern.
+
+### JSON/YAML Validity
+
+Returns default `PackageData` on read failure (line 27). Not applicable for SBT format. **PASS**.
+
+### Required Fields
+
+Missing name/version are left as `None` and the parser continues. **PASS**.
+
+### URL Format
+
+URLs accepted as-is. **PASS** per ADR spec.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PARTIAL
+
+The `resolve_alias_value` function (line 428) implements circular reference detection for alias resolution:
+
+- Uses `visiting: &mut HashSet<String>` to track currently-resolving names (line 399)
+- Inserting an already-visiting name returns `None` (line 438), breaking the cycle
+- Memoizes resolved values in `resolved: &mut HashMap<String, String>` (line 398)
+- Removes name from `visiting` after resolution completes (line 449)
+
+However, there is no explicit depth limit on the recursion. A linear chain of aliases (not circular, but deeply nested) could cause stack overflow.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code or test code within this file.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                                                         |
+| --- | ------------------- | -------- | ------------------ | --------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 23                 | No `fs::metadata().len()` check before reading; entire file loaded into memory                      |
+| 2   | P2: Recursion Depth | Medium   | 428                | `resolve_alias_value` is recursive with cycle detection but no depth limit (ADR requires 50 levels) |
+| 3   | P2: Iteration Count | Medium   | 179, 249, 521, 660 | No 100K iteration cap on statement parsing, tokenization, or dependency extraction                  |
+| 4   | P2: String Length   | Low      | 278, 363           | No 10 MB truncation with warning on string token values                                             |
+| 5   | P4: File Exists     | Low      | 23                 | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                                     |
+| 6   | P4: UTF-8 Encoding  | Low      | 23                 | No lossy UTF-8 conversion path; invalid UTF-8 causes parser to return default data                  |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 23)
+2. Add depth limit (50 levels) to `resolve_alias_value` recursion (line 428)
+3. Add iteration count cap (100K) on statement/dependency processing
+4. Add 10 MB string field truncation with warning
+5. Add `fs::metadata()` pre-check before file read
+6. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+All 6 findings addressed. Added MAX_RECURSION_DEPTH=50 to resolve_alias_value, iteration caps on parsing/tokenization/statement loops, replaced fs::read_to_string with utils version, applied truncate_field to all string values.

--- a/docs/parser-audit/swift_manifest_json.md
+++ b/docs/parser-audit/swift_manifest_json.md
@@ -1,0 +1,99 @@
+# ADR 0004 Security Audit: swift_manifest_json
+
+**File**: `src/parsers/swift_manifest_json.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `serde_json` for static JSON parsing.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` called at line 53 via `read_swift_manifest_json`. Entire file loaded into memory without size pre-check.
+
+### Recursion Depth
+
+No recursive functions found. All processing is iterative over JSON arrays. — PASS
+
+### Iteration Count
+
+- `get_dependencies` (line 136): Iterates over `deps_array` — no 100K cap
+- No other unbounded iteration loops
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+JSON files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 53 fails on missing files, handled by returning error which is caught in `extract_packages` (line 31). — Acceptable fallback.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8 content. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` errors at line 55 are handled by returning error string, caught in `extract_packages` (line 31). Returns default `PackageData`. — PASS
+
+### Required Fields
+
+Missing name results in `None` (line 59-62). Version is always `None` for manifest JSON. — PASS
+
+### URL Format
+
+URLs parsed via `get_namespace_and_name` (line 261) with simple string operations. Accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with cycle tracking.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 159: `.unwrap_or_default()` on identity extraction — safe (returns empty string)
+- Line 208: `.unwrap_or_default()` on identity extraction — safe
+- Line 281: `.unwrap_or(path)` on `.strip_suffix(".git")` — safe
+- No problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                       |
+| --- | ---------------- | -------- | ------- | --------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 53      | No file size check before reading |
+| 2   | P2 Iteration     | LOW      | 136     | No 100K cap on dependencies array |
+| 3   | P2 String Length | LOW      | —       | No field-level 10MB truncation    |
+| 4   | P4 UTF-8         | LOW      | 53      | No lossy UTF-8 fallback           |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading files, reject >100MB
+2. Add iteration cap (100K) on dependencies array

--- a/docs/parser-audit/swift_resolved.md
+++ b/docs/parser-audit/swift_resolved.md
@@ -1,0 +1,98 @@
+# ADR 0004 Security Audit: swift_resolved
+
+**File**: `src/parsers/swift_resolved.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `serde_json` for static JSON deserialization (line 108). Uses `url` crate for URL parsing (line 257).
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `read_file` (line 285) opens file and reads entire content into a `String` via `file.read_to_string()` without size pre-check.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative over pin arrays. — PASS
+
+### Iteration Count
+
+- `parse_v2_v3_pins` (line 176): Iterates over `pins` slice — no 100K cap
+- `parse_v1_pins` (line 180): Iterates over `pins` slice — no 100K cap
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+JSON files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `File::open` at line 286 will fail on missing files, error is propagated. — Acceptable.
+
+### UTF-8 Encoding
+
+`file.read_to_string` at line 288 will fail on non-UTF-8 content. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` error at line 109 is handled, returns error that results in `default_package_data()`. — PASS
+
+### Required Fields
+
+Name and version are `Option<String>` from deserialized structs. Missing values result in `None`. — PASS
+
+### URL Format
+
+URLs parsed with `Url::parse` (line 257). Invalid URLs return `None`. — PASS
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution with cycle tracking.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 118: `.unwrap_or(&[])` — safe, returns empty slice
+- Line 261: `.unwrap_or(path)` — safe, returns original path
+- No problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s)  | Description                                               |
+| --- | ---------------- | -------- | -------- | --------------------------------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | 285-289  | No file size check before reading entire file into memory |
+| 2   | P2 Iteration     | LOW      | 176, 180 | No 100K cap on pins array iteration                       |
+| 3   | P2 String Length | LOW      | —        | No field-level 10MB truncation                            |
+| 4   | P4 UTF-8         | LOW      | 288      | No lossy UTF-8 fallback                                   |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check before reading, reject >100MB
+2. Add iteration cap (100K) on pins processing

--- a/docs/parser-audit/swift_show_dependencies.md
+++ b/docs/parser-audit/swift_show_dependencies.md
@@ -1,0 +1,110 @@
+# ADR 0004 Security Audit: swift_show_dependencies
+
+**File**: `src/parsers/swift_show_dependencies.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `serde_json` for static JSON deserialization (line 83).
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string` called at line 67 without size pre-check.
+
+### Recursion Depth
+
+**CRITICAL**: `flatten_dependency` (line 118) is recursive with **NO depth tracking or cycle detection**. It recursively traverses `dep.dependencies` children (line 123-124). A deeply nested or cyclic dependency structure (though unlikely from JSON, malformed input could cause deep nesting) will cause stack overflow.
+
+Additionally, `build_dependency` (line 128) recursively calls itself on line 135 to build `nested_dependencies` for each child — also **without depth or cycle tracking**.
+
+### Iteration Count
+
+- `flatten_dependencies` (line 109): No 100K cap on total flattened dependencies
+- The recursive traversal can produce unbounded output
+
+### String Length
+
+No field-level truncation at 10MB.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+JSON files are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string` at line 67 fails on missing files, handled via `match`. — Acceptable.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` will fail on non-UTF-8. No lossy conversion fallback. — Minor gap.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` error at line 83 is handled, returns `default_package_data()`. — PASS
+
+### Required Fields
+
+Missing name/version result in `None`. — PASS
+
+### URL Format
+
+URLs accepted as-is via `parse_url_namespace_and_name` (line 236). — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: FAIL
+
+`flatten_dependency` (line 118) does not track visited nodes. While JSON deserialization typically prevents true cycles, the recursive function has no protection against deep nesting. No visited-state tracking exists.
+
+`build_dependency` (line 128) also recursively processes nested dependencies (line 132-136) without cycle detection.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- Line 161: `.unwrap_or_default()` — safe
+- No problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle          | Severity | Line(s)  | Description                                                                |
+| --- | ------------------ | -------- | -------- | -------------------------------------------------------------------------- |
+| 1   | P2 Recursion       | HIGH     | 118-125  | `flatten_dependency` recursive with no depth tracking or cycle detection   |
+| 2   | P2 Recursion       | HIGH     | 128-136  | `build_dependency` recursive on nested_dependencies with no depth tracking |
+| 3   | P2 File Size       | MEDIUM   | 67       | No file size check before reading                                          |
+| 4   | P2 Iteration       | MEDIUM   | 109      | No 100K cap on total flattened dependencies                                |
+| 5   | P2 String Length   | LOW      | —        | No field-level 10MB truncation                                             |
+| 6   | P4 UTF-8           | LOW      | 67       | No lossy UTF-8 fallback                                                    |
+| 7   | P5 Cycle Detection | HIGH     | 118, 128 | No circular dependency detection in recursive traversal                    |
+
+## Remediation Priority
+
+1. Add depth parameter (max 50) to `flatten_dependency` and `build_dependency`, break on overflow
+2. Add visited-set tracking for cycle detection in dependency tree
+3. Add `fs::metadata().len()` check before reading, reject >100MB
+4. Add iteration cap (100K) on total flattened dependencies
+
+## Remediation
+
+All 7 findings addressed. Added MAX_RECURSION_DEPTH=50 to flatten_dependency and build_dependency, iteration cap via MAX_ITERATION_COUNT, cycle detection via visited HashSet, replaced fs::read_to_string with utils version, applied truncate_field to all string fields.

--- a/docs/parser-audit/utils.md
+++ b/docs/parser-audit/utils.md
@@ -1,0 +1,114 @@
+# ADR 0004 Security Audit: utils
+
+**File**: `src/parsers/utils.rs`
+**Date**: 2026-04-14
+**Status**: DONE
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- Pure string manipulation and base64 decoding — no code execution
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- `read_file_to_string` at line 33 reads entire file with `file.read_to_string` — no size limit
+- **GAP**: This is the primary shared file-reading utility and has no `fs::metadata().len()` pre-check
+- This affects ALL parsers that use this function (python.rs, pipfile_lock.rs, poetry_lock.rs, pylock_toml.rs, uv_lock.rs, conan_data.rs)
+
+### Recursion Depth
+
+- No recursive functions
+- PASS
+
+### Iteration Count
+
+- `split_name_email` iterates characters at line 129 — O(n) bounded
+- `parse_sri` iterates decoded bytes at line 85 — O(n) bounded
+- `npm_purl` string splitting at line 46 — O(1) bounded
+- PASS — no unbounded iteration
+
+### String Length
+
+- No 10MB truncation for file contents read via `read_file_to_string`
+- No truncation for individual field values
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check in `read_file_to_string`
+- `File::open` failure propagated as `anyhow::Error`
+- **GAP**: No explicit existence check before opening
+
+### UTF-8 Encoding
+
+- `file.read_to_string` at line 36 fails on invalid UTF-8
+- **GAP**: No lossy UTF-8 conversion with warning — this is the central utility used by many parsers
+
+### JSON/YAML Validity
+
+- N/A — no JSON/YAML parsing in this module
+
+### Required Fields
+
+- N/A — this module provides utility functions, not direct parsing
+
+### URL Format
+
+- N/A — URLs not handled in this module
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+- No `.unwrap()` calls in library code
+- Test code uses `.unwrap()` which is acceptable per ADR 0004
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle     | Severity | Line(s) | Description                                                                          |
+| --- | ------------- | -------- | ------- | ------------------------------------------------------------------------------------ |
+| 1   | P2-FileSize   | CRITICAL | 33-37   | `read_file_to_string` reads entire file without size check — used by 6+ parsers      |
+| 2   | P4-UTF8       | HIGH     | 36      | `read_to_string` fails on invalid UTF-8 without lossy fallback — affects all callers |
+| 3   | P4-FileExists | LOW      | 34      | No `fs::metadata()` pre-check before `File::open`                                    |
+
+## Remediation Priority
+
+1. **CRITICAL**: Add `fs::metadata().len()` check (100MB default) in `read_file_to_string` before reading — this is the single highest-impact fix as it protects all dependent parsers
+2. Add lossy UTF-8 fallback path: on `read_to_string` failure, try `read_to_end` + `String::from_utf8_lossy` with a warning log
+3. Optionally add `fs::metadata()` existence check before `File::open`
+
+## Remediation
+
+**PR**: #664
+**Date**: 2026-04-14
+
+All findings addressed in ADR 0004 security compliance batch 1.

--- a/docs/parser-audit/uv_lock.md
+++ b/docs/parser-audit/uv_lock.md
@@ -1,0 +1,119 @@
+# ADR 0004 Security Audit: uv_lock
+
+**File**: `src/parsers/uv_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+- TOML parsing via `read_toml_file` at line 69 — static deserialization
+- No `Command::new`, `subprocess`, `eval()`, `exec()` anywhere
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+- No `fs::metadata().len()` check before `read_toml_file` at line 69
+- Entire file read into memory without size limit
+
+### Recursion Depth
+
+- `toml_value_to_json` recursively converts TOML to JSON at line 894 — no depth limit
+- **GAP**: No recursion depth limit on deeply nested TOML structures
+
+### Iteration Count
+
+- `package_tables` iteration at line 92 without cap
+- `collect_reachable_packages` BFS at line 587 has no node count limit
+- `collect_root_direct_dependencies` iterates dependency tables without cap at line 285
+- `collect_package_dependency_edges` iterates without cap at line 419
+- **GAP**: No 100,000 item cap on packages, edges, or BFS nodes
+
+### String Length
+
+- No 10MB per-field truncation for parsed values (name, version, specifier)
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Not an archive parser.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+- No `fs::metadata()` pre-check
+- `read_toml_file` failure handled gracefully at lines 70-74
+
+### UTF-8 Encoding
+
+- `read_file_to_string` fails on invalid UTF-8 without lossy fallback
+- **GAP**: No lossy UTF-8 conversion with warning
+
+### JSON/YAML Validity
+
+- TOML parse failure returns `default_package_data` at lines 71-74
+- Empty packages array returns default at lines 88-90
+- PASS — graceful degradation
+
+### Required Fields
+
+- Missing `name` returns `None` — dependency skipped via `filter_map` at line 156
+- Missing `version` returns `None` — dependency skipped at line 186
+
+### URL Format
+
+- URLs accepted as-is — compliant with ADR 0004
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: PASS
+
+- `collect_reachable_packages` at line 587 uses `HashSet<String>` visited set
+- BFS `visited.insert(package_name.clone())` at line 613 prevents revisiting
+- Cycles broken explicitly
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 86: `.unwrap_or_default()` — safe
+- Line 228: `.unwrap_or_default()` — safe (twice, for name and version)
+- Line 233: `.unwrap_or_default()` — safe
+- Line 293: `.unwrap_or_default()` — safe
+- Line 547: `.unwrap_or_default()` — safe
+- Line 563: `.unwrap_or_default()` — safe
+- Line 611: `.unwrap_or(name)` — safe
+- No dangerous bare `.unwrap()` calls in library code
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle       | Severity | Line(s)      | Description                                                      |
+| --- | --------------- | -------- | ------------ | ---------------------------------------------------------------- |
+| 1   | P2-FileSize     | HIGH     | 69           | No file size check before `read_toml_file`                       |
+| 2   | P2-Recursion    | MEDIUM   | 894          | `toml_value_to_json` recurses without depth limit on nested TOML |
+| 3   | P2-Iteration    | LOW      | 92, 285, 419 | No 100K iteration cap on packages or dependency edges            |
+| 4   | P2-StringLength | LOW      | N/A          | No 10MB per-field truncation                                     |
+| 5   | P4-UTF8         | LOW      | N/A          | No lossy UTF-8 fallback                                          |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check (100MB limit) before reading uv.lock
+2. Add recursion depth limit to `toml_value_to_json` (max 50)
+3. Add 100K iteration caps on package/dependency iteration
+4. Add lossy UTF-8 fallback with warning log

--- a/docs/parser-audit/vcpkg.md
+++ b/docs/parser-audit/vcpkg.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: vcpkg
+
+**File**: `src/parsers/vcpkg.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+Uses `serde_json::from_str` (line 32) for static JSON parsing. No `Command::new`, `subprocess`, `eval()`, or any code execution mechanism.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `extract_packages` (line 24) uses `fs::read_to_string(path)` without a size check. Additionally, `read_sibling_configuration` (line 254) reads a sibling file `vcpkg-configuration.json` without a size check.
+
+### Recursion Depth
+
+No recursive functions. All parsing is iterative over JSON structures. **PASS**.
+
+### Iteration Count
+
+No 100K iteration cap on:
+
+- `extract_dependencies` (line 134): iterates over all dependency entries without cap
+- `extract_dependencies` inner loop (line 149): iterates over feature dependencies without cap
+- `extract_maintainers` (line 106): iterates over maintainers array without cap
+- `build_extra_data` (line 225): iterates over fixed set of fields (low risk)
+
+### String Length
+
+No 10 MB truncation with warning on any field value. String fields like `name`, `version`, `description`, `homepage`, `license` are extracted without size limits (lines 53-57, 267-273).
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+Vcpkg parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. Uses `fs::read_to_string(path)` (line 24) with error handling that returns `default_package_data()` (lines 26-29). Also, `read_sibling_configuration` (line 254) uses `fs::read_to_string` on a derived sibling path without pre-check. Does not panic, but doesn't use `fs::metadata()` as specified.
+
+### UTF-8 Encoding
+
+`fs::read_to_string` returns an error for non-UTF-8 files. Error is caught and fallback data returned. No explicit `String::from_utf8()` + warning + lossy conversion path.
+
+### JSON/YAML Validity
+
+`serde_json::from_str` (line 32) returns an error on invalid JSON, caught at lines 34-37, returning `default_package_data()`. **PASS**.
+
+### Required Fields
+
+Missing `name` is handled via `get_non_empty_string` (line 53) which returns `Option<String>`. When `None`, `is_private` is set to `true` (line 72). Missing `version` handled similarly (line 54). PURL handles missing values gracefully (lines 76-78). **PASS**.
+
+### URL Format
+
+`homepage` field is accepted as-is (line 56). Per ADR 0004, accept as-is is correct. **PASS**.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution performed. Dependencies are extracted from manifest declarations only.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage found.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)        | Description                                                                                 |
+| --- | ------------------- | -------- | -------------- | ------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Medium   | 24, 254        | No `fs::metadata().len()` check before reading; files loaded into memory without size check |
+| 2   | P2: Iteration Count | Low      | 134, 149       | No 100K iteration cap on dependency/feature processing                                      |
+| 3   | P2: String Length   | Low      | 53-57, 267-273 | No 10 MB truncation with warning on string field values                                     |
+| 4   | P4: File Exists     | Low      | 24, 254        | Uses `fs::read_to_string` instead of `fs::metadata()` pre-check                             |
+| 5   | P4: UTF-8 Encoding  | Low      | 24             | No lossy UTF-8 conversion path; invalid UTF-8 causes fallback data return                   |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 24, 254)
+2. Add iteration count cap (100K) on dependency/feature processing loops
+3. Add 10 MB string field truncation with warning
+4. Add `fs::metadata()` pre-check before file read
+5. Add lossy UTF-8 conversion with warning for encoding errors

--- a/docs/parser-audit/windows_executable.md
+++ b/docs/parser-audit/windows_executable.md
@@ -1,0 +1,106 @@
+# ADR 0004 Security Audit: windows_executable
+
+**File**: `src/parsers/windows_executable.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `Command::new`, `exec()`, `eval()`, or subprocess calls. Uses `object` crate for static PE binary parsing. All analysis is done on raw bytes via memory-mapped structures.
+
+## Principle 2: DoS Protection
+
+**Status**: PARTIAL
+
+### File Size
+
+The parser operates on `bytes: &[u8]` received from the scanner. File size checking is the caller's responsibility. However, the module has `MAX_SIBLING_LICENSE_BYTES` (256KB, line 28) for sibling license files — a partial size limit. The main binary bytes have no size limit in this module.
+
+### Recursion Depth
+
+No recursive functions. All processing is iterative (XML parsing loop, version info iteration). — PASS
+
+### Iteration Count
+
+- `iter_version_blocks` (line 348): Iterator over version blocks — no 100K cap
+- `extract_utf16_version_string_fallback` (line 324): Processes entire byte array — no size cap
+- `WINDOWS_VERSION_FALLBACK_KEYS` iteration (line 331): Fixed small iteration (11 keys) — PASS
+- `build_windows_executable_package` (line 438): No cap on string tables or dependencies
+
+### String Length
+
+No field-level truncation at 10MB. PE version string values used as-is.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+PE binaries are not archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+For sibling license reading (`read_sibling_license_text`, line 759), `fs::metadata` IS checked at line 771. File size IS checked at line 773 against `MAX_SIBLING_LICENSE_BYTES`. — PASS for sibling files.
+
+For main binary parsing, the function signature accepts `bytes: &[u8]` — file existence and reading is the caller's responsibility.
+
+### UTF-8 Encoding
+
+- `decode_utf16_bytes` (line 423): Uses `String::from_utf16(&units).ok()` — silently drops invalid UTF-16 rather than using lossy conversion. Should use `String::from_utf16_lossy()` or at minimum log a warning.
+- `extract_utf16_version_string_fallback` (line 324): Uses `String::from_utf16_lossy` — PASS
+- `String::from_utf8` is not used (PE uses UTF-16LE encoding)
+
+### JSON/YAML Validity
+
+N/A — binary format.
+
+### Required Fields
+
+Missing name results in `fallback_windows_executable_name` (line 535). If still `None`, returns `None` from `build_windows_executable_package` (line 471). — PASS
+
+### URL Format
+
+URLs accepted as-is. — Per ADR, acceptable.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+No dependency resolution.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: FAIL
+
+- Line 297: `block_bytes.get(children_start..).unwrap_or(&[])` — safe, fallback to empty slice
+- Line 360: `bytes.get(next_offset..).unwrap_or(&[])` — safe, fallback to empty slice
+- Line 797: `file_stem.and_then(|stem| stem.to_str()).unwrap_or(trimmed)` — safe fallback
+- No truly problematic `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No subprocess calls found.
+
+## Findings Summary
+
+| #   | Principle        | Severity | Line(s) | Description                                                                                           |
+| --- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| 1   | P2 File Size     | MEDIUM   | —       | No file size check in this module for main binary bytes (caller's responsibility)                     |
+| 2   | P2 Iteration     | LOW      | 348     | No 100K cap on version block iteration                                                                |
+| 3   | P2 String Length | LOW      | —       | No field-level 10MB truncation                                                                        |
+| 4   | P4 UTF-8         | MEDIUM   | 423     | `String::from_utf16().ok()` silently drops invalid UTF-16; should use lossy conversion or log warning |
+
+## Remediation Priority
+
+1. Replace `String::from_utf16().ok()` with `String::from_utf16_lossy()` at line 423
+2. Add iteration cap (100K) on version block processing
+3. Consider adding explicit file size check documentation for callers

--- a/docs/parser-audit/yarn_lock.md
+++ b/docs/parser-audit/yarn_lock.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: yarn_lock
+
+**File**: `src/parsers/yarn_lock.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `yaml_serde` for v2 YAML parsing and custom line-based parsing for v1 format (static). All processing is data extraction.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 59 reads entire file without size validation. Additionally, `load_manifest_dependency_info` at line 505 reads a second file (`package.json`) without size validation.
+
+### Recursion Depth
+
+No recursive functions in this parser. `parse_yarn_v1_block` at line 374 and `parse_yaml_dependencies` at line 760 are iterative. No recursion depth concern.
+
+### Iteration Count
+
+- `content.split("\n\n")` at line 258: iterates all blocks without a 100K cap. A malicious yarn.lock with >100K blocks would iterate without limit.
+- `yaml_map` iteration at line 107: iterates all YAML entries without cap.
+- `lines` iteration at line 403: iterates lines within a block without cap.
+- `mapping` iteration at line 766: iterates dependency entries without cap.
+- `manifest_dependencies` keys at lines 587, 565: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from YAML/JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 59 will fail if the file doesn't exist, but error is handled gracefully. However, `load_manifest_dependency_info` at line 505 also reads `package.json` from the parent directory without pre-check — this is silently handled with `let Ok(content) = ...` pattern.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 59 fails on invalid UTF-8 with no lossy fallback. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+- v2: `yaml_serde::from_str(content)` at line 91 handles parse failure gracefully, returning `default_package_data()` with a warning. PASS.
+- v1: Custom text parsing handles malformed data gracefully by skipping invalid blocks. PASS.
+
+### Required Fields
+
+Missing `name` and `version` result in `None` values throughout. Package data fields default to `None`. PASS.
+
+### URL Format
+
+URLs (resolved URLs) are accepted as-is. PASS.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependency graphs. It extracts flat dependency lists from lockfiles.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code. All uses are `.unwrap_or()`, `.unwrap_or_default()`, or `.unwrap_or_else()`.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)            | Description                                                                                            |
+| --- | ------------------- | -------- | ------------------ | ------------------------------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 59, 505            | No `fs::metadata().len()` check before `fs::read_to_string()` (both lockfile and sibling package.json) |
+| 2   | P2: Iteration Count | Low      | 258, 107, 403, 766 | No 100K iteration cap on block/entry/dependency loops                                                  |
+| 3   | P2: String Length   | Low      | Various            | No 10 MB per-field truncation                                                                          |
+| 4   | P4: File Exists     | Low      | 59, 505            | No explicit `fs::metadata()` pre-check before reading                                                  |
+| 5   | P4: UTF-8 Encoding  | Low      | 59                 | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure                                     |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading files (lines 59, 505)
+2. Add 100K iteration cap to block/entry/dependency loops
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/docs/parser-audit/yarn_pnp.md
+++ b/docs/parser-audit/yarn_pnp.md
@@ -1,0 +1,104 @@
+# ADR 0004 Security Audit: yarn_pnp
+
+**File**: `src/parsers/yarn_pnp.rs`
+**Date**: 2026-04-14
+**Status**: PARTIAL
+
+## Principle 1: No Code Execution
+
+**Status**: PASS
+
+No `eval()`, `exec()`, `Command::new`, or subprocess calls. Uses `serde_json` for JSON parsing (static). The `extract_raw_runtime_state_json` function at line 149 performs manual bracket-matching to extract JSON from a JavaScript file, but does not execute any code — it's purely text scanning.
+
+## Principle 2: DoS Protection
+
+**Status**: FAIL
+
+### File Size
+
+No `fs::metadata().len()` check before reading. `fs::read_to_string(path)` at line 21 reads entire file without size validation. A `.pnp.cjs` file could be arbitrarily large.
+
+### Recursion Depth
+
+No recursive functions. No recursion depth concern.
+
+### Iteration Count
+
+- `content[json_start..].char_indices()` at line 160: iterates all characters in the JSON portion without cap. A very large JSON blob would iterate without limit.
+- `registry_entries` iteration at line 66: iterates all registry entries without a 100K cap.
+- `array.iter()` at line 120: no iteration cap on dependency pairs.
+- `value.as_object().into_iter().flatten()` at line 131: no iteration cap.
+
+### String Length
+
+No 10 MB per-field truncation. Field values from JSON are stored as-is without length checks.
+
+## Principle 3: Archive Safety
+
+**Status**: N/A
+
+This parser does not handle archives.
+
+## Principle 4: Input Validation
+
+**Status**: PARTIAL
+
+### File Exists
+
+No `fs::metadata()` pre-check. `fs::read_to_string(path)` at line 21 will fail if the file doesn't exist, but error is handled gracefully returning `default_package_data()`.
+
+### UTF-8 Encoding
+
+`fs::read_to_string(path)` at line 21 fails on invalid UTF-8 with no lossy fallback. However, the `.pnp.cjs` file is JavaScript, so UTF-8 is expected. Non-UTF-8 files cause total parse failure without encoding warning.
+
+### JSON/YAML Validity
+
+`serde_json::from_str(json_text)` at line 51 handles parse failure gracefully via `?` operator propagating to the `Err` branch, which logs a warning and returns `default_package_data()`. PASS.
+
+If `extract_raw_runtime_state_json` at line 149 fails to find the marker, it returns `None`, which is converted to an `Err` and handled. PASS.
+
+### Required Fields
+
+Missing package names/versions result in `None` or skipped entries (e.g., `split_locator` at line 141 returns `Option`). PASS.
+
+### URL Format
+
+URLs are not extracted from this parser. N/A.
+
+## Principle 5: Circular Dependency Detection
+
+**Status**: N/A
+
+This parser does not resolve transitive dependency graphs.
+
+## Additional Checks
+
+### .unwrap() in Library Code
+
+**Status**: PASS
+
+No bare `.unwrap()` calls in library code.
+
+### Command::new / Subprocess Usage
+
+**Status**: PASS
+
+No `Command::new` or subprocess usage.
+
+## Findings Summary
+
+| #   | Principle           | Severity | Line(s)      | Description                                                        |
+| --- | ------------------- | -------- | ------------ | ------------------------------------------------------------------ |
+| 1   | P2: File Size       | Medium   | 21           | No `fs::metadata().len()` check before `fs::read_to_string()`      |
+| 2   | P2: Iteration Count | Low      | 160, 66, 120 | No 100K iteration cap on character/entry/dependency loops          |
+| 3   | P2: String Length   | Low      | Various      | No 10 MB per-field truncation                                      |
+| 4   | P4: File Exists     | Low      | 21           | No explicit `fs::metadata()` pre-check before reading              |
+| 5   | P4: UTF-8 Encoding  | Low      | 21           | No lossy UTF-8 fallback; non-UTF-8 files cause total parse failure |
+
+## Remediation Priority
+
+1. Add `fs::metadata().len()` check with 100 MB limit before reading file (line 21)
+2. Add 100K iteration cap to character scanning loop (line 160) and registry entry loop (line 66)
+3. Add 10 MB field value truncation with warning
+4. Add `fs::metadata()` pre-check for file existence
+5. Add lossy UTF-8 fallback for non-UTF-8 files

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -68,7 +68,7 @@ impl PackageParser for NpmLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read package-lock.json at {:?}: {}", path, e);

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -23,10 +23,11 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha1Digest, Sha512Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{npm_purl, parse_sri};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, npm_purl, parse_sri, read_file_to_string, truncate_field,
+};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use super::PackageParser;
@@ -43,6 +44,7 @@ const FIELD_DEV: &str = "dev";
 const FIELD_OPTIONAL: &str = "optional";
 const FIELD_DEV_OPTIONAL: &str = "devOptional";
 const FIELD_LINK: &str = "link";
+const MAX_RECURSION_DEPTH: usize = 50;
 
 /// npm lockfile parser supporting package-lock.json v1, v2, and v3 formats.
 ///
@@ -66,7 +68,7 @@ impl PackageParser for NpmLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read package-lock.json at {:?}: {}", path, e);
@@ -87,17 +89,19 @@ impl PackageParser for NpmLockParser {
             .and_then(|v| v.as_i64())
             .unwrap_or(1);
 
-        let root_name = json
-            .get(FIELD_NAME)
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+        let root_name = truncate_field(
+            json.get(FIELD_NAME)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        );
 
-        let root_version = json
-            .get(FIELD_VERSION)
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+        let root_version = truncate_field(
+            json.get(FIELD_VERSION)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        );
 
         vec![if lockfile_version == 1 {
             parse_lockfile_v1(&json, root_name, root_version, lockfile_version)
@@ -140,12 +144,12 @@ fn parse_lockfile_v2_plus(
 
     // Root dependencies are in top-level "dependencies" and "devDependencies"
     if let Some(root_deps_obj) = json.get(FIELD_DEPENDENCIES).and_then(|v| v.as_object()) {
-        for key in root_deps_obj.keys() {
+        for key in root_deps_obj.keys().take(MAX_ITERATION_COUNT) {
             root_deps.insert(key.clone());
         }
     }
     if let Some(root_dev_deps_obj) = json.get("devDependencies").and_then(|v| v.as_object()) {
-        for key in root_dev_deps_obj.keys() {
+        for key in root_dev_deps_obj.keys().take(MAX_ITERATION_COUNT) {
             root_deps.insert(key.clone());
         }
     }
@@ -157,7 +161,7 @@ fn parse_lockfile_v2_plus(
 
     let mut dependencies = Vec::new();
 
-    for (key, value) in packages {
+    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
         // Skip the root package (empty string key)
         if key.is_empty() {
             continue;
@@ -180,7 +184,7 @@ fn parse_lockfile_v2_plus(
         let version = value
             .get(FIELD_VERSION)
             .and_then(|v| v.as_str())
-            .map(str::to_string);
+            .map(|v| truncate_field(v.to_string()));
 
         let is_dev = value
             .get(FIELD_DEV)
@@ -195,7 +199,10 @@ fn parse_lockfile_v2_plus(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let resolved = value.get(FIELD_RESOLVED).and_then(|v| v.as_str());
+        let resolved = value
+            .get(FIELD_RESOLVED)
+            .and_then(|v| v.as_str())
+            .map(|v| truncate_field(v.to_string()));
         let integrity = value.get(FIELD_INTEGRITY).and_then(|v| v.as_str());
         let from = value.get("from").and_then(|v| v.as_str());
         let in_bundle = value
@@ -366,11 +373,19 @@ fn parse_dependencies_v1_with_depth(
     dependencies_obj: &serde_json::Map<String, Value>,
     depth: usize,
 ) -> Vec<Dependency> {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!(
+            "Max recursion depth {} exceeded in v1 dependency parsing",
+            MAX_RECURSION_DEPTH
+        );
+        return Vec::new();
+    }
+
     let mut dependencies = Vec::new();
 
-    for (package_name, dep_data) in dependencies_obj {
+    for (package_name, dep_data) in dependencies_obj.iter().take(MAX_ITERATION_COUNT) {
         let version = match dep_data.get(FIELD_VERSION).and_then(|v| v.as_str()) {
-            Some(v) => v.to_string(),
+            Some(v) => truncate_field(v.to_string()),
             None => continue,
         };
 
@@ -383,7 +398,10 @@ fn parse_dependencies_v1_with_depth(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let resolved = dep_data.get(FIELD_RESOLVED).and_then(|v| v.as_str());
+        let resolved = dep_data
+            .get(FIELD_RESOLVED)
+            .and_then(|v| v.as_str())
+            .map(|v| truncate_field(v.to_string()));
         let integrity = dep_data.get(FIELD_INTEGRITY).and_then(|v| v.as_str());
         let from = dep_data.get("from").and_then(|v| v.as_str());
         let in_bundle = dep_data
@@ -403,7 +421,7 @@ fn parse_dependencies_v1_with_depth(
             package_name,
             version,
             is_dev,
-            false, // v1 lockfiles don't have devOptional flag
+            false,
             is_optional,
             resolved,
             integrity,
@@ -554,7 +572,7 @@ fn collect_root_dependency_names(
     root_deps: &mut std::collections::HashSet<String>,
 ) {
     if let Some(entries) = value.and_then(|value| value.as_object()) {
-        for key in entries.keys() {
+        for key in entries.keys().take(MAX_ITERATION_COUNT) {
             root_deps.insert(key.clone());
         }
     }
@@ -689,7 +707,7 @@ fn build_npm_dependency(
     is_dev: bool,
     is_dev_optional: bool,
     is_optional: bool,
-    resolved: Option<&str>,
+    resolved: Option<String>,
     integrity: Option<&str>,
     is_direct: bool,
     from: Option<&str>,
@@ -697,19 +715,24 @@ fn build_npm_dependency(
     nested_deps: Vec<Dependency>,
 ) -> Dependency {
     let (dep_namespace, dep_name) = extract_namespace_and_name(package_name);
+    let dep_namespace = truncate_field(dep_namespace);
+    let dep_name = truncate_field(dep_name);
     let (scope, is_runtime, is_optional_flag) =
         determine_scope(is_dev, is_dev_optional, is_optional);
 
     let alias_spec = parse_npm_alias_spec(&version);
     let (purl_namespace, purl_name, resolved_version, is_pinned, dep_purl, download_url) =
         if let Some((alias_namespace, alias_name, alias_constraint)) = alias_spec.clone() {
+            let alias_namespace = truncate_field(alias_namespace);
+            let alias_name = truncate_field(alias_name);
+            let alias_constraint = truncate_field(alias_constraint);
             let is_pinned = is_exact_version(&alias_constraint);
             let dep_purl = create_purl(
                 &alias_namespace,
                 &alias_name,
                 is_pinned.then_some(alias_constraint.as_str()),
             );
-            let download_url = non_version_download_url(&alias_constraint, resolved);
+            let download_url = non_version_download_url(&alias_constraint, resolved.as_deref());
 
             (
                 alias_namespace,
@@ -726,7 +749,7 @@ fn build_npm_dependency(
                 &dep_name,
                 is_pinned.then_some(version.as_str()),
             );
-            let download_url = non_version_download_url(&version, resolved);
+            let download_url = non_version_download_url(&version, resolved.as_deref());
 
             (
                 dep_namespace.clone(),
@@ -739,7 +762,7 @@ fn build_npm_dependency(
         };
 
     let (sha1_from_integrity, sha512_from_integrity) = parse_integrity_field(integrity);
-    let sha1_from_url = resolved.and_then(parse_resolved_url);
+    let sha1_from_url = resolved.as_deref().and_then(parse_resolved_url);
     let sha1 = sha1_from_integrity.or(sha1_from_url);
 
     let mut dep_extra_data = HashMap::new();
@@ -775,7 +798,7 @@ fn build_npm_dependency(
 
     Dependency {
         purl: dep_purl,
-        extracted_requirement: Some(version),
+        extracted_requirement: Some(truncate_field(version)),
         scope: Some(scope.to_string()),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional_flag),
@@ -791,21 +814,23 @@ fn build_link_dependency(
     is_dev: bool,
     is_dev_optional: bool,
     is_optional: bool,
-    resolved: Option<&str>,
+    resolved: Option<String>,
     is_direct: bool,
 ) -> Dependency {
     let (dep_namespace, dep_name) = extract_namespace_and_name(package_name);
+    let dep_namespace = truncate_field(dep_namespace);
+    let dep_name = truncate_field(dep_name);
     let (scope, is_runtime, is_optional_flag) =
         determine_scope(is_dev, is_dev_optional, is_optional);
     let mut extra_data = HashMap::from([("link".to_string(), Value::Bool(true))]);
 
-    if let Some(resolved) = resolved {
-        extra_data.insert("resolved".to_string(), Value::String(resolved.to_string()));
+    if let Some(resolved) = &resolved {
+        extra_data.insert("resolved".to_string(), Value::String(resolved.clone()));
     }
 
     Dependency {
         purl: create_purl(&dep_namespace, &dep_name, None),
-        extracted_requirement: resolved.map(str::to_string),
+        extracted_requirement: resolved.map(truncate_field),
         scope: Some(scope.to_string()),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional_flag),

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -24,8 +24,9 @@ use crate::models::{
     DatasourceId, Dependency, Md5Digest, PackageData, PackageType, ResolvedPackage, Sha1Digest,
     Sha256Digest, Sha512Digest,
 };
-use crate::parsers::utils::{npm_purl, parse_sri};
-use std::fs;
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, npm_purl, parse_sri, read_file_to_string, truncate_field,
+};
 use std::path::Path;
 use yaml_serde::Value;
 
@@ -48,7 +49,7 @@ impl PackageParser for PnpmLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path) {
             Ok(content) => content,
             Err(e) => {
                 crate::parser_warn!("Failed to read pnpm lockfile at {:?}: {}", path, e);
@@ -93,13 +94,12 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
 
     // Step 1: Parse importers section to identify direct dependencies
     if let Some(importers) = lock_data.get("importers").and_then(|v| v.as_mapping()) {
-        for (_importer_path, importer_data) in importers {
-            // Get production dependencies
+        for (_importer_path, importer_data) in importers.iter().take(MAX_ITERATION_COUNT) {
             if let Some(deps) = importer_data
                 .get("dependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (name, version_data) in deps {
+                for (name, version_data) in deps.iter().take(MAX_ITERATION_COUNT) {
                     if let Some(version) = version_data.get("version").and_then(|v| v.as_str()) {
                         let pkg_key = format_package_key_v9(name.as_str().unwrap_or(""), version);
                         prod_roots.insert(pkg_key);
@@ -107,12 +107,11 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
                 }
             }
 
-            // Get dev dependencies
             if let Some(dev_deps) = importer_data
                 .get("devDependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (name, version_data) in dev_deps {
+                for (name, version_data) in dev_deps.iter().take(MAX_ITERATION_COUNT) {
                     if let Some(version) = version_data.get("version").and_then(|v| v.as_str()) {
                         let pkg_key = format_package_key_v9(name.as_str().unwrap_or(""), version);
                         dev_roots.insert(pkg_key);
@@ -126,12 +125,12 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
     let mut graph: HashMap<String, Vec<String>> = HashMap::new();
 
     if let Some(snapshots) = lock_data.get("snapshots").and_then(|v| v.as_mapping()) {
-        for (pkg_key, pkg_data) in snapshots {
+        for (pkg_key, pkg_data) in snapshots.iter().take(MAX_ITERATION_COUNT) {
             let pkg_key_str = pkg_key.as_str().unwrap_or("").to_string();
             let mut children = Vec::new();
 
             if let Some(deps) = pkg_data.get("dependencies").and_then(|v| v.as_mapping()) {
-                for (dep_name, dep_version) in deps {
+                for (dep_name, dep_version) in deps.iter().take(MAX_ITERATION_COUNT) {
                     let dep_name_str = dep_name.as_str().unwrap_or("");
                     let dep_version_str = dep_version.as_str().unwrap_or("");
                     let child_key = format!("{}@{}", dep_name_str, dep_version_str);
@@ -143,7 +142,7 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
                 .get("optionalDependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (dep_name, dep_version) in opt_deps {
+                for (dep_name, dep_version) in opt_deps.iter().take(MAX_ITERATION_COUNT) {
                     let dep_name_str = dep_name.as_str().unwrap_or("");
                     let dep_version_str = dep_version.as_str().unwrap_or("");
                     let child_key = format!("{}@{}", dep_name_str, dep_version_str);
@@ -164,7 +163,12 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
         prod_reachable.insert(root.clone());
     }
 
+    let mut bfs_iterations: usize = 0;
     while let Some(current) = queue.pop_front() {
+        bfs_iterations += 1;
+        if bfs_iterations > MAX_ITERATION_COUNT {
+            break;
+        }
         if let Some(children) = graph.get(&current) {
             for child in children {
                 if prod_reachable.insert(child.clone()) {
@@ -187,10 +191,8 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
 
 /// Format package key for v9 (name@version format)
 fn format_package_key_v9(name: &str, version: &str) -> String {
-    // Handle scoped packages and peer dependencies
-    // Version might contain peer dep info like "8.28.2(vue@2.7.16)"
     let clean_version = version.split('(').next().unwrap_or(version);
-    format!("{}@{}", name, clean_version)
+    truncate_field(format!("{}@{}", name, clean_version))
 }
 
 /// Parse pnpm lockfile and extract package data
@@ -210,7 +212,7 @@ fn parse_pnpm_lockfile(lock_data: &Value) -> PackageData {
 
     // Extract packages based on version
     if let Some(packages_map) = lock_data.get("packages").and_then(|v| v.as_mapping()) {
-        for (purl_fields, data) in packages_map {
+        for (purl_fields, data) in packages_map.iter().take(MAX_ITERATION_COUNT) {
             let purl_fields_str = match purl_fields.as_str() {
                 Some(s) => s,
                 None => continue,
@@ -376,7 +378,7 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     let mut all_dependencies = Vec::new();
 
     if let Some(deps) = data.get("dependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in deps {
+        for (name, version) in deps.iter().take(MAX_ITERATION_COUNT) {
             if let Some(dep) = create_simple_dependency(name.as_str(), version.as_str(), None) {
                 all_dependencies.push(dep);
             }
@@ -384,7 +386,7 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     }
 
     if let Some(dev_deps) = data.get("devDependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in dev_deps {
+        for (name, version) in dev_deps.iter().take(MAX_ITERATION_COUNT) {
             if let Some(dep) =
                 create_simple_dependency(name.as_str(), version.as_str(), Some("dev".to_string()))
             {
@@ -394,7 +396,7 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     }
 
     if let Some(peer_deps) = data.get("peerDependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in peer_deps {
+        for (name, version) in peer_deps.iter().take(MAX_ITERATION_COUNT) {
             if let Some(dep) =
                 create_simple_dependency(name.as_str(), version.as_str(), Some("peer".to_string()))
             {
@@ -407,7 +409,7 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
         .get("optionalDependencies")
         .and_then(|v| v.as_mapping())
     {
-        for (name, version) in opt_deps {
+        for (name, version) in opt_deps.iter().take(MAX_ITERATION_COUNT) {
             if let Some(dep) = create_simple_dependency(
                 name.as_str(),
                 version.as_str(),
@@ -431,18 +433,20 @@ fn create_simple_dependency(
 
     let (namespace_str, pkg_name) = extract_namespace_and_name(name);
     let namespace = if !namespace_str.is_empty() {
-        Some(namespace_str)
+        Some(truncate_field(namespace_str))
     } else {
         None
     };
-    let purl = create_purl(&namespace, &pkg_name, version);
+    let pkg_name = truncate_field(pkg_name.to_string());
+    let version = truncate_field(version.to_string());
+    let purl = create_purl(&namespace, &pkg_name, &version);
 
     let is_runtime = scope.as_deref() != Some("dev");
     let is_optional = scope.as_deref() == Some("optional");
 
     Some(Dependency {
         purl: Some(purl),
-        extracted_requirement: Some(version.to_string()),
+        extracted_requirement: Some(version),
         scope,
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
@@ -461,6 +465,9 @@ pub fn extract_dependency(
     is_dev_only_v9: bool,
 ) -> Option<Dependency> {
     let (namespace, name, version) = parse_purl_fields(clean_purl_fields, lockfile_version)?;
+    let namespace = namespace.map(truncate_field);
+    let name = truncate_field(name);
+    let version = truncate_field(version);
 
     // Create PURL
     let purl = create_purl(&namespace, &name, &version);

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -49,7 +49,7 @@ impl PackageParser for PnpmLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 crate::parser_warn!("Failed to read pnpm lockfile at {:?}: {}", path, e);

--- a/src/parsers/pylock_toml.rs
+++ b/src/parsers/pylock_toml.rs
@@ -13,6 +13,7 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parsers::python::read_toml_file;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 use super::PackageParser;
 
@@ -38,6 +39,7 @@ const FIELD_WHEELS: &str = "wheels";
 const FIELD_HASHES: &str = "hashes";
 const FIELD_TOOL: &str = "tool";
 const FIELD_ATTESTATION_IDENTITIES: &str = "attestation-identities";
+const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct PylockTomlParser;
 
@@ -116,6 +118,7 @@ fn parse_pylock_toml(toml_content: &TomlValue) -> PackageData {
 
     let package_tables: Vec<&TomlMap<String, TomlValue>> = package_values
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(TomlValue::as_table)
         .collect();
     if package_tables.is_empty() {
@@ -232,7 +235,7 @@ fn build_top_level_dependency(
     Some(Dependency {
         purl: create_pypi_purl(&name, version.as_deref()),
         extracted_requirement: None,
-        scope,
+        scope: scope.map(truncate_field),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
         is_pinned: Some(is_package_pinned(package_table)),
@@ -305,6 +308,7 @@ fn build_resolved_dependency(package_table: &TomlMap<String, TomlValue>) -> Opti
 }
 
 fn build_dependency_indices(package_tables: &[&TomlMap<String, TomlValue>]) -> Vec<Vec<usize>> {
+    let mut total_iterations: usize = 0;
     package_tables
         .iter()
         .map(|package_table| {
@@ -315,6 +319,10 @@ fn build_dependency_indices(package_tables: &[&TomlMap<String, TomlValue>]) -> V
                 .flatten()
                 .filter_map(TomlValue::as_table)
                 .flat_map(|reference| {
+                    if total_iterations >= MAX_ITERATION_COUNT {
+                        return Vec::new();
+                    }
+                    total_iterations += 1;
                     resolve_dependency_reference_indices(package_tables, reference)
                 })
                 .collect()
@@ -329,6 +337,7 @@ fn resolve_dependency_reference_indices(
     let matches: Vec<usize> = package_tables
         .iter()
         .enumerate()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(index, package_table)| {
             package_reference_matches(package_table, reference).then_some(index)
         })
@@ -348,11 +357,15 @@ fn package_reference_matches(
     reference.iter().all(|(key, ref_value)| {
         package_table
             .get(key)
-            .is_some_and(|pkg_value| toml_values_match(pkg_value, ref_value))
+            .is_some_and(|pkg_value| toml_values_match(pkg_value, ref_value, 0))
     })
 }
 
-fn toml_values_match(left: &TomlValue, right: &TomlValue) -> bool {
+fn toml_values_match(left: &TomlValue, right: &TomlValue, depth: usize) -> bool {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!("toml_values_match: recursion depth limit exceeded");
+        return false;
+    }
     match (left, right) {
         (TomlValue::String(left), TomlValue::String(right)) => left == right,
         (TomlValue::Integer(left), TomlValue::Integer(right)) => left == right,
@@ -364,12 +377,12 @@ fn toml_values_match(left: &TomlValue, right: &TomlValue) -> bool {
                 && left
                     .iter()
                     .zip(right.iter())
-                    .all(|(left, right)| toml_values_match(left, right))
+                    .all(|(left, right)| toml_values_match(left, right, depth + 1))
         }
         (TomlValue::Table(left), TomlValue::Table(right)) => {
             right.iter().all(|(key, right_value)| {
                 left.get(key)
-                    .is_some_and(|left_value| toml_values_match(left_value, right_value))
+                    .is_some_and(|left_value| toml_values_match(left_value, right_value, depth + 1))
             })
         }
         _ => false,
@@ -393,6 +406,9 @@ fn collect_reachable_indices(dependency_indices: &[Vec<usize>], roots: &[usize])
     let mut queue: VecDeque<usize> = roots.iter().copied().collect();
 
     while let Some(index) = queue.pop_front() {
+        if visited.len() >= MAX_ITERATION_COUNT {
+            break;
+        }
         if !visited.insert(index) {
             continue;
         }
@@ -457,7 +473,7 @@ fn extract_marker_memberships(marker: &str, variable_name: &str) -> Vec<String> 
         .filter_map(|captures| {
             captures
                 .get(1)
-                .map(|value| value.as_str().trim().to_string())
+                .map(|value| truncate_field(value.as_str().trim().to_string()))
         })
         .filter(|value| !value.is_empty())
         .collect();
@@ -482,14 +498,14 @@ fn normalized_package_name(package_table: &TomlMap<String, TomlValue>) -> Option
     package_table
         .get(FIELD_NAME)
         .and_then(TomlValue::as_str)
-        .map(|value| value.trim().to_ascii_lowercase())
+        .map(|value| truncate_field(value.trim().to_ascii_lowercase()))
 }
 
 fn package_version(package_table: &TomlMap<String, TomlValue>) -> Option<String> {
     package_table
         .get(FIELD_VERSION)
         .and_then(TomlValue::as_str)
-        .map(|value| value.to_string())
+        .map(|value| truncate_field(value.to_string()))
 }
 
 fn is_package_pinned(package_table: &TomlMap<String, TomlValue>) -> bool {
@@ -580,12 +596,12 @@ fn extract_artifact_metadata(
             archive_table
                 .get("url")
                 .and_then(TomlValue::as_str)
-                .map(|value| value.to_string())
+                .map(|value| truncate_field(value.to_string()))
                 .or_else(|| {
                     archive_table
                         .get("path")
                         .and_then(TomlValue::as_str)
-                        .map(|value| value.to_string())
+                        .map(|value| truncate_field(value.to_string()))
                 }),
             extract_hash_by_name(archive_table, "sha256"),
             extract_hash_by_name(archive_table, "sha512"),
@@ -598,12 +614,12 @@ fn extract_artifact_metadata(
             sdist_table
                 .get("url")
                 .and_then(TomlValue::as_str)
-                .map(|value| value.to_string())
+                .map(|value| truncate_field(value.to_string()))
                 .or_else(|| {
                     sdist_table
                         .get("path")
                         .and_then(TomlValue::as_str)
-                        .map(|value| value.to_string())
+                        .map(|value| truncate_field(value.to_string()))
                 }),
             extract_hash_by_name(sdist_table, "sha256"),
             extract_hash_by_name(sdist_table, "sha512"),
@@ -621,12 +637,12 @@ fn extract_artifact_metadata(
         wheel_table
             .and_then(|table| table.get("url"))
             .and_then(TomlValue::as_str)
-            .map(|value| value.to_string())
+            .map(|value| truncate_field(value.to_string()))
             .or_else(|| {
                 wheel_table
                     .and_then(|table| table.get("path"))
                     .and_then(TomlValue::as_str)
-                    .map(|value| value.to_string())
+                    .map(|value| truncate_field(value.to_string()))
             }),
         wheel_table.and_then(|table| extract_hash_by_name(table, "sha256")),
         wheel_table.and_then(|table| extract_hash_by_name(table, "sha512")),
@@ -640,7 +656,7 @@ fn extract_hash_by_name(table: &TomlMap<String, TomlValue>, name: &str) -> Optio
         .and_then(TomlValue::as_table)
         .and_then(|hashes| hashes.get(name))
         .and_then(TomlValue::as_str)
-        .map(|value| value.to_string())
+        .map(|value| truncate_field(value.to_string()))
 }
 
 fn extract_string_set(toml_content: &TomlValue, key: &str) -> HashSet<String> {
@@ -699,7 +715,7 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
         {
             return None;
         }
-        return Some(purl.to_string());
+        return Some(truncate_field(purl.to_string()));
     }
 
     let mut purl = format!("pkg:pypi/{}", name);
@@ -709,7 +725,7 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
         purl.push('@');
         purl.push_str(version);
     }
-    Some(purl)
+    Some(truncate_field(purl))
 }
 
 fn toml_value_to_json(value: &TomlValue) -> JsonValue {

--- a/src/parsers/sbt.rs
+++ b/src/parsers/sbt.rs
@@ -22,7 +22,7 @@ impl PackageParser for SbtParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read {:?}: {}", path, error);

--- a/src/parsers/sbt.rs
+++ b/src/parsers/sbt.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -9,6 +8,9 @@ use serde_json::json;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct SbtParser;
 
@@ -20,7 +22,7 @@ impl PackageParser for SbtParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read {:?}: {}", path, error);
@@ -44,12 +46,12 @@ impl PackageParser for SbtParser {
         vec![PackageData {
             package_type: Some(Self::PACKAGE_TYPE),
             primary_language: Some("Scala".to_string()),
-            namespace: parsed.organization,
-            name: parsed.name,
-            version: parsed.version,
-            description: parsed.description,
-            homepage_url,
-            extracted_license_statement,
+            namespace: parsed.organization.map(truncate_field),
+            name: parsed.name.map(truncate_field),
+            version: parsed.version.map(truncate_field),
+            description: parsed.description.map(truncate_field),
+            homepage_url: homepage_url.map(truncate_field),
+            extracted_license_statement: extracted_license_statement.map(truncate_field),
             dependencies: parsed.dependencies,
             datasource_id: Some(DatasourceId::SbtBuildSbt),
             purl,
@@ -184,8 +186,14 @@ fn split_top_level_statements(input: &str) -> Vec<String> {
     let mut brace_depth = 0usize;
     let mut in_string = false;
     let mut escaped = false;
+    let mut iterations = 0usize;
 
     for ch in input.chars() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            break;
+        }
+
         if in_string {
             current.push(ch);
             if escaped {
@@ -250,8 +258,14 @@ fn tokenize(statement: &str) -> Vec<Token> {
     let chars: Vec<char> = statement.chars().collect();
     let mut tokens = Vec::new();
     let mut index = 0;
+    let mut iterations = 0usize;
 
     while index < chars.len() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            break;
+        }
+
         let ch = chars[index];
 
         if ch.is_whitespace() {
@@ -387,7 +401,7 @@ fn matches_chars(chars: &[char], index: usize, expected: &[char]) -> bool {
 fn resolve_string_aliases(statements: &[String]) -> HashMap<String, String> {
     let mut raw_aliases = HashMap::new();
 
-    for statement in statements {
+    for statement in statements.iter().take(MAX_ITERATION_COUNT) {
         let tokens = tokenize(statement);
         if let Some((name, expr)) = parse_alias_declaration(&tokens) {
             raw_aliases.insert(name, expr);
@@ -397,7 +411,9 @@ fn resolve_string_aliases(statements: &[String]) -> HashMap<String, String> {
     let mut resolved = HashMap::new();
     for name in raw_aliases.keys() {
         let mut visiting = HashSet::new();
-        if let Some(value) = resolve_alias_value(name, &raw_aliases, &mut resolved, &mut visiting) {
+        if let Some(value) =
+            resolve_alias_value(name, &raw_aliases, &mut resolved, &mut visiting, 0)
+        {
             resolved.insert(name.clone(), value);
         }
     }
@@ -430,7 +446,16 @@ fn resolve_alias_value(
     raw_aliases: &HashMap<String, AliasExpr>,
     resolved: &mut HashMap<String, String>,
     visiting: &mut HashSet<String>,
+    depth: usize,
 ) -> Option<String> {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!(
+            "Recursion depth exceeded in alias resolution for '{}'",
+            name
+        );
+        return None;
+    }
+
     if let Some(value) = resolved.get(name) {
         return Some(value.clone());
     }
@@ -442,7 +467,7 @@ fn resolve_alias_value(
     let value = match raw_aliases.get(name)? {
         AliasExpr::Literal(value) => Some(value.clone()),
         AliasExpr::Reference(reference) => {
-            resolve_alias_value(reference, raw_aliases, resolved, visiting)
+            resolve_alias_value(reference, raw_aliases, resolved, visiting, depth + 1)
         }
     };
 
@@ -501,7 +526,7 @@ fn parse_statements(statements: &[String], aliases: &HashMap<String, String>) ->
     let bundle_aliases = resolve_seq_aliases(statements);
     let mut state = SbtParseAccumulator::default();
 
-    for statement in statements {
+    for statement in statements.iter().take(MAX_ITERATION_COUNT) {
         let tokens = tokenize(statement);
         process_statement_tokens(&tokens, aliases, &bundle_aliases, &mut state);
     }
@@ -607,8 +632,8 @@ fn parse_literal_string_expr(
     aliases: &HashMap<String, String>,
 ) -> Option<String> {
     match tokens {
-        [Token::Str(value)] => Some(value.clone()),
-        [Token::Ident(name)] => aliases.get(name).cloned(),
+        [Token::Str(value)] => Some(truncate_field(value.clone())),
+        [Token::Ident(name)] => aliases.get(name).cloned().map(truncate_field),
         _ => None,
     }
 }
@@ -633,7 +658,7 @@ fn parse_url_expr(tokens: &[Token]) -> Option<String> {
             Token::Str(url),
             Token::Symbol(")"),
             Token::Symbol(")"),
-        ] if some == "Some" && url_fn == "url" => Some(url.clone()),
+        ] if some == "Some" && url_fn == "url" => Some(truncate_field(url.clone())),
         _ => None,
     }
 }
@@ -650,8 +675,8 @@ fn parse_license_append(tokens: &[Token]) -> Option<LicenseEntry> {
             Token::Str(url),
             Token::Symbol(")"),
         ] if name == "licenses" && url_fn == "url" => Some(LicenseEntry {
-            name: license_name.clone(),
-            url: url.clone(),
+            name: truncate_field(license_name.clone()),
+            url: truncate_field(url.clone()),
         }),
         _ => None,
     }
@@ -707,8 +732,8 @@ fn parse_dependency_seq(
     };
 
     let mut dependencies = Vec::new();
-    for item in items {
-        if let Some(dependency) = parse_dependency_expr(&item, aliases, inherited_scope) {
+    for item in items.iter().take(MAX_ITERATION_COUNT) {
+        if let Some(dependency) = parse_dependency_expr(item, aliases, inherited_scope) {
             dependencies.push(dependency);
         }
     }
@@ -915,6 +940,9 @@ fn build_dependency(
     scope: Option<String>,
     operator: &str,
 ) -> Option<Dependency> {
+    let namespace = truncate_field(namespace);
+    let name = truncate_field(name);
+    let version = truncate_field(version);
     let purl = build_maven_purl(
         Some(namespace.as_str()),
         Some(name.as_str()),

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -67,7 +67,7 @@ impl PackageParser for SwiftShowDependenciesParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!(

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -111,10 +111,10 @@ pub(crate) fn parse_swift_show_dependencies(content: &str) -> PackageData {
 
 fn flatten_dependencies(deps: &[SwiftDependency]) -> Vec<Dependency> {
     let mut result = Vec::new();
-    let mut visited = HashSet::new();
 
     for dep in deps {
-        flatten_dependency(dep, true, &mut result, &mut visited, 0);
+        let mut path = HashSet::new();
+        flatten_dependency(dep, true, &mut result, &mut path, 0);
     }
 
     result
@@ -124,7 +124,7 @@ fn flatten_dependency(
     dep: &SwiftDependency,
     is_direct: bool,
     result: &mut Vec<Dependency>,
-    visited: &mut HashSet<String>,
+    path: &mut HashSet<String>,
     depth: usize,
 ) {
     if depth >= MAX_RECURSION_DEPTH {
@@ -145,8 +145,7 @@ fn flatten_dependency(
         .or(dep.name.as_deref())
         .unwrap_or("")
         .to_string();
-    if !dep_key.is_empty() && !visited.insert(dep_key.clone()) {
-        warn!("Circular dependency detected for '{}', skipping", dep_key);
+    if !dep_key.is_empty() && !path.insert(dep_key.clone()) {
         return;
     }
 
@@ -155,7 +154,11 @@ fn flatten_dependency(
     }
 
     for child in &dep.dependencies {
-        flatten_dependency(child, false, result, visited, depth + 1);
+        flatten_dependency(child, false, result, path, depth + 1);
+    }
+
+    if !dep_key.is_empty() {
+        path.remove(&dep_key);
     }
 }
 

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -12,15 +12,18 @@
 //! - Extracts full dependency graph with versions (beyond Python which only extracts name)
 //! - Spec: https://forums.swift.org/t/swiftpm-show-dependencies-without-fetching-dependencies/51154
 
-use std::fs;
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::parser_warn as warn;
 use serde::{Deserialize, Serialize};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 const PACKAGE_TYPE: PackageType = PackageType::Swift;
 
@@ -64,7 +67,7 @@ impl PackageParser for SwiftShowDependenciesParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path) {
             Ok(c) => c,
             Err(e) => {
                 warn!(
@@ -96,9 +99,9 @@ pub(crate) fn parse_swift_show_dependencies(content: &str) -> PackageData {
     PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Swift".to_string()),
-        name: data.name,
-        version,
-        homepage_url,
+        name: data.name.map(truncate_field),
+        version: version.map(truncate_field),
+        homepage_url: homepage_url.map(truncate_field),
         dependencies,
         datasource_id: Some(DatasourceId::SwiftPackageShowDependencies),
         purl,
@@ -108,36 +111,76 @@ pub(crate) fn parse_swift_show_dependencies(content: &str) -> PackageData {
 
 fn flatten_dependencies(deps: &[SwiftDependency]) -> Vec<Dependency> {
     let mut result = Vec::new();
+    let mut visited = HashSet::new();
+
     for dep in deps {
-        flatten_dependency(dep, true, &mut result);
+        flatten_dependency(dep, true, &mut result, &mut visited, 0);
     }
 
     result
 }
 
-fn flatten_dependency(dep: &SwiftDependency, is_direct: bool, result: &mut Vec<Dependency>) {
-    if let Some(dependency) = build_dependency(dep, is_direct) {
+fn flatten_dependency(
+    dep: &SwiftDependency,
+    is_direct: bool,
+    result: &mut Vec<Dependency>,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!(
+            "Recursion depth exceeded in swift dependency flattening at depth {}",
+            depth
+        );
+        return;
+    }
+
+    if result.len() >= MAX_ITERATION_COUNT {
+        return;
+    }
+
+    let dep_key = dep
+        .identity
+        .as_deref()
+        .or(dep.name.as_deref())
+        .unwrap_or("")
+        .to_string();
+    if !dep_key.is_empty() && !visited.insert(dep_key.clone()) {
+        warn!("Circular dependency detected for '{}', skipping", dep_key);
+        return;
+    }
+
+    if let Some(dependency) = build_dependency(dep, is_direct, depth) {
         result.push(dependency);
     }
 
     for child in &dep.dependencies {
-        flatten_dependency(child, false, result);
+        flatten_dependency(child, false, result, visited, depth + 1);
     }
 }
 
-fn build_dependency(dep: &SwiftDependency, is_direct: bool) -> Option<Dependency> {
-    let name = dep.name.as_ref()?.clone();
+fn build_dependency(dep: &SwiftDependency, is_direct: bool, depth: usize) -> Option<Dependency> {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!(
+            "Recursion depth exceeded in swift dependency building at depth {}",
+            depth
+        );
+        return None;
+    }
+
+    let name = truncate_field(dep.name.as_ref()?.clone());
     let version = normalize_version(dep.version.clone());
     let purl = create_dependency_purl(dep, &name, version.as_deref());
     let nested_dependencies = dep
         .dependencies
         .iter()
-        .filter_map(|child| build_dependency(child, true))
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(|child| build_dependency(child, true, depth + 1))
         .collect();
 
     Some(Dependency {
-        purl: Some(purl.clone()),
-        extracted_requirement: version.clone(),
+        purl: Some(truncate_field(purl.clone())),
+        extracted_requirement: version.clone().map(truncate_field),
         scope: Some("dependencies".to_string()),
         is_runtime: None,
         is_optional: None,
@@ -160,9 +203,9 @@ fn build_dependency(dep: &SwiftDependency, is_direct: bool) -> Option<Dependency
             purl: None,
             ..ResolvedPackage::new(
                 PACKAGE_TYPE,
-                extract_namespace(dep.url.as_deref()).unwrap_or_default(),
+                truncate_field(extract_namespace(dep.url.as_deref()).unwrap_or_default()),
                 name,
-                version.clone().unwrap_or_default(),
+                truncate_field(version.clone().unwrap_or_default()),
             )
         })),
         extra_data: None,

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -201,6 +201,23 @@ pub fn split_name_email(s: &str) -> (Option<String>, Option<String>) {
     }
 }
 
+pub const MAX_ITERATION_COUNT: usize = 100_000;
+
+pub const MAX_FIELD_LENGTH: usize = 10 * 1024 * 1024;
+
+pub fn truncate_field(value: String) -> String {
+    if value.len() <= MAX_FIELD_LENGTH {
+        return value;
+    }
+    let truncated: String = value.chars().take(MAX_FIELD_LENGTH).collect();
+    crate::parser_warn!(
+        "Field value truncated from {} to {} bytes",
+        value.len(),
+        MAX_FIELD_LENGTH
+    );
+    truncated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -201,23 +201,6 @@ pub fn split_name_email(s: &str) -> (Option<String>, Option<String>) {
     }
 }
 
-pub const MAX_ITERATION_COUNT: usize = 100_000;
-
-pub const MAX_FIELD_LENGTH: usize = 10 * 1024 * 1024;
-
-pub fn truncate_field(value: String) -> String {
-    if value.len() <= MAX_FIELD_LENGTH {
-        return value;
-    }
-    let truncated: String = value.chars().take(MAX_FIELD_LENGTH).collect();
-    crate::parser_warn!(
-        "Field value truncated from {} to {} bytes",
-        value.len(),
-        MAX_FIELD_LENGTH
-    );
-    truncated
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers (Batch 2 of ongoing audit remediation)
- **swift_show_dependencies** (7 findings): recursion depth limits (50), iteration caps, cycle detection via visited set, `read_file_to_string`, `truncate_field`
- **sbt** (6 findings): recursion depth limit on `resolve_alias_value`, iteration caps on parsing loops, `read_file_to_string`, `truncate_field`
- **pylock_toml** (6 findings): depth limit on `toml_values_match`, iteration caps on package/BFS loops, `truncate_field`
- **pnpm_lock** (6 findings): iteration caps on all package/dependency/BFS loops, `read_file_to_string`, `truncate_field`
- **npm_lock** (6 findings): depth limit on `parse_dependencies_v1_with_depth`, iteration caps, `read_file_to_string`, `truncate_field`
- Adds shared utilities: `MAX_ITERATION_COUNT`, `MAX_FIELD_LENGTH`, `truncate_field` in `utils.rs`

## Changes

| Parser | File Size | Recursion | Iteration | String Truncation | UTF-8/Cycle |
|--------|-----------|-----------|-----------|-------------------|-------------|
| swift_show_dependencies | ✅ `read_file_to_string` | ✅ depth=50 + visited set | ✅ `MAX_ITERATION_COUNT` | ✅ `truncate_field` | ✅ lossy + cycle detection |
| sbt | ✅ `read_file_to_string` | ✅ depth=50 | ✅ `MAX_ITERATION_COUNT` | ✅ `truncate_field` | ✅ lossy |
| pylock_toml | ✅ via `read_toml_file` | ✅ depth=50 | ✅ `MAX_ITERATION_COUNT` | ✅ `truncate_field` | ✅ lossy |
| pnpm_lock | ✅ `read_file_to_string` | N/A (no recursion) | ✅ `MAX_ITERATION_COUNT` | ✅ `truncate_field` | ✅ lossy |
| npm_lock | ✅ `read_file_to_string` | ✅ depth=50 | ✅ `MAX_ITERATION_COUNT` | ✅ `truncate_field` | ✅ lossy |

## Testing

- `cargo check` ✅
- `cargo clippy --all-targets --all-features` ✅ (0 warnings)
- `cargo fmt` ✅
- Pre-commit hooks ✅

## Related

- Batch 1 PR: #664
- Follows ADR 0004 security audit findings for each parser