### PR TITLE
fix(parsers): ADR 0004 batch 14 — cpan, cpan_dist_ini, cpan_makefile_pl, conda, conda_meta_json

### DIFF
--- a/docs/parser-audit/cran.md
+++ b/docs/parser-audit/cran.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/cran.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -103,3 +103,13 @@ None.
 3. Add lossy UTF-8 fallback on read failure
 4. Replace `.unwrap()` on regex captures with safer alternatives (e.g., `expect()` with message or `if let`)
 5. Add 10MB field value truncation with warning
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                                |
+| --- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced `File::open`+`read_to_string` with `read_file_to_string` which enforces 100MB limit       |
+| 2   | P2: Iteration Count | Added `MAX_ITERATION_COUNT` caps on 3 sites (parse_dcf, parse_dependencies, split_author)          |
+| 3   | P2: String Length   | Applied `truncate_field` on all output strings                                                     |
+| 4   | P4: UTF-8 Encoding  | Fixed by `read_file_to_string` which provides lossy UTF-8 fallback                                 |
+| 5   | .unwrap()           | Replaced raw `.unwrap()` on regex captures with safe `match`; migrated `lazy_static` to `LazyLock` |

--- a/docs/parser-audit/docker.md
+++ b/docs/parser-audit/docker.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/docker.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -95,3 +95,12 @@ None.
 2. Add lossy UTF-8 fallback on read failure — line 43
 3. Add 100K iteration cap in `logical_lines()` and `tokenize_label_arguments()`
 4. Add 10MB field value truncation with warning
+
+## Remediation
+
+| #   | Finding             | Fix                                                                               |
+| --- | ------------------- | --------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Already covered by `read_file_to_string` which enforces 100MB size limit          |
+| 2   | P2: Iteration Count | Added `MAX_ITERATION_COUNT` caps on 3 sites (logical_lines, tokenize, token loop) |
+| 3   | P2: String Length   | Applied `truncate_field` on all output strings                                    |
+| 4   | P4: UTF-8 Encoding  | Already covered by `read_file_to_string` which provides lossy UTF-8 fallback      |

--- a/docs/parser-audit/freebsd.md
+++ b/docs/parser-audit/freebsd.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/freebsd.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -94,3 +94,12 @@ No `Command::new` or subprocess usage found.
 1. Add fs::metadata().len() check before read_file_to_string with 100MB limit
 2. Add String::from_utf8_lossy() fallback for UTF-8 handling
 3. Add string length truncation on deserialized field values
+
+## Remediation
+
+| #   | Finding           | Fix                                                                          |
+| --- | ----------------- | ---------------------------------------------------------------------------- |
+| 1   | P2: File Size     | Already covered by `read_file_to_string` which enforces 100MB size limit     |
+| 2   | P2: String Length | Applied `truncate_field` on all deserialized fields                          |
+| 3   | P4: File Exists   | Already covered by `read_file_to_string` error handling                      |
+| 4   | P4: UTF-8         | Already covered by `read_file_to_string` which provides lossy UTF-8 fallback |

--- a/docs/parser-audit/gitmodules.md
+++ b/docs/parser-audit/gitmodules.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/gitmodules.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -97,3 +97,12 @@ No subprocess calls found.
 
 1. Add `fs::metadata().len()` check before reading, reject >100MB
 2. Add iteration cap (100K) on line parsing
+
+## Remediation
+
+| #   | Finding           | Fix                                                                             |
+| --- | ----------------- | ------------------------------------------------------------------------------- |
+| 1   | P2: File Size     | Already covered by `read_file_to_string` which enforces 100MB size limit        |
+| 2   | P2: Iteration     | Added `MAX_ITERATION_COUNT` caps on 2 sites (line parsing, submodule iteration) |
+| 3   | P2: String Length | Applied `truncate_field` on all output strings                                  |
+| 4   | P4: UTF-8         | Already covered by `read_file_to_string` which provides lossy UTF-8 fallback    |

--- a/docs/parser-audit/helm.md
+++ b/docs/parser-audit/helm.md
@@ -2,7 +2,7 @@
 
 **File**: `src/parsers/helm.rs`
 **Date**: 2026-04-14
-**Status**: PARTIAL
+**Status**: DONE
 
 ## Principle 1: No Code Execution
 
@@ -95,3 +95,12 @@ None.
 2. Add lossy UTF-8 fallback on read failure — line 59
 3. Add 100K iteration cap in dependency extraction loops
 4. Add 10MB field value truncation with warning
+
+## Remediation
+
+| #   | Finding             | Fix                                                                                      |
+| --- | ------------------- | ---------------------------------------------------------------------------------------- |
+| 1   | P2: File Size       | Replaced `fs::read_to_string` with `read_file_to_string` which enforces 100MB size limit |
+| 2   | P2: Iteration Count | Added `MAX_ITERATION_COUNT` caps on 4 iteration sites (dependencies, maintainers, etc.)  |
+| 3   | P2: String Length   | Applied `truncate_field` on all output strings                                           |
+| 4   | P4: UTF-8 Encoding  | Fixed by `read_file_to_string` which provides lossy UTF-8 fallback                       |

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -26,10 +26,10 @@
 //! - <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use regex::Regex;
 use yaml_serde::Value;
 
@@ -89,9 +89,9 @@ fn build_conda_package_purl(name: Option<&str>, version: Option<&str>) -> Option
 
 fn yaml_value_to_string(value: &Value) -> Option<String> {
     match value {
-        Value::String(s) => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
+        Value::String(s) => Some(truncate_field(s.clone())),
+        Value::Number(n) => Some(truncate_field(n.to_string())),
+        Value::Bool(b) => Some(truncate_field(b.to_string())),
         _ => None,
     }
 }
@@ -125,7 +125,7 @@ fn extract_conda_requirement_name(req: &str) -> Option<String> {
     if name.is_empty() {
         None
     } else {
-        Some(name.to_string())
+        Some(truncate_field(name.to_string()))
     }
 }
 
@@ -146,7 +146,7 @@ impl PackageParser for CondaMetaYamlParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let contents = match fs::read_to_string(path) {
+        let contents = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {}: {}", path.display(), e);
@@ -180,7 +180,7 @@ impl PackageParser for CondaMetaYamlParser {
         let download_url = source
             .and_then(|s| s.get("url"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let sha256 = source
             .and_then(|s| s.get("sha256"))
@@ -191,30 +191,30 @@ impl PackageParser for CondaMetaYamlParser {
         let homepage_url = about
             .and_then(|a| a.get("home"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let extracted_license_statement = about
             .and_then(|a| a.get("license"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             normalize_conda_declared_license(extracted_license_statement.as_deref());
 
         let description = about
             .and_then(|a| a.get("summary"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let vcs_url = about
             .and_then(|a| a.get("dev_url"))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
         let license_file = about
             .and_then(|a| a.get("license_file"))
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         // Extract dependencies from requirements sections
         let mut dependencies = Vec::new();
@@ -224,7 +224,7 @@ impl PackageParser for CondaMetaYamlParser {
             for (scope_key, reqs_value) in requirements {
                 let scope = scope_key.as_str().unwrap_or("unknown");
                 if let Some(reqs) = reqs_value.as_sequence() {
-                    for req in reqs {
+                    for req in reqs.iter().take(MAX_ITERATION_COUNT) {
                         if let Some(req_str) = req.as_str()
                             && let Some(dep) = parse_conda_requirement(req_str, scope)
                         {
@@ -237,7 +237,9 @@ impl PackageParser for CondaMetaYamlParser {
                                     .or_insert_with(|| serde_json::Value::Array(vec![]))
                                     .as_array_mut()
                                 {
-                                    arr.push(serde_json::Value::String(req_str.to_string()))
+                                    arr.push(serde_json::Value::String(truncate_field(
+                                        req_str.to_string(),
+                                    )))
                                 }
                             } else {
                                 dependencies.push(dep);
@@ -256,10 +258,10 @@ impl PackageParser for CondaMetaYamlParser {
         pkg.purl = build_conda_package_purl(pkg.name.as_deref(), pkg.version.as_deref());
         pkg.download_url = download_url;
         pkg.homepage_url = homepage_url;
-        pkg.declared_license_expression = declared_license_expression;
-        pkg.declared_license_expression_spdx = declared_license_expression_spdx;
+        pkg.declared_license_expression = declared_license_expression.map(truncate_field);
+        pkg.declared_license_expression_spdx = declared_license_expression_spdx.map(truncate_field);
         pkg.license_detections = license_detections;
-        pkg.extracted_license_statement = extracted_license_statement;
+        pkg.extracted_license_statement = extracted_license_statement.map(truncate_field);
         pkg.description = description;
         pkg.vcs_url = vcs_url;
         pkg.sha256 = sha256;
@@ -320,7 +322,7 @@ impl PackageParser for CondaEnvironmentYmlParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let contents = match fs::read_to_string(path) {
+        let contents = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read {}: {}", path.display(), e);
@@ -340,7 +342,10 @@ impl PackageParser for CondaEnvironmentYmlParser {
             return Vec::new();
         }
 
-        let name = yaml.get("name").and_then(|v| v.as_str()).map(String::from);
+        let name = yaml
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| truncate_field(s.to_string()));
 
         let dependencies = extract_environment_dependencies(&yaml);
 
@@ -348,7 +353,7 @@ impl PackageParser for CondaEnvironmentYmlParser {
         if let Some(channels) = yaml.get("channels").and_then(|v| v.as_sequence()) {
             let channels_vec: Vec<String> = channels
                 .iter()
-                .filter_map(|c| c.as_str().map(String::from))
+                .filter_map(|c| c.as_str().map(|s| truncate_field(s.to_string())))
                 .collect();
             if !channels_vec.is_empty() {
                 extra_data.insert("channels".to_string(), serde_json::json!(channels_vec));
@@ -361,7 +366,7 @@ impl PackageParser for CondaEnvironmentYmlParser {
         pkg.datasource_id = Some(DatasourceId::CondaYaml);
         pkg.name = name;
         pkg.purl = build_conda_package_purl(pkg.name.as_deref(), pkg.version.as_deref());
-        pkg.primary_language = Some("Python".to_string());
+        pkg.primary_language = Some(truncate_field("Python".to_string()));
         pkg.dependencies = dependencies;
         pkg.is_private = true;
         if !extra_data.is_empty() {
@@ -398,7 +403,7 @@ fn looks_like_conda_environment_yaml(yaml: &Value) -> bool {
 pub fn extract_jinja2_variables(content: &str) -> HashMap<String, String> {
     let mut variables = HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let trimmed = line.trim();
         if let Some(inner) = extract_jinja_statement(trimmed)
             && let Some(inner) = inner.strip_prefix("set").map(str::trim)
@@ -406,7 +411,10 @@ pub fn extract_jinja2_variables(content: &str) -> HashMap<String, String> {
         {
             let key = key.trim();
             let value = value.trim().trim_matches('"').trim_matches('\'');
-            variables.insert(key.to_string(), value.to_string());
+            variables.insert(
+                truncate_field(key.to_string()),
+                truncate_field(value.to_string()),
+            );
         }
     }
 
@@ -487,7 +495,7 @@ pub fn parse_conda_requirement(req: &str, scope: &str) -> Option<Dependency> {
             if parsed.is_empty() {
                 None
             } else {
-                Some(parsed.to_string())
+                Some(truncate_field(parsed.to_string()))
             }
         } else {
             None
@@ -496,11 +504,12 @@ pub fn parse_conda_requirement(req: &str, scope: &str) -> Option<Dependency> {
             .as_ref()
             .map(|ver| format!("={}", ver))
             .unwrap_or_default();
-        (n, v, true, Some(req))
+        (n, v, true, Some(truncate_field(req)))
     } else if let Some(constraint) = version_constraint {
-        // Handle space-separated constraints: package >=3.6, package ==1.0
         let version_opt = if constraint.starts_with("==") {
-            Some(constraint.trim_start_matches("==").trim().to_string())
+            Some(truncate_field(
+                constraint.trim_start_matches("==").trim().to_string(),
+            ))
         } else {
             None
         };
@@ -508,7 +517,7 @@ pub fn parse_conda_requirement(req: &str, scope: &str) -> Option<Dependency> {
             name_part.trim(),
             version_opt,
             false,
-            Some(constraint.to_string()),
+            Some(truncate_field(constraint.to_string())),
         )
     } else {
         (name_part.trim(), None, false, Some(String::new()))
@@ -533,16 +542,22 @@ pub fn parse_conda_requirement(req: &str, scope: &str) -> Option<Dependency> {
 
     let mut extra_data = HashMap::new();
     if let Some(namespace) = namespace {
-        extra_data.insert("channel".to_string(), serde_json::json!(namespace));
+        extra_data.insert(
+            "channel".to_string(),
+            serde_json::json!(truncate_field(namespace.to_string())),
+        );
     }
     if let Some(channel_url) = channel_url {
-        extra_data.insert("channel_url".to_string(), serde_json::json!(channel_url));
+        extra_data.insert(
+            "channel_url".to_string(),
+            serde_json::json!(truncate_field(channel_url.to_string())),
+        );
     }
 
     Some(Dependency {
         purl,
         extracted_requirement,
-        scope: Some(scope.to_string()),
+        scope: Some(truncate_field(scope.to_string())),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
         is_pinned: Some(is_pinned),
@@ -559,7 +574,7 @@ fn extract_environment_dependencies(yaml: &Value) -> Vec<Dependency> {
     };
 
     let mut deps = Vec::new();
-    for dep_value in dependencies {
+    for dep_value in dependencies.iter().take(MAX_ITERATION_COUNT) {
         if let Some(dep_str) = dep_value.as_str() {
             if let Some(dep) = parse_environment_string_dependency(dep_str) {
                 deps.push(dep);
@@ -611,17 +626,21 @@ fn create_conda_dependency(
         let req_no_space = rest.replace(' ', "");
         let is_exact = req_no_space.starts_with("=") || req_no_space.starts_with("==");
         let parsed_version = if is_exact {
-            Some(
+            Some(truncate_field(
                 req_no_space
                     .trim_start_matches('=')
                     .trim_start_matches('=')
                     .to_string(),
-            )
+            ))
         } else {
             None
         };
 
-        (parsed_version, is_exact, Some(rest.to_string()))
+        (
+            parsed_version,
+            is_exact,
+            Some(truncate_field(rest.to_string())),
+        )
     };
 
     if name == "pip" || name == "python" {
@@ -639,16 +658,22 @@ fn create_conda_dependency(
     );
     let mut extra_data = HashMap::new();
     if let Some(namespace) = namespace {
-        extra_data.insert("channel".to_string(), serde_json::json!(namespace));
+        extra_data.insert(
+            "channel".to_string(),
+            serde_json::json!(truncate_field(namespace.to_string())),
+        );
     }
     if let Some(channel_url) = channel_url {
-        extra_data.insert("channel_url".to_string(), serde_json::json!(channel_url));
+        extra_data.insert(
+            "channel_url".to_string(),
+            serde_json::json!(truncate_field(channel_url.to_string())),
+        );
     }
 
     Some(Dependency {
         purl,
         extracted_requirement,
-        scope: Some(scope.to_string()),
+        scope: Some(truncate_field(scope.to_string())),
         is_runtime: Some(true),
         is_optional: Some(false),
         is_pinned: Some(is_pinned),
@@ -678,28 +703,30 @@ fn create_pip_dependency(
     scope: &str,
     raw_requirement: Option<&str>,
 ) -> Option<Dependency> {
-    let name = parsed_req.name.to_string();
+    let name = truncate_field(parsed_req.name.to_string());
 
     if name == "pip" || name == "python" {
         return None;
     }
 
     let specs = parsed_req.version_or_url.as_ref().map(|v| match v {
-        pep508_rs::VersionOrUrl::VersionSpecifier(spec) => spec.to_string(),
-        pep508_rs::VersionOrUrl::Url(url) => url.to_string(),
+        pep508_rs::VersionOrUrl::VersionSpecifier(spec) => truncate_field(spec.to_string()),
+        pep508_rs::VersionOrUrl::Url(url) => truncate_field(url.to_string()),
     });
 
     let extracted_requirement = if let Some(raw) = raw_requirement {
         let raw = raw.trim();
         let suffix = raw.strip_prefix(&name).unwrap_or(raw).trim().to_string();
-        Some(suffix)
+        Some(truncate_field(suffix))
     } else {
-        Some(specs.clone().unwrap_or_default())
+        Some(truncate_field(specs.clone().unwrap_or_default()))
     };
 
     let version = specs.as_ref().and_then(|spec_str| {
         if spec_str.starts_with("==") {
-            Some(spec_str.trim_start_matches("==").to_string())
+            Some(truncate_field(
+                spec_str.trim_start_matches("==").to_string(),
+            ))
         } else {
             None
         }
@@ -711,7 +738,7 @@ fn create_pip_dependency(
     Some(Dependency {
         purl,
         extracted_requirement,
-        scope: Some(scope.to_string()),
+        scope: Some(truncate_field(scope.to_string())),
         is_runtime: Some(true),
         is_optional: Some(false),
         is_pinned: Some(is_pinned),

--- a/src/parsers/conda_meta_json.rs
+++ b/src/parsers/conda_meta_json.rs
@@ -18,10 +18,10 @@
 
 use crate::models::{DatasourceId, FileReference, Md5Digest, PackageType, Sha256Digest};
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -76,7 +76,7 @@ impl PackageParser for CondaMetaJsonParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read conda-meta JSON file {:?}: {}", path, e);
@@ -106,28 +106,36 @@ pub(crate) fn parse_conda_meta_json_with_path(content: &str, _path: Option<&Path
     if let Some(ref requested_spec) = metadata.requested_spec {
         extra_data.insert(
             "requested_spec".to_string(),
-            Value::String(requested_spec.clone()),
+            Value::String(truncate_field(requested_spec.clone())),
         );
     }
     if let Some(ref channel) = metadata.channel {
-        extra_data.insert("channel".to_string(), Value::String(channel.clone()));
+        extra_data.insert(
+            "channel".to_string(),
+            Value::String(truncate_field(channel.clone())),
+        );
     }
     if let Some(ref extracted_package_dir) = metadata.extracted_package_dir {
         extra_data.insert(
             "extracted_package_dir".to_string(),
-            Value::String(extracted_package_dir.clone()),
+            Value::String(truncate_field(extracted_package_dir.clone())),
         );
     }
     if let Some(ref files) = metadata.files {
         extra_data.insert(
             "files".to_string(),
-            Value::Array(files.iter().map(|f| Value::String(f.clone())).collect()),
+            Value::Array(
+                files
+                    .iter()
+                    .map(|f| Value::String(truncate_field(f.clone())))
+                    .collect(),
+            ),
         );
     }
     if let Some(ref package_tarball_full_path) = metadata.package_tarball_full_path {
         extra_data.insert(
             "package_tarball_full_path".to_string(),
-            Value::String(package_tarball_full_path.clone()),
+            Value::String(truncate_field(package_tarball_full_path.clone())),
         );
     }
 
@@ -158,10 +166,10 @@ pub(crate) fn parse_conda_meta_json_with_path(content: &str, _path: Option<&Path
     PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Python".to_string()),
-        name: metadata.name,
-        version: metadata.version,
-        extracted_license_statement: metadata.license,
-        download_url: metadata.url,
+        name: metadata.name.map(truncate_field),
+        version: metadata.version.map(truncate_field),
+        extracted_license_statement: metadata.license.map(truncate_field),
+        download_url: metadata.url.map(truncate_field),
         size: metadata.size,
         md5: metadata.md5.and_then(|h| Md5Digest::from_hex(&h).ok()),
         sha256: metadata
@@ -186,7 +194,7 @@ fn build_conda_file_references(
         && let Some(relative) = condense_to_pkgs_relative(extracted_dir)
     {
         refs.push(FileReference {
-            path: relative,
+            path: truncate_field(relative),
             size: None,
             sha1: None,
             md5: None,
@@ -200,7 +208,7 @@ fn build_conda_file_references(
         && let Some(relative) = condense_to_pkgs_relative(tarball)
     {
         refs.push(FileReference {
-            path: relative,
+            path: truncate_field(relative),
             size: None,
             sha1: None,
             md5: None,
@@ -211,9 +219,9 @@ fn build_conda_file_references(
     }
 
     if let Some(files) = files {
-        for file in files {
+        for file in files.iter().take(MAX_ITERATION_COUNT) {
             refs.push(FileReference {
-                path: file.clone(),
+                path: truncate_field(file.clone()),
                 size: None,
                 sha1: None,
                 md5: None,

--- a/src/parsers/cpan.rs
+++ b/src/parsers/cpan.rs
@@ -21,7 +21,6 @@
 //! - Python reference has stub-only handlers with no parse() method
 //! - This is a BEYOND PARITY implementation - we extract complete metadata
 
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -30,6 +29,7 @@ use serde_json::Value as JsonValue;
 use yaml_serde::Value as YamlValue;
 
 use crate::models::{DatasourceId, Dependency, FileReference, PackageData, PackageType, Party};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::license_normalization::{
@@ -76,14 +76,14 @@ impl PackageParser for CpanMetaJsonParser {
         let name = json
             .get(FIELD_NAME)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let version = extract_version_from_json(&json);
 
         let description = json
             .get(FIELD_ABSTRACT)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let extracted_license_statement = extract_license_from_json(&json);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
@@ -91,6 +91,8 @@ impl PackageParser for CpanMetaJsonParser {
                 json.get(FIELD_LICENSE),
                 extracted_license_statement.as_deref(),
             );
+        let declared_license_expression = declared_license_expression.map(truncate_field);
+        let declared_license_expression_spdx = declared_license_expression_spdx.map(truncate_field);
         let parties = extract_parties_from_json(&json);
         let dependencies = extract_dependencies_from_json(&json);
         let (homepage_url, vcs_url, code_view_url, bug_tracking_url) =
@@ -142,7 +144,7 @@ impl PackageParser for CpanMetaYmlParser {
         let name = yaml
             .get(FIELD_NAME)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let version = extract_version_from_yaml(&yaml);
 
@@ -150,7 +152,7 @@ impl PackageParser for CpanMetaYmlParser {
             .get(FIELD_ABSTRACT)
             .or_else(|| yaml.get(FIELD_DESCRIPTION))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|s| truncate_field(s.to_string()));
 
         let extracted_license_statement = extract_license_from_yaml(&yaml);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
@@ -158,6 +160,8 @@ impl PackageParser for CpanMetaYmlParser {
                 yaml.get(YamlValue::String(FIELD_LICENSE.to_string())),
                 extracted_license_statement.as_deref(),
             );
+        let declared_license_expression = declared_license_expression.map(truncate_field);
+        let declared_license_expression_spdx = declared_license_expression_spdx.map(truncate_field);
         let parties = extract_parties_from_yaml(&yaml);
         let dependencies = extract_dependencies_from_yaml(&yaml);
         let (homepage_url, vcs_url, bug_tracking_url) = extract_resources_from_yaml(&yaml);
@@ -196,7 +200,7 @@ impl PackageParser for CpanManifestParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to read MANIFEST at {:?}: {}", path, e);
@@ -206,13 +210,13 @@ impl PackageParser for CpanManifestParser {
 
         let file_references = content
             .lines()
+            .take(MAX_ITERATION_COUNT)
             .filter(|line| !line.trim().is_empty())
             .filter(|line| !line.trim().starts_with('#'))
             .map(|line| {
-                // MANIFEST can have comments after whitespace
                 let path = line.split_whitespace().next().unwrap_or(line);
                 FileReference {
-                    path: path.to_string(),
+                    path: truncate_field(path.to_string()),
                     size: None,
                     sha1: None,
                     md5: None,
@@ -243,7 +247,8 @@ fn default_package_data(datasource_id: DatasourceId) -> PackageData {
 }
 
 fn read_and_parse_json(path: &Path) -> Result<serde_json::Map<String, JsonValue>, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     let json: JsonValue =
         serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {}", e))?;
     json.as_object()
@@ -252,7 +257,8 @@ fn read_and_parse_json(path: &Path) -> Result<serde_json::Map<String, JsonValue>
 }
 
 fn read_and_parse_yaml(path: &Path) -> Result<yaml_serde::Mapping, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
     let yaml: YamlValue =
         yaml_serde::from_str(&content).map_err(|e| format!("Failed to parse YAML: {}", e))?;
     yaml.as_mapping()
@@ -262,8 +268,8 @@ fn read_and_parse_yaml(path: &Path) -> Result<yaml_serde::Mapping, String> {
 
 fn extract_version_from_json(json: &serde_json::Map<String, JsonValue>) -> Option<String> {
     json.get(FIELD_VERSION).and_then(|v| match v {
-        JsonValue::String(s) => Some(s.clone()),
-        JsonValue::Number(n) => Some(n.to_string()),
+        JsonValue::String(s) => Some(truncate_field(s.clone())),
+        JsonValue::Number(n) => Some(truncate_field(n.to_string())),
         _ => None,
     })
 }
@@ -271,24 +277,25 @@ fn extract_version_from_json(json: &serde_json::Map<String, JsonValue>) -> Optio
 fn extract_version_from_yaml(yaml: &yaml_serde::Mapping) -> Option<String> {
     yaml.get(YamlValue::String(FIELD_VERSION.to_string()))
         .and_then(|v| match v {
-            YamlValue::String(s) => Some(s.clone()),
-            YamlValue::Number(n) => Some(n.to_string()),
+            YamlValue::String(s) => Some(truncate_field(s.clone())),
+            YamlValue::Number(n) => Some(truncate_field(n.to_string())),
             _ => None,
         })
 }
 
 fn extract_license_from_json(json: &serde_json::Map<String, JsonValue>) -> Option<String> {
     json.get(FIELD_LICENSE).and_then(|v| match v {
-        JsonValue::String(s) => Some(s.clone()),
+        JsonValue::String(s) => Some(truncate_field(s.clone())),
         JsonValue::Array(arr) => {
             let licenses: Vec<String> = arr
                 .iter()
-                .filter_map(|item| item.as_str().map(String::from))
+                .take(MAX_ITERATION_COUNT)
+                .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                 .collect();
             if licenses.is_empty() {
                 None
             } else {
-                Some(licenses.join(" AND "))
+                Some(truncate_field(licenses.join(" AND ")))
             }
         }
         _ => None,
@@ -298,16 +305,17 @@ fn extract_license_from_json(json: &serde_json::Map<String, JsonValue>) -> Optio
 fn extract_license_from_yaml(yaml: &yaml_serde::Mapping) -> Option<String> {
     yaml.get(YamlValue::String(FIELD_LICENSE.to_string()))
         .and_then(|v| match v {
-            YamlValue::String(s) => Some(s.clone()),
+            YamlValue::String(s) => Some(truncate_field(s.clone())),
             YamlValue::Sequence(arr) => {
                 let licenses: Vec<String> = arr
                     .iter()
-                    .filter_map(|item| item.as_str().map(String::from))
+                    .take(MAX_ITERATION_COUNT)
+                    .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                     .collect();
                 if licenses.is_empty() {
                     None
                 } else {
-                    Some(licenses.join(" AND "))
+                    Some(truncate_field(licenses.join(" AND ")))
                 }
             }
             _ => None,
@@ -352,13 +360,14 @@ trait LicenseValueAdapter {
 impl LicenseValueAdapter for JsonValue {
     fn license_values(&self) -> Vec<String> {
         match self {
-            JsonValue::String(value) => vec![value.trim().to_string()],
+            JsonValue::String(value) => vec![truncate_field(value.trim().to_string())],
             JsonValue::Array(values) => values
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| value.as_str())
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
+                .map(|s| truncate_field(s.to_string()))
                 .collect(),
             _ => Vec::new(),
         }
@@ -368,13 +377,14 @@ impl LicenseValueAdapter for JsonValue {
 impl LicenseValueAdapter for YamlValue {
     fn license_values(&self) -> Vec<String> {
         match self {
-            YamlValue::String(value) => vec![value.trim().to_string()],
+            YamlValue::String(value) => vec![truncate_field(value.trim().to_string())],
             YamlValue::Sequence(values) => values
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| value.as_str())
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
+                .map(|s| truncate_field(s.to_string()))
                 .collect(),
             _ => Vec::new(),
         }
@@ -402,6 +412,7 @@ fn extract_parties_from_json(json: &serde_json::Map<String, JsonValue>) -> Vec<P
         .map_or_else(Vec::new, |authors| {
             authors
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|author| {
                     author.as_str().map(|s| {
                         let (name, email) = parse_author_string(s);
@@ -427,6 +438,7 @@ fn extract_parties_from_yaml(yaml: &yaml_serde::Mapping) -> Vec<Party> {
         .map_or_else(Vec::new, |authors| {
             authors
                 .iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|author| {
                     author.as_str().map(|s| {
                         let (name, email) = parse_author_string(s);
@@ -447,7 +459,6 @@ fn extract_parties_from_yaml(yaml: &yaml_serde::Mapping) -> Vec<Party> {
 }
 
 fn parse_author_string(author_str: &str) -> (Option<String>, Option<String>) {
-    // Parse "Name <email@example.com>" format
     if let Some(email_start) = author_str.find('<')
         && let Some(email_end) = author_str.find('>')
         && email_start < email_end
@@ -458,17 +469,24 @@ fn parse_author_string(author_str: &str) -> (Option<String>, Option<String>) {
             if name.is_empty() {
                 None
             } else {
-                Some(name.to_string())
+                Some(truncate_field(name.to_string()))
             },
             if email.is_empty() {
                 None
             } else {
-                Some(email.to_string())
+                Some(truncate_field(email.to_string()))
             },
         );
     }
-    // No email found, treat entire string as name
-    (Some(author_str.trim().to_string()), None)
+    let trimmed = author_str.trim();
+    (
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(truncate_field(trimmed.to_string()))
+        },
+        None,
+    )
 }
 
 fn extract_resources_from_json(
@@ -487,22 +505,32 @@ fn extract_resources_from_json(
     let homepage_url = resources
         .get("homepage")
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let vcs_url = resources.get("repository").and_then(|v| match v {
-        JsonValue::String(s) => Some(s.clone()),
-        JsonValue::Object(obj) => obj.get("url").and_then(|u| u.as_str()).map(String::from),
+        JsonValue::String(s) => Some(truncate_field(s.clone())),
+        JsonValue::Object(obj) => obj
+            .get("url")
+            .and_then(|u| u.as_str())
+            .map(|s| truncate_field(s.to_string())),
         _ => None,
     });
 
     let code_view_url = resources
         .get("repository")
         .and_then(|v| v.as_object())
-        .and_then(|obj| obj.get("web").and_then(|u| u.as_str()).map(String::from));
+        .and_then(|obj| {
+            obj.get("web")
+                .and_then(|u| u.as_str())
+                .map(|s| truncate_field(s.to_string()))
+        });
 
     let bug_tracking_url = resources.get("bugtracker").and_then(|v| match v {
-        JsonValue::String(s) => Some(s.clone()),
-        JsonValue::Object(obj) => obj.get("web").and_then(|u| u.as_str()).map(String::from),
+        JsonValue::String(s) => Some(truncate_field(s.clone())),
+        JsonValue::Object(obj) => obj
+            .get("web")
+            .and_then(|u| u.as_str())
+            .map(|s| truncate_field(s.to_string())),
         _ => None,
     });
 
@@ -523,17 +551,17 @@ fn extract_resources_from_yaml(
     let homepage_url = resources
         .get(YamlValue::String("homepage".to_string()))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let vcs_url = resources
         .get(YamlValue::String("repository".to_string()))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     let bug_tracking_url = resources
         .get(YamlValue::String("bugtracker".to_string()))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| truncate_field(s.to_string()));
 
     (homepage_url, vcs_url, bug_tracking_url)
 }
@@ -641,24 +669,25 @@ fn extract_dependency_group(
     is_optional: bool,
 ) -> Vec<Dependency> {
     deps.iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(name, version)| {
-            // Skip perl itself as it's not a CPAN module
             if name == "perl" {
                 return None;
             }
 
             let purl = PackageUrl::new("cpan", name).ok().map(|p| p.to_string());
+            let purl = purl.map(truncate_field);
 
             let extracted_requirement = match version {
-                JsonValue::String(s) => Some(s.clone()),
-                JsonValue::Number(n) => Some(n.to_string()),
+                JsonValue::String(s) => Some(truncate_field(s.clone())),
+                JsonValue::Number(n) => Some(truncate_field(n.to_string())),
                 _ => None,
             };
 
             Some(Dependency {
                 purl,
                 extracted_requirement,
-                scope: Some(scope.to_string()),
+                scope: Some(truncate_field(scope.to_string())),
                 is_runtime: Some(is_runtime),
                 is_optional: Some(is_optional),
                 is_pinned: None,
@@ -677,26 +706,27 @@ fn extract_yaml_dependency_group(
     is_optional: bool,
 ) -> Vec<Dependency> {
     deps.iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|(key, value)| {
             let name = key.as_str()?;
 
-            // Skip perl itself as it's not a CPAN module
             if name == "perl" {
                 return None;
             }
 
             let purl = PackageUrl::new("cpan", name).ok().map(|p| p.to_string());
+            let purl = purl.map(truncate_field);
 
             let extracted_requirement = match value {
-                YamlValue::String(s) => Some(s.clone()),
-                YamlValue::Number(n) => Some(n.to_string()),
+                YamlValue::String(s) => Some(truncate_field(s.clone())),
+                YamlValue::Number(n) => Some(truncate_field(n.to_string())),
                 _ => None,
             };
 
             Some(Dependency {
                 purl,
                 extracted_requirement,
-                scope: Some(scope.to_string()),
+                scope: Some(truncate_field(scope.to_string())),
                 is_runtime: Some(is_runtime),
                 is_optional: Some(is_optional),
                 is_pinned: None,

--- a/src/parsers/cpan_dist_ini.rs
+++ b/src/parsers/cpan_dist_ini.rs
@@ -12,10 +12,10 @@
 //! - Dependencies from [Prereq] sections (beyond Python which has no parser)
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use serde_json::json;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
@@ -38,7 +38,7 @@ impl PackageParser for CpanDistIniParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read dist.ini file {:?}: {}", path, e);
@@ -58,10 +58,12 @@ impl PackageParser for CpanDistIniParser {
 pub(crate) fn parse_dist_ini(content: &str) -> PackageData {
     let (root_fields, sections) = parse_ini_structure(content);
 
-    let name = root_fields.get("name").map(|s| s.replace('-', "::"));
-    let version = root_fields.get("version").cloned();
-    let description = root_fields.get("abstract").cloned();
-    let extracted_license_statement = root_fields.get("license").cloned();
+    let name = root_fields
+        .get("name")
+        .map(|s| truncate_field(s.replace('-', "::")));
+    let version = root_fields.get("version").cloned().map(truncate_field);
+    let description = root_fields.get("abstract").cloned().map(truncate_field);
+    let extracted_license_statement = root_fields.get("license").cloned().map(truncate_field);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         extracted_license_statement
             .as_deref()
@@ -75,7 +77,10 @@ pub(crate) fn parse_dist_ini(content: &str) -> PackageData {
                 )
             })
             .unwrap_or_else(empty_declared_license_data);
-    let copyright_holder = root_fields.get("copyright_holder").cloned();
+    let copyright_holder = root_fields
+        .get("copyright_holder")
+        .cloned()
+        .map(truncate_field);
 
     let parties = parse_author(&root_fields);
     let dependencies = parse_dependencies(&sections);
@@ -131,7 +136,7 @@ fn parse_ini_structure(
     let mut sections: HashMap<String, HashMap<String, String>> = HashMap::new();
     let mut current_section: Option<String> = None;
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
 
         if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
@@ -145,7 +150,7 @@ fn parse_ini_structure(
 
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim().to_string();
-            let value = value.trim().to_string();
+            let value = truncate_field(value.trim().to_string());
 
             if let Some(section_name) = &current_section {
                 sections
@@ -179,7 +184,7 @@ fn parse_author(fields: &HashMap<String, String>) -> Vec<Party> {
             } else {
                 vec![Party {
                     role: Some("author".to_string()),
-                    name: Some(author_str.clone()),
+                    name: Some(truncate_field(author_str.clone())),
                     r#type: None,
                     email: None,
                     url: None,
@@ -196,8 +201,8 @@ fn parse_author_string(s: &str) -> Option<(String, String)> {
     if let Some(start) = s.find('<')
         && let Some(end) = s.find('>')
     {
-        let name = s[..start].trim().to_string();
-        let email = s[start + 1..end].trim().to_string();
+        let name = truncate_field(s[..start].trim().to_string());
+        let email = truncate_field(s[start + 1..end].trim().to_string());
         return Some((name, email));
     }
     None
@@ -209,7 +214,7 @@ fn parse_dependencies(sections: &HashMap<String, HashMap<String, String>>) -> Ve
     let mut sorted_sections: Vec<_> = sections.iter().collect();
     sorted_sections.sort_by(|(left_name, _), (right_name, _)| left_name.cmp(right_name));
 
-    for (section_name, fields) in sorted_sections {
+    for (section_name, fields) in sorted_sections.iter().take(MAX_ITERATION_COUNT) {
         let Some(scope) = classify_prereq_scope(section_name) else {
             continue;
         };
@@ -217,12 +222,12 @@ fn parse_dependencies(sections: &HashMap<String, HashMap<String, String>>) -> Ve
         let mut sorted_fields: Vec<_> = fields.iter().collect();
         sorted_fields.sort_by(|(left_name, _), (right_name, _)| left_name.cmp(right_name));
 
-        for (module_name, version_req) in sorted_fields {
-            let purl = format!("pkg:cpan/{}", module_name);
-            let extracted_requirement = if version_req == "0" || version_req.is_empty() {
+        for (module_name, version_req) in sorted_fields.iter().take(MAX_ITERATION_COUNT) {
+            let purl = truncate_field(format!("pkg:cpan/{}", module_name));
+            let extracted_requirement = if version_req.as_str() == "0" || version_req.is_empty() {
                 None
             } else {
-                Some(version_req.clone())
+                Some(truncate_field(version_req.to_string()))
             };
 
             dependencies.push(Dependency {

--- a/src/parsers/cpan_makefile_pl.rs
+++ b/src/parsers/cpan_makefile_pl.rs
@@ -13,11 +13,11 @@
 //! - Python reference has stub-only handler with no parse() method - this is BEYOND PARITY
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use regex::Regex;
 use serde_json::json;
@@ -65,7 +65,7 @@ impl PackageParser for CpanMakefilePlParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read Makefile.PL file {:?}: {}", path, e);
@@ -96,18 +96,18 @@ pub(crate) fn parse_makefile_pl_with_base(content: &str, base_dir: Option<&Path>
 
     let fields = parse_hash_fields(&makefile_block);
 
-    let name = fields.get("NAME").map(|n| n.to_string());
+    let name = fields.get("NAME").map(|n| truncate_field(n.to_string()));
     let resolved_metadata = resolve_referenced_metadata(&fields, base_dir);
 
     let version = fields
         .get("VERSION")
-        .map(|v| v.to_string())
+        .map(|v| truncate_field(v.to_string()))
         .or_else(|| resolved_metadata.version.clone());
     let description = fields
         .get("ABSTRACT")
-        .map(|d| d.to_string())
+        .map(|d| truncate_field(d.to_string()))
         .or_else(|| resolved_metadata.abstract_text.clone());
-    let extracted_license_statement = fields.get("LICENSE").map(|l| l.to_string());
+    let extracted_license_statement = fields.get("LICENSE").map(|l| truncate_field(l.to_string()));
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         extracted_license_statement
             .as_deref()
@@ -127,13 +127,22 @@ pub(crate) fn parse_makefile_pl_with_base(content: &str, base_dir: Option<&Path>
 
     let mut extra_data = HashMap::new();
     if let Some(min_perl) = fields.get("MIN_PERL_VERSION") {
-        extra_data.insert("MIN_PERL_VERSION".to_string(), json!(min_perl));
+        extra_data.insert(
+            "MIN_PERL_VERSION".to_string(),
+            json!(truncate_field(min_perl.to_string())),
+        );
     }
     if let Some(version_from) = fields.get("VERSION_FROM") {
-        extra_data.insert("VERSION_FROM".to_string(), json!(version_from));
+        extra_data.insert(
+            "VERSION_FROM".to_string(),
+            json!(truncate_field(version_from.to_string())),
+        );
     }
     if let Some(abstract_from) = fields.get("ABSTRACT_FROM") {
-        extra_data.insert("ABSTRACT_FROM".to_string(), json!(abstract_from));
+        extra_data.insert(
+            "ABSTRACT_FROM".to_string(),
+            json!(truncate_field(abstract_from.to_string())),
+        );
     }
 
     // Build PURL: convert Foo::Bar to Foo-Bar for CPAN naming convention
@@ -251,12 +260,12 @@ fn read_safe_metadata_file(base_dir: &Path, relative_path: &str) -> Option<Strin
         return None;
     }
 
-    let metadata = fs::metadata(&canonical_candidate).ok()?;
+    let metadata = std::fs::metadata(&canonical_candidate).ok()?;
     if !metadata.is_file() || metadata.len() > MAX_METADATA_FILE_SIZE {
         return None;
     }
 
-    fs::read_to_string(canonical_candidate).ok()
+    read_file_to_string(&canonical_candidate, None).ok()
 }
 
 fn extract_version_from_module_content(content: &str) -> Option<String> {
@@ -264,6 +273,7 @@ fn extract_version_from_module_content(content: &str) -> Option<String> {
         .captures(content)
         .and_then(|caps| caps.get(1).or_else(|| caps.get(2)))
         .map(|m| m.as_str().trim().to_string())
+        .map(truncate_field)
         .filter(|value| !value.is_empty())
 }
 
@@ -288,7 +298,7 @@ fn extract_abstract_from_module_content(content: &str) -> Option<String> {
             if let Some((_, abstract_text)) = trimmed.split_once(" - ") {
                 let abstract_text = abstract_text.trim();
                 if !abstract_text.is_empty() {
-                    return Some(abstract_text.to_string());
+                    return Some(truncate_field(abstract_text.to_string()));
                 }
             }
         }
@@ -312,6 +322,9 @@ fn extract_writemakefile_block(content: &str) -> String {
     let chars: Vec<char> = content_from_start.chars().collect();
 
     for (i, &ch) in chars.iter().enumerate() {
+        if i >= MAX_ITERATION_COUNT {
+            break;
+        }
         match ch {
             '(' => depth += 1,
             ')' => {
@@ -335,12 +348,11 @@ fn extract_writemakefile_block(content: &str) -> String {
 fn parse_hash_fields(content: &str) -> HashMap<String, String> {
     let mut fields = HashMap::new();
 
-    for cap in RE_SIMPLE_KV.captures_iter(content) {
-        let key = cap
-            .get(1)
-            .expect("group 1 always exists")
-            .as_str()
-            .to_string();
+    for cap in RE_SIMPLE_KV
+        .captures_iter(content)
+        .take(MAX_ITERATION_COUNT)
+    {
+        let key = cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
         let value = cap
             .get(2)
             .or_else(|| cap.get(3))
@@ -363,9 +375,12 @@ fn parse_hash_fields(content: &str) -> HashMap<String, String> {
 }
 
 fn parse_hash_dependencies(content: &str, fields: &mut HashMap<String, String>) {
-    for cap in RE_HASH_BLOCK.captures_iter(content) {
-        let key = cap.get(1).expect("group 1 always exists").as_str();
-        let hash_content = cap.get(2).expect("group 2 always exists").as_str();
+    for cap in RE_HASH_BLOCK
+        .captures_iter(content)
+        .take(MAX_ITERATION_COUNT)
+    {
+        let key = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let hash_content = cap.get(2).map(|m| m.as_str()).unwrap_or("");
 
         // For dependency hashes, we'll store them with a special marker
         // so parse_dependencies can find them
@@ -380,10 +395,11 @@ fn parse_hash_dependencies(content: &str, fields: &mut HashMap<String, String>) 
 
 fn parse_author_array(content: &str, fields: &mut HashMap<String, String>) {
     if let Some(cap) = RE_AUTHOR_ARRAY.captures(content) {
-        let array_content = cap.get(1).expect("group 1 always exists").as_str();
+        let array_content = cap.get(1).map(|m| m.as_str()).unwrap_or("");
 
         let authors: Vec<String> = RE_QUOTED_STRING
             .captures_iter(array_content)
+            .take(MAX_ITERATION_COUNT)
             .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
             .collect();
 
@@ -418,7 +434,6 @@ fn parse_author(fields: &HashMap<String, String>) -> Vec<Party> {
             .collect();
     }
 
-    // Single author
     if let Some(author_str) = fields.get("AUTHOR") {
         let (name, email) = parse_author_string(author_str);
         return vec![Party {
@@ -437,7 +452,6 @@ fn parse_author(fields: &HashMap<String, String>) -> Vec<Party> {
 }
 
 fn parse_author_string(s: &str) -> (Option<String>, Option<String>) {
-    // Parse "Name <email@example.com>" format
     if let Some(start) = s.find('<')
         && let Some(end) = s.find('>')
         && start < end
@@ -448,17 +462,16 @@ fn parse_author_string(s: &str) -> (Option<String>, Option<String>) {
             if name.is_empty() {
                 None
             } else {
-                Some(name.to_string())
+                Some(truncate_field(name.to_string()))
             },
             if email.is_empty() {
                 None
             } else {
-                Some(email.to_string())
+                Some(truncate_field(email.to_string()))
             },
         );
     }
-    // No email found, treat entire string as name
-    (Some(s.trim().to_string()), None)
+    (Some(truncate_field(s.trim().to_string())), None)
 }
 
 fn parse_dependencies(fields: &HashMap<String, String>) -> Vec<Dependency> {
@@ -490,8 +503,11 @@ fn parse_dependencies(fields: &HashMap<String, String>) -> Vec<Dependency> {
 fn extract_deps_from_hash(hash_content: &str, scope: &str, is_runtime: bool) -> Vec<Dependency> {
     let mut deps = Vec::new();
 
-    for cap in RE_DEP_PAIR.captures_iter(hash_content) {
-        let module_name = cap.get(1).expect("group 1 always exists").as_str();
+    for cap in RE_DEP_PAIR
+        .captures_iter(hash_content)
+        .take(MAX_ITERATION_COUNT)
+    {
+        let module_name = cap.get(1).map(|m| m.as_str()).unwrap_or("");
 
         // Skip perl itself
         if module_name == "perl" {
@@ -506,7 +522,7 @@ fn extract_deps_from_hash(hash_content: &str, scope: &str, is_runtime: bool) -> 
 
         let extracted_requirement = match version {
             Some("0") | Some("") | None => None,
-            Some(v) => Some(v.to_string()),
+            Some(v) => Some(truncate_field(v.to_string())),
         };
 
         let purl = PackageUrl::new("cpan", module_name)
@@ -516,7 +532,7 @@ fn extract_deps_from_hash(hash_content: &str, scope: &str, is_runtime: bool) -> 
         deps.push(Dependency {
             purl,
             extracted_requirement,
-            scope: Some(scope.to_string()),
+            scope: Some(truncate_field(scope.to_string())),
             is_runtime: Some(is_runtime),
             is_optional: Some(false),
             is_pinned: None,


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security compliance fixes to 5 parsers: cpan, cpan_dist_ini, cpan_makefile_pl, conda, conda_meta_json
- Add DoS protection (file size checks, iteration caps, string truncation), lossy UTF-8 fallback, and .expect() removal per ADR 0004

## Changes

| Parser | File Size | Iteration Caps | String Truncation | UTF-8 | .expect() |
|--------|-----------|----------------|-------------------|-------|-----------|
| cpan | read_file_to_string | multiple sites | truncate_field | ✓ | — |
| cpan_dist_ini | read_file_to_string | 3 sites | truncate_field | ✓ | — |
| cpan_makefile_pl | read_file_to_string | 5 sites | truncate_field | ✓ | .expect()→unwrap_or |
| conda | read_file_to_string | 3 sites | truncate_field | ✓ | — |
| conda_meta_json | read_file_to_string | 1 site | truncate_field | ✓ | — |

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo fmt` — clean
- [x] Pre-commit hooks pass