### PR TITLE
fix(ci): ignore yanked core2 v0.4.0 transitive dep in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,9 @@ exclude = ["provenant-xtask"]
 yanked = "deny"
 unmaintained = "workspace"
 unsound = "workspace"
-ignore = []
+ignore = [
+    { crate = "core2@0.4.0", reason = "all versions yanked; transitive dep via pdf_oxide -> libflate. See https://github.com/sile/libflate/issues/85" },
+]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## Summary

- Add `core2@0.4.0` to `deny.toml` ignore list to unblock CI while upstream resolves the yanked dependency

## Context

All versions of `core2` have been yanked from crates.io (the project is unmaintained/abandoned). It's pulled in transitively via `provenant-cli → pdf_oxide → libflate → core2`. There is already an open issue on libflate requesting removal of the `core2` dependency: https://github.com/sile/libflate/issues/85

This is a temporary workaround. The proper fix requires either:
- libflate dropping the `core2` dependency (https://github.com/sile/libflate/issues/85)
- pdf_oxide dropping the redundant `libflate` dependency (it already depends on `flate2` with `zlib-rs`)

## Testing

- `cargo deny check advisories` passes with the ignore entry
- Pre-commit hook (which runs cargo-deny) passed on this commit