### PR TITLE
fix(parsers): ADR 0004 security compliance for deno, dart, conan, cargo_lock, bun_lock

### DIFF
--- a/src/parsers/bun_lock.rs
+++ b/src/parsers/bun_lock.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -9,7 +8,7 @@ use crate::models::{
     DatasourceId, Dependency, Md5Digest, PackageData, PackageType, ResolvedPackage, Sha1Digest,
     Sha256Digest, Sha512Digest,
 };
-use crate::parsers::utils::{npm_purl, parse_sri};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
 
 use super::PackageParser;
 
@@ -40,7 +39,7 @@ impl PackageParser for BunLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match crate::parsers::utils::read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read bun.lock at {:?}: {}", path, e);
@@ -63,7 +62,7 @@ impl PackageParser for BunLockParser {
 fn default_package_data() -> PackageData {
     PackageData {
         package_type: Some(BunLockParser::PACKAGE_TYPE),
-        primary_language: Some("JavaScript".to_string()),
+        primary_language: Some(truncate_field("JavaScript".to_string())),
         datasource_id: Some(DatasourceId::BunLock),
         extra_data: Some(HashMap::new()),
         ..Default::default()
@@ -80,9 +79,9 @@ fn parse_bun_lockfile(root: &JsonValue) -> PackageData {
         .map(split_namespace_name)
         .unwrap_or((None, None));
 
-    result.namespace = namespace;
-    result.name = name;
-    result.version = workspace_context.root_version.clone();
+    result.namespace = namespace.map(truncate_field);
+    result.name = name.map(truncate_field);
+    result.version = workspace_context.root_version.clone().map(truncate_field);
     result.purl = result
         .name
         .as_ref()
@@ -112,7 +111,7 @@ fn parse_bun_lockfile(root: &JsonValue) -> PackageData {
     };
 
     let mut dependencies = Vec::new();
-    for (key, value) in packages {
+    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
         if let Some(dependency) = parse_package_entry(
             key,
             value,
@@ -146,27 +145,30 @@ fn extract_workspace_info(root: &JsonValue) -> WorkspaceContext {
     let root_name = root_workspace
         .and_then(|value| value.get("name"))
         .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned);
+        .map(|s| truncate_field(s.to_owned()));
     let root_version = root_workspace
         .and_then(|value| value.get("version"))
         .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned);
+        .map(|s| truncate_field(s.to_owned()));
 
     if let Some(workspaces) = workspaces {
-        for workspace in workspaces.values() {
+        for workspace in workspaces.values().take(MAX_ITERATION_COUNT) {
             if let Some(name) = workspace.get("name").and_then(|value| value.as_str())
                 && let Some(version) = workspace.get("version").and_then(|value| value.as_str())
             {
-                workspace_versions.insert(name.to_string(), version.to_string());
+                workspace_versions.insert(
+                    truncate_field(name.to_string()),
+                    truncate_field(version.to_string()),
+                );
             }
             if let Some(name) = workspace.get("name").and_then(|value| value.as_str()) {
-                workspace_entries.insert(name.to_string(), workspace.clone());
+                workspace_entries.insert(truncate_field(name.to_string()), workspace.clone());
             }
         }
     }
 
     if let Some(workspaces) = workspaces {
-        for workspace in workspaces.values() {
+        for workspace in workspaces.values().take(MAX_ITERATION_COUNT) {
             insert_manifest_dependency_info(
                 workspace.get("dependencies"),
                 "dependencies",
@@ -218,9 +220,9 @@ fn insert_manifest_dependency_info(
         return;
     };
 
-    for name in map.keys() {
+    for name in map.keys().take(MAX_ITERATION_COUNT) {
         out.insert(
-            name.clone(),
+            truncate_field(name.clone()),
             ManifestDependencyInfo {
                 scope,
                 is_runtime,
@@ -240,6 +242,8 @@ fn parse_package_entry(
     let tuple = value.as_array()?;
     let resolution = tuple.first()?.as_str()?;
     let (package_name, locator) = split_locator(resolution)?;
+    let package_name = truncate_field(package_name);
+    let locator = truncate_field(locator);
     let package_version = resolve_locator_version(&package_name, &locator, workspace_versions);
 
     let manifest_info = direct_deps
@@ -248,24 +252,34 @@ fn parse_package_entry(
     let (scope, is_runtime, is_optional, is_direct) = manifest_info
         .map(|info| {
             (
-                info.scope.to_string(),
+                truncate_field(info.scope.to_string()),
                 info.is_runtime,
                 info.is_optional,
                 true,
             )
         })
-        .unwrap_or_else(|| ("dependencies".to_string(), true, false, false));
+        .unwrap_or_else(|| {
+            (
+                truncate_field("dependencies".to_string()),
+                true,
+                false,
+                false,
+            )
+        });
 
-    let purl = npm_purl(&package_name, package_version.as_deref());
+    let purl = npm_purl(&package_name, package_version.as_deref()).map(truncate_field);
     let resolved_download_url =
-        resolved_download_url(&package_name, &locator, tuple, package_version.as_deref());
+        resolved_download_url(&package_name, &locator, tuple, package_version.as_deref())
+            .map(truncate_field);
     let (sha1, sha256, sha512, md5) = parse_integrity_tuple(tuple);
     let nested_dependencies =
         extract_nested_dependencies(&package_name, tuple, workspace_versions, workspace_entries);
 
     let (namespace, name) = split_namespace_name(&package_name);
+    let namespace = namespace.map(truncate_field);
+    let name = name.map(truncate_field);
     let resolved_package = ResolvedPackage {
-        primary_language: Some("JavaScript".to_string()),
+        primary_language: Some(truncate_field("JavaScript".to_string())),
         download_url: resolved_download_url,
         sha1: sha1.and_then(|h| Sha1Digest::from_hex(&h).ok()),
         sha256: sha256.and_then(|h| Sha256Digest::from_hex(&h).ok()),
@@ -283,13 +297,15 @@ fn parse_package_entry(
             BunLockParser::PACKAGE_TYPE,
             namespace.unwrap_or_default(),
             name.unwrap_or_else(|| package_name.clone()),
-            package_version.clone().unwrap_or_default(),
+            truncate_field(package_version.clone().unwrap_or_default()),
         )
     };
 
     Some(Dependency {
         purl,
-        extracted_requirement: Some(package_version.clone().unwrap_or(locator.clone())),
+        extracted_requirement: Some(truncate_field(
+            package_version.clone().unwrap_or(locator.clone()),
+        )),
         scope: Some(scope),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
@@ -305,7 +321,10 @@ fn split_locator(resolution: &str) -> Option<(String, String)> {
     if name.is_empty() || locator.is_empty() {
         return None;
     }
-    Some((name.to_string(), locator.to_string()))
+    Some((
+        truncate_field(name.to_string()),
+        truncate_field(locator.to_string()),
+    ))
 }
 
 fn resolve_locator_version(
@@ -330,7 +349,7 @@ fn resolve_locator_version(
         return None;
     }
 
-    Some(locator.to_string())
+    Some(truncate_field(locator.to_string()))
 }
 
 fn resolved_download_url(
@@ -342,7 +361,7 @@ fn resolved_download_url(
     if let Some(url) = tuple.get(1).and_then(|value| value.as_str())
         && !url.is_empty()
     {
-        return Some(url.to_string());
+        return Some(truncate_field(url.to_string()));
     }
 
     if locator.starts_with("workspace:")
@@ -357,7 +376,7 @@ fn resolved_download_url(
         || locator.starts_with("git+")
         || locator.starts_with("github:")
     {
-        return Some(locator.to_string());
+        return Some(truncate_field(locator.to_string()));
     }
 
     version.and_then(|version| default_registry_download_url(package_name, version))
@@ -367,10 +386,10 @@ fn default_registry_download_url(package_name: &str, version: &str) -> Option<St
     let (namespace, name) = split_namespace_name(package_name);
     let name = name?;
     let package_path = qualify_name(&namespace, &name);
-    Some(format!(
+    Some(truncate_field(format!(
         "https://registry.npmjs.org/{}/-/{}-{}.tgz",
         package_path, name, version
-    ))
+    )))
 }
 
 fn parse_integrity_tuple(
@@ -460,6 +479,7 @@ fn build_nested_dependencies(
     };
 
     deps.iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(name, value)| {
             let requirement = value.as_str()?;
             let version = if requirement.starts_with("workspace:") {
@@ -469,9 +489,9 @@ fn build_nested_dependencies(
             };
 
             Some(Dependency {
-                purl: npm_purl(name, version),
-                extracted_requirement: Some(requirement.to_string()),
-                scope: Some(scope.to_string()),
+                purl: npm_purl(name, version).map(truncate_field),
+                extracted_requirement: Some(truncate_field(requirement.to_string())),
+                scope: Some(truncate_field(scope.to_string())),
                 is_runtime: Some(is_runtime),
                 is_optional: Some(is_optional),
                 is_pinned: Some(false),
@@ -486,11 +506,14 @@ fn build_nested_dependencies(
 fn split_namespace_name(full_name: &str) -> (Option<String>, Option<String>) {
     if full_name.starts_with('@') {
         let mut parts = full_name.splitn(2, '/');
-        let namespace = parts.next().map(ToOwned::to_owned);
-        let name = parts.next().map(ToOwned::to_owned);
+        let namespace = parts.next().map(|s| truncate_field(s.to_owned()));
+        let name = parts.next().map(|s| truncate_field(s.to_owned()));
         (namespace, name)
     } else {
-        (Some(String::new()), Some(full_name.to_string()))
+        (
+            Some(String::new()),
+            Some(truncate_field(full_name.to_string())),
+        )
     }
 }
 

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -20,11 +20,10 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Sha256Digest};
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::json;
 use std::collections::{HashMap, hash_map::Entry};
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use toml::Value;
 
@@ -66,17 +65,17 @@ impl PackageParser for CargoLockParser {
         let name = root_package
             .and_then(|p| p.get("name"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let version = root_package
             .and_then(|p| p.get("version"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let checksum = root_package
             .and_then(|p| p.get("checksum"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let (sha256, extra_data) = match checksum.as_deref() {
             Some(h) if h.len() == 64 && Sha256Digest::from_hex(h).is_ok() => {
@@ -95,14 +94,20 @@ impl PackageParser for CargoLockParser {
         let purl = match (&name, &version) {
             (Some(n), Some(v)) => PackageUrl::new("cargo", n).ok().and_then(|mut p| {
                 p.with_version(v.as_str()).ok()?;
-                Some(p.to_string())
+                Some(truncate_field(p.to_string()))
             }),
             _ => None,
         };
 
         let api_data_url = match (&name, &version) {
-            (Some(n), Some(v)) => Some(format!("https://crates.io/api/v1/crates/{}/{}", n, v)),
-            (Some(n), None) => Some(format!("https://crates.io/api/v1/crates/{}", n)),
+            (Some(n), Some(v)) => Some(truncate_field(format!(
+                "https://crates.io/api/v1/crates/{}/{}",
+                n, v
+            ))),
+            (Some(n), None) => Some(truncate_field(format!(
+                "https://crates.io/api/v1/crates/{}",
+                n
+            ))),
             _ => None,
         };
 
@@ -154,10 +159,8 @@ impl PackageParser for CargoLockParser {
 }
 
 fn read_cargo_lock(path: &Path) -> Result<Value, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
 
@@ -178,14 +181,14 @@ fn extract_all_dependencies(
     let package_versions = build_package_versions(packages);
     let package_provenance = build_package_provenance(packages);
     let root_package_key = root_package.and_then(package_key_from_table);
-    for package in packages {
+    for package in packages.iter().take(MAX_ITERATION_COUNT) {
         if let Some(pkg_table) = package.as_table() {
             let is_root_package = package_key_from_table(pkg_table)
                 .zip(root_package_key)
                 .is_some_and(|(package_key, root_key)| package_key == root_key);
 
             if let Some(deps) = pkg_table.get("dependencies").and_then(|v| v.as_array()) {
-                for dep in deps {
+                for dep in deps.iter().take(MAX_ITERATION_COUNT) {
                     if let Some(dep_str) = dep.as_str() {
                         let parsed_dependency = parse_dependency_string(dep_str);
                         let name = parsed_dependency.name;
@@ -200,11 +203,13 @@ fn extract_all_dependencies(
 
                         if !name.is_empty() {
                             let purl = if resolved_version.is_empty() {
-                                PackageUrl::new("cargo", name).ok().map(|p| p.to_string())
+                                PackageUrl::new("cargo", name)
+                                    .ok()
+                                    .map(|p| truncate_field(p.to_string()))
                             } else {
                                 PackageUrl::new("cargo", name).ok().and_then(|mut p| {
                                     p.with_version(resolved_version).ok()?;
-                                    Some(p.to_string())
+                                    Some(truncate_field(p.to_string()))
                                 })
                             };
 
@@ -220,7 +225,7 @@ fn extract_all_dependencies(
                                 extracted_requirement: if resolved_version.is_empty() {
                                     None
                                 } else {
-                                    Some(resolved_version.to_string())
+                                    Some(truncate_field(resolved_version.to_string()))
                                 },
                                 scope: None,
                                 is_runtime: None,
@@ -249,7 +254,11 @@ fn extract_all_dependencies(
         }
     }
 
-    for package in packages.iter().filter_map(|package| package.as_table()) {
+    for package in packages
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(|package| package.as_table())
+    {
         let Some((name, version)) = package_key_from_table(package) else {
             continue;
         };
@@ -273,8 +282,8 @@ fn extract_all_dependencies(
         }
 
         let dependency = Dependency {
-            purl: Some(purl.to_string()),
-            extracted_requirement: Some(version.to_string()),
+            purl: Some(truncate_field(purl.to_string())),
+            extracted_requirement: Some(truncate_field(version.to_string())),
             scope: None,
             is_runtime: None,
             is_optional: None,
@@ -387,17 +396,26 @@ fn build_dependency_extra_data(
             .and_then(|candidates| select_dependency_provenance(candidates, source_hint))
     {
         if let Some(source) = provenance.source {
-            extra_data.insert("source".to_string(), json!(source));
+            extra_data.insert(
+                "source".to_string(),
+                json!(truncate_field(source.to_string())),
+            );
         }
         if let Some(checksum) = provenance.checksum {
-            extra_data.insert("checksum".to_string(), json!(checksum));
+            extra_data.insert(
+                "checksum".to_string(),
+                json!(truncate_field(checksum.to_string())),
+            );
         }
     }
 
     if !extra_data.contains_key("source")
         && let Some(source) = source_hint
     {
-        extra_data.insert("source".to_string(), json!(source));
+        extra_data.insert(
+            "source".to_string(),
+            json!(truncate_field(source.to_string())),
+        );
     }
 
     if extra_data.is_empty() {

--- a/src/parsers/conan.rs
+++ b/src/parsers/conan.rs
@@ -21,7 +21,6 @@
 //! - Version constraints use Conan-specific operators: [>, <, ranges]
 //! - Only exact versions (without operators) are extracted as pinned versions
 
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -36,6 +35,10 @@ use super::PackageParser;
 use super::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_declared_license_key,
 };
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+
+const MAX_AST_DEPTH: usize = 50;
+const MAX_AST_NODES: usize = 10_000;
 
 /// Conan conanfile.py recipe parser.
 ///
@@ -51,7 +54,7 @@ impl PackageParser for ConanFilePyParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let contents = match fs::read_to_string(path) {
+        let contents = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {}: {}", path.display(), e);
@@ -106,20 +109,35 @@ fn extract_conanfile_data(class_def: &ast::StmtClassDef) -> PackageData {
     let mut requires_list = Vec::new();
     let mut tool_requires_list = Vec::new();
 
-    for stmt in class_def.body.iter() {
+    for stmt in class_def.body.iter().take(MAX_ITERATION_COUNT) {
         match stmt {
             ast::Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
                 if let Some(target_name) = get_assignment_target(targets) {
                     match target_name.as_str() {
-                        "name" => name = get_string_value(value),
-                        "version" => version = get_string_value(value),
-                        "description" => description = get_string_value(value),
-                        "author" => _author = get_string_value(value),
-                        "homepage" => homepage_url = get_string_value(value),
-                        "url" => vcs_url = get_string_value(value),
-                        "license" => license_list = get_list_values(value),
-                        "topics" => keywords = get_list_values(value),
-                        "requires" => requires_list = get_list_values(value),
+                        "name" => name = get_string_value(value).map(truncate_field),
+                        "version" => version = get_string_value(value).map(truncate_field),
+                        "description" => description = get_string_value(value).map(truncate_field),
+                        "author" => _author = get_string_value(value).map(truncate_field),
+                        "homepage" => homepage_url = get_string_value(value).map(truncate_field),
+                        "url" => vcs_url = get_string_value(value).map(truncate_field),
+                        "license" => {
+                            license_list = get_list_values(value)
+                                .into_iter()
+                                .map(truncate_field)
+                                .collect()
+                        }
+                        "topics" => {
+                            keywords = get_list_values(value)
+                                .into_iter()
+                                .map(truncate_field)
+                                .collect()
+                        }
+                        "requires" => {
+                            requires_list = get_list_values(value)
+                                .into_iter()
+                                .map(truncate_field)
+                                .collect()
+                        }
                         _ => {}
                     }
                 }
@@ -152,16 +170,21 @@ fn extract_conanfile_data(class_def: &ast::StmtClassDef) -> PackageData {
     );
 
     let extracted_license = if !license_list.is_empty() {
-        Some(license_list.join(", "))
+        Some(truncate_field(license_list.join(", ")))
     } else {
         None
     };
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         if license_list.len() == 1 {
             if let Some(normalized) = normalize_declared_license_key(&license_list[0]) {
-                build_declared_license_data(
+                let (expr, spdx, detections) = build_declared_license_data(
                     normalized,
                     DeclaredLicenseMatchMetadata::single_line(&license_list[0]),
+                );
+                (
+                    expr.map(truncate_field),
+                    spdx.map(truncate_field),
+                    detections,
                 )
             } else {
                 (None, None, Vec::new())
@@ -230,9 +253,17 @@ fn get_list_values(expr: &ast::Expr) -> Vec<String> {
 /// Extract self.requires() method calls from function body
 fn extract_self_requires_calls(body: &[ast::Stmt], method_name: &str) -> Option<Vec<String>> {
     let mut requires = Vec::new();
+    let mut node_count = 0usize;
 
     for stmt in body {
-        collect_self_method_calls(stmt, method_name, &mut requires);
+        collect_self_method_calls(stmt, method_name, &mut requires, 0, &mut node_count);
+        if node_count >= MAX_AST_NODES {
+            warn!(
+                "Exceeded MAX_AST_NODES ({}) in extract_self_requires_calls",
+                MAX_AST_NODES
+            );
+            break;
+        }
     }
 
     if requires.is_empty() {
@@ -242,7 +273,25 @@ fn extract_self_requires_calls(body: &[ast::Stmt], method_name: &str) -> Option<
     }
 }
 
-fn collect_self_method_calls(stmt: &ast::Stmt, method_name: &str, out: &mut Vec<String>) {
+fn collect_self_method_calls(
+    stmt: &ast::Stmt,
+    method_name: &str,
+    out: &mut Vec<String>,
+    depth: usize,
+    node_count: &mut usize,
+) {
+    if depth > MAX_AST_DEPTH {
+        warn!(
+            "Exceeded MAX_AST_DEPTH ({}) in collect_self_method_calls",
+            MAX_AST_DEPTH
+        );
+        return;
+    }
+    *node_count += 1;
+    if *node_count > MAX_AST_NODES {
+        return;
+    }
+
     match stmt {
         ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
             if let ast::Expr::Call(call) = value.as_ref()
@@ -250,7 +299,7 @@ fn collect_self_method_calls(stmt: &ast::Stmt, method_name: &str, out: &mut Vec<
                 && let Some(arg) = call.arguments.args.first()
                 && let Some(req) = get_string_value(arg)
             {
-                out.push(req);
+                out.push(truncate_field(req));
             }
         }
         ast::Stmt::If(ast::StmtIf {
@@ -259,11 +308,11 @@ fn collect_self_method_calls(stmt: &ast::Stmt, method_name: &str, out: &mut Vec<
             ..
         }) => {
             for nested in body {
-                collect_self_method_calls(nested, method_name, out);
+                collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
             }
             for clause in elif_else_clauses {
                 for nested in &clause.body {
-                    collect_self_method_calls(nested, method_name, out);
+                    collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
                 }
             }
         }
@@ -271,7 +320,7 @@ fn collect_self_method_calls(stmt: &ast::Stmt, method_name: &str, out: &mut Vec<
         | ast::Stmt::While(ast::StmtWhile { body, .. })
         | ast::Stmt::For(ast::StmtFor { body, .. }) => {
             for nested in body {
-                collect_self_method_calls(nested, method_name, out);
+                collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
             }
         }
         ast::Stmt::Try(ast::StmtTry {
@@ -282,19 +331,19 @@ fn collect_self_method_calls(stmt: &ast::Stmt, method_name: &str, out: &mut Vec<
             ..
         }) => {
             for nested in body.iter().chain(orelse.iter()).chain(finalbody.iter()) {
-                collect_self_method_calls(nested, method_name, out);
+                collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
             }
             for handler in handlers {
                 let ast::ExceptHandler::ExceptHandler(handler) = handler;
                 for nested in &handler.body {
-                    collect_self_method_calls(nested, method_name, out);
+                    collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
                 }
             }
         }
         ast::Stmt::Match(ast::StmtMatch { cases, .. }) => {
             for case in cases {
                 for nested in &case.body {
-                    collect_self_method_calls(nested, method_name, out);
+                    collect_self_method_calls(nested, method_name, out, depth + 1, node_count);
                 }
             }
         }
@@ -325,7 +374,7 @@ impl PackageParser for ConanfileTxtParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let contents = match fs::read_to_string(path) {
+        let contents = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {}: {}", path.display(), e);
@@ -359,7 +408,7 @@ impl PackageParser for ConanLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let contents = match fs::read_to_string(path) {
+        let contents = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {}: {}", path.display(), e);
@@ -389,7 +438,7 @@ impl PackageParser for ConanLockParser {
 
 fn parse_conan_reference(ref_str: &str) -> Option<Dependency> {
     let (name, version_spec) = if let Some((n, v)) = ref_str.split_once('/') {
-        (n.trim(), Some(v.trim().to_string()))
+        (n.trim(), Some(truncate_field(v.trim().to_string())))
     } else {
         (ref_str.trim(), None)
     };
@@ -419,7 +468,7 @@ fn parse_conan_reference(ref_str: &str) -> Option<Dependency> {
         .unwrap_or(false);
 
     Some(Dependency {
-        purl: Some(purl),
+        purl: Some(truncate_field(purl)),
         extracted_requirement: version_spec,
         scope: Some("install".to_string()),
         is_runtime: Some(true),
@@ -435,7 +484,7 @@ fn parse_conanfile_txt(contents: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     let mut current_section = None;
 
-    for line in contents.lines() {
+    for line in contents.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -473,7 +522,7 @@ fn parse_conan_lock(json: &Value) -> Vec<Dependency> {
     if let Some(graph_lock) = json.get("graph_lock")
         && let Some(nodes) = graph_lock.get("nodes").and_then(|n| n.as_object())
     {
-        for (_node_id, node_data) in nodes {
+        for (_node_id, node_data) in nodes.iter().take(MAX_ITERATION_COUNT) {
             if let Some(ref_str) = node_data.get("ref").and_then(|r| r.as_str())
                 && !ref_str.is_empty()
                 && ref_str != "conanfile"

--- a/src/parsers/dart.rs
+++ b/src/parsers/dart.rs
@@ -21,10 +21,10 @@
 //! - Supports both pub.dev and Git-hosted packages
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use yaml_serde::{Mapping, Value};
 
@@ -33,6 +33,8 @@ use crate::models::{
 };
 
 use super::PackageParser;
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 const FIELD_NAME: &str = "name";
 const FIELD_VERSION: &str = "version";
@@ -115,23 +117,24 @@ impl PackageParser for PubspecLockParser {
 }
 
 fn read_yaml_file(path: &Path) -> Result<Value, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     yaml_serde::from_str(&content).map_err(|e| format!("Failed to parse YAML: {}", e))
 }
 
 fn parse_pubspec_yaml(yaml_content: &Value) -> PackageData {
-    let name = extract_string_field(yaml_content, FIELD_NAME);
-    let version = extract_string_field(yaml_content, FIELD_VERSION);
-    let description = extract_description_field(yaml_content);
-    let homepage_url = extract_string_field(yaml_content, FIELD_HOMEPAGE);
-    let raw_license = extract_string_field(yaml_content, FIELD_LICENSE);
-    let vcs_url = extract_string_field(yaml_content, FIELD_REPOSITORY);
-    let bug_tracking_url = extract_string_field(yaml_content, FIELD_ISSUE_TRACKER);
-    let archive_url = extract_string_field(yaml_content, FIELD_ARCHIVE_URL);
+    let name = extract_string_field(yaml_content, FIELD_NAME).map(truncate_field);
+    let version = extract_string_field(yaml_content, FIELD_VERSION).map(truncate_field);
+    let description = extract_description_field(yaml_content).map(truncate_field);
+    let homepage_url = extract_string_field(yaml_content, FIELD_HOMEPAGE).map(truncate_field);
+    let raw_license = extract_string_field(yaml_content, FIELD_LICENSE).map(truncate_field);
+    let vcs_url = extract_string_field(yaml_content, FIELD_REPOSITORY).map(truncate_field);
+    let bug_tracking_url =
+        extract_string_field(yaml_content, FIELD_ISSUE_TRACKER).map(truncate_field);
+    let archive_url = extract_string_field(yaml_content, FIELD_ARCHIVE_URL).map(truncate_field);
 
     let parties = extract_authors(yaml_content);
 
-    // Extract license statement only - detection happens in separate engine
     let declared_license_expression = None;
     let declared_license_expression_spdx = None;
     let license_detections = Vec::new();
@@ -173,23 +176,24 @@ fn parse_pubspec_yaml(yaml_content: &Value) -> PackageData {
 
     let purl = name
         .as_ref()
-        .and_then(|name| build_purl(name, version.as_deref()));
+        .and_then(|name| build_purl(name, version.as_deref()))
+        .map(truncate_field);
 
     let (api_data_url, repository_homepage_url, repository_download_url) =
         if let (Some(name_val), Some(version_val)) = (&name, &version) {
             (
-                Some(format!(
+                Some(truncate_field(format!(
                     "https://pub.dev/api/packages/{}/versions/{}",
                     name_val, version_val
-                )),
-                Some(format!(
+                ))),
+                Some(truncate_field(format!(
                     "https://pub.dev/packages/{}/versions/{}",
                     name_val, version_val
-                )),
-                Some(format!(
+                ))),
+                Some(truncate_field(format!(
                     "https://pub.dartlang.org/packages/{}/versions/{}.tar.gz",
                     name_val, version_val
-                )),
+                ))),
             )
         } else {
             (None, None, None)
@@ -259,12 +263,12 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
     if let Some(sdks) = lock_data.get(FIELD_SDKS).and_then(Value::as_mapping) {
-        for (name_value, version_value) in sdks {
+        for (name_value, version_value) in sdks.iter().take(MAX_ITERATION_COUNT) {
             if let (Some(name), Some(version_str)) = (name_value.as_str(), version_value.as_str()) {
-                let purl = build_dependency_purl(name, None);
+                let purl = build_dependency_purl(name, None).map(truncate_field);
                 dependencies.push(Dependency {
                     purl,
-                    extracted_requirement: Some(version_str.to_string()),
+                    extracted_requirement: Some(truncate_field(version_str.to_string())),
                     scope: Some("sdk".to_string()),
                     is_runtime: Some(true),
                     is_optional: Some(false),
@@ -276,10 +280,10 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
             }
         }
     } else if let Some(version_str) = lock_data.get(FIELD_SDK).and_then(Value::as_str) {
-        let purl = build_dependency_purl("dart", None);
+        let purl = build_dependency_purl("dart", None).map(truncate_field);
         dependencies.push(Dependency {
             purl,
-            extracted_requirement: Some(version_str.to_string()),
+            extracted_requirement: Some(truncate_field(version_str.to_string())),
             scope: Some("sdk".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -298,7 +302,7 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
         reachable_lock_packages(packages, &["direct main", "direct overridden"]);
     let dev_only_reachable = reachable_lock_packages(packages, &["direct dev"]);
 
-    for (name_value, details_value) in packages {
+    for (name_value, details_value) in packages.iter().take(MAX_ITERATION_COUNT) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
@@ -309,10 +313,10 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
 
         let version = mapping_get(details, FIELD_VERSION)
             .and_then(Value::as_str)
-            .map(|value| value.to_string());
+            .map(|value| truncate_field(value.to_string()));
         let dependency_kind = mapping_get(details, FIELD_DEPENDENCY)
             .and_then(Value::as_str)
-            .map(|value| value.to_string());
+            .map(|value| truncate_field(value.to_string()));
         let (is_runtime, is_optional, is_direct) = classify_lock_dependency(
             name,
             dependency_kind.as_deref(),
@@ -324,7 +328,7 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
             .as_ref()
             .is_some_and(|value| !value.trim().is_empty());
 
-        let purl = build_dependency_purl(name, version.as_deref());
+        let purl = build_dependency_purl(name, version.as_deref()).map(truncate_field);
         let sha256 = extract_sha256(details).and_then(|h| Sha256Digest::from_hex(&h).ok());
         let resolved_dependencies = extract_lock_package_dependencies(details);
         let resolved_package = build_resolved_package(
@@ -337,7 +341,7 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
 
         dependencies.push(Dependency {
             purl,
-            extracted_requirement: version.clone(),
+            extracted_requirement: version.clone().map(truncate_field),
             scope: dependency_kind,
             is_runtime: Some(is_runtime),
             is_optional: Some(is_optional),
@@ -358,7 +362,7 @@ fn extract_lock_package_dependencies(details: &Mapping) -> Vec<Dependency> {
         return dependencies;
     };
 
-    for (name_value, requirement_value) in dep_map {
+    for (name_value, requirement_value) in dep_map.iter().take(MAX_ITERATION_COUNT) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
@@ -376,8 +380,8 @@ fn extract_lock_package_dependencies(details: &Mapping) -> Vec<Dependency> {
         };
 
         dependencies.push(Dependency {
-            purl,
-            extracted_requirement: Some(requirement),
+            purl: purl.map(truncate_field),
+            extracted_requirement: Some(truncate_field(requirement)),
             scope: Some(FIELD_DEPENDENCIES.to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),
@@ -432,8 +436,8 @@ fn build_resolved_package(
         ..ResolvedPackage::new(
             PubspecLockParser::PACKAGE_TYPE,
             String::new(),
-            name.to_string(),
-            version.clone().unwrap_or_default(),
+            truncate_field(name.to_string()),
+            truncate_field(version.clone().unwrap_or_default()),
         )
     }
 }
@@ -451,12 +455,12 @@ fn collect_dependencies(
         return dependencies;
     };
 
-    for (name_value, requirement_value) in dep_map {
+    for (name_value, requirement_value) in dep_map.iter().take(MAX_ITERATION_COUNT) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
         };
-        let requirement = dependency_requirement_from_value(requirement_value);
+        let requirement = dependency_requirement_from_value(requirement_value).map(truncate_field);
         let is_pinned = requirement
             .as_deref()
             .is_some_and(is_pubspec_version_pinned);
@@ -467,7 +471,7 @@ fn collect_dependencies(
         };
 
         dependencies.push(Dependency {
-            purl,
+            purl: purl.map(truncate_field),
             extracted_requirement: requirement,
             scope: scope.map(|value| value.to_string()),
             is_runtime: Some(is_runtime),
@@ -500,16 +504,21 @@ fn dependency_requirement_from_value(value: &Value) -> Option<String> {
     }
 
     if let Some(map) = value.as_mapping() {
-        return format_dependency_mapping(map);
+        return format_dependency_mapping(map, 0);
     }
 
     None
 }
 
-fn format_dependency_mapping(map: &Mapping) -> Option<String> {
+fn format_dependency_mapping(map: &Mapping, depth: usize) -> Option<String> {
+    if depth >= MAX_RECURSION_DEPTH {
+        warn!("Recursion depth exceeded in format_dependency_mapping");
+        return None;
+    }
+
     let mut parts = Vec::new();
 
-    for (key, value) in map {
+    for (key, value) in map.iter().take(MAX_ITERATION_COUNT) {
         let Some(key_str) = key.as_str() else {
             continue;
         };
@@ -521,7 +530,7 @@ fn format_dependency_mapping(map: &Mapping) -> Option<String> {
         } else if let Some(value) = value.as_f64() {
             value.to_string()
         } else if let Some(nested) = value.as_mapping() {
-            format_dependency_mapping(nested)?
+            format_dependency_mapping(nested, depth + 1)?
         } else {
             continue;
         };
@@ -625,7 +634,7 @@ fn extract_authors(yaml_content: &Value) -> Vec<crate::models::Party> {
     use crate::models::Party;
     let mut parties = Vec::new();
 
-    if let Some(author) = extract_string_field(yaml_content, FIELD_AUTHOR) {
+    if let Some(author) = extract_string_field(yaml_content, FIELD_AUTHOR).map(truncate_field) {
         parties.push(Party {
             r#type: None,
             role: Some("author".to_string()),
@@ -641,12 +650,12 @@ fn extract_authors(yaml_content: &Value) -> Vec<crate::models::Party> {
     if let Some(authors_value) = yaml_content.get(FIELD_AUTHORS)
         && let Some(authors_array) = authors_value.as_sequence()
     {
-        for author_value in authors_array {
+        for author_value in authors_array.iter().take(MAX_ITERATION_COUNT) {
             if let Some(author_str) = author_value.as_str() {
                 parties.push(Party {
                     r#type: None,
                     role: Some("author".to_string()),
-                    name: Some(author_str.to_string()),
+                    name: Some(truncate_field(author_str.to_string())),
                     email: None,
                     url: None,
                     organization: None,
@@ -725,7 +734,7 @@ fn extract_string_list_field(yaml_content: &Value, field: &str) -> Vec<String> {
         .filter_map(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(|value| value.to_string())
+        .map(|value| truncate_field(value.to_string()))
         .collect()
 }
 
@@ -770,8 +779,9 @@ fn extract_lock_descriptor_extra_data(
 fn reachable_lock_packages(packages: &Mapping, roots: &[&str]) -> HashSet<String> {
     let mut reachable = HashSet::new();
     let mut queue = VecDeque::new();
+    let mut iterations = 0usize;
 
-    for (name_value, details_value) in packages {
+    for (name_value, details_value) in packages.iter().take(MAX_ITERATION_COUNT) {
         let Some(name) = name_value.as_str() else {
             continue;
         };
@@ -780,11 +790,17 @@ fn reachable_lock_packages(packages: &Mapping, roots: &[&str]) -> HashSet<String
         };
         let kind = mapping_get(details, FIELD_DEPENDENCY).and_then(Value::as_str);
         if roots.contains(&kind.unwrap_or_default()) {
-            queue.push_back(name.to_string());
+            queue.push_back(truncate_field(name.to_string()));
         }
     }
 
     while let Some(current) = queue.pop_front() {
+        if iterations >= MAX_ITERATION_COUNT {
+            warn!("Iteration count exceeded in reachable_lock_packages BFS");
+            break;
+        }
+        iterations += 1;
+
         if !reachable.insert(current.clone()) {
             continue;
         }
@@ -800,8 +816,12 @@ fn reachable_lock_packages(packages: &Mapping, roots: &[&str]) -> HashSet<String
             continue;
         };
 
-        for dep_name in dep_map.keys().filter_map(Value::as_str) {
-            queue.push_back(dep_name.to_string());
+        for dep_name in dep_map
+            .keys()
+            .filter_map(Value::as_str)
+            .take(MAX_ITERATION_COUNT)
+        {
+            queue.push_back(truncate_field(dep_name.to_string()));
         }
     }
 

--- a/src/parsers/deno.rs
+++ b/src/parsers/deno.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
 use url::Url;
@@ -34,7 +34,7 @@ impl PackageParser for DenoParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match crate::parsers::utils::read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read Deno config at {:?}: {}", path, e);
@@ -61,12 +61,12 @@ fn parse_deno_config(json: &Value) -> PackageData {
         .map(split_package_identity)
         .map(|(namespace, name)| {
             (
-                namespace.map(|value| value.to_string()),
-                Some(name.to_string()),
+                namespace.map(|value| truncate_field(value.to_string())),
+                Some(truncate_field(name.to_string())),
             )
         })
         .unwrap_or((None, None));
-    let version = extract_non_empty_string(json, FIELD_VERSION);
+    let version = extract_non_empty_string(json, FIELD_VERSION).map(truncate_field);
     let dependencies = extract_import_dependencies(json);
     let extra_data = extract_extra_data(json);
     let purl = match (namespace.as_deref(), name.as_deref(), version.as_deref()) {
@@ -116,7 +116,7 @@ fn parse_deno_config(json: &Value) -> PackageData {
         repository_download_url: None,
         api_data_url: None,
         datasource_id: Some(DatasourceId::DenoJson),
-        purl,
+        purl: purl.map(truncate_field),
     }
 }
 
@@ -125,6 +125,7 @@ fn extract_import_dependencies(json: &Value) -> Vec<Dependency> {
         .and_then(Value::as_object)
         .into_iter()
         .flatten()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(alias, value)| {
             value
                 .as_str()
@@ -150,8 +151,8 @@ fn build_import_dependency(alias: &str, specifier: &str) -> Dependency {
     };
 
     Dependency {
-        purl,
-        extracted_requirement: Some(specifier.to_string()),
+        purl: purl.map(truncate_field),
+        extracted_requirement: Some(truncate_field(specifier.to_string())),
         scope: Some("imports".to_string()),
         is_runtime: Some(true),
         is_optional: Some(false),
@@ -159,8 +160,8 @@ fn build_import_dependency(alias: &str, specifier: &str) -> Dependency {
         is_direct: Some(true),
         resolved_package: None,
         extra_data: Some(HashMap::from([(
-            "import_alias".to_string(),
-            Value::String(alias.to_string()),
+            truncate_field("import_alias".to_string()),
+            Value::String(truncate_field(alias.to_string())),
         )])),
     }
 }


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: deno, dart, conan, cargo_lock, bun_lock
- Replace `fs::read_to_string`/`File::open`+`read_to_string` with `read_file_to_string(path, None)` (P2-FileSize + P4-FileExists + P4-UTF8)
- Add `MAX_ITERATION_COUNT` caps on loops (P2-Iteration)
- Apply `truncate_field()` to extracted string values (P2-StringLength)
- Add `MAX_RECURSION_DEPTH=50` to recursive functions in dart and conan (P2-Recursion)

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` passes with 0 warnings
- [x] `cargo fmt` passes
- [x] Pre-commit hooks pass