### PR TITLE
fix(parsers): ADR 0004 batch 13 — helm, gitmodules, freebsd, docker, cran

### DIFF
--- a/docs/audit/clojure.md
+++ b/docs/audit/clojure.md
@@ -1,0 +1,29 @@
+# Clojure Parser — ADR 0004 Audit
+
+**Status**: DONE
+**Parser**: `clojure.rs`
+**ADR**: [0004-security-first-parsing](../adr/0004-security-first-parsing.md)
+
+## Findings
+
+| #   | Principle         | Finding                                                |
+| --- | ----------------- | ------------------------------------------------------ |
+| 1   | Recursion Depth   | No recursion depth limit on nested form/reader parsing |
+| 2   | File Size         | No file size check before reading                      |
+| 3   | Iteration Caps    | No iteration limit on reader or parser loops           |
+| 4   | String Truncation | No field-length truncation for extracted strings       |
+| 5   | File Exists       | No pre-read file existence check                       |
+| 6   | UTF-8             | No explicit UTF-8 validation on file reads             |
+
+## Remediation
+
+All findings addressed in commit on branch `fix/adr0004-batch3-nix-meson-hexlock-debian-clojure` (PR #666).
+
+| #   | Principle         | Fix Applied                                                                                                    |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Recursion Depth   | Added `MAX_RECURSION_DEPTH=50` in `Reader` struct; nested form reading checks depth before recursing           |
+| 2   | File Size         | Replaced raw file reads with `read_file_to_string` which enforces the 100 MB size limit                        |
+| 3   | Iteration Caps    | Added `MAX_ITERATION_COUNT` constant; reader and parser loops break early with warning when exceeded           |
+| 4   | String Truncation | Applied `truncate_field` to all extracted string fields (project name, version, description, URL, etc.)        |
+| 5   | File Exists       | `read_file_to_string` performs `fs::metadata()` check before attempting to read; missing files return an error |
+| 6   | UTF-8             | `read_file_to_string` performs validated UTF-8 decode; malformed input returns an error instead of panicking   |

--- a/docs/audit/debian.md
+++ b/docs/audit/debian.md
@@ -1,0 +1,29 @@
+# Debian Parser — ADR 0004 Audit
+
+**Status**: DONE
+**Parser**: `debian.rs`
+**ADR**: [0004-security-first-parsing](../adr/0004-security-first-parsing.md)
+
+## Findings
+
+| #   | Principle         | Finding                                                         |
+| --- | ----------------- | --------------------------------------------------------------- |
+| 1   | File Size         | File size check already present via `read_file_to_string`       |
+| 2   | Iteration Caps    | No iteration limit on paragraph or field parsing loops          |
+| 3   | String Truncation | No field-length truncation for extracted strings                |
+| 4   | Archive Safety    | No archive bomb protections for `.deb` extraction               |
+| 5   | UTF-8             | No explicit lossy UTF-8 handling for control file bytes         |
+| 6   | No `.unwrap()`    | `.unwrap()` on `LazyLock` initialization and other parser paths |
+
+## Remediation
+
+All findings addressed in commit on branch `fix/adr0004-batch3-nix-meson-hexlock-debian-clojure` (PR #666).
+
+| #   | Principle         | Fix Applied                                                                                                                                                                      |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | File Size         | `read_file_to_string` already enforces the 100 MB size limit; no change needed                                                                                                   |
+| 2   | Iteration Caps    | Added `MAX_ITERATION_COUNT` constant; paragraph and field parsing loops break early with warning when exceeded                                                                   |
+| 3   | String Truncation | Applied `truncate_field` to all extracted string fields (package name, version, description, etc.)                                                                               |
+| 4   | Archive Safety    | Added 1 GB uncompressed limit, 100:1 compression ratio check, path traversal blocking (`../`), per-entry size limit, and bounded decompression reads for `.deb` archive handling |
+| 5   | UTF-8             | Replaced raw byte handling with `from_utf8_lossy` for control file content; malformed bytes degrade gracefully                                                                   |
+| 6   | No `.unwrap()`    | Replaced `LazyLock` `.unwrap()` with safe `match`/`if let` patterns; parser paths propagate errors via `Result`                                                                  |

--- a/docs/audit/hex_lock.md
+++ b/docs/audit/hex_lock.md
@@ -1,0 +1,29 @@
+# Hex Lock Parser — ADR 0004 Audit
+
+**Status**: DONE
+**Parser**: `hex_lock.rs`
+**ADR**: [0004-security-first-parsing](../adr/0004-security-first-parsing.md)
+
+## Findings
+
+| #   | Principle         | Finding                                                |
+| --- | ----------------- | ------------------------------------------------------ |
+| 1   | Recursion Depth   | No recursion depth limit on nested Elixir term parsing |
+| 2   | File Size         | No file size check before reading                      |
+| 3   | Iteration Caps    | No iteration limit on tokenizer or parser loops        |
+| 4   | String Truncation | No field-length truncation for extracted strings       |
+| 5   | File Exists       | No pre-read file existence check                       |
+| 6   | UTF-8             | No explicit UTF-8 validation on file reads             |
+
+## Remediation
+
+All findings addressed in commit on branch `fix/adr0004-batch3-nix-meson-hexlock-debian-clojure` (PR #666).
+
+| #   | Principle         | Fix Applied                                                                                                    |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Recursion Depth   | Added `MAX_RECURSION_DEPTH=50` in `Parser` struct; nested term parsing checks depth before recursing           |
+| 2   | File Size         | Replaced raw file reads with `read_file_to_string` which enforces the 100 MB size limit                        |
+| 3   | Iteration Caps    | Added `MAX_ITERATION_COUNT` constant; tokenizer and parser loops break early with warning when exceeded        |
+| 4   | String Truncation | Applied `truncate_field` to all extracted string fields (package name, version, checksum, requirement, etc.)   |
+| 5   | File Exists       | `read_file_to_string` performs `fs::metadata()` check before attempting to read; missing files return an error |
+| 6   | UTF-8             | `read_file_to_string` performs validated UTF-8 decode; malformed input returns an error instead of panicking   |

--- a/docs/audit/meson.md
+++ b/docs/audit/meson.md
@@ -1,0 +1,29 @@
+# Meson Parser — ADR 0004 Audit
+
+**Status**: DONE
+**Parser**: `meson.rs`
+**ADR**: [0004-security-first-parsing](../adr/0004-security-first-parsing.md)
+
+## Findings
+
+| #   | Principle         | Finding                                               |
+| --- | ----------------- | ----------------------------------------------------- |
+| 1   | Recursion Depth   | No recursion depth limit on nested expression parsing |
+| 2   | File Size         | No file size check before reading                     |
+| 3   | Iteration Caps    | No iteration limit on parser loops                    |
+| 4   | String Truncation | No field-length truncation for extracted strings      |
+| 5   | File Exists       | No pre-read file existence check                      |
+| 6   | UTF-8             | No explicit UTF-8 validation on file reads            |
+
+## Remediation
+
+All findings addressed in commit on branch `fix/adr0004-batch3-nix-meson-hexlock-debian-clojure` (PR #666).
+
+| #   | Principle         | Fix Applied                                                                                                    |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Recursion Depth   | Added `MAX_RECURSION_DEPTH=50` in `Parser` struct; nested expression parsing checks depth before recursing     |
+| 2   | File Size         | Replaced raw file reads with `read_file_to_string` which enforces the 100 MB size limit                        |
+| 3   | Iteration Caps    | Added `MAX_ITERATION_COUNT` constant; parser loops break early with warning when exceeded                      |
+| 4   | String Truncation | Applied `truncate_field` to all extracted string fields (project name, version, license, etc.)                 |
+| 5   | File Exists       | `read_file_to_string` performs `fs::metadata()` check before attempting to read; missing files return an error |
+| 6   | UTF-8             | `read_file_to_string` performs validated UTF-8 decode; malformed input returns an error instead of panicking   |

--- a/docs/audit/nix.md
+++ b/docs/audit/nix.md
@@ -1,0 +1,29 @@
+# Nix Parser — ADR 0004 Audit
+
+**Status**: DONE
+**Parser**: `nix.rs`
+**ADR**: [0004-security-first-parsing](../adr/0004-security-first-parsing.md)
+
+## Findings
+
+| #   | Principle                  | Finding                                                         |
+| --- | -------------------------- | --------------------------------------------------------------- |
+| 1   | Recursion Depth            | No recursion depth limit on AST evaluation or wrapper traversal |
+| 2   | File Size                  | No file size check before reading                               |
+| 3   | Iteration Caps             | No iteration limit on tokenizer or parser loops                 |
+| 4   | String Truncation          | No field-length truncation for extracted strings                |
+| 5   | UTF-8                      | No explicit UTF-8 validation on file reads                      |
+| 6   | No `.expect()`/`.unwrap()` | Some `.expect()` calls in parser paths                          |
+
+## Remediation
+
+All findings addressed in commit on branch `fix/adr0004-batch3-nix-meson-hexlock-debian-clojure` (PR #666).
+
+| #   | Principle                  | Fix Applied                                                                                                    |
+| --- | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Recursion Depth            | Added `MAX_RECURSION_DEPTH=50` in `Parser` struct; AST eval functions check and return early on depth overflow |
+| 2   | File Size                  | Replaced raw file reads with `read_file_to_string` which enforces the 100 MB size limit                        |
+| 3   | Iteration Caps             | Added `MAX_ITERATION_COUNT` constant; tokenizer and parser loops break early with warning when exceeded        |
+| 4   | String Truncation          | Applied `truncate_field` to all extracted string fields (description, URL, license, etc.)                      |
+| 5   | UTF-8                      | `read_file_to_string` performs validated UTF-8 decode; malformed input returns an error instead of panicking   |
+| 6   | No `.expect()`/`.unwrap()` | Replaced `.expect()` calls with proper `Result` propagation and safe match arms                                |

--- a/docs/parser-audit/arch.md
+++ b/docs/parser-audit/arch.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/arch.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -100,3 +100,10 @@ No `Command::new` or subprocess usage found.
 1. Add fs::metadata().len() check before read_file_to_string with 100MB limit
 2. Add iteration count caps on line/field loops
 3. Add String::from_utf8_lossy() fallback for UTF-8 handling
+
+## Remediation
+
+- Finding #1 (P2 File Size): Already using `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to `parse_key_value_lines`, `parse_srcinfo_like`, `build_dependencies`, and `build_extra_data`
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, description, homepage_url, extracted_license_statement, packager name/email, extracted_requirement, dep names, extra_data values)
+- Findings #4, #5 (P4): Already covered by `read_file_to_string(path, None)`

--- a/docs/parser-audit/bower.md
+++ b/docs/parser-audit/bower.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/bower.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -100,3 +100,10 @@ No `Command::new` or subprocess usage.
 3. Add 10 MB field value truncation with warning
 4. Add `fs::metadata()` pre-check for file existence
 5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to license, keyword, author, and dependency iterations
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, description, homepage_url, license, keywords, parties, vcs_url, purl, extracted_requirement)
+- Findings #4, #5 (P4): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/buck.md
+++ b/docs/parser-audit/buck.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/buck.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -102,3 +102,10 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `std::fs::read_to_string` with `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to statement iteration, dict extraction, list extraction, and string list kwarg
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, namespace, extracted_license_statement, copyright, homepage_url, download_url, vcs_url, purl, subpath)
+- Findings #4, #5 (P4): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/bun_lock.md
+++ b/docs/parser-audit/bun_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/bun_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -100,3 +100,10 @@ No `Command::new` or subprocess usage.
 3. Add 10 MB field value truncation with warning
 4. Add `fs::metadata()` pre-check for file existence
 5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)`
+- Finding #2 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to packages, workspaces, manifest deps, nested deps, and map keys
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (namespace, name, version, purl, scope, extracted_requirement, resolved_download_url, primary_language, etc.)
+- Findings #4, #5 (P4): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/cargo_lock.md
+++ b/docs/parser-audit/cargo_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/cargo_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -101,3 +101,10 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `File::open`+`read_to_string` with `read_file_to_string(path, None)`
+- Finding #2 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to packages and deps iteration
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, checksum, purl, extracted_requirement, source, api_data_url)
+- Findings #4, #5 (P4): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/conan.md
+++ b/docs/parser-audit/conan.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/conan.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -113,3 +113,11 @@ No `Command::new` or subprocess usage found.
 2. Add AST node count and recursion depth limits to `collect_self_method_calls` (like python.rs: `MAX_SETUP_PY_AST_DEPTH`=50, `MAX_SETUP_PY_AST_NODES`=10,000)
 3. Add 100K iteration caps on line/entry iteration
 4. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced all 3 `fs::read_to_string` calls with `read_file_to_string(path, None)`
+- Finding #2 (P2 Recursion): Added `MAX_AST_DEPTH = 50` and `MAX_AST_NODES = 10_000` to `collect_self_method_calls` with depth tracking and node count
+- Finding #3 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to class body statements, conanfile.txt lines, and conan.lock JSON entries
+- Finding #4 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, description, author, homepage, url, license, topics, requires, purl, extracted_requirement)
+- Finding #5 (P4 UTF-8): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/dart.md
+++ b/docs/parser-audit/dart.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/dart.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,11 @@ None.
 3. Add 100K iteration cap in dependency extraction and BFS traversal loops
 4. Add lossy UTF-8 fallback on read failure
 5. Add 10MB field value truncation with warning
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Recursion Depth): Added `depth: usize` parameter and `MAX_RECURSION_DEPTH = 50` to `format_dependency_mapping`, with `warn!` on overflow
+- Finding #3 (P2 Iteration Count): Added `MAX_ITERATION_COUNT` caps to lock packages, SDKs, dependency maps, BFS queue, format_dependency_mapping, and authors loops
+- Finding #4 (P2 String Length): Applied `truncate_field()` to all extracted string values across all parsers
+- Finding #5 (P4 UTF-8): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/deno.md
+++ b/docs/parser-audit/deno.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/deno.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -98,3 +98,10 @@ No `Command::new` or subprocess usage.
 3. Add 10 MB field value truncation with warning
 4. Add `fs::metadata()` pre-check for file existence
 5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Iteration Count): Added `.take(MAX_ITERATION_COUNT)` to import entries iteration
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (namespace, name, version, purl, extracted_requirement, import_alias)
+- Findings #4, #5 (P4): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/deno_lock.md
+++ b/docs/parser-audit/deno_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/deno_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -104,3 +104,13 @@ No `Command::new` or subprocess usage.
 3. Add 10 MB field value truncation with warning
 4. Add `fs::metadata()` pre-check for file existence
 5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                                                              |
+| --- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | P2: File Size       | Replaced `fs::read_to_string` with `read_file_to_string(path, None)` which enforces 100MB size limit                                             |
+| 2   | P2: Iteration Count | Added `.take(MAX_ITERATION_COUNT)` to 6 iteration sites (workspace_direct, jsr_map, npm_map, redirects, npm deps, JSR deps)                      |
+| 3   | P2: String Length   | Applied `truncate_field()` to all extracted string values (purl, extracted_requirement, namespace, name, version, download_url, redirect fields) |
+| 4   | P4: File Exists     | `read_file_to_string` uses `fs::metadata()` pre-check internally                                                                                 |
+| 5   | P4: UTF-8 Encoding  | `read_file_to_string` provides lossy UTF-8 fallback internally                                                                                   |

--- a/docs/parser-audit/go.md
+++ b/docs/parser-audit/go.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/go.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -112,3 +112,13 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                                                                           |
+| --- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced all 5 `fs::read_to_string` calls with `read_file_to_string(path, None)` — GoMod, GoSum, GoWork, resolve_workspace_use_dependencies, Godeps           |
+| 2   | P2: Iteration Count | Added `.take(MAX_ITERATION_COUNT)` to 6 line/dependency iteration loops across all parsers                                                                    |
+| 3   | P2: String Length   | Applied `truncate_field()` to all extracted string values across all 4 parsers (namespace, name, version, purl, extracted_requirement, homepage_url, vcs_url) |
+| 4   | P4: File Exists     | `read_file_to_string` uses `fs::metadata()` pre-check internally                                                                                              |
+| 5   | P4: UTF-8 Encoding  | `read_file_to_string` provides lossy UTF-8 fallback internally                                                                                                |

--- a/docs/parser-audit/go_mod_graph.md
+++ b/docs/parser-audit/go_mod_graph.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/go_mod_graph.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -100,3 +100,13 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                            |
+| --- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced `fs::read_to_string` with `read_file_to_string(path, None)` which enforces 100MB size limit           |
+| 2   | P2: Iteration Count | Added `.take(MAX_ITERATION_COUNT)` to line iteration                                                           |
+| 3   | P2: String Length   | Applied `truncate_field()` to root_module, purl, extracted_requirement, homepage_url, vcs_url, namespace, name |
+| 4   | P4: File Exists     | `read_file_to_string` uses `fs::metadata()` pre-check internally                                               |
+| 5   | P4: UTF-8 Encoding  | `read_file_to_string` provides lossy UTF-8 fallback internally                                                 |

--- a/docs/parser-audit/gradle.md
+++ b/docs/parser-audit/gradle.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/gradle.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -102,3 +102,13 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning on string token values
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for non-UTF-8 files
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                                                                                 |
+| --- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced `fs::read_to_string` with `read_file_to_string(path, None)` at both call sites (build file + version catalog)                                              |
+| 2   | P2: Iteration Count | Added `MAX_ITERATION_COUNT` caps on lexer token production, `parse_block` iterations, dependency extraction, and catalog parsing                                    |
+| 3   | P2: String Length   | Applied `truncate_field()` to all extracted string values including name, version, namespace, purl, extracted_requirement, license fields, and catalog entry values |
+| 4   | P4: File Exists     | `read_file_to_string` uses `fs::metadata()` pre-check internally                                                                                                    |
+| 5   | P4: UTF-8 Encoding  | `read_file_to_string` provides lossy UTF-8 fallback internally                                                                                                      |

--- a/docs/parser-audit/gradle_lock.md
+++ b/docs/parser-audit/gradle_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/gradle_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,13 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before `File::open`
 5. Add explicit lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                      |
+| --- | ------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced `File::open`+`BufReader` with `read_file_to_string(path, None)` which enforces 100MB size limit |
+| 2   | P2: Iteration Count | Added `.take(MAX_ITERATION_COUNT)` to line iteration                                                     |
+| 3   | P2: String Length   | Applied `truncate_field()` to group, artifact, version, purl, and configuration strings                  |
+| 4   | P4: File Exists     | `read_file_to_string` uses `fs::metadata()` pre-check internally                                         |
+| 5   | P4: UTF-8 Encoding  | `read_file_to_string` provides lossy UTF-8 fallback internally                                           |

--- a/docs/parser-audit/gradle_module.md
+++ b/docs/parser-audit/gradle_module.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/gradle_module.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -102,3 +102,11 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before `File::open`
 5. Consider adding explicit JSON nesting depth tracking beyond serde_json's defaults
+
+## Remediation
+
+- #1 P2: File Size — Replaced `File::open`+`serde_json::from_reader` with `read_file_to_string`+`serde_json::from_str`
+- #2 P2: Iteration Count — Added `.take(MAX_ITERATION_COUNT)` on variant/file/dependency processing
+- #3 P2: String Length — Applied `truncate_field()` to all JSON string field values
+- #4 P4: File Exists — Fixed by `read_file_to_string`
+- #5 P2: Recursion Depth — Acceptable; serde_json handles internally, parser has no recursive functions

--- a/docs/parser-audit/hackage.md
+++ b/docs/parser-audit/hackage.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/hackage.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -110,3 +110,11 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning
 4. Add `fs::metadata()` pre-check before file read
 5. Add lossy UTF-8 conversion with warning for encoding errors
+
+## Remediation
+
+- #1 P2: File Size — Replaced all 3 `fs::read_to_string` calls with `read_file_to_string(path, None)` (100MB limit)
+- #2 P2: Iteration Count — Added `MAX_ITERATION_COUNT` caps on cabal/stack/dependency parsing loops
+- #3 P2: String Length — Applied `truncate_field()` to all string field values
+- #4 P4: File Exists — Fixed by `read_file_to_string`
+- #5 P4: UTF-8 Encoding — Fixed by `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/julia.md
+++ b/docs/parser-audit/julia.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/julia.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,11 @@ None.
 3. Add 100K iteration cap in dependency extraction loops
 4. Add lossy UTF-8 fallback on read failure
 5. Add 10MB field value truncation with warning
+
+## Remediation
+
+- #1 P2: File Size — Replaced `File::open`+`read_to_string` with `read_file_to_string(path, None)` (100MB limit)
+- #2 P2: Recursion Depth — Added `MAX_RECURSION_DEPTH=50` to `toml_to_json` recursion
+- #3 P2: Iteration Count — Added `.take(MAX_ITERATION_COUNT)` on author/dependency loops
+- #4 P2: String Length — Applied `truncate_field()` to all extracted string values
+- #5 P4: UTF-8 Encoding — Fixed by `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/maven.md
+++ b/docs/parser-audit/maven.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/maven.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -112,3 +112,11 @@ No `Command::new` or subprocess usage found.
 3. Add 10 MB string field truncation with warning on parsed text content
 4. Add `fs::metadata()` pre-check before `File::open`
 5. Replace `unwrap_or_default()` on text decode with explicit UTF-8 validation + warning + lossy conversion
+
+## Remediation
+
+- #1 P2: File Size — Verified all 3 file-read sites already use `read_file_to_string` (100MB limit enforced)
+- #2 P2: Iteration Count — Added iteration counter on XML event loop (breaks at 100K with `warn!`); added `.take(MAX_ITERATION_COUNT)` on OSGi parsing loops
+- #3 P2: String Length — Applied `truncate_field()` to all extracted string values across pom.xml, pom.properties, and MANIFEST.MF parsers
+- #4 P4: File Exists — Covered by `read_file_to_string`
+- #5 P4: UTF-8 Encoding — Replaced `e.decode().unwrap_or_default()` with lossy UTF-8 conversion + `warn!` on decode error

--- a/docs/parser-audit/microsoft_update_manifest.md
+++ b/docs/parser-audit/microsoft_update_manifest.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/microsoft_update_manifest.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -94,3 +94,10 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading, reject >100MB
 2. Replace `String::from_utf8().ok()` with `String::from_utf8_lossy()` for XML attribute values
+
+## Remediation
+
+- **#1 P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — enforces 100MB size check before reading and provides lossy UTF-8 fallback.
+- **#2 P2 Iteration**: Added `MAX_ITERATION_COUNT` counter cap to XML parsing loop.
+- **#3 P2 String Length**: Applied `truncate_field()` to all extracted string values (version, description, copyright, homepage_url, purl).
+- **#4 P4 UTF-8**: Replaced `String::from_utf8().ok()` with `String::from_utf8_lossy()` + `warn!` log for XML attribute values — invalid UTF-8 is now preserved via lossy conversion instead of silently dropped.

--- a/docs/parser-audit/npm_workspace.md
+++ b/docs/parser-audit/npm_workspace.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/npm_workspace.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,11 @@ No `Command::new` or subprocess usage.
 3. Add 10 MB field value truncation with warning
 4. Add `fs::metadata()` pre-check for file existence
 5. Add lossy UTF-8 fallback for non-UTF-8 files
+
+## Remediation
+
+- #1 P2: File Size — Replaced `fs::read_to_string` with `read_file_to_string(path, None)` (100MB limit + file-exists check)
+- #2 P2: Iteration Count — Added `.take(MAX_ITERATION_COUNT)` on workspace patterns iteration
+- #3 P2: String Length — Applied `truncate_field()` to workspace pattern strings
+- #4 P4: File Exists — Fixed by `read_file_to_string`
+- #5 P4: UTF-8 Encoding — Fixed by `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/nuget.md
+++ b/docs/parser-audit/nuget.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/nuget.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -123,3 +123,11 @@ None.
 3. Add 100K iteration cap on primary parsing loops
 4. Add 10MB field value truncation with warning
 5. Add lossy UTF-8 fallback for file reads
+
+## Remediation
+
+1. **P2 HIGH**: No file size checks for 7 non-archive parsers — Added `fs::metadata()` checks with `MAX_MANIFEST_SIZE` or replaced with `read_file_to_string`
+2. **P2 MEDIUM**: No recursion depth limit on import resolution — Added `MAX_RECURSION_DEPTH=50` to `resolve_directory_packages_props` and `resolve_directory_build_props`
+3. **P2 MEDIUM**: No iteration caps on XML/JSON loops — Added `MAX_ITERATION_COUNT` caps on all primary parsing loops
+4. **P2 LOW**: No string truncation — Added `truncate_field()` to all extracted string values
+5. **P4 LOW**: No lossy UTF-8 for non-archive reads — Replaced `serde_json::from_reader` with `read_file_to_string`+`from_str` for JSON parsers; added `check_file_size` for XML parsers

--- a/docs/parser-audit/opam.md
+++ b/docs/parser-audit/opam.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/opam.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -103,3 +103,10 @@ None.
 2. Add 100K iteration cap in line processing loops
 3. Add lossy UTF-8 fallback on read failure
 4. Add 10MB field value truncation with warning
+
+## Remediation
+
+- **#1 P2 File Size**: Replaced `std::fs::read_to_string` with `read_file_to_string(path, None)` — enforces 100MB size check before reading and provides lossy UTF-8 fallback.
+- **#2 P2 Iteration**: Added `MAX_ITERATION_COUNT` counter caps to all 5 while loops (parse_opam_data, parse_multiline_string, parse_string_array, parse_dependency_array, parse_checksums).
+- **#3 P2 String Length**: Applied `truncate_field()` to all extracted string values.
+- **#4 P4 UTF-8**: Fixed automatically by `read_file_to_string` — lossy UTF-8 conversion replaces silent failure on non-UTF-8 content.

--- a/docs/parser-audit/pipfile_lock.md
+++ b/docs/parser-audit/pipfile_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/pipfile_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -109,3 +109,11 @@ No `Command::new` or subprocess usage found.
 1. Add `fs::metadata().len()` check (100MB limit) before reading Pipfile.lock and Pipfile
 2. Add 100K iteration caps on dependency/package iteration
 3. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+1. **P2 HIGH**: No file size check for Pipfile.lock — Replaced `fs::read_to_string` with `read_file_to_string`
+2. **P2 HIGH**: No file size check for Pipfile — Already covered by `read_toml_file` internally
+3. **P2 LOW**: No iteration caps — Added `MAX_ITERATION_COUNT` caps on deps/packages/sources
+4. **P2 LOW**: No string truncation — Added `truncate_field()` to all extracted string values
+5. **P4 LOW**: No lossy UTF-8 — Fixed by `read_file_to_string`

--- a/docs/parser-audit/pixi.md
+++ b/docs/parser-audit/pixi.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/pixi.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -102,3 +102,10 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading files, reject >100MB
 2. Add iteration caps (100K) on dependency extraction loops
+
+## Remediation
+
+- **#1 P2 File Size**: Already covered by `read_file_to_string` and `read_toml_file` — both enforce size limits. Verified, no changes needed.
+- **#2 P2 Iteration**: Added `.take(MAX_ITERATION_COUNT)` to all 7 iteration sites (extract_manifest_dependencies, extract_conda_dependencies, extract_pypi_dependencies, extract_v6_lock_dependencies, collect_v6_package_refs, extract_v4_lock_dependencies, extract_authors).
+- **#3 P2 String Length**: Applied `truncate_field()` to all extracted string values in PackageData, Dependency, Party, and FileReference fields.
+- **#4 P4 UTF-8**: Already covered by `read_file_to_string` — lossy UTF-8 conversion is built in. No changes needed.

--- a/docs/parser-audit/podfile.md
+++ b/docs/parser-audit/podfile.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/podfile.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -104,3 +104,11 @@ No `Command::new`, `std::process::Command`, or subprocess usage found.
 3. **[P2: DoS] Add iteration count cap** (100K) to line processing loop with early-break and warning
 4. **[P2: DoS] Add string field truncation** at 10MB with warning log
 5. **[Additional] Replace `.unwrap()`** in `lazy_static!` with `expect()` or `Regex::new(...).expect("POD_PATTERN regex is valid")` for explicit panics with context
+
+## Remediation
+
+- **#1 P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — enforces 100MB size check before reading and provides lossy UTF-8 fallback.
+- **#2 P2 Iteration**: Added `.take(MAX_ITERATION_COUNT)` to `content.lines()` iteration.
+- **#3 P2 String Length**: Applied `truncate_field()` to name, version_req, git_url, local_path, purl, extracted_requirement.
+- **#4 P4 UTF-8**: Fixed automatically by `read_file_to_string` — lossy UTF-8 conversion replaces silent failure on non-UTF-8 content.
+- **#5 Additional**: Replaced `lazy_static!` + `.unwrap()` with `LazyLock<Regex>` + `.expect("valid regex")` for explicit panic with context.

--- a/docs/parser-audit/podfile_lock.md
+++ b/docs/parser-audit/podfile_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/podfile_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -101,3 +101,10 @@ No `Command::new`, `std::process::Command`, or subprocess usage found.
 2. **[P4: Input] Add lossy UTF-8 fallback** — use `fs::read()` + `String::from_utf8_lossy()` instead of `fs::read_to_string()`
 3. **[P2: DoS] Add iteration count caps** (100K) to all YAML sequence/mapping loops with early-break and warning
 4. **[P2: DoS] Add string field truncation** at 10MB with warning log
+
+## Remediation
+
+- **#1 P2 File Size**: Replaced `fs::read_to_string` with `read_file_to_string(path, None)` — enforces 100MB size check before reading and provides lossy UTF-8 fallback.
+- **#2 P2 Iteration**: Added `.take(MAX_ITERATION_COUNT)` to all 8 YAML sequence/mapping iteration sites (PODS, DEPENDENCIES, SPEC REPOS, CHECKSUMS loops).
+- **#3 P2 String Length**: Applied `truncate_field()` to all extracted string values (namespace, name, version, requirement, repo_name, checksum, etc.).
+- **#4 P4 UTF-8**: Fixed automatically by `read_file_to_string` — lossy UTF-8 conversion replaces silent failure on non-UTF-8 content.

--- a/docs/parser-audit/podspec.md
+++ b/docs/parser-audit/podspec.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/podspec.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -119,3 +119,12 @@ No `Command::new`, `std::process::Command`, or subprocess usage found.
 4. **[P2: DoS] Add iteration count caps** (100K) to all line processing loops with early-break and warning
 5. **[Additional] Replace `.unwrap()`** in `lazy_static!` blocks with `expect("regex is valid")` for explicit panics with context
 6. **[P2: DoS] Add string field truncation** at 10MB with warning log
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)` which enforces 100MB size limit
+- Finding #2 (P2 Iteration): Added `.take(MAX_ITERATION_COUNT)` caps to all 6 line-processing loops
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, description, homepage_url, license, vcs_url, purl, extracted_requirement, party name/email)
+- Finding #4 (P4 UTF-8): Fixed automatically by `read_file_to_string` (lossy UTF-8 fallback)
+- Finding #5 (Additional .unwrap()): Replaced nested `.unwrap_or_else(|_| ... .unwrap())` with safe `.or_else().ok()` pattern
+- Finding #6 (Additional lazy_static): Replaced `lazy_static!` regex block with `std::sync::LazyLock<Regex>` + `.expect("valid regex")`

--- a/docs/parser-audit/podspec_json.md
+++ b/docs/parser-audit/podspec_json.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/podspec_json.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -104,3 +104,12 @@ No `Command::new`, `std::process::Command`, or subprocess usage found.
 4. **[P2: DoS] Add iteration count caps** (100K) to authors/dependencies iteration loops with early-break and warning
 5. **[P2: DoS] Add size check** before cloning full JSON into `extra_data["podspec.json"]` at line 147
 6. **[P2: DoS] Add string field truncation** at 10MB with warning log
+
+## Remediation
+
+1. **P2 Medium**: No file size pre-check — Replaced `File::open`+`read_to_string` with `read_file_to_string`
+2. **P2 Medium**: No iteration caps — Added `MAX_ITERATION_COUNT` caps on authors/deps
+3. **P2 Low**: No extra_data size check — Added 10MB size check before cloning JSON to `extra_data`
+4. **P2 Low**: No string truncation — Added `truncate_field()` to all extracted string values
+5. **P4 Medium**: No lossy UTF-8 — Fixed by `read_file_to_string`
+6. **Additional Medium**: `.unwrap()` in PURL fallback — Replaced with safe `.or_else().ok()` and `.map()` pattern

--- a/docs/parser-audit/poetry_lock.md
+++ b/docs/parser-audit/poetry_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/poetry_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -107,3 +107,10 @@ No `Command::new` or subprocess usage found.
 1. Add `fs::metadata().len()` check (100MB limit) before reading poetry.lock
 2. Add 100K iteration caps on package/dependency iteration
 3. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+- Finding #1 (P2 File Size): Already covered by `read_toml_file` → `read_file_to_string` which enforces 100MB size limit
+- Finding #2 (P2 Iteration): Added `.take(MAX_ITERATION_COUNT)` caps on packages and dependency iteration loops
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, purl, extracted_requirement, scope, repository URLs, api_data_url, sha256, python_version, lock_version)
+- Finding #4 (P4 UTF-8): Already covered by `read_toml_file` → `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/readme.md
+++ b/docs/parser-audit/readme.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/readme.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -93,3 +93,10 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading, reject >100MB
 2. Add line iteration cap (100K) on README parsing
+
+## Remediation
+
+- Finding #1 (P2 File Size): Already covered by `read_file_to_string(path, None)` which enforces 100MB size limit
+- Finding #2 (P2 Iteration): Added `.take(MAX_ITERATION_COUNT)` cap on line iteration
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, copyright, download_url, homepage_url, extracted_license_statement, fallback name)
+- Finding #4 (P4 UTF-8): Already covered by `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/requirements_txt.md
+++ b/docs/parser-audit/requirements_txt.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/requirements_txt.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -112,3 +112,11 @@ No `Command::new` or subprocess usage found.
 2. Add explicit recursion depth counter (max 50) to `parse_requirements_with_includes`
 3. Add 100K iteration cap on lines/dependencies with early break and warning
 4. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+1. **P2 HIGH**: No file size check — Replaced `fs::read_to_string` with `read_file_to_string`
+2. **P2 MEDIUM**: No recursion depth limit — Added `MAX_RECURSION_DEPTH=50` to `parse_requirements_with_includes`
+3. **P2 LOW**: No iteration caps — Added `MAX_ITERATION_COUNT` caps on lines and dependencies
+4. **P2 LOW**: No string truncation — Added `truncate_field()` to all extracted string values
+5. **P4 LOW**: No lossy UTF-8 — Fixed by `read_file_to_string`

--- a/docs/parser-audit/rpm_db.md
+++ b/docs/parser-audit/rpm_db.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_db.rs`
 **Date**: 2026-04-14
-**Status**: NON-COMPLIANT
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -111,3 +111,12 @@ No `.unwrap()` calls in library code (excluding test module at line 614).
 3. Add iteration count caps on package/dependency/file loops
 4. Add String::from_utf8_lossy() for rpm query output
 5. Add string length truncation on field values
+
+## Remediation
+
+1. **P1 CRITICAL**: `Command::new("rpm")` subprocess execution — REMOVED entirely; native parsing only
+2. **P2 HIGH**: No file size check — Added `fs::metadata()` pre-check with `MAX_MANIFEST_SIZE=100MB`
+3. **P2 MEDIUM**: No iteration caps — Added `MAX_ITERATION_COUNT` caps on packages, requires, file_names, base_names, dir_names
+4. **P2 MEDIUM**: No string truncation — Added `truncate_field()` to all extracted string values
+5. **P4 LOW**: No `fs::metadata` pre-check — Covered by finding #2
+6. **P4 LOW**: `String::from_utf8` on rpm stdout — Moot since `Command::new` removed; native parsing uses lossy UTF-8

--- a/docs/parser-audit/rpm_db_native_bdb.md
+++ b/docs/parser-audit/rpm_db_native_bdb.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_db_native/bdb.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,10 @@ No `Command::new` or subprocess usage found.
 2. Add iteration cap on page loop (0..=last_page_number)
 3. Add depth limit on overflow page chain traversal
 4. Add size limit on accumulated overflow value data
+
+## Remediation
+
+- Finding #1 (P2 File Size): Added `fs::metadata()` pre-check before `File::open` with `MAX_MANIFEST_SIZE` (100MB) limit
+- Finding #2 (P2 Iteration Pages): Capped `last_page_number` to `MAX_ITERATION_COUNT` with warning on truncation
+- Finding #3 (P2 Iteration Overflow): Added depth counter with `MAX_ITERATION_COUNT` limit on overflow page chain traversal; added cumulative size check against `MAX_FIELD_LENGTH` (10MB)
+- Finding #4 (P2 Iteration Hash): Capped hash page entry count to `MAX_ITERATION_COUNT` with warning and break

--- a/docs/parser-audit/rpm_mariner_manifest.md
+++ b/docs/parser-audit/rpm_mariner_manifest.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_mariner_manifest.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,13 @@ No `Command::new` or subprocess usage found.
 1. Add fs::metadata().len() check before reading with 100MB limit
 2. Add iteration count cap on line loop
 3. Add String::from_utf8_lossy() fallback for UTF-8 handling
+
+## Remediation
+
+All 5 findings addressed:
+
+1. **P2-FileSize**: Replaced `fs::read_to_string` with `read_file_to_string` which enforces a size limit.
+2. **P2-Iteration**: Added `MAX_ITERATION_COUNT` cap on lines.
+3. **P2-StringLength**: Added `truncate_field` on name, version, arch, filename, and namespace.
+4. **P4-Pre-check**: Covered by `read_file_to_string`.
+5. **P4-UTF8**: Covered by `read_file_to_string`.

--- a/docs/parser-audit/rpm_parser.md
+++ b/docs/parser-audit/rpm_parser.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_parser.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -99,3 +99,13 @@ No `Command::new` or subprocess usage found.
 1. Add fs::metadata().len() check before opening RPM files with 100MB limit
 2. Add iteration count caps on dependency/relationship loops
 3. Add string length truncation on field values
+
+## Remediation
+
+All 5 findings addressed:
+
+1. **P2-FileSize**: Added `fs::metadata()` check with 100MB limit before opening RPM files.
+2. **P2-Iteration**: Added `MAX_ITERATION_COUNT` caps on dependency and relationship iteration.
+3. **P2-StringLength**: Added `truncate_field` on all string fields.
+4. **P4-Pre-check**: Addressed by the file size check.
+5. **P4-UTF8**: No change needed; the `rpm` crate returns validated `String` types.

--- a/docs/parser-audit/rpm_specfile.md
+++ b/docs/parser-audit/rpm_specfile.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_specfile.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -105,3 +105,14 @@ No `Command::new` or subprocess usage found.
 2. Add iteration count caps on line/dependency loops
 3. Add String::from_utf8_lossy() fallback for UTF-8 handling
 4. Replace .unwrap() at line 42 with expect() or proper initialization
+
+## Remediation
+
+All 6 findings addressed:
+
+1. **P2-FileSize**: Already covered by `read_file_to_string` which enforces a size limit.
+2. **P2-Iteration**: Added `MAX_ITERATION_COUNT` caps on all 9 iteration sites.
+3. **P2-StringLength**: Added `truncate_field` on all expanded tags, dependencies, and purl.
+4. **P4-UTF8**: Already covered by `read_file_to_string`.
+5. **P4-Pre-check**: Already covered by `read_file_to_string`.
+6. **LazyLock .unwrap()**: Acceptable for compile-time constants; `Regex::new` in `LazyLock` with a static pattern cannot fail at runtime.

--- a/docs/parser-audit/rpm_yumdb.md
+++ b/docs/parser-audit/rpm_yumdb.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/rpm_yumdb.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,13 @@ No `Command::new` or subprocess usage found.
 1. Add fs::metadata().len() check before reading key files with 100MB limit
 2. Add iteration count cap on directory entry loop
 3. Add String::from_utf8_lossy() fallback for UTF-8 handling
+
+## Remediation
+
+All 5 findings addressed:
+
+1. **P2-FileSize**: Replaced `fs::read_to_string` with `read_file_to_string` which enforces a size limit.
+2. **P2-Iteration**: Added `MAX_ITERATION_COUNT` cap on directory entries.
+3. **P2-StringLength**: Added `truncate_field` on name, version, arch, key values, and purl.
+4. **P4-Pre-check**: Covered by `read_file_to_string`.
+5. **P4-UTF8**: Covered by `read_file_to_string`.

--- a/docs/parser-audit/swift_manifest_json.md
+++ b/docs/parser-audit/swift_manifest_json.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/swift_manifest_json.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,10 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading files, reject >100MB
 2. Add iteration cap (100K) on dependencies array
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `fs::read_to_string` with `read_file_to_string(path, None)` which enforces 100MB size limit
+- Finding #2 (P2 Iteration): Added `.take(MAX_ITERATION_COUNT)` cap on dependencies array iteration
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, tools_version, namespace, purl, extracted_requirement, version)
+- Finding #4 (P4 UTF-8): Fixed automatically by `read_file_to_string` (lossy UTF-8 fallback)

--- a/docs/parser-audit/swift_resolved.md
+++ b/docs/parser-audit/swift_resolved.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/swift_resolved.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -96,3 +96,10 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading, reject >100MB
 2. Add iteration cap (100K) on pins processing
+
+## Remediation
+
+- Finding #1 (P2 File Size): Replaced `File::open`+`read_to_string` with `read_file_to_string(path, None)` — provides 100MB size check, file-exists check, and lossy UTF-8 fallback
+- Finding #2 (P2 Iteration): Added `MAX_ITERATION_COUNT` caps to `parse_v2_v3_pins` and `parse_v1_pins` pins iteration
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, purl, namespace, extracted_requirement)
+- Finding #4 (P4 UTF-8): Fixed automatically by switching to `read_file_to_string`

--- a/docs/parser-audit/uv_lock.md
+++ b/docs/parser-audit/uv_lock.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/uv_lock.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -117,3 +117,13 @@ No `Command::new` or subprocess usage found.
 2. Add recursion depth limit to `toml_value_to_json` (max 50)
 3. Add 100K iteration caps on package/dependency iteration
 4. Add lossy UTF-8 fallback with warning log
+
+## Remediation
+
+All 5 findings addressed:
+
+1. **P2-FileSize**: Already covered by `read_toml_file` → `read_file_to_string` which enforces a size limit.
+2. **P2-Recursion**: Added `MAX_RECURSION_DEPTH=50` to `toml_value_to_json`.
+3. **P2-Iteration**: Added `MAX_ITERATION_COUNT` caps on package/dependency/edge iteration.
+4. **P2-StringLength**: Added `truncate_field` on name, version, purl, extracted_requirement, scope, and URL fields.
+5. **P4-UTF8**: Already covered by `read_file_to_string`.

--- a/docs/parser-audit/windows_executable.md
+++ b/docs/parser-audit/windows_executable.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/windows_executable.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -104,3 +104,10 @@ No subprocess calls found.
 1. Replace `String::from_utf16().ok()` with `String::from_utf16_lossy()` at line 423
 2. Add iteration cap (100K) on version block processing
 3. Consider adding explicit file size check documentation for callers
+
+## Remediation
+
+- Finding #1 (P2 File Size): No change needed — parser operates on `bytes: &[u8]` from scanner; sibling license files already have size checks
+- Finding #2 (P2 Iteration): Added `MAX_ITERATION_COUNT` cap to `iter_version_blocks` with `warn!` on overflow
+- Finding #3 (P2 String Length): Applied `truncate_field()` to all extracted string values (name, version, description, homepage_url, purl, company_name, extracted_license_statement, copyright, holder)
+- Finding #4 (P4 UTF-8): Replaced `String::from_utf16().ok()` with lossy conversion using `char::decode_utf16` with `warn!` on invalid UTF-16

--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -21,16 +21,15 @@
 //! - Authors@R field is NOT parsed (requires R interpreter)
 
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
-use lazy_static::lazy_static;
 use packageurl::PackageUrl;
 use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -48,16 +47,21 @@ impl PackageParser for CranParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let fields = match read_description_file(path) {
-            Ok(content) => parse_dcf(&content),
+        let content = match read_file_to_string(path, None) {
+            Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read DESCRIPTION at {:?}: {}", path, e);
                 return vec![default_package_data()];
             }
         };
+        let fields = parse_dcf(&content);
 
-        let name = fields.get("Package").map(|s| s.trim().to_string());
-        let version = fields.get("Version").map(|s| s.trim().to_string());
+        let name = fields
+            .get("Package")
+            .map(|s| truncate_field(s.trim().to_string()));
+        let version = fields
+            .get("Version")
+            .map(|s| truncate_field(s.trim().to_string()));
 
         // Generate PURL
         let purl = create_package_url(&name, &version);
@@ -65,18 +69,20 @@ impl PackageParser for CranParser {
         // Generate repository URLs
         let repository_homepage_url = name
             .as_ref()
-            .map(|n| format!("https://cran.r-project.org/package={}", n));
+            .map(|n| truncate_field(format!("https://cran.r-project.org/package={}", n)));
 
         // Build description from Title and Description fields
         let description = build_description(&fields);
 
         // Extract license statement
-        let extracted_license_statement = fields.get("License").map(|s| s.trim().to_string());
+        let extracted_license_statement = fields
+            .get("License")
+            .map(|s| truncate_field(s.trim().to_string()));
 
         // Extract URL field
         let homepage_url = fields
             .get("URL")
-            .map(|s| s.split(',').next().unwrap_or("").trim().to_string())
+            .map(|s| truncate_field(s.split(',').next().unwrap_or("").trim().to_string()))
             .filter(|s| !s.is_empty());
 
         // Extract parties (Author and Maintainer)
@@ -161,29 +167,12 @@ impl PackageParser for CranParser {
     }
 }
 
-/// Read a DESCRIPTION file into a string.
-fn read_description_file(path: &Path) -> Result<String, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
-
-    Ok(content)
-}
-
-/// Parse DCF (Debian Control File) format into a HashMap of fields.
-///
-/// DCF format is similar to RFC822:
-/// - Field names followed by colon and value
-/// - Continuation lines start with whitespace (space or tab)
-/// - Field names are case-sensitive
 fn parse_dcf(content: &str) -> HashMap<String, String> {
     let mut fields: HashMap<String, String> = HashMap::new();
     let mut current_field: Option<String> = None;
     let mut current_value = String::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         // Check if line is a continuation (starts with whitespace)
         if line.starts_with(' ') || line.starts_with('\t') {
             if current_field.is_some() {
@@ -196,7 +185,7 @@ fn parse_dcf(content: &str) -> HashMap<String, String> {
         } else if let Some((field_name, field_value)) = line.split_once(':') {
             // New field: save previous field if any
             if let Some(field) = current_field.take() {
-                fields.insert(field, current_value.clone());
+                fields.insert(field, truncate_field(current_value.clone()));
                 current_value.clear();
             }
 
@@ -209,7 +198,7 @@ fn parse_dcf(content: &str) -> HashMap<String, String> {
 
     // Save the last field
     if let Some(field) = current_field {
-        fields.insert(field, current_value);
+        fields.insert(field, truncate_field(current_value));
     }
 
     fields
@@ -222,7 +211,7 @@ fn parse_dcf(content: &str) -> HashMap<String, String> {
 fn parse_dependencies(deps_str: &str, scope: Option<&str>) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for dep in deps_str.split(',') {
+    for dep in deps_str.split(',').take(MAX_ITERATION_COUNT) {
         let dep = dep.trim();
         if dep.is_empty() {
             continue;
@@ -272,8 +261,8 @@ fn parse_dependencies(deps_str: &str, scope: Option<&str>) -> Vec<Dependency> {
 
         dependencies.push(Dependency {
             purl,
-            extracted_requirement,
-            scope: scope.map(|s| s.to_string()),
+            extracted_requirement: extracted_requirement.map(truncate_field),
+            scope: scope.map(|s| truncate_field(s.to_string())),
             is_runtime: Some(scope.is_none() || scope == Some("imports")),
             is_optional: Some(scope == Some("suggests") || scope == Some("enhances")),
             is_pinned: Some(is_pinned),
@@ -286,10 +275,9 @@ fn parse_dependencies(deps_str: &str, scope: Option<&str>) -> Vec<Dependency> {
     dependencies
 }
 
-lazy_static! {
-    static ref VERSION_CONSTRAINT_RE: Regex =
-        Regex::new(r"^([a-zA-Z0-9.]+)\s*\(([><=]+)\s*([0-9.]+)\)\s*$").unwrap();
-}
+static VERSION_CONSTRAINT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^([a-zA-Z0-9.]+)\s*\(([><=]+)\s*([0-9.]+)\)\s*$").expect("valid regex")
+});
 
 /// Examples:
 /// - "cli (>= 3.6.2)" -> ("cli", Some(">= 3.6.2"), true)
@@ -297,22 +285,33 @@ lazy_static! {
 /// - "glue (== 1.3.2)" -> ("glue", Some("== 1.3.2"), true)
 fn parse_version_constraint(dep: &str) -> (String, Option<String>, bool) {
     if let Some(captures) = VERSION_CONSTRAINT_RE.captures(dep) {
-        let name = captures.get(1).unwrap().as_str().to_string();
-        let operator = captures.get(2).unwrap().as_str();
-        let version = captures.get(3).unwrap().as_str();
-        let requirement = format!("{} {}", operator, version);
+        let name = match captures.get(1) {
+            Some(m) => truncate_field(m.as_str().to_string()),
+            None => return (truncate_field(dep.trim().to_string()), None, false),
+        };
+        let operator = match captures.get(2) {
+            Some(m) => m.as_str(),
+            None => return (name, None, false),
+        };
+        let version = match captures.get(3) {
+            Some(m) => m.as_str(),
+            None => return (name, None, false),
+        };
+        let requirement = truncate_field(format!("{} {}", operator, version));
         let is_pinned = operator == "==";
 
         (name, Some(requirement), is_pinned)
     } else {
-        // No version constraint
-        (dep.trim().to_string(), None, false)
+        (truncate_field(dep.trim().to_string()), None, false)
     }
 }
 
 /// Extract version number from a requirement string like ">= 3.6.2" or "== 1.0.0".
 fn extract_version_from_requirement(requirement: &str) -> Option<String> {
-    requirement.split_whitespace().nth(1).map(|s| s.to_string())
+    requirement
+        .split_whitespace()
+        .nth(1)
+        .map(|s| truncate_field(s.to_string()))
 }
 
 /// Build description from Title and Description fields.
@@ -321,9 +320,11 @@ fn build_description(fields: &HashMap<String, String>) -> Option<String> {
     let desc = fields.get("Description").map(|s| s.trim());
 
     match (title, desc) {
-        (Some(t), Some(d)) if !t.is_empty() && !d.is_empty() => Some(format!("{}\n{}", t, d)),
-        (Some(t), _) if !t.is_empty() => Some(t.to_string()),
-        (_, Some(d)) if !d.is_empty() => Some(d.to_string()),
+        (Some(t), Some(d)) if !t.is_empty() && !d.is_empty() => {
+            Some(truncate_field(format!("{}\n{}", t, d)))
+        }
+        (Some(t), _) if !t.is_empty() => Some(truncate_field(t.to_string())),
+        (_, Some(d)) if !d.is_empty() => Some(truncate_field(d.to_string())),
         _ => None,
     }
 }
@@ -334,7 +335,7 @@ fn split_author_entries(author_str: &str) -> Vec<&str> {
     let mut bracket_depth: usize = 0;
     let mut paren_depth: usize = 0;
 
-    for (idx, ch) in author_str.char_indices() {
+    for (idx, ch) in author_str.char_indices().take(MAX_ITERATION_COUNT) {
         match ch {
             '[' => bracket_depth += 1,
             ']' => bracket_depth = bracket_depth.saturating_sub(1),
@@ -380,9 +381,9 @@ fn parse_party(info: &str, role: &str) -> Option<Party> {
 
             if !email.contains('@') {
                 return Some(Party {
-                    r#type: Some("person".to_string()),
-                    role: Some(role.to_string()),
-                    name: Some(info.to_string()),
+                    r#type: Some(truncate_field("person".to_string())),
+                    role: Some(truncate_field(role.to_string())),
+                    name: Some(truncate_field(info.to_string())),
                     email: None,
                     url: None,
                     organization: None,
@@ -392,10 +393,18 @@ fn parse_party(info: &str, role: &str) -> Option<Party> {
             }
 
             return Some(Party {
-                r#type: Some("person".to_string()),
-                role: Some(role.to_string()),
-                name: if name.is_empty() { None } else { Some(name) },
-                email: if email.is_empty() { None } else { Some(email) },
+                r#type: Some(truncate_field("person".to_string())),
+                role: Some(truncate_field(role.to_string())),
+                name: if name.is_empty() {
+                    None
+                } else {
+                    Some(truncate_field(name))
+                },
+                email: if email.is_empty() {
+                    None
+                } else {
+                    Some(truncate_field(email))
+                },
                 url: None,
                 organization: None,
                 organization_url: None,
@@ -406,9 +415,9 @@ fn parse_party(info: &str, role: &str) -> Option<Party> {
 
     // Just a name or email
     Some(Party {
-        r#type: Some("person".to_string()),
-        role: Some(role.to_string()),
-        name: Some(info.to_string()),
+        r#type: Some(truncate_field("person".to_string())),
+        role: Some(truncate_field(role.to_string())),
+        name: Some(truncate_field(info.to_string())),
         email: None,
         url: None,
         organization: None,

--- a/src/parsers/docker.rs
+++ b/src/parsers/docker.rs
@@ -5,7 +5,7 @@ use crate::parser_warn as warn;
 use serde_json::json;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
-use crate::parsers::utils::read_file_to_string;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
@@ -64,17 +64,25 @@ pub(crate) fn parse_dockerfile(content: &str) -> PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Dockerfile".to_string()),
         datasource_id: Some(DatasourceId::Dockerfile),
-        name: oci_labels.get("org.opencontainers.image.title").cloned(),
+        name: oci_labels
+            .get("org.opencontainers.image.title")
+            .map(|v| truncate_field(v.clone())),
         description: oci_labels
             .get("org.opencontainers.image.description")
-            .cloned(),
-        homepage_url: oci_labels.get("org.opencontainers.image.url").cloned(),
-        vcs_url: oci_labels.get("org.opencontainers.image.source").cloned(),
-        version: oci_labels.get("org.opencontainers.image.version").cloned(),
+            .map(|v| truncate_field(v.clone())),
+        homepage_url: oci_labels
+            .get("org.opencontainers.image.url")
+            .map(|v| truncate_field(v.clone())),
+        vcs_url: oci_labels
+            .get("org.opencontainers.image.source")
+            .map(|v| truncate_field(v.clone())),
+        version: oci_labels
+            .get("org.opencontainers.image.version")
+            .map(|v| truncate_field(v.clone())),
         declared_license_expression,
         declared_license_expression_spdx,
         license_detections,
-        extracted_license_statement,
+        extracted_license_statement: extracted_license_statement.map(truncate_field),
         extra_data,
         ..Default::default()
     }
@@ -98,8 +106,14 @@ fn extract_oci_labels(content: &str) -> HashMap<String, String> {
 fn logical_lines(content: &str) -> Vec<String> {
     let mut lines = Vec::new();
     let mut current = String::new();
+    let mut iterations = 0usize;
 
     for raw_line in content.lines() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            warn!("logical_lines: exceeded MAX_ITERATION_COUNT, truncating");
+            break;
+        }
         let line = raw_line.trim_end();
         let trimmed = line.trim();
 
@@ -160,13 +174,17 @@ fn parse_label_instruction(rest: &str, labels: &mut HashMap<String, String>) {
     }
 
     if tokens.first().is_some_and(|token| token.contains('=')) {
-        for token in tokens {
+        for (i, token) in tokens.into_iter().enumerate() {
+            if i >= MAX_ITERATION_COUNT {
+                warn!("parse_label_instruction: exceeded MAX_ITERATION_COUNT, truncating");
+                break;
+            }
             let Some((key, value)) = token.split_once('=') else {
                 continue;
             };
             let key = key.trim();
             if key.starts_with(OCI_LABEL_PREFIX) {
-                labels.insert(key.to_string(), value.trim().to_string());
+                labels.insert(key.to_string(), truncate_field(value.trim().to_string()));
             }
         }
         return;
@@ -175,7 +193,10 @@ fn parse_label_instruction(rest: &str, labels: &mut HashMap<String, String>) {
     if let Some((key, values)) = tokens.split_first()
         && key.starts_with(OCI_LABEL_PREFIX)
     {
-        labels.insert(key.to_string(), values.join(" ").trim().to_string());
+        labels.insert(
+            key.to_string(),
+            truncate_field(values.join(" ").trim().to_string()),
+        );
     }
 }
 
@@ -184,8 +205,14 @@ fn tokenize_label_arguments(input: &str) -> Vec<String> {
     let mut current = String::new();
     let mut chars = input.chars().peekable();
     let mut quote: Option<char> = None;
+    let mut iterations = 0usize;
 
     while let Some(ch) = chars.next() {
+        iterations += 1;
+        if iterations > MAX_ITERATION_COUNT {
+            warn!("tokenize_label_arguments: exceeded MAX_ITERATION_COUNT, truncating");
+            break;
+        }
         match quote {
             Some(current_quote) => {
                 if ch == '\\' {

--- a/src/parsers/freebsd.rs
+++ b/src/parsers/freebsd.rs
@@ -26,7 +26,7 @@ use packageurl::PackageUrl;
 use serde::Deserialize;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
-use crate::parsers::utils::read_file_to_string;
+use crate::parsers::utils::{read_file_to_string, truncate_field};
 use crate::utils::spdx::{ExpressionRelation, combine_license_expressions_with_relation};
 
 use super::PackageParser;
@@ -95,19 +95,24 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
         }
     };
 
-    let name = manifest.name.clone();
-    let version = manifest.version.clone();
-    let description = manifest.description;
-    let homepage_url = manifest.www;
-    let keywords = manifest.categories.unwrap_or_default();
+    let name = manifest.name.map(truncate_field);
+    let version = manifest.version.map(truncate_field);
+    let description = manifest.description.map(truncate_field);
+    let homepage_url = manifest.www.map(truncate_field);
+    let keywords = manifest
+        .categories
+        .unwrap_or_default()
+        .into_iter()
+        .map(truncate_field)
+        .collect();
 
     // Build qualifiers from arch and origin
     let mut qualifiers = HashMap::new();
     if let Some(ref arch) = manifest.arch {
-        qualifiers.insert("arch".to_string(), arch.clone());
+        qualifiers.insert("arch".to_string(), truncate_field(arch.clone()));
     }
     if let Some(ref origin) = manifest.origin {
-        qualifiers.insert("origin".to_string(), origin.clone());
+        qualifiers.insert("origin".to_string(), truncate_field(origin.clone()));
     }
 
     // Build parties from maintainer (just an email address)
@@ -117,7 +122,7 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
             r#type: Some("person".to_string()),
             role: Some("maintainer".to_string()),
             name: None,
-            email: Some(maintainer_email),
+            email: Some(truncate_field(maintainer_email)),
             url: None,
             organization: None,
             organization_url: None,
@@ -126,12 +131,15 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
     }
 
     // Build extracted_license_statement from licenses and licenselogic
-    let extracted_license_statement =
-        build_license_statement(&manifest.licenses, &manifest.licenselogic);
+    let licenses = manifest
+        .licenses
+        .map(|lics| lics.into_iter().map(truncate_field).collect());
+    let licenselogic = manifest.licenselogic.map(truncate_field);
+    let extracted_license_statement = build_license_statement(&licenses, &licenselogic);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         build_freebsd_license_data(
-            manifest.licenses.as_deref(),
-            manifest.licenselogic.as_deref(),
+            licenses.as_deref(),
+            licenselogic.as_deref(),
             extracted_license_statement.as_deref(),
         );
 
@@ -139,16 +147,16 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
     let code_view_url = manifest
         .origin
         .as_ref()
-        .map(|origin| format!("https://svnweb.freebsd.org/ports/head/{}", origin));
+        .map(|origin| truncate_field(format!("https://svnweb.freebsd.org/ports/head/{}", origin)));
 
     // Build download_url from arch, name, and version
     let download_url = if let (Some(arch), Some(pkg_name), Some(pkg_version)) =
         (&manifest.arch, &name, &version)
     {
-        Some(format!(
+        Some(truncate_field(format!(
             "https://pkg.freebsd.org/{}/latest/All/{}-{}.txz",
             arch, pkg_name, pkg_version
-        ))
+        )))
     } else {
         None
     };
@@ -161,6 +169,7 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
             manifest.origin.as_deref(),
         )
     });
+    let purl = purl.map(truncate_field);
 
     PackageData {
         datasource_id: Some(DatasourceId::FreebsdCompactManifest),
@@ -179,7 +188,7 @@ pub(crate) fn parse_freebsd_manifest(content: &str) -> PackageData {
         declared_license_expression,
         declared_license_expression_spdx,
         license_detections,
-        extracted_license_statement,
+        extracted_license_statement: extracted_license_statement.map(truncate_field),
         code_view_url,
         download_url,
         purl,

--- a/src/parsers/gitmodules.rs
+++ b/src/parsers/gitmodules.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use crate::parser_warn as warn;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::utils::read_file_to_string;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -62,10 +62,11 @@ impl PackageParser for GitmodulesParser {
 
         let dependencies: Vec<Dependency> = submodules
             .into_iter()
+            .take(MAX_ITERATION_COUNT)
             .map(|sub| Dependency {
-                purl: sub.purl,
-                extracted_requirement: Some(format!("{} at {}", sub.path, sub.url)),
-                scope: Some("runtime".to_string()),
+                purl: sub.purl.map(truncate_field),
+                extracted_requirement: Some(truncate_field(format!("{} at {}", sub.path, sub.url))),
+                scope: Some(truncate_field("runtime".to_string())),
                 is_runtime: Some(true),
                 is_optional: Some(false),
                 is_direct: Some(true),
@@ -95,7 +96,7 @@ fn parse_gitmodules(content: &str) -> Vec<Submodule> {
     let mut current_section: Option<HashMap<String, String>> = None;
     let mut current_name: Option<String> = None;
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
 
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
@@ -112,14 +113,14 @@ fn parse_gitmodules(content: &str) -> Vec<Submodule> {
 
             let section_name = &line[1..line.len() - 1];
             if let Some(stripped) = section_name.strip_prefix("submodule ") {
-                current_name = Some(stripped.trim_matches('"').to_string());
+                current_name = Some(truncate_field(stripped.trim_matches('"').to_string()));
                 current_section = Some(HashMap::new());
             }
         } else if let Some(ref mut section) = current_section
             && let Some((key, value)) = line.split_once('=')
         {
-            let key = key.trim().to_string();
-            let value = value.trim().to_string();
+            let key = truncate_field(key.trim().to_string());
+            let value = truncate_field(value.trim().to_string());
             section.insert(key, value);
         }
     }
@@ -135,8 +136,8 @@ fn parse_gitmodules(content: &str) -> Vec<Submodule> {
 }
 
 fn build_submodule(_name: String, section: HashMap<String, String>) -> Option<Submodule> {
-    let path = section.get("path").cloned().unwrap_or_default();
-    let url = section.get("url").cloned().unwrap_or_default();
+    let path = truncate_field(section.get("path").cloned().unwrap_or_default());
+    let url = truncate_field(section.get("url").cloned().unwrap_or_default());
 
     if path.is_empty() && url.is_empty() {
         return None;
@@ -174,7 +175,7 @@ fn parse_github_url(url: &str) -> Option<String> {
         return None;
     };
 
-    Some(format!("pkg:github/{}/{}", namespace, name))
+    Some(truncate_field(format!("pkg:github/{}/{}", namespace, name)))
 }
 
 fn parse_gitlab_url(url: &str) -> Option<String> {
@@ -188,7 +189,7 @@ fn parse_gitlab_url(url: &str) -> Option<String> {
         return None;
     };
 
-    Some(format!("pkg:gitlab/{}/{}", namespace, name))
+    Some(truncate_field(format!("pkg:gitlab/{}/{}", namespace, name)))
 }
 
 fn parse_repo_path(path: &str) -> Option<(String, String)> {
@@ -199,8 +200,8 @@ fn parse_repo_path(path: &str) -> Option<(String, String)> {
         return None;
     }
 
-    let name = parts.last()?.to_string();
-    let namespace = parts[..parts.len() - 1].join("/");
+    let name = truncate_field(parts.last()?.to_string());
+    let namespace = truncate_field(parts[..parts.len() - 1].join("/"));
 
     if namespace.is_empty() || name.is_empty() {
         return None;

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 use yaml_serde::{Mapping, Value};
@@ -57,7 +57,7 @@ impl PackageParser for HelmChartLockParser {
 
 fn read_yaml_file(path: &Path) -> Result<Value, String> {
     let content =
-        fs::read_to_string(path).map_err(|error| format!("Failed to read file: {error}"))?;
+        read_file_to_string(path, None).map_err(|error| format!("Failed to read file: {error}"))?;
     yaml_serde::from_str(&content).map_err(|error| format!("Failed to parse YAML: {error}"))
 }
 
@@ -125,6 +125,7 @@ fn extract_chart_yaml_dependencies(yaml_content: &Value) -> Vec<Dependency> {
 
     entries
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(Value::as_mapping)
         .filter_map(parse_chart_yaml_dependency)
         .collect()
@@ -189,6 +190,7 @@ fn extract_chart_lock_dependencies(yaml_content: &Value) -> Vec<Dependency> {
 
     entries
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(Value::as_mapping)
         .filter_map(parse_chart_lock_dependency)
         .collect()
@@ -249,6 +251,7 @@ fn extract_maintainers(yaml_content: &Value) -> Vec<Party> {
 
     maintainers
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(Value::as_mapping)
         .filter_map(|mapping| {
             let name = mapping_get(mapping, "name").and_then(yaml_value_to_string)?;
@@ -281,17 +284,21 @@ fn extract_string_list_field(yaml_content: &Value, field: &str) -> Vec<String> {
 
 fn extract_string_values(value: &Value) -> Vec<String> {
     match value {
-        Value::String(value) => vec![value.clone()],
-        Value::Sequence(values) => values.iter().filter_map(yaml_value_to_string).collect(),
+        Value::String(value) => vec![truncate_field(value.clone())],
+        Value::Sequence(values) => values
+            .iter()
+            .take(MAX_ITERATION_COUNT)
+            .filter_map(yaml_value_to_string)
+            .collect(),
         _ => Vec::new(),
     }
 }
 
 fn yaml_value_to_string(value: &Value) -> Option<String> {
     match value {
-        Value::String(value) => Some(value.clone()),
-        Value::Number(value) => Some(value.to_string()),
-        Value::Bool(value) => Some(value.to_string()),
+        Value::String(value) => Some(truncate_field(value.clone())),
+        Value::Number(value) => Some(truncate_field(value.to_string())),
+        Value::Bool(value) => Some(truncate_field(value.to_string())),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: helm, gitmodules, freebsd, docker, cran
- Add DoS protection (file size checks, iteration caps, string truncation), lossy UTF-8 fallback, and .unwrap() removal per ADR 0004

## Changes

| Parser | File Size | Iteration Caps | String Truncation | UTF-8 | .unwrap() |
|--------|-----------|----------------|-------------------|-------|-----------|
| helm | read_file_to_string | 4 sites | truncate_field | ✓ | — |
| gitmodules | already covered | 2 sites | truncate_field | ✓ | — |
| freebsd | already covered | — | truncate_field | ✓ | — |
| docker | already covered | 3 sites | truncate_field | ✓ | — |
| cran | read_file_to_string | 3 sites | truncate_field | ✓ | LazyLock |

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Pre-commit hooks pass