### PR TITLE
fix(output): keep schema-backed party nulls on the wire

### DIFF
--- a/src/output_schema/party.rs
+++ b/src/output_schema/party.rs
@@ -2,15 +2,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OutputParty {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization: Option<String>,

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -348,6 +348,17 @@ fn test_json_contract_preserves_scancode_style_nulls_for_package_like_objects() 
         version: Some("1.3.0".to_string()),
         ..Default::default()
     };
+    let mut package_data = package_data;
+    package_data.parties = vec![Party {
+        r#type: None,
+        role: Some("author".to_string()),
+        name: Some("Example Author".to_string()),
+        email: None,
+        url: None,
+        organization: None,
+        organization_url: None,
+        timezone: None,
+    }];
     let package = Package::from_package_data(&package_data, "package.json".to_string());
 
     let file = sample_plain_text_file(
@@ -414,6 +425,21 @@ fn test_json_contract_preserves_scancode_style_nulls_for_package_like_objects() 
     assert!(package_data["md5"].is_null());
     assert!(package_data["sha256"].is_null());
     assert!(package_data["sha512"].is_null());
+
+    let party = &package["parties"][0];
+    assert!(party.get("type").is_some());
+    assert_eq!(party["type"], Value::Null);
+    assert_eq!(party["role"], serde_json::json!("author"));
+    assert_eq!(party["name"], serde_json::json!("Example Author"));
+    assert!(party.get("email").is_some());
+    assert_eq!(party["email"], Value::Null);
+    assert!(party.get("url").is_some());
+    assert_eq!(party["url"], Value::Null);
+
+    let package_data_party = &value["files"][0]["package_data"][0]["parties"][0];
+    assert_eq!(package_data_party["type"], Value::Null);
+    assert_eq!(package_data_party["email"], Value::Null);
+    assert_eq!(package_data_party["url"], Value::Null);
 
     let dependency = &value["dependencies"][0];
     assert!(dependency["extra_data"].is_null());


### PR DESCRIPTION
## Summary

- keep schema-backed party keys (`type`, `role`, `name`, `email`, `url`) present as explicit `null` when absent so Provenant matches ScanCode's documented Party shape and current package outputs more closely
- extend the JSON writer contract test to cover both top-level `packages[]` and nested `files[].package_data[]` party serialization

## Issues

- Covers: follow-up schema-shape audit for ScanCode-backed fields
- Closes:

## Scope and exclusions

- Included:
  - `OutputParty` serialization shape for ScanCode-backed fields
  - focused public JSON contract assertions for package and package_data party objects
- Explicit exclusions:
  - no broader package/dependency null-vs-omitted overhaul
  - no changes to runtime-only license-match fields in this PR

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred:
  - continue the broader schema/runtime audit for remaining non-party fields where ScanCode docs are stale or incomplete

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct:
  - the change is covered by a focused writer contract test rather than golden fixture refreshes, and it aligns the emitted party shape with both the formal ScanCode Party schema and upstream package outputs that use explicit `null` for absent party fields