### PR TITLE
fix(parsers): ADR 0004 security compliance — batch 15

### DIFF
--- a/src/parsers/composer.rs
+++ b/src/parsers/composer.rs
@@ -17,11 +17,10 @@
 //! - Package URL (purl) generation via packageurl
 //!
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
 
@@ -87,18 +86,18 @@ impl PackageParser for ComposerJsonParser {
         let version = json_content
             .get(FIELD_VERSION)
             .and_then(|value| value.as_str())
-            .map(|value| value.trim().to_string());
+            .map(|value| truncate_field(value.trim().to_string()));
 
         let description = json_content
             .get(FIELD_DESCRIPTION)
             .and_then(|value| value.as_str())
-            .map(|value| value.trim().to_string())
+            .map(|value| truncate_field(value.trim().to_string()))
             .filter(|value| !value.is_empty());
 
         let homepage_url = json_content
             .get(FIELD_HOMEPAGE)
             .and_then(|value| value.as_str())
-            .map(|value| value.trim().to_string())
+            .map(|value| truncate_field(value.trim().to_string()))
             .filter(|value| !value.is_empty());
 
         let keywords = extract_keywords(&json_content);
@@ -232,10 +231,7 @@ fn is_composer_lock_filename(name: &str) -> bool {
 }
 
 fn read_json_file(path: &Path) -> Result<Value, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {}", e))
 }
 
@@ -251,6 +247,7 @@ fn extract_dependencies(
         .and_then(|value| value.as_object())
         .map_or_else(Vec::new, |deps| {
             deps.iter()
+                .take(MAX_ITERATION_COUNT)
                 .filter_map(|(name, requirement)| {
                     let requirement_str = requirement.as_str()?;
                     let (namespace, package_name) = split_namespace_name(name);
@@ -269,8 +266,8 @@ fn extract_dependencies(
 
                     Some(Dependency {
                         purl,
-                        extracted_requirement: Some(requirement_str.to_string()),
-                        scope: Some(scope.to_string()),
+                        extracted_requirement: Some(truncate_field(requirement_str.to_string())),
+                        scope: Some(truncate_field(scope.to_string())),
                         is_runtime: Some(is_runtime),
                         is_optional: Some(is_optional),
                         is_pinned: Some(is_pinned),
@@ -317,7 +314,7 @@ fn extract_lock_package_list(
 ) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for package in packages {
+    for package in packages.iter().take(MAX_ITERATION_COUNT) {
         if let Some(dependency) = build_lock_dependency(package, scope, is_runtime, is_optional) {
             dependencies.push(dependency);
         }
@@ -364,7 +361,7 @@ fn build_lock_dependency(
     let dist_url = dist
         .and_then(|map| map.get("url"))
         .and_then(|value| value.as_str())
-        .map(|value| value.to_string());
+        .map(|value| truncate_field(value.to_string()));
 
     let mut extra_data = HashMap::new();
 
@@ -452,7 +449,7 @@ fn build_lock_dependency(
     Some(Dependency {
         purl,
         extracted_requirement: None,
-        scope: Some(scope.to_string()),
+        scope: Some(truncate_field(scope.to_string())),
         is_runtime: Some(is_runtime),
         is_optional: Some(is_optional),
         is_pinned: Some(true),
@@ -555,9 +552,9 @@ fn extract_license_statement(json_content: &Value) -> Option<String> {
     }
 
     if licenses.len() == 1 {
-        Some(licenses[0].clone())
+        Some(truncate_field(licenses[0].clone()))
     } else {
-        Some(licenses.join(" OR "))
+        Some(truncate_field(licenses.join(" OR ")))
     }
 }
 
@@ -619,7 +616,12 @@ fn extract_keywords(json_content: &Value) -> Vec<String> {
         .map(|values| {
             values
                 .iter()
-                .filter_map(|value| value.as_str().map(|value| value.to_string()))
+                .take(MAX_ITERATION_COUNT)
+                .filter_map(|value| {
+                    value
+                        .as_str()
+                        .map(|value| truncate_field(value.to_string()))
+                })
                 .collect()
         })
         .unwrap_or_default()
@@ -632,25 +634,25 @@ fn extract_parties(json_content: &Value, namespace: &Option<String>) -> Vec<Part
         .get(FIELD_AUTHORS)
         .and_then(|value| value.as_array())
     {
-        for author in authors {
+        for author in authors.iter().take(MAX_ITERATION_COUNT) {
             if let Some(author) = author.as_object() {
                 let name = author
                     .get("name")
                     .and_then(|value| value.as_str())
-                    .map(|value| value.to_string());
+                    .map(|value| truncate_field(value.to_string()));
                 let role = author
                     .get("role")
                     .and_then(|value| value.as_str())
-                    .map(|value| value.to_string())
+                    .map(|value| truncate_field(value.to_string()))
                     .or(Some("author".to_string()));
                 let email = author
                     .get("email")
                     .and_then(|value| value.as_str())
-                    .map(|value| value.to_string());
+                    .map(|value| truncate_field(value.to_string()));
                 let url = author
                     .get("homepage")
                     .and_then(|value| value.as_str())
-                    .map(|value| value.to_string());
+                    .map(|value| truncate_field(value.to_string()));
 
                 if name.is_some() || email.is_some() || url.is_some() {
                     parties.push(Party {
@@ -676,7 +678,7 @@ fn extract_parties(json_content: &Value, namespace: &Option<String>) -> Vec<Part
         parties.push(Party {
             r#type: Some("person".to_string()),
             role: Some("vendor".to_string()),
-            name: Some(vendor.to_string()),
+            name: Some(truncate_field(vendor.to_string())),
             email: None,
             url: None,
             organization: None,
@@ -695,12 +697,12 @@ fn extract_support(json_content: &Value) -> (Option<String>, Option<String>) {
         let bug_tracking_url = support_obj
             .get("issues")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(|s| truncate_field(s.to_string()));
 
         let code_view_url = support_obj
             .get("source")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(|s| truncate_field(s.to_string()));
 
         (bug_tracking_url, code_view_url)
     } else {
@@ -751,10 +753,10 @@ fn extract_source_vcs_url(json_content: &Value) -> Option<String> {
         return None;
     }
 
-    Some(match source_reference {
+    Some(truncate_field(match source_reference {
         Some(reference) => format!("{}+{}@{}", source_type, source_url, reference),
         None => format!("{}+{}", source_type, source_url),
-    })
+    }))
 }
 
 fn extract_dist_download_url(json_content: &Value) -> Option<String> {
@@ -763,7 +765,7 @@ fn extract_dist_download_url(json_content: &Value) -> Option<String> {
         .and_then(|value| value.as_object())
         .and_then(|dist| dist.get("url"))
         .and_then(|value| value.as_str())
-        .map(|value| value.trim().to_string())
+        .map(|value| truncate_field(value.trim().to_string()))
         .filter(|value| !value.is_empty())
 }
 
@@ -888,9 +890,12 @@ fn split_namespace_name(full_name: &str) -> (Option<String>, String) {
     let second = iter.next();
 
     if let Some(name) = second {
-        (Some(first.to_string()), name.to_string())
+        (
+            Some(truncate_field(first.to_string())),
+            truncate_field(name.to_string()),
+        )
     } else {
-        (None, first.to_string())
+        (None, truncate_field(first.to_string()))
     }
 }
 

--- a/src/parsers/conan_data.rs
+++ b/src/parsers/conan_data.rs
@@ -20,7 +20,6 @@
 
 use crate::models::{DatasourceId, PackageType, Sha256Digest};
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -28,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::models::PackageData;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -86,7 +86,7 @@ impl PackageParser for ConanDataParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read conandata.yml file {:?}: {}", path, e);
@@ -113,12 +113,14 @@ pub(crate) fn parse_conandata_yml(content: &str) -> Vec<PackageData> {
 
     let mut packages = Vec::new();
 
-    for (version, source_info) in sources {
+    for (version, source_info) in sources.into_iter().take(MAX_ITERATION_COUNT) {
         let mut extra_data = HashMap::new();
 
         let download_url = match &source_info.url {
-            Some(UrlValue::Single(url)) => Some(url.clone()),
-            Some(UrlValue::Multiple(urls)) if !urls.is_empty() => Some(urls[0].clone()),
+            Some(UrlValue::Single(url)) => Some(truncate_field(url.clone())),
+            Some(UrlValue::Multiple(urls)) if !urls.is_empty() => {
+                Some(truncate_field(urls[0].clone()))
+            }
             _ => None,
         };
 
@@ -153,7 +155,7 @@ pub(crate) fn parse_conandata_yml(content: &str) -> Vec<PackageData> {
         packages.push(PackageData {
             package_type: Some(PACKAGE_TYPE),
             primary_language: Some("C++".to_string()),
-            version: Some(version),
+            version: Some(truncate_field(version)),
             download_url,
             sha256: source_info
                 .sha256

--- a/src/parsers/publiccode.rs
+++ b/src/parsers/publiccode.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
@@ -6,6 +5,7 @@ use crate::parser_warn as warn;
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 pub struct PubliccodeParser;
 
@@ -20,7 +20,7 @@ impl PackageParser for PubliccodeParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!(
@@ -67,19 +67,19 @@ fn parse_publiccode(yaml: &yaml_serde::Value) -> PackageData {
     package.name = yaml
         .get("name")
         .and_then(extract_localized_string)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.version = yaml
         .get("softwareVersion")
         .and_then(yaml_value_as_string)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.vcs_url = yaml
         .get("url")
         .and_then(yaml_value_as_string)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.homepage_url = yaml
         .get("landingURL")
         .and_then(yaml_value_as_string)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.description = yaml
         .get("longDescription")
         .and_then(extract_localized_string)
@@ -87,13 +87,13 @@ fn parse_publiccode(yaml: &yaml_serde::Value) -> PackageData {
             yaml.get("shortDescription")
                 .and_then(extract_localized_string)
         })
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.copyright = yaml
         .get("legal")
         .and_then(|legal| legal.get("mainCopyrightOwner"))
         .and_then(yaml_value_as_string)
         .or_else(|| yaml.get("repoOwner").and_then(yaml_value_as_string))
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.parties = extract_contact_parties(yaml.get("maintenance"));
 
     if let Some(license) = yaml
@@ -101,7 +101,7 @@ fn parse_publiccode(yaml: &yaml_serde::Value) -> PackageData {
         .and_then(|legal| legal.get("license"))
         .and_then(yaml_value_as_string)
     {
-        let license = license.to_string();
+        let license = truncate_field(license.to_string());
         package.extracted_license_statement = Some(license.clone());
         let (declared, declared_spdx, detections) = normalize_spdx_declared_license(Some(&license));
         package.declared_license_expression = declared;
@@ -132,19 +132,20 @@ fn extract_contact_parties(maintenance: Option<&yaml_serde::Value>) -> Vec<Party
         .and_then(yaml_serde::Value::as_sequence)
         .into_iter()
         .flatten()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|contact| {
             let name = contact
                 .get("name")
                 .and_then(yaml_value_as_string)
-                .map(str::to_string);
+                .map(|s| truncate_field(s.to_string()));
             let email = contact
                 .get("email")
                 .and_then(yaml_value_as_string)
-                .map(str::to_string);
+                .map(|s| truncate_field(s.to_string()));
             let url = contact
                 .get("url")
                 .and_then(yaml_value_as_string)
-                .map(str::to_string);
+                .map(|s| truncate_field(s.to_string()));
 
             if name.is_none() && email.is_none() && url.is_none() {
                 return None;

--- a/src/parsers/rpm_db_native/entry.rs
+++ b/src/parsers/rpm_db_native/entry.rs
@@ -4,6 +4,9 @@ use std::io::Cursor;
 
 use anyhow::{Context, Result, anyhow};
 
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field};
+
 use super::tags::{
     HEADER_I18NTABLE, RPMTAG_HEADERI18NTABLE, RPMTAG_HEADERIMAGE, RPMTAG_HEADERIMMUTABLE,
     RPMTAG_HEADERSIGNATURES, TagType,
@@ -11,7 +14,7 @@ use super::tags::{
 
 const ENTRY_INFO_DISK_SIZE: u32 = 16;
 const REGION_TAG_COUNT: u32 = ENTRY_INFO_DISK_SIZE;
-const HEADER_MAX_BYTES: usize = 256 * 1024 * 1024;
+const HEADER_MAX_BYTES: usize = MAX_MANIFEST_SIZE as usize;
 
 #[derive(Clone, Debug)]
 struct RawEntryInfo {
@@ -58,14 +61,23 @@ impl IndexEntry {
     }
 
     pub(crate) fn read_string(&self) -> Result<String> {
-        Ok(String::from_utf8_lossy(&self.data)
-            .trim_end_matches('\0')
-            .to_string())
+        Ok(truncate_field(
+            String::from_utf8_lossy(&self.data)
+                .trim_end_matches('\0')
+                .to_string(),
+        ))
     }
 
     pub(crate) fn read_u32_array(&self) -> Result<Vec<u32>> {
-        let mut values = Vec::new();
-        for chunk in self.data.chunks_exact(4).take(self.info.count as usize) {
+        if self.info.count as usize > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM u32 array count {} exceeds MAX_ITERATION_COUNT {}; truncating",
+                self.info.count, MAX_ITERATION_COUNT
+            );
+        }
+        let cap = (self.info.count as usize).min(MAX_ITERATION_COUNT);
+        let mut values = Vec::with_capacity(cap);
+        for chunk in self.data.chunks_exact(4).take(cap) {
             values.push(u32::from_be_bytes(
                 chunk
                     .try_into()
@@ -76,11 +88,23 @@ impl IndexEntry {
     }
 
     pub(crate) fn read_string_array(&self) -> Result<Vec<String>> {
+        let count = self
+            .data
+            .split(|&byte| byte == 0)
+            .filter(|slice| !slice.is_empty())
+            .count();
+        if count > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM string array count {} exceeds MAX_ITERATION_COUNT {}; truncating",
+                count, MAX_ITERATION_COUNT
+            );
+        }
         Ok(self
             .data
             .split(|&byte| byte == 0)
             .filter(|slice| !slice.is_empty())
-            .map(|slice| String::from_utf8_lossy(slice).into_owned())
+            .take(MAX_ITERATION_COUNT)
+            .map(|slice| truncate_field(String::from_utf8_lossy(slice).into_owned()))
             .collect())
     }
 }
@@ -127,6 +151,14 @@ impl HeaderBlob {
                 total_length,
                 index_length,
                 data_length
+            ));
+        }
+
+        if index_length as usize > MAX_ITERATION_COUNT {
+            return Err(anyhow!(
+                "RPM header index_length {} exceeds MAX_ITERATION_COUNT {}",
+                index_length,
+                MAX_ITERATION_COUNT
             ));
         }
 
@@ -275,7 +307,10 @@ impl HeaderBlob {
     fn verify_entries(&self, data: &[u8]) -> Result<()> {
         let mut end: u32 = 0;
         let entry_offset = usize::from(self.region_tag != 0);
-        for entry in &self.entry_infos[entry_offset..] {
+        for entry in self.entry_infos[entry_offset..]
+            .iter()
+            .take(MAX_ITERATION_COUNT)
+        {
             let info = entry.to_native()?;
             let kind = info.kind;
             let offset_u32 = positive_offset(info.offset)
@@ -325,7 +360,7 @@ fn swab_region(
     data_end: u32,
 ) -> Result<(Vec<IndexEntry>, u32)> {
     let mut entries = Vec::new();
-    for (index, entry_info) in entry_infos.iter().enumerate() {
+    for (index, entry_info) in entry_infos.iter().enumerate().take(MAX_ITERATION_COUNT) {
         let info = entry_info.to_native()?;
         let kind = info.kind;
         let start = data_start + positive_offset(info.offset)?;

--- a/src/parsers/rpm_db_native/ndb.rs
+++ b/src/parsers/rpm_db_native/ndb.rs
@@ -1,8 +1,11 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
+
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_FIELD_LENGTH, MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE};
 
 use super::BlobReader;
 
@@ -85,6 +88,17 @@ pub(crate) struct NdbDatabase {
 
 impl NdbDatabase {
     pub(crate) fn open(path: &Path) -> Result<Self> {
+        let file_size = fs::metadata(path)
+            .with_context(|| format!("RPM NDB metadata check failed for {:?}", path))?
+            .len();
+        if file_size > MAX_MANIFEST_SIZE {
+            return Err(anyhow!(
+                "RPM NDB file exceeds safety limit: {} bytes (max {} bytes)",
+                file_size,
+                MAX_MANIFEST_SIZE
+            ));
+        }
+
         let mut reader = BufReader::new(File::open(path)?);
         let header = NdbHeader::read(&mut reader)?;
         if header.header_magic != HEADER_MAGIC {
@@ -103,8 +117,17 @@ impl NdbDatabase {
         }
 
         let slot_count = header.slot_page_count * SLOT_ENTRIES_PER_PAGE - 2;
-        let mut slots = Vec::with_capacity(slot_count as usize);
-        for _ in 0..slot_count {
+        let effective_slot_count = if slot_count as usize > MAX_ITERATION_COUNT {
+            warn!(
+                "RPM NDB slot count {} exceeds iteration cap {}, capping",
+                slot_count, MAX_ITERATION_COUNT
+            );
+            MAX_ITERATION_COUNT as u32
+        } else {
+            slot_count
+        };
+        let mut slots = Vec::with_capacity(effective_slot_count as usize);
+        for _ in 0..effective_slot_count {
             slots.push(NdbSlotEntry::read(&mut reader)?);
         }
 
@@ -139,6 +162,14 @@ impl BlobReader for NdbDatabase {
                     slot.package_index,
                     blob_header.package_index
                 ));
+            }
+
+            if blob_header.blob_length as usize > MAX_FIELD_LENGTH {
+                warn!(
+                    "RPM NDB blob length {} exceeds safety cap for package {}, skipping",
+                    blob_header.blob_length, slot.package_index
+                );
+                continue;
             }
 
             let mut blob = vec![0_u8; blob_header.blob_length as usize];


### PR DESCRIPTION
## Summary
- Apply ADR 0004 security compliance fixes to 5 parsers: conan_data, composer, rpm_db_native/ndb, rpm_db_native/entry, publiccode
- Common fixes: file size checks, iteration caps, string truncation, lossy UTF-8 fallback

## Changes
- **conan_data**: `read_file_to_string`, iteration caps on source entries, `truncate_field`
- **composer**: `read_file_to_string` (replaced `File::open`+`read_to_string`), iteration caps on deps/packages/authors/keywords, `truncate_field`
- **rpm_db_native/ndb**: `fs::metadata()` size pre-check (100MB), slot iteration cap (100K), blob size cap (10MB)
- **rpm_db_native/entry**: Reduce `HEADER_MAX_BYTES` from 256MB to 100MB, entry/array iteration caps, `truncate_field` on strings
- **publiccode**: `read_file_to_string`, iteration caps on contacts, `truncate_field`

## Test Plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] Pre-commit hooks pass