### PR TITLE
fix(parsers): apply ADR 0004 security hardening for batch 18

### DIFF
--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -1,3 +1,6 @@
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_FIELD_LENGTH, MAX_ITERATION_COUNT, truncate_field};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Pep508Requirement {
     pub name: String,
@@ -9,6 +12,14 @@ pub(crate) struct Pep508Requirement {
 }
 
 pub(crate) fn parse_pep508_requirement(input: &str) -> Option<Pep508Requirement> {
+    if input.len() > MAX_FIELD_LENGTH {
+        warn!(
+            "pep508: input exceeds MAX_FIELD_LENGTH ({} bytes), skipping",
+            input.len()
+        );
+        return None;
+    }
+
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return None;
@@ -28,11 +39,11 @@ pub(crate) fn parse_pep508_requirement(input: &str) -> Option<Pep508Requirement>
     if let Some((name_part, url)) = split_name_at_url(requirement_part) {
         let (name, extras, _rest) = parse_name_and_extras(&name_part)?;
         return Some(Pep508Requirement {
-            name,
+            name: truncate_field(name),
             extras,
             specifiers: None,
-            marker,
-            url: Some(url),
+            marker: marker.map(truncate_field),
+            url: Some(truncate_field(url)),
             is_name_at_url: true,
         });
     }
@@ -41,10 +52,10 @@ pub(crate) fn parse_pep508_requirement(input: &str) -> Option<Pep508Requirement>
     let specifiers = normalize_specifiers(rest);
 
     Some(Pep508Requirement {
-        name,
+        name: truncate_field(name),
         extras,
-        specifiers,
-        marker,
+        specifiers: specifiers.map(truncate_field),
+        marker: marker.map(truncate_field),
         url: None,
         is_name_at_url: false,
     })
@@ -78,7 +89,7 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
     }
 
     let mut name_end = trimmed.len();
-    for (idx, ch) in trimmed.char_indices() {
+    for (idx, ch) in trimmed.char_indices().take(MAX_ITERATION_COUNT) {
         if ch == '[' || ch.is_whitespace() || matches!(ch, '<' | '>' | '=' | '!' | '~' | ';') {
             name_end = idx;
             break;
@@ -100,9 +111,10 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
         let extras_str = &rest_trimmed[1..close_idx];
         extras = extras_str
             .split(',')
+            .take(MAX_ITERATION_COUNT)
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
-            .map(|value| value.to_string())
+            .map(|value| truncate_field(value.to_string()))
             .collect();
         rest = &rest_trimmed[close_idx + 1..];
     }

--- a/src/parsers/rfc822.rs
+++ b/src/parsers/rfc822.rs
@@ -25,6 +25,9 @@
 
 use std::collections::HashMap;
 
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+
 /// Parsed RFC822 metadata containing headers and an optional body.
 ///
 /// Headers are stored as `HashMap<String, Vec<String>>` to support duplicate
@@ -72,10 +75,18 @@ pub fn parse_rfc822_content(content: &str) -> Rfc822Metadata {
     let mut body_lines: Vec<String> = Vec::new();
     let mut in_headers = true;
 
-    for line in content.lines() {
+    for (i, line) in content.lines().enumerate() {
+        if i >= MAX_ITERATION_COUNT {
+            warn!(
+                "RFC822 parser iteration limit reached ({MAX_ITERATION_COUNT}), truncating input"
+            );
+            break;
+        }
+
         if in_headers {
             if line.is_empty() {
                 if let Some(name) = current_name.take() {
+                    current_value = truncate_field(current_value);
                     add_header_value(&mut headers, &name, &current_value);
                     current_value.clear();
                 }
@@ -92,6 +103,7 @@ pub fn parse_rfc822_content(content: &str) -> Rfc822Metadata {
             }
 
             if let Some(name) = current_name.take() {
+                current_value = truncate_field(current_value);
                 add_header_value(&mut headers, &name, &current_value);
                 current_value.clear();
             }
@@ -107,6 +119,7 @@ pub fn parse_rfc822_content(content: &str) -> Rfc822Metadata {
 
     // Flush last header if still open (no trailing blank line)
     if let Some(name) = current_name.take() {
+        current_value = truncate_field(current_value);
         add_header_value(&mut headers, &name, &current_value);
     }
 
@@ -133,7 +146,14 @@ pub fn parse_rfc822_paragraphs(content: &str) -> Vec<Rfc822Metadata> {
     let mut paragraphs = Vec::new();
     let mut current_paragraph = String::new();
 
-    for line in content.lines() {
+    for (i, line) in content.lines().enumerate() {
+        if i >= MAX_ITERATION_COUNT {
+            warn!(
+                "RFC822 paragraph parser iteration limit reached ({MAX_ITERATION_COUNT}), truncating input"
+            );
+            break;
+        }
+
         if line.is_empty() {
             if !current_paragraph.is_empty() {
                 // Parse the accumulated paragraph as a single-paragraph RFC822
@@ -168,7 +188,14 @@ fn parse_paragraph_headers(content: &str) -> Rfc822Metadata {
     let mut current_name: Option<String> = None;
     let mut current_value = String::new();
 
-    for line in content.lines() {
+    for (i, line) in content.lines().enumerate() {
+        if i >= MAX_ITERATION_COUNT {
+            warn!(
+                "RFC822 paragraph headers parser iteration limit reached ({MAX_ITERATION_COUNT}), truncating input"
+            );
+            break;
+        }
+
         // Continuation line
         if line.starts_with(' ') || line.starts_with('\t') {
             if current_name.is_some() {
@@ -181,6 +208,7 @@ fn parse_paragraph_headers(content: &str) -> Rfc822Metadata {
 
         // Flush previous header
         if let Some(name) = current_name.take() {
+            current_value = truncate_field(current_value);
             add_header_value(&mut headers, &name, &current_value);
             current_value.clear();
         }
@@ -194,6 +222,7 @@ fn parse_paragraph_headers(content: &str) -> Rfc822Metadata {
 
     // Flush last header
     if let Some(name) = current_name.take() {
+        current_value = truncate_field(current_value);
         add_header_value(&mut headers, &name, &current_value);
     }
 

--- a/src/parsers/rpm_db_native/mod.rs
+++ b/src/parsers/rpm_db_native/mod.rs
@@ -6,9 +6,13 @@ mod package;
 mod sqlite;
 mod tags;
 
+use std::fs;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE};
 
 use self::bdb::BdbDatabase;
 use self::entry::HeaderBlob;
@@ -32,6 +36,15 @@ pub(crate) fn read_installed_rpm_packages(
     path: &Path,
     kind: InstalledRpmDbKind,
 ) -> Result<Vec<InstalledRpmPackage>> {
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > MAX_MANIFEST_SIZE {
+        return Err(anyhow!(
+            "RPM database file too large: {} bytes (max {} bytes)",
+            metadata.len(),
+            MAX_MANIFEST_SIZE
+        ));
+    }
+
     let mut reader: Box<dyn BlobReader> = match kind {
         InstalledRpmDbKind::Bdb => Box::new(BdbDatabase::open(path)?),
         InstalledRpmDbKind::Ndb => Box::new(NdbDatabase::open(path)?),
@@ -49,9 +62,18 @@ pub(crate) fn read_installed_rpm_packages(
         }
     };
 
-    reader
-        .read_blobs()?
+    let blobs = reader.read_blobs()?;
+    if blobs.len() > MAX_ITERATION_COUNT {
+        warn!(
+            "RPM database blob iteration exceeded MAX_ITERATION_COUNT ({} blobs), truncating to {}",
+            blobs.len(),
+            MAX_ITERATION_COUNT
+        );
+    }
+
+    blobs
         .into_iter()
+        .take(MAX_ITERATION_COUNT)
         .map(|blob| {
             let header = HeaderBlob::parse(&blob)?;
             let entries = header.import_entries(&blob)?;

--- a/src/parsers/rpm_db_native/package.rs
+++ b/src/parsers/rpm_db_native/package.rs
@@ -1,5 +1,8 @@
 use anyhow::{Result, anyhow};
 
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+
 use super::entry::IndexEntry;
 use super::tags::{
     RPMTAG_ARCH, RPMTAG_BASENAMES, RPMTAG_DIRINDEXES, RPMTAG_DIRNAMES, RPMTAG_DISTRIBUTION,
@@ -31,7 +34,14 @@ pub(crate) struct InstalledRpmPackage {
 
 pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<InstalledRpmPackage> {
     let mut package = InstalledRpmPackage::default();
-    for entry in entries {
+    for (i, entry) in entries.into_iter().enumerate() {
+        if i >= MAX_ITERATION_COUNT {
+            warn!(
+                "RPM entry iteration exceeded MAX_ITERATION_COUNT ({}), stopping",
+                MAX_ITERATION_COUNT
+            );
+            break;
+        }
         match entry.info.tag {
             RPMTAG_DIRINDEXES => {
                 ensure_kind(&entry, TagType::Int32, "dir indexes")?;
@@ -39,19 +49,31 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
             }
             RPMTAG_DIRNAMES => {
                 ensure_kind(&entry, TagType::StringArray, "dir names")?;
-                package.dir_names = entry.read_string_array()?;
+                package.dir_names = entry
+                    .read_string_array()?
+                    .into_iter()
+                    .map(truncate_field)
+                    .collect();
             }
             RPMTAG_BASENAMES => {
                 ensure_kind(&entry, TagType::StringArray, "base names")?;
-                package.base_names = entry.read_string_array()?;
+                package.base_names = entry
+                    .read_string_array()?
+                    .into_iter()
+                    .map(truncate_field)
+                    .collect();
             }
             RPMTAG_FILENAMES => {
                 ensure_kind(&entry, TagType::StringArray, "file names")?;
-                package.file_names = entry.read_string_array()?;
+                package.file_names = entry
+                    .read_string_array()?
+                    .into_iter()
+                    .map(truncate_field)
+                    .collect();
             }
             RPMTAG_NAME => {
                 ensure_kind(&entry, TagType::String, "name")?;
-                package.name = entry.read_string()?;
+                package.name = truncate_field(entry.read_string()?);
             }
             RPMTAG_EPOCH => {
                 ensure_kind(&entry, TagType::Int32, "epoch")?;
@@ -59,31 +81,31 @@ pub(crate) fn parse_installed_rpm_package(entries: Vec<IndexEntry>) -> Result<In
             }
             RPMTAG_VERSION => {
                 ensure_kind(&entry, TagType::String, "version")?;
-                package.version = entry.read_string()?;
+                package.version = truncate_field(entry.read_string()?);
             }
             RPMTAG_RELEASE => {
                 ensure_kind(&entry, TagType::String, "release")?;
-                package.release = entry.read_string()?;
+                package.release = truncate_field(entry.read_string()?);
             }
             RPMTAG_ARCH => {
                 ensure_kind(&entry, TagType::String, "arch")?;
-                package.arch = entry.read_string()?;
+                package.arch = truncate_field(entry.read_string()?);
             }
             RPMTAG_SOURCERPM => {
                 ensure_kind(&entry, TagType::String, "source rpm")?;
-                package.source_rpm = normalize_none(entry.read_string()?);
+                package.source_rpm = normalize_none(truncate_field(entry.read_string()?));
             }
             RPMTAG_LICENSE => {
                 ensure_kind(&entry, TagType::String, "license")?;
-                package.license = normalize_none(entry.read_string()?);
+                package.license = normalize_none(truncate_field(entry.read_string()?));
             }
             RPMTAG_VENDOR => {
                 ensure_kind(&entry, TagType::String, "vendor")?;
-                package.vendor = normalize_none(entry.read_string()?);
+                package.vendor = normalize_none(truncate_field(entry.read_string()?));
             }
             RPMTAG_DISTRIBUTION => {
                 ensure_kind(&entry, TagType::String, "distribution")?;
-                package.distribution = normalize_none(entry.read_string()?);
+                package.distribution = normalize_none(truncate_field(entry.read_string()?));
             }
             RPMTAG_PLATFORM => {
                 ensure_kind(&entry, TagType::String, "platform")?;

--- a/src/parsers/rpm_db_native/sqlite.rs
+++ b/src/parsers/rpm_db_native/sqlite.rs
@@ -1,9 +1,13 @@
+use std::fs;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
 use rusqlite::{Connection, OpenFlags};
+
+use crate::parser_warn as warn;
+use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE};
 
 use super::BlobReader;
 
@@ -15,6 +19,15 @@ pub(crate) struct SqliteDatabase {
 
 impl SqliteDatabase {
     pub(crate) fn open(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)?;
+        if metadata.len() > MAX_MANIFEST_SIZE {
+            return Err(anyhow!(
+                "RPM sqlite database too large: {} bytes (max {} bytes)",
+                metadata.len(),
+                MAX_MANIFEST_SIZE
+            ));
+        }
+
         let mut header = [0_u8; 16];
         File::open(path)?.read_exact(&mut header)?;
         if header != SQLITE_HEADER_MAGIC {
@@ -28,12 +41,17 @@ impl SqliteDatabase {
 
 impl BlobReader for SqliteDatabase {
     fn read_blobs(&mut self) -> Result<Vec<Vec<u8>>> {
-        let mut statement = self
-            .connection
-            .prepare("SELECT blob FROM Packages ORDER BY hnum")?;
+        let mut statement = self.connection.prepare(&format!(
+            "SELECT blob FROM Packages ORDER BY hnum LIMIT {}",
+            MAX_ITERATION_COUNT
+        ))?;
         let rows = statement.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
         let mut blobs = Vec::new();
-        for row in rows {
+        for (i, row) in rows.enumerate() {
+            if i >= MAX_ITERATION_COUNT {
+                warn!("RPM sqlite database row iteration exceeded MAX_ITERATION_COUNT, truncating");
+                break;
+            }
             blobs.push(row?);
         }
         Ok(blobs)


### PR DESCRIPTION
## Summary

- Apply ADR 0004 security hardening to the final 5 parsers with audit findings: `rpm_db_native/sqlite`, `rpm_db_native/package`, `rpm_db_native/mod`, `rfc822`, and `pep508`
- P2-FileSize: add `fs::metadata()` size checks against `MAX_MANIFEST_SIZE` for `rpm_db_native/sqlite` and `rpm_db_native/mod`
- P2-Iteration: add `MAX_ITERATION_COUNT` caps on SQLite row iteration, RPM entry iteration, RFC822 line loops, and pep508 char/extras loops
- P2-StringLength: apply `truncate_field()` to all extracted string fields in `rpm_db_native/package`, RFC822 header values, and pep508 returned strings
- P4-InputValidation: add input length check in pep508 before parsing

## Related

- Part of the ADR 0004 security compliance effort across all parser audit reports
- Batch 18 (final batch with findings)