### PR TITLE
chore: upgrade libflate 2.2.1 → 2.3.0, remove core2 yanked ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,15 +584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,25 +1832,25 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libflate"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -2117,6 +2108,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,6 @@ yanked = "deny"
 unmaintained = "workspace"
 unsound = "workspace"
 ignore = [
-    { crate = "core2@0.4.0", reason = "all versions yanked; transitive dep via pdf_oxide -> libflate. See https://github.com/sile/libflate/issues/85" },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- Upgrade `libflate` from 2.2.1 → 2.3.0 and `libflate_lz77` from 2.2.0 → 2.3.0 (transitive dep via `pdf_oxide`)
- Remove the `core2@0.4.0` yanked-crate ignore from `deny.toml` since libflate 2.3.0 replaced `core2` with `no_std_io2`, resolving the yanked dependency

## Why

libflate 2.3.0 replaced the yanked `core2` dependency with `no_std_io2`, eliminating the need for the cargo-deny ignore entry. See https://github.com/sile/libflate/issues/85.

## Files changed

- `Cargo.lock` — libflate/libflate_lz77 bumped, core2 removed, no_std_io2 added
- `deny.toml` — removed `core2@0.4.0` from `[advisories]` ignore list