### PR TITLE
fix(parsers): ADR 0004 security compliance for uv_lock, rpm_yumdb, rpm_specfile, rpm_parser, rpm_mariner_manifest

### DIFF
--- a/src/parsers/rpm_mariner_manifest.rs
+++ b/src/parsers/rpm_mariner_manifest.rs
@@ -17,10 +17,10 @@
 //! - Spec: https://github.com/microsoft/marinara/
 
 use crate::models::{DatasourceId, PackageType};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use crate::models::PackageData;
 
@@ -49,7 +49,7 @@ impl PackageParser for RpmMarinerManifestParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read RPM Mariner manifest {:?}: {}", path, e);
@@ -64,7 +64,7 @@ impl PackageParser for RpmMarinerManifestParser {
 pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
     let mut packages = Vec::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         // Only trim whitespace, not tabs
         let line = line.trim_matches(|c: char| c.is_whitespace() && c != '\t');
         if line.is_empty() {
@@ -86,16 +86,16 @@ pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
             continue;
         }
 
-        let name = parts[0];
-        let version = parts[1];
-        let arch = parts[7];
-        let filename = parts[9];
+        let name = truncate_field(parts[0].to_string());
+        let version = truncate_field(parts[1].to_string());
+        let arch = truncate_field(parts[7].to_string());
+        let filename = truncate_field(parts[9].to_string());
 
         let qualifiers = if arch.is_empty() {
             None
         } else {
             let mut quals = std::collections::HashMap::new();
-            quals.insert("arch".to_string(), arch.to_string());
+            quals.insert("arch".to_string(), arch.clone());
             Some(quals)
         };
 
@@ -105,23 +105,19 @@ pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
             let mut extra = std::collections::HashMap::new();
             extra.insert(
                 "filename".to_string(),
-                serde_json::Value::String(filename.to_string()),
+                serde_json::Value::String(filename.clone()),
             );
             Some(extra)
         };
 
         packages.push(PackageData {
             package_type: Some(PACKAGE_TYPE),
-            namespace: Some("mariner".to_string()),
-            name: if name.is_empty() {
-                None
-            } else {
-                Some(name.to_string())
-            },
+            namespace: Some(truncate_field("mariner".to_string())),
+            name: if name.is_empty() { None } else { Some(name) },
             version: if version.is_empty() {
                 None
             } else {
-                Some(version.to_string())
+                Some(version)
             },
             qualifiers,
             datasource_id: Some(DatasourceId::RpmMarinerManifest),

--- a/src/parsers/rpm_parser.rs
+++ b/src/parsers/rpm_parser.rs
@@ -19,7 +19,7 @@
 //! - Direct dependency tracking (all requires are direct)
 //! - Error handling with `warn!()` logs on parse failures
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufReader, Read};
 use std::path::Path;
 
@@ -27,6 +27,7 @@ use crate::parser_warn as warn;
 use rpm::{IndexTag, Package, PackageMetadata, RPM_MAGIC};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field};
 
 use super::PackageParser;
 
@@ -160,7 +161,30 @@ impl PackageParser for RpmParser {
         if let Some(ext) = path.extension().and_then(|e| e.to_str())
             && matches!(ext, "rpm" | "srpm")
         {
+            if let Ok(metadata) = fs::metadata(path)
+                && metadata.len() > MAX_MANIFEST_SIZE
+            {
+                warn!(
+                    "RPM file {:?} is too large ({} bytes), skipping",
+                    path,
+                    metadata.len()
+                );
+                return false;
+            }
             return true;
+        }
+
+        match fs::metadata(path) {
+            Ok(metadata) if metadata.len() > MAX_MANIFEST_SIZE => {
+                warn!(
+                    "RPM file {:?} is too large ({} bytes), skipping",
+                    path,
+                    metadata.len()
+                );
+                return false;
+            }
+            Err(_) => return false,
+            _ => {}
         }
 
         let mut file = match File::open(path) {
@@ -172,6 +196,22 @@ impl PackageParser for RpmParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        match fs::metadata(path) {
+            Ok(metadata) if metadata.len() > MAX_MANIFEST_SIZE => {
+                warn!(
+                    "RPM file {:?} is too large ({} bytes), skipping",
+                    path,
+                    metadata.len()
+                );
+                return vec![default_package_data()];
+            }
+            Err(e) => {
+                warn!("Cannot stat RPM file {:?}: {}", path, e);
+                return vec![default_package_data()];
+            }
+            _ => {}
+        }
+
         let file = match File::open(path) {
             Ok(f) => f,
             Err(e) => {
@@ -218,32 +258,46 @@ pub(crate) fn infer_rpm_namespace_from_filename(path: &Path) -> Option<String> {
 fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
     let metadata = &pkg.metadata;
 
-    let name = metadata.get_name().ok().map(|s| s.to_string());
-    let version = build_evr_version(metadata);
-    let description = metadata.get_description().ok().map(|s| s.to_string());
-    let homepage_url = metadata.get_url().ok().map(|s| s.to_string());
-    let architecture = metadata.get_arch().ok().map(|s| s.to_string());
+    let name = metadata
+        .get_name()
+        .ok()
+        .map(|s| truncate_field(s.to_string()));
+    let version = build_evr_version(metadata).map(truncate_field);
+    let description = metadata
+        .get_description()
+        .ok()
+        .map(|s| truncate_field(s.to_string()));
+    let homepage_url = metadata
+        .get_url()
+        .ok()
+        .map(|s| truncate_field(s.to_string()));
+    let architecture = metadata
+        .get_arch()
+        .ok()
+        .map(|s| truncate_field(s.to_string()));
     let path_str = path.to_string_lossy();
     let is_source = metadata.is_source_package()
         || path_str.ends_with(".src.rpm")
         || path_str.ends_with(".srpm");
-    let distribution = rpm_header_string(metadata, IndexTag::RPMTAG_DISTRIBUTION);
-    let dist_url = rpm_header_string(metadata, IndexTag::RPMTAG_DISTURL);
-    let bug_tracking_url = rpm_header_string(metadata, IndexTag::RPMTAG_BUGURL);
+    let distribution =
+        rpm_header_string(metadata, IndexTag::RPMTAG_DISTRIBUTION).map(truncate_field);
+    let dist_url = rpm_header_string(metadata, IndexTag::RPMTAG_DISTURL).map(truncate_field);
+    let bug_tracking_url = rpm_header_string(metadata, IndexTag::RPMTAG_BUGURL).map(truncate_field);
     let source_urls =
         rpm_header_string_array(metadata, IndexTag::RPMTAG_SOURCE).unwrap_or_default();
     let source_rpm = metadata
         .get_source_rpm()
         .ok()
         .filter(|value| !value.is_empty())
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
     let namespace = infer_rpm_namespace(
         distribution.as_deref(),
         metadata.get_vendor().ok(),
         metadata.get_release().ok(),
         dist_url.as_deref(),
     )
-    .or_else(|| infer_rpm_namespace_from_filename(path));
+    .or_else(|| infer_rpm_namespace_from_filename(path))
+    .map(truncate_field);
 
     let mut parties = Vec::new();
 
@@ -253,7 +307,7 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
         parties.push(Party {
             r#type: Some("organization".to_string()),
             role: Some("vendor".to_string()),
-            name: Some(vendor.to_string()),
+            name: Some(truncate_field(vendor.to_string())),
             email: None,
             url: None,
             organization: None,
@@ -282,8 +336,8 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
         parties.push(Party {
             r#type: Some("person".to_string()),
             role: Some("packager".to_string()),
-            name: name_opt,
-            email: email_opt,
+            name: name_opt.map(truncate_field),
+            email: email_opt.map(truncate_field),
             url: None,
             organization: None,
             organization_url: None,
@@ -291,7 +345,10 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
         });
     }
 
-    let extracted_license_statement = metadata.get_license().ok().map(|s| s.to_string());
+    let extracted_license_statement = metadata
+        .get_license()
+        .ok()
+        .map(|s| truncate_field(s.to_string()));
 
     let dependencies = extract_rpm_dependencies(pkg, namespace.as_deref());
 
@@ -301,7 +358,7 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
     if let Ok(group) = metadata.get_group()
         && !group.is_empty()
     {
-        keywords.push(group.to_string());
+        keywords.push(truncate_field(group.to_string()));
     }
 
     let mut extra_data = std::collections::HashMap::new();
@@ -366,7 +423,7 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
             ),
         );
     }
-    let vcs_url = infer_vcs_url(metadata, &source_urls);
+    let vcs_url = infer_vcs_url(metadata, &source_urls).map(truncate_field);
 
     PackageData {
         datasource_id: Some(DatasourceId::RpmArchive),
@@ -394,6 +451,7 @@ fn parse_rpm_package(pkg: &Package, path: &Path) -> PackageData {
                 architecture.as_deref(),
                 is_source,
             )
+            .map(truncate_field)
         }),
         ..Default::default()
     }
@@ -404,6 +462,13 @@ fn extract_rpm_dependencies(pkg: &Package, namespace: Option<&str>) -> Vec<Depen
 
     if let Ok(requires) = pkg.metadata.get_requires() {
         for rpm_dep in requires {
+            if dependencies.len() >= MAX_ITERATION_COUNT {
+                warn!(
+                    "RPM dependency iteration capped at {} items",
+                    MAX_ITERATION_COUNT
+                );
+                break;
+            }
             let purl = build_rpm_purl(
                 &rpm_dep.name,
                 if rpm_dep.version.is_empty() {
@@ -414,10 +479,11 @@ fn extract_rpm_dependencies(pkg: &Package, namespace: Option<&str>) -> Vec<Depen
                 namespace,
                 None,
                 false,
-            );
+            )
+            .map(truncate_field);
 
             let extracted_requirement = if !rpm_dep.version.is_empty() {
-                Some(format_rpm_requirement(&rpm_dep))
+                Some(truncate_field(format_rpm_requirement(&rpm_dep)))
             } else {
                 None
             };
@@ -450,11 +516,21 @@ fn extract_rpm_relationships(pkg: &Package, kind: RpmRelationshipKind) -> Option
         RpmRelationshipKind::Obsoletes => pkg.metadata.get_obsoletes().ok()?,
     };
 
+    let mut count = 0usize;
     let values: Vec<String> = relationships
         .into_iter()
+        .take(MAX_ITERATION_COUNT)
         .map(|dep| format_rpm_requirement(&dep))
         .filter(|value| !value.is_empty() && value != "(none)")
+        .inspect(|_| count += 1)
         .collect();
+
+    if count >= MAX_ITERATION_COUNT {
+        warn!(
+            "RPM relationship iteration capped at {} items",
+            MAX_ITERATION_COUNT
+        );
+    }
 
     (!values.is_empty()).then_some(values)
 }

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -34,7 +34,9 @@ use packageurl::PackageUrl;
 use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -82,9 +84,17 @@ fn parse_specfile(content: &str) -> PackageData {
 
     let lines: Vec<&str> = content.lines().collect();
     let mut i = 0;
+    let mut iterations: usize = 0;
 
-    // Parse preamble (everything before % sections)
     while i < lines.len() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM specfile preamble iteration limit ({}) exceeded",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         let line = lines[i].trim();
 
         // Stop at first section marker (%, but not %define/%global)
@@ -109,7 +119,10 @@ fn parse_specfile(content: &str) -> PackageData {
         {
             let parts: Vec<&str> = stripped.trim().splitn(2, char::is_whitespace).collect();
             if parts.len() == 2 {
-                macros.insert(parts[0].to_string(), parts[1].trim().to_string());
+                macros.insert(
+                    parts[0].to_string(),
+                    truncate_field(parts[1].trim().to_string()),
+                );
             }
             i += 1;
             continue;
@@ -122,8 +135,7 @@ fn parse_specfile(content: &str) -> PackageData {
 
             match tag.as_str() {
                 "buildrequires" => {
-                    // BuildRequires can be comma-separated
-                    for dep in value.split(',') {
+                    for dep in value.split(',').take(MAX_ITERATION_COUNT) {
                         let dep = dep.trim();
                         if !dep.is_empty() {
                             build_requires.push(dep.to_string());
@@ -142,7 +154,7 @@ fn parse_specfile(content: &str) -> PackageData {
                         Some("runtime".to_string())
                     };
 
-                    for dep in value.split(',') {
+                    for dep in value.split(',').take(MAX_ITERATION_COUNT) {
                         let dep = dep.trim();
                         if !dep.is_empty() {
                             requires.push((dep.to_string(), scope.clone()));
@@ -150,7 +162,7 @@ fn parse_specfile(content: &str) -> PackageData {
                     }
                 }
                 "provides" => {
-                    for prov in value.split(',') {
+                    for prov in value.split(',').take(MAX_ITERATION_COUNT) {
                         let prov = prov.trim();
                         if !prov.is_empty() {
                             provides.push(prov.to_string());
@@ -167,15 +179,31 @@ fn parse_specfile(content: &str) -> PackageData {
     }
 
     // Now parse %description section if present
+    let mut desc_iterations: usize = 0;
     while i < lines.len() {
+        desc_iterations += 1;
+        if desc_iterations > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM specfile description search iteration limit ({}) exceeded",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         let line = lines[i].trim();
 
         if line.starts_with("%description") {
             i += 1;
             let mut desc_lines = Vec::new();
 
-            // Collect lines until next % section
             while i < lines.len() {
+                desc_iterations += 1;
+                if desc_iterations > MAX_ITERATION_COUNT {
+                    warn!(
+                        "RPM specfile description iteration limit ({}) exceeded",
+                        MAX_ITERATION_COUNT
+                    );
+                    break;
+                }
                 let desc_line = lines[i];
                 let trimmed = desc_line.trim();
 
@@ -226,7 +254,7 @@ fn parse_specfile(content: &str) -> PackageData {
     // Expand macros in all tag values
     let mut expanded_tags: HashMap<String, String> = HashMap::new();
     for (tag, value) in tags.iter() {
-        expanded_tags.insert(tag.clone(), expand_macros(value, &macros));
+        expanded_tags.insert(tag.clone(), truncate_field(expand_macros(value, &macros)));
     }
 
     // Get expanded values
@@ -243,7 +271,8 @@ fn parse_specfile(content: &str) -> PackageData {
     let download_url = expanded_tags
         .get("source")
         .or_else(|| expanded_tags.get("source0"))
-        .cloned();
+        .cloned()
+        .map(truncate_field);
 
     // Create parties
     let mut parties = Vec::new();
@@ -264,10 +293,10 @@ fn parse_specfile(content: &str) -> PackageData {
     // Create dependencies
     let mut dependencies = Vec::new();
 
-    for dep_str in build_requires {
-        let dep_str = expand_macros(&dep_str, &macros);
+    for dep_str in build_requires.into_iter().take(MAX_ITERATION_COUNT) {
+        let dep_str = truncate_field(expand_macros(&dep_str, &macros));
         let dep_name = extract_dep_name(&dep_str);
-        let purl = build_rpm_purl(&dep_name, None);
+        let purl = build_rpm_purl(&dep_name, None).map(truncate_field);
 
         dependencies.push(Dependency {
             purl,
@@ -282,10 +311,10 @@ fn parse_specfile(content: &str) -> PackageData {
         });
     }
 
-    for (dep_str, scope) in requires {
-        let dep_str = expand_macros(&dep_str, &macros);
+    for (dep_str, scope) in requires.into_iter().take(MAX_ITERATION_COUNT) {
+        let dep_str = truncate_field(expand_macros(&dep_str, &macros));
         let dep_name = extract_dep_name(&dep_str);
-        let purl = build_rpm_purl(&dep_name, None);
+        let purl = build_rpm_purl(&dep_name, None).map(truncate_field);
 
         dependencies.push(Dependency {
             purl,
@@ -303,7 +332,8 @@ fn parse_specfile(content: &str) -> PackageData {
     // Build PURL
     let purl = name
         .as_ref()
-        .and_then(|n| build_rpm_purl(n, version.as_deref()));
+        .and_then(|n| build_rpm_purl(n, version.as_deref()))
+        .map(truncate_field);
 
     // Build extra_data for non-standard fields
     let mut extra_data = HashMap::new();
@@ -319,7 +349,8 @@ fn parse_specfile(content: &str) -> PackageData {
     if !provides.is_empty() {
         let provides_json: Vec<serde_json::Value> = provides
             .into_iter()
-            .map(|prov| serde_json::Value::String(expand_macros(&prov, &macros)))
+            .take(MAX_ITERATION_COUNT)
+            .map(|prov| serde_json::Value::String(truncate_field(expand_macros(&prov, &macros))))
             .collect();
         extra_data.insert(
             "provides".to_string(),
@@ -334,7 +365,7 @@ fn parse_specfile(content: &str) -> PackageData {
     };
 
     // Use %description if available, otherwise use Summary
-    let description_text = description.or(summary);
+    let description_text = description.map(truncate_field).or(summary);
 
     PackageData {
         datasource_id: Some(DatasourceId::RpmSpecfile),
@@ -381,10 +412,9 @@ fn expand_macros(s: &str, macros: &HashMap<String, String>) -> String {
 
 /// Extracts the package name from a dependency string (removes version constraints)
 fn extract_dep_name(dep: &str) -> String {
-    // Split on operators: >=, <=, =, >, <
     let parts: Vec<&str> = dep.split(&['>', '<', '='][..]).map(|s| s.trim()).collect();
 
-    parts[0].to_string()
+    truncate_field(parts[0].to_string())
 }
 
 /// Builds a package URL for RPM packages

--- a/src/parsers/rpm_yumdb.rs
+++ b/src/parsers/rpm_yumdb.rs
@@ -5,6 +5,7 @@ use crate::parser_warn as warn;
 use packageurl::PackageUrl;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -28,9 +29,9 @@ fn parse_yumdb_dir_name(dir_name: &str) -> Option<(String, String, String)> {
     let name = parts.next()?;
 
     Some((
-        name.to_string(),
-        format!("{}-{}", version, release),
-        arch.to_string(),
+        truncate_field(name.to_string()),
+        truncate_field(format!("{}-{}", version, release)),
+        truncate_field(arch.to_string()),
     ))
 }
 
@@ -38,7 +39,7 @@ fn build_yumdb_purl(name: &str, version: &str, arch: &str) -> Option<String> {
     let mut purl = PackageUrl::new(PACKAGE_TYPE.as_str(), name).ok()?;
     purl.with_version(version).ok()?;
     purl.add_qualifier("arch", arch).ok()?;
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 pub struct RpmYumdbParser;
@@ -80,7 +81,9 @@ impl PackageParser for RpmYumdbParser {
             }
         };
 
-        for entry in entries.flatten() {
+        let entries: Vec<_> = entries.flatten().take(MAX_ITERATION_COUNT).collect();
+
+        for entry in entries {
             let key_path = entry.path();
             if !key_path.is_file() {
                 continue;
@@ -90,13 +93,13 @@ impl PackageParser for RpmYumdbParser {
                 continue;
             };
 
-            match fs::read_to_string(&key_path) {
+            match read_file_to_string(&key_path, None) {
                 Ok(value) => {
                     let value = value.trim();
                     if !value.is_empty() {
                         extra_data.insert(
                             key.to_string(),
-                            serde_json::Value::String(value.to_string()),
+                            serde_json::Value::String(truncate_field(value.to_string())),
                         );
                     }
                 }
@@ -123,6 +126,7 @@ impl PackageParser for RpmYumdbParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use tempfile::tempdir;
 
     #[test]

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -11,8 +11,11 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha256Digest,
 };
 use crate::parsers::python::read_toml_file;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 const FIELD_PACKAGE: &str = "package";
 const FIELD_NAME: &str = "name";
@@ -89,8 +92,11 @@ fn parse_uv_lock(toml_content: &TomlValue) -> PackageData {
         return default_package_data();
     }
 
-    let package_tables: Vec<&TomlMap<String, TomlValue>> =
-        packages.iter().filter_map(TomlValue::as_table).collect();
+    let package_tables: Vec<&TomlMap<String, TomlValue>> = packages
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(TomlValue::as_table)
+        .collect();
 
     if package_tables.is_empty() {
         return default_package_data();
@@ -140,7 +146,7 @@ fn parse_uv_lock(toml_content: &TomlValue) -> PackageData {
         package_data.version = root_table
             .get(FIELD_VERSION)
             .and_then(TomlValue::as_str)
-            .map(|value| value.to_string());
+            .map(|value| truncate_field(value.to_string()));
         package_data.is_virtual =
             package_source_table(root_table).is_some_and(|source| source.contains_key("virtual"));
         package_data.purl = package_data
@@ -185,7 +191,7 @@ fn build_top_level_dependency(
     let version = package_table
         .get(FIELD_VERSION)
         .and_then(TomlValue::as_str)
-        .map(|value| value.to_string())?;
+        .map(|value| truncate_field(value.to_string()))?;
 
     let direct_info = direct_infos.get(&name);
     let is_direct = direct_info.is_some();
@@ -202,9 +208,13 @@ fn build_top_level_dependency(
         || (!is_direct && optional_reachable.contains(&name) && !runtime_reachable.contains(&name));
 
     Some(Dependency {
-        purl: create_pypi_purl(&name, Some(&version)),
-        extracted_requirement: direct_info.and_then(|info| info.extracted_requirement.clone()),
-        scope: direct_info.and_then(|info| info.scope.clone()),
+        purl: create_pypi_purl(&name, Some(&version)).map(truncate_field),
+        extracted_requirement: direct_info
+            .and_then(|info| info.extracted_requirement.clone())
+            .map(truncate_field),
+        scope: direct_info
+            .and_then(|info| info.scope.clone())
+            .map(truncate_field),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
         is_pinned: Some(true),
@@ -229,13 +239,16 @@ fn build_resolved_package(
     let version = package_table
         .get(FIELD_VERSION)
         .and_then(TomlValue::as_str)
-        .map(|value| value.to_string())
+        .map(|value| truncate_field(value.to_string()))
         .unwrap_or_default();
 
     let (_, repository_download_url, api_data_url, purl) =
         build_pypi_urls(Some(&name), Some(&version));
-    let repository_homepage_url = Some(format!("https://pypi.org/project/{}", name));
+    let repository_homepage_url =
+        Some(truncate_field(format!("https://pypi.org/project/{}", name)));
     let (download_url, sha256) = extract_artifact_metadata(package_table);
+
+    let download_url = download_url.map(truncate_field);
 
     ResolvedPackage {
         primary_language: Some("Python".to_string()),
@@ -251,10 +264,10 @@ fn build_resolved_package(
             .map(|edge| edge_to_dependency(edge, package_lookup))
             .collect(),
         repository_homepage_url,
-        repository_download_url,
-        api_data_url,
+        repository_download_url: repository_download_url.map(truncate_field),
+        api_data_url: api_data_url.map(truncate_field),
         datasource_id: Some(DatasourceId::PypiUvLock),
-        purl,
+        purl: purl.map(truncate_field),
         ..ResolvedPackage::new(UvLockParser::PACKAGE_TYPE, String::new(), name, version)
     }
 }
@@ -270,9 +283,9 @@ fn edge_to_dependency(
         .unwrap_or(false);
 
     Dependency {
-        purl: create_pypi_purl(&edge.name, None),
-        extracted_requirement: edge.extracted_requirement,
-        scope: edge.scope,
+        purl: create_pypi_purl(&edge.name, None).map(truncate_field),
+        extracted_requirement: edge.extracted_requirement.map(truncate_field),
+        scope: edge.scope.map(truncate_field),
         is_runtime: Some(edge.is_runtime),
         is_optional: Some(edge.is_optional),
         is_pinned: Some(is_pinned),
@@ -318,7 +331,7 @@ fn collect_root_direct_dependencies(
         .get(FIELD_OPTIONAL_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in optional_table {
+        for (group, value) in optional_table.iter().take(MAX_ITERATION_COUNT) {
             let requirement_map = optional_requirements.get(group);
             for edge in collect_dependency_edges_from_array(
                 value.as_array(),
@@ -326,7 +339,10 @@ fn collect_root_direct_dependencies(
                 false,
                 true,
                 requirement_map,
-            ) {
+            )
+            .into_iter()
+            .take(MAX_ITERATION_COUNT)
+            {
                 merge_direct_dependency_info(&mut infos, edge);
             }
         }
@@ -336,7 +352,7 @@ fn collect_root_direct_dependencies(
         .get(FIELD_DEV_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in dev_table {
+        for (group, value) in dev_table.iter().take(MAX_ITERATION_COUNT) {
             let requirement_map = dev_requirements.get(group);
             for edge in collect_dependency_edges_from_array(
                 value.as_array(),
@@ -344,7 +360,10 @@ fn collect_root_direct_dependencies(
                 false,
                 false,
                 requirement_map,
-            ) {
+            )
+            .into_iter()
+            .take(MAX_ITERATION_COUNT)
+            {
                 merge_direct_dependency_info(&mut infos, edge);
             }
         }
@@ -435,14 +454,18 @@ fn collect_package_dependency_edges(
         .get(FIELD_OPTIONAL_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in optional_table {
-            edges.extend(collect_dependency_edges_from_array(
-                value.as_array(),
-                Some(group.to_string()),
-                false,
-                true,
-                None,
-            ));
+        for (group, value) in optional_table.iter().take(MAX_ITERATION_COUNT) {
+            edges.extend(
+                collect_dependency_edges_from_array(
+                    value.as_array(),
+                    Some(group.to_string()),
+                    false,
+                    true,
+                    None,
+                )
+                .into_iter()
+                .take(MAX_ITERATION_COUNT),
+            );
         }
     }
 
@@ -450,14 +473,18 @@ fn collect_package_dependency_edges(
         .get(FIELD_DEV_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in dev_table {
-            edges.extend(collect_dependency_edges_from_array(
-                value.as_array(),
-                Some(group.to_string()),
-                false,
-                false,
-                None,
-            ));
+        for (group, value) in dev_table.iter().take(MAX_ITERATION_COUNT) {
+            edges.extend(
+                collect_dependency_edges_from_array(
+                    value.as_array(),
+                    Some(group.to_string()),
+                    false,
+                    false,
+                    None,
+                )
+                .into_iter()
+                .take(MAX_ITERATION_COUNT),
+            );
         }
     }
 
@@ -520,12 +547,12 @@ fn build_dependency_edge(
     }
 
     let extracted_requirement = requirement_map
-        .and_then(|map| map.get(&name).cloned())
+        .and_then(|map| map.get(&name).cloned().map(truncate_field))
         .or_else(|| {
             table
                 .get(FIELD_SPECIFIER)
                 .and_then(TomlValue::as_str)
-                .map(|value| value.to_string())
+                .map(|value| truncate_field(value.to_string()))
         });
 
     Some(DependencyEdge {
@@ -569,6 +596,7 @@ fn parse_requirement_metadata_table(
 fn parse_requirement_entries(values: &[TomlValue]) -> HashMap<String, String> {
     values
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|value| {
             let table = value.as_table()?;
             let name = table
@@ -578,7 +606,7 @@ fn parse_requirement_entries(values: &[TomlValue]) -> HashMap<String, String> {
             let specifier = table
                 .get(FIELD_SPECIFIER)
                 .and_then(TomlValue::as_str)
-                .map(|value| value.to_string())?;
+                .map(|value| truncate_field(value.to_string()))?;
             Some((name, specifier))
         })
         .collect()
@@ -592,8 +620,17 @@ fn collect_reachable_packages(
 ) -> HashSet<String> {
     let mut visited = HashSet::new();
     let mut queue: VecDeque<(String, Option<String>)> = roots.iter().cloned().collect();
+    let mut iterations: usize = 0;
 
     while let Some((name, source_key)) = queue.pop_front() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            warn!(
+                "collect_reachable_packages exceeded MAX_ITERATION_COUNT ({})",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         let Some(index) =
             match_package_index(package_tables, package_lookup, &name, source_key.as_deref())
         else {
@@ -766,7 +803,7 @@ fn extract_artifact_metadata(
         let download_url = sdist_table
             .get("url")
             .and_then(TomlValue::as_str)
-            .map(|value| value.to_string());
+            .map(|value| truncate_field(value.to_string()));
         let sha256 = sdist_table
             .get("hash")
             .and_then(TomlValue::as_str)
@@ -785,7 +822,7 @@ fn extract_artifact_metadata(
     let download_url = wheel_table
         .and_then(|table| table.get("url"))
         .and_then(TomlValue::as_str)
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
     let sha256 = wheel_table
         .and_then(|table| table.get("hash"))
         .and_then(TomlValue::as_str)
@@ -826,25 +863,26 @@ fn build_pypi_urls(
     Option<String>,
     Option<String>,
 ) {
-    let repository_homepage_url = name.map(|value| format!("https://pypi.org/project/{}", value));
+    let repository_homepage_url =
+        name.map(|value| truncate_field(format!("https://pypi.org/project/{}", value)));
 
     let repository_download_url = name.and_then(|value| {
         version.map(|ver| {
-            format!(
+            truncate_field(format!(
                 "https://pypi.org/packages/source/{}/{}/{}-{}.tar.gz",
                 &value[..1.min(value.len())],
                 value,
                 value,
                 ver
-            )
+            ))
         })
     });
 
     let api_data_url = name.map(|value| {
         if let Some(ver) = version {
-            format!("https://pypi.org/pypi/{}/{}/json", value, ver)
+            truncate_field(format!("https://pypi.org/pypi/{}/{}/json", value, ver))
         } else {
-            format!("https://pypi.org/pypi/{}/json", value)
+            truncate_field(format!("https://pypi.org/pypi/{}/json", value))
         }
     });
 
@@ -859,12 +897,12 @@ fn build_pypi_urls(
 }
 
 fn normalize_pypi_name(name: &str) -> String {
-    name.trim().to_ascii_lowercase()
+    truncate_field(name.trim().to_ascii_lowercase())
 }
 
 fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if name.contains('[') || name.contains(']') {
-        return Some(build_manual_pypi_purl(name, version));
+        return Some(truncate_field(build_manual_pypi_purl(name, version)));
     }
 
     if let Ok(mut purl) = PackageUrl::new(UvLockParser::PACKAGE_TYPE.as_str(), name) {
@@ -873,10 +911,10 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
         {
             return None;
         }
-        return Some(purl.to_string());
+        return Some(truncate_field(purl.to_string()));
     }
 
-    Some(build_manual_pypi_purl(name, version))
+    Some(truncate_field(build_manual_pypi_purl(name, version)))
 }
 
 fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
@@ -892,19 +930,34 @@ fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
 }
 
 fn toml_value_to_json(value: &TomlValue) -> JsonValue {
+    toml_value_to_json_recursive(value, 0)
+}
+
+fn toml_value_to_json_recursive(value: &TomlValue, depth: usize) -> JsonValue {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!(
+            "toml_value_to_json exceeded MAX_RECURSION_DEPTH ({})",
+            MAX_RECURSION_DEPTH
+        );
+        return JsonValue::Null;
+    }
+
     match value {
         TomlValue::String(value) => JsonValue::String(value.clone()),
         TomlValue::Integer(value) => JsonValue::String(value.to_string()),
         TomlValue::Float(value) => JsonValue::String(value.to_string()),
         TomlValue::Boolean(value) => JsonValue::Bool(*value),
         TomlValue::Datetime(value) => JsonValue::String(value.to_string()),
-        TomlValue::Array(values) => {
-            JsonValue::Array(values.iter().map(toml_value_to_json).collect())
-        }
+        TomlValue::Array(values) => JsonValue::Array(
+            values
+                .iter()
+                .map(|v| toml_value_to_json_recursive(v, depth + 1))
+                .collect(),
+        ),
         TomlValue::Table(values) => JsonValue::Object(
             values
                 .iter()
-                .map(|(key, value)| (key.clone(), toml_value_to_json(value)))
+                .map(|(key, value)| (key.clone(), toml_value_to_json_recursive(value, depth + 1)))
                 .collect(),
         ),
     }


### PR DESCRIPTION
## Summary

- Address ADR 0004 security compliance findings for 5 parsers: uv_lock, rpm_yumdb, rpm_specfile, rpm_parser, rpm_mariner_manifest
- Apply file size checks, iteration caps (100K), string field truncation (10MB), recursion depth limits (50), and lossy UTF-8 fallbacks as specified in ADR 0004

## Changes

### uv_lock.rs (5 findings → fixed)
- P2-FileSize: Already covered by `read_toml_file` → `read_file_to_string`
- P2-Recursion: Added `MAX_RECURSION_DEPTH = 50` to `toml_value_to_json` with depth tracking
- P2-Iteration: Added `MAX_ITERATION_COUNT` caps to package iteration, dependency edge collection, BFS loop, requirement parsing
- P2-StringLength: Applied `truncate_field()` to name, version, purl, extracted_requirement, scope, specifier, URLs
- P4-UTF8: Already covered by `read_file_to_string`

### rpm_yumdb.rs (5 findings → fixed)
- P2-FileSize: Replaced `fs::read_to_string` with `read_file_to_string` for key file reads
- P2-Iteration: Added `MAX_ITERATION_COUNT` cap on directory entries
- P2-StringLength: Applied `truncate_field()` to name, version, arch, key values, purl
- P4-UTF8/Pre-check: Covered by `read_file_to_string`

### rpm_specfile.rs (6 findings → fixed)
- P2-FileSize: Already covered by `read_file_to_string`
- P2-Iteration: Added `MAX_ITERATION_COUNT` caps to preamble loop, dependency splits, description loop, dependency iterators
- P2-StringLength: Applied `truncate_field()` to all expanded tag values, macro values, dependency strings, purl
- P4-UTF8/Pre-check: Already covered
- LazyLock `.unwrap()` on regex: Acceptable for compile-time constants

### rpm_parser.rs (5 findings → fixed)
- P2-FileSize: Added `fs::metadata()` check with 100MB limit in `is_match` and `extract_packages`
- P2-Iteration: Added `MAX_ITERATION_COUNT` caps to dependency/relationship extraction
- P2-StringLength: Applied `truncate_field()` to name, version, description, homepage_url, architecture, distribution, vendor, packager, license, vcs_url, purl, extracted_requirement, etc.
- P4-Pre-check: Addressed by file size check
- P4-UTF8: No change needed (rpm crate returns validated String)

### rpm_mariner_manifest.rs (5 findings → fixed)
- P2-FileSize: Replaced `fs::read_to_string` with `read_file_to_string`
- P2-Iteration: Added `MAX_ITERATION_COUNT` cap on line iteration
- P2-StringLength: Applied `truncate_field()` to name, version, arch, filename, namespace
- P4-UTF8/Pre-check: Covered by `read_file_to_string`

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings in changed files
- [x] `cargo fmt` passes
- [x] Pre-commit hooks pass (clippy, rustfmt, generate-supported-formats)