### PR TITLE
fix(parsers): reuse scan license engine during finalization

### DIFF
--- a/src/parsers/clojure_test.rs
+++ b/src/parsers/clojure_test.rs
@@ -200,6 +200,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());
@@ -226,6 +227,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());
@@ -249,6 +251,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());
@@ -281,6 +284,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());
@@ -306,6 +310,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());
@@ -337,6 +342,7 @@ mod tests {
             || ClojureProjectCljParser::extract_packages(&path),
             "ClojureProjectCljParser",
             &path,
+            None,
         );
 
         assert!(result.scan_errors.is_empty());

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -1,6 +1,10 @@
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
+
+#[cfg(test)]
+use std::cell::Cell;
 
 use crate::parser_warn as warn;
+use crate::parsers::active_parser_license_engine;
 use crate::parsers::utils::MAX_ITERATION_COUNT;
 
 use crate::license_detection::LicenseDetectionEngine;
@@ -18,11 +22,11 @@ pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
 
 const MAX_RECURSION_DEPTH: usize = 50;
 
-static PARSER_LICENSE_ENGINE: LazyLock<Option<LicenseDetectionEngine>> = LazyLock::new(|| {
+static PARSER_LICENSE_ENGINE: LazyLock<Option<Arc<LicenseDetectionEngine>>> = LazyLock::new(|| {
     let cache_config =
         LicenseCacheConfig::new(LicenseCacheConfig::default_root_dir(), false, false);
     match LicenseDetectionEngine::from_embedded_with_cache(&cache_config) {
-        Ok(engine) => Some(engine),
+        Ok(engine) => Some(Arc::new(engine)),
         Err(error) => {
             warn!(
                 "Failed to initialize embedded license engine for parser declared-license normalization: {}",
@@ -32,6 +36,35 @@ static PARSER_LICENSE_ENGINE: LazyLock<Option<LicenseDetectionEngine>> = LazyLoc
         }
     }
 });
+
+#[cfg(test)]
+thread_local! {
+    static LAST_PARSER_LICENSE_ENGINE_PTR: Cell<usize> = const { Cell::new(0) };
+}
+
+fn parser_license_engine() -> Option<Arc<LicenseDetectionEngine>> {
+    let engine = active_parser_license_engine().or_else(|| PARSER_LICENSE_ENGINE.as_ref().cloned());
+    #[cfg(test)]
+    if let Some(active_engine) = engine.as_ref() {
+        LAST_PARSER_LICENSE_ENGINE_PTR.with(|slot| {
+            slot.set(Arc::as_ptr(active_engine) as usize);
+        });
+    }
+    engine
+}
+
+#[cfg(test)]
+pub(crate) fn clear_last_parser_license_engine_ptr() {
+    LAST_PARSER_LICENSE_ENGINE_PTR.with(|slot| slot.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn last_parser_license_engine_ptr() -> Option<usize> {
+    LAST_PARSER_LICENSE_ENGINE_PTR.with(|slot| {
+        let ptr = slot.get();
+        (ptr != 0).then_some(ptr)
+    })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NormalizedDeclaredLicense {
@@ -110,7 +143,7 @@ pub(crate) fn detect_declared_license_from_text(
         return empty_declared_license_data();
     }
 
-    let Some(engine) = PARSER_LICENSE_ENGINE.as_ref() else {
+    let Some(engine) = parser_license_engine() else {
         return empty_declared_license_data();
     };
     let Ok(detections) = engine.detect_with_kind(text, false, false) else {
@@ -154,7 +187,7 @@ pub(crate) fn normalize_spdx_expression(statement: &str) -> Option<NormalizedDec
         return None;
     }
 
-    let engine = PARSER_LICENSE_ENGINE.as_ref()?;
+    let engine = parser_license_engine()?;
     let expression = parse_expression(statement).ok()?;
     let (declared_ast, declared_spdx_ast) =
         normalize_expression_ast(&expression, engine.index(), 0)?;
@@ -173,7 +206,7 @@ pub(crate) fn normalize_declared_license_key(key: &str) -> Option<NormalizedDecl
         return None;
     }
 
-    let engine = PARSER_LICENSE_ENGINE.as_ref()?;
+    let engine = parser_license_engine()?;
     normalize_license_key(key, engine.index())
 }
 
@@ -301,7 +334,7 @@ fn derive_declared_rule_metadata(
         return None;
     }
 
-    let engine = PARSER_LICENSE_ENGINE.as_ref()?;
+    let engine = parser_license_engine()?;
     let detections = engine.detect_with_kind(matched_text, false, false).ok()?;
     let license_match = detections
         .into_iter()

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -319,13 +319,16 @@ mod golden_test;
 use std::cell::RefCell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
+use std::sync::Arc;
 
+use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{PackageData, PackageType};
 use crate::parsers::license_normalization::finalize_package_declared_license_references;
 use crate::parsers::utils::MAX_ITERATION_COUNT;
 
 thread_local! {
     static PARSER_DIAGNOSTIC_STACK: RefCell<Vec<Vec<String>>> = const { RefCell::new(Vec::new()) };
+    static PARSER_LICENSE_ENGINE_STACK: RefCell<Vec<Option<Arc<LicenseDetectionEngine>>>> = const { RefCell::new(Vec::new()) };
 }
 
 #[derive(Debug, Default)]
@@ -348,6 +351,7 @@ pub(crate) fn capture_parser_diagnostics<F>(
     extract: F,
     handler_name: &str,
     path: &Path,
+    license_engine: Option<Arc<LicenseDetectionEngine>>,
 ) -> ParsePackagesResult
 where
     F: FnOnce() -> Vec<PackageData>,
@@ -355,21 +359,29 @@ where
     PARSER_DIAGNOSTIC_STACK.with(|stack| {
         stack.borrow_mut().push(Vec::new());
     });
+    PARSER_LICENSE_ENGINE_STACK.with(|stack| {
+        stack.borrow_mut().push(license_engine);
+    });
 
-    let extract_result = catch_unwind(AssertUnwindSafe(extract));
+    let extract_result = catch_unwind(AssertUnwindSafe(|| {
+        extract()
+            .into_iter()
+            .map(|mut package| {
+                finalize_package_declared_license_references(&mut package);
+                package
+            })
+            .take(MAX_ITERATION_COUNT)
+            .collect::<Vec<_>>()
+    }));
+    PARSER_LICENSE_ENGINE_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
     let mut scan_errors =
         PARSER_DIAGNOSTIC_STACK.with(|stack| stack.borrow_mut().pop().unwrap_or_default());
 
     match extract_result {
         Ok(packages) => ParsePackagesResult {
-            packages: packages
-                .into_iter()
-                .map(|mut package| {
-                    finalize_package_declared_license_references(&mut package);
-                    package
-                })
-                .take(MAX_ITERATION_COUNT)
-                .collect(),
+            packages,
             scan_errors,
         },
         Err(payload) => {
@@ -385,6 +397,10 @@ where
             }
         }
     }
+}
+
+pub(crate) fn active_parser_license_engine() -> Option<Arc<LicenseDetectionEngine>> {
+    PARSER_LICENSE_ENGINE_STACK.with(|stack| stack.borrow().last().cloned().flatten())
 }
 
 pub(crate) fn record_parser_diagnostic(message: String) -> bool {
@@ -598,7 +614,10 @@ macro_rules! register_package_handlers {
         parsers: [$($(#[$parser_meta:meta])* $parser:ty),* $(,)?],
         recognizers: [$($recognizer:ty),* $(,)?] $(,)?
     ) => {
-        pub fn try_parse_file(path: &Path) -> Option<ParsePackagesResult> {
+        pub fn try_parse_file_with_license_engine(
+            path: &Path,
+            license_engine: Option<Arc<LicenseDetectionEngine>>,
+        ) -> Option<ParsePackagesResult> {
             $(
                 $(#[$parser_meta])*
                 if <$parser>::is_match(path) {
@@ -606,6 +625,7 @@ macro_rules! register_package_handlers {
                         || <$parser>::extract_packages(path),
                         stringify!($parser),
                         path,
+                        license_engine.clone(),
                     ));
                 }
             )*
@@ -615,10 +635,15 @@ macro_rules! register_package_handlers {
                         || <$recognizer>::extract_packages(path),
                         stringify!($recognizer),
                         path,
+                        license_engine.clone(),
                     ));
                 }
             )*
             None
+        }
+
+        pub fn try_parse_file(path: &Path) -> Option<ParsePackagesResult> {
+            try_parse_file_with_license_engine(path, None)
         }
 
         // Used by the parser-golden maintenance tool in `xtask`.
@@ -652,6 +677,77 @@ macro_rules! register_package_handlers {
             ]
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{active_parser_license_engine, capture_parser_diagnostics};
+    use crate::license_detection::LicenseDetectionEngine;
+    use crate::models::PackageData;
+    use crate::parsers::license_normalization::{
+        clear_last_parser_license_engine_ptr, last_parser_license_engine_ptr,
+    };
+    use std::path::Path;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_capture_parser_diagnostics_exposes_active_license_engine() {
+        let engine =
+            Arc::new(LicenseDetectionEngine::from_embedded().expect("embedded engine should load"));
+
+        let result = capture_parser_diagnostics(
+            || {
+                assert!(active_parser_license_engine().is_some());
+                vec![PackageData::default()]
+            },
+            "TestParser",
+            Path::new("testdata/package.json"),
+            Some(engine),
+        );
+
+        assert_eq!(result.packages.len(), 1);
+        assert!(active_parser_license_engine().is_none());
+    }
+
+    #[test]
+    fn test_capture_parser_diagnostics_keeps_active_license_engine_for_finalization() {
+        let engine =
+            Arc::new(LicenseDetectionEngine::from_embedded().expect("embedded engine should load"));
+        clear_last_parser_license_engine_ptr();
+
+        let result = capture_parser_diagnostics(
+            || {
+                vec![PackageData {
+                    declared_license_expression: Some("mit".to_string()),
+                    declared_license_expression_spdx: Some("MIT".to_string()),
+                    extracted_license_statement: Some("MIT".to_string()),
+                    extra_data: Some(HashMap::from([(
+                        "license_file".to_string(),
+                        serde_json::Value::String("LICENSE".to_string()),
+                    )])),
+                    ..Default::default()
+                }]
+            },
+            "TestParser",
+            Path::new("testdata/package.json"),
+            Some(Arc::clone(&engine)),
+        );
+
+        assert_eq!(result.packages.len(), 1);
+        assert_eq!(
+            last_parser_license_engine_ptr(),
+            Some(Arc::as_ptr(&engine) as usize)
+        );
+        assert_eq!(
+            result.packages[0].license_detections[0].matches[0]
+                .referenced_filenames
+                .as_ref(),
+            Some(&vec!["LICENSE".to_string()])
+        );
+        assert!(active_parser_license_engine().is_none());
+    }
 }
 
 register_package_handlers! {
@@ -825,6 +921,7 @@ mod panic_isolation_tests {
             || -> Vec<PackageData> { panic!("panic boom") },
             "PanicParser",
             path,
+            None,
         );
 
         assert!(result.packages.is_empty());
@@ -841,6 +938,7 @@ mod panic_isolation_tests {
             || -> Vec<PackageData> { panic!("panic boom") },
             "PanicParser",
             panic_path,
+            None,
         );
 
         let ok_path = Path::new("fixtures/recovered-package.json");
@@ -854,6 +952,7 @@ mod panic_isolation_tests {
             },
             "RecoveringParser",
             ok_path,
+            None,
         );
 
         assert_eq!(result.packages.len(), 1);

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -7,8 +7,8 @@ use crate::models::{DatasourceId, FileInfo, FileInfoBuilder, FileType, Sha256Dig
 use crate::parsers::compiled_binary::{
     is_supported_compiled_binary_format, try_parse_compiled_bytes,
 };
-use crate::parsers::try_parse_file;
 use crate::parsers::windows_executable::try_parse_windows_executable_bytes;
+use crate::parsers::{try_parse_file, try_parse_file_with_license_engine};
 use crate::progress::ScanProgress;
 use crate::scanner::{LicenseScanOptions, TextDetectionOptions};
 use crate::utils::file::{
@@ -163,23 +163,27 @@ fn extract_information_from_content(
 
     if text_options.detect_packages {
         let started = Instant::now();
-        let parse_result = try_parse_file(&filesystem_path)
-            .or_else(|| {
-                text_options
-                    .detect_application_packages
-                    .then(|| try_parse_windows_executable_bytes(&filesystem_path, &buffer))
-                    .flatten()
-            })
-            .or_else(|| {
-                text_options
-                    .detect_packages_in_compiled
-                    .then(|| {
-                        (classification.is_binary && is_supported_compiled_binary_format(&buffer))
-                            .then(|| try_parse_compiled_bytes(&buffer))
-                            .flatten()
-                    })
-                    .flatten()
-            });
+        let parse_result = if let Some(engine) = license_engine.clone() {
+            try_parse_file_with_license_engine(&filesystem_path, Some(engine))
+        } else {
+            try_parse_file(&filesystem_path)
+        }
+        .or_else(|| {
+            text_options
+                .detect_application_packages
+                .then(|| try_parse_windows_executable_bytes(&filesystem_path, &buffer))
+                .flatten()
+        })
+        .or_else(|| {
+            text_options
+                .detect_packages_in_compiled
+                .then(|| {
+                    (classification.is_binary && is_supported_compiled_binary_format(&buffer))
+                        .then(|| try_parse_compiled_bytes(&buffer))
+                        .flatten()
+                })
+                .flatten()
+        });
 
         if let Some(parse_result) = parse_result {
             let packages = parse_result


### PR DESCRIPTION
## Summary

- reuse the active scan `LicenseDetectionEngine` through parser extraction and declared-license finalization so package scans do not initialize the embedded engine twice
- thread the scan engine into parser dispatch and keep the parser-local engine context alive until `finalize_package_declared_license_references(...)` completes
- add focused regression coverage for parser engine exposure, parser finalization reuse, scanner parser discovery, and the `provenant --package` CLI path

## Issues

- Covers: duplicate `License index built from embedded artifact ...` logging during scan-driven parser normalization

## Scope and exclusions

- Included: parser engine lifecycle plumbing, parser normalization reuse, targeted regression tests, and helper test-callsite updates required by the new parser diagnostic signature
- Explicit exclusions: broader parser API redesigns, unrelated parser refactors, and fixture/output changes

## Follow-up work

- Created or intentionally deferred: non-blocking docs/comment cleanup for references that still describe scanner dispatch only through `try_parse_file()`