### PR TITLE
fix(parsers): ADR 0004 batch 11 - swift_manifest_json, bdb, readme, poetry_lock, podspec

### DIFF
--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -21,11 +21,10 @@
 //! - Dependency version constraints are parsed from DSL
 //! - Graceful error handling with `warn!()` logs on parse failures
 
-use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
-use lazy_static::lazy_static;
 use md5::{Digest, Md5};
 use packageurl::PackageUrl;
 use regex::Regex;
@@ -33,6 +32,7 @@ use regex::Regex;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parsers::PackageParser;
 use crate::parsers::license_normalization::normalize_spdx_declared_license;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Parses CocoaPods specification files (.podspec).
 ///
@@ -61,7 +61,7 @@ impl PackageParser for PodspecParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {:?}: {}", path, e);
@@ -69,24 +69,25 @@ impl PackageParser for PodspecParser {
             }
         };
 
-        let name = extract_field(&content, &NAME_PATTERN);
-        let version = extract_field(&content, &VERSION_PATTERN);
-        let summary = extract_field(&content, &SUMMARY_PATTERN);
+        let name = extract_field(&content, &NAME_PATTERN).map(truncate_field);
+        let version = extract_field(&content, &VERSION_PATTERN).map(truncate_field);
+        let summary = extract_field(&content, &SUMMARY_PATTERN).map(truncate_field);
         let description =
-            merge_summary_and_description(summary.as_deref(), extract_description(&content));
-        let homepage_url = extract_field(&content, &HOMEPAGE_PATTERN);
-        let license = extract_license_statement(&content);
+            merge_summary_and_description(summary.as_deref(), extract_description(&content))
+                .map(truncate_field);
+        let homepage_url = extract_field(&content, &HOMEPAGE_PATTERN).map(truncate_field);
+        let license = extract_license_statement(&content).map(truncate_field);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             normalize_podspec_declared_license(&content, license.as_deref());
-        let source = extract_source_url(&content);
+        let source = extract_source_url(&content).map(truncate_field);
         let authors = extract_authors(&content);
 
         let parties = authors
             .into_iter()
             .map(|(name, email)| Party {
                 r#type: Some("person".to_string()),
-                name: Some(name),
-                email,
+                name: Some(truncate_field(name)),
+                email: email.map(truncate_field),
                 url: None,
                 role: Some("author".to_string()),
                 organization: None,
@@ -133,12 +134,17 @@ impl PackageParser for PodspecParser {
             _ => None,
         };
         let purl = if let Some(name_str) = &name {
-            let mut purl = PackageUrl::new(Self::PACKAGE_TYPE.as_str(), name_str)
-                .unwrap_or_else(|_| PackageUrl::new("generic", name_str).unwrap());
-            if let Some(version_str) = &version {
-                let _ = purl.with_version(version_str);
+            let purl_result = PackageUrl::new(Self::PACKAGE_TYPE.as_str(), name_str)
+                .or_else(|_| PackageUrl::new("generic", name_str));
+            match purl_result {
+                Ok(mut purl) => {
+                    if let Some(version_str) = &version {
+                        let _ = purl.with_version(version_str);
+                    }
+                    Some(truncate_field(purl.to_string()))
+                }
+                Err(_) => None,
             }
-            Some(purl.to_string())
         } else {
             None
         };
@@ -199,24 +205,32 @@ fn default_package_data() -> PackageData {
     }
 }
 
-lazy_static! {
-    // Regex patterns matching Python reference implementation
-    static ref NAME_PATTERN: Regex = Regex::new(r"\.name\s*=\s*(.+)").unwrap();
-    static ref VERSION_PATTERN: Regex = Regex::new(r"\.version\s*=\s*(.+)").unwrap();
-    static ref SUMMARY_PATTERN: Regex = Regex::new(r"\.summary\s*=\s*(.+)").unwrap();
-    static ref DESCRIPTION_PATTERN: Regex = Regex::new(r"\.description\s*=\s*(.+)").unwrap();
-    static ref HOMEPAGE_PATTERN: Regex = Regex::new(r"\.homepage\s*=\s*(.+)").unwrap();
-    static ref LICENSE_PATTERN: Regex = Regex::new(r"\.license\s*=\s*(.+)").unwrap();
-    static ref SOURCE_PATTERN: Regex = Regex::new(r"\.source\s*=\s*(.+)").unwrap();
-    static ref AUTHOR_PATTERN: Regex = Regex::new(r"\.authors?\s*=\s*(.+)").unwrap();
-    static ref SOURCE_GIT_PATTERN: Regex = Regex::new(r#":git\s*=>\s*['\"]([^'\"]+)['\"]"#).unwrap();
-    static ref SOURCE_HTTP_PATTERN: Regex = Regex::new(r#":http\s*=>\s*['\"]([^'\"]+)['\"]"#).unwrap();
+static NAME_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.name\s*=\s*(.+)").expect("valid regex"));
+static VERSION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.version\s*=\s*(.+)").expect("valid regex"));
+static SUMMARY_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.summary\s*=\s*(.+)").expect("valid regex"));
+static DESCRIPTION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.description\s*=\s*(.+)").expect("valid regex"));
+static HOMEPAGE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.homepage\s*=\s*(.+)").expect("valid regex"));
+static LICENSE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.license\s*=\s*(.+)").expect("valid regex"));
+static SOURCE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.source\s*=\s*(.+)").expect("valid regex"));
+static AUTHOR_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\.authors?\s*=\s*(.+)").expect("valid regex"));
+static SOURCE_GIT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#":git\s*=>\s*['\"]([^'\"]+)['\"]"#).expect("valid regex"));
+static SOURCE_HTTP_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#":http\s*=>\s*['\"]([^'\"]+)['\"]"#).expect("valid regex"));
 
-    // Dependency patterns (using pod/dependency method calls)
-    static ref DEPENDENCY_PATTERN: Regex = Regex::new(
-        r#"(?:s\.)?(?:dependency|add_dependency|add_(?:runtime|development)_dependency)\s+['"]([^'"]+)['"](?:\s*,\s*(.+))?"#
-    ).unwrap();
-}
+static DEPENDENCY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+    r#"(?:s\.)?(?:dependency|add_dependency|add_(?:runtime|development)_dependency)\s+['"]([^'"]+)['"](?:\s*,\s*(.+))?"#
+).expect("valid regex")
+});
 
 fn extract_license_statement(content: &str) -> Option<String> {
     extract_field(content, &LICENSE_PATTERN).map(|value| normalize_ruby_hash_literal(&value))
@@ -285,7 +299,7 @@ fn normalize_ruby_hash_literal(value: &str) -> String {
 
 /// Extract a single field using a regex pattern
 fn extract_field(content: &str, pattern: &Regex) -> Option<String> {
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let cleaned_line = pre_process(line);
         if let Some(value) = pattern.captures(&cleaned_line).and_then(|caps| caps.get(1)) {
             return Some(clean_string(value.as_str()));
@@ -296,7 +310,7 @@ fn extract_field(content: &str, pattern: &Regex) -> Option<String> {
 
 /// Extract description, handling multiline heredoc format
 fn extract_description(content: &str) -> Option<String> {
-    let lines: Vec<&str> = content.lines().collect();
+    let lines: Vec<&str> = content.lines().take(MAX_ITERATION_COUNT).collect();
 
     for (i, line) in lines.iter().enumerate() {
         let cleaned = pre_process(line);
@@ -345,7 +359,7 @@ fn extract_multiline_description(lines: &[&str], start_index: usize) -> Option<S
     let mut description_lines = Vec::new();
     let mut found_start = false;
 
-    for line in lines.iter().skip(start_index) {
+    for line in lines.iter().take(MAX_ITERATION_COUNT).skip(start_index) {
         if !found_start && line.contains("<<-") {
             found_start = true;
             continue;
@@ -371,7 +385,7 @@ fn extract_multiline_description(lines: &[&str], start_index: usize) -> Option<S
 fn extract_authors(content: &str) -> Vec<(String, Option<String>)> {
     let mut authors = Vec::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let cleaned_line = pre_process(line);
         if let Some(value) = AUTHOR_PATTERN
             .captures(&cleaned_line)
@@ -397,7 +411,7 @@ fn extract_authors(content: &str) -> Vec<(String, Option<String>)> {
 }
 
 fn extract_source_url(content: &str) -> Option<String> {
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let cleaned_line = pre_process(line);
         let Some(value) = SOURCE_PATTERN
             .captures(&cleaned_line)
@@ -459,7 +473,7 @@ fn parse_author_string(author: &str) -> (String, Option<String>) {
 fn extract_dependencies(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let cleaned_line = pre_process(line);
         if let Some(caps) = DEPENDENCY_PATTERN.captures(&cleaned_line) {
             let method = caps.get(0).map(|m| m.as_str()).unwrap_or("");
@@ -492,8 +506,8 @@ fn create_dependency(name: &str, version_req: Option<String>, method: &str) -> O
     let is_development = method.contains("add_development_dependency");
 
     Some(Dependency {
-        purl: Some(purl.to_string()),
-        extracted_requirement: version_req,
+        purl: Some(truncate_field(purl.to_string())),
+        extracted_requirement: version_req.map(truncate_field),
         scope: Some(
             if is_development {
                 "development"

--- a/src/parsers/poetry_lock.rs
+++ b/src/parsers/poetry_lock.rs
@@ -31,6 +31,7 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha256Digest,
 };
 use crate::parsers::python::{build_pypi_urls, read_toml_file};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 use super::PackageParser;
 
@@ -83,7 +84,7 @@ fn parse_poetry_lock(toml_content: &TomlValue) -> PackageData {
         .and_then(|value| value.as_table());
 
     let mut dependencies = Vec::new();
-    for package in packages {
+    for package in packages.iter().take(MAX_ITERATION_COUNT) {
         if let Some(package_table) = package.as_table()
             && let Some(dependency) = build_dependency_from_package(package_table)
         {
@@ -150,7 +151,7 @@ fn build_metadata_extra_data(
         {
             extra_data.insert(
                 "python_version".to_string(),
-                serde_json::Value::String(python_versions.to_string()),
+                serde_json::Value::String(truncate_field(python_versions.to_string())),
             );
         }
 
@@ -165,7 +166,7 @@ fn build_metadata_extra_data(
             {
                 extra_data.insert(
                     "lock_version".to_string(),
-                    serde_json::Value::String(lock_version),
+                    serde_json::Value::String(truncate_field(lock_version)),
                 );
             }
         }
@@ -182,12 +183,13 @@ fn build_dependency_from_package(package_table: &TomlMap<String, TomlValue>) -> 
     let name = package_table
         .get(FIELD_NAME)
         .and_then(|value| value.as_str())
-        .map(normalize_pypi_name)?;
+        .map(normalize_pypi_name)
+        .map(truncate_field)?;
 
     let version = package_table
         .get(FIELD_VERSION)
         .and_then(|value| value.as_str())
-        .map(|value| value.to_string())?;
+        .map(|value| truncate_field(value.to_string()))?;
 
     let purl = create_pypi_purl(&name, Some(&version));
 
@@ -226,6 +228,11 @@ fn build_resolved_package(
     let (repository_homepage_url, repository_download_url, api_data_url, purl) =
         build_pypi_urls(Some(name), Some(version));
 
+    let repository_homepage_url = repository_homepage_url.map(truncate_field);
+    let repository_download_url = repository_download_url.map(truncate_field);
+    let api_data_url = api_data_url.map(truncate_field);
+    let purl = purl.map(truncate_field);
+
     // Extract sha256 hash from files array (first file's hash)
     let sha256 = extract_sha256_from_files(package_table);
 
@@ -247,8 +254,8 @@ fn build_resolved_package(
         ..ResolvedPackage::new(
             PoetryLockParser::PACKAGE_TYPE,
             String::new(),
-            name.to_string(),
-            version.to_string(),
+            truncate_field(name.to_string()),
+            truncate_field(version.to_string()),
         )
     }
 }
@@ -260,7 +267,7 @@ fn extract_package_dependencies(package_table: &TomlMap<String, TomlValue>) -> V
         .get(FIELD_DEPENDENCIES)
         .and_then(|value| value.as_table())
     {
-        for (dep_name, dep_value) in dep_table {
+        for (dep_name, dep_value) in dep_table.iter().take(MAX_ITERATION_COUNT) {
             if let Some(dependency) = build_dependency_from_table(dep_name, dep_value) {
                 dependencies.push(dependency);
             }
@@ -271,9 +278,9 @@ fn extract_package_dependencies(package_table: &TomlMap<String, TomlValue>) -> V
         .get(FIELD_EXTRAS)
         .and_then(|value| value.as_table())
     {
-        for (extra_name, extra_values) in extras_table {
+        for (extra_name, extra_values) in extras_table.iter().take(MAX_ITERATION_COUNT) {
             if let Some(extra_list) = extra_values.as_array() {
-                for extra in extra_list {
+                for extra in extra_list.iter().take(MAX_ITERATION_COUNT) {
                     if let Some(spec) = extra.as_str()
                         && let Some(dependency) = build_dependency_from_extra(extra_name, spec)
                     {
@@ -289,12 +296,12 @@ fn extract_package_dependencies(package_table: &TomlMap<String, TomlValue>) -> V
 
 fn build_dependency_from_table(dep_name: &str, dep_value: &TomlValue) -> Option<Dependency> {
     let (requirement, is_optional) = match dep_value {
-        TomlValue::String(value) => (Some(value.to_string()), false),
+        TomlValue::String(value) => (Some(truncate_field(value.to_string())), false),
         TomlValue::Table(table) => (
             table
                 .get(FIELD_VERSION)
                 .and_then(|value| value.as_str())
-                .map(|value| value.to_string()),
+                .map(|value| truncate_field(value.to_string())),
             table
                 .get("optional")
                 .and_then(|value| value.as_bool())
@@ -309,7 +316,7 @@ fn build_dependency_from_table(dep_name: &str, dep_value: &TomlValue) -> Option<
     Some(Dependency {
         purl,
         extracted_requirement: requirement,
-        scope: Some(FIELD_DEPENDENCIES.to_string()),
+        scope: Some(truncate_field(FIELD_DEPENDENCIES.to_string())),
         is_runtime: Some(true),
         is_optional: Some(is_optional),
         is_pinned: Some(false),
@@ -326,7 +333,7 @@ fn build_dependency_from_extra(extra_name: &str, spec: &str) -> Option<Dependenc
     Some(Dependency {
         purl,
         extracted_requirement: requirement,
-        scope: Some(extra_name.to_string()),
+        scope: Some(truncate_field(extra_name.to_string())),
         is_runtime: None,
         is_optional: Some(true),
         is_pinned: Some(false),
@@ -349,16 +356,16 @@ fn parse_poetry_dependency_spec(spec: &str) -> Option<(String, Option<String>)> 
         if name_part.is_empty() {
             return None;
         }
-        let normalized_name = normalize_pypi_name(name_part);
+        let normalized_name = truncate_field(normalize_pypi_name(name_part));
         let requirement = if requirement.is_empty() {
             None
         } else {
-            Some(requirement.to_string())
+            Some(truncate_field(requirement.to_string()))
         };
         return Some((normalized_name, requirement));
     }
 
-    Some((normalize_pypi_name(trimmed), None))
+    Some((truncate_field(normalize_pypi_name(trimmed)), None))
 }
 
 fn normalize_pypi_name(name: &str) -> String {
@@ -367,7 +374,7 @@ fn normalize_pypi_name(name: &str) -> String {
 
 fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if name.contains('[') || name.contains(']') {
-        return Some(build_manual_pypi_purl(name, version));
+        return Some(truncate_field(build_manual_pypi_purl(name, version)));
     }
 
     if let Ok(mut purl) = PackageUrl::new(PoetryLockParser::PACKAGE_TYPE.as_str(), name) {
@@ -376,10 +383,10 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
         {
             return None;
         }
-        return Some(purl.to_string());
+        return Some(truncate_field(purl.to_string()));
     }
 
-    Some(build_manual_pypi_purl(name, version))
+    Some(truncate_field(build_manual_pypi_purl(name, version)))
 }
 
 fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
@@ -406,7 +413,11 @@ fn extract_sha256_from_files(package_table: &TomlMap<String, TomlValue>) -> Opti
         .and_then(|first_file| first_file.as_table())
         .and_then(|file_table| file_table.get("hash"))
         .and_then(|hash_value| hash_value.as_str())
-        .and_then(|hash_str| hash_str.strip_prefix("sha256:").map(|s| s.to_string()))
+        .and_then(|hash_str| {
+            hash_str
+                .strip_prefix("sha256:")
+                .map(|s| truncate_field(s.to_string()))
+        })
 }
 
 fn default_package_data() -> PackageData {

--- a/src/parsers/readme.rs
+++ b/src/parsers/readme.rs
@@ -24,7 +24,7 @@
 use crate::models::PackageData;
 use crate::models::{DatasourceId, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::read_file_to_string;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use std::path::Path;
 
 use super::PackageParser;
@@ -64,7 +64,7 @@ impl PackageParser for ReadmeParser {
         let mut pkg = default_package_data();
 
         // Parse key:value pairs
-        for line in content.lines() {
+        for line in content.lines().take(MAX_ITERATION_COUNT) {
             let line = line.trim();
             if line.is_empty() {
                 continue;
@@ -88,22 +88,22 @@ impl PackageParser for ReadmeParser {
             let key_lower = key.to_lowercase();
             match key_lower.as_str() {
                 "name" | "project" => {
-                    pkg.name = Some(value.to_string());
+                    pkg.name = Some(truncate_field(value.to_string()));
                 }
                 "version" => {
-                    pkg.version = Some(value.to_string());
+                    pkg.version = Some(truncate_field(value.to_string()));
                 }
                 "copyright" => {
-                    pkg.copyright = Some(value.to_string());
+                    pkg.copyright = Some(truncate_field(value.to_string()));
                 }
                 "download link" | "downloaded from" => {
-                    pkg.download_url = Some(value.to_string());
+                    pkg.download_url = Some(truncate_field(value.to_string()));
                 }
                 "homepage" | "website" | "repo" | "source" | "upstream" | "url" | "project url" => {
-                    pkg.homepage_url = Some(value.to_string());
+                    pkg.homepage_url = Some(truncate_field(value.to_string()));
                 }
                 "licence" | "license" => {
-                    pkg.extracted_license_statement = Some(value.to_string());
+                    pkg.extracted_license_statement = Some(truncate_field(value.to_string()));
                 }
                 _ => {
                     // Unrecognized field, skip
@@ -116,7 +116,7 @@ impl PackageParser for ReadmeParser {
             && let Some(parent) = path.parent()
             && let Some(parent_name) = parent.file_name()
         {
-            pkg.name = Some(parent_name.to_string_lossy().to_string());
+            pkg.name = Some(truncate_field(parent_name.to_string_lossy().to_string()));
         }
 
         vec![pkg]

--- a/src/parsers/rpm_db_native/bdb.rs
+++ b/src/parsers/rpm_db_native/bdb.rs
@@ -1,8 +1,11 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
+
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_FIELD_LENGTH, MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE};
 
 use super::BlobReader;
 
@@ -27,6 +30,17 @@ pub(crate) struct BdbDatabase {
 
 impl BdbDatabase {
     pub(crate) fn open(path: &Path) -> Result<Self> {
+        let file_metadata = fs::metadata(path)
+            .map_err(|e| anyhow!("RPM BDB cannot stat file {:?}: {}", path, e))?;
+        if file_metadata.len() > MAX_MANIFEST_SIZE {
+            return Err(anyhow!(
+                "RPM BDB file {:?} is {} bytes, exceeding the {} byte limit",
+                path,
+                file_metadata.len(),
+                MAX_MANIFEST_SIZE
+            ));
+        }
+
         let mut file = File::open(path)?;
         let mut page = [0_u8; 512];
         file.read_exact(&mut page)?;
@@ -53,8 +67,17 @@ impl BdbDatabase {
         let page_size = self.metadata.generic.page_size as usize;
         let mut value = Vec::new();
         let mut current_page = entry.page_number as usize;
+        let mut depth = 0usize;
 
         while current_page != 0 {
+            depth += 1;
+            if depth > MAX_ITERATION_COUNT {
+                return Err(anyhow!(
+                    "RPM BDB overflow page chain exceeded {} pages",
+                    MAX_ITERATION_COUNT
+                ));
+            }
+
             self.file
                 .seek(SeekFrom::Start((page_size * current_page) as u64))?;
             let mut page = vec![0_u8; page_size];
@@ -73,6 +96,14 @@ impl BdbDatabase {
                 &page[PAGE_HEADER_SIZE..]
             };
             value.extend_from_slice(page_bytes);
+
+            if value.len() > MAX_FIELD_LENGTH {
+                return Err(anyhow!(
+                    "RPM BDB overflow value exceeded {} bytes",
+                    MAX_FIELD_LENGTH
+                ));
+            }
+
             current_page = header.next_page_number as usize;
         }
 
@@ -93,7 +124,18 @@ impl BlobReader for BdbDatabase {
         let page_size = self.metadata.generic.page_size as usize;
         let mut values = Vec::new();
 
-        for _ in 0..=self.metadata.generic.last_page_number {
+        let last_page = self.metadata.generic.last_page_number;
+        let effective_last_page = if last_page as usize > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM BDB last_page_number {} exceeds {}, capping iteration",
+                last_page, MAX_ITERATION_COUNT
+            );
+            MAX_ITERATION_COUNT as u32
+        } else {
+            last_page
+        };
+
+        for _ in 0..=effective_last_page {
             let mut page = vec![0_u8; page_size];
             self.file.read_exact(&mut page)?;
             let page_end_offset = self.file.stream_position()?;
@@ -132,19 +174,34 @@ fn hash_page_value_indexes(page: &[u8], entry_count: u16) -> Result<Vec<u16>> {
         ));
     }
 
+    let capped_entry_count = if entry_count as usize > MAX_ITERATION_COUNT {
+        warn!(
+            "RPM BDB hash page entry count {} exceeds {}, capping",
+            entry_count, MAX_ITERATION_COUNT
+        );
+        MAX_ITERATION_COUNT as u16
+    } else {
+        entry_count
+    };
+
     let index_bytes = page
-        .get(PAGE_HEADER_SIZE..PAGE_HEADER_SIZE + entry_count as usize * HASH_INDEX_ENTRY_SIZE)
+        .get(
+            PAGE_HEADER_SIZE
+                ..PAGE_HEADER_SIZE + capped_entry_count as usize * HASH_INDEX_ENTRY_SIZE,
+        )
         .ok_or_else(|| anyhow!("RPM BDB hash index slice is out of bounds"))?;
 
-    Ok(index_bytes
-        .chunks_exact(2 * HASH_INDEX_ENTRY_SIZE)
-        .map(|chunk| {
-            u16::from_le_bytes([
-                chunk[HASH_INDEX_ENTRY_SIZE],
-                chunk[HASH_INDEX_ENTRY_SIZE + 1],
-            ])
-        })
-        .collect())
+    let mut result = Vec::new();
+    for chunk in index_bytes.chunks_exact(2 * HASH_INDEX_ENTRY_SIZE) {
+        if result.len() >= MAX_ITERATION_COUNT {
+            break;
+        }
+        result.push(u16::from_le_bytes([
+            chunk[HASH_INDEX_ENTRY_SIZE],
+            chunk[HASH_INDEX_ENTRY_SIZE + 1],
+        ]));
+    }
+    Ok(result)
 }
 
 #[derive(Debug)]

--- a/src/parsers/swift_manifest_json.rs
+++ b/src/parsers/swift_manifest_json.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
+
+use super::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 use crate::parser_warn as warn;
 use packageurl::PackageUrl;
@@ -50,7 +51,8 @@ impl PackageParser for SwiftManifestJsonParser {
 }
 
 fn read_swift_manifest_json(path: &Path) -> Result<Value, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = crate::parsers::utils::read_file_to_string(path, None)
+        .map_err(|e| format!("Failed to read file: {}", e))?;
 
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {}", e))
 }
@@ -59,7 +61,7 @@ fn parse_swift_manifest(manifest: &Value) -> PackageData {
     let name = manifest
         .get("name")
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let dependencies = get_dependencies(manifest.get("dependencies"));
     let platforms = manifest.get("platforms").cloned();
@@ -68,7 +70,7 @@ fn parse_swift_manifest(manifest: &Value) -> PackageData {
         .get("toolsVersion")
         .and_then(|tv| tv.get("_version"))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let mut extra_data = HashMap::new();
     if let Some(platforms_val) = platforms {
@@ -81,7 +83,7 @@ fn parse_swift_manifest(manifest: &Value) -> PackageData {
         );
     }
 
-    let purl = create_package_url(&name, &None);
+    let purl = create_package_url(&name, &None).map(truncate_field);
 
     PackageData {
         package_type: Some(SwiftManifestJsonParser::PACKAGE_TYPE),
@@ -140,7 +142,7 @@ fn get_dependencies(dependencies: Option<&Value>) -> Vec<Dependency> {
 
     let mut dependent_packages = Vec::new();
 
-    for dependency in deps_array {
+    for dependency in deps_array.iter().take(MAX_ITERATION_COUNT) {
         if let Some(dep) = parse_manifest_dependency(dependency) {
             dependent_packages.push(dep);
         }
@@ -158,9 +160,14 @@ fn parse_manifest_dependency(dependency: &Value) -> Option<Dependency> {
             .and_then(|v| v.as_str())
             .unwrap_or_default();
 
-        let (namespace, dep_name) = extract_namespace_and_name(source, identity);
+        let (mut namespace, mut dep_name) = extract_namespace_and_name(source, identity);
+        namespace = namespace.map(truncate_field);
+        dep_name = truncate_field(dep_name);
         let (version, is_pinned, requirement_kind) = extract_version_requirement(source);
-        let purl = create_dependency_purl(&namespace, &dep_name, &version, is_pinned);
+        let version = version.map(truncate_field);
+        let purl = truncate_field(create_dependency_purl(
+            &namespace, &dep_name, &version, is_pinned,
+        ));
         let mut extra_data = HashMap::from([
             (
                 "dependency_kind".to_string(),
@@ -210,8 +217,8 @@ fn parse_manifest_dependency(dependency: &Value) -> Option<Dependency> {
             return None;
         }
 
-        let dep_name = identity.to_string();
-        let purl = create_dependency_purl(&None, &dep_name, &None, false);
+        let dep_name = truncate_field(identity.to_string());
+        let purl = truncate_field(create_dependency_purl(&None, &dep_name, &None, false));
         let mut extra_data = HashMap::from([(
             "dependency_kind".to_string(),
             serde_json::Value::String("fileSystem".to_string()),


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: swift_manifest_json, rpm_db_native/bdb, readme, poetry_lock, podspec
- Part of ongoing ADR 0004 audit remediation (batch 11 of N)

## Changes

### swift_manifest_json.rs (4 findings)
- Replaced `fs::read_to_string` with `read_file_to_string` (file size + UTF-8)
- Added `MAX_ITERATION_COUNT` cap on dependencies array
- Applied `truncate_field()` to all string values

### rpm_db_native/bdb.rs (4 findings)
- Added `fs::metadata()` size pre-check before `File::open`
- Capped page iteration to `MAX_ITERATION_COUNT`
- Added depth limit + size check on overflow page chain traversal
- Capped hash page entry count processing

### readme.rs (4 findings)
- Added `MAX_ITERATION_COUNT` cap on line iteration
- Applied `truncate_field()` to all string values
- File size + UTF-8 already covered by `read_file_to_string`

### poetry_lock.rs (4 findings)
- Added `MAX_ITERATION_COUNT` caps on packages/dependencies iteration
- Applied `truncate_field()` to all string values
- File size + UTF-8 already covered by `read_toml_file`

### podspec.rs (6 findings)
- Replaced `fs::read_to_string` with `read_file_to_string` (file size + UTF-8)
- Added `MAX_ITERATION_COUNT` caps on all 6 line-processing loops
- Applied `truncate_field()` to all string values
- Replaced nested `.unwrap()` in PURL creation with safe `.ok()` pattern
- Replaced `lazy_static!` regexes with `LazyLock<Regex>` + `.expect("valid regex")`

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Pre-commit hooks pass