### PR TITLE
fix(parsers): ADR 0004 batch 12 - podfile_lock, podfile, pixi, opam, microsoft_update_manifest

### DIFF
--- a/src/parsers/microsoft_update_manifest.rs
+++ b/src/parsers/microsoft_update_manifest.rs
@@ -10,7 +10,6 @@
 //! - Spec: Windows Update manifests
 
 use crate::models::{DatasourceId, PackageType};
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -18,6 +17,7 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 
 use crate::models::PackageData;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -33,7 +33,7 @@ impl PackageParser for MicrosoftUpdateManifestParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read .mum file {:?}: {}", path, e);
@@ -60,15 +60,44 @@ pub(crate) fn parse_mum_xml(content: &str) -> PackageData {
     let mut homepage_url = None;
 
     let mut buf = Vec::new();
+    let mut iteration_count: usize = 0;
 
     loop {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!(
+                "Exceeded MAX_ITERATION_COUNT ({}) parsing .mum XML, stopping",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         match reader.read_event_into(&mut buf) {
             Ok(Event::Empty(e)) => {
                 if e.name().as_ref() == b"assemblyIdentity" {
                     for attr in e.attributes().filter_map(|a| a.ok()) {
                         match attr.key.as_ref() {
-                            b"name" => name = String::from_utf8(attr.value.to_vec()).ok(),
-                            b"version" => version = String::from_utf8(attr.value.to_vec()).ok(),
+                            b"name" => {
+                                let raw = attr.value.to_vec();
+                                let has_invalid = String::from_utf8(raw.clone()).is_err();
+                                let val = String::from_utf8_lossy(&raw).into_owned();
+                                if has_invalid {
+                                    warn!(
+                                        "Invalid UTF-8 in 'name' attribute, using lossy conversion"
+                                    );
+                                }
+                                name = Some(truncate_field(val));
+                            }
+                            b"version" => {
+                                let raw = attr.value.to_vec();
+                                let has_invalid = String::from_utf8(raw.clone()).is_err();
+                                let val = String::from_utf8_lossy(&raw).into_owned();
+                                if has_invalid {
+                                    warn!(
+                                        "Invalid UTF-8 in 'version' attribute, using lossy conversion"
+                                    );
+                                }
+                                version = Some(truncate_field(val));
+                            }
                             _ => {}
                         }
                     }
@@ -79,11 +108,37 @@ pub(crate) fn parse_mum_xml(content: &str) -> PackageData {
                     for attr in e.attributes().filter_map(|a| a.ok()) {
                         match attr.key.as_ref() {
                             b"description" => {
-                                description = String::from_utf8(attr.value.to_vec()).ok()
+                                let raw = attr.value.to_vec();
+                                let has_invalid = String::from_utf8(raw.clone()).is_err();
+                                let val = String::from_utf8_lossy(&raw).into_owned();
+                                if has_invalid {
+                                    warn!(
+                                        "Invalid UTF-8 in 'description' attribute, using lossy conversion"
+                                    );
+                                }
+                                description = Some(truncate_field(val));
                             }
-                            b"copyright" => copyright = String::from_utf8(attr.value.to_vec()).ok(),
+                            b"copyright" => {
+                                let raw = attr.value.to_vec();
+                                let has_invalid = String::from_utf8(raw.clone()).is_err();
+                                let val = String::from_utf8_lossy(&raw).into_owned();
+                                if has_invalid {
+                                    warn!(
+                                        "Invalid UTF-8 in 'copyright' attribute, using lossy conversion"
+                                    );
+                                }
+                                copyright = Some(truncate_field(val));
+                            }
                             b"supportInformation" => {
-                                homepage_url = String::from_utf8(attr.value.to_vec()).ok()
+                                let raw = attr.value.to_vec();
+                                let has_invalid = String::from_utf8(raw.clone()).is_err();
+                                let val = String::from_utf8_lossy(&raw).into_owned();
+                                if has_invalid {
+                                    warn!(
+                                        "Invalid UTF-8 in 'supportInformation' attribute, using lossy conversion"
+                                    );
+                                }
+                                homepage_url = Some(truncate_field(val));
                             }
                             _ => {}
                         }

--- a/src/parsers/opam.rs
+++ b/src/parsers/opam.rs
@@ -30,6 +30,7 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parsers::PackageParser;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data_from_pair,
@@ -52,7 +53,7 @@ impl PackageParser for OpamParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        vec![match std::fs::read_to_string(path) {
+        vec![match read_file_to_string(path, None) {
             Ok(text) => parse_opam(&text),
             Err(e) => {
                 warn!("Failed to read OPAM file {:?}: {}", path, e);
@@ -212,8 +213,14 @@ fn parse_opam_data(text: &str) -> OpamData {
     let mut data = OpamData::default();
     let lines: Vec<&str> = text.lines().collect();
     let mut i = 0;
+    let mut iteration_count: usize = 0;
 
     while i < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!("parse_opam_data: exceeded MAX_ITERATION_COUNT, breaking");
+            break;
+        }
         let line = lines[i];
 
         // Parse key: value format
@@ -287,21 +294,26 @@ fn clean_value(value: &str) -> Option<String> {
     if cleaned.is_empty() {
         None
     } else {
-        Some(cleaned.to_string())
+        Some(truncate_field(cleaned.to_string()))
     }
 }
 
 /// Parse a multiline string enclosed in triple quotes
 fn parse_multiline_string(lines: &[&str], i: &mut usize) -> Option<String> {
     let mut result = String::new();
+    let mut iteration_count: usize = 0;
 
-    // First line might contain opening """ and some content
     if let Some((_, value)) = parse_key_value(lines[*i]) {
         result.push_str(value.trim_matches('"').trim());
     }
 
     *i += 1;
     while *i < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!("parse_multiline_string: exceeded MAX_ITERATION_COUNT, breaking");
+            break;
+        }
         let line = lines[*i];
         result.push(' ');
         result.push_str(line.trim_matches('"').trim());
@@ -316,20 +328,25 @@ fn parse_multiline_string(lines: &[&str], i: &mut usize) -> Option<String> {
     if cleaned.is_empty() {
         None
     } else {
-        Some(cleaned)
+        Some(truncate_field(cleaned))
     }
 }
 
 /// Parse a string array (single-line or multiline)
 fn parse_string_array(lines: &[&str], i: &mut usize, first_value: &str) -> Vec<String> {
     let mut result = Vec::new();
+    let mut iteration_count: usize = 0;
 
     let mut content = first_value.to_string();
 
-    // If it's a multiline array (starts with [ but no matching ])
     if content.contains('[') && !content.contains(']') {
         *i += 1;
         while *i < lines.len() {
+            iteration_count += 1;
+            if iteration_count > MAX_ITERATION_COUNT {
+                warn!("parse_string_array: exceeded MAX_ITERATION_COUNT, breaking");
+                break;
+            }
             let line = lines[*i];
             content.push(' ');
             content.push_str(line);
@@ -341,14 +358,12 @@ fn parse_string_array(lines: &[&str], i: &mut usize, first_value: &str) -> Vec<S
         }
     }
 
-    // Parse the content
     let cleaned = content.trim_matches('[').trim_matches(']').trim();
 
-    // Split by quote-delimited strings
     for part in split_quoted_strings(cleaned) {
         let p = part.trim_matches('"').trim();
         if !p.is_empty() {
-            result.push(p.to_string());
+            result.push(truncate_field(p.to_string()));
         }
     }
 
@@ -358,9 +373,15 @@ fn parse_string_array(lines: &[&str], i: &mut usize, first_value: &str) -> Vec<S
 /// Parse dependency array
 fn parse_dependency_array(lines: &[&str], i: &mut usize) -> Vec<(String, String)> {
     let mut result = Vec::new();
+    let mut iteration_count: usize = 0;
 
     *i += 1;
     while *i < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!("parse_dependency_array: exceeded MAX_ITERATION_COUNT, breaking");
+            break;
+        }
         let line = lines[*i];
 
         if line.trim().contains(']') {
@@ -388,14 +409,14 @@ fn parse_dependency_line(line: &str) -> Option<(String, String)> {
     let regex = Regex::new(r#""([^"]+)"\s*(.*)$"#).ok()?;
     let caps = regex.captures(line)?;
 
-    let name = caps.get(1)?.as_str().to_string();
+    let name = truncate_field(caps.get(1)?.as_str().to_string());
     let version_part = caps.get(2)?.as_str().trim();
 
     // Extract the operator and version constraint
     let constraint = if version_part.is_empty() {
         String::new()
     } else {
-        extract_version_constraint(version_part)
+        truncate_field(extract_version_constraint(version_part))
     };
 
     Some((name, constraint))
@@ -442,8 +463,14 @@ fn parse_checksums(lines: &[&str], i: &mut usize, data: &mut OpamData) {
         }
     }
 
+    let mut iteration_count: usize = 0;
     *i += 1;
     while *i < lines.len() {
+        iteration_count += 1;
+        if iteration_count > MAX_ITERATION_COUNT {
+            warn!("parse_checksums: exceeded MAX_ITERATION_COUNT, breaking");
+            break;
+        }
         let line = lines[*i];
 
         if line.trim().contains(']') {
@@ -527,7 +554,7 @@ fn extract_parties(authors: &[String], maintainers: &[String]) -> Vec<Party> {
         parties.push(Party {
             r#type: Some("person".to_string()),
             role: Some("author".to_string()),
-            name: Some(author.clone()),
+            name: Some(truncate_field(author.clone())),
             email: None,
             url: None,
             organization: None,
@@ -542,7 +569,7 @@ fn extract_parties(authors: &[String], maintainers: &[String]) -> Vec<Party> {
             r#type: Some("person".to_string()),
             role: Some("maintainer".to_string()),
             name: None,
-            email: Some(maintainer.clone()),
+            email: Some(truncate_field(maintainer.clone())),
             url: None,
             organization: None,
             organization_url: None,
@@ -557,8 +584,8 @@ fn extract_parties(authors: &[String], maintainers: &[String]) -> Vec<Party> {
 fn extract_dependencies(deps: &[(String, String)]) -> Vec<Dependency> {
     deps.iter()
         .map(|(name, version_constraint)| Dependency {
-            purl: Some(format!("pkg:opam/{}", name)),
-            extracted_requirement: Some(version_constraint.clone()),
+            purl: Some(truncate_field(format!("pkg:opam/{}", name))),
+            extracted_requirement: Some(truncate_field(version_constraint.clone())),
             scope: Some("dependency".to_string()),
             is_runtime: Some(true),
             is_optional: Some(false),

--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -10,7 +10,9 @@ use toml::map::Map as TomlMap;
 use crate::models::{DatasourceId, Dependency, FileReference, PackageData, PackageType, Party};
 use crate::parsers::conda::build_purl as build_conda_purl;
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{read_file_to_string, split_name_email};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -102,10 +104,11 @@ fn parse_pixi_toml(toml_content: &TomlValue) -> PackageData {
     let name = identity
         .and_then(|table| table.get(FIELD_NAME))
         .and_then(TomlValue::as_str)
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_string()));
     let version = identity
         .and_then(|table| table.get(FIELD_VERSION))
-        .and_then(toml_value_to_string);
+        .and_then(toml_value_to_string)
+        .map(truncate_field);
 
     let mut package = default_package_data(Some(DatasourceId::PixiToml));
     package.name = name.clone();
@@ -114,24 +117,25 @@ fn parse_pixi_toml(toml_content: &TomlValue) -> PackageData {
     package.description = identity
         .and_then(|table| table.get(FIELD_DESCRIPTION))
         .and_then(TomlValue::as_str)
-        .map(|value| value.trim().to_string());
+        .map(|value| truncate_field(value.trim().to_string()));
     package.homepage_url = identity
         .and_then(|table| table.get(FIELD_HOMEPAGE))
         .and_then(TomlValue::as_str)
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_string()));
     package.vcs_url = identity
         .and_then(|table| table.get(FIELD_REPOSITORY))
         .and_then(TomlValue::as_str)
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_string()));
     package.parties = extract_authors(identity);
     package.extracted_license_statement = identity
         .and_then(|table| table.get(FIELD_LICENSE))
         .and_then(TomlValue::as_str)
-        .map(ToOwned::to_owned);
+        .map(|v| truncate_field(v.to_string()));
     package.file_references = extract_manifest_file_references(identity);
     package.purl = name
         .as_deref()
-        .and_then(|value| build_pixi_purl(value, version.as_deref()));
+        .and_then(|value| build_pixi_purl(value, version.as_deref()))
+        .map(truncate_field);
     package.dependencies = extract_manifest_dependencies(toml_content);
     package.extra_data = build_manifest_extra_data(toml_content, identity);
     package
@@ -185,14 +189,15 @@ fn extract_authors(identity: Option<&TomlMap<String, TomlValue>>) -> Vec<Party> 
         .and_then(TomlValue::as_array)
         .into_iter()
         .flatten()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(TomlValue::as_str)
         .map(|author| {
             let (name, email) = split_name_email(author);
             Party {
                 r#type: None,
                 role: Some("author".to_string()),
-                name,
-                email,
+                name: name.map(truncate_field),
+                email: email.map(truncate_field),
                 url: None,
                 organization: None,
                 organization_url: None,
@@ -215,7 +220,7 @@ fn extract_manifest_file_references(
         let path = path.trim();
         if !path.is_empty() {
             references.push(FileReference {
-                path: path.to_string(),
+                path: truncate_field(path.to_string()),
                 size: None,
                 sha1: None,
                 md5: None,
@@ -232,7 +237,7 @@ fn extract_manifest_file_references(
             let already_present = references.iter().any(|reference| reference.path == path);
             if !already_present {
                 references.push(FileReference {
-                    path: path.to_string(),
+                    path: truncate_field(path.to_string()),
                     size: None,
                     sha1: None,
                     md5: None,
@@ -267,7 +272,7 @@ fn extract_manifest_dependencies(toml_content: &TomlValue) -> Vec<Dependency> {
         .get(FIELD_FEATURE)
         .and_then(TomlValue::as_table)
     {
-        for (feature_name, value) in feature_table {
+        for (feature_name, value) in feature_table.iter().take(MAX_ITERATION_COUNT) {
             let Some(feature) = value.as_table() else {
                 continue;
             };
@@ -296,6 +301,7 @@ fn extract_conda_dependencies(
 ) -> Vec<Dependency> {
     table
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(name, value)| build_conda_dependency(name, value, scope, optional))
         .collect()
 }
@@ -306,10 +312,13 @@ fn build_conda_dependency(
     scope: Option<&str>,
     optional: bool,
 ) -> Option<Dependency> {
-    let requirement = extract_conda_requirement(value);
+    let requirement = extract_conda_requirement(value).map(truncate_field);
     let exact_requirement = match value {
-        TomlValue::String(value) => Some(value.to_string()),
-        TomlValue::Table(table) => table.get(FIELD_VERSION).and_then(toml_value_to_string),
+        TomlValue::String(value) => Some(truncate_field(value.to_string())),
+        TomlValue::Table(table) => table
+            .get(FIELD_VERSION)
+            .and_then(toml_value_to_string)
+            .map(truncate_field),
         _ => None,
     };
     let pinned = exact_requirement
@@ -319,12 +328,17 @@ fn build_conda_dependency(
         .as_deref()
         .filter(|_| pinned)
         .map(|value| value.trim_start_matches('='));
-    let purl = build_conda_purl("conda", None, name, exact_version, None, None, None);
+    let purl =
+        build_conda_purl("conda", None, name, exact_version, None, None, None).map(truncate_field);
 
     let mut extra_data = HashMap::new();
     if let TomlValue::Table(dep_table) = value {
         for key in ["channel", "build", "path", "url", "git"] {
-            if let Some(val) = dep_table.get(key).and_then(toml_value_to_string) {
+            if let Some(val) = dep_table
+                .get(key)
+                .and_then(toml_value_to_string)
+                .map(truncate_field)
+            {
                 extra_data.insert(key.to_string(), JsonValue::String(val));
             }
         }
@@ -333,7 +347,7 @@ fn build_conda_dependency(
     Some(Dependency {
         purl,
         extracted_requirement: requirement.clone(),
-        scope: scope.map(ToOwned::to_owned),
+        scope: scope.map(|s| truncate_field(s.to_string())),
         is_runtime: Some(true),
         is_optional: Some(optional),
         is_pinned: Some(pinned),
@@ -350,6 +364,7 @@ fn extract_pypi_dependencies(
 ) -> Vec<Dependency> {
     table
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(name, value)| build_pypi_dependency(name, value, scope, optional))
         .collect()
 }
@@ -361,10 +376,13 @@ fn build_pypi_dependency(
     optional: bool,
 ) -> Option<Dependency> {
     let normalized_name = normalize_pypi_name(name);
-    let requirement = extract_pypi_requirement(value);
+    let requirement = extract_pypi_requirement(value).map(truncate_field);
     let exact_requirement = match value {
-        TomlValue::String(value) => Some(value.to_string()),
-        TomlValue::Table(table) => table.get(FIELD_VERSION).and_then(toml_value_to_string),
+        TomlValue::String(value) => Some(truncate_field(value.to_string())),
+        TomlValue::Table(table) => table
+            .get(FIELD_VERSION)
+            .and_then(toml_value_to_string)
+            .map(truncate_field),
         _ => None,
     };
     let pinned = exact_requirement
@@ -374,7 +392,7 @@ fn build_pypi_dependency(
         .as_deref()
         .filter(|_| pinned)
         .map(|value| value.trim_start_matches('='));
-    let purl = build_pypi_purl(&normalized_name, exact_version);
+    let purl = build_pypi_purl(&normalized_name, exact_version).map(truncate_field);
 
     let mut extra_data = HashMap::new();
     if let TomlValue::Table(dep_table) = value {
@@ -388,7 +406,11 @@ fn build_pypi_dependency(
             "rev",
             "subdirectory",
         ] {
-            if let Some(val) = dep_table.get(key).and_then(toml_value_to_string) {
+            if let Some(val) = dep_table
+                .get(key)
+                .and_then(toml_value_to_string)
+                .map(truncate_field)
+            {
                 extra_data.insert(key.replace('-', "_"), JsonValue::String(val));
             }
         }
@@ -403,7 +425,7 @@ fn build_pypi_dependency(
     Some(Dependency {
         purl,
         extracted_requirement: requirement.clone(),
-        scope: scope.map(ToOwned::to_owned),
+        scope: scope.map(|s| truncate_field(s.to_string())),
         is_runtime: Some(true),
         is_optional: Some(optional),
         is_pinned: Some(pinned),
@@ -467,6 +489,7 @@ fn extract_v6_lock_dependencies(lock_content: &JsonValue) -> Vec<Dependency> {
 
     packages
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(JsonValue::as_object)
         .filter_map(|table| build_v6_lock_dependency(table, &environment_refs))
         .collect()
@@ -481,7 +504,7 @@ fn collect_v6_package_refs(lock_content: &JsonValue) -> HashMap<String, Vec<Json
         return refs;
     };
 
-    for (env_name, env_value) in environments {
+    for (env_name, env_value) in environments.iter().take(MAX_ITERATION_COUNT) {
         let Some(env_table) = env_value.as_object() else {
             continue;
         };
@@ -491,16 +514,16 @@ fn collect_v6_package_refs(lock_content: &JsonValue) -> HashMap<String, Vec<Json
         else {
             continue;
         };
-        for (platform, values) in package_platforms {
+        for (platform, values) in package_platforms.iter().take(MAX_ITERATION_COUNT) {
             let Some(entries) = values.as_array() else {
                 continue;
             };
-            for entry in entries {
+            for entry in entries.iter().take(MAX_ITERATION_COUNT) {
                 let Some(table) = entry.as_object() else {
                     continue;
                 };
                 for (kind, locator_value) in table {
-                    if let Some(locator) = json_value_to_string(locator_value) {
+                    if let Some(locator) = json_value_to_string(locator_value).map(truncate_field) {
                         let mut data = JsonMap::new();
                         data.insert(
                             "environment".to_string(),
@@ -530,12 +553,19 @@ fn build_v6_lock_dependency(
     table: &JsonMap<String, JsonValue>,
     refs: &HashMap<String, Vec<JsonValue>>,
 ) -> Option<Dependency> {
-    if let Some(locator) = table.get("pypi").and_then(json_value_to_string) {
+    if let Some(locator) = table
+        .get("pypi")
+        .and_then(json_value_to_string)
+        .map(truncate_field)
+    {
         let name = table
             .get(FIELD_NAME)
             .and_then(JsonValue::as_str)
             .map(normalize_pypi_name)?;
-        let version = table.get(FIELD_VERSION).and_then(json_value_to_string)?;
+        let version = table
+            .get(FIELD_VERSION)
+            .and_then(json_value_to_string)
+            .map(truncate_field)?;
         let mut extra = HashMap::new();
         extra.insert("source".to_string(), JsonValue::String(locator.clone()));
         if let Some(val) = table.get("requires_dist").cloned() {
@@ -558,8 +588,8 @@ fn build_v6_lock_dependency(
             );
         }
         return Some(Dependency {
-            purl: build_pypi_purl(&name, Some(&version)),
-            extracted_requirement: Some(version),
+            purl: build_pypi_purl(&name, Some(&version)).map(truncate_field),
+            extracted_requirement: Some(version.clone()),
             scope: None,
             is_runtime: None,
             is_optional: None,
@@ -570,9 +600,16 @@ fn build_v6_lock_dependency(
         });
     }
 
-    if let Some(locator) = table.get("conda").and_then(json_value_to_string) {
+    if let Some(locator) = table
+        .get("conda")
+        .and_then(json_value_to_string)
+        .map(truncate_field)
+    {
         let name = conda_name_from_locator(&locator)?;
-        let version = table.get(FIELD_VERSION).and_then(json_value_to_string);
+        let version = table
+            .get(FIELD_VERSION)
+            .and_then(json_value_to_string)
+            .map(truncate_field);
         let mut extra = HashMap::new();
         extra.insert("source".to_string(), JsonValue::String(locator.clone()));
         for key in [
@@ -597,7 +634,8 @@ fn build_v6_lock_dependency(
             );
         }
         return Some(Dependency {
-            purl: build_conda_purl("conda", None, &name, version.as_deref(), None, None, None),
+            purl: build_conda_purl("conda", None, &name, version.as_deref(), None, None, None)
+                .map(truncate_field),
             extracted_requirement: version,
             scope: None,
             is_runtime: None,
@@ -619,6 +657,7 @@ fn extract_v4_lock_dependencies(lock_content: &JsonValue) -> Vec<Dependency> {
 
     packages
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(JsonValue::as_object)
         .filter_map(build_v4_lock_dependency)
         .collect()
@@ -626,8 +665,14 @@ fn extract_v4_lock_dependencies(lock_content: &JsonValue) -> Vec<Dependency> {
 
 fn build_v4_lock_dependency(table: &JsonMap<String, JsonValue>) -> Option<Dependency> {
     let kind = table.get("kind").and_then(JsonValue::as_str)?;
-    let name = table.get(FIELD_NAME).and_then(json_value_to_string)?;
-    let version = table.get(FIELD_VERSION).and_then(json_value_to_string);
+    let name = table
+        .get(FIELD_NAME)
+        .and_then(json_value_to_string)
+        .map(truncate_field)?;
+    let version = table
+        .get(FIELD_VERSION)
+        .and_then(json_value_to_string)
+        .map(truncate_field);
     let mut extra = HashMap::new();
     for key in [
         "url",
@@ -649,8 +694,11 @@ fn build_v4_lock_dependency(table: &JsonMap<String, JsonValue>) -> Option<Depend
 
     Some(Dependency {
         purl: match kind {
-            "pypi" => build_pypi_purl(&normalize_pypi_name(&name), version.as_deref()),
-            "conda" => build_conda_purl("conda", None, &name, version.as_deref(), None, None, None),
+            "pypi" => {
+                build_pypi_purl(&normalize_pypi_name(&name), version.as_deref()).map(truncate_field)
+            }
+            "conda" => build_conda_purl("conda", None, &name, version.as_deref(), None, None, None)
+                .map(truncate_field),
             _ => None,
         },
         extracted_requirement: version,
@@ -712,7 +760,7 @@ fn json_value_to_string(value: &JsonValue) -> Option<String> {
 }
 
 fn normalize_pypi_name(name: &str) -> String {
-    name.trim().replace('_', "-").to_ascii_lowercase()
+    truncate_field(name.trim().replace('_', "-").to_ascii_lowercase())
 }
 
 fn build_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
@@ -720,7 +768,7 @@ fn build_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if let Some(version) = version {
         purl.with_version(version).ok()?;
     }
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 fn build_pixi_purl(name: &str, version: Option<&str>) -> Option<String> {
@@ -728,7 +776,7 @@ fn build_pixi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if let Some(version) = version {
         purl.with_version(version).ok()?;
     }
-    Some(purl.to_string())
+    Some(truncate_field(purl.to_string()))
 }
 
 fn is_exact_constraint(value: &str) -> bool {
@@ -755,7 +803,7 @@ fn conda_name_from_locator(locator: &str) -> Option<String> {
     let mut parts = stem.rsplitn(3, '-');
     let _ = parts.next()?;
     let _ = parts.next()?;
-    Some(parts.next()?.to_string())
+    Some(truncate_field(parts.next()?.to_string()))
 }
 
 fn default_package_data(datasource_id: Option<DatasourceId>) -> PackageData {

--- a/src/parsers/podfile.rs
+++ b/src/parsers/podfile.rs
@@ -19,16 +19,16 @@
 //! - Local path dependencies (`:path =>`) are tracked as dependencies
 //! - Graceful error handling with `warn!()` logs
 
-use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
-use lazy_static::lazy_static;
 use packageurl::PackageUrl;
 use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::PackageParser;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Parses CocoaPods Podfile dependency files.
 ///
@@ -51,7 +51,7 @@ impl PackageParser for PodfileParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {:?}: {}", path, e);
@@ -117,23 +117,23 @@ fn default_package_data() -> PackageData {
     }
 }
 
-lazy_static! {
-    static ref POD_PATTERN: Regex = Regex::new(
+static POD_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
         r#"pod\s+['"]([^'"]+)['"](?:\s*,\s*['"]([^'"]+)['"])?(?:\s*,\s*:git\s*=>\s*['"]([^'"]+)['"])?(?:\s*,\s*:path\s*=>\s*['"]([^'"]+)['"])?"#
-    ).unwrap();
-}
+    ).expect("valid regex")
+});
 
 /// Extract dependencies from Podfile
 fn extract_dependencies(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let cleaned_line = pre_process(line);
         if let Some(caps) = POD_PATTERN.captures(&cleaned_line) {
-            let name = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-            let version_req = caps.get(2).map(|m| m.as_str().to_string());
-            let git_url = caps.get(3).map(|m| m.as_str().to_string());
-            let local_path = caps.get(4).map(|m| m.as_str().to_string());
+            let name = truncate_field(caps.get(1).map(|m| m.as_str()).unwrap_or("").to_string());
+            let version_req = caps.get(2).map(|m| truncate_field(m.as_str().to_string()));
+            let git_url = caps.get(3).map(|m| truncate_field(m.as_str().to_string()));
+            let local_path = caps.get(4).map(|m| truncate_field(m.as_str().to_string()));
 
             if let Some(dep) = create_dependency(name, version_req, git_url, local_path) {
                 dependencies.push(dep);
@@ -146,7 +146,7 @@ fn extract_dependencies(content: &str) -> Vec<Dependency> {
 
 /// Create a Dependency from parsed components
 fn create_dependency(
-    name: &str,
+    name: String,
     version_req: Option<String>,
     _git_url: Option<String>,
     _local_path: Option<String>,
@@ -155,7 +155,7 @@ fn create_dependency(
         return None;
     }
 
-    let purl = PackageUrl::new("cocoapods", name).ok()?;
+    let purl = PackageUrl::new("cocoapods", &name).ok()?;
 
     let is_pinned = version_req
         .as_ref()
@@ -163,8 +163,8 @@ fn create_dependency(
         .unwrap_or(false);
 
     Some(Dependency {
-        purl: Some(purl.to_string()),
-        extracted_requirement: version_req,
+        purl: Some(truncate_field(purl.to_string())),
+        extracted_requirement: version_req.map(truncate_field),
         scope: Some("dependencies".to_string()),
         is_runtime: None,
         is_optional: None,

--- a/src/parsers/podfile_lock.rs
+++ b/src/parsers/podfile_lock.rs
@@ -20,7 +20,6 @@
 //! - Graceful error handling with `warn!()` logs
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -29,6 +28,7 @@ use yaml_serde::Value;
 use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha1Digest,
 };
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -60,7 +60,7 @@ impl PackageParser for PodfileLockParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Podfile.lock at {:?}: {}", path, e);
@@ -99,7 +99,7 @@ impl DependencyDataByPurl {
         };
 
         if let Some(pods) = data.get("PODS").and_then(|v| v.as_sequence()) {
-            for pod in pods {
+            for pod in pods.iter().take(MAX_ITERATION_COUNT) {
                 let main_pod_str = match pod {
                     Value::String(s) => Some(s.as_str()),
                     Value::Mapping(m) => m.keys().next().and_then(|k| k.as_str()),
@@ -115,7 +115,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(deps) = data.get("DEPENDENCIES").and_then(|v| v.as_sequence()) {
-            for dep in deps {
+            for dep in deps.iter().take(MAX_ITERATION_COUNT) {
                 if let Some(dep_str) = dep.as_str() {
                     let (base_purl, _) = parse_dep_to_base_purl_and_version(dep_str);
                     dep_data.direct_dependency_purls.push(base_purl);
@@ -124,13 +124,13 @@ impl DependencyDataByPurl {
         }
 
         if let Some(spec_repos) = data.get("SPEC REPOS").and_then(|v| v.as_mapping()) {
-            for (repo_key, packages) in spec_repos {
+            for (repo_key, packages) in spec_repos.iter().take(MAX_ITERATION_COUNT) {
                 let repo_name = match repo_key.as_str() {
-                    Some(s) => s.to_string(),
+                    Some(s) => truncate_field(s.to_string()),
                     None => continue,
                 };
                 if let Some(packages) = packages.as_sequence() {
-                    for package in packages {
+                    for package in packages.iter().take(MAX_ITERATION_COUNT) {
                         if let Some(pkg_str) = package.as_str() {
                             let (base_purl, _) = parse_dep_to_base_purl_and_version(pkg_str);
                             dep_data
@@ -143,21 +143,21 @@ impl DependencyDataByPurl {
         }
 
         if let Some(checksums) = data.get("SPEC CHECKSUMS").and_then(|v| v.as_mapping()) {
-            for (name_key, checksum_val) in checksums {
+            for (name_key, checksum_val) in checksums.iter().take(MAX_ITERATION_COUNT) {
                 if let (Some(name), Some(checksum)) = (name_key.as_str(), checksum_val.as_str()) {
                     let (base_purl, _) = parse_dep_to_base_purl_and_version(name);
                     dep_data
                         .checksum_by_base_purl
-                        .insert(base_purl, checksum.to_string());
+                        .insert(base_purl, truncate_field(checksum.to_string()));
                 }
             }
         }
 
         if let Some(checkout_opts) = data.get("CHECKOUT OPTIONS").and_then(|v| v.as_mapping()) {
-            for (name_key, source) in checkout_opts {
+            for (name_key, source) in checkout_opts.iter().take(MAX_ITERATION_COUNT) {
                 if let (Some(name), Some(mapping)) = (name_key.as_str(), source.as_mapping()) {
                     let base_purl = make_base_purl(name);
-                    let processed = process_external_source(mapping);
+                    let processed = truncate_field(process_external_source(mapping));
                     dep_data
                         .external_sources_by_base_purl
                         .insert(base_purl, processed);
@@ -166,7 +166,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(ext_sources) = data.get("EXTERNAL SOURCES").and_then(|v| v.as_mapping()) {
-            for (name_key, source) in ext_sources {
+            for (name_key, source) in ext_sources.iter().take(MAX_ITERATION_COUNT) {
                 if let (Some(name), Some(mapping)) = (name_key.as_str(), source.as_mapping()) {
                     let base_purl = make_base_purl(name);
                     if dep_data
@@ -175,7 +175,7 @@ impl DependencyDataByPurl {
                     {
                         continue;
                     }
-                    let processed = process_external_source(mapping);
+                    let processed = truncate_field(process_external_source(mapping));
                     dep_data
                         .external_sources_by_base_purl
                         .insert(base_purl, processed);
@@ -192,10 +192,10 @@ fn parse_podfile_lock(data: &Value) -> PackageData {
     let mut dependencies = Vec::new();
 
     if let Some(pods) = data.get("PODS").and_then(|v| v.as_sequence()) {
-        for pod in pods {
+        for pod in pods.iter().take(MAX_ITERATION_COUNT) {
             match pod {
                 Value::Mapping(m) => {
-                    for (main_pod_key, dep_pods_val) in m {
+                    for (main_pod_key, dep_pods_val) in m.iter().take(MAX_ITERATION_COUNT) {
                         if let Some(main_pod_str) = main_pod_key.as_str() {
                             let dep_pods: Vec<&str> = dep_pods_val
                                 .as_sequence()
@@ -220,11 +220,11 @@ fn parse_podfile_lock(data: &Value) -> PackageData {
     let cocoapods_version = data
         .get("COCOAPODS")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
     let podfile_checksum = data
         .get("PODFILE CHECKSUM")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(|s| truncate_field(s.to_string()));
 
     let mut extra_data = HashMap::new();
     if let Some(v) = cocoapods_version {
@@ -353,7 +353,7 @@ pub(crate) fn parse_dep_requirements(
     let (name_part, version, requirement) = if let Some(paren_idx) = dep.find('(') {
         let name_part = dep[..paren_idx].trim();
         let version_part = dep[paren_idx..].trim_matches(|c| c == '(' || c == ')' || c == ' ');
-        let requirement = version_part.to_string();
+        let requirement = truncate_field(version_part.to_string());
         let version = version_part.trim_start_matches(|c: char| !c.is_ascii_digit() && c != '.');
         let version = version.trim();
         (
@@ -361,7 +361,7 @@ pub(crate) fn parse_dep_requirements(
             if version.is_empty() {
                 None
             } else {
-                Some(version.to_string())
+                Some(truncate_field(version.to_string()))
             },
             Some(requirement),
         )
@@ -371,9 +371,12 @@ pub(crate) fn parse_dep_requirements(
 
     let (namespace, name) = if name_part.contains('/') {
         let (ns, n) = name_part.split_once('/').unwrap_or(("", &name_part));
-        (Some(ns.trim().to_string()), n.trim().to_string())
+        (
+            Some(truncate_field(ns.trim().to_string())),
+            truncate_field(n.trim().to_string()),
+        )
     } else {
-        (None, name_part.trim().to_string())
+        (None, truncate_field(name_part.trim().to_string()))
     };
 
     (namespace, name, version, requirement)


### PR DESCRIPTION
## Summary

- ADR 0004 security compliance fixes for 5 parsers: podfile_lock, podfile, pixi, opam, microsoft_update_manifest
- Replaces `fs::read_to_string` with `read_file_to_string` (100MB size check + lossy UTF-8 fallback)
- Adds `MAX_ITERATION_COUNT` caps on all unbounded loops
- Applies `truncate_field()` to all extracted string values
- Replaces `lazy_static!` + `.unwrap()` with `LazyLock` + `.expect()` in podfile.rs
- Replaces `String::from_utf8().ok()` with `String::from_utf8_lossy()` in microsoft_update_manifest.rs

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` passes with 0 warnings
- [x] `cargo fmt` passes
- [x] Pre-commit hooks pass