### PR TITLE
fix(parsers): ADR 0004 security compliance — batch 3 (nix, meson, hex_lock, debian, clojure)

### DIFF
--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -1,14 +1,16 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct ClojureDepsEdnParser;
 
@@ -20,7 +22,7 @@ impl PackageParser for ClojureDepsEdnParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read deps.edn at {:?}: {}", path, error);
@@ -56,7 +58,7 @@ impl PackageParser for ClojureProjectCljParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read project.clj at {:?}: {}", path, error);
@@ -115,6 +117,7 @@ enum Form {
 struct Reader {
     chars: Vec<char>,
     index: usize,
+    depth: usize,
 }
 
 impl Reader {
@@ -122,12 +125,19 @@ impl Reader {
         Self {
             chars: input.chars().collect(),
             index: 0,
+            depth: 0,
         }
     }
 
     fn parse_all(mut self) -> Result<Vec<Form>, String> {
         let mut forms = Vec::new();
+        let mut count = 0usize;
         while self.skip_ws_and_comments() {
+            count += 1;
+            if count > MAX_ITERATION_COUNT {
+                warn!("Reached MAX_ITERATION_COUNT in parse_all, stopping early");
+                break;
+            }
             forms.push(self.parse_form()?);
         }
         Ok(forms)
@@ -155,24 +165,52 @@ impl Reader {
     }
 
     fn parse_form(&mut self) -> Result<Form, String> {
+        if self.depth > MAX_RECURSION_DEPTH {
+            return Err("recursion depth exceeded".to_string());
+        }
         self.skip_ws_and_comments();
         match self.peek() {
             Some('"') => self.parse_string().map(Form::String),
             Some(':') => self.parse_keyword().map(Form::Keyword),
-            Some('[') => self.parse_collection('[', ']').map(Form::Vector),
-            Some('(') => self.parse_collection('(', ')').map(Form::List),
-            Some('{') => self.parse_map(),
+            Some('[') => {
+                self.depth += 1;
+                let result = self.parse_collection('[', ']').map(Form::Vector);
+                self.depth -= 1;
+                result
+            }
+            Some('(') => {
+                self.depth += 1;
+                let result = self.parse_collection('(', ')').map(Form::List);
+                self.depth -= 1;
+                result
+            }
+            Some('{') => {
+                self.depth += 1;
+                let result = self.parse_map();
+                self.depth -= 1;
+                result
+            }
             Some('^') => {
                 self.index += 1;
+                self.depth += 1;
                 let _ = self.parse_form()?;
-                self.parse_form()
+                let result = self.parse_form();
+                self.depth -= 1;
+                result
             }
             Some('~') | Some('\'') | Some('`') | Some('@') => {
                 self.index += 1;
+                self.depth += 1;
                 let form = self.parse_form()?;
+                self.depth -= 1;
                 Ok(Form::Prefixed(Box::new(form)))
             }
-            Some('#') => self.parse_dispatch_form(),
+            Some('#') => {
+                self.depth += 1;
+                let result = self.parse_dispatch_form();
+                self.depth -= 1;
+                result
+            }
             Some(_) => self.parse_atom(),
             None => Err("unexpected end of input".to_string()),
         }
@@ -265,6 +303,7 @@ impl Reader {
     fn parse_collection(&mut self, open: char, close: char) -> Result<Vec<Form>, String> {
         self.expect(open)?;
         let mut forms = Vec::new();
+        let mut count = 0usize;
         loop {
             self.skip_ws_and_comments();
             if self.peek() == Some(close) {
@@ -274,13 +313,20 @@ impl Reader {
             if self.peek().is_none() {
                 return Err(format!("unterminated collection starting with {open}"));
             }
+            count += 1;
+            if count > MAX_ITERATION_COUNT {
+                warn!("Reached MAX_ITERATION_COUNT in parse_collection, stopping early");
+                break;
+            }
             forms.push(self.parse_form()?);
         }
+        Ok(forms)
     }
 
     fn parse_map(&mut self) -> Result<Form, String> {
         self.expect('{')?;
         let mut entries = Vec::new();
+        let mut count = 0usize;
         loop {
             self.skip_ws_and_comments();
             if self.peek() == Some('}') {
@@ -290,6 +336,11 @@ impl Reader {
             if self.peek().is_none() {
                 return Err("unterminated map".to_string());
             }
+            count += 1;
+            if count > MAX_ITERATION_COUNT {
+                warn!("Reached MAX_ITERATION_COUNT in parse_map, stopping early");
+                break;
+            }
             let key = self.parse_form()?;
             self.skip_ws_and_comments();
             if self.peek() == Some('}') {
@@ -298,6 +349,7 @@ impl Reader {
             let value = self.parse_form()?;
             entries.push((key, value));
         }
+        Ok(Form::Map(entries))
     }
 
     fn parse_atom(&mut self) -> Result<Form, String> {
@@ -415,10 +467,10 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
     };
 
     let mut package = default_package_data(Some(DatasourceId::ClojureProjectClj));
-    package.namespace = namespace.clone();
-    package.name = Some(name.clone());
-    package.version = Some(version.to_string());
-    package.purl = build_maven_purl(namespace.as_deref(), &name, Some(version));
+    package.namespace = namespace.clone().map(truncate_field);
+    package.name = Some(truncate_field(name.clone()));
+    package.version = Some(truncate_field(version.to_string()));
+    package.purl = build_maven_purl(namespace.as_deref(), &name, Some(version)).map(truncate_field);
 
     let mut index = 3usize;
     while index + 1 < items.len() {
@@ -429,16 +481,20 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
         let value = &items[index + 1];
 
         match key {
-            "description" => package.description = form_as_string(value).map(ToOwned::to_owned),
-            "url" => package.homepage_url = form_as_string(value).map(ToOwned::to_owned),
+            "description" => {
+                package.description = form_as_string(value).map(|s| truncate_field(s.to_owned()))
+            }
+            "url" => {
+                package.homepage_url = form_as_string(value).map(|s| truncate_field(s.to_owned()))
+            }
             "license" => {
-                package.extracted_license_statement = format_license(value);
+                package.extracted_license_statement = format_license(value).map(truncate_field);
             }
             "scm" => {
                 if let Form::Map(entries) = value {
                     package.vcs_url = map_get_keyword(entries, "url")
                         .and_then(form_as_string)
-                        .map(ToOwned::to_owned);
+                        .map(|s| truncate_field(s.to_owned()));
                 }
             }
             "dependencies" => {
@@ -482,6 +538,7 @@ fn extract_deps_map(
 ) -> Vec<Dependency> {
     entries
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(lib, coord)| build_deps_edn_dependency(lib, coord, scope, runtime))
         .collect()
 }
@@ -522,8 +579,9 @@ fn build_deps_edn_dependency(
             namespace.as_deref(),
             &name,
             requirement.as_deref().map(strip_exact_prefix),
-        ),
-        extracted_requirement: requirement,
+        )
+        .map(truncate_field),
+        extracted_requirement: requirement.map(truncate_field),
         scope: scope.map(ToOwned::to_owned),
         is_runtime: Some(runtime),
         is_optional: Some(scope.is_some()),
@@ -537,6 +595,7 @@ fn build_deps_edn_dependency(
 fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<Dependency> {
     entries
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|entry| {
             let Form::Vector(parts) = entry else {
                 return None;
@@ -567,8 +626,9 @@ fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<De
                     namespace.as_deref(),
                     &name,
                     Some(strip_exact_prefix(version)),
-                ),
-                extracted_requirement: Some(version.to_string()),
+                )
+                .map(truncate_field),
+                extracted_requirement: Some(truncate_field(version.to_string())),
                 scope: scope.map(ToOwned::to_owned),
                 is_runtime: Some(is_runtime),
                 is_optional: Some(is_optional),

--- a/src/parsers/debian.rs
+++ b/src/parsers/debian.rs
@@ -32,6 +32,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
 use packageurl::PackageUrl;
@@ -42,7 +43,9 @@ use crate::models::{
     PackageType, Party,
 };
 use crate::parsers::rfc822::{self, Rfc822Metadata};
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 use crate::utils::spdx::combine_license_expressions;
 
 use super::PackageParser;
@@ -52,6 +55,17 @@ use super::license_normalization::{
 };
 
 const PACKAGE_TYPE: PackageType = PackageType::Deb;
+
+const MAX_ARCHIVE_SIZE: u64 = 1024 * 1024 * 1024;
+const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
+const MAX_COMPRESSION_RATIO: usize = 100;
+
+static DEP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^\s*([a-zA-Z0-9][a-zA-Z0-9.+\-]+)\s*(?:\(([<>=!]+)\s*([^)]+)\))?\s*(?:\[.*\])?\s*$",
+    )
+    .expect("compile-time constant dependency regex")
+});
 
 fn default_package_data(datasource_id: DatasourceId) -> PackageData {
     PackageData {
@@ -277,7 +291,6 @@ fn parse_debian_control(content: &str) -> Vec<PackageData> {
         return Vec::new();
     }
 
-    // Determine if first paragraph is a Source paragraph
     let has_source = rfc822::get_header_first(&paragraphs[0].headers, "source").is_some();
 
     let (source_paragraph, binary_start) = if has_source {
@@ -286,12 +299,17 @@ fn parse_debian_control(content: &str) -> Vec<PackageData> {
         (None, 0)
     };
 
-    // Extract source-level shared metadata
     let source_meta = source_paragraph.map(extract_source_meta);
 
     let mut packages = Vec::new();
+    let mut count = 0usize;
 
     for para in &paragraphs[binary_start..] {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("parse_debian_control: exceeded MAX_ITERATION_COUNT paragraphs, stopping");
+            break;
+        }
         if let Some(pkg) = build_package_from_paragraph(
             para,
             source_meta.as_ref(),
@@ -318,8 +336,14 @@ fn parse_debian_control(content: &str) -> Vec<PackageData> {
 fn parse_dpkg_status(content: &str) -> Vec<PackageData> {
     let paragraphs = rfc822::parse_rfc822_paragraphs(content);
     let mut packages = Vec::new();
+    let mut count = 0usize;
 
     for para in &paragraphs {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("parse_dpkg_status: exceeded MAX_ITERATION_COUNT paragraphs, stopping");
+            break;
+        }
         let status = rfc822::get_header_first(&para.headers, "status");
         if status.as_deref() != Some("install ok installed") {
             continue;
@@ -402,15 +426,15 @@ fn extract_source_meta(paragraph: &Rfc822Metadata) -> SourceMeta {
         }
     }
 
-    let homepage_url = rfc822::get_header_first(&paragraph.headers, "homepage");
+    let homepage_url = rfc822::get_header_first(&paragraph.headers, "homepage").map(truncate_field);
 
-    // VCS-Git: may contain branch info after space
     let vcs_url = rfc822::get_header_first(&paragraph.headers, "vcs-git")
-        .map(|url| url.split_whitespace().next().unwrap_or(&url).to_string());
+        .map(|url| truncate_field(url.split_whitespace().next().unwrap_or(&url).to_string()));
 
-    let code_view_url = rfc822::get_header_first(&paragraph.headers, "vcs-browser");
+    let code_view_url =
+        rfc822::get_header_first(&paragraph.headers, "vcs-browser").map(truncate_field);
 
-    let bug_tracking_url = rfc822::get_header_first(&paragraph.headers, "bugs");
+    let bug_tracking_url = rfc822::get_header_first(&paragraph.headers, "bugs").map(truncate_field);
 
     SourceMeta {
         parties,
@@ -430,12 +454,14 @@ fn build_package_from_paragraph(
     source_meta: Option<&SourceMeta>,
     datasource_id: DatasourceId,
 ) -> Option<PackageData> {
-    let name = rfc822::get_header_first(&paragraph.headers, "package")?;
-    let version = rfc822::get_header_first(&paragraph.headers, "version");
-    let architecture = rfc822::get_header_first(&paragraph.headers, "architecture");
-    let description = rfc822::get_header_first(&paragraph.headers, "description");
+    let name = rfc822::get_header_first(&paragraph.headers, "package").map(truncate_field)?;
+    let version = rfc822::get_header_first(&paragraph.headers, "version").map(truncate_field);
+    let architecture =
+        rfc822::get_header_first(&paragraph.headers, "architecture").map(truncate_field);
+    let description =
+        rfc822::get_header_first(&paragraph.headers, "description").map(truncate_field);
     let maintainer_str = rfc822::get_header_first(&paragraph.headers, "maintainer");
-    let homepage = rfc822::get_header_first(&paragraph.headers, "homepage");
+    let homepage = rfc822::get_header_first(&paragraph.headers, "homepage").map(truncate_field);
     let source_field = rfc822::get_header_first(&paragraph.headers, "source");
     let section = rfc822::get_header_first(&paragraph.headers, "section");
     let installed_size = rfc822::get_header_first(&paragraph.headers, "installed-size");
@@ -564,8 +590,8 @@ fn build_package_from_paragraph(
 }
 
 fn build_package_from_source_paragraph(paragraph: &Rfc822Metadata) -> Option<PackageData> {
-    let name = rfc822::get_header_first(&paragraph.headers, "source")?;
-    let version = rfc822::get_header_first(&paragraph.headers, "version");
+    let name = rfc822::get_header_first(&paragraph.headers, "source").map(truncate_field)?;
+    let version = rfc822::get_header_first(&paragraph.headers, "version").map(truncate_field);
     let maintainer_str = rfc822::get_header_first(&paragraph.headers, "maintainer");
 
     let namespace = detect_namespace(version.as_deref(), maintainer_str.as_deref());
@@ -731,20 +757,12 @@ fn parse_dependency_field(
 ) -> Vec<Dependency> {
     let mut deps = Vec::new();
 
-    // Regex for parsing individual dependency: name (operator version)
-    // Debian operators: <<, <=, =, >=, >>
-    let dep_re = Regex::new(
-        r"^\s*([a-zA-Z0-9][a-zA-Z0-9.+\-]+)\s*(?:\(([<>=!]+)\s*([^)]+)\))?\s*(?:\[.*\])?\s*$",
-    )
-    .unwrap();
-
-    for group in dep_str.split(',') {
+    for group in dep_str.split(',').take(MAX_ITERATION_COUNT) {
         let group = group.trim();
         if group.is_empty() {
             continue;
         }
 
-        // Handle alternatives (|)
         let alternatives: Vec<&str> = group.split('|').collect();
         let has_alternatives = alternatives.len() > 1;
 
@@ -754,7 +772,7 @@ fn parse_dependency_field(
                 continue;
             }
 
-            if let Some(caps) = dep_re.captures(alt) {
+            if let Some(caps) = DEP_RE.captures(alt) {
                 let pkg_name = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
                 let operator = caps.get(2).map(|m| m.as_str().trim());
                 let version = caps.get(3).map(|m| m.as_str().trim());
@@ -763,13 +781,12 @@ fn parse_dependency_field(
                     continue;
                 }
 
-                // Skip substitution variables like ${shlibs:Depends}
                 if pkg_name.starts_with('$') {
                     continue;
                 }
 
                 let extracted_requirement = match (operator, version) {
-                    (Some(op), Some(ver)) => Some(format!("{} {}", op, ver)),
+                    (Some(op), Some(ver)) => Some(truncate_field(format!("{} {}", op, ver))),
                     _ => None,
                 };
 
@@ -905,8 +922,14 @@ fn strip_pgp_signature(content: &str) -> String {
     let mut result = String::new();
     let mut in_pgp_block = false;
     let mut in_signature = false;
+    let mut count = 0usize;
 
     for line in content.lines() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("strip_pgp_signature: exceeded MAX_ITERATION_COUNT lines, stopping");
+            break;
+        }
         if line.starts_with("-----BEGIN PGP SIGNED MESSAGE-----") {
             in_pgp_block = true;
             continue;
@@ -940,9 +963,9 @@ fn parse_dsc_content(content: &str) -> PackageData {
     let metadata = rfc822::parse_rfc822_content(&clean_content);
     let headers = &metadata.headers;
 
-    let name = rfc822::get_header_first(headers, "source");
-    let version = rfc822::get_header_first(headers, "version");
-    let architecture = rfc822::get_header_first(headers, "architecture");
+    let name = rfc822::get_header_first(headers, "source").map(truncate_field);
+    let version = rfc822::get_header_first(headers, "version").map(truncate_field);
+    let architecture = rfc822::get_header_first(headers, "architecture").map(truncate_field);
     let namespace = Some("debian".to_string());
 
     let mut package = PackageData {
@@ -951,10 +974,10 @@ fn parse_dsc_content(content: &str) -> PackageData {
         namespace: namespace.clone(),
         name: name.clone(),
         version: version.clone(),
-        description: rfc822::get_header_first(headers, "description"),
-        homepage_url: rfc822::get_header_first(headers, "homepage"),
-        vcs_url: rfc822::get_header_first(headers, "vcs-git"),
-        code_view_url: rfc822::get_header_first(headers, "vcs-browser"),
+        description: rfc822::get_header_first(headers, "description").map(truncate_field),
+        homepage_url: rfc822::get_header_first(headers, "homepage").map(truncate_field),
+        vcs_url: rfc822::get_header_first(headers, "vcs-git").map(truncate_field),
+        code_view_url: rfc822::get_header_first(headers, "vcs-browser").map(truncate_field),
         ..Default::default()
     };
 
@@ -1112,13 +1135,14 @@ fn parse_source_tarball_filename(filename: &str, datasource_id: DatasourceId) ->
         return default_package_data(datasource_id);
     }
 
-    let name = parts[0].to_string();
+    let name = truncate_field(parts[0].to_string());
     let version_with_suffix = parts[1];
 
     let version = version_with_suffix
         .trim_end_matches(".orig")
         .trim_end_matches(".debian")
         .to_string();
+    let version = truncate_field(version);
 
     let namespace = Some("debian".to_string());
 
@@ -1233,16 +1257,25 @@ fn parse_debian_file_list(
     datasource_id: DatasourceId,
 ) -> PackageData {
     let (name, arch_qualifier) = if let Some((pkg, arch)) = filename.split_once(':') {
-        (Some(pkg.to_string()), Some(arch.to_string()))
+        (
+            Some(truncate_field(pkg.to_string())),
+            Some(arch.to_string()),
+        )
     } else if filename == "md5sums" {
         (None, None)
     } else {
-        (Some(filename.to_string()), None)
+        (Some(truncate_field(filename.to_string())), None)
     };
 
     let mut file_references = Vec::new();
+    let mut count = 0usize;
 
     for line in content.lines() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("parse_debian_file_list: exceeded MAX_ITERATION_COUNT lines, stopping");
+            break;
+        }
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -1405,7 +1438,13 @@ fn parse_copyright_file(content: &str, package_name: Option<&str>) -> PackageDat
     let mut other_license_detections = Vec::new();
 
     if is_dep5 {
+        let mut para_count = 0usize;
         for para in &paragraphs {
+            para_count += 1;
+            if para_count > MAX_ITERATION_COUNT {
+                warn!("parse_copyright_file: exceeded MAX_ITERATION_COUNT paragraphs, stopping");
+                break;
+            }
             if let Some(copyright_text) =
                 rfc822::get_header_first(&para.metadata.headers, "copyright")
             {
@@ -1482,7 +1521,7 @@ fn parse_copyright_file(content: &str, package_name: Option<&str>) -> PackageDat
     let extracted_license_statement = if license_statements.is_empty() {
         None
     } else {
-        Some(license_statements.join(" AND "))
+        Some(truncate_field(license_statements.join(" AND ")))
     };
 
     let license_detections = primary_license_detection.into_iter().collect::<Vec<_>>();
@@ -1507,7 +1546,7 @@ fn parse_copyright_file(content: &str, package_name: Option<&str>) -> PackageDat
         datasource_id: Some(DatasourceId::DebianCopyright),
         package_type: Some(PACKAGE_TYPE),
         namespace: namespace.clone(),
-        name: package_name.map(|s| s.to_string()),
+        name: package_name.map(|s| truncate_field(s.to_string())),
         parties,
         declared_license_expression,
         declared_license_expression_spdx,
@@ -1531,8 +1570,16 @@ fn parse_copyright_paragraphs_with_lines(content: &str) -> Vec<CopyrightParagrap
     let mut paragraphs = Vec::new();
     let mut current_lines = Vec::new();
     let mut current_start_line = 1usize;
+    let mut count = 0usize;
 
     for (idx, line) in content.lines().enumerate() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!(
+                "parse_copyright_paragraphs_with_lines: exceeded MAX_ITERATION_COUNT lines, stopping"
+            );
+            break;
+        }
         let line_no = idx + 1;
         if line.is_empty() {
             if !current_lines.is_empty() {
@@ -1617,7 +1664,16 @@ fn build_primary_license_detection(
     line_no: usize,
 ) -> LicenseDetection {
     let normalized = normalize_debian_license_name(license_name);
-    let line = LineNumber::new(line_no).unwrap();
+    let line = match LineNumber::new(line_no) {
+        Some(l) => l,
+        None => {
+            warn!(
+                "build_primary_license_detection: line number {} out of range, clamping to 1",
+                line_no
+            );
+            LineNumber::new(1).expect("1 is a valid line number")
+        }
+    };
 
     build_declared_license_detection(
         &normalized,
@@ -1644,8 +1700,14 @@ fn normalize_debian_license_name(license_name: &str) -> NormalizedDeclaredLicens
 
 fn parse_copyright_holders(text: &str) -> Vec<String> {
     let mut holders = Vec::new();
+    let mut count = 0usize;
 
     for line in text.lines() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("parse_copyright_holders: exceeded MAX_ITERATION_COUNT lines, stopping");
+            break;
+        }
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -1678,8 +1740,14 @@ fn parse_copyright_holders(text: &str) -> Vec<String> {
 fn extract_unstructured_field(content: &str, field_name: &str) -> Option<String> {
     let mut in_field = false;
     let mut field_content = String::new();
+    let mut count = 0usize;
 
     for line in content.lines() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("extract_unstructured_field: exceeded MAX_ITERATION_COUNT lines, stopping");
+            break;
+        }
         if line.starts_with(field_name) {
             in_field = true;
             field_content.push_str(line.trim_start_matches(field_name).trim());
@@ -1698,7 +1766,7 @@ fn extract_unstructured_field(content: &str, field_name: &str) -> Option<String>
     if trimmed.is_empty() {
         None
     } else {
-        Some(trimmed.to_string())
+        Some(truncate_field(trimmed.to_string()))
     }
 }
 
@@ -1743,40 +1811,107 @@ fn extract_deb_archive(path: &Path) -> Result<PackageData, String> {
     use liblzma::read::XzDecoder;
     use std::io::{Cursor, Read};
 
+    let file_metadata =
+        std::fs::metadata(path).map_err(|e| format!("Failed to stat .deb file: {}", e))?;
+    if file_metadata.len() > MAX_ARCHIVE_SIZE {
+        return Err(format!(
+            ".deb file exceeds MAX_ARCHIVE_SIZE ({} bytes)",
+            file_metadata.len()
+        ));
+    }
+    let compressed_size = file_metadata.len() as usize;
+
     let file = std::fs::File::open(path).map_err(|e| format!("Failed to open .deb file: {}", e))?;
 
     let mut archive = ar::Archive::new(file);
     let mut package: Option<PackageData> = None;
+    let mut total_extracted: usize = 0;
 
     while let Some(entry_result) = archive.next_entry() {
-        let mut entry = entry_result.map_err(|e| format!("Failed to read ar entry: {}", e))?;
+        let entry = entry_result.map_err(|e| format!("Failed to read ar entry: {}", e))?;
 
-        let entry_name = std::str::from_utf8(entry.header().identifier())
-            .map_err(|e| format!("Invalid entry name: {}", e))?;
+        let entry_name_raw = entry.header().identifier();
+        let entry_name = String::from_utf8_lossy(entry_name_raw);
+        let had_replacement = entry_name_raw.iter().any(|&b| b > 127);
+        if had_replacement {
+            warn!(
+                "extract_deb_archive: non-UTF-8 bytes in entry name replaced with lossy conversion"
+            );
+        }
         let entry_name = entry_name.trim().to_string();
 
         if entry_name == "control.tar.gz" || entry_name.starts_with("control.tar") {
+            let entry_size = entry.header().size();
+            if entry_size > MAX_FILE_SIZE {
+                warn!(
+                    "extract_deb_archive: control tar entry exceeds MAX_FILE_SIZE ({} bytes), skipping",
+                    entry_size
+                );
+                continue;
+            }
             let mut control_data = Vec::new();
             entry
+                .take(MAX_FILE_SIZE)
                 .read_to_end(&mut control_data)
                 .map_err(|e| format!("Failed to read control.tar.gz: {}", e))?;
 
+            total_extracted += control_data.len();
+            if compressed_size > 0 && total_extracted / compressed_size > MAX_COMPRESSION_RATIO {
+                warn!(
+                    "extract_deb_archive: compression ratio exceeded MAX_COMPRESSION_RATIO, stopping"
+                );
+                break;
+            }
+            if total_extracted > MAX_ARCHIVE_SIZE as usize {
+                warn!(
+                    "extract_deb_archive: cumulative extracted size exceeded MAX_ARCHIVE_SIZE, stopping"
+                );
+                break;
+            }
+
             if entry_name.ends_with(".gz") {
                 let decoder = GzDecoder::new(Cursor::new(control_data));
-                if let Some(parsed_package) = parse_control_tar_archive(decoder)? {
+                if let Some(parsed_package) =
+                    parse_control_tar_archive(decoder, &mut total_extracted, compressed_size)?
+                {
                     package = Some(parsed_package);
                 }
             } else if entry_name.ends_with(".xz") {
                 let decoder = XzDecoder::new(Cursor::new(control_data));
-                if let Some(parsed_package) = parse_control_tar_archive(decoder)? {
+                if let Some(parsed_package) =
+                    parse_control_tar_archive(decoder, &mut total_extracted, compressed_size)?
+                {
                     package = Some(parsed_package);
                 }
             }
         } else if entry_name.starts_with("data.tar") {
+            let entry_size = entry.header().size();
+            if entry_size > MAX_FILE_SIZE {
+                warn!(
+                    "extract_deb_archive: data tar entry exceeds MAX_FILE_SIZE ({} bytes), skipping",
+                    entry_size
+                );
+                continue;
+            }
             let mut data = Vec::new();
             entry
+                .take(MAX_FILE_SIZE)
                 .read_to_end(&mut data)
                 .map_err(|e| format!("Failed to read data archive: {}", e))?;
+
+            total_extracted += data.len();
+            if compressed_size > 0 && total_extracted / compressed_size > MAX_COMPRESSION_RATIO {
+                warn!(
+                    "extract_deb_archive: compression ratio exceeded MAX_COMPRESSION_RATIO, stopping"
+                );
+                break;
+            }
+            if total_extracted > MAX_ARCHIVE_SIZE as usize {
+                warn!(
+                    "extract_deb_archive: cumulative extracted size exceeded MAX_ARCHIVE_SIZE, stopping"
+                );
+                break;
+            }
 
             let Some(current_package) = package.as_mut() else {
                 continue;
@@ -1784,10 +1919,20 @@ fn extract_deb_archive(path: &Path) -> Result<PackageData, String> {
 
             if entry_name.ends_with(".gz") {
                 let decoder = GzDecoder::new(Cursor::new(data));
-                merge_deb_data_archive(decoder, current_package)?;
+                merge_deb_data_archive(
+                    decoder,
+                    current_package,
+                    &mut total_extracted,
+                    compressed_size,
+                )?;
             } else if entry_name.ends_with(".xz") {
                 let decoder = XzDecoder::new(Cursor::new(data));
-                merge_deb_data_archive(decoder, current_package)?;
+                merge_deb_data_archive(
+                    decoder,
+                    current_package,
+                    &mut total_extracted,
+                    compressed_size,
+                )?;
             }
         }
     }
@@ -1795,7 +1940,11 @@ fn extract_deb_archive(path: &Path) -> Result<PackageData, String> {
     package.ok_or_else(|| ".deb archive does not contain control.tar.* metadata".to_string())
 }
 
-fn parse_control_tar_archive<R: std::io::Read>(reader: R) -> Result<Option<PackageData>, String> {
+fn parse_control_tar_archive<R: std::io::Read>(
+    reader: R,
+    total_extracted: &mut usize,
+    compressed_size: usize,
+) -> Result<Option<PackageData>, String> {
     use std::io::Read;
 
     let mut tar_archive = tar::Archive::new(reader);
@@ -1804,18 +1953,51 @@ fn parse_control_tar_archive<R: std::io::Read>(reader: R) -> Result<Option<Packa
         .entries()
         .map_err(|e| format!("Failed to read tar entries: {}", e))?
     {
-        let mut tar_entry =
-            tar_entry_result.map_err(|e| format!("Failed to read tar entry: {}", e))?;
+        let tar_entry = tar_entry_result.map_err(|e| format!("Failed to read tar entry: {}", e))?;
 
         let tar_path = tar_entry
             .path()
             .map_err(|e| format!("Failed to get tar path: {}", e))?;
 
+        if tar_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            warn!(
+                "parse_control_tar_archive: skipping tar entry with path traversal: {:?}",
+                tar_path
+            );
+            continue;
+        }
+
+        if tar_entry.size() > MAX_FILE_SIZE {
+            warn!(
+                "parse_control_tar_archive: tar entry exceeds MAX_FILE_SIZE ({} bytes), skipping",
+                tar_entry.size()
+            );
+            continue;
+        }
+
         if tar_path.ends_with("control") {
             let mut control_content = String::new();
             tar_entry
+                .take(MAX_FILE_SIZE)
                 .read_to_string(&mut control_content)
                 .map_err(|e| format!("Failed to read control file: {}", e))?;
+
+            *total_extracted += control_content.len();
+            if compressed_size > 0 && *total_extracted / compressed_size > MAX_COMPRESSION_RATIO {
+                warn!(
+                    "parse_control_tar_archive: compression ratio exceeded MAX_COMPRESSION_RATIO, stopping"
+                );
+                return Ok(None);
+            }
+            if *total_extracted > MAX_ARCHIVE_SIZE as usize {
+                warn!(
+                    "parse_control_tar_archive: cumulative extracted size exceeded MAX_ARCHIVE_SIZE, stopping"
+                );
+                return Ok(None);
+            }
 
             let paragraphs = rfc822::parse_rfc822_paragraphs(&control_content);
             if paragraphs.is_empty() {
@@ -1838,6 +2020,8 @@ fn parse_control_tar_archive<R: std::io::Read>(reader: R) -> Result<Option<Packa
 fn merge_deb_data_archive<R: std::io::Read>(
     reader: R,
     package: &mut PackageData,
+    total_extracted: &mut usize,
+    compressed_size: usize,
 ) -> Result<(), String> {
     use std::io::Read;
 
@@ -1847,12 +2031,32 @@ fn merge_deb_data_archive<R: std::io::Read>(
         .entries()
         .map_err(|e| format!("Failed to read data tar entries: {}", e))?
     {
-        let mut tar_entry =
+        let tar_entry =
             tar_entry_result.map_err(|e| format!("Failed to read data tar entry: {}", e))?;
 
         let tar_path = tar_entry
             .path()
             .map_err(|e| format!("Failed to get data tar path: {}", e))?;
+
+        if tar_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            warn!(
+                "merge_deb_data_archive: skipping tar entry with path traversal: {:?}",
+                tar_path
+            );
+            continue;
+        }
+
+        if tar_entry.size() > MAX_FILE_SIZE {
+            warn!(
+                "merge_deb_data_archive: tar entry exceeds MAX_FILE_SIZE ({} bytes), skipping",
+                tar_entry.size()
+            );
+            continue;
+        }
+
         let tar_path_str = tar_path.to_string_lossy();
 
         if tar_path_str.ends_with(&format!(
@@ -1864,8 +2068,23 @@ fn merge_deb_data_archive<R: std::io::Read>(
         )) {
             let mut copyright_content = String::new();
             tar_entry
+                .take(MAX_FILE_SIZE)
                 .read_to_string(&mut copyright_content)
                 .map_err(|e| format!("Failed to read copyright file from data tar: {}", e))?;
+
+            *total_extracted += copyright_content.len();
+            if compressed_size > 0 && *total_extracted / compressed_size > MAX_COMPRESSION_RATIO {
+                warn!(
+                    "merge_deb_data_archive: compression ratio exceeded MAX_COMPRESSION_RATIO, stopping"
+                );
+                return Ok(());
+            }
+            if *total_extracted > MAX_ARCHIVE_SIZE as usize {
+                warn!(
+                    "merge_deb_data_archive: cumulative extracted size exceeded MAX_ARCHIVE_SIZE, stopping"
+                );
+                return Ok(());
+            }
 
             let copyright_pkg = parse_copyright_file(&copyright_content, package.name.as_deref());
             merge_debian_copyright_into_package(package, &copyright_pkg);
@@ -1905,10 +2124,10 @@ fn parse_deb_filename(filename: &str) -> PackageData {
         return default_package_data(DatasourceId::DebianDeb);
     }
 
-    let name = parts[0].to_string();
-    let version = parts[1].to_string();
+    let name = truncate_field(parts[0].to_string());
+    let version = truncate_field(parts[1].to_string());
     let architecture = if parts.len() >= 3 {
-        Some(parts[2].to_string())
+        Some(truncate_field(parts[2].to_string()))
     } else {
         None
     };
@@ -2040,8 +2259,14 @@ pub(crate) fn extract_package_name_from_deb_path(path: &Path) -> Option<String> 
 
 fn parse_md5sums_in_package(content: &str, package_name: Option<&str>) -> PackageData {
     let mut file_references = Vec::new();
+    let mut count = 0usize;
 
     for line in content.lines() {
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!("parse_md5sums_in_package: exceeded MAX_ITERATION_COUNT lines, stopping");
+            break;
+        }
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -2082,7 +2307,7 @@ fn parse_md5sums_in_package(content: &str, package_name: Option<&str>) -> Packag
         datasource_id: Some(DatasourceId::DebianMd5SumsInExtractedDeb),
         package_type: Some(PACKAGE_TYPE),
         namespace: namespace.clone(),
-        name: package_name.map(|s| s.to_string()),
+        name: package_name.map(|s| truncate_field(s.to_string())),
         file_references,
         ..Default::default()
     };

--- a/src/parsers/hex_lock.rs
+++ b/src/parsers/hex_lock.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
@@ -11,6 +11,8 @@ use crate::models::{
 };
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct HexLockParser;
 
@@ -30,6 +32,7 @@ struct Parser<'a> {
     chars: Vec<char>,
     pos: usize,
     source: &'a str,
+    depth: usize,
 }
 
 impl PackageParser for HexLockParser {
@@ -40,7 +43,7 @@ impl PackageParser for HexLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read mix.lock at {:?}: {}", path, e);
@@ -81,7 +84,7 @@ fn parse_mix_lock(content: &str) -> Result<PackageData, String> {
     };
 
     let mut dependencies = Vec::new();
-    for (key, value) in entries {
+    for (key, value) in entries.into_iter().take(MAX_ITERATION_COUNT) {
         if let Some(dep) = build_dependency_from_lock_entry(&key, &value)? {
             dependencies.push(dep);
         }
@@ -96,7 +99,7 @@ fn build_dependency_from_lock_entry(
     key: &Term,
     value: &Term,
 ) -> Result<Option<Dependency>, String> {
-    let app_name = term_to_string(key)?;
+    let app_name = truncate_field(term_to_string(key)?);
 
     let tuple = match value {
         Term::Tuple(items) => items,
@@ -112,13 +115,13 @@ fn build_dependency_from_lock_entry(
         return Ok(None);
     }
 
-    let package_name = term_to_atom(&tuple[1])?;
-    let version = term_to_string(&tuple[2])?;
-    let inner_checksum = term_to_string(&tuple[3])?;
+    let package_name = truncate_field(term_to_atom(&tuple[1])?);
+    let version = truncate_field(term_to_string(&tuple[2])?);
+    let inner_checksum = truncate_field(term_to_string(&tuple[3])?);
     let managers = term_to_atom_list(&tuple[4])?;
     let nested_dependencies = term_to_dependency_tuples(&tuple[5])?;
-    let repo = term_to_string(&tuple[6])?;
-    let outer_checksum = term_to_string(&tuple[7])?;
+    let repo = truncate_field(term_to_string(&tuple[6])?);
+    let outer_checksum = truncate_field(term_to_string(&tuple[7])?);
 
     let purl = build_hex_purl(&package_name, Some(&version), Some(&repo));
     let resolved_package = ResolvedPackage {
@@ -130,25 +133,33 @@ fn build_dependency_from_lock_entry(
         md5: None,
         is_virtual: true,
         extra_data: Some(HashMap::from([
-            ("repo".to_string(), JsonValue::String(repo.clone())),
+            (
+                "repo".to_string(),
+                JsonValue::String(truncate_field(repo.clone())),
+            ),
             (
                 "outer_checksum".to_string(),
-                JsonValue::String(outer_checksum.clone()),
+                JsonValue::String(truncate_field(outer_checksum.clone())),
             ),
             (
                 "managers".to_string(),
-                JsonValue::Array(managers.into_iter().map(JsonValue::String).collect()),
+                JsonValue::Array(
+                    managers
+                        .into_iter()
+                        .map(|m| JsonValue::String(truncate_field(m)))
+                        .collect(),
+                ),
             ),
         ])),
         dependencies: nested_dependencies
             .into_iter()
             .map(build_nested_dependency)
             .collect::<Result<Vec<_>, _>>()?,
-        repository_homepage_url: Some(build_hexdocs_homepage(&package_name, &repo)),
+        repository_homepage_url: Some(truncate_field(build_hexdocs_homepage(&package_name, &repo))),
         repository_download_url: None,
-        api_data_url: Some(build_hex_api_url(&package_name, &repo)),
+        api_data_url: Some(truncate_field(build_hex_api_url(&package_name, &repo))),
         datasource_id: Some(DatasourceId::HexMixLock),
-        purl: build_hex_purl(&package_name, Some(&version), Some(&repo)),
+        purl: build_hex_purl(&package_name, Some(&version), Some(&repo)).map(truncate_field),
         ..ResolvedPackage::new(
             PackageType::Hex,
             if repo == "hexpm" {
@@ -162,8 +173,8 @@ fn build_dependency_from_lock_entry(
     };
 
     Ok(Some(Dependency {
-        purl,
-        extracted_requirement: Some(version),
+        purl: purl.map(truncate_field),
+        extracted_requirement: Some(truncate_field(version)),
         scope: Some("dependencies".to_string()),
         is_runtime: None,
         is_optional: None,
@@ -172,19 +183,21 @@ fn build_dependency_from_lock_entry(
         resolved_package: Some(Box::new(resolved_package)),
         extra_data: Some(HashMap::from([(
             "app".to_string(),
-            JsonValue::String(app_name),
+            JsonValue::String(truncate_field(app_name)),
         )])),
     }))
 }
 
 fn build_nested_dependency(tuple: DependencyTuple) -> Result<Dependency, String> {
-    let package_name = tuple
-        .hex_name
-        .clone()
-        .unwrap_or_else(|| tuple.app_name.clone());
+    let package_name = truncate_field(
+        tuple
+            .hex_name
+            .clone()
+            .unwrap_or_else(|| tuple.app_name.clone()),
+    );
     Ok(Dependency {
-        purl: build_hex_purl(&package_name, None, tuple.repo.as_deref()),
-        extracted_requirement: Some(tuple.requirement),
+        purl: build_hex_purl(&package_name, None, tuple.repo.as_deref()).map(truncate_field),
+        extracted_requirement: Some(truncate_field(tuple.requirement)),
         scope: Some("dependencies".to_string()),
         is_runtime: Some(!tuple.optional),
         is_optional: Some(tuple.optional),
@@ -219,17 +232,25 @@ fn term_to_dependency_tuples(term: &Term) -> Result<Vec<DependencyTuple>, String
     };
 
     let mut result = Vec::new();
-    for item in items {
+    for item in items.iter().take(MAX_ITERATION_COUNT) {
         let tuple = match item {
             Term::Tuple(items) if items.len() == 3 => items,
             _ => continue,
         };
 
-        let app_name = term_to_atom(&tuple[0])?;
-        let requirement = term_to_string(&tuple[1])?;
+        let app_name = truncate_field(term_to_atom(&tuple[0])?);
+        let requirement = truncate_field(term_to_string(&tuple[1])?);
         let opts = term_to_keyword_map(&tuple[2])?;
-        let hex_name = opts.get("hex").map(term_to_atom).transpose()?;
-        let repo = opts.get("repo").map(term_to_string).transpose()?;
+        let hex_name = opts
+            .get("hex")
+            .map(term_to_atom)
+            .transpose()?
+            .map(truncate_field);
+        let repo = opts
+            .get("repo")
+            .map(term_to_string)
+            .transpose()?
+            .map(truncate_field);
         let optional = opts
             .get("optional")
             .and_then(|term| match term {
@@ -327,10 +348,14 @@ impl<'a> Parser<'a> {
             chars: source.chars().collect(),
             pos: 0,
             source,
+            depth: 0,
         }
     }
 
     fn parse_term(&mut self) -> Result<Term, String> {
+        if self.depth > MAX_RECURSION_DEPTH {
+            return Err("recursion depth exceeded".to_string());
+        }
         self.skip_ws();
         match self.peek() {
             Some('%') => self.parse_map(),
@@ -349,21 +374,31 @@ impl<'a> Parser<'a> {
         self.expect('%')?;
         self.expect('{')?;
         let mut entries = Vec::new();
+        let mut count = 0usize;
         loop {
             self.skip_ws();
             if self.peek() == Some('}') {
                 self.pos += 1;
                 break;
             }
+            if count >= MAX_ITERATION_COUNT {
+                warn!("map entry count exceeded MAX_ITERATION_COUNT in mix.lock");
+                break;
+            }
+            self.depth += 1;
             let key = self.parse_term()?;
+            self.depth -= 1;
             self.skip_ws();
             if self.starts_with("=>") {
                 self.expect_sequence("=>")?;
             } else {
                 self.expect(':')?;
             }
+            self.depth += 1;
             let value = self.parse_term()?;
+            self.depth -= 1;
             entries.push((key, value));
+            count += 1;
             self.skip_ws();
             if self.peek() == Some(',') {
                 self.pos += 1;
@@ -375,13 +410,21 @@ impl<'a> Parser<'a> {
     fn parse_tuple(&mut self) -> Result<Term, String> {
         self.expect('{')?;
         let mut items = Vec::new();
+        let mut count = 0usize;
         loop {
             self.skip_ws();
             if self.peek() == Some('}') {
                 self.pos += 1;
                 break;
             }
+            if count >= MAX_ITERATION_COUNT {
+                warn!("tuple item count exceeded MAX_ITERATION_COUNT in mix.lock");
+                break;
+            }
+            self.depth += 1;
             items.push(self.parse_term()?);
+            self.depth -= 1;
+            count += 1;
             self.skip_ws();
             if self.peek() == Some(',') {
                 self.pos += 1;
@@ -395,6 +438,7 @@ impl<'a> Parser<'a> {
         let mut keyword_entries = Vec::new();
         let mut items = Vec::new();
         let mut saw_keyword = false;
+        let mut count = 0usize;
 
         loop {
             self.skip_ws();
@@ -402,15 +446,24 @@ impl<'a> Parser<'a> {
                 self.pos += 1;
                 break;
             }
+            if count >= MAX_ITERATION_COUNT {
+                warn!("list item count exceeded MAX_ITERATION_COUNT in mix.lock");
+                break;
+            }
 
             if let Some(keyword) = self.try_parse_keyword_key() {
                 saw_keyword = true;
+                self.depth += 1;
                 let value = self.parse_term()?;
+                self.depth -= 1;
                 keyword_entries.push((keyword, value));
             } else {
+                self.depth += 1;
                 items.push(self.parse_term()?);
+                self.depth -= 1;
             }
 
+            count += 1;
             self.skip_ws();
             if self.peek() == Some(',') {
                 self.pos += 1;

--- a/src/parsers/meson.rs
+++ b/src/parsers/meson.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -10,6 +9,7 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 pub struct MesonParser;
 
@@ -21,7 +21,7 @@ impl PackageParser for MesonParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read meson.build at {:?}: {}", path, error);
@@ -45,7 +45,7 @@ fn parse_meson_build(content: &str) -> Result<PackageData, String> {
     let mut dependencies = Vec::new();
     let mut control_flow_depth = 0usize;
 
-    for statement in statements {
+    for statement in statements.into_iter().take(MAX_ITERATION_COUNT) {
         let trimmed = statement.trim();
         if trimmed.is_empty() {
             continue;
@@ -116,7 +116,7 @@ fn apply_project_call(
 
     package.package_type = Some(PackageType::Meson);
     package.datasource_id = Some(DatasourceId::MesonBuild);
-    package.name = Some(name.to_string());
+    package.name = Some(truncate_field(name.to_string()));
 
     let languages = call
         .positional
@@ -125,7 +125,7 @@ fn apply_project_call(
         .flat_map(extract_string_values)
         .collect::<Vec<_>>();
     if let Some(primary_language) = languages.first() {
-        package.primary_language = Some(primary_language.clone());
+        package.primary_language = Some(truncate_field(primary_language.clone()));
     }
     if !languages.is_empty() {
         extra_data.insert(
@@ -135,7 +135,7 @@ fn apply_project_call(
     }
 
     if let Some(version) = call.keyword.get("version").and_then(expr_as_string) {
-        package.version = Some(version.to_string());
+        package.version = Some(truncate_field(version.to_string()));
     }
 
     let licenses = call
@@ -144,7 +144,7 @@ fn apply_project_call(
         .map(extract_string_values)
         .unwrap_or_default();
     if !licenses.is_empty() {
-        package.extracted_license_statement = Some(licenses.join("\n"));
+        package.extracted_license_statement = Some(truncate_field(licenses.join("\n")));
         if licenses.len() == 1 {
             let (declared_license_expression, declared_license_expression_spdx, license_detections) =
                 normalize_spdx_declared_license(licenses.first().map(String::as_str));
@@ -198,6 +198,7 @@ fn extract_dependencies_from_call(call: &CallExpr) -> Vec<Dependency> {
 
     dependency_names
         .into_iter()
+        .take(MAX_ITERATION_COUNT)
         .map(|name| {
             let mut extra_data = HashMap::new();
 
@@ -248,7 +249,8 @@ fn extract_dependencies_from_call(call: &CallExpr) -> Vec<Dependency> {
                 purl: build_dependency_purl(&name),
                 extracted_requirement: extracted_requirement
                     .clone()
-                    .filter(|value| !value.is_empty()),
+                    .filter(|value| !value.is_empty())
+                    .map(truncate_field),
                 scope: Some("dependencies".to_string()),
                 is_runtime: Some(native != Some(true)),
                 is_optional: Some(required == Some(false)),
@@ -266,13 +268,13 @@ fn build_project_purl(name: &str, version: Option<&str>) -> Option<String> {
     if let Some(version) = version {
         purl.with_version(version).ok()?;
     }
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 fn build_dependency_purl(name: &str) -> Option<String> {
     let mut purl = PackageUrl::new("generic", name).ok()?;
     purl.with_namespace("meson").ok()?;
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 fn default_package_data() -> PackageData {
@@ -301,8 +303,13 @@ fn strip_comments(input: &str) -> Result<String, String> {
     let mut in_string = false;
     let mut string_delimiter = '\0';
     let mut escaped = false;
+    let mut chars_processed = 0usize;
 
     while index < chars.len() {
+        chars_processed += 1;
+        if chars_processed > MAX_ITERATION_COUNT {
+            break;
+        }
         let ch = chars[index];
 
         if in_string {
@@ -353,8 +360,13 @@ fn split_statements(input: &str) -> Vec<String> {
     let mut in_string = false;
     let mut string_delimiter = '\0';
     let mut escaped = false;
+    let mut chars_processed = 0usize;
 
     for ch in input.chars() {
+        chars_processed += 1;
+        if chars_processed > MAX_ITERATION_COUNT {
+            break;
+        }
         current.push(ch);
 
         if in_string {
@@ -440,14 +452,18 @@ fn parse_statement(statement: &str) -> Result<Statement, String> {
 
     if let [Token::Ident(name), Token::Equal, rest @ ..] = tokens.as_slice() {
         let mut parser = Parser::new(rest);
+        parser.depth += 1;
         let expr = parser.parse_expr()?;
+        parser.depth -= 1;
         parser.expect_end()?;
         let _ = name;
         return Ok(Statement::Assignment(expr));
     }
 
     let mut parser = Parser::new(&tokens);
+    parser.depth += 1;
     let expr = parser.parse_expr()?;
+    parser.depth -= 1;
     parser.expect_end()?;
     Ok(Statement::Expr(expr))
 }
@@ -458,6 +474,9 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
     let mut index = 0usize;
 
     while index < chars.len() {
+        if tokens.len() >= MAX_ITERATION_COUNT {
+            break;
+        }
         let ch = chars[index];
         if ch.is_whitespace() {
             index += 1;
@@ -548,17 +567,27 @@ fn is_ident_continue(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '_'
 }
 
+const MAX_RECURSION_DEPTH: usize = 50;
+
 struct Parser<'a> {
     tokens: &'a [Token],
     index: usize,
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
     fn new(tokens: &'a [Token]) -> Self {
-        Self { tokens, index: 0 }
+        Self {
+            tokens,
+            index: 0,
+            depth: 0,
+        }
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
+        if self.depth > MAX_RECURSION_DEPTH {
+            return Err("recursion depth exceeded".to_string());
+        }
         match self.peek() {
             Some(Token::Str(value)) => {
                 self.index += 1;
@@ -578,8 +607,16 @@ impl<'a> Parser<'a> {
     fn parse_array(&mut self) -> Result<Expr, String> {
         self.expect(Token::LBracket)?;
         let mut values = Vec::new();
+        let mut element_count = 0usize;
         while !matches!(self.peek(), Some(Token::RBracket)) {
-            values.push(self.parse_expr()?);
+            element_count += 1;
+            if element_count > MAX_ITERATION_COUNT {
+                break;
+            }
+            self.depth += 1;
+            let expr = self.parse_expr()?;
+            self.depth -= 1;
+            values.push(expr);
             if matches!(self.peek(), Some(Token::Comma)) {
                 self.index += 1;
             } else if !matches!(self.peek(), Some(Token::RBracket)) {
@@ -607,17 +644,27 @@ impl<'a> Parser<'a> {
         self.expect(Token::LParen)?;
         let mut positional = Vec::new();
         let mut keyword = HashMap::new();
+        let mut arg_count = 0usize;
 
         while !matches!(self.peek(), Some(Token::RParen)) {
+            arg_count += 1;
+            if arg_count > MAX_ITERATION_COUNT {
+                break;
+            }
             if let (Some(Token::Ident(arg_name)), Some(Token::Colon)) =
                 (self.peek(), self.peek_n(1))
             {
                 let arg_name = arg_name.clone();
                 self.index += 2;
+                self.depth += 1;
                 let value = self.parse_expr()?;
+                self.depth -= 1;
                 keyword.insert(arg_name, value);
             } else {
-                positional.push(self.parse_expr()?);
+                self.depth += 1;
+                let expr = self.parse_expr()?;
+                self.depth -= 1;
+                positional.push(expr);
             }
 
             if matches!(self.peek(), Some(Token::Comma)) {

--- a/src/parsers/nix.rs
+++ b/src/parsers/nix.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -7,8 +6,11 @@ use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct NixFlakeLockParser;
 
@@ -20,7 +22,7 @@ impl PackageParser for NixFlakeLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read flake.lock at {:?}: {}", path, error);
@@ -56,7 +58,7 @@ impl PackageParser for NixFlakeParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read flake.nix at {:?}: {}", path, error);
@@ -81,7 +83,7 @@ impl PackageParser for NixDefaultParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read default.nix at {:?}: {}", path, error);
@@ -158,6 +160,11 @@ impl Lexer {
         let mut tokens = Vec::new();
 
         while let Some(ch) = self.peek() {
+            if tokens.len() >= MAX_ITERATION_COUNT {
+                warn!("Lexer exceeded MAX_ITERATION_COUNT token limit");
+                break;
+            }
+
             if ch.is_whitespace() {
                 self.index += 1;
                 continue;
@@ -432,11 +439,16 @@ impl Lexer {
 struct Parser {
     tokens: Vec<Token>,
     index: usize,
+    depth: usize,
 }
 
 impl Parser {
     fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, index: 0 }
+        Self {
+            tokens,
+            index: 0,
+            depth: 0,
+        }
     }
 
     fn parse(mut self) -> Result<Expr, String> {
@@ -448,22 +460,35 @@ impl Parser {
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
+        if self.depth > MAX_RECURSION_DEPTH {
+            return Err("recursion depth exceeded".to_string());
+        }
+
         if self.peek() == Some(&Token::LBrace) && self.looks_like_lambda_binder_set()? {
             self.skip_lambda_binder_set()?;
             self.expect(&Token::Colon)?;
-            return self.parse_expr();
+            self.depth += 1;
+            let result = self.parse_expr();
+            self.depth -= 1;
+            return result;
         }
 
         if self.looks_like_prefixed_lambda_binder_set()? {
             self.index += 1;
             self.skip_lambda_binder_set()?;
             self.expect(&Token::Colon)?;
-            return self.parse_expr();
+            self.depth += 1;
+            let result = self.parse_expr();
+            self.depth -= 1;
+            return result;
         }
 
         let first = self.parse_term()?;
         if self.consume(&Token::Colon) {
-            return self.parse_expr();
+            self.depth += 1;
+            let result = self.parse_expr();
+            self.depth -= 1;
+            return result;
         }
 
         let mut terms = vec![first];
@@ -472,7 +497,7 @@ impl Parser {
         }
 
         let expr = if terms.len() == 1 {
-            terms.pop().expect("single term")
+            terms.pop().unwrap()
         } else {
             Expr::Application(terms)
         };
@@ -500,9 +525,14 @@ impl Parser {
             Some(Token::Ident(keyword)) if keyword == "let" => self.parse_let_in_expr(),
             Some(Token::Ident(keyword)) if keyword == "with" => {
                 self.index += 1;
+                self.depth += 1;
                 let _ = self.parse_expr()?;
+                self.depth -= 1;
                 self.expect(&Token::Semicolon)?;
-                self.parse_expr()
+                self.depth += 1;
+                let result = self.parse_expr();
+                self.depth -= 1;
+                result
             }
             Some(Token::Ident(keyword)) if keyword == "rec" => {
                 if matches!(self.peek_n(1), Some(Token::LBrace)) {
@@ -516,7 +546,9 @@ impl Parser {
             Some(Token::LBracket) => self.parse_list(),
             Some(Token::LParen) => {
                 self.index += 1;
+                self.depth += 1;
                 let expr = self.parse_expr()?;
+                self.depth -= 1;
                 self.expect(&Token::RParen)?;
                 Ok(expr)
             }
@@ -535,6 +567,11 @@ impl Parser {
                 return Err("unterminated let expression".to_string());
             }
 
+            if bindings.len() >= MAX_ITERATION_COUNT {
+                warn!("parse_let_in_expr exceeded MAX_ITERATION_COUNT bindings limit");
+                break;
+            }
+
             if matches!(self.peek(), Some(Token::Ident(keyword)) if keyword == "inherit") {
                 bindings.extend(self.parse_inherit_entries()?);
                 continue;
@@ -542,15 +579,20 @@ impl Parser {
 
             let key = self.parse_attr_path()?;
             self.expect(&Token::Equals)?;
+            self.depth += 1;
             let value = self.parse_expr()?;
+            self.depth -= 1;
             self.expect(&Token::Semicolon)?;
             bindings.push((key, value));
         }
 
         self.take_exact_ident("in")?;
+        self.depth += 1;
+        let body = self.parse_expr()?;
+        self.depth -= 1;
         Ok(Expr::Let {
             bindings,
-            body: Box::new(self.parse_expr()?),
+            body: Box::new(body),
         })
     }
 
@@ -567,6 +609,11 @@ impl Parser {
                 return Err("unterminated attribute set".to_string());
             }
 
+            if entries.len() >= MAX_ITERATION_COUNT {
+                warn!("parse_attrset exceeded MAX_ITERATION_COUNT entries limit");
+                break;
+            }
+
             if matches!(self.peek(), Some(Token::Ident(keyword)) if keyword == "inherit") {
                 entries.extend(self.parse_inherit_entries()?);
                 continue;
@@ -574,10 +621,14 @@ impl Parser {
 
             let key = self.parse_attr_path()?;
             self.expect(&Token::Equals)?;
+            self.depth += 1;
             let value = self.parse_expr()?;
+            self.depth -= 1;
             self.expect(&Token::Semicolon)?;
             entries.push((key, value));
         }
+
+        Ok(Expr::AttrSet(entries))
     }
 
     fn parse_attr_path(&mut self) -> Result<Vec<String>, String> {
@@ -592,7 +643,9 @@ impl Parser {
         self.take_exact_ident("inherit")?;
 
         let inherit_from = if self.consume(&Token::LParen) {
+            self.depth += 1;
             let expr = self.parse_expr()?;
+            self.depth -= 1;
             self.expect(&Token::RParen)?;
             Some(expr)
         } else {
@@ -603,6 +656,11 @@ impl Parser {
         while !self.consume(&Token::Semicolon) {
             if self.peek().is_none() {
                 return Err("unterminated inherit statement".to_string());
+            }
+
+            if entries.len() >= MAX_ITERATION_COUNT {
+                warn!("parse_inherit_entries exceeded MAX_ITERATION_COUNT entries limit");
+                break;
             }
 
             let name = self.take_attr_key()?;
@@ -626,7 +684,15 @@ impl Parser {
             if self.peek().is_none() {
                 return Err("unterminated list".to_string());
             }
+
+            if items.len() >= MAX_ITERATION_COUNT {
+                warn!("parse_list exceeded MAX_ITERATION_COUNT items limit");
+                break;
+            }
+
+            self.depth += 1;
             items.push(self.parse_expr()?);
+            self.depth -= 1;
         }
         Ok(Expr::List(items))
     }
@@ -775,12 +841,13 @@ impl Parser {
 fn parse_flake_nix(path: &Path, content: &str) -> Result<PackageData, String> {
     let expr = parse_nix_expr(content)?;
     let scopes = Vec::new();
-    let (root, scopes) = root_attrset_with_scopes(&expr, &scopes)
+    let (root, scopes) = root_attrset_with_scopes(&expr, &scopes, 0)
         .ok_or_else(|| "flake.nix root was not an attribute set".to_string())?;
 
     let mut package = default_flake_package_data();
-    package.name = fallback_name(path);
-    package.description = find_string_attr_with_scopes(root, &["description"], &scopes);
+    package.name = fallback_name(path).map(truncate_field);
+    package.description =
+        find_string_attr_with_scopes(root, &["description"], &scopes).map(truncate_field);
     package.purl = package
         .name
         .as_deref()
@@ -822,7 +889,7 @@ fn parse_flake_lock(path: &Path, json: &JsonValue) -> Result<PackageData, String
         .ok_or_else(|| "flake.lock root node missing inputs".to_string())?;
 
     let mut package = default_flake_lock_package_data();
-    package.name = fallback_name(path);
+    package.name = fallback_name(path).map(truncate_field);
     package.purl = package
         .name
         .as_deref()
@@ -835,6 +902,7 @@ fn parse_flake_lock(path: &Path, json: &JsonValue) -> Result<PackageData, String
 
     package.dependencies = root_inputs
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(input_name, node_ref)| build_lock_dependency(input_name, node_ref, nodes))
         .collect();
     package
@@ -888,7 +956,8 @@ fn build_lock_dependency(
 
     Some(Dependency {
         purl: build_nix_purl(input_name, revision),
-        extracted_requirement: build_locked_requirement(locked, node.get("original")),
+        extracted_requirement: build_locked_requirement(locked, node.get("original"))
+            .map(truncate_field),
         scope: Some("inputs".to_string()),
         is_runtime: Some(false),
         is_optional: Some(false),
@@ -984,7 +1053,7 @@ fn build_flake_dependencies(
 
             Dependency {
                 purl: build_nix_purl(&name, None),
-                extracted_requirement: info.requirement,
+                extracted_requirement: info.requirement.map(truncate_field),
                 scope: Some("inputs".to_string()),
                 is_runtime: Some(false),
                 is_optional: Some(false),
@@ -1041,7 +1110,7 @@ fn collect_input_path(
             }
             Expr::Symbol(value) => {
                 inputs.entry(input_name.clone()).or_default().requirement =
-                    expr_as_string_with_scopes(&Expr::Symbol(value.clone()), scopes)
+                    expr_as_string_with_scopes(&Expr::Symbol(value.clone()), scopes, 0)
             }
             _ => {}
         }
@@ -1063,19 +1132,19 @@ fn apply_input_field(
     scopes: &[&[(Vec<String>, Expr)]],
 ) {
     if path == ["url"] {
-        info.requirement = expr_as_string_with_scopes(expr, scopes);
+        info.requirement = expr_as_string_with_scopes(expr, scopes, 0);
         return;
     }
 
     if path == ["flake"] {
-        info.flake = expr_as_bool_with_scopes(expr, scopes);
+        info.flake = expr_as_bool_with_scopes(expr, scopes, 0);
         return;
     }
 
     if path.len() == 3
         && path[0] == "inputs"
         && path[2] == "follows"
-        && let Some(value) = expr_as_string_with_scopes(expr, scopes)
+        && let Some(value) = expr_as_string_with_scopes(expr, scopes, 0)
     {
         info.follows.push(value);
     }
@@ -1087,16 +1156,17 @@ fn build_list_dependencies(
     runtime: bool,
     scopes: &[&[(Vec<String>, Expr)]],
 ) -> Vec<Dependency> {
-    let Some(expr) = find_attr(entries, &[field_name]) else {
+    let Some(expr) = find_attr(entries, &[field_name], 0) else {
         return Vec::new();
     };
-    let Some(items) = list_items_with_scopes(expr, scopes) else {
+    let Some(items) = list_items_with_scopes(expr, scopes, 0) else {
         return Vec::new();
     };
 
     items
         .iter()
-        .flat_map(|expr| expr_to_dependency_symbols_with_scopes(expr, scopes))
+        .take(MAX_ITERATION_COUNT)
+        .flat_map(|expr| expr_to_dependency_symbols_with_scopes(expr, scopes, 0))
         .filter_map(|symbol| {
             let name = symbol.rsplit('.').next()?.to_string();
             Some(Dependency {
@@ -1117,20 +1187,26 @@ fn build_list_dependencies(
 fn expr_to_dependency_symbols_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
+    depth: usize,
 ) -> Vec<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("expr_to_dependency_symbols_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return Vec::new();
+    }
+
     match expr {
         Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, 0)
-            .map(|resolved| expr_to_dependency_symbols_with_scopes(resolved, scopes))
+            .map(|resolved| expr_to_dependency_symbols_with_scopes(resolved, scopes, depth + 1))
             .unwrap_or_else(|| vec![symbol.clone()]),
         Expr::Application(parts) => parts
             .iter()
-            .filter_map(|expr| expr_as_symbol_with_scopes(expr, scopes))
+            .filter_map(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))
             .collect(),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_to_dependency_symbols_with_scopes(body, &scopes)
+            expr_to_dependency_symbols_with_scopes(body, &scopes, depth + 1)
         }
-        Expr::Select { .. } => expr_as_symbol_with_scopes(expr, scopes)
+        Expr::Select { .. } => expr_as_symbol_with_scopes(expr, scopes, 0)
             .into_iter()
             .collect(),
         _ => Vec::new(),
@@ -1149,7 +1225,7 @@ fn build_nix_purl(name: &str, version: Option<&str>) -> Option<String> {
     if let Some(version) = version {
         purl.with_version(version).ok()?;
     }
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 fn parse_nix_expr(content: &str) -> Result<Expr, String> {
@@ -1167,17 +1243,23 @@ fn attrset_entries(expr: &Expr) -> Option<&[(Vec<String>, Expr)]> {
 fn list_items_with_scopes<'a>(
     expr: &'a Expr,
     scopes: &[&'a [(Vec<String>, Expr)]],
+    depth: usize,
 ) -> Option<&'a [Expr]> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("list_items_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::List(items) => Some(items),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            list_items_with_scopes(body, &scopes)
+            list_items_with_scopes(body, &scopes, depth + 1)
         }
         Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, 0)
-            .and_then(|resolved| list_items_with_scopes(resolved, scopes)),
+            .and_then(|resolved| list_items_with_scopes(resolved, scopes, depth + 1)),
         Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| list_items_with_scopes(resolved, scopes)),
+            .and_then(|resolved| list_items_with_scopes(resolved, scopes, depth + 1)),
         _ => None,
     }
 }
@@ -1189,16 +1271,25 @@ fn expr_as_symbol(expr: &Expr) -> Option<String> {
     }
 }
 
-fn expr_as_symbol_with_scopes(expr: &Expr, scopes: &[&[(Vec<String>, Expr)]]) -> Option<String> {
+fn expr_as_symbol_with_scopes(
+    expr: &Expr,
+    scopes: &[&[(Vec<String>, Expr)]],
+    depth: usize,
+) -> Option<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("expr_as_symbol_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes))
+            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, depth + 1))
             .or_else(|| Some(value.clone())),
         Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes)),
+            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, depth + 1)),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_symbol_with_scopes(body, &scopes)
+            expr_as_symbol_with_scopes(body, &scopes, depth + 1)
         }
         _ => expr_as_symbol(expr),
     }
@@ -1212,36 +1303,54 @@ fn expr_as_bool(expr: &Expr) -> Option<bool> {
     }
 }
 
-fn expr_as_bool_with_scopes(expr: &Expr, scopes: &[&[(Vec<String>, Expr)]]) -> Option<bool> {
+fn expr_as_bool_with_scopes(
+    expr: &Expr,
+    scopes: &[&[(Vec<String>, Expr)]],
+    depth: usize,
+) -> Option<bool> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("expr_as_bool_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_bool_with_scopes(body, &scopes)
+            expr_as_bool_with_scopes(body, &scopes, depth + 1)
         }
         Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes))
+            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, depth + 1))
             .or_else(|| expr_as_bool(expr)),
         Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes)),
+            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, depth + 1)),
         _ => expr_as_bool(expr),
     }
 }
 
-fn expr_as_string_with_scopes(expr: &Expr, scopes: &[&[(Vec<String>, Expr)]]) -> Option<String> {
+fn expr_as_string_with_scopes(
+    expr: &Expr,
+    scopes: &[&[(Vec<String>, Expr)]],
+    depth: usize,
+) -> Option<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("expr_as_string_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::String(value) => Some(interpolate_string(value, scopes)),
         Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes))
+            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, depth + 1))
             .or_else(|| Some(value.clone())),
         Expr::Application(parts) => parts
             .last()
-            .and_then(|expr| expr_as_string_with_scopes(expr, scopes)),
+            .and_then(|expr| expr_as_string_with_scopes(expr, scopes, depth + 1)),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_string_with_scopes(body, &scopes)
+            expr_as_string_with_scopes(body, &scopes, depth + 1)
         }
         Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes)),
+            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, depth + 1)),
         _ => None,
     }
 }
@@ -1249,16 +1358,31 @@ fn expr_as_string_with_scopes(expr: &Expr, scopes: &[&[(Vec<String>, Expr)]]) ->
 fn expr_to_scalar_string_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
+    depth: usize,
 ) -> Option<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("expr_to_scalar_string_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::Application(parts) => parts
             .last()
-            .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes)),
-        _ => expr_as_string_with_scopes(expr, scopes),
+            .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, depth + 1)),
+        _ => expr_as_string_with_scopes(expr, scopes, depth),
     }
 }
 
-fn find_attr<'a>(entries: &'a [(Vec<String>, Expr)], path: &[&str]) -> Option<&'a Expr> {
+fn find_attr<'a>(
+    entries: &'a [(Vec<String>, Expr)],
+    path: &[&str],
+    depth: usize,
+) -> Option<&'a Expr> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("find_attr exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     for (key, value) in entries {
         if key.iter().map(String::as_str).eq(path.iter().copied()) {
             return Some(value);
@@ -1270,7 +1394,7 @@ fn find_attr<'a>(entries: &'a [(Vec<String>, Expr)], path: &[&str]) -> Option<&'
                 .map(String::as_str)
                 .eq(path[..key.len()].iter().copied())
             && let Expr::AttrSet(child_entries) = value
-            && let Some(found) = find_attr(child_entries, &path[key.len()..])
+            && let Some(found) = find_attr(child_entries, &path[key.len()..], depth + 1)
         {
             return Some(found);
         }
@@ -1284,7 +1408,9 @@ fn find_string_attr_with_scopes(
     path: &[&str],
     scopes: &[&[(Vec<String>, Expr)]],
 ) -> Option<String> {
-    find_attr(entries, path).and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes))
+    find_attr(entries, path, 0)
+        .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
+        .map(truncate_field)
 }
 
 fn find_mk_derivation_attrset(expr: &Expr) -> Option<&[(Vec<String>, Expr)]> {
@@ -1315,12 +1441,18 @@ fn extend_scopes<'a>(
 fn root_attrset_with_scopes<'a>(
     expr: &'a Expr,
     scopes: &[NixAttrEntriesRef<'a>],
+    depth: usize,
 ) -> Option<(NixAttrEntriesRef<'a>, NixScopeStack<'a>)> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("root_attrset_with_scopes exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
+
     match expr {
         Expr::AttrSet(entries) => Some((entries, scopes.to_vec())),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            root_attrset_with_scopes(body, &scopes)
+            root_attrset_with_scopes(body, &scopes, depth + 1)
         }
         _ => None,
     }
@@ -1330,7 +1462,7 @@ fn lookup_binding<'a>(scopes: &[NixAttrEntriesRef<'a>], name: &str) -> Option<&'
     scopes
         .iter()
         .rev()
-        .find_map(|bindings| find_attr(bindings, &[name]))
+        .find_map(|bindings| find_attr(bindings, &[name], 0))
 }
 
 fn resolve_symbol<'a>(
@@ -1338,7 +1470,7 @@ fn resolve_symbol<'a>(
     scopes: &[NixAttrEntriesRef<'a>],
     depth: usize,
 ) -> Option<&'a Expr> {
-    if depth > 8 {
+    if depth > MAX_RECURSION_DEPTH {
         return None;
     }
 
@@ -1363,7 +1495,7 @@ fn resolve_select<'a>(
     scopes: &[NixAttrEntriesRef<'a>],
     depth: usize,
 ) -> Option<&'a Expr> {
-    if depth > 8 {
+    if depth > MAX_RECURSION_DEPTH {
         return None;
     }
 
@@ -1371,6 +1503,7 @@ fn resolve_select<'a>(
         Expr::AttrSet(entries) => find_attr(
             entries,
             &path.iter().map(String::as_str).collect::<Vec<_>>(),
+            0,
         ),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
@@ -1407,7 +1540,7 @@ fn interpolate_string(value: &str, scopes: &[&[(Vec<String>, Expr)]]) -> String 
                 .chars()
                 .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
             && let Some(resolved) = resolve_symbol(placeholder, scopes, 0)
-            && let Some(replacement) = expr_as_string_with_scopes(resolved, scopes)
+            && let Some(replacement) = expr_as_string_with_scopes(resolved, scopes, 0)
         {
             result.push_str(&replacement);
         } else {
@@ -1514,11 +1647,11 @@ fn build_default_package_from_attrset(
             .or_else(|| find_string_attr_with_scopes(derivation, &["description"], scopes));
     package.homepage_url = find_string_attr_with_scopes(derivation, &["meta", "homepage"], scopes)
         .or_else(|| find_string_attr_with_scopes(derivation, &["homepage"], scopes));
-    package.extracted_license_statement = find_attr(derivation, &["meta", "license"])
-        .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes))
+    package.extracted_license_statement = find_attr(derivation, &["meta", "license"], 0)
+        .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
         .or_else(|| {
-            find_attr(derivation, &["license"])
-                .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes))
+            find_attr(derivation, &["license"], 0)
+                .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
         });
     package.dependencies = [
         build_list_dependencies(derivation, "nativeBuildInputs", false, scopes),
@@ -1528,7 +1661,7 @@ fn build_default_package_from_attrset(
     ]
     .concat();
     if package.name.is_none() {
-        package.name = fallback_name(path);
+        package.name = fallback_name(path).map(truncate_field);
     }
     package.purl = package
         .name
@@ -1551,13 +1684,13 @@ fn try_follow_local_nix_application(
 
     let local_path = parts
         .get(1)
-        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes))?;
+        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
     if !is_local_nix_path(&local_path) {
         return None;
     }
 
     let resolved_path = resolve_local_nix_path(path, &local_path)?;
-    let content = fs::read_to_string(&resolved_path).ok()?;
+    let content = read_file_to_string(&resolved_path, None).ok()?;
     let expr = parse_nix_expr(&content).ok()?;
     Some((expr, resolved_path))
 }
@@ -1577,6 +1710,7 @@ fn try_follow_selected_local_import(
         find_attr(
             entries,
             &select_path.iter().map(String::as_str).collect::<Vec<_>>(),
+            0,
         )
     })?;
     Some((selected.clone(), imported_path))
@@ -1656,6 +1790,7 @@ fn extract_flake_compat_package_from_select(
         .file_name()
         .and_then(|name| name.to_str())
         .map(ToOwned::to_owned)
+        .map(truncate_field)
         .or_else(|| fallback_name(path));
     package.purl = package
         .name
@@ -1706,14 +1841,14 @@ fn source_root_from_flake_compat_application(
 
     let import_path = parts
         .get(1)
-        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes))?;
+        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
     if !is_local_nix_path(&import_path) {
         return None;
     }
 
     let args = parts.iter().find_map(attrset_entries)?;
-    let src_value =
-        find_attr(args, &["src"]).and_then(|expr| expr_as_symbol_with_scopes(expr, scopes))?;
+    let src_value = find_attr(args, &["src"], 0)
+        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
     if !is_local_path(&src_value) {
         return None;
     }
@@ -1757,6 +1892,7 @@ fn extract_flake_compat_default_package_from_content(
                 .filter(|name| *name != ".")
                 .map(ToOwned::to_owned)
         })
+        .map(truncate_field)
         .or_else(|| fallback_name(path));
     if package.name.is_none() {
         return Err("default.nix did not contain a supported mkDerivation call".to_string());


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: nix, meson, hex_lock, debian, clojure
- Part of systematic ADR 0004 remediation across all parsers (batch 3 of N)

## Changes

### nix.rs (7 findings → fixed)
- **P2 Recursion**: Added `depth` field to `Parser` struct, `MAX_RECURSION_DEPTH = 50` check in `parse_expr`; added `depth` parameter to all recursive AST evaluation functions (`expr_to_dependency_symbols_with_scopes`, `expr_as_symbol_with_scopes`, `expr_as_bool_with_scopes`, `expr_as_string_with_scopes`, `list_items_with_scopes`, `root_attrset_with_scopes`, `find_attr`, `expr_to_scalar_string_with_scopes`)
- **P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps to tokenizer, `parse_let_in_expr`, `parse_attrset`, `parse_list`, `parse_inherit_entries`, `root_inputs.iter()`, `build_list_dependencies`
- **P2 String**: Applied `truncate_field()` to all extracted string values
- **P4 UTF-8**: Fixed via `read_file_to_string`
- **Additional**: Replaced `.expect()` in library code with safe alternative

### meson.rs (6 findings → fixed)
- **P2 Recursion**: Added `depth` field to `Parser`, `MAX_RECURSION_DEPTH = 50` check in `parse_expr`; increment/decrement around mutual recursion with `parse_array`/`parse_identifier_or_call`
- **P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps to `strip_comments`, `split_statements`, `tokenize`, `parse_meson_build`, `parse_array`, `parse_identifier_or_call`, `extract_dependencies_from_call`
- **P2 String**: Applied `truncate_field()` to all extracted string values

### hex_lock.rs (6 findings → fixed)
- **P2 Recursion**: Added `depth` field to `Parser`, `MAX_RECURSION_DEPTH = 50` check in `parse_term`; increment/decrement around mutual recursion with `parse_map`/`parse_tuple`/`parse_list`
- **P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps to `parse_map`, `parse_tuple`, `parse_list`, `parse_mix_lock`, `term_to_dependency_tuples`
- **P2 String**: Applied `truncate_field()` to all extracted string values

### debian.rs (7 findings → fixed)
- **P2 File Size**: All reads already use `read_file_to_string(path, None)` — verified
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps to `parse_dpkg_status`, `parse_debian_control`, `parse_dependency_field`, `parse_copyright_file`, `parse_debian_file_list`, `parse_copyright_holders`, and others
- **P2 String**: Applied `truncate_field()` to all extracted string values
- **P3 Archive Safety**: Added 1GB uncompressed limit, 100:1 compression ratio check, path traversal blocking, per-entry size limit (50MB), cumulative extracted size tracking, bounded `read_to_end` via `Read::take()` in `extract_deb_archive`, `parse_control_tar_archive`, `merge_deb_data_archive`
- **P4 UTF-8**: Replaced `std::str::from_utf8` with `String::from_utf8_lossy` for archive entry names
- **Additional**: Replaced `Regex::new().unwrap()` with `LazyLock<Regex>`; replaced `LineNumber::new().unwrap()` with safe `match`

### clojure.rs (6 findings → fixed)
- **P2 Recursion**: Added `depth` field to `Reader`, `MAX_RECURSION_DEPTH = 50` check in `parse_form`; increment/decrement around recursive calls
- **P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps to `parse_all`, `parse_collection`, `parse_map`, `extract_deps_map`, `extract_project_dependencies`
- **P2 String**: Applied `truncate_field()` to all extracted string values

## Validation

- `cargo check` ✓
- `cargo clippy --all-targets --all-features` ✓ (0 warnings)
- `cargo fmt` ✓
- Pre-commit hooks ✓

## Related

- Batch 1 (PR #664): utils, npm, cargo, python, ruby, alpine — merged
- Batch 2 (PR #665): swift_show_dependencies, sbt, pylock_toml, pnpm_lock, npm_lock