### PR TITLE
fix(parsers): ADR 0004 batch 7 — npm_workspace, maven, julia, hackage, gradle_module

### DIFF
--- a/src/parsers/gradle_module.rs
+++ b/src/parsers/gradle_module.rs
@@ -1,9 +1,8 @@
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::{Map as JsonMap, Value};
 
@@ -61,11 +60,11 @@ impl PackageParser for GradleModuleParser {
             return false;
         }
 
-        let Ok(file) = File::open(path) else {
+        let Ok(content) = read_file_to_string(path, None) else {
             return false;
         };
 
-        let Ok(value) = serde_json::from_reader::<_, Value>(BufReader::new(file)) else {
+        let Ok(value) = serde_json::from_str(&content) else {
             return false;
         };
 
@@ -73,15 +72,15 @@ impl PackageParser for GradleModuleParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let file = match File::open(path) {
-            Ok(file) => file,
+        let content = match read_file_to_string(path, None) {
+            Ok(content) => content,
             Err(e) => {
-                warn!("Failed to open Gradle module file at {:?}: {}", path, e);
+                warn!("Failed to read Gradle module file at {:?}: {}", path, e);
                 return vec![default_package_data()];
             }
         };
 
-        let json: Value = match serde_json::from_reader(BufReader::new(file)) {
+        let json: Value = match serde_json::from_str(&content) {
             Ok(json) => json,
             Err(e) => {
                 warn!("Failed to parse Gradle module JSON at {:?}: {}", path, e);
@@ -121,15 +120,15 @@ fn parse_gradle_module(json: &Value) -> PackageData {
     let namespace = component
         .get("group")
         .and_then(Value::as_str)
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
     let name = component
         .get("module")
         .and_then(Value::as_str)
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
     let version = component
         .get("version")
         .and_then(Value::as_str)
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
 
     let (dependencies, file_references, top_level_artifact, variant_metadata) =
         extract_variant_data(json.get(FIELD_VARIANTS).and_then(Value::as_array));
@@ -143,7 +142,7 @@ fn parse_gradle_module(json: &Value) -> PackageData {
     if let Some(format_version) = json.get(FIELD_FORMAT_VERSION).and_then(Value::as_str) {
         extra_data.insert(
             "format_version".to_string(),
-            Value::String(format_version.to_string()),
+            Value::String(truncate_field(format_version.to_string())),
         );
     }
 
@@ -156,11 +155,14 @@ fn parse_gradle_module(json: &Value) -> PackageData {
         if let Some(gradle_version) = gradle_object.get("version").and_then(Value::as_str) {
             extra_data.insert(
                 "gradle_version".to_string(),
-                Value::String(gradle_version.to_string()),
+                Value::String(truncate_field(gradle_version.to_string())),
             );
         }
         if let Some(build_id) = gradle_object.get("buildId").and_then(Value::as_str) {
-            extra_data.insert("build_id".to_string(), Value::String(build_id.to_string()));
+            extra_data.insert(
+                "build_id".to_string(),
+                Value::String(truncate_field(build_id.to_string())),
+            );
         }
     }
 
@@ -237,7 +239,12 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
     let mut seen_files: HashSet<String> = HashSet::new();
     let mut top_level_artifact: Option<JsonMap<String, Value>> = None;
 
-    for variant in variants.into_iter().flatten().filter_map(Value::as_object) {
+    for variant in variants
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .take(MAX_ITERATION_COUNT)
+    {
         let category = variant
             .get(FIELD_ATTRIBUTES)
             .and_then(Value::as_object)
@@ -246,11 +253,13 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
             .unwrap_or_default();
         let is_documentation = category == "documentation";
 
-        let variant_name = variant
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
+        let variant_name = truncate_field(
+            variant
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        );
         let scope = classify_variant_scope(variant);
         let precedence = scope_precedence(scope.as_deref());
         let is_runtime = match scope.as_deref() {
@@ -284,20 +293,28 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
             }
 
             if let Some(files) = variant.get(FIELD_FILES).and_then(Value::as_array) {
-                for file in files.iter().filter_map(Value::as_object) {
-                    let file_path = file
-                        .get("url")
-                        .and_then(Value::as_str)
-                        .or_else(|| file.get("name").and_then(Value::as_str))
-                        .unwrap_or_default()
-                        .to_string();
+                for file in files
+                    .iter()
+                    .filter_map(Value::as_object)
+                    .take(MAX_ITERATION_COUNT)
+                {
+                    let file_path = truncate_field(
+                        file.get("url")
+                            .and_then(Value::as_str)
+                            .or_else(|| file.get("name").and_then(Value::as_str))
+                            .unwrap_or_default()
+                            .to_string(),
+                    );
                     if file_path.is_empty() || !seen_files.insert(file_path.clone()) {
                         continue;
                     }
                     let (size, sha1, md5, sha256, sha512) = extract_file_hashes(file);
                     let mut extra_data = HashMap::new();
                     if let Some(name) = file.get("name").and_then(Value::as_str) {
-                        extra_data.insert("name".to_string(), Value::String(name.to_string()));
+                        extra_data.insert(
+                            "name".to_string(),
+                            Value::String(truncate_field(name.to_string())),
+                        );
                     }
                     file_references.push(FileReference {
                         path: file_path,
@@ -322,6 +339,7 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
             .into_iter()
             .flatten()
             .filter_map(Value::as_object)
+            .take(MAX_ITERATION_COUNT)
         {
             let Some(group) = dependency.get("group").and_then(Value::as_str) else {
                 continue;
@@ -343,7 +361,7 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
                 entry.is_optional = is_optional;
                 entry.precedence = precedence;
             }
-            entry.purl = purl;
+            entry.purl = purl.map(truncate_field);
             entry.extracted_requirement = requirement.clone();
             entry.is_pinned = Some(requirement.as_deref().is_some_and(is_exact_version));
             entry.extra_data = merge_dependency_extra_data(entry.extra_data.take(), dep_extra_data);
@@ -538,13 +556,13 @@ fn scope_precedence(scope: Option<&str>) -> u8 {
 
 fn extract_dependency_requirement(version_value: Option<&Value>) -> Option<String> {
     match version_value {
-        Some(Value::String(version)) => Some(version.to_string()),
+        Some(Value::String(version)) => Some(truncate_field(version.to_string())),
         Some(Value::Object(version)) => version
             .get("strictly")
             .or_else(|| version.get("requires"))
             .or_else(|| version.get("prefers"))
             .and_then(Value::as_str)
-            .map(|value| value.to_string()),
+            .map(|value| truncate_field(value.to_string())),
         _ => None,
     }
 }

--- a/src/parsers/hackage.rs
+++ b/src/parsers/hackage.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -8,7 +7,9 @@ use serde_json::Value as JsonValue;
 use yaml_serde::{Mapping, Value as YamlValue};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
-use crate::parsers::utils::split_name_email;
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -29,7 +30,7 @@ impl PackageParser for HackageCabalParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read cabal file {:?}: {}", path, error);
@@ -49,7 +50,7 @@ impl PackageParser for HackageCabalProjectParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read cabal.project {:?}: {}", path, error);
@@ -69,7 +70,7 @@ impl PackageParser for HackageStackYamlParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read stack.yaml {:?}: {}", path, error);
@@ -124,15 +125,20 @@ fn default_package_data(datasource_id: DatasourceId) -> PackageData {
 fn parse_cabal_manifest(content: &str) -> PackageData {
     let parsed = parse_cabal_data(content);
     let keywords = merge_keywords(&parsed.category_keywords, &parsed.explicit_keywords);
-    let description = combine_summary_and_description(&parsed.synopsis, &parsed.description);
+    let description =
+        combine_summary_and_description(&parsed.synopsis, &parsed.description).map(truncate_field);
     let parties = build_parties(&parsed.authors, &parsed.maintainers);
-    let purl = build_hackage_purl(parsed.name.as_deref(), parsed.version.as_deref());
+    let purl =
+        build_hackage_purl(parsed.name.as_deref(), parsed.version.as_deref()).map(truncate_field);
     let repository_homepage_url = parsed
         .name
         .as_ref()
         .map(|name| match parsed.version.as_ref() {
-            Some(version) => format!("https://hackage.haskell.org/package/{}-{}", name, version),
-            None => format!("https://hackage.haskell.org/package/{}", name),
+            Some(version) => truncate_field(format!(
+                "https://hackage.haskell.org/package/{}-{}",
+                name, version
+            )),
+            None => truncate_field(format!("https://hackage.haskell.org/package/{}", name)),
         });
 
     PackageData {
@@ -189,8 +195,18 @@ fn parse_cabal_project(content: &str) -> PackageData {
     let mut source_repo_entries: Vec<HashMap<String, JsonValue>> = Vec::new();
     let mut current_source_repo: Option<HashMap<String, JsonValue>> = None;
     let mut index = 0;
+    let mut iteration_count = 0usize;
 
     while index < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!(
+                "parse_cabal_project: exceeded MAX_ITERATION_COUNT ({}) at line {}, stopping",
+                MAX_ITERATION_COUNT, index
+            );
+            break;
+        }
+
         let cleaned = strip_cabal_comment(lines[index]);
         let trimmed = cleaned.trim();
         let indent = indentation(cleaned);
@@ -266,7 +282,7 @@ fn parse_cabal_project(content: &str) -> PackageData {
         source_repo_entries.push(entry);
     }
 
-    for entry in source_repo_entries {
+    for entry in source_repo_entries.into_iter().take(MAX_ITERATION_COUNT) {
         dependencies.push(build_source_repository_dependency(entry));
     }
 
@@ -304,7 +320,7 @@ fn parse_stack_yaml(yaml: &YamlValue) -> PackageData {
         dependencies.extend(parse_stack_extra_dep_entries(extra_deps));
     }
 
-    for (key, value) in mapping {
+    for (key, value) in mapping.iter().take(MAX_ITERATION_COUNT) {
         let Some(key) = key.as_str() else {
             continue;
         };
@@ -329,8 +345,17 @@ fn parse_cabal_data(content: &str) -> CabalData {
     let mut current_component: Option<ComponentContext> = None;
     let mut in_source_repository = false;
     let mut index = 0;
+    let mut iteration_count = 0usize;
 
     while index < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!(
+                "parse_cabal_data: exceeded MAX_ITERATION_COUNT ({}) at line {}, stopping",
+                MAX_ITERATION_COUNT, index
+            );
+            break;
+        }
         let cleaned = strip_cabal_comment(lines[index]);
         let trimmed = cleaned.trim();
         let indent = indentation(cleaned);
@@ -353,15 +378,25 @@ fn parse_cabal_data(content: &str) -> CabalData {
         };
 
         match key.as_str() {
-            "name" if indent == 0 => data.name = clean_single_line(&value),
-            "version" if indent == 0 => data.version = clean_single_line(&value),
-            "synopsis" if indent == 0 => data.synopsis = clean_single_line(&value),
-            "description" if indent == 0 => {
-                data.description = normalize_cabal_multiline(&value);
+            "name" if indent == 0 => data.name = clean_single_line(&value).map(truncate_field),
+            "version" if indent == 0 => {
+                data.version = clean_single_line(&value).map(truncate_field)
             }
-            "license" if indent == 0 => data.license = clean_single_line(&value),
-            "homepage" if indent == 0 => data.homepage_url = clean_single_line(&value),
-            "bug-reports" if indent == 0 => data.bug_tracking_url = clean_single_line(&value),
+            "synopsis" if indent == 0 => {
+                data.synopsis = clean_single_line(&value).map(truncate_field)
+            }
+            "description" if indent == 0 => {
+                data.description = normalize_cabal_multiline(&value).map(truncate_field);
+            }
+            "license" if indent == 0 => {
+                data.license = clean_single_line(&value).map(truncate_field)
+            }
+            "homepage" if indent == 0 => {
+                data.homepage_url = clean_single_line(&value).map(truncate_field)
+            }
+            "bug-reports" if indent == 0 => {
+                data.bug_tracking_url = clean_single_line(&value).map(truncate_field)
+            }
             "author" if indent == 0 => data.authors.extend(split_comma_separated(&value)),
             "maintainer" if indent == 0 => {
                 data.maintainers.extend(split_comma_separated(&value));
@@ -373,7 +408,7 @@ fn parse_cabal_data(content: &str) -> CabalData {
                 data.explicit_keywords.extend(split_keywords(&value));
             }
             "location" if in_source_repository && data.vcs_url.is_none() => {
-                data.vcs_url = clean_single_line(&value);
+                data.vcs_url = clean_single_line(&value).map(truncate_field);
             }
             "build-depends" => {
                 data.dependencies
@@ -411,7 +446,7 @@ fn parse_path_like_entries(value: &str, scope: &str, optional: bool) -> Vec<Depe
 
             Dependency {
                 purl: None,
-                extracted_requirement: Some(entry),
+                extracted_requirement: Some(truncate_field(entry)),
                 scope: Some(scope.to_string()),
                 is_runtime: None,
                 is_optional: Some(optional),
@@ -430,7 +465,7 @@ fn parse_import_entries(value: &str) -> Vec<Dependency> {
         .filter(|entry| !entry.is_empty())
         .map(|entry| Dependency {
             purl: None,
-            extracted_requirement: Some(entry),
+            extracted_requirement: Some(truncate_field(entry)),
             scope: Some("import".to_string()),
             is_runtime: None,
             is_optional: Some(false),
@@ -460,6 +495,7 @@ fn parse_stack_package_entries(value: &YamlValue) -> Vec<Dependency> {
 
     sequence
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|entry| match entry {
             YamlValue::String(path) => {
                 let mut extra_data = HashMap::new();
@@ -467,7 +503,7 @@ fn parse_stack_package_entries(value: &YamlValue) -> Vec<Dependency> {
 
                 Some(Dependency {
                     purl: None,
-                    extracted_requirement: Some(path.clone()),
+                    extracted_requirement: Some(truncate_field(path.clone())),
                     scope: Some("packages".to_string()),
                     is_runtime: None,
                     is_optional: Some(false),
@@ -480,7 +516,8 @@ fn parse_stack_package_entries(value: &YamlValue) -> Vec<Dependency> {
             YamlValue::Mapping(map) => {
                 let extracted_requirement = mapping_string(map, "location")
                     .or_else(|| mapping_string(map, "git"))
-                    .or_else(|| mapping_string(map, "url"));
+                    .or_else(|| mapping_string(map, "url"))
+                    .map(truncate_field);
                 let extra_data = serde_json::to_value(entry)
                     .ok()
                     .and_then(|value| value.as_object().cloned())
@@ -510,6 +547,7 @@ fn parse_stack_extra_dep_entries(value: &YamlValue) -> Vec<Dependency> {
 
     sequence
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|entry| match entry {
             YamlValue::String(spec) => parse_stack_extra_dep_string(spec),
             YamlValue::Mapping(map) => Some(parse_stack_extra_dep_mapping(map, entry)),
@@ -534,7 +572,7 @@ fn parse_stack_extra_dep_string(spec: &str) -> Option<Dependency> {
         parse_hackage_spec_dependency(package_spec, Some("extra-deps"), None, None).unwrap_or(
             Dependency {
                 purl: None,
-                extracted_requirement: Some(package_spec.to_string()),
+                extracted_requirement: Some(truncate_field(package_spec.to_string())),
                 scope: Some("extra-deps".to_string()),
                 is_runtime: None,
                 is_optional: Some(false),
@@ -551,7 +589,7 @@ fn parse_stack_extra_dep_string(spec: &str) -> Option<Dependency> {
         dependency.extra_data = Some(extra_data);
         dependency.is_pinned = Some(true);
         if dependency.extracted_requirement.is_none() {
-            dependency.extracted_requirement = Some(package_spec.to_string());
+            dependency.extracted_requirement = Some(truncate_field(package_spec.to_string()));
         }
     }
 
@@ -562,11 +600,12 @@ fn parse_stack_extra_dep_string(spec: &str) -> Option<Dependency> {
 fn parse_stack_extra_dep_mapping(map: &Mapping, raw_value: &YamlValue) -> Dependency {
     let name = mapping_string(map, "name");
     let version = mapping_string(map, "version");
-    let purl = build_hackage_purl(name.as_deref(), version.as_deref());
+    let purl = build_hackage_purl(name.as_deref(), version.as_deref()).map(truncate_field);
     let extracted_requirement = version
         .clone()
         .or_else(|| mapping_string(map, "git"))
-        .or_else(|| mapping_string(map, "url"));
+        .or_else(|| mapping_string(map, "url"))
+        .map(truncate_field);
     let extra_data = serde_json::to_value(raw_value)
         .ok()
         .and_then(|value| value.as_object().cloned())
@@ -595,7 +634,8 @@ fn build_source_repository_dependency(extra_data: HashMap<String, JsonValue>) ->
                 .get("tag")
                 .and_then(JsonValue::as_str)
                 .map(str::to_string)
-        });
+        })
+        .map(truncate_field);
 
     Dependency {
         purl: None,
@@ -643,8 +683,8 @@ fn parse_hackage_spec_dependency(
         }
 
         return Some(Dependency {
-            purl: Some(format!("pkg:hackage/{}@{}", name, version)),
-            extracted_requirement: Some(version),
+            purl: Some(truncate_field(format!("pkg:hackage/{}@{}", name, version))),
+            extracted_requirement: Some(truncate_field(version)),
             scope: scope.map(str::to_string),
             is_runtime: component.map(component_is_runtime).or(is_runtime),
             is_optional: Some(false),
@@ -674,9 +714,12 @@ fn parse_hackage_spec_dependency(
             .map(|(_, version)| version.clone())
     });
     let purl = if let Some(version) = exact_version.as_deref() {
-        Some(format!("pkg:hackage/{}@{}", resolved_name, version))
+        Some(truncate_field(format!(
+            "pkg:hackage/{}@{}",
+            resolved_name, version
+        )))
     } else {
-        Some(format!("pkg:hackage/{}", resolved_name))
+        Some(truncate_field(format!("pkg:hackage/{}", resolved_name)))
     };
 
     let mut extra_data = HashMap::new();
@@ -694,9 +737,11 @@ fn parse_hackage_spec_dependency(
     }
 
     let extracted_requirement = if let Some((_, version)) = implicit_name_version {
-        Some(version)
+        Some(truncate_field(version))
     } else {
-        (!requirement.is_empty()).then_some(requirement.to_string())
+        (!requirement.is_empty())
+            .then_some(requirement.to_string())
+            .map(truncate_field)
     };
 
     Some(Dependency {
@@ -773,7 +818,7 @@ fn split_dependency_entries(value: &str) -> Vec<String> {
     let mut brace_depth = 0usize;
     let mut bracket_depth = 0usize;
 
-    for character in value.chars() {
+    for character in value.chars().take(MAX_ITERATION_COUNT) {
         match character {
             '(' => paren_depth += 1,
             ')' => paren_depth = paren_depth.saturating_sub(1),
@@ -806,6 +851,7 @@ fn split_dependency_entries(value: &str) -> Vec<String> {
 fn split_multiline_entries(value: &str) -> Vec<String> {
     value
         .lines()
+        .take(MAX_ITERATION_COUNT)
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(|line| line.strip_prefix("-").unwrap_or(line).trim().to_string())

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -21,9 +21,8 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use toml::Value;
 
@@ -44,6 +43,8 @@ const FIELD_COMPAT: &str = "compat";
 const FIELD_TARGETS: &str = "targets";
 const FIELD_HOMEPAGE: &str = "homepage";
 
+const MAX_RECURSION_DEPTH: usize = 50;
+
 pub struct JuliaProjectTomlParser;
 
 impl PackageParser for JuliaProjectTomlParser {
@@ -61,7 +62,7 @@ impl PackageParser for JuliaProjectTomlParser {
         let name = toml_content
             .get(FIELD_NAME)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let _uuid = toml_content
             .get(FIELD_UUID)
@@ -71,12 +72,12 @@ impl PackageParser for JuliaProjectTomlParser {
         let version = toml_content
             .get(FIELD_VERSION)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let raw_license = toml_content
             .get(FIELD_LICENSE)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             raw_license
@@ -92,7 +93,7 @@ impl PackageParser for JuliaProjectTomlParser {
                 })
                 .unwrap_or_else(empty_declared_license_data);
 
-        let extracted_license_statement = raw_license.clone();
+        let extracted_license_statement = raw_license.clone().map(truncate_field);
 
         let dependencies = extract_project_dependencies(&toml_content);
 
@@ -101,12 +102,12 @@ impl PackageParser for JuliaProjectTomlParser {
         let repository_url = toml_content
             .get(FIELD_REPOSITORY)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let homepage_url = toml_content
             .get(FIELD_HOMEPAGE)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let description = None;
 
@@ -192,10 +193,8 @@ impl PackageParser for JuliaManifestTomlParser {
 }
 
 fn read_julia_toml(path: &Path) -> Result<Value, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Error reading file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
 
@@ -222,7 +221,7 @@ fn create_package_url(name: &Option<String>, version: &Option<String>) -> Option
             return None;
         }
 
-        Some(package_url.to_string())
+        Some(truncate_field(package_url.to_string()))
     })
 }
 
@@ -230,12 +229,12 @@ fn extract_parties(toml_content: &Value) -> Vec<Party> {
     let mut parties = Vec::new();
 
     if let Some(authors) = toml_content.get(FIELD_AUTHORS).and_then(|v| v.as_array()) {
-        for author in authors {
+        for author in authors.iter().take(MAX_ITERATION_COUNT) {
             if let Some(author_str) = author.as_str() {
                 parties.push(Party {
                     r#type: None,
                     role: Some("author".to_string()),
-                    name: Some(author_str.trim().to_string()),
+                    name: Some(truncate_field(author_str.trim().to_string())),
                     email: None,
                     url: None,
                     organization: None,
@@ -259,20 +258,20 @@ fn extract_project_dependencies(toml_content: &Value) -> Vec<Dependency> {
 
     let compat_table = toml_content.get(FIELD_COMPAT).and_then(|v| v.as_table());
 
-    for (dep_name, dep_value) in deps_table {
+    for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {
         let uuid = dep_value.as_str().map(String::from);
 
         let extracted_requirement = compat_table
             .and_then(|ct| ct.get(dep_name))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let is_pinned = extracted_requirement
             .as_deref()
             .is_some_and(is_julia_version_pinned);
 
         let purl = match PackageUrl::new(PackageType::Julia.as_str(), dep_name) {
-            Ok(p) => p.to_string(),
+            Ok(p) => truncate_field(p.to_string()),
             Err(e) => {
                 warn!(
                     "Failed to create PackageUrl for julia dependency '{}': {}",
@@ -315,14 +314,14 @@ fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
         None => return packages,
     };
 
-    for (dep_name, dep_value) in deps_table {
+    for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {
         let dep_entries = match dep_value.as_array() {
             Some(entries) => entries,
             None => continue,
         };
 
-        for dep_entry in dep_entries {
-            let name = Some(dep_name.clone());
+        for dep_entry in dep_entries.iter().take(MAX_ITERATION_COUNT) {
+            let name = Some(truncate_field(dep_name.clone()));
 
             let uuid = dep_entry
                 .get(FIELD_UUID)
@@ -332,7 +331,7 @@ fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
             let version = dep_entry
                 .get(FIELD_VERSION)
                 .and_then(|v| v.as_str())
-                .map(String::from);
+                .map(|s| truncate_field(s.to_string()));
 
             let purl = create_package_url(&name, &version);
 
@@ -344,7 +343,7 @@ fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
             let source_url = dep_entry
                 .get("url")
                 .and_then(|v| v.as_str())
-                .map(String::from);
+                .map(|s| truncate_field(s.to_string()));
 
             let mut extra_data_map = std::collections::HashMap::new();
             if let Some(ref uuid_val) = uuid {
@@ -449,16 +448,30 @@ fn extract_project_extra_data(
 }
 
 fn toml_to_json(value: &toml::Value) -> serde_json::Value {
+    toml_to_json_inner(value, 0)
+}
+
+fn toml_to_json_inner(value: &toml::Value, depth: usize) -> serde_json::Value {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!(
+            "Recursion depth exceeded {} in toml_to_json, returning Null",
+            MAX_RECURSION_DEPTH
+        );
+        return serde_json::Value::Null;
+    }
+
     match value {
         toml::Value::String(s) => serde_json::json!(s),
         toml::Value::Integer(i) => serde_json::json!(i),
         toml::Value::Float(f) => serde_json::json!(f),
         toml::Value::Boolean(b) => serde_json::json!(b),
-        toml::Value::Array(a) => serde_json::Value::Array(a.iter().map(toml_to_json).collect()),
+        toml::Value::Array(a) => {
+            serde_json::Value::Array(a.iter().map(|v| toml_to_json_inner(v, depth + 1)).collect())
+        }
         toml::Value::Table(t) => {
             let map: serde_json::Map<String, serde_json::Value> = t
                 .iter()
-                .map(|(k, v)| (k.clone(), toml_to_json(v)))
+                .map(|(k, v)| (k.clone(), toml_to_json_inner(v, depth + 1)))
                 .collect();
             serde_json::Value::Object(map)
         }

--- a/src/parsers/maven.rs
+++ b/src/parsers/maven.rs
@@ -23,7 +23,7 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
-use crate::parsers::utils::read_file_to_string;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use std::borrow::Cow;
@@ -869,7 +869,16 @@ impl PackageParser for MavenParser {
         let mut in_relocation = false;
         let mut relocation = MavenDependencyData::default();
 
+        let mut iteration_count: usize = 0;
         loop {
+            iteration_count += 1;
+            if iteration_count > MAX_ITERATION_COUNT {
+                warn!(
+                    "Exceeded MAX_ITERATION_COUNT ({}) parsing pom.xml at {:?}; stopping early",
+                    MAX_ITERATION_COUNT, path
+                );
+                break;
+            }
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) => {
                     let element_name = e.name().as_ref().to_vec();
@@ -964,7 +973,17 @@ impl PackageParser for MavenParser {
                     }
                 }
                 Ok(Event::Text(e)) => {
-                    let text = e.decode().unwrap_or_default().to_string();
+                    let text = match e.decode() {
+                        Ok(Cow::Borrowed(s)) => s.to_string(),
+                        Ok(Cow::Owned(s)) => s,
+                        Err(_) => {
+                            warn!(
+                                "Invalid UTF-8 in XML text content in {:?}; using lossy conversion",
+                                path
+                            );
+                            String::from_utf8_lossy(e.as_ref()).into_owned()
+                        }
+                    };
                     let current_path = current_element.last().map(|v| v.as_slice());
                     let current_parent = current_element
                         .len()
@@ -979,7 +998,7 @@ impl PackageParser for MavenParser {
                             .last()
                             .and_then(|name| std::str::from_utf8(name).ok())
                         {
-                            properties.insert(property_name.to_string(), text);
+                            properties.insert(property_name.to_string(), truncate_field(text));
                         } else {
                             warn!("Failed to decode Maven property name in {:?}", path);
                         }
@@ -1297,7 +1316,20 @@ impl PackageParser for MavenParser {
                     }
                 }
                 Ok(Event::Comment(e)) => {
-                    let comment = e.decode().unwrap_or_default().trim().to_string();
+                    let comment = match e.decode() {
+                        Ok(Cow::Borrowed(s)) => s.trim().to_string(),
+                        Ok(Cow::Owned(s)) => s.trim().to_string(),
+                        Err(_) => {
+                            warn!(
+                                "Invalid UTF-8 in XML comment in {:?}; using lossy conversion",
+                                path
+                            );
+                            String::from_utf8_lossy(e.as_ref())
+                                .into_owned()
+                                .trim()
+                                .to_string()
+                        }
+                    };
                     if current_element.is_empty()
                         && !comment.is_empty()
                         && is_license_like_comment(&comment)
@@ -1954,7 +1986,8 @@ impl PackageParser for MavenParser {
             package_data.extra_data = Some(extra_data);
         }
 
-        package_data.extracted_license_statement = build_license_statement(&licenses);
+        package_data.extracted_license_statement =
+            build_license_statement(&licenses).map(truncate_field);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             build_maven_declared_license_data(
                 &licenses,
@@ -1963,6 +1996,26 @@ impl PackageParser for MavenParser {
         package_data.declared_license_expression = declared_license_expression;
         package_data.declared_license_expression_spdx = declared_license_expression_spdx;
         package_data.license_detections = license_detections;
+
+        package_data.namespace = package_data.namespace.map(truncate_field);
+        package_data.name = package_data.name.map(truncate_field);
+        package_data.version = package_data.version.map(truncate_field);
+        package_data.description = package_data.description.map(truncate_field);
+        package_data.homepage_url = package_data.homepage_url.map(truncate_field);
+        package_data.vcs_url = package_data.vcs_url.map(truncate_field);
+        package_data.purl = package_data.purl.map(truncate_field);
+        package_data.code_view_url = package_data.code_view_url.map(truncate_field);
+        package_data.bug_tracking_url = package_data.bug_tracking_url.map(truncate_field);
+        package_data.download_url = package_data.download_url.map(truncate_field);
+        package_data.repository_homepage_url =
+            package_data.repository_homepage_url.map(truncate_field);
+        package_data.repository_download_url =
+            package_data.repository_download_url.map(truncate_field);
+        package_data.api_data_url = package_data.api_data_url.map(truncate_field);
+        for dep in &mut package_data.dependencies {
+            dep.purl = dep.purl.take().map(truncate_field);
+            dep.extracted_requirement = dep.extracted_requirement.take().map(truncate_field);
+        }
 
         vec![package_data]
     }
@@ -2109,9 +2162,9 @@ fn parse_pom_properties(path: &Path) -> PackageData {
         }
     }
 
-    package_data.namespace = group_id.clone();
-    package_data.name = artifact_id.clone();
-    package_data.version = version.clone();
+    package_data.namespace = group_id.map(truncate_field);
+    package_data.name = artifact_id.map(truncate_field);
+    package_data.version = version.map(truncate_field);
 
     // Generate PURL
     if let (Some(group_id), Some(artifact_id), Some(version)) = (
@@ -2119,10 +2172,10 @@ fn parse_pom_properties(path: &Path) -> PackageData {
         &package_data.name,
         &package_data.version,
     ) {
-        package_data.purl = Some(format!(
+        package_data.purl = Some(truncate_field(format!(
             "pkg:maven/{}/{}@{}",
             group_id, artifact_id, version
-        ));
+        )));
     }
 
     package_data
@@ -2331,6 +2384,19 @@ fn parse_manifest_mf(path: &Path) -> PackageData {
         }
     }
 
+    package_data.name = package_data.name.map(truncate_field);
+    package_data.version = package_data.version.map(truncate_field);
+    package_data.namespace = package_data.namespace.map(truncate_field);
+    package_data.description = package_data.description.map(truncate_field);
+    package_data.homepage_url = package_data.homepage_url.map(truncate_field);
+    package_data.extracted_license_statement =
+        package_data.extracted_license_statement.map(truncate_field);
+    package_data.purl = package_data.purl.map(truncate_field);
+    for dep in &mut package_data.dependencies {
+        dep.purl = dep.purl.take().map(truncate_field);
+        dep.extracted_requirement = dep.extracted_requirement.take().map(truncate_field);
+    }
+
     package_data
 }
 
@@ -2342,7 +2408,10 @@ pub(crate) fn parse_osgi_package_list(package_list: &str, scope: &str) -> Vec<De
     let mut dependencies = Vec::new();
 
     // Split by comma, but be careful not to split within quoted strings
-    for package_entry in split_osgi_list(package_list) {
+    for package_entry in split_osgi_list(package_list)
+        .into_iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         let package_entry = package_entry.trim();
         if package_entry.is_empty() {
             continue;
@@ -2386,7 +2455,10 @@ pub(crate) fn parse_osgi_package_list(package_list: &str, scope: &str) -> Vec<De
 pub(crate) fn parse_osgi_bundle_list(bundle_list: &str, scope: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for bundle_entry in split_osgi_list(bundle_list) {
+    for bundle_entry in split_osgi_list(bundle_list)
+        .into_iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         let bundle_entry = bundle_entry.trim();
         if bundle_entry.is_empty() {
             continue;

--- a/src/parsers/npm_workspace.rs
+++ b/src/parsers/npm_workspace.rs
@@ -18,7 +18,8 @@
 
 use crate::models::PackageData;
 use crate::models::{DatasourceId, PackageType};
-use std::fs;
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use std::path::Path;
 use yaml_serde::Value;
 
@@ -40,10 +41,10 @@ impl PackageParser for NpmWorkspaceParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
-                crate::parser_warn!("Failed to read npm workspace file at {:?}: {}", path, e);
+                warn!("Failed to read npm workspace file at {:?}: {}", path, e);
                 return vec![default_package_data()];
             }
         };
@@ -78,8 +79,9 @@ fn parse_workspace_file(workspace_data: &Value) -> PackageData {
         Some(workspace_patterns) => {
             let workspaces_vec: Vec<String> = workspace_patterns
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|v| v.as_str())
-                .map(|s| s.to_string())
+                .map(|s| truncate_field(s.to_string()))
                 .collect();
 
             PackageData {


### PR DESCRIPTION
## Summary

Batch 7 of ADR 0004 security compliance fixes across 5 parsers.

## Changes

### npm_workspace.rs (5 findings → fixed)
- Replaced `fs::read_to_string` with `read_file_to_string` (P2-FileSize, P4-FileExists, P4-UTF8)
- Added `MAX_ITERATION_COUNT` cap on workspace patterns iteration
- Applied `truncate_field()` to workspace pattern strings

### maven.rs (5 findings → fixed)
- Verified `read_file_to_string` already used at all 3 file-read sites (P2-FileSize, P4-FileExists)
- Added iteration counter on XML event loop + `.take(MAX_ITERATION_COUNT)` on OSGi parsing
- Applied `truncate_field()` to all string fields across pom.xml, pom.properties, MANIFEST.MF parsers
- Replaced `unwrap_or_default()` on XML text decode with lossy UTF-8 + `warn!`

### julia.rs (5 findings → fixed)
- Replaced `File::open`+`read_to_string` with `read_file_to_string` (P2-FileSize, P4-UTF8)
- Added `MAX_RECURSION_DEPTH=50` to `toml_to_json` recursion
- Added `MAX_ITERATION_COUNT` caps on author/dependency loops
- Applied `truncate_field()` to all string values

### hackage.rs (5 findings → fixed)
- Replaced `fs::read_to_string` with `read_file_to_string` (3 parsers)
- Added `MAX_ITERATION_COUNT` caps on cabal/stack/dependency loops
- Applied `truncate_field()` to all string values

### gradle_module.rs (5 findings → fixed)
- Replaced `File::open`+`serde_json::from_reader` with `read_file_to_string`+`from_str`
- Added `MAX_ITERATION_COUNT` caps on variant/file/dependency processing
- Applied `truncate_field()` to all string values

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Pre-commit hooks pass