### PR TITLE
fix(parsers): ADR 0004 security compliance — batch 4 (bun_lockb, bazel, yarn_pnp, yarn_lock, vcpkg)

### DIFF
--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -17,6 +17,7 @@
 //! Python implementation: `reference/scancode-toolkit/src/packagedcode/build.py` (BazelBuildHandler)
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::path::Path;
@@ -30,6 +31,7 @@ use super::PackageParser;
 
 type StarlarkCallArgs = ast::CallArgsP<ast::AstNoPayload>;
 const SCANCODE_SIMPLE_TOP_LEVEL_KEY: &str = "scancode_simple_top_level";
+const MAX_RECURSION_DEPTH: usize = 50;
 
 struct StarlarkCall<'a> {
     func: &'a ast::AstExpr,
@@ -62,13 +64,16 @@ impl PackageParser for BazelBuildParser {
 /// Parse a Bazel BUILD file and extract all package data
 fn parse_bazel_build(path: &Path) -> Result<Vec<PackageData>, String> {
     let content =
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+        crate::parsers::utils::read_file_to_string(path, None).map_err(|e| e.to_string())?;
     let module = parse_starlark_module("<BUILD>", content)?;
     let scancode_simple_top_level = is_scancode_simple_top_level_module(&module);
 
     let mut packages = Vec::new();
 
-    for statement in top_level_statements(&module) {
+    for statement in top_level_statements(&module)
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         if let Some(mut package_data) = extract_package_from_statement(statement) {
             set_scancode_simple_top_level(&mut package_data, scancode_simple_top_level);
             packages.push(package_data);
@@ -89,12 +94,12 @@ fn extract_package_from_statement(statement: &ast::AstStmt) -> Option<PackageDat
 
     let name = extract_string_kwarg(&call, "name")?;
     let licenses = extract_string_list_kwarg(&call, "licenses");
-    let purl = build_bazel_purl(&name, None);
+    let purl = build_bazel_purl(&name, None).map(truncate_field);
 
     Some(PackageData {
         package_type: Some(BazelBuildParser::PACKAGE_TYPE),
-        name: Some(name),
-        extracted_license_statement: licenses.map(|licenses| licenses.join(", ")),
+        name: Some(truncate_field(name)),
+        extracted_license_statement: licenses.map(|licenses| truncate_field(licenses.join(", "))),
         datasource_id: Some(DatasourceId::BazelBuild),
         purl,
         ..Default::default()
@@ -112,13 +117,14 @@ fn fallback_package_data(path: &Path) -> PackageData {
         .parent()
         .and_then(|p| p.file_name())
         .and_then(|n| n.to_str())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
 
     PackageData {
         package_type: Some(BazelBuildParser::PACKAGE_TYPE),
         purl: name
             .as_deref()
-            .and_then(|name| build_bazel_purl(name, None)),
+            .and_then(|name| build_bazel_purl(name, None))
+            .map(truncate_field),
         name,
         datasource_id: Some(DatasourceId::BazelBuild),
         ..Default::default()
@@ -248,7 +254,7 @@ impl PackageParser for BazelModuleParser {
 
 fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
     let content =
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+        crate::parsers::utils::read_file_to_string(path, None).map_err(|e| e.to_string())?;
     let module = parse_starlark_module("<MODULE.bazel>", content)?;
 
     let mut package = default_bazel_module_package_data();
@@ -256,7 +262,10 @@ fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
     let mut dependencies = Vec::new();
     let mut overrides = Vec::new();
 
-    for statement in top_level_statements(&module) {
+    for statement in top_level_statements(&module)
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         let Some(call) = extract_call(statement) else {
             continue;
         };
@@ -267,14 +276,17 @@ fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
 
         match function_name {
             "module" => {
-                package.name = extract_string_kwarg(&call, "name");
-                package.version = extract_string_kwarg(&call, "version");
+                package.name = extract_string_kwarg(&call, "name").map(truncate_field);
+                package.version = extract_string_kwarg(&call, "version").map(truncate_field);
                 package.purl = package
                     .name
                     .as_deref()
-                    .and_then(|name| build_bazel_purl(name, package.version.as_deref()));
+                    .and_then(|name| build_bazel_purl(name, package.version.as_deref()))
+                    .map(truncate_field);
 
-                if let Some(repo_name) = extract_string_kwarg(&call, "repo_name") {
+                if let Some(repo_name) =
+                    extract_string_kwarg(&call, "repo_name").map(truncate_field)
+                {
                     extra_data.insert("repo_name".to_string(), JsonValue::String(repo_name));
                 }
                 if let Some(compatibility_level) = extract_int_kwarg(&call, "compatibility_level") {
@@ -374,7 +386,11 @@ fn extract_string_list_kwarg(call: &StarlarkCall<'_>, key: &str) -> Option<Vec<S
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
-    let values: Vec<_> = items.iter().filter_map(expr_as_string).collect();
+    let values: Vec<_> = items
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(expr_as_string)
+        .collect();
     (!values.is_empty()).then_some(values)
 }
 
@@ -387,23 +403,26 @@ fn extract_int_kwarg(call: &StarlarkCall<'_>, key: &str) -> Option<i64> {
 }
 
 fn extract_kwarg_json(call: &StarlarkCall<'_>, key: &str) -> Option<JsonValue> {
-    extract_named_kwarg(call, key).and_then(expr_to_json)
+    extract_named_kwarg(call, key).and_then(|expr| expr_to_json(expr, 0))
 }
 
 fn extract_bazel_dependency(call: &StarlarkCall<'_>) -> Option<Dependency> {
-    let name = extract_string_kwarg(call, "name")?;
-    let version = extract_string_kwarg(call, "version");
+    let name = extract_string_kwarg(call, "name").map(truncate_field)?;
+    let version = extract_string_kwarg(call, "version").map(truncate_field);
     let is_dev = extract_bool_kwarg(call, "dev_dependency").unwrap_or(false);
     let mut extra_data = JsonMap::new();
 
-    for field in ["repo_name", "max_compatibility_level", "registry"] {
+    for field in ["repo_name", "max_compatibility_level", "registry"]
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         if let Some(value) = extract_kwarg_json(call, field) {
             extra_data.insert(field.to_string(), value);
         }
     }
 
     Some(Dependency {
-        purl: build_bazel_purl(&name, version.as_deref()),
+        purl: build_bazel_purl(&name, version.as_deref()).map(truncate_field),
         extracted_requirement: version.clone(),
         scope: Some(if is_dev { "dev" } else { "dependencies" }.to_string()),
         is_runtime: Some(!is_dev),
@@ -418,9 +437,9 @@ fn extract_bazel_dependency(call: &StarlarkCall<'_>) -> Option<Dependency> {
 fn extract_override(kind: &str, call: &StarlarkCall<'_>) -> JsonValue {
     let mut override_map = JsonMap::new();
     override_map.insert("kind".to_string(), JsonValue::String(kind.to_string()));
-    for argument in &call.args.args {
+    for argument in call.args.args.iter().take(MAX_ITERATION_COUNT) {
         if let ast::ArgumentP::Named(name, value) = &argument.node
-            && let Some(value) = expr_to_json(value)
+            && let Some(value) = expr_to_json(value, 0)
         {
             override_map.insert(name.node.clone(), value);
         }
@@ -453,7 +472,10 @@ fn expr_as_i64(expr: &ast::AstExpr) -> Option<i64> {
     }
 }
 
-fn expr_to_json(expr: &ast::AstExpr) -> Option<JsonValue> {
+fn expr_to_json(expr: &ast::AstExpr, depth: usize) -> Option<JsonValue> {
+    if depth > MAX_RECURSION_DEPTH {
+        return None;
+    }
     match &expr.node {
         ast::ExprP::Literal(ast::AstLiteral::String(value)) => {
             Some(JsonValue::String(value.node.clone()))
@@ -475,15 +497,18 @@ fn expr_to_json(expr: &ast::AstExpr) -> Option<JsonValue> {
             _ => None,
         },
         ast::ExprP::List(elts) | ast::ExprP::Tuple(elts) => Some(JsonValue::Array(
-            elts.iter().filter_map(expr_to_json).collect(),
+            elts.iter()
+                .take(MAX_ITERATION_COUNT)
+                .filter_map(|e| expr_to_json(e, depth + 1))
+                .collect(),
         )),
         ast::ExprP::Dict(items) => {
             let mut map = JsonMap::new();
-            for (key, value) in items {
+            for (key, value) in items.iter().take(MAX_ITERATION_COUNT) {
                 let Some(key) = expr_as_string(key) else {
                     continue;
                 };
-                if let Some(value) = expr_to_json(value) {
+                if let Some(value) = expr_to_json(value, depth + 1) {
                     map.insert(key, value);
                 }
             }

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -8,7 +8,7 @@ use serde_json::Value as JsonValue;
 use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha512Digest,
 };
-use crate::parsers::utils::{npm_purl, parse_sri};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
 
 use super::PackageParser;
 
@@ -20,6 +20,7 @@ const FIELD_COUNT_WITHOUT_SCRIPTS: usize = 7;
 const FIELD_COUNT_WITH_SCRIPTS: usize = 8;
 const PACKAGE_FIELD_LENGTHS: [usize; 8] = [8, 8, 64, 8, 8, 88, 20, 48];
 const DEPENDENCY_ENTRY_SIZE: usize = 26;
+const MAX_MANIFEST_SIZE: u64 = 100 * 1024 * 1024;
 
 #[derive(Clone, Copy)]
 struct SliceRef {
@@ -73,6 +74,21 @@ impl PackageParser for BunLockbParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        let file_size = match std::fs::metadata(path) {
+            Ok(meta) => meta.len(),
+            Err(e) => {
+                warn!("Failed to stat bun.lockb at {:?}: {}", path, e);
+                return vec![default_package_data()];
+            }
+        };
+        if file_size > MAX_MANIFEST_SIZE {
+            warn!(
+                "bun.lockb at {:?} is too large ({} bytes, max {})",
+                path, file_size, MAX_MANIFEST_SIZE
+            );
+            return vec![default_package_data()];
+        }
+
         let bytes = match std::fs::read(path) {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -160,6 +176,13 @@ fn parse_packages(
     packages_begin: usize,
     packages_end: usize,
 ) -> Result<Vec<BunLockbPackage>, String> {
+    if list_len > MAX_ITERATION_COUNT {
+        return Err(format!(
+            "bun.lockb package count {} exceeds maximum {}",
+            list_len, MAX_ITERATION_COUNT
+        ));
+    }
+
     let mut packages = vec![
         BunLockbPackage {
             name_ref: [0; 8],
@@ -291,7 +314,7 @@ fn build_package_data_from_lockb(
         .ok_or_else(|| "bun.lockb contains no packages".to_string())?;
 
     let mut package_data = default_package_data();
-    package_data.name = Some(root_package.name.clone());
+    package_data.name = Some(truncate_field(root_package.name.clone()));
     package_data.purl = npm_purl(&root_package.name, None);
 
     let extra_data = package_data.extra_data.get_or_insert_with(HashMap::new);
@@ -329,6 +352,7 @@ fn parse_dependency_entries(
 
     bytes
         .chunks_exact(DEPENDENCY_ENTRY_SIZE)
+        .take(MAX_ITERATION_COUNT)
         .map(|entry| {
             Ok(BunLockbDependencyEntry {
                 name: decode_bun_string(&entry[0..8], string_bytes)?,
@@ -346,7 +370,13 @@ fn parse_resolution_ids(bytes: &[u8]) -> Result<Vec<u32>, String> {
 
     bytes
         .chunks_exact(4)
-        .map(|chunk| Ok(u32::from_le_bytes(chunk.try_into().unwrap())))
+        .take(MAX_ITERATION_COUNT)
+        .map(|chunk| {
+            let arr: [u8; 4] = chunk
+                .try_into()
+                .map_err(|_| "Invalid bun.lockb resolution entry".to_string())?;
+            Ok(u32::from_le_bytes(arr))
+        })
         .collect()
 }
 
@@ -368,6 +398,7 @@ fn build_dependencies_for_package(
     dep_slice
         .iter()
         .zip(res_slice.iter())
+        .take(MAX_ITERATION_COUNT)
         .map(|(entry, package_id)| {
             let manifest = behavior_to_manifest(entry.behavior);
             let resolved_package = if (*package_id as usize) < packages.len() {
@@ -388,8 +419,8 @@ fn build_dependencies_for_package(
                 .and_then(|pkg| (!pkg.version.is_empty()).then_some(pkg.version.as_str()));
 
             Ok(Dependency {
-                purl: npm_purl(&entry.name, version),
-                extracted_requirement: Some(entry.literal.clone()),
+                purl: npm_purl(&truncate_field(entry.name.clone()), version),
+                extracted_requirement: Some(truncate_field(entry.literal.clone())),
                 scope: Some(manifest.scope.to_string()),
                 is_runtime: Some(manifest.is_runtime),
                 is_optional: Some(manifest.is_optional),
@@ -413,7 +444,11 @@ fn build_resolved_package(
 
     Ok(ResolvedPackage {
         primary_language: Some("JavaScript".to_string()),
-        download_url: package.resolution.resolved.clone(),
+        download_url: package
+            .resolution
+            .resolved
+            .as_ref()
+            .map(|s| truncate_field(s.clone())),
         sha1: None,
         sha256: None,
         sha512: package
@@ -439,9 +474,10 @@ fn build_resolved_package(
         purl: None,
         ..ResolvedPackage::new(
             PackageType::Npm,
-            namespace.unwrap_or_default(),
-            name.unwrap_or_else(|| package.name.clone()),
-            package.resolution.version.clone().unwrap_or_default(),
+            namespace.map(truncate_field).unwrap_or_default(),
+            name.map(truncate_field)
+                .unwrap_or_else(|| truncate_field(package.name.clone())),
+            truncate_field(package.resolution.version.clone().unwrap_or_default()),
         )
     })
 }
@@ -450,8 +486,16 @@ fn parse_slice_ref(bytes: &[u8]) -> Result<SliceRef, String> {
     if bytes.len() != 8 {
         return Err("Invalid bun.lockb slice length".to_string());
     }
-    let off = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
-    let len = u32::from_le_bytes(bytes[4..8].try_into().unwrap()) as usize;
+    let off = u32::from_le_bytes(
+        bytes[0..4]
+            .try_into()
+            .map_err(|_| "Invalid bun.lockb slice offset".to_string())?,
+    ) as usize;
+    let len = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "Invalid bun.lockb slice length".to_string())?,
+    ) as usize;
     Ok(SliceRef { off, len })
 }
 
@@ -468,9 +512,21 @@ fn parse_resolution(bytes: &[u8], string_bytes: &[u8]) -> Result<BunLockbResolut
         }),
         2 => {
             let resolved = decode_bun_string(&bytes[8..16], string_bytes)?;
-            let major = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
-            let minor = u32::from_le_bytes(bytes[20..24].try_into().unwrap());
-            let patch = u32::from_le_bytes(bytes[24..28].try_into().unwrap());
+            let major = u32::from_le_bytes(
+                bytes[16..20]
+                    .try_into()
+                    .map_err(|_| "Invalid bun.lockb version major".to_string())?,
+            );
+            let minor = u32::from_le_bytes(
+                bytes[20..24]
+                    .try_into()
+                    .map_err(|_| "Invalid bun.lockb version minor".to_string())?,
+            );
+            let patch = u32::from_le_bytes(
+                bytes[24..28]
+                    .try_into()
+                    .map_err(|_| "Invalid bun.lockb version patch".to_string())?,
+            );
             let tag_suffix = decode_version_suffix(&bytes[32..64], string_bytes)?;
             let version = if let Some(suffix) = tag_suffix {
                 format!("{}.{}.{}{}", major, minor, patch, suffix)
@@ -479,22 +535,22 @@ fn parse_resolution(bytes: &[u8], string_bytes: &[u8]) -> Result<BunLockbResolut
             };
 
             Ok(BunLockbResolution {
-                version: Some(version),
-                resolved: (!resolved.is_empty()).then_some(resolved),
+                version: Some(truncate_field(version)),
+                resolved: (!resolved.is_empty()).then_some(truncate_field(resolved)),
             })
         }
         72 => {
             let workspace = decode_bun_string(&bytes[8..16], string_bytes)?;
             Ok(BunLockbResolution {
                 version: None,
-                resolved: Some(format!("workspace:{}", workspace)),
+                resolved: Some(truncate_field(format!("workspace:{}", workspace))),
             })
         }
         4 | 8 | 16 | 24 | 32 | 64 | 80 | 100 => {
             let resolved = decode_bun_string(&bytes[8..16], string_bytes)?;
             Ok(BunLockbResolution {
                 version: None,
-                resolved: (!resolved.is_empty()).then_some(resolved),
+                resolved: (!resolved.is_empty()).then_some(truncate_field(resolved)),
             })
         }
         _ => Err(format!("Unsupported bun.lockb resolution tag {}", tag)),
@@ -528,20 +584,35 @@ fn decode_bun_string(bytes: &[u8], string_bytes: &[u8]) -> Result<String, String
 
     if bytes[7] & 0x80 == 0 {
         let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
-        return std::str::from_utf8(&bytes[..end])
-            .map(|s| s.to_string())
-            .map_err(|e| format!("Invalid inline bun.lockb UTF-8: {}", e));
+        let slice = &bytes[..end];
+        return if let Ok(s) = std::str::from_utf8(slice) {
+            Ok(s.to_string())
+        } else {
+            warn!("Invalid bun.lockb UTF-8 in string, using lossy conversion");
+            Ok(String::from_utf8_lossy(slice).into_owned())
+        };
     }
 
-    let off = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
-    let len_raw = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    let off = u32::from_le_bytes(
+        bytes[0..4]
+            .try_into()
+            .map_err(|_| "Invalid bun.lockb string offset".to_string())?,
+    ) as usize;
+    let len_raw = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "Invalid bun.lockb string length".to_string())?,
+    );
     let len = (len_raw & 0x7fff_ffff) as usize;
     let slice = string_bytes
         .get(off..off + len)
         .ok_or_else(|| "bun.lockb string offset out of bounds".to_string())?;
-    std::str::from_utf8(slice)
-        .map(|s| s.to_string())
-        .map_err(|e| format!("Invalid external bun.lockb UTF-8: {}", e))
+    if let Ok(s) = std::str::from_utf8(slice) {
+        Ok(s.to_string())
+    } else {
+        warn!("Invalid bun.lockb UTF-8 in string, using lossy conversion");
+        Ok(String::from_utf8_lossy(slice).into_owned())
+    }
 }
 
 fn parse_integrity(bytes: &[u8]) -> Option<String> {

--- a/src/parsers/vcpkg.rs
+++ b/src/parsers/vcpkg.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -7,7 +6,7 @@ use packageurl::PackageUrl;
 use serde_json::Value;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
-use crate::parsers::utils::split_name_email;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, split_name_email, truncate_field};
 
 use super::PackageParser;
 
@@ -21,7 +20,7 @@ impl PackageParser for VcpkgManifestParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match crate::parsers::utils::read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read vcpkg.json at {:?}: {}", path, e);
@@ -50,11 +49,11 @@ fn default_package_data() -> PackageData {
 }
 
 fn parse_vcpkg_manifest(path: &Path, json: &Value) -> PackageData {
-    let name = get_non_empty_string(json, "name");
-    let version = manifest_version(json);
-    let description = get_string_or_array(json, "description");
-    let homepage_url = get_non_empty_string(json, "homepage");
-    let extracted_license_statement = get_string_or_array(json, "license");
+    let name = get_non_empty_string(json, "name").map(truncate_field);
+    let version = manifest_version(json).map(truncate_field);
+    let description = get_string_or_array(json, "description").map(truncate_field);
+    let homepage_url = get_non_empty_string(json, "homepage").map(truncate_field);
+    let extracted_license_statement = get_string_or_array(json, "license").map(truncate_field);
     let parties = extract_maintainers(json);
     let dependencies = extract_dependencies(json);
     let extra_data = build_extra_data(path, json);
@@ -75,7 +74,8 @@ fn parse_vcpkg_manifest(path: &Path, json: &Value) -> PackageData {
         datasource_id: Some(DatasourceId::VcpkgJson),
         purl: name
             .as_deref()
-            .and_then(|name| build_vcpkg_purl(name, version.as_deref())),
+            .and_then(|name| build_vcpkg_purl(name, version.as_deref()))
+            .map(truncate_field),
         ..default_package_data()
     }
 }
@@ -107,6 +107,7 @@ fn extract_maintainers(json: &Value) -> Vec<Party> {
         Value::String(s) => vec![s.clone()],
         Value::Array(values) => values
             .iter()
+            .take(MAX_ITERATION_COUNT)
             .filter_map(Value::as_str)
             .map(ToOwned::to_owned)
             .collect(),
@@ -120,8 +121,8 @@ fn extract_maintainers(json: &Value) -> Vec<Party> {
             Party {
                 r#type: Some("person".to_string()),
                 role: Some("maintainer".to_string()),
-                name,
-                email,
+                name: name.map(truncate_field),
+                email: email.map(truncate_field),
                 url: None,
                 organization: None,
                 organization_url: None,
@@ -135,11 +136,16 @@ fn extract_dependencies(json: &Value) -> Vec<Dependency> {
     let mut dependencies: Vec<Dependency> = json
         .get("dependencies")
         .and_then(Value::as_array)
-        .map(|deps| deps.iter().filter_map(parse_dependency_entry).collect())
+        .map(|deps| {
+            deps.iter()
+                .take(MAX_ITERATION_COUNT)
+                .filter_map(parse_dependency_entry)
+                .collect()
+        })
         .unwrap_or_default();
 
     if let Some(features) = json.get("features").and_then(Value::as_object) {
-        for (feature_name, feature_value) in features {
+        for (feature_name, feature_value) in features.iter().take(MAX_ITERATION_COUNT) {
             let Some(feature_dependencies) =
                 feature_value.get("dependencies").and_then(Value::as_array)
             else {
@@ -148,6 +154,7 @@ fn extract_dependencies(json: &Value) -> Vec<Dependency> {
 
             for dependency in feature_dependencies
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(parse_dependency_entry)
                 .map(|mut dependency| {
                     let mut extra_data = dependency.extra_data.take().unwrap_or_default();
@@ -170,8 +177,8 @@ fn extract_dependencies(json: &Value) -> Vec<Dependency> {
 fn parse_dependency_entry(value: &Value) -> Option<Dependency> {
     match value {
         Value::String(name) => Some(Dependency {
-            purl: build_vcpkg_purl(name, None),
-            extracted_requirement: Some(name.clone()),
+            purl: build_vcpkg_purl(name, None).map(truncate_field),
+            extracted_requirement: Some(truncate_field(name.clone())),
             scope: Some("dependencies".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -189,8 +196,8 @@ fn parse_dependency_entry(value: &Value) -> Option<Dependency> {
             let extracted_requirement = obj
                 .get("version>=")
                 .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-                .or_else(|| Some(name.to_string()));
+                .map(|v| truncate_field(v.to_owned()))
+                .or_else(|| Some(truncate_field(name.to_string())));
 
             let host = obj.get("host").and_then(Value::as_bool).unwrap_or(false);
             let mut extra = HashMap::new();
@@ -207,7 +214,7 @@ fn parse_dependency_entry(value: &Value) -> Option<Dependency> {
             }
 
             Some(Dependency {
-                purl: build_vcpkg_purl(name, None),
+                purl: build_vcpkg_purl(name, None).map(truncate_field),
                 extracted_requirement,
                 scope: Some("dependencies".to_string()),
                 is_runtime: Some(!host),
@@ -251,7 +258,7 @@ fn build_extra_data(path: &Path, json: &Value) -> Option<HashMap<String, Value>>
 
 fn read_sibling_configuration(path: &Path) -> Option<Value> {
     let sibling_path = path.with_file_name("vcpkg-configuration.json");
-    let content = fs::read_to_string(&sibling_path).ok()?;
+    let content = crate::parsers::utils::read_file_to_string(&sibling_path, None).ok()?;
     match serde_json::from_str(&content) {
         Ok(value) => Some(value),
         Err(e) => {

--- a/src/parsers/yarn_lock.rs
+++ b/src/parsers/yarn_lock.rs
@@ -24,10 +24,9 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha512Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{npm_purl, parse_sri};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 use yaml_serde::Value;
 
@@ -56,7 +55,7 @@ impl PackageParser for YarnLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match crate::parsers::utils::read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read yarn.lock at {:?}: {}", path, e);
@@ -104,7 +103,7 @@ fn parse_yarn_v2(
     let mut dependencies = Vec::new();
     let package_extra_data = extract_yarn_v2_package_extra_data(yaml_map);
 
-    for (spec, details) in yaml_map {
+    for (spec, details) in yaml_map.iter().take(MAX_ITERATION_COUNT) {
         if spec.as_str().map(|s| s == "__metadata").unwrap_or(false) {
             continue;
         }
@@ -123,11 +122,13 @@ fn parse_yarn_v2(
         let resolution = extract_yaml_string(details_map, "resolution").unwrap_or_default();
 
         let (namespace_opt, name, resolved_version) = parse_yarn_v2_resolution(&resolution);
-        let namespace = namespace_opt.unwrap_or_default();
+        let namespace = namespace_opt.map(truncate_field).unwrap_or_default();
+        let name = truncate_field(name);
+        let resolved_version = truncate_field(resolved_version);
         let full_name = full_package_name(&namespace, &name);
         let manifest_info = manifest_dependencies.get(&full_name);
-        let purl = create_purl(&namespace, &name, &resolved_version);
-        let checksum = extract_yaml_string(details_map, "checksum");
+        let purl = create_purl(&namespace, &name, &resolved_version).map(truncate_field);
+        let checksum = extract_yaml_string(details_map, "checksum").map(truncate_field);
 
         let deps_yaml = details_map.get("dependencies");
         let peer_deps_yaml = details_map.get("peerDependencies");
@@ -185,7 +186,7 @@ fn parse_yarn_v2(
 
         let dependency = Dependency {
             purl,
-            extracted_requirement: Some(resolved_version.clone()),
+            extracted_requirement: Some(truncate_field(resolved_version.clone())),
             scope,
             is_runtime,
             is_optional,
@@ -194,7 +195,7 @@ fn parse_yarn_v2(
             resolved_package: Some(Box::new(resolved_package)),
             extra_data: Some(HashMap::from([(
                 "resolution".to_string(),
-                JsonValue::String(resolution),
+                JsonValue::String(truncate_field(resolution)),
             )])),
         };
 
@@ -255,7 +256,7 @@ fn parse_yarn_v1(
     let mut dependencies = Vec::new();
     let mut seen_purls = HashSet::new();
 
-    for block in content.split("\n\n") {
+    for block in content.split("\n\n").take(MAX_ITERATION_COUNT) {
         if is_empty_or_comment_block(block) {
             continue;
         }
@@ -395,6 +396,9 @@ fn parse_yarn_v1_block(
     }
 
     let (namespace, name, constraint) = parse_yarn_v1_requirement(requirement_line);
+    let namespace = truncate_field(namespace);
+    let name = truncate_field(name);
+    let constraint = truncate_field(constraint);
 
     if name.is_empty() {
         return None;
@@ -412,14 +416,16 @@ fn parse_yarn_v1_block(
         }
 
         if trimmed.starts_with("version") {
-            version = extract_quoted_value(trimmed).unwrap_or_default();
+            version = truncate_field(extract_quoted_value(trimmed).unwrap_or_default());
         } else if trimmed.starts_with("resolved") {
-            resolved_url = extract_quoted_value(trimmed).unwrap_or_default();
+            resolved_url = truncate_field(extract_quoted_value(trimmed).unwrap_or_default());
         } else if trimmed.starts_with("integrity") {
-            integrity = trimmed
-                .strip_prefix("integrity")
-                .map(|s| s.trim().to_string())
-                .unwrap_or_default();
+            integrity = truncate_field(
+                trimmed
+                    .strip_prefix("integrity")
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default(),
+            );
         } else if trimmed.starts_with("dependencies") {
             // Dependencies block - parse indented lines
             continue;
@@ -441,7 +447,7 @@ fn parse_yarn_v1_block(
 
     let full_name = full_package_name(&namespace, &name);
     let manifest_info = manifest_dependencies.get(&full_name);
-    let purl = create_purl(&namespace, &name, &version);
+    let purl = create_purl(&namespace, &name, &version).map(truncate_field);
     let (scope, is_runtime, is_optional, is_direct) = manifest_info
         .map(|info| {
             (
@@ -507,7 +513,7 @@ fn load_manifest_dependency_info(path: &Path) -> HashMap<String, ManifestDepende
     };
 
     let manifest_path = parent.join("package.json");
-    let Ok(content) = fs::read_to_string(manifest_path) else {
+    let Ok(content) = crate::parsers::utils::read_file_to_string(&manifest_path, None) else {
         return HashMap::new();
     };
 
@@ -567,7 +573,7 @@ fn load_manifest_dependency_info(path: &Path) -> HashMap<String, ManifestDepende
         .get("peerDependencies")
         .and_then(|value| value.as_object())
     {
-        for name in peer_dependencies.keys() {
+        for name in peer_dependencies.keys().take(MAX_ITERATION_COUNT) {
             dependencies.insert(
                 name.clone(),
                 ManifestDependencyInfo {
@@ -589,7 +595,7 @@ fn insert_manifest_dependency_info(
     info: ManifestDependencyInfo,
 ) {
     if let Some(entries) = json.get(field).and_then(|value| value.as_object()) {
-        for name in entries.keys() {
+        for name in entries.keys().take(MAX_ITERATION_COUNT) {
             dependencies.insert(name.clone(), info.clone());
         }
     }
@@ -634,8 +640,11 @@ fn parse_yarn_v1_dependency_line(
     }
 
     let (namespace, name, constraint) = parse_yarn_v1_requirement(trimmed);
+    let namespace = truncate_field(namespace);
+    let name = truncate_field(name);
+    let constraint = truncate_field(constraint);
 
-    let purl = create_purl(&namespace, &name, parent_version);
+    let purl = create_purl(&namespace, &name, parent_version).map(truncate_field);
 
     Some(Dependency {
         purl,
@@ -740,7 +749,7 @@ fn extract_yarn_v2_resolved_extra_data(
     let mut extra_data = HashMap::new();
     extra_data.insert(
         "resolution".to_string(),
-        JsonValue::String(resolution.to_string()),
+        JsonValue::String(truncate_field(resolution.to_string())),
     );
 
     for field in ["languageName", "linkType", "bin", "dependenciesMeta"] {
@@ -768,7 +777,7 @@ fn parse_yaml_dependencies(yaml_value: Option<&Value>) -> Vec<Dependency> {
     if let Some(deps_value) = yaml_value
         && let Some(mapping) = deps_value.as_mapping()
     {
-        for (key, value) in mapping {
+        for (key, value) in mapping.iter().take(MAX_ITERATION_COUNT) {
             let name = match key.as_str() {
                 Some(s) => s.to_string(),
                 None => continue,
@@ -780,7 +789,10 @@ fn parse_yaml_dependencies(yaml_value: Option<&Value>) -> Vec<Dependency> {
             };
 
             let (namespace, dep_name) = extract_namespace_and_name(&name);
-            let purl = create_purl(&namespace, &dep_name, &constraint);
+            let namespace = truncate_field(namespace);
+            let dep_name = truncate_field(dep_name);
+            let constraint = truncate_field(constraint);
+            let purl = create_purl(&namespace, &dep_name, &constraint).map(truncate_field);
 
             dependencies.push(Dependency {
                 purl,

--- a/src/parsers/yarn_pnp.rs
+++ b/src/parsers/yarn_pnp.rs
@@ -1,10 +1,9 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::npm_purl;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, truncate_field};
 
 use super::PackageParser;
 
@@ -18,7 +17,7 @@ impl PackageParser for YarnPnpParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match crate::parsers::utils::read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read .pnp.cjs at {:?}: {}", path, error);
@@ -63,7 +62,7 @@ fn parse_yarn_pnp(content: &str) -> Result<PackageData, String> {
     let mut seen_locators = HashSet::new();
     let mut dependencies = Vec::new();
 
-    for entry in registry_entries {
+    for entry in registry_entries.iter().take(MAX_ITERATION_COUNT) {
         let Some(locator) = entry.get(0).and_then(serde_json::Value::as_str) else {
             continue;
         };
@@ -74,10 +73,15 @@ fn parse_yarn_pnp(content: &str) -> Result<PackageData, String> {
             continue;
         };
 
-        let version = reference.strip_prefix("npm:");
+        let version = reference
+            .strip_prefix("npm:")
+            .map(|v| truncate_field(v.to_string()));
         dependencies.push(Dependency {
-            purl: npm_purl(name, version),
-            extracted_requirement: Some(reference.to_string()),
+            purl: npm_purl(
+                truncate_field(name.to_string()).as_str(),
+                version.as_deref(),
+            ),
+            extracted_requirement: Some(truncate_field(reference.to_string())),
             scope: Some("dependencies".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -90,7 +94,7 @@ fn parse_yarn_pnp(content: &str) -> Result<PackageData, String> {
             resolved_package: None,
             extra_data: Some(HashMap::from([(
                 "locator".to_string(),
-                serde_json::Value::String(locator.to_string()),
+                serde_json::Value::String(truncate_field(locator.to_string())),
             )])),
         });
     }
@@ -117,11 +121,15 @@ fn parse_dependency_pairs(value: &serde_json::Value) -> HashMap<String, String> 
     if let Some(array) = value.as_array() {
         return array
             .iter()
+            .take(MAX_ITERATION_COUNT)
             .filter_map(|pair| {
                 let pair = pair.as_array()?;
                 let name = pair.first()?.as_str()?;
                 let reference = pair.get(1)?.as_str()?;
-                Some((name.to_string(), reference.to_string()))
+                Some((
+                    truncate_field(name.to_string()),
+                    truncate_field(reference.to_string()),
+                ))
             })
             .collect();
     }
@@ -130,10 +138,14 @@ fn parse_dependency_pairs(value: &serde_json::Value) -> HashMap<String, String> 
         .as_object()
         .into_iter()
         .flatten()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(name, reference)| {
-            reference
-                .as_str()
-                .map(|reference| (name.clone(), reference.to_string()))
+            reference.as_str().map(|reference| {
+                (
+                    truncate_field(name.clone()),
+                    truncate_field(reference.to_string()),
+                )
+            })
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 more parsers: `bun_lockb`, `bazel`, `yarn_pnp`, `yarn_lock`, `vcpkg`

## Changes

### bun_lockb.rs (6 findings → fixed)
- **P2 File Size**: Added `MAX_MANIFEST_SIZE` (100MB) pre-check before `std::fs::read()` — binary file, kept `fs::read` instead of `read_file_to_string`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps on `parse_packages` (list_len check), dependency entries, resolution IDs, and dependency zip
- **P2 String**: Applied `truncate_field()` to all string values in PackageData/Dependency/ResolvedPackage
- **P4 UTF-8**: Replaced `std::str::from_utf8` with lossy conversion + `warn!` in `decode_bun_string`
- **Additional**: Replaced `try_into().unwrap()` with `try_into().map_err()?` at 3 sites

### bazel.rs (6 findings → fixed)
- **P2 File Size/Exists/UTF-8**: Replaced `std::fs::read_to_string` with `read_file_to_string` in both parsers
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps on statement loops, list items, override args, dependency fields, and `expr_to_json` collections
- **P2 String**: Applied `truncate_field()` to name, version, repo_name, license strings, and purl
- **P2 Recursion**: Added `depth` parameter + `MAX_RECURSION_DEPTH = 50` to `expr_to_json`

### yarn_pnp.rs (5 findings → fixed)
- **P2 File Size/Exists/UTF-8**: Replaced `fs::read_to_string` with `read_file_to_string`, removed `use std::fs`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps on registry entries and dependency pair iterations
- **P2 String**: Applied `truncate_field()` to name, reference, locator, and version strings

### yarn_lock.rs (5 findings → fixed)
- **P2 File Size/Exists/UTF-8**: Replaced `fs::read_to_string` with `read_file_to_string` at both call sites, removed `use std::fs`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps on v1 blocks, v2 YAML map, yaml deps, manifest deps
- **P2 String**: Applied `truncate_field()` to namespace, name, version, constraint, resolved_url, integrity, resolution, purl, extracted_requirement, checksum

### vcpkg.rs (5 findings → fixed)
- **P2 File Size/Exists/UTF-8**: Replaced `fs::read_to_string` with `read_file_to_string` at both call sites, removed `use std::fs`
- **P2 Iteration**: Added `MAX_ITERATION_COUNT` caps on deps, features, feature deps, and maintainers
- **P2 String**: Applied `truncate_field()` to name, version, description, homepage_url, license, purl, party name/email, and extracted_requirement

## Validation

- `cargo check` ✓
- `cargo clippy --all-targets --all-features` ✓ (0 warnings)
- `cargo fmt` ✓
- Pre-commit hooks ✓