### PR TITLE
fix(parsers): ADR 0004 security compliance for gradle_lock, gradle, go_mod_graph, go, deno_lock

### DIFF
--- a/src/parsers/deno_lock.rs
+++ b/src/parsers/deno_lock.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -12,7 +11,7 @@ use crate::models::{
 };
 
 use super::PackageParser;
-use super::utils::parse_sri;
+use super::utils::{MAX_ITERATION_COUNT, parse_sri, read_file_to_string, truncate_field};
 
 const FIELD_VERSION: &str = "version";
 const FIELD_SPECIFIERS: &str = "specifiers";
@@ -33,7 +32,7 @@ impl PackageParser for DenoLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read deno.lock at {:?}: {}", path, e);
@@ -71,7 +70,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
     let mut direct_jsr_keys = HashSet::new();
     let mut direct_npm_keys = HashSet::new();
 
-    for specifier in &workspace_direct {
+    for specifier in workspace_direct.iter().take(MAX_ITERATION_COUNT) {
         if let Some(resolved_key) = specifiers.get(specifier).and_then(Value::as_str) {
             if specifier.starts_with("jsr:") {
                 if let Some(full_key) = resolve_jsr_full_key(specifier, resolved_key)
@@ -93,7 +92,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
     }
 
     if let Some(jsr_map) = json.get(FIELD_JSR).and_then(Value::as_object) {
-        for key in jsr_map.keys() {
+        for key in jsr_map.keys().take(MAX_ITERATION_COUNT) {
             if direct_jsr_keys.contains(key) {
                 continue;
             }
@@ -104,7 +103,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
     }
 
     if let Some(npm_map) = json.get(FIELD_NPM).and_then(Value::as_object) {
-        for key in npm_map.keys() {
+        for key in npm_map.keys().take(MAX_ITERATION_COUNT) {
             if direct_npm_keys.contains(key) {
                 continue;
             }
@@ -115,7 +114,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
     }
 
     if let Some(redirects) = json.get(FIELD_REDIRECTS).and_then(Value::as_object) {
-        for (source, target) in redirects {
+        for (source, target) in redirects.iter().take(MAX_ITERATION_COUNT) {
             let Some(target_url) = target.as_str() else {
                 continue;
             };
@@ -126,11 +125,12 @@ fn parse_deno_lock(json: &Value) -> PackageData {
                 .and_then(Value::as_str)
                 .and_then(|value| Sha256Digest::from_hex(value).ok());
 
-            let name = remote_name(target_url).unwrap_or_else(|| source.to_string());
-            let purl = create_remote_purl(target_url);
+            let name =
+                truncate_field(remote_name(target_url).unwrap_or_else(|| source.to_string()));
+            let purl = create_remote_purl(target_url).map(truncate_field);
             let resolved_package = ResolvedPackage {
                 primary_language: Some("TypeScript".to_string()),
-                download_url: Some(target_url.to_string()),
+                download_url: Some(truncate_field(target_url.to_string())),
                 sha1: None,
                 sha256: hash,
                 sha512: None,
@@ -138,7 +138,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
                 is_virtual: true,
                 extra_data: Some(HashMap::from([(
                     "redirect_source".to_string(),
-                    Value::String(source.to_string()),
+                    Value::String(truncate_field(source.to_string())),
                 )])),
                 dependencies: Vec::new(),
                 repository_homepage_url: None,
@@ -156,7 +156,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
 
             dependencies.push(Dependency {
                 purl,
-                extracted_requirement: Some(source.to_string()),
+                extracted_requirement: Some(truncate_field(source.to_string())),
                 scope: Some("imports".to_string()),
                 is_runtime: Some(true),
                 is_optional: Some(false),
@@ -201,7 +201,7 @@ fn extract_workspace_dependencies(json: &Value) -> Vec<String> {
         .into_iter()
         .flatten()
         .filter_map(Value::as_str)
-        .map(|value| value.to_string())
+        .map(|value| truncate_field(value.to_string()))
         .collect()
 }
 
@@ -214,11 +214,19 @@ fn build_jsr_dependency(
     let jsr_entry = jsr_section.get(resolved_key)?;
     let jsr_object = jsr_entry.as_object()?;
     let (namespace, name, version) = parse_jsr_key(resolved_key)?;
-    let purl = create_generic_purl(Some(&format!("jsr.io/{}", namespace)), &name, Some(version));
+    let namespace = truncate_field(namespace);
+    let name = truncate_field(name);
+    let version_str = truncate_field(version.to_string());
+    let purl = create_generic_purl(
+        Some(&format!("jsr.io/{}", namespace)),
+        &name,
+        Some(&version_str),
+    )
+    .map(truncate_field);
 
     Some(Dependency {
         purl: purl.clone(),
-        extracted_requirement: extracted_requirement.map(|value| value.to_string()),
+        extracted_requirement: extracted_requirement.map(|value| truncate_field(value.to_string())),
         scope: Some("imports".to_string()),
         is_runtime: Some(true),
         is_optional: Some(false),
@@ -249,12 +257,7 @@ fn build_jsr_dependency(
             api_data_url: None,
             datasource_id: Some(DatasourceId::DenoLock),
             purl,
-            ..ResolvedPackage::new(
-                DenoLockParser::PACKAGE_TYPE,
-                namespace,
-                name,
-                version.to_string(),
-            )
+            ..ResolvedPackage::new(DenoLockParser::PACKAGE_TYPE, namespace, name, version_str)
         })),
         extra_data: None,
     })
@@ -269,11 +272,14 @@ fn build_npm_dependency(
     let npm_entry = npm_section.get(resolved_key)?;
     let npm_object = npm_entry.as_object()?;
     let (namespace, name, version) = parse_npm_key(resolved_key)?;
-    let purl = create_npm_purl(namespace.as_deref(), &name, Some(version));
+    let namespace = namespace.map(truncate_field);
+    let name = truncate_field(name);
+    let version_str = truncate_field(version.to_string());
+    let purl = create_npm_purl(namespace.as_deref(), &name, Some(&version_str)).map(truncate_field);
 
     Some(Dependency {
         purl: purl.clone(),
-        extracted_requirement: extracted_requirement.map(|value| value.to_string()),
+        extracted_requirement: extracted_requirement.map(|value| truncate_field(value.to_string())),
         scope: Some("imports".to_string()),
         is_runtime: Some(true),
         is_optional: Some(false),
@@ -284,7 +290,7 @@ fn build_npm_dependency(
             download_url: npm_object
                 .get("tarball")
                 .and_then(Value::as_str)
-                .map(|value| value.to_string()),
+                .map(|value| truncate_field(value.to_string())),
             sha1: None,
             sha256: None,
             sha512: npm_object
@@ -306,11 +312,13 @@ fn build_npm_dependency(
                 .into_iter()
                 .flatten()
                 .filter_map(Value::as_str)
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| {
                     let (namespace, name, version) = parse_npm_key(value)?;
                     Some(Dependency {
-                        purl: create_npm_purl(namespace.as_deref(), &name, Some(version)),
-                        extracted_requirement: Some(value.to_string()),
+                        purl: create_npm_purl(namespace.as_deref(), &name, Some(version))
+                            .map(truncate_field),
+                        extracted_requirement: Some(truncate_field(value.to_string())),
                         scope: Some("dependencies".to_string()),
                         is_runtime: Some(true),
                         is_optional: Some(false),
@@ -330,7 +338,7 @@ fn build_npm_dependency(
                 PackageType::Npm,
                 namespace.unwrap_or_default(),
                 name,
-                version.to_string(),
+                version_str,
             )
         })),
         extra_data: None,
@@ -346,11 +354,13 @@ fn extract_jsr_resolved_dependencies(
         .into_iter()
         .flatten()
         .filter_map(Value::as_str)
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|value| {
             let (namespace, name, version) = parse_jsr_dependency_reference(value)?;
             Some(Dependency {
-                purl: create_generic_purl(Some(&format!("jsr.io/{}", namespace)), &name, version),
-                extracted_requirement: Some(value.to_string()),
+                purl: create_generic_purl(Some(&format!("jsr.io/{}", namespace)), &name, version)
+                    .map(truncate_field),
+                extracted_requirement: Some(truncate_field(value.to_string())),
                 scope: Some("dependencies".to_string()),
                 is_runtime: Some(true),
                 is_optional: Some(false),

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -24,9 +24,9 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 
 use super::PackageParser;
@@ -43,7 +43,7 @@ impl PackageParser for GoModParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read go.mod at {:?}: {}", path, e);
@@ -79,7 +79,7 @@ pub fn parse_go_mod(content: &str) -> PackageData {
     let mut retracted_versions: Vec<String> = Vec::new();
     let mut block_state = BlockState::None;
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with("//") {
@@ -141,8 +141,8 @@ pub fn parse_go_mod(content: &str) -> PackageData {
             let module_path = strip_comment(module_path).trim();
             if !module_path.is_empty() {
                 let (ns, n) = split_module_path(module_path);
-                namespace = ns;
-                name = Some(n);
+                namespace = ns.map(truncate_field);
+                name = Some(truncate_field(n));
             }
             continue;
         }
@@ -151,7 +151,7 @@ pub fn parse_go_mod(content: &str) -> PackageData {
         if let Some(version) = trimmed.strip_prefix("go ") {
             let version = strip_comment(version).trim();
             if !version.is_empty() {
-                go_version = Some(version.to_string());
+                go_version = Some(truncate_field(version.to_string()));
             }
             continue;
         }
@@ -160,7 +160,7 @@ pub fn parse_go_mod(content: &str) -> PackageData {
         if let Some(tc) = trimmed.strip_prefix("toolchain ") {
             let tc = strip_comment(tc).trim();
             if !tc.is_empty() {
-                toolchain = Some(tc.to_string());
+                toolchain = Some(truncate_field(tc.to_string()));
             }
             continue;
         }
@@ -210,9 +210,11 @@ pub fn parse_go_mod(content: &str) -> PackageData {
 
     let homepage_url = full_module
         .as_ref()
-        .map(|m| format!("https://pkg.go.dev/{}", m));
+        .map(|m| truncate_field(format!("https://pkg.go.dev/{}", m)));
 
-    let vcs_url = full_module.as_ref().map(|m| format!("https://{}.git", m));
+    let vcs_url = full_module
+        .as_ref()
+        .map(|m| truncate_field(format!("https://{}.git", m)));
 
     let repository_homepage_url = homepage_url.clone();
 
@@ -320,10 +322,8 @@ fn parse_dependency_line(line: &str, scope: &str) -> Option<Dependency> {
     }
 
     let module_path = parts[0];
-    // Bug #8 and #10: Version is taken as-is, preserving +incompatible and pseudo-versions
-    let version = parts[1].to_string();
+    let version = truncate_field(parts[1].to_string());
 
-    // Generate PURL with version
     let purl = create_golang_purl(module_path, Some(&version));
 
     Some(Dependency {
@@ -361,18 +361,18 @@ fn parse_replace_line(line: &str) -> Option<Dependency> {
     let old_module = old_parts[0];
     let old_version = old_parts.get(1).copied();
     let new_module = new_parts[0];
-    let new_version = new_parts.get(1).map(|s| s.to_string());
+    let new_version = new_parts.get(1).map(|s| truncate_field(s.to_string()));
 
     let purl = create_golang_purl(new_module, new_version.as_deref());
 
     let mut extra = std::collections::HashMap::new();
     extra.insert(
         "replace_old".to_string(),
-        serde_json::Value::String(old_module.to_string()),
+        serde_json::Value::String(truncate_field(old_module.to_string())),
     );
     extra.insert(
         "replace_new".to_string(),
-        serde_json::Value::String(new_module.to_string()),
+        serde_json::Value::String(truncate_field(new_module.to_string())),
     );
     if let Some(ref v) = new_version {
         extra.insert(
@@ -383,7 +383,7 @@ fn parse_replace_line(line: &str) -> Option<Dependency> {
     if let Some(ov) = old_version {
         extra.insert(
             "replace_old_version".to_string(),
-            serde_json::Value::String(ov.to_string()),
+            serde_json::Value::String(truncate_field(ov.to_string())),
         );
     }
 
@@ -424,9 +424,12 @@ pub(crate) fn split_module_path(path: &str) -> (Option<String>, String) {
         Some(idx) => {
             let namespace = &path[..idx];
             let name = &path[idx + 1..];
-            (Some(namespace.to_string()), name.to_string())
+            (
+                Some(truncate_field(namespace.to_string())),
+                truncate_field(name.to_string()),
+            )
         }
-        None => (None, path.to_string()),
+        None => (None, truncate_field(path.to_string())),
     }
 }
 
@@ -536,7 +539,7 @@ impl PackageParser for GoSumParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read go.sum at {:?}: {}", path, e);
@@ -556,7 +559,7 @@ pub fn parse_go_sum(content: &str) -> PackageData {
     let mut dependencies = Vec::new();
     let mut seen = HashSet::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -582,7 +585,7 @@ pub fn parse_go_sum(content: &str) -> PackageData {
 
         dependencies.push(Dependency {
             purl,
-            extracted_requirement: Some(version.to_string()),
+            extracted_requirement: Some(truncate_field(version.to_string())),
             scope: Some("dependency".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -653,7 +656,7 @@ impl PackageParser for GoWorkParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read go.work at {:?}: {}", path, e);
@@ -677,7 +680,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
     let mut unresolved_use_paths: Vec<String> = Vec::new();
     let mut block_state = BlockState::None;
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with("//") {
@@ -694,7 +697,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
                 BlockState::Require => {
                     let use_path = extract_single_go_token(trimmed);
                     if let Some(use_path) = use_path.filter(|path| !path.is_empty()) {
-                        use_paths.push(use_path.to_string());
+                        use_paths.push(truncate_field(use_path));
                     }
                 }
                 BlockState::Replace => {
@@ -719,7 +722,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
         if let Some(version) = trimmed.strip_prefix("go ") {
             let version = strip_comment(version).trim();
             if !version.is_empty() {
-                go_version = Some(version.to_string());
+                go_version = Some(truncate_field(version.to_string()));
             }
             continue;
         }
@@ -727,7 +730,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
         if let Some(tc) = trimmed.strip_prefix("toolchain ") {
             let tc = strip_comment(tc).trim();
             if !tc.is_empty() {
-                toolchain = Some(tc.to_string());
+                toolchain = Some(truncate_field(tc.to_string()));
             }
             continue;
         }
@@ -735,7 +738,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
         if let Some(rest) = trimmed.strip_prefix("use ") {
             let use_path = extract_single_go_token(rest);
             if let Some(use_path) = use_path.filter(|path| !path.is_empty()) {
-                use_paths.push(use_path.to_string());
+                use_paths.push(truncate_field(use_path));
             }
             continue;
         }
@@ -843,9 +846,9 @@ fn resolve_workspace_use_dependencies(
     let mut dependencies = Vec::new();
     let mut unresolved = Vec::new();
 
-    for use_path in use_paths {
+    for use_path in use_paths.iter().take(MAX_ITERATION_COUNT) {
         let go_mod_path = base_dir.join(use_path).join("go.mod");
-        let module_path = fs::read_to_string(&go_mod_path)
+        let module_path = read_file_to_string(&go_mod_path, None)
             .ok()
             .and_then(|content| extract_module_path_from_go_mod(&content));
 
@@ -861,18 +864,18 @@ fn resolve_workspace_use_dependencies(
         let mut extra_data = HashMap::new();
         extra_data.insert(
             "workspace_path".to_string(),
-            serde_json::Value::String(use_path.clone()),
+            serde_json::Value::String(truncate_field(use_path.clone())),
         );
         if let Some(module_path) = module_path {
             extra_data.insert(
                 "workspace_module_path".to_string(),
-                serde_json::Value::String(module_path),
+                serde_json::Value::String(truncate_field(module_path)),
             );
         }
 
         dependencies.push(Dependency {
             purl,
-            extracted_requirement: Some(use_path.clone()),
+            extracted_requirement: Some(truncate_field(use_path.clone())),
             scope: Some("use".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -887,12 +890,12 @@ fn resolve_workspace_use_dependencies(
 }
 
 fn extract_module_path_from_go_mod(content: &str) -> Option<String> {
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
         if let Some(module_path) = trimmed.strip_prefix("module ") {
             let module_path = strip_comment(module_path).trim();
             if !module_path.is_empty() {
-                return Some(module_path.to_string());
+                return Some(truncate_field(module_path.to_string()));
             }
         }
     }
@@ -915,7 +918,7 @@ fn parse_workspace_replace_line(line: &str) -> Option<Dependency> {
     let old_module = old_parts[0].as_str();
     let old_version = old_parts.get(1).map(|s| s.as_str());
     let new_module = new_parts[0].as_str();
-    let new_version = new_parts.get(1).cloned();
+    let new_version = new_parts.get(1).map(|s| truncate_field(s.clone()));
     let is_local_path = new_module.starts_with("./")
         || new_module.starts_with("../")
         || new_module.starts_with('/')
@@ -930,11 +933,11 @@ fn parse_workspace_replace_line(line: &str) -> Option<Dependency> {
     let mut extra = std::collections::HashMap::new();
     extra.insert(
         "replace_old".to_string(),
-        serde_json::Value::String(old_module.to_string()),
+        serde_json::Value::String(truncate_field(old_module.to_string())),
     );
     extra.insert(
         "replace_new".to_string(),
-        serde_json::Value::String(new_module.to_string()),
+        serde_json::Value::String(truncate_field(new_module.to_string())),
     );
     if let Some(ref v) = new_version {
         extra.insert(
@@ -945,7 +948,7 @@ fn parse_workspace_replace_line(line: &str) -> Option<Dependency> {
     if let Some(ov) = old_version {
         extra.insert(
             "replace_old_version".to_string(),
-            serde_json::Value::String(ov.to_string()),
+            serde_json::Value::String(truncate_field(ov.to_string())),
         );
     }
     if is_local_path {
@@ -1034,7 +1037,7 @@ impl PackageParser for GodepsParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Godeps.json at {:?}: {}", path, e);
@@ -1062,12 +1065,12 @@ pub fn parse_godeps_json(content: &str) -> PackageData {
     let import_path = json
         .get("ImportPath")
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let go_version = json
         .get("GoVersion")
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let (namespace, name) = match &import_path {
         Some(ip) => {
@@ -1084,7 +1087,7 @@ pub fn parse_godeps_json(content: &str) -> PackageData {
     let mut dependencies = Vec::new();
 
     if let Some(deps) = json.get("Deps").and_then(|v| v.as_array()) {
-        for dep in deps {
+        for dep in deps.iter().take(MAX_ITERATION_COUNT) {
             let dep_import_path = dep.get("ImportPath").and_then(|v| v.as_str());
             let rev = dep.get("Rev").and_then(|v| v.as_str());
 
@@ -1093,7 +1096,7 @@ pub fn parse_godeps_json(content: &str) -> PackageData {
 
                 dependencies.push(Dependency {
                     purl: dep_purl,
-                    extracted_requirement: rev.map(String::from),
+                    extracted_requirement: rev.map(|s| truncate_field(s.to_string())),
                     scope: Some("Deps".to_string()),
                     is_runtime: Some(true),
                     is_optional: Some(false),
@@ -1114,9 +1117,11 @@ pub fn parse_godeps_json(content: &str) -> PackageData {
 
     let homepage_url = import_path
         .as_ref()
-        .map(|m| format!("https://pkg.go.dev/{}", m));
+        .map(|m| truncate_field(format!("https://pkg.go.dev/{}", m)));
 
-    let vcs_url = import_path.as_ref().map(|m| format!("https://{}.git", m));
+    let vcs_url = import_path
+        .as_ref()
+        .map(|m| truncate_field(format!("https://{}.git", m)));
 
     PackageData {
         package_type: Some(PACKAGE_TYPE),

--- a/src/parsers/go_mod_graph.rs
+++ b/src/parsers/go_mod_graph.rs
@@ -1,10 +1,9 @@
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::Path;
 
-use crate::parser_warn as warn;
-
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::go::{create_golang_purl, split_module_path};
@@ -32,7 +31,7 @@ impl PackageParser for GoModGraphParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Go module graph at {:?}: {}", path, e);
@@ -54,7 +53,7 @@ pub(crate) fn parse_go_mod_graph(content: &str) -> PackageData {
     let mut root_module: Option<String> = None;
     let mut dependency_map: BTreeMap<String, Dependency> = BTreeMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -75,7 +74,7 @@ pub(crate) fn parse_go_mod_graph(content: &str) -> PackageData {
         let target = parse_graph_module(target);
 
         if source.version.is_none() && root_module.is_none() {
-            root_module = Some(source.module_path.to_string());
+            root_module = Some(truncate_field(source.module_path.to_string()));
         }
 
         let Some(purl) = create_golang_purl(target.module_path, target.version) else {
@@ -90,8 +89,8 @@ pub(crate) fn parse_go_mod_graph(content: &str) -> PackageData {
                 }
             })
             .or_insert_with(|| Dependency {
-                purl: Some(purl),
-                extracted_requirement: target.version.map(str::to_string),
+                purl: Some(truncate_field(purl)),
+                extracted_requirement: target.version.map(|v| truncate_field(v.to_string())),
                 scope: Some("dependency".to_string()),
                 is_runtime: Some(true),
                 is_optional: Some(false),
@@ -109,22 +108,23 @@ pub(crate) fn parse_go_mod_graph(content: &str) -> PackageData {
 
     let homepage_url = root_module
         .as_ref()
-        .map(|module| format!("https://pkg.go.dev/{module}"));
+        .map(|module| truncate_field(format!("https://pkg.go.dev/{module}")));
 
     let vcs_url = root_module
         .as_ref()
-        .map(|module| format!("https://{module}.git"));
+        .map(|module| truncate_field(format!("https://{module}.git")));
 
     let purl = root_module
         .as_deref()
-        .and_then(|module| create_golang_purl(module, None));
+        .and_then(|module| create_golang_purl(module, None))
+        .map(truncate_field);
 
     PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Go".to_string()),
         datasource_id: Some(DatasourceId::GoModGraph),
-        namespace,
-        name: (!name.is_empty()).then_some(name),
+        namespace: namespace.map(truncate_field),
+        name: (!name.is_empty()).then_some(truncate_field(name)),
         homepage_url: homepage_url.clone(),
         repository_homepage_url: homepage_url,
         vcs_url,
@@ -152,6 +152,7 @@ fn parse_graph_module(token: &str) -> GraphModule<'_> {
 mod tests {
     use super::*;
     use crate::models::DatasourceId;
+    use std::fs;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -21,10 +21,10 @@
 //! - Graceful error handling with `warn!()` logs
 //! - Direct dependency tracking (all in build file are direct)
 
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::json;
 
@@ -78,7 +78,7 @@ impl PackageParser for GradleParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {:?}: {}", path, e);
@@ -178,6 +178,13 @@ fn lex(input: &str) -> Vec<Tok> {
     let mut tokens = Vec::new();
 
     while i < len {
+        if tokens.len() >= MAX_ITERATION_COUNT {
+            warn!(
+                "Lexer exceeded MAX_ITERATION_COUNT ({}) tokens, stopping",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         let c = chars[i];
 
         if c == '/' && i + 1 < len && chars[i + 1] == '/' {
@@ -208,6 +215,7 @@ fn lex(input: &str) -> Vec<Tok> {
                 i += 1;
             }
             let val: String = chars[start..i].iter().collect();
+            let val = truncate_field(val);
             if i < len && chars[i] == '\'' {
                 tokens.push(Tok::Str(val));
                 i += 1;
@@ -228,6 +236,7 @@ fn lex(input: &str) -> Vec<Tok> {
                 }
             }
             let val: String = chars[start..i].iter().collect();
+            let val = truncate_field(val);
             if i < len && chars[i] == '"' {
                 tokens.push(Tok::Str(val));
                 i += 1;
@@ -280,7 +289,7 @@ fn lex(input: &str) -> Vec<Tok> {
                     i += 1;
                 }
                 let val: String = chars[start..i].iter().collect();
-                tokens.push(Tok::Ident(val));
+                tokens.push(Tok::Ident(truncate_field(val)));
             }
             _ => {
                 i += 1;
@@ -357,7 +366,7 @@ fn extract_dependencies(tokens: &[Tok]) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
     for block in blocks {
-        for rd in parse_block(&block) {
+        for rd in parse_block(&block).into_iter().take(MAX_ITERATION_COUNT) {
             if rd.name.is_empty() {
                 continue;
             }
@@ -373,8 +382,17 @@ fn extract_dependencies(tokens: &[Tok]) -> Vec<Dependency> {
 fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
     let mut deps = Vec::new();
     let mut i = 0;
+    let mut iterations = 0;
 
     while i < tokens.len() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            warn!(
+                "parse_block exceeded MAX_ITERATION_COUNT ({}) iterations, stopping",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         // Skip nested blocks (closures like `{ transitive = true }`)
         if tokens[i] == Tok::OpenBrace {
             let mut depth = 1;
@@ -518,10 +536,12 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
         {
             deps.push(RawDep {
                 namespace: String::new(),
-                name: last_seg.to_string(),
+                name: truncate_field(last_seg.to_string()),
                 version: String::new(),
-                scope: scope_name.clone(),
-                catalog_alias: val.strip_prefix("libs.").map(|alias| alias.to_string()),
+                scope: truncate_field(scope_name.clone()),
+                catalog_alias: val
+                    .strip_prefix("libs.")
+                    .map(|alias| truncate_field(alias.to_string())),
                 project_path: None,
             });
             i = next + 1;
@@ -668,8 +688,8 @@ fn parse_map_entries(tokens: &[Tok]) -> Option<RawDep> {
             && let Tok::Str(ref val) = tokens[i + 2]
         {
             match label.as_str() {
-                "name" => name = val.clone(),
-                "version" => version = val.clone(),
+                "name" => name = truncate_field(val.clone()),
+                "version" => version = truncate_field(val.clone()),
                 _ => {}
             }
             i += 3;
@@ -708,9 +728,9 @@ fn parse_named_params(scope: &str, tokens: &[Tok]) -> Option<(RawDep, usize)> {
             && let Tok::Str(ref val) = tokens[i + 2]
         {
             match label.as_str() {
-                "group" => group = val.clone(),
-                "name" => name = val.clone(),
-                "version" => version = val.clone(),
+                "group" => group = truncate_field(val.clone()),
+                "name" => name = truncate_field(val.clone()),
+                "version" => version = truncate_field(val.clone()),
                 _ => {}
             }
             i += 3;
@@ -754,13 +774,13 @@ fn parse_project_ref(tokens: &[Tok]) -> Option<RawDep> {
             namespace: if segments.is_empty() {
                 String::new()
             } else {
-                segments.join("/")
+                truncate_field(segments.join("/"))
             },
-            name: name.to_string(),
+            name: truncate_field(name.to_string()),
             version: String::new(),
             scope: "project".to_string(),
             catalog_alias: None,
-            project_path: Some(module_name.to_string()),
+            project_path: Some(truncate_field(module_name.to_string())),
         });
     }
     None
@@ -770,24 +790,32 @@ fn parse_colon_string(val: &str, scope: &str) -> RawDep {
     let parts: Vec<&str> = val.split(':').collect();
     let (namespace, name, version) = match parts.len() {
         n if n >= 4 => (
-            parts[0].to_string(),
-            parts[1].to_string(),
-            parts[2].to_string(),
+            truncate_field(parts[0].to_string()),
+            truncate_field(parts[1].to_string()),
+            truncate_field(parts[2].to_string()),
         ),
         3 => (
-            parts[0].to_string(),
-            parts[1].to_string(),
-            parts[2].to_string(),
+            truncate_field(parts[0].to_string()),
+            truncate_field(parts[1].to_string()),
+            truncate_field(parts[2].to_string()),
         ),
-        2 => (parts[0].to_string(), parts[1].to_string(), String::new()),
-        _ => (String::new(), val.to_string(), String::new()),
+        2 => (
+            truncate_field(parts[0].to_string()),
+            truncate_field(parts[1].to_string()),
+            String::new(),
+        ),
+        _ => (
+            String::new(),
+            truncate_field(val.to_string()),
+            String::new(),
+        ),
     };
 
     RawDep {
         namespace,
         name,
         version,
-        scope: scope.to_string(),
+        scope: truncate_field(scope.to_string()),
         catalog_alias: None,
         project_path: None,
     }
@@ -859,19 +887,25 @@ fn create_dependency(raw: &RawDep) -> Option<Dependency> {
     let (is_runtime, is_optional) = classify_scope(scope);
     let is_pinned = !version.is_empty();
 
-    let purl_string = purl.to_string().replace("$", "%24").replace('\'', "%27");
+    let purl_string = truncate_field(purl.to_string().replace("$", "%24").replace('\'', "%27"));
     let mut extra_data = std::collections::HashMap::new();
     if let Some(alias) = &raw.catalog_alias {
-        extra_data.insert("catalog_alias".to_string(), json!(alias));
+        extra_data.insert(
+            "catalog_alias".to_string(),
+            json!(truncate_field(alias.clone())),
+        );
     }
     if let Some(project_path) = &raw.project_path {
-        extra_data.insert("project_path".to_string(), json!(project_path));
+        extra_data.insert(
+            "project_path".to_string(),
+            json!(truncate_field(project_path.clone())),
+        );
     }
 
     Some(Dependency {
         purl: Some(purl_string),
-        extracted_requirement: Some(version.to_string()),
-        scope: Some(scope.to_string()),
+        extracted_requirement: Some(truncate_field(version.to_string())),
+        scope: Some(truncate_field(scope.to_string())),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
         is_pinned: Some(is_pinned),
@@ -936,8 +970,8 @@ fn resolve_gradle_version_catalog_aliases(path: &Path, dependencies: &mut [Depen
             }
         }
 
-        dep.purl = purl.map(|p| p.to_string());
-        dep.extracted_requirement = entry.version.clone();
+        dep.purl = purl.map(|p| truncate_field(p.to_string()));
+        dep.extracted_requirement = entry.version.as_ref().map(|v| truncate_field(v.clone()));
         dep.is_pinned = Some(entry.version.is_some());
     }
 }
@@ -961,12 +995,12 @@ fn find_gradle_version_catalog(path: &Path) -> Option<std::path::PathBuf> {
 fn parse_gradle_version_catalog(
     path: &Path,
 ) -> Option<std::collections::HashMap<String, GradleCatalogEntry>> {
-    let content = fs::read_to_string(path).ok()?;
+    let content = read_file_to_string(path, None).ok()?;
     let mut section = "";
     let mut versions = std::collections::HashMap::new();
     let mut libraries = std::collections::HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.split('#').next().unwrap_or("").trim();
         if trimmed.is_empty() {
             continue;
@@ -985,7 +1019,7 @@ fn parse_gradle_version_catalog(
 
         match section {
             "versions" => {
-                versions.insert(key, strip_quotes(&value).to_string());
+                versions.insert(key, truncate_field(strip_quotes(&value).to_string()));
             }
             "libraries" => {
                 libraries.insert(key, value);
@@ -995,11 +1029,11 @@ fn parse_gradle_version_catalog(
     }
 
     let mut result = std::collections::HashMap::new();
-    for (alias, raw_value) in libraries {
+    for (alias, raw_value) in libraries.into_iter().take(MAX_ITERATION_COUNT) {
         let Some(entry) = parse_gradle_catalog_entry(&raw_value, &versions) else {
             continue;
         };
-        result.insert(alias.replace('-', "."), entry);
+        result.insert(truncate_field(alias.replace('-', ".")), entry);
     }
 
     Some(result)
@@ -1012,9 +1046,9 @@ fn parse_gradle_catalog_entry(
     if raw_value.starts_with('"') && raw_value.ends_with('"') {
         let notation = strip_quotes(raw_value);
         let mut parts = notation.split(':');
-        let namespace = parts.next()?.to_string();
-        let name = parts.next()?.to_string();
-        let version = parts.next().map(|v| v.to_string());
+        let namespace = truncate_field(parts.next()?.to_string());
+        let name = truncate_field(parts.next()?.to_string());
+        let version = parts.next().map(|v| truncate_field(v.to_string()));
         return Some(GradleCatalogEntry {
             namespace,
             name,
@@ -1028,30 +1062,33 @@ fn parse_gradle_catalog_entry(
 
     let inner = &raw_value[1..raw_value.len() - 1];
     let mut fields = std::collections::HashMap::new();
-    for pair in inner.split(',') {
+    for pair in inner.split(',').take(MAX_ITERATION_COUNT) {
         let Some((key, value)) = pair.split_once('=') else {
             continue;
         };
         fields.insert(
-            key.trim().to_string(),
-            strip_quotes(value.trim()).to_string(),
+            truncate_field(key.trim().to_string()),
+            truncate_field(strip_quotes(value.trim()).to_string()),
         );
     }
 
     let (namespace, name) = if let Some(module) = fields.get("module") {
         let (group, artifact) = module.split_once(':')?;
-        (group.to_string(), artifact.to_string())
+        (
+            truncate_field(group.to_string()),
+            truncate_field(artifact.to_string()),
+        )
     } else {
         (
-            fields.get("group")?.to_string(),
-            fields.get("name")?.to_string(),
+            truncate_field(fields.get("group")?.to_string()),
+            truncate_field(fields.get("name")?.to_string()),
         )
     };
 
     let version = if let Some(version) = fields.get("version") {
-        Some(version.to_string())
+        Some(truncate_field(version.to_string()))
     } else if let Some(version_ref) = fields.get("version.ref") {
-        versions.get(version_ref).cloned()
+        versions.get(version_ref).cloned().map(truncate_field)
     } else {
         None
     };
@@ -1101,10 +1138,20 @@ fn extract_gradle_license_metadata(
                         normalized,
                         DeclaredLicenseMatchMetadata::single_line(matched_text),
                     );
-                    return (extracted, declared, declared_spdx, detections);
+                    return (
+                        extracted.map(truncate_field),
+                        declared.map(truncate_field),
+                        declared_spdx.map(truncate_field),
+                        detections,
+                    );
                 }
 
-                return (extracted, None, None, empty_declared_license_data().2);
+                return (
+                    extracted.map(truncate_field),
+                    None,
+                    None,
+                    empty_declared_license_data().2,
+                );
             }
             i = block_end + 1;
             continue;
@@ -1154,8 +1201,8 @@ fn parse_license_block(tokens: &[Tok]) -> Option<(String, Option<String>)> {
 fn next_string_literal(tokens: &[Tok], start: usize) -> Option<String> {
     for token in tokens.iter().skip(start) {
         match token {
-            Tok::Str(value) => return Some(value.clone()),
-            Tok::MalformedStr(value) => return Some(value.clone()),
+            Tok::Str(value) => return Some(truncate_field(value.clone())),
+            Tok::MalformedStr(value) => return Some(truncate_field(value.clone())),
             Tok::Ident(_) | Tok::Colon | Tok::Equals | Tok::OpenParen | Tok::CloseParen => continue,
             _ => break,
         }
@@ -1188,7 +1235,7 @@ fn format_gradle_license_statement(name: &str, url: Option<&str>) -> Option<Stri
     if let Some(url) = url {
         output.push_str(&format!("    url: {url}\n"));
     }
-    Some(output)
+    Some(truncate_field(output))
 }
 
 fn derive_gradle_license_expression(name: &str, url: Option<&str>) -> Option<String> {
@@ -1202,13 +1249,13 @@ fn derive_gradle_license_expression(name: &str, url: Option<&str>) -> Option<Str
             || lower.contains("apache license, version 2.0")
             || lower.contains("apache.org/licenses/license-2.0")
         {
-            return Some("Apache-2.0".to_string());
+            return Some(truncate_field("Apache-2.0".to_string()));
         }
         if trimmed == "MIT" || lower.contains("opensource.org/licenses/mit") {
-            return Some("MIT".to_string());
+            return Some(truncate_field("MIT".to_string()));
         }
         if trimmed == "BSD-2-Clause" || trimmed == "BSD-3-Clause" {
-            return Some(trimmed.to_string());
+            return Some(truncate_field(trimmed.to_string()));
         }
     }
 

--- a/src/parsers/gradle_lock.rs
+++ b/src/parsers/gradle_lock.rs
@@ -22,11 +22,10 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Resolved
 use crate::parser_warn as warn;
 use packageurl::PackageUrl;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use super::PackageParser;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Gradle gradle.lockfile parser.
 ///
@@ -43,16 +42,15 @@ impl PackageParser for GradleLockfileParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let file = match File::open(path) {
-            Ok(f) => f,
+        let content = match read_file_to_string(path, None) {
+            Ok(c) => c,
             Err(e) => {
-                warn!("Failed to open gradle.lockfile at {:?}: {}", path, e);
+                warn!("Failed to read gradle.lockfile at {:?}: {}", path, e);
                 return vec![default_package_data()];
             }
         };
 
-        let reader = BufReader::new(file);
-        let dependencies = extract_dependencies(reader);
+        let dependencies = extract_dependencies(&content);
 
         vec![PackageData {
             package_type: Some(Self::PACKAGE_TYPE),
@@ -102,18 +100,10 @@ impl PackageParser for GradleLockfileParser {
 }
 
 /// Extract dependencies from gradle.lockfile
-fn extract_dependencies<R: BufRead>(reader: R) -> Vec<Dependency> {
+fn extract_dependencies(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(e) => {
-                warn!("Failed to read line from gradle.lockfile: {}", e);
-                continue;
-            }
-        };
-
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
 
         // Skip empty lines and comments
@@ -146,7 +136,7 @@ fn parse_dependency_line(line: &str) -> Option<Dependency> {
         .split(',')
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
+        .map(|v| truncate_field(v.to_string()))
         .collect();
 
     // Parse GAV (group:artifact:version)
@@ -155,15 +145,15 @@ fn parse_dependency_line(line: &str) -> Option<Dependency> {
         return None;
     }
 
-    let group = parts[0].to_string();
-    let artifact = parts[1].to_string();
-    let version = parts[2].to_string();
+    let group = truncate_field(parts[0].to_string());
+    let artifact = truncate_field(parts[1].to_string());
+    let version = truncate_field(parts[2].to_string());
 
     // Generate purl
     let purl = PackageUrl::new("maven", &artifact).ok().and_then(|mut p| {
         p.with_namespace(&group).ok()?;
         p.with_version(&version).ok()?;
-        Some(p.to_string())
+        Some(truncate_field(p.to_string()))
     });
 
     // Build extra_data with group and artifact separately
@@ -241,7 +231,6 @@ fn default_package_data() -> PackageData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
 
     #[test]
     fn test_is_match_gradle_lockfile() {
@@ -329,8 +318,7 @@ mod tests {
     #[test]
     fn test_extract_dependencies_multiple_lines() {
         let content = "com.example:lib1:1.0.0=compileClasspath\ncom.example:lib2:2.0.0=runtimeClasspath\ncom.test:lib3:3.0.0=testRuntimeClasspath";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         assert_eq!(deps.len(), 3);
         assert_eq!(deps[0].resolved_package.as_ref().unwrap().name, "lib1");
@@ -341,8 +329,7 @@ mod tests {
     #[test]
     fn test_extract_dependencies_with_comments_and_empty_lines() {
         let content = "# This is a comment\ncom.example:lib1:1.0.0=compileClasspath\n\n# Another comment\ncom.example:lib2:2.0.0=runtimeClasspath\n";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         assert_eq!(deps.len(), 2);
         assert_eq!(deps[0].resolved_package.as_ref().unwrap().name, "lib1");
@@ -352,8 +339,7 @@ mod tests {
     #[test]
     fn test_extract_dependencies_empty_file() {
         let content = "";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         assert_eq!(deps.len(), 0);
     }
@@ -361,8 +347,7 @@ mod tests {
     #[test]
     fn test_extract_dependencies_only_comments() {
         let content = "# Comment 1\n# Comment 2\n# Comment 3";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         assert_eq!(deps.len(), 0);
     }
@@ -370,8 +355,7 @@ mod tests {
     #[test]
     fn test_extract_first_package_returns_correct_package_type() {
         let content = "com.example:lib:1.0.0=compileClasspath";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         assert!(!deps.is_empty());
         assert_eq!(
@@ -408,8 +392,7 @@ mod tests {
     #[test]
     fn test_extract_dependencies_malformed_lines_ignored() {
         let content = "com.example:lib1:1.0.0=compileClasspath\ninvalid-line\ncom.example:lib2:2.0.0=runtimeClasspath";
-        let reader = Cursor::new(content);
-        let deps = extract_dependencies(reader);
+        let deps = extract_dependencies(content);
 
         // Only valid dependencies are extracted
         assert_eq!(deps.len(), 2);


### PR DESCRIPTION
## Summary

- ADR 0004 security compliance fixes for 5 parsers: gradle_lock, gradle, go_mod_graph, go, deno_lock
- Each parser fixed: file size checks (100MB via `read_file_to_string`), iteration caps (`MAX_ITERATION_COUNT`), string field truncation (`truncate_field`), lossy UTF-8 fallback

## Changes

- **gradle_lock.rs**: Replaced `File::open`+`BufReader` with `read_file_to_string`, iteration cap on lines, truncate_field on group/artifact/version/purl
- **gradle.rs**: Replaced `fs::read_to_string` with `read_file_to_string`, iteration caps on lexer/dependencies/catalog, truncate_field on all output strings
- **go_mod_graph.rs**: Replaced `fs::read_to_string` with `read_file_to_string`, iteration cap on lines, truncate_field on all output strings
- **go.rs**: Replaced 5 `fs::read_to_string` calls with `read_file_to_string`, iteration caps on 6 line/dep loops, truncate_field across all 4 parsers
- **deno_lock.rs**: Replaced `fs::read_to_string` with `read_file_to_string`, iteration caps on 6 JSR/npm/redirect loops, truncate_field on all output strings

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Pre-commit hooks pass