### PR TITLE
fix(parsers): ADR 0004 security compliance for buck, bower, arch, windows_executable, swift_resolved

### DIFF
--- a/src/parsers/arch.rs
+++ b/src/parsers/arch.rs
@@ -6,7 +6,9 @@ use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -79,7 +81,7 @@ type MultiMap = HashMap<String, Vec<String>>;
 fn parse_key_value_lines(content: &str) -> MultiMap {
     let mut fields: MultiMap = HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -92,7 +94,7 @@ fn parse_key_value_lines(content: &str) -> MultiMap {
                 fields
                     .entry(key.to_string())
                     .or_default()
-                    .push(value.to_string());
+                    .push(truncate_field(value.to_string()));
             }
         }
     }
@@ -105,7 +107,7 @@ fn parse_srcinfo_like(content: &str, datasource_id: DatasourceId) -> Vec<Package
     let mut packages: Vec<MultiMap> = Vec::new();
     let mut current_is_pkgbase = true;
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -122,13 +124,16 @@ fn parse_srcinfo_like(content: &str, datasource_id: DatasourceId) -> Vec<Package
             pkgbase
                 .entry(key.to_string())
                 .or_default()
-                .push(value.to_string());
+                .push(truncate_field(value.to_string()));
             current_is_pkgbase = true;
             continue;
         }
 
         if key == "pkgname" {
-            packages.push(HashMap::from([(key.to_string(), vec![value.to_string()])]));
+            packages.push(HashMap::from([(
+                key.to_string(),
+                vec![truncate_field(value.to_string())],
+            )]));
             current_is_pkgbase = false;
             continue;
         }
@@ -142,7 +147,7 @@ fn parse_srcinfo_like(content: &str, datasource_id: DatasourceId) -> Vec<Package
         target
             .entry(key.to_string())
             .or_default()
-            .push(value.to_string());
+            .push(truncate_field(value.to_string()));
     }
 
     if packages.is_empty() {
@@ -272,29 +277,29 @@ fn build_package_from_arch_metadata(
     let purl_arch = (arch_values.len() == 1).then(|| arch_values[0].as_str());
 
     let mut package = default_package_data(datasource_id);
-    package.name = name.clone();
-    package.version = version.clone();
-    package.description = description;
-    package.homepage_url = homepage_url;
-    package.extracted_license_statement = extracted_license_statement;
+    package.name = name.map(truncate_field);
+    package.version = version.map(truncate_field);
+    package.description = description.map(truncate_field);
+    package.homepage_url = homepage_url.map(truncate_field);
+    package.extracted_license_statement = extracted_license_statement.map(truncate_field);
     package.primary_language = None;
-    package.purl = name
+    package.purl = package
+        .name
         .as_deref()
-        .and_then(|name| build_alpm_purl(name, version.as_deref(), purl_arch));
+        .and_then(|name| build_alpm_purl(name, package.version.as_deref(), purl_arch));
     package.source_packages = pkgbase
-        .as_deref()
-        .and_then(|base| build_alpm_purl(base, version.as_deref(), purl_arch))
+        .and_then(|base| build_alpm_purl(&base, package.version.as_deref(), purl_arch))
         .into_iter()
         .collect();
 
     if !is_srcinfo_like {
         if let Some(packager) = get_first(fields, "packager") {
-            let (name, email) = split_name_email(&packager);
+            let (packager_name, packager_email) = split_name_email(&packager);
             package.parties.push(Party {
                 r#type: Some("person".to_string()),
                 role: Some("packager".to_string()),
-                name,
-                email,
+                name: packager_name.map(truncate_field),
+                email: packager_email.map(truncate_field),
                 url: None,
                 organization: None,
                 organization_url: None,
@@ -348,16 +353,16 @@ fn build_dependencies(fields: &MultiMap) -> Vec<Dependency> {
     let mut keys: Vec<_> = fields.keys().cloned().collect();
     keys.sort();
 
-    for key in keys {
-        let Some((scope, is_runtime, is_optional)) = dependency_semantics(&key) else {
+    for key in keys.iter().take(MAX_ITERATION_COUNT) {
+        let Some((scope, is_runtime, is_optional)) = dependency_semantics(key) else {
             continue;
         };
 
-        for value in get_all(fields, &key) {
+        for value in get_all(fields, key) {
             if let Some(dep_name) = extract_arch_dependency_name(&value) {
                 dependencies.push(Dependency {
                     purl: build_alpm_purl(&dep_name, None, None),
-                    extracted_requirement: Some(value.clone()),
+                    extracted_requirement: Some(truncate_field(value.clone())),
                     scope: Some(scope.to_string()),
                     is_runtime: Some(is_runtime),
                     is_optional: Some(is_optional),
@@ -390,7 +395,7 @@ fn extract_arch_dependency_name(value: &str) -> Option<String> {
     let dep = value.split(':').next()?.trim();
     let end = dep.find(['<', '>', '=']).unwrap_or(dep.len());
     let name = dep[..end].trim();
-    (!name.is_empty()).then(|| name.to_string())
+    (!name.is_empty()).then(|| truncate_field(name.to_string()))
 }
 
 fn build_extra_data(
@@ -405,24 +410,36 @@ fn build_extra_data(
 
     let mut extra = HashMap::new();
 
-    for (key, values) in fields {
+    for (key, values) in fields.iter().take(MAX_ITERATION_COUNT) {
         if consumed.contains(key.as_str()) {
             continue;
         }
 
         let value = if should_force_array_extra_value(key) {
-            JsonValue::Array(values.iter().cloned().map(JsonValue::String).collect())
+            JsonValue::Array(
+                values
+                    .iter()
+                    .cloned()
+                    .map(|v| JsonValue::String(truncate_field(v)))
+                    .collect(),
+            )
         } else if values.len() == 1 {
             if key == "builddate" {
                 values[0]
                     .parse::<u64>()
                     .map(JsonValue::from)
-                    .unwrap_or_else(|_| JsonValue::String(values[0].clone()))
+                    .unwrap_or_else(|_| JsonValue::String(truncate_field(values[0].clone())))
             } else {
-                JsonValue::String(values[0].clone())
+                JsonValue::String(truncate_field(values[0].clone()))
             }
         } else {
-            JsonValue::Array(values.iter().cloned().map(JsonValue::String).collect())
+            JsonValue::Array(
+                values
+                    .iter()
+                    .cloned()
+                    .map(|v| JsonValue::String(truncate_field(v)))
+                    .collect(),
+            )
         };
         extra.insert(key.clone(), value);
     }
@@ -436,7 +453,10 @@ fn build_extra_data(
         && !extra.contains_key("arch")
         && let Some(arch) = purl_arch
     {
-        extra.insert("arch".to_string(), JsonValue::String(arch.to_string()));
+        extra.insert(
+            "arch".to_string(),
+            JsonValue::String(truncate_field(arch.to_string())),
+        );
     }
 
     (!extra.is_empty()).then_some(extra)

--- a/src/parsers/bower.rs
+++ b/src/parsers/bower.rs
@@ -21,9 +21,9 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
-use std::fs;
 use std::path::Path;
 
 use super::PackageParser;
@@ -65,7 +65,7 @@ impl PackageParser for BowerJsonParser {
         let name = json
             .get(FIELD_NAME)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         // If name is missing, the package is considered private
         let is_private = if name.is_none() {
@@ -79,22 +79,24 @@ impl PackageParser for BowerJsonParser {
         let version = json
             .get(FIELD_VERSION)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let description = json
             .get(FIELD_DESCRIPTION)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let extracted_license_statement = extract_license_statement(&json);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             normalize_bower_declared_license(&json, extracted_license_statement.as_deref());
+        let declared_license_expression = declared_license_expression.map(truncate_field);
+        let declared_license_expression_spdx = declared_license_expression_spdx.map(truncate_field);
         let keywords = extract_keywords(&json);
         let parties = extract_parties(&json);
         let homepage_url = json
             .get(FIELD_HOMEPAGE)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let vcs_url = extract_vcs_url(&json);
         let dependencies = extract_dependencies(&json, FIELD_DEPENDENCIES, "dependencies", true);
@@ -155,7 +157,8 @@ impl PackageParser for BowerJsonParser {
 
 /// Reads and parses a JSON file
 fn read_and_parse_json(path: &Path) -> Result<Value, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {}", e))
 }
 
@@ -169,12 +172,13 @@ fn extract_license_statement(json: &Value) -> Option<String> {
                 if trimmed.is_empty() {
                     None
                 } else {
-                    Some(trimmed.to_string())
+                    Some(truncate_field(trimmed.to_string()))
                 }
             }
             Value::Array(licenses) => {
                 let license_strings: Vec<String> = licenses
                     .iter()
+                    .take(MAX_ITERATION_COUNT)
                     .filter_map(|v| v.as_str())
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
@@ -184,7 +188,7 @@ fn extract_license_statement(json: &Value) -> Option<String> {
                 if license_strings.is_empty() {
                     None
                 } else {
-                    Some(license_strings.join(" AND "))
+                    Some(truncate_field(license_strings.join(" AND ")))
                 }
             }
             _ => None,
@@ -203,6 +207,7 @@ fn normalize_bower_declared_license(
         Some(Value::Array(licenses)) => {
             let normalized = licenses
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| value.as_str().map(str::trim))
                 .filter(|value| !value.is_empty())
                 .map(normalize_declared_license_key)
@@ -231,8 +236,9 @@ fn extract_keywords(json: &Value) -> Vec<String> {
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|v| v.as_str())
-                .map(String::from)
+                .map(|s| truncate_field(s.to_string()))
                 .collect()
         })
         .unwrap_or_default()
@@ -244,7 +250,7 @@ fn extract_parties(json: &Value) -> Vec<Party> {
     let mut parties = Vec::new();
 
     if let Some(authors) = json.get(FIELD_AUTHORS).and_then(|v| v.as_array()) {
-        for author in authors {
+        for author in authors.iter().take(MAX_ITERATION_COUNT) {
             if let Some(party) = extract_party_from_author(author) {
                 parties.push(party);
             }
@@ -258,13 +264,12 @@ fn extract_parties(json: &Value) -> Vec<Party> {
 fn extract_party_from_author(author: &Value) -> Option<Party> {
     match author {
         Value::String(s) => {
-            // Parse "Name <email>" format
             let (name, email) = parse_author_string(s);
             Some(Party {
                 r#type: Some("person".to_string()),
                 role: Some("author".to_string()),
-                name,
-                email,
+                name: name.map(truncate_field),
+                email: email.map(truncate_field),
                 url: None,
                 organization: None,
                 organization_url: None,
@@ -272,12 +277,18 @@ fn extract_party_from_author(author: &Value) -> Option<Party> {
             })
         }
         Value::Object(obj) => {
-            let name = obj.get("name").and_then(|v| v.as_str()).map(String::from);
-            let email = obj.get("email").and_then(|v| v.as_str()).map(String::from);
+            let name = obj
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_field(s.to_string()));
+            let email = obj
+                .get("email")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_field(s.to_string()));
             let url = obj
                 .get("homepage")
                 .and_then(|v| v.as_str())
-                .map(String::from);
+                .map(|s| truncate_field(s.to_string()));
 
             Some(Party {
                 r#type: Some("person".to_string()),
@@ -290,19 +301,16 @@ fn extract_party_from_author(author: &Value) -> Option<Party> {
                 timezone: None,
             })
         }
-        _ => {
-            // Handle other types by converting to string representation
-            Some(Party {
-                r#type: Some("person".to_string()),
-                role: Some("author".to_string()),
-                name: Some(format!("{:?}", author)),
-                email: None,
-                url: None,
-                organization: None,
-                organization_url: None,
-                timezone: None,
-            })
-        }
+        _ => Some(Party {
+            r#type: Some("person".to_string()),
+            role: Some("author".to_string()),
+            name: Some(truncate_field(format!("{:?}", author))),
+            email: None,
+            url: None,
+            organization: None,
+            organization_url: None,
+            timezone: None,
+        }),
     }
 }
 
@@ -319,23 +327,22 @@ fn parse_author_string(author_str: &str) -> (Option<String>, Option<String>) {
         let name = if name.is_empty() {
             None
         } else {
-            Some(name.to_string())
+            Some(truncate_field(name.to_string()))
         };
         let email = if email.is_empty() {
             None
         } else {
-            Some(email.to_string())
+            Some(truncate_field(email.to_string()))
         };
 
         return (name, email);
     }
 
-    // No email found, return entire string as name
     let trimmed = author_str.trim();
     if trimmed.is_empty() {
         (None, None)
     } else {
-        (Some(trimmed.to_string()), None)
+        (Some(truncate_field(trimmed.to_string())), None)
     }
 }
 
@@ -349,7 +356,7 @@ fn extract_vcs_url(json: &Value) -> Option<String> {
 
             match (repo_type, repo_url) {
                 (Some(t), Some(u)) if !t.is_empty() && !u.is_empty() => {
-                    Some(format!("{}+{}", t, u))
+                    Some(truncate_field(format!("{}+{}", t, u)))
                 }
                 _ => None,
             }
@@ -370,14 +377,15 @@ fn extract_dependencies(
         .and_then(|deps| deps.as_object())
         .map_or_else(Vec::new, |deps| {
             deps.iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|(name, requirement)| {
                     let requirement_str = requirement.as_str()?;
                     let package_url =
                         PackageUrl::new(BowerJsonParser::PACKAGE_TYPE.as_str(), name).ok()?;
 
                     Some(Dependency {
-                        purl: Some(package_url.to_string()),
-                        extracted_requirement: Some(requirement_str.to_string()),
+                        purl: Some(truncate_field(package_url.to_string())),
+                        extracted_requirement: Some(truncate_field(requirement_str.to_string())),
                         scope: Some(scope.to_string()),
                         is_runtime: Some(is_runtime),
                         is_optional: Some(!is_runtime),

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use starlark_syntax::syntax::ast;
 use starlark_syntax::syntax::module::AstModuleFields;
@@ -88,13 +89,15 @@ impl PackageParser for BuckMetadataBzlParser {
 
 /// Parse a Buck BUCK file (same logic as Bazel BUILD)
 fn parse_buck_build(path: &Path) -> Result<Vec<PackageData>, String> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     let module = parse_starlark_module("<BUCK>", content)?;
 
     let mut packages = Vec::new();
 
-    for statement in top_level_statements(&module) {
+    for statement in top_level_statements(&module)
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         if let Some(package_data) = extract_build_package_from_statement(statement) {
             packages.push(package_data);
         }
@@ -105,12 +108,13 @@ fn parse_buck_build(path: &Path) -> Result<Vec<PackageData>, String> {
 
 /// Parse a Buck METADATA.bzl file
 fn parse_metadata_bzl(path: &Path) -> Result<PackageData, String> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     let module = parse_starlark_module("<METADATA.bzl>", content)?;
 
-    // Look for METADATA = {...} assignment
-    for statement in top_level_statements(&module) {
+    for statement in top_level_statements(&module)
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+    {
         if let Some(dict) = extract_metadata_assignment_dict(statement) {
             return Ok(extract_metadata_dict(dict));
         }
@@ -202,7 +206,7 @@ fn extract_metadata_assignment_dict(
 fn extract_metadata_dict(dict: &[(ast::AstExpr, ast::AstExpr)]) -> PackageData {
     let mut fields: HashMap<String, MetadataValue> = HashMap::new();
 
-    for (key, value) in dict {
+    for (key, value) in dict.iter().take(MAX_ITERATION_COUNT) {
         let Some(key_name) = expr_as_string(key) else {
             continue;
         };
@@ -312,17 +316,17 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
 
     // Extract name
     if let Some(name) = get_metadata_string(&fields, &["name"]) {
-        pkg.name = Some(name);
+        pkg.name = Some(truncate_field(name));
     }
 
     // Extract version
     if let Some(version) = get_metadata_string(&fields, &["version"]) {
-        pkg.version = Some(version);
+        pkg.version = Some(truncate_field(version));
     }
 
     // Extract namespace from explicit metadata when present.
     if let Some(namespace) = get_metadata_string(&fields, &["namespace"]) {
-        pkg.namespace = Some(namespace);
+        pkg.namespace = Some(truncate_field(namespace));
     }
 
     // Extract package type from canonical or legacy ecosystem fields.
@@ -344,17 +348,17 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
         } else {
             None
         };
-        pkg.extracted_license_statement = extracted_license_statement;
+        pkg.extracted_license_statement = extracted_license_statement.map(truncate_field);
     } else if let Some(license_expression) = get_metadata_string(&fields, &["license_expression"]) {
-        pkg.extracted_license_statement = Some(license_expression);
+        pkg.extracted_license_statement = Some(truncate_field(license_expression));
     }
 
     if let Some(copyright) = get_metadata_list(&fields, &["copyrights"]) {
         if !copyright.is_empty() {
-            pkg.copyright = Some(copyright.join("\n"));
+            pkg.copyright = Some(truncate_field(copyright.join("\n")));
         }
     } else if let Some(copyright) = get_metadata_string(&fields, &["copyright"]) {
-        pkg.copyright = Some(copyright);
+        pkg.copyright = Some(truncate_field(copyright));
     }
 
     // Extract homepage (upstream_address, upstream_url, or homepage_url)
@@ -362,17 +366,17 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
         &fields,
         &["upstream_address", "upstream_url", "homepage_url"],
     ) {
-        pkg.homepage_url = Some(homepage_url);
+        pkg.homepage_url = Some(truncate_field(homepage_url));
     }
 
     // Extract download_url
     if let Some(download_url) = get_metadata_string(&fields, &["download_url"]) {
-        pkg.download_url = Some(download_url);
+        pkg.download_url = Some(truncate_field(download_url));
     }
 
     // Extract vcs_url
     if let Some(vcs_url) = get_metadata_string(&fields, &["vcs_url"]) {
-        pkg.vcs_url = Some(vcs_url);
+        pkg.vcs_url = Some(truncate_field(vcs_url));
     }
 
     // Extract sha1 (download_archive_sha1)
@@ -438,18 +442,17 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
     if let Some(purl_str) = get_metadata_string(&fields, &["package_url"])
         && let Ok(purl) = purl_str.parse::<PackageUrl>()
     {
-        pkg.purl = Some(purl.to_string());
+        pkg.purl = Some(truncate_field(purl.to_string()));
 
-        // Override package fields with purl data
         if let Ok(package_type) = purl.ty().parse::<PackageType>() {
             pkg.package_type = Some(package_type);
         }
         if let Some(ns) = purl.namespace() {
-            pkg.namespace = Some(ns.to_string());
+            pkg.namespace = Some(truncate_field(ns.to_string()));
         }
-        pkg.name = Some(purl.name().to_string());
+        pkg.name = Some(truncate_field(purl.name().to_string()));
         if let Some(ver) = purl.version() {
-            pkg.version = Some(ver.to_string());
+            pkg.version = Some(truncate_field(ver.to_string()));
         }
         // Qualifiers
         if !purl.qualifiers().is_empty() {
@@ -478,7 +481,11 @@ fn metadata_value_from_expr(expr: &ast::AstExpr) -> Option<MetadataValue> {
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
-    let values: Vec<_> = items.iter().filter_map(expr_as_string).collect();
+    let values: Vec<_> = items
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(expr_as_string)
+        .collect();
     (!values.is_empty()).then_some(MetadataValue::List(values))
 }
 
@@ -503,9 +510,9 @@ fn extract_build_package_from_statement(statement: &ast::AstStmt) -> Option<Pack
         .map(split_buck_license_values)
         .unwrap_or_default();
     let extracted_license_statement = if !license_statements.is_empty() {
-        Some(license_statements.join(", "))
+        Some(truncate_field(license_statements.join(", ")))
     } else if !license_references.is_empty() {
-        Some(license_references.join(", "))
+        Some(truncate_field(license_references.join(", ")))
     } else {
         None
     };
@@ -514,7 +521,7 @@ fn extract_build_package_from_statement(statement: &ast::AstStmt) -> Option<Pack
 
     Some(PackageData {
         package_type: Some(BuckBuildParser::PACKAGE_TYPE),
-        name: Some(package_name),
+        name: Some(truncate_field(package_name)),
         extracted_license_statement,
         extra_data: (!extra_data.is_empty()).then_some(extra_data),
         datasource_id: Some(DatasourceId::BuckFile),
@@ -557,7 +564,11 @@ fn extract_named_kwarg_string_list(call: &StarlarkCall<'_>, key: &str) -> Option
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
-    let values: Vec<_> = items.iter().filter_map(expr_as_string).collect();
+    let values: Vec<_> = items
+        .iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(expr_as_string)
+        .collect();
     (!values.is_empty()).then_some(values)
 }
 

--- a/src/parsers/swift_resolved.rs
+++ b/src/parsers/swift_resolved.rs
@@ -4,8 +4,6 @@
 //! - **v1**: Pins under `object.pins[]`, uses `package` and `repositoryURL` fields
 //! - **v2/v3**: Pins under `pins[]`, uses `identity`, `location`, and `kind` fields
 
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -15,6 +13,7 @@ use url::Url;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::PackageParser;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Parses Swift Package Manager lockfiles (Package.resolved).
 ///
@@ -174,15 +173,21 @@ fn parse_resolved(path: &Path) -> Result<PackageData, String> {
 }
 
 fn parse_v2_v3_pins(pins: &[PinV2]) -> Vec<Dependency> {
-    pins.iter().filter_map(pin_v2_to_dependency).collect()
+    pins.iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(pin_v2_to_dependency)
+        .collect()
 }
 
 fn parse_v1_pins(pins: &[PinV1]) -> Vec<Dependency> {
-    pins.iter().filter_map(pin_v1_to_dependency).collect()
+    pins.iter()
+        .take(MAX_ITERATION_COUNT)
+        .filter_map(pin_v1_to_dependency)
+        .collect()
 }
 
 fn pin_v2_to_dependency(pin: &PinV2) -> Option<Dependency> {
-    let mut name = pin.identity.clone();
+    let mut name = pin.identity.clone().map(truncate_field);
     let mut namespace: Option<String> = None;
 
     if let Some(location) = &pin.location
@@ -199,12 +204,13 @@ fn pin_v2_to_dependency(pin: &PinV2) -> Option<Dependency> {
         .state
         .version
         .clone()
-        .or_else(|| pin.state.revision.clone());
+        .or_else(|| pin.state.revision.clone())
+        .map(truncate_field);
 
     let purl = build_purl(&name, namespace.as_deref(), version.as_deref());
 
     Some(Dependency {
-        purl,
+        purl: purl.map(truncate_field),
         extracted_requirement: version,
         scope: Some("dependencies".to_string()),
         is_runtime: None,
@@ -217,7 +223,7 @@ fn pin_v2_to_dependency(pin: &PinV2) -> Option<Dependency> {
 }
 
 fn pin_v1_to_dependency(pin: &PinV1) -> Option<Dependency> {
-    let mut name = pin.package.clone();
+    let mut name = pin.package.clone().map(truncate_field);
     let mut namespace: Option<String> = None;
 
     if let Some(url) = &pin.repository_url
@@ -233,12 +239,13 @@ fn pin_v1_to_dependency(pin: &PinV1) -> Option<Dependency> {
         .state
         .version
         .clone()
-        .or_else(|| pin.state.revision.clone());
+        .or_else(|| pin.state.revision.clone())
+        .map(truncate_field);
 
     let purl = build_purl(&name, namespace.as_deref(), version.as_deref());
 
     Some(Dependency {
-        purl,
+        purl: purl.map(truncate_field),
         extracted_requirement: version,
         scope: Some("dependencies".to_string()),
         is_runtime: None,
@@ -268,7 +275,10 @@ fn get_namespace_and_name(url: &str) -> Option<(String, String)> {
         return None;
     }
 
-    Some((ns.to_string(), name.to_string()))
+    Some((
+        truncate_field(ns.to_string()),
+        truncate_field(name.to_string()),
+    ))
 }
 
 fn build_purl(name: &str, namespace: Option<&str>, version: Option<&str>) -> Option<String> {
@@ -283,11 +293,7 @@ fn build_purl(name: &str, namespace: Option<&str>, version: Option<&str>) -> Opt
 }
 
 fn read_file(path: &Path) -> Result<String, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
-    Ok(content)
+    read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))
 }
 
 fn default_package_data() -> PackageData {

--- a/src/parsers/windows_executable.rs
+++ b/src/parsers/windows_executable.rs
@@ -9,12 +9,14 @@ use object::read::FileKind;
 use packageurl::PackageUrl;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
+use crate::parser_warn as warn;
 use crate::register_parser;
 
 use super::ParsePackagesResult;
 use super::license_normalization::{
     detect_declared_license_from_text, normalize_spdx_declared_license,
 };
+use super::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 register_parser!(
     "Windows PE executable with VERSIONINFO package metadata",
@@ -346,8 +348,17 @@ fn find_utf16_version_value(text: &str, key: &str) -> Option<String> {
 }
 
 fn iter_version_blocks(mut bytes: &[u8]) -> impl Iterator<Item = Option<VersionBlock<'_>>> + '_ {
+    let mut count = 0usize;
     std::iter::from_fn(move || {
         if bytes.is_empty() {
+            return None;
+        }
+
+        count += 1;
+        if count > MAX_ITERATION_COUNT {
+            warn!(
+                "iter_version_blocks exceeded MAX_ITERATION_COUNT ({MAX_ITERATION_COUNT}), stopping iteration"
+            );
             return None;
         }
 
@@ -428,7 +439,17 @@ fn decode_utf16_bytes(bytes: &[u8]) -> Option<String> {
         .chunks_exact(2)
         .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
         .collect::<Vec<_>>();
-    String::from_utf16(&units).ok()
+    match String::from_utf16(&units) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!("decode_utf16_bytes: invalid UTF-16 sequence, using lossy conversion: {e}");
+            Some(
+                char::decode_utf16(units)
+                    .map(|r| r.unwrap_or('\u{FFFD}'))
+                    .collect(),
+            )
+        }
+    }
 }
 
 fn align_to_4(offset: usize) -> usize {
@@ -448,7 +469,7 @@ fn build_windows_executable_package(
         fallback,
         &["ProductName", "OriginalFilename", "InternalName"],
     )
-    .map(trim_windows_executable_name);
+    .map(|v| truncate_field(trim_windows_executable_name(v)));
     let version = preferred_string_with_fallback(
         strings,
         fallback,
@@ -464,11 +485,12 @@ fn build_windows_executable_package(
             .fixed
             .as_ref()
             .and_then(|fixed| fixed.product_version.clone())
-    });
+    })
+    .map(truncate_field);
 
     let name = name
         .filter(|value| !value.is_empty())
-        .or_else(|| fallback_windows_executable_name(path))?;
+        .or_else(|| fallback_windows_executable_name(path).map(truncate_field))?;
 
     let mut package = PackageData {
         package_type: Some(PackageType::Winexe),
@@ -479,14 +501,17 @@ fn build_windows_executable_package(
             strings,
             fallback,
             &["FileDescription", "Comments"],
-        ),
-        homepage_url: preferred_string_with_fallback(strings, fallback, &["URL", "WWW"]),
-        purl: create_winexe_purl(&name, version.as_deref()),
+        )
+        .map(truncate_field),
+        homepage_url: preferred_string_with_fallback(strings, fallback, &["URL", "WWW"])
+            .map(truncate_field),
+        purl: create_winexe_purl(&name, version.as_deref()).map(truncate_field),
         ..Default::default()
     };
 
     if let Some(company_name) =
         preferred_string_with_fallback(strings, fallback, &["CompanyName", "Company"])
+            .map(truncate_field)
     {
         package.parties.push(Party {
             r#type: Some("organization".to_string()),
@@ -500,7 +525,8 @@ fn build_windows_executable_package(
         });
     }
 
-    let license_statement = windows_license_statement_with_fallback(strings, fallback);
+    let license_statement =
+        windows_license_statement_with_fallback(strings, fallback).map(truncate_field);
     let normalizable_license = windows_normalizable_license_text_with_fallback(strings, fallback);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         normalize_spdx_declared_license(normalizable_license.as_deref());
@@ -508,12 +534,14 @@ fn build_windows_executable_package(
     package.declared_license_expression = declared_license_expression;
     package.declared_license_expression_spdx = declared_license_expression_spdx;
     package.license_detections = license_detections;
-    package.copyright = preferred_string_with_fallback(strings, fallback, &["LegalCopyright"]);
+    package.copyright =
+        preferred_string_with_fallback(strings, fallback, &["LegalCopyright"]).map(truncate_field);
     package.holder = package
         .copyright
         .as_deref()
         .map(extract_windows_holder)
-        .filter(|value| !value.is_empty());
+        .filter(|value| !value.is_empty())
+        .map(truncate_field);
 
     merge_sibling_license_text(path, &mut package);
 
@@ -527,7 +555,7 @@ fn build_windows_executable_fallback(path: &Path) -> Option<PackageData> {
         package_type: Some(PackageType::Winexe),
         datasource_id: Some(DatasourceId::WindowsExecutable),
         name: Some(name.clone()),
-        purl: create_winexe_purl(&name, None),
+        purl: create_winexe_purl(&name, None).map(truncate_field),
         ..Default::default()
     })
 }


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: buck, bower, arch, windows_executable, swift_resolved
- Replace `fs::read_to_string`/`File::open`+`read_to_string` with `read_file_to_string(path, None)` (P2-FileSize + P4-FileExists + P4-UTF8)
- Add `MAX_ITERATION_COUNT` caps on loops (P2-Iteration)
- Apply `truncate_field()` to extracted string values (P2-StringLength)
- Fix UTF-16 lossy conversion in windows_executable (P4-UTF8)

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` passes with 0 warnings
- [x] `cargo fmt` passes
- [x] Pre-commit hooks pass