### PR TITLE
fix(parsers): ADR 0004 security compliance — batch 17

### DIFF
--- a/src/parsers/about.rs
+++ b/src/parsers/about.rs
@@ -23,8 +23,8 @@
 
 use crate::models::{DatasourceId, FileReference, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
+use crate::parsers::utils::{read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
-use std::fs;
 use std::path::Path;
 use std::str::FromStr;
 use url::Url;
@@ -85,23 +85,23 @@ impl PackageParser for AboutFileParser {
         let about_namespace = yaml
             .get(FIELD_NAMESPACE)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         let purl_string = yaml
             .get(FIELD_PURL)
             .and_then(|v| v.as_str())
             .or_else(|| yaml.get(FIELD_PACKAGE_URL).and_then(|v| v.as_str()))
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         // Parse purl if present
         let (purl_type, purl_namespace, purl_name, purl_version) =
             if let Some(ref purl_str) = purl_string {
                 match PackageUrl::from_str(purl_str) {
                     Ok(purl) => (
-                        Some(purl.ty().to_string()),
-                        purl.namespace().map(String::from),
-                        Some(purl.name().to_string()),
-                        purl.version().map(String::from),
+                        Some(truncate_field(purl.ty().to_string())),
+                        purl.namespace().map(|v| truncate_field(v.to_string())),
+                        Some(truncate_field(purl.name().to_string())),
+                        purl.version().map(|v| truncate_field(v.to_string())),
                     ),
                     Err(e) => {
                         warn!("Failed to parse purl '{}': {}", purl_str, e);
@@ -137,14 +137,16 @@ impl PackageParser for AboutFileParser {
                 inferred
                     .as_ref()
                     .and_then(|identity| identity.namespace.clone())
-            });
+            })
+            .map(truncate_field);
 
         // Name and version from YAML or purl
         let name = yaml
             .get(FIELD_NAME)
             .and_then(yaml_value_to_string)
             .or(purl_name.clone())
-            .or_else(|| inferred.as_ref().and_then(|identity| identity.name.clone()));
+            .or_else(|| inferred.as_ref().and_then(|identity| identity.name.clone()))
+            .map(truncate_field);
 
         let version = yaml
             .get(FIELD_VERSION)
@@ -154,29 +156,30 @@ impl PackageParser for AboutFileParser {
                 inferred
                     .as_ref()
                     .and_then(|identity| identity.version.clone())
-            });
+            })
+            .map(truncate_field);
 
         // Homepage URL (two possible field names)
         let homepage_url = yaml
             .get(FIELD_HOME_URL)
             .and_then(|v| v.as_str())
             .or_else(|| yaml.get(FIELD_HOMEPAGE_URL).and_then(|v| v.as_str()))
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         let download_url = yaml
             .get(FIELD_DOWNLOAD_URL)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         let copyright = yaml
             .get(FIELD_COPYRIGHT)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         let extracted_license_statement = yaml
             .get(FIELD_LICENSE_EXPRESSION)
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
         let file_references = extract_file_references(&yaml);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             extracted_license_statement
@@ -197,37 +200,39 @@ impl PackageParser for AboutFileParser {
         let vcs_url = yaml
             .get(Value::String("vcs_url".to_string()))
             .and_then(|v| v.as_str())
-            .map(String::from);
+            .map(|v| truncate_field(v.to_string()));
 
         let extra_data = build_extra_data(&yaml);
 
-        let purl = purl_string.or_else(|| {
-            let name = yaml
-                .get(FIELD_NAME)
-                .and_then(yaml_value_to_string)
-                .or(purl_name.clone())
-                .or_else(|| inferred.as_ref().and_then(|identity| identity.name.clone()));
-            let version = yaml
-                .get(FIELD_VERSION)
-                .and_then(yaml_value_to_string)
-                .or(purl_version.clone())
-                .or_else(|| {
+        let purl = purl_string
+            .or_else(|| {
+                let name = yaml
+                    .get(FIELD_NAME)
+                    .and_then(yaml_value_to_string)
+                    .or(purl_name.clone())
+                    .or_else(|| inferred.as_ref().and_then(|identity| identity.name.clone()));
+                let version = yaml
+                    .get(FIELD_VERSION)
+                    .and_then(yaml_value_to_string)
+                    .or(purl_version.clone())
+                    .or_else(|| {
+                        inferred
+                            .as_ref()
+                            .and_then(|identity| identity.version.clone())
+                    });
+                let namespace = about_namespace.clone().or_else(|| {
                     inferred
                         .as_ref()
-                        .and_then(|identity| identity.version.clone())
+                        .and_then(|identity| identity.namespace.clone())
                 });
-            let namespace = about_namespace.clone().or_else(|| {
-                inferred
-                    .as_ref()
-                    .and_then(|identity| identity.namespace.clone())
-            });
-            build_about_purl(
-                package_type,
-                namespace.as_deref(),
-                name.as_deref(),
-                version.as_deref(),
-            )
-        });
+                build_about_purl(
+                    package_type,
+                    namespace.as_deref(),
+                    name.as_deref(),
+                    version.as_deref(),
+                )
+            })
+            .map(truncate_field);
 
         // Owner party
         let parties = extract_owner_party(&yaml);
@@ -288,7 +293,8 @@ impl PackageParser for AboutFileParser {
 
 /// Reads and parses a YAML file.
 fn read_and_parse_yaml(path: &Path) -> Result<yaml_serde::Mapping, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content =
+        read_file_to_string(path, None).map_err(|e| format!("Failed to read file: {}", e))?;
 
     let value: Value =
         yaml_serde::from_str(&content).map_err(|e| format!("Failed to parse YAML: {}", e))?;
@@ -314,11 +320,8 @@ fn extract_owner_party(yaml: &yaml_serde::Mapping) -> Vec<Party> {
     let owner = yaml
         .get(Value::String(FIELD_OWNER.to_string()))
         .map(|v| match v {
-            Value::String(s) => s.clone(),
-            _ => {
-                // Convert non-string values to their debug representation
-                format!("{:?}", v)
-            }
+            Value::String(s) => truncate_field(s.clone()),
+            _ => truncate_field(format!("{:?}", v)),
         });
 
     if let Some(owner_name) = owner {
@@ -357,7 +360,7 @@ fn extract_file_references(yaml: &yaml_serde::Mapping) -> Vec<FileReference> {
 
     if let Some(path) = about_resource {
         refs.push(FileReference {
-            path: path.to_string(),
+            path: truncate_field(path.to_string()),
             size: None,
             sha1: None,
             md5: None,
@@ -369,7 +372,7 @@ fn extract_file_references(yaml: &yaml_serde::Mapping) -> Vec<FileReference> {
 
     for path in [license_file, notice_file].into_iter().flatten() {
         refs.push(FileReference {
-            path: path.to_string(),
+            path: truncate_field(path.to_string()),
             size: None,
             sha1: None,
             md5: None,
@@ -454,7 +457,10 @@ fn build_extra_data(
         if let Some(value) = yaml.get(Value::String(key.to_string()))
             && let Some(value) = yaml_value_to_string(value)
         {
-            extra_data.insert(key.to_string(), serde_json::Value::String(value));
+            extra_data.insert(
+                key.to_string(),
+                serde_json::Value::String(truncate_field(value)),
+            );
         }
     }
     (!extra_data.is_empty()).then_some(extra_data)

--- a/src/parsers/chef.rs
+++ b/src/parsers/chef.rs
@@ -21,9 +21,10 @@
 //! - IO.read(...) expressions in Ruby files are skipped (cannot evaluate Ruby code)
 
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
 use packageurl::PackageUrl;
@@ -33,6 +34,7 @@ use serde_json::Value;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 
 use super::PackageParser;
+use super::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, read_file_to_string, truncate_field};
 
 const FIELD_NAME: &str = "name";
 const FIELD_VERSION: &str = "version";
@@ -45,6 +47,14 @@ const FIELD_SOURCE_URL: &str = "source_url";
 const FIELD_ISSUES_URL: &str = "issues_url";
 const FIELD_DEPENDENCIES: &str = "dependencies";
 const FIELD_DEPENDS: &str = "depends";
+
+static RE_FIELD: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*(\w+)\s+['"](.+?)['"]"#).expect("valid regex"));
+static RE_DEPENDS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*depends\s+['"](.+?)['"](?:\s*,\s*['"](.+?)['"])?"#).expect("valid regex")
+});
+static RE_IO_READ: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"IO\.read\(").expect("valid regex"));
 
 struct ChefPackageFields {
     datasource_id: DatasourceId,
@@ -95,45 +105,52 @@ impl PackageParser for ChefMetadataJsonParser {
             .get(FIELD_NAME)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let version = json_content
             .get(FIELD_VERSION)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
-        let description = extract_description(&json_content);
+        let description = extract_description(&json_content).map(truncate_field);
 
         let extracted_license_statement = json_content
             .get(FIELD_LICENSE)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let maintainer_name = json_content
             .get(FIELD_MAINTAINER)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let maintainer_email = json_content
             .get(FIELD_MAINTAINER_EMAIL)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let code_view_url = json_content
             .get(FIELD_SOURCE_URL)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let bug_tracking_url = json_content
             .get(FIELD_ISSUES_URL)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let mut deps: HashMap<String, Option<String>> = HashMap::new();
 
@@ -141,22 +158,30 @@ impl PackageParser for ChefMetadataJsonParser {
             .get(FIELD_DEPENDENCIES)
             .and_then(|v| v.as_object())
         {
-            for (dep_name, dep_version) in deps_obj {
+            for (dep_name, dep_version) in deps_obj.iter().take(MAX_ITERATION_COUNT) {
                 let version_constraint = dep_version
                     .as_str()
                     .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty());
-                deps.insert(dep_name.trim().to_string(), version_constraint);
+                    .filter(|s| !s.is_empty())
+                    .map(truncate_field);
+                deps.insert(
+                    truncate_field(dep_name.trim().to_string()),
+                    version_constraint,
+                );
             }
         }
 
         if let Some(depends_obj) = json_content.get(FIELD_DEPENDS).and_then(|v| v.as_object()) {
-            for (dep_name, dep_version) in depends_obj {
+            for (dep_name, dep_version) in depends_obj.iter().take(MAX_ITERATION_COUNT) {
                 let version_constraint = dep_version
                     .as_str()
                     .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty());
-                deps.insert(dep_name.trim().to_string(), version_constraint);
+                    .filter(|s| !s.is_empty())
+                    .map(truncate_field);
+                deps.insert(
+                    truncate_field(dep_name.trim().to_string()),
+                    version_constraint,
+                );
             }
         }
 
@@ -176,10 +201,7 @@ impl PackageParser for ChefMetadataJsonParser {
 }
 
 fn read_json_file(path: &Path) -> Result<Value, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {}", e))?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let contents = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     serde_json::from_str(&contents).map_err(|e| format!("Failed to parse JSON: {}", e))
 }
 
@@ -218,6 +240,18 @@ impl PackageParser for ChefMetadataRbParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        if let Ok(metadata) = fs::metadata(path)
+            && metadata.len() > MAX_MANIFEST_SIZE
+        {
+            warn!(
+                "File {:?} is {} bytes, exceeding the {} byte limit",
+                path,
+                metadata.len(),
+                MAX_MANIFEST_SIZE
+            );
+            return vec![default_package_data(DatasourceId::ChefCookbookMetadataRb)];
+        }
+
         let file = match File::open(path) {
             Ok(f) => f,
             Err(e) => {
@@ -230,15 +264,13 @@ impl PackageParser for ChefMetadataRbParser {
         let mut fields: HashMap<String, String> = HashMap::new();
         let mut deps: HashMap<String, Option<String>> = HashMap::new();
 
-        let field_pattern = Regex::new(r#"^\s*(\w+)\s+['"](.+?)['"]"#).unwrap();
-        let depends_pattern =
-            Regex::new(r#"^\s*depends\s+['"](.+?)['"](?:\s*,\s*['"](.+?)['"])?"#).unwrap();
-        let io_read_pattern = Regex::new(r"IO\.read\(").unwrap();
-
-        for line in reader.lines() {
+        for line in reader.lines().take(MAX_ITERATION_COUNT) {
             let line = match line {
                 Ok(l) => l,
-                Err(_) => continue,
+                Err(e) => {
+                    warn!("Skipping non-UTF-8 line in {:?}: {}", path, e);
+                    continue;
+                }
             };
 
             let trimmed = line.trim();
@@ -247,27 +279,40 @@ impl PackageParser for ChefMetadataRbParser {
                 continue;
             }
 
-            if io_read_pattern.is_match(&line) {
+            if RE_IO_READ.is_match(&line) {
                 continue;
             }
 
-            if let Some(caps) = depends_pattern.captures(&line) {
-                let dep_name = caps.get(1).map(|m| m.as_str().to_string()).unwrap();
+            if let Some(caps) = RE_DEPENDS.captures(&line) {
+                let dep_name = caps
+                    .get(1)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
                 let dep_version = caps.get(2).map(|m| m.as_str().to_string());
-                deps.insert(dep_name, dep_version);
+                if !dep_name.is_empty() {
+                    deps.insert(dep_name, dep_version);
+                }
                 continue;
             }
 
-            if let Some(caps) = field_pattern.captures(&line) {
-                let key = caps.get(1).map(|m| m.as_str().to_string()).unwrap();
-                let value = caps.get(2).map(|m| m.as_str().to_string()).unwrap();
+            if let Some(caps) = RE_FIELD.captures(&line) {
+                let key = caps
+                    .get(1)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
+                let value = caps
+                    .get(2)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
 
-                match key.as_str() {
-                    "name" | "version" | "description" | "long_description" | "license"
-                    | "maintainer" | "maintainer_email" | "source_url" | "issues_url" => {
-                        fields.insert(key, value);
+                if !key.is_empty() && !value.is_empty() {
+                    match key.as_str() {
+                        "name" | "version" | "description" | "long_description" | "license"
+                        | "maintainer" | "maintainer_email" | "source_url" | "issues_url" => {
+                            fields.insert(key, value);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }
@@ -275,48 +320,57 @@ impl PackageParser for ChefMetadataRbParser {
         let name = fields
             .get("name")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let version = fields
             .get("version")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let description = fields
             .get("description")
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
+            .map(truncate_field)
             .or_else(|| {
                 fields
                     .get("long_description")
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
+                    .map(truncate_field)
             });
 
         let extracted_license_statement = fields
             .get("license")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let maintainer_name = fields
             .get("maintainer")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let maintainer_email = fields
             .get("maintainer_email")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let code_view_url = fields
             .get("source_url")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         let bug_tracking_url = fields
             .get("issues_url")
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(truncate_field);
 
         vec![build_package(ChefPackageFields {
             datasource_id: DatasourceId::ChefCookbookMetadataRb,
@@ -349,9 +403,9 @@ fn build_package(fields: ChefPackageFields) -> PackageData {
     let parties = if maintainer_name.is_some() || maintainer_email.is_some() {
         vec![Party {
             r#type: None,
-            role: Some("maintainer".to_string()),
-            name: maintainer_name,
-            email: maintainer_email,
+            role: Some(truncate_field("maintainer".to_string())),
+            name: maintainer_name.map(truncate_field),
+            email: maintainer_email.map(truncate_field),
             url: None,
             organization: None,
             organization_url: None,
@@ -365,12 +419,12 @@ fn build_package(fields: ChefPackageFields) -> PackageData {
         .into_iter()
         .map(|(dep_name, version_constraint)| {
             let purl = PackageUrl::new("chef", &dep_name)
-                .map(|p| p.to_string())
+                .map(|p| truncate_field(p.to_string()))
                 .ok();
             Dependency {
                 purl,
-                extracted_requirement: version_constraint,
-                scope: Some("dependencies".to_string()),
+                extracted_requirement: version_constraint.map(truncate_field),
+                scope: Some(truncate_field("dependencies".to_string())),
                 is_runtime: Some(true),
                 is_optional: Some(false),
                 is_pinned: None,
@@ -389,18 +443,18 @@ fn build_package(fields: ChefPackageFields) -> PackageData {
 
     let (download_url, repository_download_url, repository_homepage_url, api_data_url) =
         if let (Some(n), Some(v)) = (&name, &version) {
-            let download = format!(
+            let download = truncate_field(format!(
                 "https://supermarket.chef.io/cookbooks/{}/versions/{}/download",
                 n, v
-            );
-            let homepage = format!(
+            ));
+            let homepage = truncate_field(format!(
                 "https://supermarket.chef.io/cookbooks/{}/versions/{}/",
                 n, v
-            );
-            let api = format!(
+            ));
+            let api = truncate_field(format!(
                 "https://supermarket.chef.io/api/v1/cookbooks/{}/versions/{}",
                 n, v
-            );
+            ));
             (
                 Some(download.clone()),
                 Some(download),
@@ -415,7 +469,7 @@ fn build_package(fields: ChefPackageFields) -> PackageData {
         (Some(name), Some(version)) => PackageUrl::new("chef", name)
             .map(|mut p| {
                 let _ = p.with_version(version);
-                p.to_string()
+                truncate_field(p.to_string())
             })
             .ok(),
         _ => None,
@@ -437,7 +491,7 @@ fn build_package(fields: ChefPackageFields) -> PackageData {
         repository_homepage_url,
         api_data_url,
         purl,
-        primary_language: Some("Ruby".to_string()),
+        primary_language: Some(truncate_field("Ruby".to_string())),
         ..Default::default()
     }
 }

--- a/src/parsers/citation.rs
+++ b/src/parsers/citation.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
@@ -6,6 +5,7 @@ use crate::parser_warn as warn;
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
+use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 pub struct CitationCffParser;
 
@@ -17,7 +17,7 @@ impl PackageParser for CitationCffParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match fs::read_to_string(path) {
+        let content = match read_file_to_string(path, None) {
             Ok(content) => content,
             Err(error) => {
                 warn!("Failed to read CITATION.cff at {:?}: {}", path, error);
@@ -58,28 +58,28 @@ fn parse_citation_cff(yaml: &yaml_serde::Value) -> PackageData {
     package.name = yaml
         .get("title")
         .and_then(yaml_serde::Value::as_str)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.version = yaml
         .get("version")
         .and_then(yaml_serde::Value::as_str)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.description = yaml
         .get("abstract")
         .and_then(yaml_serde::Value::as_str)
         .or_else(|| yaml.get("message").and_then(yaml_serde::Value::as_str))
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.homepage_url = yaml
         .get("url")
         .and_then(yaml_serde::Value::as_str)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.vcs_url = yaml
         .get("repository-code")
         .and_then(yaml_serde::Value::as_str)
-        .map(str::to_string);
+        .map(|s| truncate_field(s.to_string()));
     package.parties = extract_author_parties(yaml.get("authors"));
 
     if let Some(license) = yaml.get("license").and_then(yaml_serde::Value::as_str) {
-        let license = license.to_string();
+        let license = truncate_field(license.to_string());
         package.extracted_license_statement = Some(license.clone());
         let (declared, declared_spdx, detections) = normalize_spdx_declared_license(Some(&license));
         package.declared_license_expression = declared;
@@ -95,31 +95,34 @@ fn extract_author_parties(value: Option<&yaml_serde::Value>) -> Vec<Party> {
         .and_then(yaml_serde::Value::as_sequence)
         .into_iter()
         .flatten()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|entry| {
             let name = entry
                 .get("name")
                 .and_then(yaml_serde::Value::as_str)
-                .map(str::to_string)
+                .map(|s| truncate_field(s.to_string()))
                 .or_else(|| {
                     let given = entry.get("given-names").and_then(yaml_serde::Value::as_str);
                     let family = entry
                         .get("family-names")
                         .and_then(yaml_serde::Value::as_str);
                     match (given, family) {
-                        (Some(given), Some(family)) => Some(format!("{given} {family}")),
-                        (Some(given), None) => Some(given.to_string()),
-                        (None, Some(family)) => Some(family.to_string()),
+                        (Some(given), Some(family)) => {
+                            Some(truncate_field(format!("{given} {family}")))
+                        }
+                        (Some(given), None) => Some(truncate_field(given.to_string())),
+                        (None, Some(family)) => Some(truncate_field(family.to_string())),
                         (None, None) => None,
                     }
                 });
             let email = entry
                 .get("email")
                 .and_then(yaml_serde::Value::as_str)
-                .map(str::to_string);
+                .map(|s| truncate_field(s.to_string()));
             let url = entry
                 .get("orcid")
                 .and_then(yaml_serde::Value::as_str)
-                .map(str::to_string);
+                .map(|s| truncate_field(s.to_string()));
 
             if name.is_none() && email.is_none() && url.is_none() {
                 return None;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -322,6 +322,7 @@ use std::path::Path;
 
 use crate::models::{PackageData, PackageType};
 use crate::parsers::license_normalization::finalize_package_declared_license_references;
+use crate::parsers::utils::MAX_ITERATION_COUNT;
 
 thread_local! {
     static PARSER_DIAGNOSTIC_STACK: RefCell<Vec<Vec<String>>> = const { RefCell::new(Vec::new()) };
@@ -367,6 +368,7 @@ where
                     finalize_package_declared_license_references(&mut package);
                     package
                 })
+                .take(MAX_ITERATION_COUNT)
                 .collect(),
             scan_errors,
         },

--- a/src/parsers/rpm_license_files.rs
+++ b/src/parsers/rpm_license_files.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use crate::models::PackageData;
 use crate::parsers::PackageParser;
+use crate::parsers::utils::truncate_field;
 
 const PACKAGE_TYPE: PackageType = PackageType::Rpm;
 
@@ -60,7 +61,10 @@ impl PackageParser for RpmLicenseFilesParser {
         // Split by usr/share/licenses/ and get the next path component
         let name = if let Some(after_licenses) = path_str.split("usr/share/licenses/").nth(1) {
             // Get the first path component after licenses/ (the package name)
-            after_licenses.split('/').next().map(|s| s.to_string())
+            after_licenses
+                .split('/')
+                .next()
+                .map(|s| truncate_field(s.to_string()))
         } else {
             None
         };
@@ -80,7 +84,7 @@ impl PackageParser for RpmLicenseFilesParser {
             if let Ok(mut purl) = PackageUrl::new(PACKAGE_TYPE.as_str(), package_name)
                 && purl.with_namespace("mariner").is_ok()
             {
-                pkg.purl = Some(purl.to_string());
+                pkg.purl = Some(truncate_field(purl.to_string()));
             }
         }
 


### PR DESCRIPTION
## Summary
- Apply ADR 0004 security compliance fixes to 5 parsers: citation, chef, about, rpm_license_files, mod

## Changes
- **citation**: `read_file_to_string`, iteration cap on authors, `truncate_field`
- **chef**: `LazyLock<Regex>` replacing `Regex::new().unwrap()`, safe capture group handling, `read_file_to_string`, UTF-8 warning on non-UTF-8 lines, `truncate_field`
- **about**: `read_file_to_string`, `truncate_field` on all extracted strings
- **rpm_license_files**: `truncate_field` on path-derived name/purl values
- **mod**: `MAX_ITERATION_COUNT` cap on packages returned by parsers

## Test Plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] Pre-commit hooks pass