### PR TITLE
fix(parsers): ADR 0004 security compliance — batch 16

### DIFF
--- a/src/parsers/compiled_binary.rs
+++ b/src/parsers/compiled_binary.rs
@@ -8,6 +8,8 @@ use packageurl::PackageUrl;
 use serde::Deserialize;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 use crate::register_parser;
 
 use super::ParsePackagesResult;
@@ -110,6 +112,7 @@ fn parse_rust_binary_bytes(bytes: &[u8]) -> Vec<PackageData> {
     audit_data
         .packages
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .map(|package| build_rust_binary_package(package, &audit_data.packages))
         .collect()
 }
@@ -133,13 +136,14 @@ fn build_rust_binary_package(
     let dependencies = package
         .dependencies
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|index| packages.get(*index))
         .filter_map(|dependency| {
             let purl = create_cargo_purl(&dependency.name, &dependency.version)?;
             Some(Dependency {
                 purl: Some(purl),
-                extracted_requirement: Some(dependency.version.clone()),
-                scope: dependency.kind.clone(),
+                extracted_requirement: Some(truncate_field(dependency.version.clone())),
+                scope: dependency.kind.as_ref().map(|k| truncate_field(k.clone())),
                 is_runtime: Some(dependency.kind.as_deref() != Some("build")),
                 is_optional: Some(false),
                 is_pinned: Some(true),
@@ -168,8 +172,8 @@ fn build_rust_binary_package(
         package_type: Some(PackageType::Cargo),
         datasource_id: Some(DatasourceId::RustBinary),
         primary_language: Some("Rust".to_string()),
-        name: Some(package.name.clone()),
-        version: Some(package.version.clone()),
+        name: Some(truncate_field(package.name.clone())),
+        version: Some(truncate_field(package.version.clone())),
         is_private,
         repository_homepage_url,
         repository_download_url,
@@ -236,7 +240,14 @@ fn decode_go_build_info_inline(bytes: &[u8], header_offset: usize) -> Option<(St
     let (modinfo, _) = decode_varint_bytes(payload)?;
 
     let modinfo = if modinfo.len() >= 33 && modinfo.get(modinfo.len() - 17) == Some(&b'\n') {
-        String::from_utf8(modinfo[16..modinfo.len() - 16].to_vec()).ok()?
+        let slice = &modinfo[16..modinfo.len() - 16];
+        let lossy = String::from_utf8_lossy(slice);
+        if lossy.is_ascii() {
+            lossy.into_owned()
+        } else {
+            warn!("invalid UTF-8 in Go build info modinfo");
+            lossy.into_owned()
+        }
     } else {
         String::new()
     };
@@ -248,10 +259,12 @@ fn decode_varint_string(bytes: &[u8]) -> Option<(String, &[u8])> {
     let (length, consumed) = decode_uvarint(bytes)?;
     let start = consumed;
     let end = start.checked_add(length)?;
-    let value = std::str::from_utf8(bytes.get(start..end)?)
-        .ok()?
-        .to_string();
-    Some((value, &bytes[end..]))
+    let raw = bytes.get(start..end)?;
+    let lossy = String::from_utf8_lossy(raw);
+    if !raw.is_ascii() {
+        warn!("invalid UTF-8 in varint string field");
+    }
+    Some((lossy.into_owned(), &bytes[end..]))
 }
 
 fn decode_varint_bytes(bytes: &[u8]) -> Option<(Vec<u8>, &[u8])> {
@@ -281,7 +294,7 @@ fn decode_uvarint(bytes: &[u8]) -> Option<(usize, usize)> {
 
 fn parse_go_modinfo_packages(modinfo: &str) -> Vec<PackageData> {
     let mut packages = Vec::new();
-    for line in modinfo.lines() {
+    for line in modinfo.lines().take(MAX_ITERATION_COUNT) {
         if let Some(rest) = line.strip_prefix("path\t") {
             packages.push(build_go_binary_package(rest, None, true));
             continue;
@@ -314,6 +327,8 @@ fn build_go_binary_package(
     is_private: bool,
 ) -> PackageData {
     let (namespace, name) = split_module_path(module_path);
+    let name = truncate_field(name);
+    let version = version.map(truncate_field);
     let repository_homepage_url = Some(format!("https://pkg.go.dev/{module_path}"));
     let purl = create_golang_purl(module_path, version.as_deref());
 
@@ -334,7 +349,10 @@ fn build_go_binary_package(
 
 fn split_module_path(module_path: &str) -> (Option<String>, String) {
     match module_path.rsplit_once('/') {
-        Some((namespace, name)) => (Some(namespace.to_string()), name.to_string()),
+        Some((namespace, name)) => (
+            Some(truncate_field(namespace.to_string())),
+            name.to_string(),
+        ),
         None => (None, module_path.to_string()),
     }
 }

--- a/src/parsers/haxe.rs
+++ b/src/parsers/haxe.rs
@@ -21,8 +21,6 @@ use crate::parser_warn as warn;
 use packageurl::PackageUrl;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use super::PackageParser;
@@ -30,6 +28,7 @@ use super::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data_from_pair,
     empty_declared_license_data,
 };
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Haxe package manifest (haxelib.json) parser.
 ///
@@ -53,12 +52,12 @@ impl PackageParser for HaxeParser {
             }
         };
 
-        let name = json_content.name;
-        let version = json_content.version;
+        let name = json_content.name.map(truncate_field);
+        let version = json_content.version.map(truncate_field);
 
         // Generate PURL
         let purl = create_package_url(&name, &version);
-        let extracted_license_statement = json_content.license.clone();
+        let extracted_license_statement = json_content.license.map(truncate_field);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             normalize_haxe_declared_license(extracted_license_statement.as_deref());
 
@@ -78,7 +77,11 @@ impl PackageParser for HaxeParser {
 
         // Extract dependencies (maintain insertion order by sorting)
         let mut dependencies = Vec::new();
-        let mut deps_list: Vec<_> = json_content.dependencies.into_iter().collect();
+        let mut deps_list: Vec<_> = json_content
+            .dependencies
+            .into_iter()
+            .take(MAX_ITERATION_COUNT)
+            .collect();
         deps_list.sort_by(|a, b| a.0.cmp(&b.0));
 
         for (dep_name, dep_version) in deps_list {
@@ -100,11 +103,15 @@ impl PackageParser for HaxeParser {
 
         // Extract contributors as parties
         let mut parties = Vec::new();
-        for contrib in json_content.contributors {
+        for contrib in json_content
+            .contributors
+            .into_iter()
+            .take(MAX_ITERATION_COUNT)
+        {
             parties.push(Party {
                 r#type: Some("person".to_string()),
                 role: Some("contributor".to_string()),
-                name: Some(contrib.clone()),
+                name: Some(truncate_field(contrib.clone())),
                 email: None,
                 url: Some(format!("https://lib.haxe.org/u/{}", contrib)),
                 organization: None,
@@ -121,11 +128,16 @@ impl PackageParser for HaxeParser {
             qualifiers: None,
             subpath: None,
             primary_language: Some("Haxe".to_string()),
-            description: json_content.description,
+            description: json_content.description.map(truncate_field),
             release_date: None,
             parties,
-            keywords: json_content.tags,
-            homepage_url: json_content.url,
+            keywords: json_content
+                .tags
+                .into_iter()
+                .take(MAX_ITERATION_COUNT)
+                .map(truncate_field)
+                .collect(),
+            homepage_url: json_content.url.map(truncate_field),
             download_url,
             size: None,
             sha1: None,
@@ -183,11 +195,8 @@ struct HaxelibJson {
 
 /// Read and parse a haxelib.json file.
 fn read_haxelib_json(path: &Path) -> Result<HaxelibJson, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-
-    let mut content = String::new();
-    file.read_to_string(&mut content)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
 
     serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {}", e))
 }

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
+use crate::parsers::utils::MAX_ITERATION_COUNT;
 
 use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::expression::{
@@ -14,6 +15,8 @@ use crate::utils::spdx::{
 };
 
 pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
+
+const MAX_RECURSION_DEPTH: usize = 50;
 
 static PARSER_LICENSE_ENGINE: LazyLock<Option<LicenseDetectionEngine>> = LazyLock::new(|| {
     let cache_config =
@@ -153,7 +156,8 @@ pub(crate) fn normalize_spdx_expression(statement: &str) -> Option<NormalizedDec
 
     let engine = PARSER_LICENSE_ENGINE.as_ref()?;
     let expression = parse_expression(statement).ok()?;
-    let (declared_ast, declared_spdx_ast) = normalize_expression_ast(&expression, engine.index())?;
+    let (declared_ast, declared_spdx_ast) =
+        normalize_expression_ast(&expression, engine.index(), 0)?;
     let declared_ast = simplify_expression(&declared_ast);
     let declared_spdx_ast = simplify_expression(&declared_spdx_ast);
 
@@ -437,7 +441,7 @@ fn collect_reference_strings(value: Option<&serde_json::Value>, references: &mut
             }
         }
         serde_json::Value::Array(values) => {
-            for value in values {
+            for value in values.iter().take(MAX_ITERATION_COUNT) {
                 if let Some(value) = value.as_str().filter(|value| !value.trim().is_empty()) {
                     references.push(value.trim().to_string());
                 }
@@ -450,7 +454,16 @@ fn collect_reference_strings(value: Option<&serde_json::Value>, references: &mut
 fn normalize_expression_ast(
     expression: &LicenseExpression,
     index: &LicenseIndex,
+    depth: usize,
 ) -> Option<(LicenseExpression, LicenseExpression)> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!(
+            "normalize_expression_ast: recursion depth {} exceeded limit {}, returning None",
+            depth, MAX_RECURSION_DEPTH
+        );
+        return None;
+    }
+
     match expression {
         LicenseExpression::License(key) => normalize_license_key(key, index).map(|normalized| {
             (
@@ -463,8 +476,8 @@ fn normalize_expression_ast(
             LicenseExpression::LicenseRef(key.clone()),
         )),
         LicenseExpression::And { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
 
             Some((
                 LicenseExpression::And {
@@ -478,8 +491,8 @@ fn normalize_expression_ast(
             ))
         }
         LicenseExpression::Or { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
 
             Some((
                 LicenseExpression::Or {
@@ -493,8 +506,8 @@ fn normalize_expression_ast(
             ))
         }
         LicenseExpression::With { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
 
             Some((
                 LicenseExpression::With {
@@ -588,7 +601,7 @@ fn render_canonical_expression(expression: &LicenseExpression) -> String {
 
 fn render_flat_boolean_chain(expression: &LicenseExpression, operator: BooleanOperator) -> String {
     let mut parts = Vec::new();
-    collect_boolean_chain(expression, operator, &mut parts);
+    collect_boolean_chain(expression, operator, &mut parts, 0);
 
     let separator = match operator {
         BooleanOperator::And => " AND ",
@@ -606,12 +619,22 @@ fn collect_boolean_chain<'a>(
     expression: &'a LicenseExpression,
     operator: BooleanOperator,
     parts: &mut Vec<&'a LicenseExpression>,
+    depth: usize,
 ) {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!(
+            "collect_boolean_chain: recursion depth {} exceeded limit {}, truncating chain",
+            depth, MAX_RECURSION_DEPTH
+        );
+        parts.push(expression);
+        return;
+    }
+
     match (operator, expression) {
         (BooleanOperator::And, LicenseExpression::And { left, right })
         | (BooleanOperator::Or, LicenseExpression::Or { left, right }) => {
-            collect_boolean_chain(left, operator, parts);
-            collect_boolean_chain(right, operator, parts);
+            collect_boolean_chain(left, operator, parts, depth + 1);
+            collect_boolean_chain(right, operator, parts, depth + 1);
         }
         _ => parts.push(expression),
     }

--- a/src/parsers/os_release.rs
+++ b/src/parsers/os_release.rs
@@ -21,7 +21,6 @@
 
 use crate::models::{DatasourceId, PackageType};
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -29,6 +28,7 @@ use crate::parser_warn as warn;
 use crate::models::PackageData;
 
 use super::PackageParser;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 const PACKAGE_TYPE: PackageType = PackageType::LinuxDistro;
 
@@ -44,7 +44,7 @@ impl PackageParser for OsReleaseParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read os-release file {:?}: {}", path, e);
@@ -74,16 +74,15 @@ pub(crate) fn parse_os_release(content: &str) -> PackageData {
     // Namespace and name mapping logic from Python reference
     let (namespace, name) = determine_namespace_and_name(id, id_like, &pretty_name);
 
-    // Extract URL fields (beyond Python implementation)
-    let homepage_url = fields.get("HOME_URL").cloned();
-    let bug_tracking_url = fields.get("BUG_REPORT_URL").cloned();
-    let code_view_url = fields.get("SUPPORT_URL").cloned();
+    let homepage_url = fields.get("HOME_URL").cloned().map(truncate_field);
+    let bug_tracking_url = fields.get("BUG_REPORT_URL").cloned().map(truncate_field);
+    let code_view_url = fields.get("SUPPORT_URL").cloned().map(truncate_field);
 
     PackageData {
         package_type: Some(PACKAGE_TYPE),
-        namespace: Some(namespace.to_string()),
-        name: Some(name.to_string()),
-        version: version_id,
+        namespace: Some(truncate_field(namespace.to_string())),
+        name: Some(truncate_field(name.to_string())),
+        version: version_id.map(truncate_field),
         homepage_url,
         bug_tracking_url,
         code_view_url,
@@ -121,7 +120,7 @@ fn determine_namespace_and_name<'a>(
 fn parse_key_value_pairs(content: &str) -> HashMap<String, String> {
     let mut fields = HashMap::new();
 
-    for line in content.lines() {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
         let line = line.trim();
 
         // Skip empty lines and comments

--- a/src/parsers/pip_inspect_deplock.rs
+++ b/src/parsers/pip_inspect_deplock.rs
@@ -34,6 +34,8 @@ use super::license_normalization::normalize_spdx_declared_license;
 use super::python::PythonParser;
 #[cfg(test)]
 use super::python::extract_requires_dist_dependencies;
+#[cfg(test)]
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
 
 const PACKAGE_TYPE: PackageType = PackageType::Pypi;
 
@@ -107,6 +109,7 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
     // Find the main package (has direct_url and is_requested)
     let main_package = installed_packages
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .find(|p| p.requested.unwrap_or(false) && p.direct_url.is_some());
 
     let metadata = if let Some(pkg) = main_package {
@@ -115,6 +118,7 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
         // If no main package found, try to find any requested package
         installed_packages
             .iter()
+            .take(MAX_ITERATION_COUNT)
             .find(|p| p.requested.unwrap_or(false))
             .and_then(|p| p.metadata.as_ref())
     };
@@ -147,7 +151,7 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
     let keywords = metadata
         .keywords
         .as_ref()
-        .map(|k| vec![k.clone()])
+        .map(|k| vec![truncate_field(k.clone())])
         .unwrap_or_default();
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         normalize_spdx_declared_license(metadata.license.as_deref());
@@ -160,13 +164,16 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
     PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Python".to_string()),
-        name: metadata.name.clone(),
-        version: metadata.version.clone(),
+        name: metadata.name.as_ref().map(|v| truncate_field(v.clone())),
+        version: metadata.version.as_ref().map(|v| truncate_field(v.clone())),
         declared_license_expression,
         declared_license_expression_spdx,
         license_detections,
-        extracted_license_statement: metadata.license.clone(),
-        description: metadata.description.clone(),
+        extracted_license_statement: metadata.license.as_ref().map(|v| truncate_field(v.clone())),
+        description: metadata
+            .description
+            .as_ref()
+            .map(|v| truncate_field(v.clone())),
         keywords,
         is_virtual: true,
         extra_data: extra_data_opt,


### PR DESCRIPTION
## Summary
- Apply ADR 0004 security compliance fixes to 5 parsers: pip_inspect_deplock, os_release, license_normalization, haxe, compiled_binary

## Changes
- **pip_inspect_deplock**: Iteration caps on installed packages, `truncate_field` on extracted strings
- **os_release**: `read_file_to_string`, iteration cap on lines, `truncate_field`
- **license_normalization**: `MAX_RECURSION_DEPTH=50` on `normalize_expression_ast` and `collect_boolean_chain`, iteration cap on reference strings
- **haxe**: `read_file_to_string`, iteration caps on deps/contributors, `truncate_field`
- **compiled_binary**: Iteration caps on packages/deps/modinfo, lossy UTF-8 conversion, `truncate_field`

## Test Plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] Pre-commit hooks pass