### PR TITLE
fix(parsers): apply ADR 0004 security hardening across 10 parsers

### DIFF
--- a/.opencode/skills/add-parser/SKILL.md
+++ b/.opencode/skills/add-parser/SKILL.md
@@ -124,7 +124,13 @@ Every parser should use these shared helpers rather than reimplementing ADR 0004
 - `read_file_to_string(path, max_size)` — stat-before-read size check (default 100 MB), UTF-8 with lossy fallback and warning
 - `truncate_field(value)` — caps individual string fields to 10 MB (`MAX_FIELD_LENGTH`), warns on truncation
 - `MAX_ITERATION_COUNT` (100,000) — `.take(MAX_ITERATION_COUNT)` on every `.iter()` over user-supplied collections (dependencies, keywords, authors, archive entries, etc.)
-- `MAX_MANIFEST_SIZE`, `MAX_FIELD_LENGTH` — ADR 0004 resource-limit constants
+- `MAX_MANIFEST_SIZE`, `MAX_FIELD_LENGTH`, `MAX_RECURSION_DEPTH` (50) — ADR 0004 resource-limit constants
+- `RecursionGuard<K>` — tracks recursion depth and detects cycles; use in every recursive parser function:
+  - **Depth-only** (no cycle detection): `RecursionGuard<()>` with `guard.descend()` / `guard.ascend()`. Create with `RecursionGuard::depth_only()`.
+  - **Depth + cycle detection**: `RecursionGuard<K>` where `K: Hash + Eq` (e.g., `usize` for package indices, `String` for dependency names, `PathBuf` for file paths). Use `guard.enter(key)` / `guard.leave(key)`. Create with `RecursionGuard::new()`.
+  - `guard.exceeded()` returns `true` when depth exceeds `MAX_RECURSION_DEPTH` — check before recursing and return early with `warn!()`.
+  - `guard.enter(key)` returns `true` if `key` was already visited (cycle) — return early with `warn!()`.
+  - Always pair `descend()`/`ascend()` or `enter()`/`leave()` so depth stays consistent.
 
 **Use existing parsers as templates**:
 

--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -17,7 +17,7 @@
 //! Python implementation: `reference/scancode-toolkit/src/packagedcode/build.py` (BazelBuildHandler)
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::path::Path;
@@ -31,7 +31,6 @@ use super::PackageParser;
 
 type StarlarkCallArgs = ast::CallArgsP<ast::AstNoPayload>;
 const SCANCODE_SIMPLE_TOP_LEVEL_KEY: &str = "scancode_simple_top_level";
-const MAX_RECURSION_DEPTH: usize = 50;
 
 struct StarlarkCall<'a> {
     func: &'a ast::AstExpr,
@@ -403,7 +402,8 @@ fn extract_int_kwarg(call: &StarlarkCall<'_>, key: &str) -> Option<i64> {
 }
 
 fn extract_kwarg_json(call: &StarlarkCall<'_>, key: &str) -> Option<JsonValue> {
-    extract_named_kwarg(call, key).and_then(|expr| expr_to_json(expr, 0))
+    extract_named_kwarg(call, key)
+        .and_then(|expr| expr_to_json(expr, &mut RecursionGuard::depth_only()))
 }
 
 fn extract_bazel_dependency(call: &StarlarkCall<'_>) -> Option<Dependency> {
@@ -439,7 +439,7 @@ fn extract_override(kind: &str, call: &StarlarkCall<'_>) -> JsonValue {
     override_map.insert("kind".to_string(), JsonValue::String(kind.to_string()));
     for argument in call.args.args.iter().take(MAX_ITERATION_COUNT) {
         if let ast::ArgumentP::Named(name, value) = &argument.node
-            && let Some(value) = expr_to_json(value, 0)
+            && let Some(value) = expr_to_json(value, &mut RecursionGuard::depth_only())
         {
             override_map.insert(name.node.clone(), value);
         }
@@ -472,11 +472,11 @@ fn expr_as_i64(expr: &ast::AstExpr) -> Option<i64> {
     }
 }
 
-fn expr_to_json(expr: &ast::AstExpr, depth: usize) -> Option<JsonValue> {
-    if depth > MAX_RECURSION_DEPTH {
+fn expr_to_json(expr: &ast::AstExpr, guard: &mut RecursionGuard<()>) -> Option<JsonValue> {
+    if guard.descend() {
         return None;
     }
-    match &expr.node {
+    let result = match &expr.node {
         ast::ExprP::Literal(ast::AstLiteral::String(value)) => {
             Some(JsonValue::String(value.node.clone()))
         }
@@ -499,7 +499,7 @@ fn expr_to_json(expr: &ast::AstExpr, depth: usize) -> Option<JsonValue> {
         ast::ExprP::List(elts) | ast::ExprP::Tuple(elts) => Some(JsonValue::Array(
             elts.iter()
                 .take(MAX_ITERATION_COUNT)
-                .filter_map(|e| expr_to_json(e, depth + 1))
+                .filter_map(|e| expr_to_json(e, guard))
                 .collect(),
         )),
         ast::ExprP::Dict(items) => {
@@ -508,14 +508,16 @@ fn expr_to_json(expr: &ast::AstExpr, depth: usize) -> Option<JsonValue> {
                 let Some(key) = expr_as_string(key) else {
                     continue;
                 };
-                if let Some(value) = expr_to_json(value, depth + 1) {
+                if let Some(value) = expr_to_json(value, guard) {
                     map.insert(key, value);
                 }
             }
             Some(JsonValue::Object(map))
         }
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn build_bazel_purl(name: &str, version: Option<&str>) -> Option<String> {

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -8,7 +8,9 @@ use serde_json::Value as JsonValue;
 use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha512Digest,
 };
-use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, npm_purl, parse_sri, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -21,39 +23,6 @@ const FIELD_COUNT_WITH_SCRIPTS: usize = 8;
 const PACKAGE_FIELD_LENGTHS: [usize; 8] = [8, 8, 64, 8, 8, 88, 20, 48];
 const DEPENDENCY_ENTRY_SIZE: usize = 26;
 const MAX_MANIFEST_SIZE: u64 = 100 * 1024 * 1024;
-const MAX_RECURSION_DEPTH: usize = 50;
-
-struct RecursionGuard {
-    depth: usize,
-    visited: HashSet<usize>,
-}
-
-impl RecursionGuard {
-    fn new() -> Self {
-        Self {
-            depth: 0,
-            visited: HashSet::new(),
-        }
-    }
-
-    fn exceeded(&self) -> bool {
-        self.depth > MAX_RECURSION_DEPTH
-    }
-
-    fn enter(&mut self, pkg_idx: usize) -> bool {
-        if self.visited.contains(&pkg_idx) {
-            return true;
-        }
-        self.visited.insert(pkg_idx);
-        self.depth += 1;
-        false
-    }
-
-    fn leave(&mut self, pkg_idx: usize) {
-        self.visited.remove(&pkg_idx);
-        self.depth -= 1;
-    }
-}
 
 #[derive(Clone, Copy)]
 struct SliceRef {
@@ -370,7 +339,7 @@ fn build_package_data_from_lockb(
         &resolution_ids,
         buffers.string_bytes,
         true,
-        &mut RecursionGuard::new(),
+        &mut RecursionGuard::<usize>::new(),
     )?;
 
     Ok(package_data)
@@ -421,7 +390,7 @@ fn build_dependencies_for_package(
     resolution_ids: &[u32],
     string_bytes: &[u8],
     is_direct: bool,
-    guard: &mut RecursionGuard,
+    guard: &mut RecursionGuard<usize>,
 ) -> Result<Vec<Dependency>, String> {
     if guard.exceeded() {
         warn!(
@@ -494,7 +463,7 @@ fn build_resolved_package(
     dependency_entries: &[BunLockbDependencyEntry],
     resolution_ids: &[u32],
     string_bytes: &[u8],
-    guard: &mut RecursionGuard,
+    guard: &mut RecursionGuard<usize>,
 ) -> Result<ResolvedPackage, String> {
     if guard.exceeded() {
         warn!(

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -21,6 +21,39 @@ const FIELD_COUNT_WITH_SCRIPTS: usize = 8;
 const PACKAGE_FIELD_LENGTHS: [usize; 8] = [8, 8, 64, 8, 8, 88, 20, 48];
 const DEPENDENCY_ENTRY_SIZE: usize = 26;
 const MAX_MANIFEST_SIZE: u64 = 100 * 1024 * 1024;
+const MAX_RECURSION_DEPTH: usize = 50;
+
+struct RecursionGuard {
+    depth: usize,
+    visited: HashSet<usize>,
+}
+
+impl RecursionGuard {
+    fn new() -> Self {
+        Self {
+            depth: 0,
+            visited: HashSet::new(),
+        }
+    }
+
+    fn exceeded(&self) -> bool {
+        self.depth > MAX_RECURSION_DEPTH
+    }
+
+    fn enter(&mut self, pkg_idx: usize) -> bool {
+        if self.visited.contains(&pkg_idx) {
+            return true;
+        }
+        self.visited.insert(pkg_idx);
+        self.depth += 1;
+        false
+    }
+
+    fn leave(&mut self, pkg_idx: usize) {
+        self.visited.remove(&pkg_idx);
+        self.depth -= 1;
+    }
+}
 
 #[derive(Clone, Copy)]
 struct SliceRef {
@@ -337,6 +370,7 @@ fn build_package_data_from_lockb(
         &resolution_ids,
         buffers.string_bytes,
         true,
+        &mut RecursionGuard::new(),
     )?;
 
     Ok(package_data)
@@ -387,7 +421,16 @@ fn build_dependencies_for_package(
     resolution_ids: &[u32],
     string_bytes: &[u8],
     is_direct: bool,
+    guard: &mut RecursionGuard,
 ) -> Result<Vec<Dependency>, String> {
+    if guard.exceeded() {
+        warn!(
+            "bun.lockb build_dependencies_for_package exceeded MAX_RECURSION_DEPTH ({})",
+            MAX_RECURSION_DEPTH
+        );
+        return Ok(vec![]);
+    }
+
     let dep_slice = dependency_entries
         .get(package.dependencies.off..package.dependencies.off + package.dependencies.len)
         .ok_or_else(|| "bun.lockb dependency slice is out of bounds".to_string())?;
@@ -402,14 +445,26 @@ fn build_dependencies_for_package(
         .map(|(entry, package_id)| {
             let manifest = behavior_to_manifest(entry.behavior);
             let resolved_package = if (*package_id as usize) < packages.len() {
-                let resolved = &packages[*package_id as usize];
-                Some(Box::new(build_resolved_package(
-                    resolved,
-                    packages,
-                    dependency_entries,
-                    resolution_ids,
-                    string_bytes,
-                )?))
+                let pkg_idx = *package_id as usize;
+                if guard.enter(pkg_idx) {
+                    warn!(
+                        "bun.lockb circular dependency detected for package index {}",
+                        pkg_idx
+                    );
+                    None
+                } else {
+                    let resolved = &packages[pkg_idx];
+                    let result = build_resolved_package(
+                        resolved,
+                        packages,
+                        dependency_entries,
+                        resolution_ids,
+                        string_bytes,
+                        guard,
+                    )?;
+                    guard.leave(pkg_idx);
+                    Some(Box::new(result))
+                }
             } else {
                 None
             };
@@ -439,7 +494,49 @@ fn build_resolved_package(
     dependency_entries: &[BunLockbDependencyEntry],
     resolution_ids: &[u32],
     string_bytes: &[u8],
+    guard: &mut RecursionGuard,
 ) -> Result<ResolvedPackage, String> {
+    if guard.exceeded() {
+        warn!(
+            "bun.lockb build_resolved_package exceeded MAX_RECURSION_DEPTH ({})",
+            MAX_RECURSION_DEPTH
+        );
+        let (namespace, name) = split_namespace_name(&package.name);
+        return Ok(ResolvedPackage {
+            primary_language: Some("JavaScript".to_string()),
+            download_url: package
+                .resolution
+                .resolved
+                .as_ref()
+                .map(|s| truncate_field(s.clone())),
+            sha1: None,
+            sha256: None,
+            sha512: package
+                .integrity
+                .as_ref()
+                .and_then(|s| {
+                    parse_sri(s).and_then(|(alg, hash)| (alg == "sha512").then_some(hash))
+                })
+                .and_then(|h| Sha512Digest::from_hex(&h).ok()),
+            md5: None,
+            is_virtual: true,
+            extra_data: None,
+            dependencies: vec![],
+            repository_homepage_url: None,
+            repository_download_url: None,
+            api_data_url: None,
+            datasource_id: Some(DatasourceId::BunLockb),
+            purl: None,
+            ..ResolvedPackage::new(
+                PackageType::Npm,
+                namespace.map(truncate_field).unwrap_or_default(),
+                name.map(truncate_field)
+                    .unwrap_or_else(|| truncate_field(package.name.clone())),
+                truncate_field(package.resolution.version.clone().unwrap_or_default()),
+            )
+        });
+    }
+
     let (namespace, name) = split_namespace_name(&package.name);
 
     Ok(ResolvedPackage {
@@ -466,6 +563,7 @@ fn build_resolved_package(
             resolution_ids,
             string_bytes,
             false,
+            guard,
         )?,
         repository_homepage_url: None,
         repository_download_url: None,

--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -21,7 +21,7 @@
 use crate::models::{DatasourceId, Dependency, FileReference, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, split_name_email, truncate_field,
 };
 use packageurl::PackageUrl;
 use std::path::Path;
@@ -519,33 +519,30 @@ fn extract_file_references(toml_content: &Value) -> Vec<FileReference> {
     file_references
 }
 
-const MAX_TOML_DEPTH: usize = 50;
-
-fn toml_to_json(value: &toml::Value, depth: usize) -> serde_json::Value {
-    if depth > MAX_TOML_DEPTH {
-        warn!(
-            "TOML nesting depth exceeded {}, returning Null",
-            MAX_TOML_DEPTH
-        );
+fn toml_to_json(value: &toml::Value, guard: &mut RecursionGuard<()>) -> serde_json::Value {
+    if guard.descend() {
+        warn!("TOML nesting depth exceeded, returning Null");
         return serde_json::Value::Null;
     }
-    match value {
+    let result = match value {
         toml::Value::String(s) => serde_json::json!(s),
         toml::Value::Integer(i) => serde_json::json!(i),
         toml::Value::Float(f) => serde_json::json!(f),
         toml::Value::Boolean(b) => serde_json::json!(b),
         toml::Value::Array(a) => {
-            serde_json::Value::Array(a.iter().map(|v| toml_to_json(v, depth + 1)).collect())
+            serde_json::Value::Array(a.iter().map(|v| toml_to_json(v, guard)).collect())
         }
         toml::Value::Table(t) => {
             let map: serde_json::Map<String, serde_json::Value> = t
                 .iter()
-                .map(|(k, v)| (k.clone(), toml_to_json(v, depth + 1)))
+                .map(|(k, v)| (k.clone(), toml_to_json(v, guard)))
                 .collect();
             serde_json::Value::Object(map)
         }
         toml::Value::Datetime(d) => serde_json::json!(d.to_string()),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 /// Extracts extra_data fields (rust-version, edition, documentation, license-file, workspace)
@@ -610,7 +607,10 @@ fn extract_extra_data(
         }
 
         if let Some(publish_value) = package.get(FIELD_PUBLISH) {
-            extra_data.insert("publish".to_string(), toml_to_json(publish_value, 0));
+            extra_data.insert(
+                "publish".to_string(),
+                toml_to_json(publish_value, &mut RecursionGuard::depth_only()),
+            );
         }
 
         // Check for workspace inheritance markers for other fields
@@ -671,7 +671,10 @@ fn extract_extra_data(
 
     // Extract workspace table if it exists
     if let Some(workspace_value) = toml_content.get("workspace") {
-        extra_data.insert("workspace".to_string(), toml_to_json(workspace_value, 0));
+        extra_data.insert(
+            "workspace".to_string(),
+            toml_to_json(workspace_value, &mut RecursionGuard::depth_only()),
+        );
     }
 
     if extra_data.is_empty() {

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -434,15 +434,15 @@ fn parse_deps_edn_form(form: &Form) -> Result<PackageData, String> {
                 }
             }
         }
-        if let Some(json) = form_to_json(&Form::Map(alias_map.clone())) {
+        if let Some(json) = form_to_json(&Form::Map(alias_map.clone()), 0) {
             extra_data.insert("aliases".to_string(), json);
         }
     }
 
-    if let Some(value) = map_get_keyword(entries, "paths").and_then(form_to_json) {
+    if let Some(value) = map_get_keyword(entries, "paths").and_then(|f| form_to_json(f, 0)) {
         extra_data.insert("paths".to_string(), value);
     }
-    if let Some(value) = map_get_keyword(entries, "mvn/repos").and_then(form_to_json) {
+    if let Some(value) = map_get_keyword(entries, "mvn/repos").and_then(|f| form_to_json(f, 0)) {
         extra_data.insert("mvn_repos".to_string(), value);
     }
 
@@ -488,7 +488,7 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
                 package.homepage_url = form_as_string(value).map(|s| truncate_field(s.to_owned()))
             }
             "license" => {
-                package.extracted_license_statement = format_license(value).map(truncate_field);
+                package.extracted_license_statement = format_license(value, 0).map(truncate_field);
             }
             "scm" => {
                 if let Form::Map(entries) = value {
@@ -568,7 +568,7 @@ fn build_deps_edn_dependency(
             ("local/root", "local_root"),
             ("exclusions", "exclusions"),
         ] {
-            if let Some(value) = map_get_keyword(entries, key).and_then(form_to_json) {
+            if let Some(value) = map_get_keyword(entries, key).and_then(|f| form_to_json(f, 0)) {
                 extra_data.insert(data_key.to_string(), value);
             }
         }
@@ -607,7 +607,7 @@ fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<De
             let mut index = 2usize;
             while index + 1 < parts.len() {
                 if let Some(key) = form_as_keyword(&parts[index])
-                    && let Some(value) = form_to_json(&parts[index + 1])
+                    && let Some(value) = form_to_json(&parts[index + 1], 0)
                 {
                     extra_data.insert(key.replace('-', "_"), value);
                 }
@@ -692,37 +692,51 @@ fn map_key_name(form: &Form) -> Option<String> {
     }
 }
 
-fn form_to_json(form: &Form) -> Option<JsonValue> {
+fn form_to_json(form: &Form, depth: usize) -> Option<JsonValue> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("form_to_json exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
     Some(match form {
         Form::Nil => JsonValue::Null,
         Form::Bool(value) => JsonValue::Bool(*value),
         Form::String(value) => JsonValue::String(value.clone()),
         Form::Keyword(value) => JsonValue::String(format!(":{value}")),
         Form::Symbol(value) => JsonValue::String(value.clone()),
-        Form::Vector(values) | Form::List(values) => {
-            JsonValue::Array(values.iter().filter_map(form_to_json).collect())
-        }
+        Form::Vector(values) | Form::List(values) => JsonValue::Array(
+            values
+                .iter()
+                .filter_map(|f| form_to_json(f, depth + 1))
+                .collect(),
+        ),
         Form::Map(entries) => {
             let mut map = serde_json::Map::new();
             for (key, value) in entries {
                 let Some(key_name) = map_key_name(key) else {
                     continue;
                 };
-                if let Some(json) = form_to_json(value) {
+                if let Some(json) = form_to_json(value, depth + 1) {
                     map.insert(key_name, json);
                 }
             }
             JsonValue::Object(map)
         }
-        Form::Prefixed(value) => form_to_json(value)?,
+        Form::Prefixed(value) => form_to_json(value, depth + 1)?,
     })
 }
 
-fn format_license(form: &Form) -> Option<String> {
+fn format_license(form: &Form, depth: usize) -> Option<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        warn!("format_license exceeded MAX_RECURSION_DEPTH");
+        return None;
+    }
     match form {
         Form::Map(entries) => format_license_map(entries),
         Form::Vector(values) | Form::List(values) => {
-            let licenses: Vec<String> = values.iter().filter_map(format_license).collect();
+            let licenses: Vec<String> = values
+                .iter()
+                .filter_map(|f| format_license(f, depth + 1))
+                .collect();
             if licenses.is_empty() {
                 None
             } else {

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -2,15 +2,15 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct ClojureDepsEdnParser;
 
@@ -117,7 +117,7 @@ enum Form {
 struct Reader {
     chars: Vec<char>,
     index: usize,
-    depth: usize,
+    guard: RecursionGuard<()>,
 }
 
 impl Reader {
@@ -125,7 +125,7 @@ impl Reader {
         Self {
             chars: input.chars().collect(),
             index: 0,
-            depth: 0,
+            guard: RecursionGuard::depth_only(),
         }
     }
 
@@ -165,55 +165,39 @@ impl Reader {
     }
 
     fn parse_form(&mut self) -> Result<Form, String> {
-        if self.depth > MAX_RECURSION_DEPTH {
+        if self.guard.descend() {
             return Err("recursion depth exceeded".to_string());
         }
         self.skip_ws_and_comments();
-        match self.peek() {
+        let result = match self.peek() {
             Some('"') => self.parse_string().map(Form::String),
             Some(':') => self.parse_keyword().map(Form::Keyword),
-            Some('[') => {
-                self.depth += 1;
-                let result = self.parse_collection('[', ']').map(Form::Vector);
-                self.depth -= 1;
-                result
-            }
-            Some('(') => {
-                self.depth += 1;
-                let result = self.parse_collection('(', ')').map(Form::List);
-                self.depth -= 1;
-                result
-            }
-            Some('{') => {
-                self.depth += 1;
-                let result = self.parse_map();
-                self.depth -= 1;
-                result
-            }
+            Some('[') => self.parse_collection('[', ']').map(Form::Vector),
+            Some('(') => self.parse_collection('(', ')').map(Form::List),
+            Some('{') => self.parse_map(),
             Some('^') => {
                 self.index += 1;
-                self.depth += 1;
                 let _ = self.parse_form()?;
                 let result = self.parse_form();
-                self.depth -= 1;
-                result
+                self.guard.ascend();
+                return result;
             }
             Some('~') | Some('\'') | Some('`') | Some('@') => {
                 self.index += 1;
-                self.depth += 1;
                 let form = self.parse_form()?;
-                self.depth -= 1;
-                Ok(Form::Prefixed(Box::new(form)))
+                self.guard.ascend();
+                return Ok(Form::Prefixed(Box::new(form)));
             }
             Some('#') => {
-                self.depth += 1;
                 let result = self.parse_dispatch_form();
-                self.depth -= 1;
-                result
+                self.guard.ascend();
+                return result;
             }
             Some(_) => self.parse_atom(),
             None => Err("unexpected end of input".to_string()),
-        }
+        };
+        self.guard.ascend();
+        result
     }
 
     fn parse_dispatch_form(&mut self) -> Result<Form, String> {
@@ -434,15 +418,22 @@ fn parse_deps_edn_form(form: &Form) -> Result<PackageData, String> {
                 }
             }
         }
-        if let Some(json) = form_to_json(&Form::Map(alias_map.clone()), 0) {
+        if let Some(json) = form_to_json(
+            &Form::Map(alias_map.clone()),
+            &mut RecursionGuard::depth_only(),
+        ) {
             extra_data.insert("aliases".to_string(), json);
         }
     }
 
-    if let Some(value) = map_get_keyword(entries, "paths").and_then(|f| form_to_json(f, 0)) {
+    if let Some(value) = map_get_keyword(entries, "paths")
+        .and_then(|f| form_to_json(f, &mut RecursionGuard::depth_only()))
+    {
         extra_data.insert("paths".to_string(), value);
     }
-    if let Some(value) = map_get_keyword(entries, "mvn/repos").and_then(|f| form_to_json(f, 0)) {
+    if let Some(value) = map_get_keyword(entries, "mvn/repos")
+        .and_then(|f| form_to_json(f, &mut RecursionGuard::depth_only()))
+    {
         extra_data.insert("mvn_repos".to_string(), value);
     }
 
@@ -488,7 +479,8 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
                 package.homepage_url = form_as_string(value).map(|s| truncate_field(s.to_owned()))
             }
             "license" => {
-                package.extracted_license_statement = format_license(value, 0).map(truncate_field);
+                package.extracted_license_statement =
+                    format_license(value, &mut RecursionGuard::depth_only()).map(truncate_field);
             }
             "scm" => {
                 if let Form::Map(entries) = value {
@@ -568,7 +560,9 @@ fn build_deps_edn_dependency(
             ("local/root", "local_root"),
             ("exclusions", "exclusions"),
         ] {
-            if let Some(value) = map_get_keyword(entries, key).and_then(|f| form_to_json(f, 0)) {
+            if let Some(value) = map_get_keyword(entries, key)
+                .and_then(|f| form_to_json(f, &mut RecursionGuard::depth_only()))
+            {
                 extra_data.insert(data_key.to_string(), value);
             }
         }
@@ -607,7 +601,8 @@ fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<De
             let mut index = 2usize;
             while index + 1 < parts.len() {
                 if let Some(key) = form_as_keyword(&parts[index])
-                    && let Some(value) = form_to_json(&parts[index + 1], 0)
+                    && let Some(value) =
+                        form_to_json(&parts[index + 1], &mut RecursionGuard::depth_only())
                 {
                     extra_data.insert(key.replace('-', "_"), value);
                 }
@@ -692,12 +687,12 @@ fn map_key_name(form: &Form) -> Option<String> {
     }
 }
 
-fn form_to_json(form: &Form, depth: usize) -> Option<JsonValue> {
-    if depth > MAX_RECURSION_DEPTH {
+fn form_to_json(form: &Form, guard: &mut RecursionGuard<()>) -> Option<JsonValue> {
+    if guard.descend() {
         warn!("form_to_json exceeded MAX_RECURSION_DEPTH");
         return None;
     }
-    Some(match form {
+    let result = Some(match form {
         Form::Nil => JsonValue::Null,
         Form::Bool(value) => JsonValue::Bool(*value),
         Form::String(value) => JsonValue::String(value.clone()),
@@ -706,7 +701,7 @@ fn form_to_json(form: &Form, depth: usize) -> Option<JsonValue> {
         Form::Vector(values) | Form::List(values) => JsonValue::Array(
             values
                 .iter()
-                .filter_map(|f| form_to_json(f, depth + 1))
+                .filter_map(|f| form_to_json(f, guard))
                 .collect(),
         ),
         Form::Map(entries) => {
@@ -715,27 +710,29 @@ fn form_to_json(form: &Form, depth: usize) -> Option<JsonValue> {
                 let Some(key_name) = map_key_name(key) else {
                     continue;
                 };
-                if let Some(json) = form_to_json(value, depth + 1) {
+                if let Some(json) = form_to_json(value, guard) {
                     map.insert(key_name, json);
                 }
             }
             JsonValue::Object(map)
         }
-        Form::Prefixed(value) => form_to_json(value, depth + 1)?,
-    })
+        Form::Prefixed(value) => form_to_json(value, guard)?,
+    });
+    guard.ascend();
+    result
 }
 
-fn format_license(form: &Form, depth: usize) -> Option<String> {
-    if depth > MAX_RECURSION_DEPTH {
+fn format_license(form: &Form, guard: &mut RecursionGuard<()>) -> Option<String> {
+    if guard.descend() {
         warn!("format_license exceeded MAX_RECURSION_DEPTH");
         return None;
     }
-    match form {
+    let result = match form {
         Form::Map(entries) => format_license_map(entries),
         Form::Vector(values) | Form::List(values) => {
             let licenses: Vec<String> = values
                 .iter()
-                .filter_map(|f| format_license(f, depth + 1))
+                .filter_map(|f| format_license(f, guard))
                 .collect();
             if licenses.is_empty() {
                 None
@@ -744,7 +741,9 @@ fn format_license(form: &Form, depth: usize) -> Option<String> {
             }
         }
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn format_license_map(entries: &[(Form, Form)]) -> Option<String> {

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -686,6 +686,7 @@ fn create_conda_dependency(
 fn extract_pip_dependencies(pip_deps: &[Value]) -> Vec<Dependency> {
     pip_deps
         .iter()
+        .take(MAX_ITERATION_COUNT)
         .filter_map(|pip_dep| {
             if let Some(pip_req_str) = pip_dep.as_str()
                 && let Ok(parsed_req) = pip_req_str.parse::<pep508_rs::Requirement>()

--- a/src/parsers/cpan_makefile_pl.rs
+++ b/src/parsers/cpan_makefile_pl.rs
@@ -30,26 +30,31 @@ use super::license_normalization::{
     empty_declared_license_data, normalize_declared_license_key, normalize_spdx_expression,
 };
 
-static RE_WRITEMAKEFILE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"WriteMakefile1?\s*\(").unwrap());
+static RE_WRITEMAKEFILE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"WriteMakefile1?\s*\(").expect("valid regex: WriteMakefile call pattern")
+});
 static RE_SIMPLE_KV: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?m)^\s*([A-Z_]+)\s*=>\s*(?:'([^']*)'|"([^"]*)"|q\{([^}]*)\}|q\(([^)]*)\))"#)
-        .unwrap()
+        .expect("valid regex: simple key=>value pattern")
 });
-static RE_HASH_BLOCK: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"([A-Z_]+)\s*=>\s*\{([^}]*)\}").unwrap());
-static RE_AUTHOR_ARRAY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"AUTHOR\s*=>\s*\[([^\]]*)\]").unwrap());
-static RE_QUOTED_STRING: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"['"]([^'"]*)['"']"#).unwrap());
+static RE_HASH_BLOCK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"([A-Z_]+)\s*=>\s*\{([^}]*)\}").expect("valid regex: hash block pattern")
+});
+static RE_AUTHOR_ARRAY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"AUTHOR\s*=>\s*\[([^\]]*)\]").expect("valid regex: AUTHOR array pattern")
+});
+static RE_QUOTED_STRING: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"['"]([^'"]*)['"']"#).expect("valid regex: quoted string pattern")
+});
 static RE_DEP_PAIR: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"['"]([^'"]+)['"]\s*=>\s*(?:'([^']*)'|"([^"]*)"|(\d+))"#).unwrap()
+    Regex::new(r#"['"]([^'"]+)['"]\s*=>\s*(?:'([^']*)'|"([^"]*)"|(\d+))"#)
+        .expect("valid regex: dependency pair pattern")
 });
 static RE_VERSION_ASSIGNMENT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?m)^\s*(?:our\s+)?\$(?:[A-Za-z_][\w:]*::)?VERSION\s*=\s*(?:'([^']+)'|"([^"]+)")"#,
     )
-    .unwrap()
+    .expect("valid regex: VERSION assignment pattern")
 });
 
 const PACKAGE_TYPE: PackageType = PackageType::Cpan;

--- a/src/parsers/dart.rs
+++ b/src/parsers/dart.rs
@@ -24,7 +24,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use yaml_serde::{Mapping, Value};
 
@@ -33,8 +35,6 @@ use crate::models::{
 };
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 const FIELD_NAME: &str = "name";
 const FIELD_VERSION: &str = "version";
@@ -504,14 +504,14 @@ fn dependency_requirement_from_value(value: &Value) -> Option<String> {
     }
 
     if let Some(map) = value.as_mapping() {
-        return format_dependency_mapping(map, 0);
+        return format_dependency_mapping(map, &mut RecursionGuard::depth_only());
     }
 
     None
 }
 
-fn format_dependency_mapping(map: &Mapping, depth: usize) -> Option<String> {
-    if depth >= MAX_RECURSION_DEPTH {
+fn format_dependency_mapping(map: &Mapping, guard: &mut RecursionGuard<()>) -> Option<String> {
+    if guard.descend() {
         warn!("Recursion depth exceeded in format_dependency_mapping");
         return None;
     }
@@ -530,13 +530,15 @@ fn format_dependency_mapping(map: &Mapping, depth: usize) -> Option<String> {
         } else if let Some(value) = value.as_f64() {
             value.to_string()
         } else if let Some(nested) = value.as_mapping() {
-            format_dependency_mapping(nested, depth + 1)?
+            format_dependency_mapping(nested, guard)?
         } else {
             continue;
         };
 
         parts.push(format!("{}: {}", key_str, value_str));
     }
+
+    guard.ascend();
 
     if parts.is_empty() {
         None

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -25,6 +25,8 @@ use std::path::Path;
 
 use crate::parser_warn as warn;
 use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+
+const MAX_RECURSION_DEPTH: usize = 50;
 use packageurl::PackageUrl;
 use serde_json::json;
 
@@ -327,7 +329,16 @@ fn find_dependency_blocks(tokens: &[Tok]) -> Vec<Vec<Tok>> {
             let start = i;
             while i < tokens.len() && depth > 0 {
                 match &tokens[i] {
-                    Tok::OpenBrace => depth += 1,
+                    Tok::OpenBrace => {
+                        depth += 1;
+                        if depth > MAX_RECURSION_DEPTH {
+                            warn!(
+                                "Gradle parser: nesting depth exceeded {} in find_dependency_blocks",
+                                MAX_RECURSION_DEPTH
+                            );
+                            break;
+                        }
+                    }
                     Tok::CloseBrace => depth -= 1,
                     _ => {}
                 }
@@ -399,7 +410,16 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             i += 1;
             while i < tokens.len() && depth > 0 {
                 match &tokens[i] {
-                    Tok::OpenBrace => depth += 1,
+                    Tok::OpenBrace => {
+                        depth += 1;
+                        if depth > MAX_RECURSION_DEPTH {
+                            warn!(
+                                "Gradle parser: nesting depth exceeded {} in parse_block",
+                                MAX_RECURSION_DEPTH
+                            );
+                            break;
+                        }
+                    }
                     Tok::CloseBrace => depth -= 1,
                     _ => {}
                 }
@@ -829,7 +849,16 @@ fn find_matching_paren(tokens: &[Tok], start: usize) -> Option<usize> {
     let mut i = start + 1;
     while i < tokens.len() && depth > 0 {
         match &tokens[i] {
-            Tok::OpenParen => depth += 1,
+            Tok::OpenParen => {
+                depth += 1;
+                if depth > MAX_RECURSION_DEPTH {
+                    warn!(
+                        "Gradle parser: nesting depth exceeded {} in find_matching_paren",
+                        MAX_RECURSION_DEPTH
+                    );
+                    break;
+                }
+            }
             Tok::CloseParen => depth -= 1,
             _ => {}
         }
@@ -849,7 +878,16 @@ fn find_matching_bracket(tokens: &[Tok], start: usize) -> Option<usize> {
     let mut i = start + 1;
     while i < tokens.len() && depth > 0 {
         match &tokens[i] {
-            Tok::OpenBracket => depth += 1,
+            Tok::OpenBracket => {
+                depth += 1;
+                if depth > MAX_RECURSION_DEPTH {
+                    warn!(
+                        "Gradle parser: nesting depth exceeded {} in find_matching_bracket",
+                        MAX_RECURSION_DEPTH
+                    );
+                    break;
+                }
+            }
             Tok::CloseBracket => depth -= 1,
             _ => {}
         }
@@ -1218,7 +1256,16 @@ fn find_matching_brace(tokens: &[Tok], start: usize) -> Option<usize> {
     let mut i = start + 1;
     while i < tokens.len() && depth > 0 {
         match &tokens[i] {
-            Tok::OpenBrace => depth += 1,
+            Tok::OpenBrace => {
+                depth += 1;
+                if depth > MAX_RECURSION_DEPTH {
+                    warn!(
+                        "Gradle parser: nesting depth exceeded {} in find_matching_brace",
+                        MAX_RECURSION_DEPTH
+                    );
+                    break;
+                }
+            }
             Tok::CloseBrace => depth -= 1,
             _ => {}
         }

--- a/src/parsers/hex_lock.rs
+++ b/src/parsers/hex_lock.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
@@ -11,8 +13,6 @@ use crate::models::{
 };
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct HexLockParser;
 
@@ -32,7 +32,7 @@ struct Parser<'a> {
     chars: Vec<char>,
     pos: usize,
     source: &'a str,
-    depth: usize,
+    guard: RecursionGuard<()>,
 }
 
 impl PackageParser for HexLockParser {
@@ -348,16 +348,16 @@ impl<'a> Parser<'a> {
             chars: source.chars().collect(),
             pos: 0,
             source,
-            depth: 0,
+            guard: RecursionGuard::depth_only(),
         }
     }
 
     fn parse_term(&mut self) -> Result<Term, String> {
-        if self.depth > MAX_RECURSION_DEPTH {
+        if self.guard.descend() {
             return Err("recursion depth exceeded".to_string());
         }
         self.skip_ws();
-        match self.peek() {
+        let result = match self.peek() {
             Some('%') => self.parse_map(),
             Some('{') => self.parse_tuple(),
             Some('[') => self.parse_list(),
@@ -367,7 +367,9 @@ impl<'a> Parser<'a> {
             Some('t') | Some('f') => self.parse_bool().map(Term::Bool),
             Some(other) => Err(format!("Unexpected character '{}' at {}", other, self.pos)),
             None => Err("Unexpected end of mix.lock".to_string()),
-        }
+        };
+        self.guard.ascend();
+        result
     }
 
     fn parse_map(&mut self) -> Result<Term, String> {
@@ -385,18 +387,14 @@ impl<'a> Parser<'a> {
                 warn!("map entry count exceeded MAX_ITERATION_COUNT in mix.lock");
                 break;
             }
-            self.depth += 1;
             let key = self.parse_term()?;
-            self.depth -= 1;
             self.skip_ws();
             if self.starts_with("=>") {
                 self.expect_sequence("=>")?;
             } else {
                 self.expect(':')?;
             }
-            self.depth += 1;
             let value = self.parse_term()?;
-            self.depth -= 1;
             entries.push((key, value));
             count += 1;
             self.skip_ws();
@@ -421,9 +419,7 @@ impl<'a> Parser<'a> {
                 warn!("tuple item count exceeded MAX_ITERATION_COUNT in mix.lock");
                 break;
             }
-            self.depth += 1;
             items.push(self.parse_term()?);
-            self.depth -= 1;
             count += 1;
             self.skip_ws();
             if self.peek() == Some(',') {
@@ -453,14 +449,10 @@ impl<'a> Parser<'a> {
 
             if let Some(keyword) = self.try_parse_keyword_key() {
                 saw_keyword = true;
-                self.depth += 1;
                 let value = self.parse_term()?;
-                self.depth -= 1;
                 keyword_entries.push((keyword, value));
             } else {
-                self.depth += 1;
                 items.push(self.parse_term()?);
-                self.depth -= 1;
             }
 
             count += 1;

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -21,7 +21,9 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use std::path::Path;
 use toml::Value;
@@ -42,8 +44,6 @@ const FIELD_DEPS: &str = "deps";
 const FIELD_COMPAT: &str = "compat";
 const FIELD_TARGETS: &str = "targets";
 const FIELD_HOMEPAGE: &str = "homepage";
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct JuliaProjectTomlParser;
 
@@ -448,35 +448,34 @@ fn extract_project_extra_data(
 }
 
 fn toml_to_json(value: &toml::Value) -> serde_json::Value {
-    toml_to_json_inner(value, 0)
+    toml_to_json_inner(value, &mut RecursionGuard::depth_only())
 }
 
-fn toml_to_json_inner(value: &toml::Value, depth: usize) -> serde_json::Value {
-    if depth > MAX_RECURSION_DEPTH {
-        warn!(
-            "Recursion depth exceeded {} in toml_to_json, returning Null",
-            MAX_RECURSION_DEPTH
-        );
+fn toml_to_json_inner(value: &toml::Value, guard: &mut RecursionGuard<()>) -> serde_json::Value {
+    if guard.descend() {
+        warn!("Recursion depth exceeded in toml_to_json, returning Null");
         return serde_json::Value::Null;
     }
 
-    match value {
+    let result = match value {
         toml::Value::String(s) => serde_json::json!(s),
         toml::Value::Integer(i) => serde_json::json!(i),
         toml::Value::Float(f) => serde_json::json!(f),
         toml::Value::Boolean(b) => serde_json::json!(b),
         toml::Value::Array(a) => {
-            serde_json::Value::Array(a.iter().map(|v| toml_to_json_inner(v, depth + 1)).collect())
+            serde_json::Value::Array(a.iter().map(|v| toml_to_json_inner(v, guard)).collect())
         }
         toml::Value::Table(t) => {
             let map: serde_json::Map<String, serde_json::Value> = t
                 .iter()
-                .map(|(k, v)| (k.clone(), toml_to_json_inner(v, depth + 1)))
+                .map(|(k, v)| (k.clone(), toml_to_json_inner(v, guard)))
                 .collect();
             serde_json::Value::Object(map)
         }
         toml::Value::Datetime(d) => serde_json::json!(d.to_string()),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn default_project_package_data() -> PackageData {

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -5,22 +5,20 @@ use std::cell::Cell;
 
 use crate::parser_warn as warn;
 use crate::parsers::active_parser_license_engine;
-use crate::parsers::utils::MAX_ITERATION_COUNT;
+use crate::parsers::utils::{RecursionGuard, MAX_ITERATION_COUNT};
 
-use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::expression::{
-    LicenseExpression, parse_expression, simplify_expression,
+    parse_expression, simplify_expression, LicenseExpression,
 };
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::license_cache::LicenseCacheConfig;
+use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{LicenseDetection, LineNumber, Match, MatchScore, PackageData};
 use crate::utils::spdx::{
-    ExpressionRelation, combine_license_expressions, combine_license_expressions_with_relation,
+    combine_license_expressions, combine_license_expressions_with_relation, ExpressionRelation,
 };
 
 pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 static PARSER_LICENSE_ENGINE: LazyLock<Option<Arc<LicenseDetectionEngine>>> = LazyLock::new(|| {
     let cache_config =
@@ -112,8 +110,8 @@ impl<'a> DeclaredLicenseMatchMetadata<'a> {
     }
 }
 
-pub(crate) fn empty_declared_license_data()
--> (Option<String>, Option<String>, Vec<LicenseDetection>) {
+pub(crate) fn empty_declared_license_data(
+) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
     (None, None, Vec::new())
 }
 
@@ -189,8 +187,11 @@ pub(crate) fn normalize_spdx_expression(statement: &str) -> Option<NormalizedDec
 
     let engine = parser_license_engine()?;
     let expression = parse_expression(statement).ok()?;
-    let (declared_ast, declared_spdx_ast) =
-        normalize_expression_ast(&expression, engine.index(), 0)?;
+    let (declared_ast, declared_spdx_ast) = normalize_expression_ast(
+        &expression,
+        engine.index(),
+        &mut RecursionGuard::depth_only(),
+    )?;
     let declared_ast = simplify_expression(&declared_ast);
     let declared_spdx_ast = simplify_expression(&declared_spdx_ast);
 
@@ -487,17 +488,14 @@ fn collect_reference_strings(value: Option<&serde_json::Value>, references: &mut
 fn normalize_expression_ast(
     expression: &LicenseExpression,
     index: &LicenseIndex,
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<(LicenseExpression, LicenseExpression)> {
-    if depth > MAX_RECURSION_DEPTH {
-        warn!(
-            "normalize_expression_ast: recursion depth {} exceeded limit {}, returning None",
-            depth, MAX_RECURSION_DEPTH
-        );
+    if guard.descend() {
+        warn!("normalize_expression_ast: recursion depth exceeded limit, returning None");
         return None;
     }
 
-    match expression {
+    let result = match expression {
         LicenseExpression::License(key) => normalize_license_key(key, index).map(|normalized| {
             (
                 LicenseExpression::License(normalized.declared_license_expression),
@@ -509,8 +507,8 @@ fn normalize_expression_ast(
             LicenseExpression::LicenseRef(key.clone()),
         )),
         LicenseExpression::And { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, guard)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, guard)?;
 
             Some((
                 LicenseExpression::And {
@@ -524,8 +522,8 @@ fn normalize_expression_ast(
             ))
         }
         LicenseExpression::Or { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, guard)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, guard)?;
 
             Some((
                 LicenseExpression::Or {
@@ -539,8 +537,8 @@ fn normalize_expression_ast(
             ))
         }
         LicenseExpression::With { left, right } => {
-            let (left_declared, left_spdx) = normalize_expression_ast(left, index, depth + 1)?;
-            let (right_declared, right_spdx) = normalize_expression_ast(right, index, depth + 1)?;
+            let (left_declared, left_spdx) = normalize_expression_ast(left, index, guard)?;
+            let (right_declared, right_spdx) = normalize_expression_ast(right, index, guard)?;
 
             Some((
                 LicenseExpression::With {
@@ -553,7 +551,9 @@ fn normalize_expression_ast(
                 },
             ))
         }
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn normalize_license_key(key: &str, index: &LicenseIndex) -> Option<NormalizedDeclaredLicense> {
@@ -634,7 +634,12 @@ fn render_canonical_expression(expression: &LicenseExpression) -> String {
 
 fn render_flat_boolean_chain(expression: &LicenseExpression, operator: BooleanOperator) -> String {
     let mut parts = Vec::new();
-    collect_boolean_chain(expression, operator, &mut parts, 0);
+    collect_boolean_chain(
+        expression,
+        operator,
+        &mut parts,
+        &mut RecursionGuard::depth_only(),
+    );
 
     let separator = match operator {
         BooleanOperator::And => " AND ",
@@ -652,13 +657,10 @@ fn collect_boolean_chain<'a>(
     expression: &'a LicenseExpression,
     operator: BooleanOperator,
     parts: &mut Vec<&'a LicenseExpression>,
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) {
-    if depth > MAX_RECURSION_DEPTH {
-        warn!(
-            "collect_boolean_chain: recursion depth {} exceeded limit {}, truncating chain",
-            depth, MAX_RECURSION_DEPTH
-        );
+    if guard.descend() {
+        warn!("collect_boolean_chain: recursion depth exceeded limit, truncating chain");
         parts.push(expression);
         return;
     }
@@ -666,11 +668,12 @@ fn collect_boolean_chain<'a>(
     match (operator, expression) {
         (BooleanOperator::And, LicenseExpression::And { left, right })
         | (BooleanOperator::Or, LicenseExpression::Or { left, right }) => {
-            collect_boolean_chain(left, operator, parts, depth + 1);
-            collect_boolean_chain(right, operator, parts, depth + 1);
+            collect_boolean_chain(left, operator, parts, guard);
+            collect_boolean_chain(right, operator, parts, guard);
         }
         _ => parts.push(expression),
     }
+    guard.ascend();
 }
 
 fn render_boolean_operand(
@@ -788,12 +791,10 @@ mod tests {
             LineNumber::new(4).expect("valid")
         );
         assert_eq!(detection.matches[0].matched_text.as_deref(), Some("MIT"));
-        assert!(
-            detection.matches[0]
-                .rule_identifier
-                .as_deref()
-                .is_some_and(|identifier| !identifier.is_empty())
-        );
+        assert!(detection.matches[0]
+            .rule_identifier
+            .as_deref()
+            .is_some_and(|identifier| !identifier.is_empty()));
     }
 
     #[test]

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -5,17 +5,17 @@ use std::cell::Cell;
 
 use crate::parser_warn as warn;
 use crate::parsers::active_parser_license_engine;
-use crate::parsers::utils::{RecursionGuard, MAX_ITERATION_COUNT};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard};
 
+use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::expression::{
-    parse_expression, simplify_expression, LicenseExpression,
+    LicenseExpression, parse_expression, simplify_expression,
 };
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::license_cache::LicenseCacheConfig;
-use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{LicenseDetection, LineNumber, Match, MatchScore, PackageData};
 use crate::utils::spdx::{
-    combine_license_expressions, combine_license_expressions_with_relation, ExpressionRelation,
+    ExpressionRelation, combine_license_expressions, combine_license_expressions_with_relation,
 };
 
 pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
@@ -110,8 +110,8 @@ impl<'a> DeclaredLicenseMatchMetadata<'a> {
     }
 }
 
-pub(crate) fn empty_declared_license_data(
-) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
+pub(crate) fn empty_declared_license_data()
+-> (Option<String>, Option<String>, Vec<LicenseDetection>) {
     (None, None, Vec::new())
 }
 
@@ -791,10 +791,12 @@ mod tests {
             LineNumber::new(4).expect("valid")
         );
         assert_eq!(detection.matches[0].matched_text.as_deref(), Some("MIT"));
-        assert!(detection.matches[0]
-            .rule_identifier
-            .as_deref()
-            .is_some_and(|identifier| !identifier.is_empty()));
+        assert!(
+            detection.matches[0]
+                .rule_identifier
+                .as_deref()
+                .is_some_and(|identifier| !identifier.is_empty())
+        );
     }
 
     #[test]

--- a/src/parsers/meson.rs
+++ b/src/parsers/meson.rs
@@ -9,7 +9,7 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field};
 
 pub struct MesonParser;
 
@@ -452,18 +452,14 @@ fn parse_statement(statement: &str) -> Result<Statement, String> {
 
     if let [Token::Ident(name), Token::Equal, rest @ ..] = tokens.as_slice() {
         let mut parser = Parser::new(rest);
-        parser.depth += 1;
         let expr = parser.parse_expr()?;
-        parser.depth -= 1;
         parser.expect_end()?;
         let _ = name;
         return Ok(Statement::Assignment(expr));
     }
 
     let mut parser = Parser::new(&tokens);
-    parser.depth += 1;
     let expr = parser.parse_expr()?;
-    parser.depth -= 1;
     parser.expect_end()?;
     Ok(Statement::Expr(expr))
 }
@@ -567,12 +563,10 @@ fn is_ident_continue(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '_'
 }
 
-const MAX_RECURSION_DEPTH: usize = 50;
-
 struct Parser<'a> {
     tokens: &'a [Token],
     index: usize,
-    depth: usize,
+    guard: RecursionGuard<()>,
 }
 
 impl<'a> Parser<'a> {
@@ -580,15 +574,15 @@ impl<'a> Parser<'a> {
         Self {
             tokens,
             index: 0,
-            depth: 0,
+            guard: RecursionGuard::depth_only(),
         }
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
-        if self.depth > MAX_RECURSION_DEPTH {
+        if self.guard.descend() {
             return Err("recursion depth exceeded".to_string());
         }
-        match self.peek() {
+        let result = match self.peek() {
             Some(Token::Str(value)) => {
                 self.index += 1;
                 Ok(Expr::String(value.clone()))
@@ -601,7 +595,9 @@ impl<'a> Parser<'a> {
             Some(Token::Ident(_)) => self.parse_identifier_or_call(),
             Some(token) => Err(format!("unexpected token {:?}", token)),
             None => Err("unexpected end of input".to_string()),
-        }
+        };
+        self.guard.ascend();
+        result
     }
 
     fn parse_array(&mut self) -> Result<Expr, String> {
@@ -613,9 +609,7 @@ impl<'a> Parser<'a> {
             if element_count > MAX_ITERATION_COUNT {
                 break;
             }
-            self.depth += 1;
             let expr = self.parse_expr()?;
-            self.depth -= 1;
             values.push(expr);
             if matches!(self.peek(), Some(Token::Comma)) {
                 self.index += 1;
@@ -656,14 +650,10 @@ impl<'a> Parser<'a> {
             {
                 let arg_name = arg_name.clone();
                 self.index += 2;
-                self.depth += 1;
                 let value = self.parse_expr()?;
-                self.depth -= 1;
                 keyword.insert(arg_name, value);
             } else {
-                self.depth += 1;
                 let expr = self.parse_expr()?;
-                self.depth -= 1;
                 positional.push(expr);
             }
 

--- a/src/parsers/nix.rs
+++ b/src/parsers/nix.rs
@@ -497,7 +497,10 @@ impl Parser {
         }
 
         let expr = if terms.len() == 1 {
-            terms.pop().unwrap()
+            terms
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| Expr::Symbol(String::new()))
         } else {
             Expr::Application(terms)
         };

--- a/src/parsers/nix.rs
+++ b/src/parsers/nix.rs
@@ -6,11 +6,11 @@ use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct NixFlakeLockParser;
 
@@ -439,7 +439,7 @@ impl Lexer {
 struct Parser {
     tokens: Vec<Token>,
     index: usize,
-    depth: usize,
+    guard: RecursionGuard<()>,
 }
 
 impl Parser {
@@ -447,7 +447,7 @@ impl Parser {
         Self {
             tokens,
             index: 0,
-            depth: 0,
+            guard: RecursionGuard::depth_only(),
         }
     }
 
@@ -460,16 +460,15 @@ impl Parser {
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
-        if self.depth > MAX_RECURSION_DEPTH {
+        if self.guard.descend() {
             return Err("recursion depth exceeded".to_string());
         }
 
         if self.peek() == Some(&Token::LBrace) && self.looks_like_lambda_binder_set()? {
             self.skip_lambda_binder_set()?;
             self.expect(&Token::Colon)?;
-            self.depth += 1;
             let result = self.parse_expr();
-            self.depth -= 1;
+            self.guard.ascend();
             return result;
         }
 
@@ -477,17 +476,15 @@ impl Parser {
             self.index += 1;
             self.skip_lambda_binder_set()?;
             self.expect(&Token::Colon)?;
-            self.depth += 1;
             let result = self.parse_expr();
-            self.depth -= 1;
+            self.guard.ascend();
             return result;
         }
 
         let first = self.parse_term()?;
         if self.consume(&Token::Colon) {
-            self.depth += 1;
             let result = self.parse_expr();
-            self.depth -= 1;
+            self.guard.ascend();
             return result;
         }
 
@@ -505,7 +502,9 @@ impl Parser {
             Expr::Application(terms)
         };
 
-        self.parse_postfix(expr)
+        let result = self.parse_postfix(expr);
+        self.guard.ascend();
+        result
     }
 
     fn parse_postfix(&mut self, mut expr: Expr) -> Result<Expr, String> {
@@ -528,14 +527,9 @@ impl Parser {
             Some(Token::Ident(keyword)) if keyword == "let" => self.parse_let_in_expr(),
             Some(Token::Ident(keyword)) if keyword == "with" => {
                 self.index += 1;
-                self.depth += 1;
                 let _ = self.parse_expr()?;
-                self.depth -= 1;
                 self.expect(&Token::Semicolon)?;
-                self.depth += 1;
-                let result = self.parse_expr();
-                self.depth -= 1;
-                result
+                self.parse_expr()
             }
             Some(Token::Ident(keyword)) if keyword == "rec" => {
                 if matches!(self.peek_n(1), Some(Token::LBrace)) {
@@ -549,9 +543,7 @@ impl Parser {
             Some(Token::LBracket) => self.parse_list(),
             Some(Token::LParen) => {
                 self.index += 1;
-                self.depth += 1;
                 let expr = self.parse_expr()?;
-                self.depth -= 1;
                 self.expect(&Token::RParen)?;
                 Ok(expr)
             }
@@ -582,17 +574,13 @@ impl Parser {
 
             let key = self.parse_attr_path()?;
             self.expect(&Token::Equals)?;
-            self.depth += 1;
             let value = self.parse_expr()?;
-            self.depth -= 1;
             self.expect(&Token::Semicolon)?;
             bindings.push((key, value));
         }
 
         self.take_exact_ident("in")?;
-        self.depth += 1;
         let body = self.parse_expr()?;
-        self.depth -= 1;
         Ok(Expr::Let {
             bindings,
             body: Box::new(body),
@@ -624,9 +612,7 @@ impl Parser {
 
             let key = self.parse_attr_path()?;
             self.expect(&Token::Equals)?;
-            self.depth += 1;
             let value = self.parse_expr()?;
-            self.depth -= 1;
             self.expect(&Token::Semicolon)?;
             entries.push((key, value));
         }
@@ -646,9 +632,7 @@ impl Parser {
         self.take_exact_ident("inherit")?;
 
         let inherit_from = if self.consume(&Token::LParen) {
-            self.depth += 1;
             let expr = self.parse_expr()?;
-            self.depth -= 1;
             self.expect(&Token::RParen)?;
             Some(expr)
         } else {
@@ -693,9 +677,7 @@ impl Parser {
                 break;
             }
 
-            self.depth += 1;
             items.push(self.parse_expr()?);
-            self.depth -= 1;
         }
         Ok(Expr::List(items))
     }
@@ -844,8 +826,9 @@ impl Parser {
 fn parse_flake_nix(path: &Path, content: &str) -> Result<PackageData, String> {
     let expr = parse_nix_expr(content)?;
     let scopes = Vec::new();
-    let (root, scopes) = root_attrset_with_scopes(&expr, &scopes, 0)
-        .ok_or_else(|| "flake.nix root was not an attribute set".to_string())?;
+    let (root, scopes) =
+        root_attrset_with_scopes(&expr, &scopes, &mut RecursionGuard::depth_only())
+            .ok_or_else(|| "flake.nix root was not an attribute set".to_string())?;
 
     let mut package = default_flake_package_data();
     package.name = fallback_name(path).map(truncate_field);
@@ -1113,7 +1096,11 @@ fn collect_input_path(
             }
             Expr::Symbol(value) => {
                 inputs.entry(input_name.clone()).or_default().requirement =
-                    expr_as_string_with_scopes(&Expr::Symbol(value.clone()), scopes, 0)
+                    expr_as_string_with_scopes(
+                        &Expr::Symbol(value.clone()),
+                        scopes,
+                        &mut RecursionGuard::depth_only(),
+                    )
             }
             _ => {}
         }
@@ -1135,19 +1122,21 @@ fn apply_input_field(
     scopes: &[&[(Vec<String>, Expr)]],
 ) {
     if path == ["url"] {
-        info.requirement = expr_as_string_with_scopes(expr, scopes, 0);
+        info.requirement =
+            expr_as_string_with_scopes(expr, scopes, &mut RecursionGuard::depth_only());
         return;
     }
 
     if path == ["flake"] {
-        info.flake = expr_as_bool_with_scopes(expr, scopes, 0);
+        info.flake = expr_as_bool_with_scopes(expr, scopes, &mut RecursionGuard::depth_only());
         return;
     }
 
     if path.len() == 3
         && path[0] == "inputs"
         && path[2] == "follows"
-        && let Some(value) = expr_as_string_with_scopes(expr, scopes, 0)
+        && let Some(value) =
+            expr_as_string_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
     {
         info.follows.push(value);
     }
@@ -1159,17 +1148,20 @@ fn build_list_dependencies(
     runtime: bool,
     scopes: &[&[(Vec<String>, Expr)]],
 ) -> Vec<Dependency> {
-    let Some(expr) = find_attr(entries, &[field_name], 0) else {
+    let Some(expr) = find_attr(entries, &[field_name], &mut RecursionGuard::depth_only()) else {
         return Vec::new();
     };
-    let Some(items) = list_items_with_scopes(expr, scopes, 0) else {
+    let Some(items) = list_items_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+    else {
         return Vec::new();
     };
 
     items
         .iter()
         .take(MAX_ITERATION_COUNT)
-        .flat_map(|expr| expr_to_dependency_symbols_with_scopes(expr, scopes, 0))
+        .flat_map(|expr| {
+            expr_to_dependency_symbols_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+        })
         .filter_map(|symbol| {
             let name = symbol.rsplit('.').next()?.to_string();
             Some(Dependency {
@@ -1190,30 +1182,36 @@ fn build_list_dependencies(
 fn expr_to_dependency_symbols_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Vec<String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("expr_to_dependency_symbols_with_scopes exceeded MAX_RECURSION_DEPTH");
         return Vec::new();
     }
 
-    match expr {
-        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, 0)
-            .map(|resolved| expr_to_dependency_symbols_with_scopes(resolved, scopes, depth + 1))
+    let result = match expr {
+        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, &mut RecursionGuard::depth_only())
+            .map(|resolved| expr_to_dependency_symbols_with_scopes(resolved, scopes, guard))
             .unwrap_or_else(|| vec![symbol.clone()]),
         Expr::Application(parts) => parts
             .iter()
-            .filter_map(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))
+            .filter_map(|expr| {
+                expr_as_symbol_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+            })
             .collect(),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_to_dependency_symbols_with_scopes(body, &scopes, depth + 1)
+            expr_to_dependency_symbols_with_scopes(body, &scopes, guard)
         }
-        Expr::Select { .. } => expr_as_symbol_with_scopes(expr, scopes, 0)
-            .into_iter()
-            .collect(),
+        Expr::Select { .. } => {
+            expr_as_symbol_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+                .into_iter()
+                .collect()
+        }
         _ => Vec::new(),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn fallback_name(path: &Path) -> Option<String> {
@@ -1246,25 +1244,29 @@ fn attrset_entries(expr: &Expr) -> Option<&[(Vec<String>, Expr)]> {
 fn list_items_with_scopes<'a>(
     expr: &'a Expr,
     scopes: &[&'a [(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<&'a [Expr]> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("list_items_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
-        Expr::List(items) => Some(items),
+    let result = match expr {
+        Expr::List(items) => Some(items.as_slice()),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            list_items_with_scopes(body, &scopes, depth + 1)
+            list_items_with_scopes(body, &scopes, guard)
         }
-        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, 0)
-            .and_then(|resolved| list_items_with_scopes(resolved, scopes, depth + 1)),
-        Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| list_items_with_scopes(resolved, scopes, depth + 1)),
+        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, &mut RecursionGuard::depth_only())
+            .and_then(|resolved| list_items_with_scopes(resolved, scopes, guard)),
+        Expr::Select { target, path } => {
+            resolve_select(target, path, scopes, &mut RecursionGuard::depth_only())
+                .and_then(|resolved| list_items_with_scopes(resolved, scopes, guard))
+        }
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn expr_as_symbol(expr: &Expr) -> Option<String> {
@@ -1277,25 +1279,29 @@ fn expr_as_symbol(expr: &Expr) -> Option<String> {
 fn expr_as_symbol_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("expr_as_symbol_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
-        Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, depth + 1))
+    let result = match expr {
+        Expr::Symbol(value) => resolve_symbol(value, scopes, &mut RecursionGuard::depth_only())
+            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, guard))
             .or_else(|| Some(value.clone())),
-        Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, depth + 1)),
+        Expr::Select { target, path } => {
+            resolve_select(target, path, scopes, &mut RecursionGuard::depth_only())
+                .and_then(|resolved| expr_as_symbol_with_scopes(resolved, scopes, guard))
+        }
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_symbol_with_scopes(body, &scopes, depth + 1)
+            expr_as_symbol_with_scopes(body, &scopes, guard)
         }
         _ => expr_as_symbol(expr),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn expr_as_bool(expr: &Expr) -> Option<bool> {
@@ -1309,84 +1315,94 @@ fn expr_as_bool(expr: &Expr) -> Option<bool> {
 fn expr_as_bool_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<bool> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("expr_as_bool_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
+    let result = match expr {
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_bool_with_scopes(body, &scopes, depth + 1)
+            expr_as_bool_with_scopes(body, &scopes, guard)
         }
-        Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, depth + 1))
+        Expr::Symbol(value) => resolve_symbol(value, scopes, &mut RecursionGuard::depth_only())
+            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, guard))
             .or_else(|| expr_as_bool(expr)),
-        Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, depth + 1)),
+        Expr::Select { target, path } => {
+            resolve_select(target, path, scopes, &mut RecursionGuard::depth_only())
+                .and_then(|resolved| expr_as_bool_with_scopes(resolved, scopes, guard))
+        }
         _ => expr_as_bool(expr),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn expr_as_string_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("expr_as_string_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
+    let result = match expr {
         Expr::String(value) => Some(interpolate_string(value, scopes)),
-        Expr::Symbol(value) => resolve_symbol(value, scopes, 0)
-            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, depth + 1))
+        Expr::Symbol(value) => resolve_symbol(value, scopes, &mut RecursionGuard::depth_only())
+            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, guard))
             .or_else(|| Some(value.clone())),
         Expr::Application(parts) => parts
             .last()
-            .and_then(|expr| expr_as_string_with_scopes(expr, scopes, depth + 1)),
+            .and_then(|expr| expr_as_string_with_scopes(expr, scopes, guard)),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            expr_as_string_with_scopes(body, &scopes, depth + 1)
+            expr_as_string_with_scopes(body, &scopes, guard)
         }
-        Expr::Select { target, path } => resolve_select(target, path, scopes, 0)
-            .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, depth + 1)),
+        Expr::Select { target, path } => {
+            resolve_select(target, path, scopes, &mut RecursionGuard::depth_only())
+                .and_then(|resolved| expr_as_string_with_scopes(resolved, scopes, guard))
+        }
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn expr_to_scalar_string_with_scopes(
     expr: &Expr,
     scopes: &[&[(Vec<String>, Expr)]],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("expr_to_scalar_string_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
+    let result = match expr {
         Expr::Application(parts) => parts
             .last()
-            .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, depth + 1)),
-        _ => expr_as_string_with_scopes(expr, scopes, depth),
-    }
+            .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, guard)),
+        _ => expr_as_string_with_scopes(expr, scopes, guard),
+    };
+    guard.ascend();
+    result
 }
 
 fn find_attr<'a>(
     entries: &'a [(Vec<String>, Expr)],
     path: &[&str],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<&'a Expr> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("find_attr exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    for (key, value) in entries {
+    let result = entries.iter().find_map(|(key, value)| {
         if key.iter().map(String::as_str).eq(path.iter().copied()) {
             return Some(value);
         }
@@ -1397,13 +1413,16 @@ fn find_attr<'a>(
                 .map(String::as_str)
                 .eq(path[..key.len()].iter().copied())
             && let Expr::AttrSet(child_entries) = value
-            && let Some(found) = find_attr(child_entries, &path[key.len()..], depth + 1)
+            && let Some(found) = find_attr(child_entries, &path[key.len()..], guard)
         {
             return Some(found);
         }
-    }
 
-    None
+        None
+    });
+
+    guard.ascend();
+    result
 }
 
 fn find_string_attr_with_scopes(
@@ -1411,8 +1430,10 @@ fn find_string_attr_with_scopes(
     path: &[&str],
     scopes: &[&[(Vec<String>, Expr)]],
 ) -> Option<String> {
-    find_attr(entries, path, 0)
-        .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
+    find_attr(entries, path, &mut RecursionGuard::depth_only())
+        .and_then(|expr| {
+            expr_to_scalar_string_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+        })
         .map(truncate_field)
 }
 
@@ -1444,36 +1465,38 @@ fn extend_scopes<'a>(
 fn root_attrset_with_scopes<'a>(
     expr: &'a Expr,
     scopes: &[NixAttrEntriesRef<'a>],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<(NixAttrEntriesRef<'a>, NixScopeStack<'a>)> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!("root_attrset_with_scopes exceeded MAX_RECURSION_DEPTH");
         return None;
     }
 
-    match expr {
-        Expr::AttrSet(entries) => Some((entries, scopes.to_vec())),
+    let result = match expr {
+        Expr::AttrSet(entries) => Some((entries.as_slice(), scopes.to_vec())),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            root_attrset_with_scopes(body, &scopes, depth + 1)
+            root_attrset_with_scopes(body, &scopes, guard)
         }
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn lookup_binding<'a>(scopes: &[NixAttrEntriesRef<'a>], name: &str) -> Option<&'a Expr> {
     scopes
         .iter()
         .rev()
-        .find_map(|bindings| find_attr(bindings, &[name], 0))
+        .find_map(|bindings| find_attr(bindings, &[name], &mut RecursionGuard::depth_only()))
 }
 
 fn resolve_symbol<'a>(
     symbol: &str,
     scopes: &[NixAttrEntriesRef<'a>],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<&'a Expr> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         return None;
     }
 
@@ -1482,13 +1505,15 @@ fn resolve_symbol<'a>(
     let mut expr = lookup_binding(scopes, head)?;
     let rest = parts.collect::<Vec<_>>();
     if rest.is_empty() {
+        guard.ascend();
         return Some(expr);
     }
 
     for segment in rest {
-        expr = resolve_select(expr, &[segment.to_string()], scopes, depth + 1)?;
+        expr = resolve_select(expr, &[segment.to_string()], scopes, guard)?;
     }
 
+    guard.ascend();
     Some(expr)
 }
 
@@ -1496,31 +1521,33 @@ fn resolve_select<'a>(
     target: &'a Expr,
     path: &[String],
     scopes: &[NixAttrEntriesRef<'a>],
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Option<&'a Expr> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.descend() {
         return None;
     }
 
-    match target {
+    let result = match target {
         Expr::AttrSet(entries) => find_attr(
             entries,
             &path.iter().map(String::as_str).collect::<Vec<_>>(),
-            0,
+            guard,
         ),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
-            resolve_select(body, path, &scopes, depth + 1)
+            resolve_select(body, path, &scopes, guard)
         }
-        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, depth + 1)
-            .and_then(|resolved| resolve_select(resolved, path, scopes, depth + 1)),
+        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, guard)
+            .and_then(|resolved| resolve_select(resolved, path, scopes, guard)),
         Expr::Select {
             target: inner_target,
             path: inner_path,
-        } => resolve_select(inner_target, inner_path, scopes, depth + 1)
-            .and_then(|resolved| resolve_select(resolved, path, scopes, depth + 1)),
+        } => resolve_select(inner_target, inner_path, scopes, guard)
+            .and_then(|resolved| resolve_select(resolved, path, scopes, guard)),
         _ => None,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn interpolate_string(value: &str, scopes: &[&[(Vec<String>, Expr)]]) -> String {
@@ -1542,8 +1569,10 @@ fn interpolate_string(value: &str, scopes: &[&[(Vec<String>, Expr)]]) -> String 
             && placeholder
                 .chars()
                 .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
-            && let Some(resolved) = resolve_symbol(placeholder, scopes, 0)
-            && let Some(replacement) = expr_as_string_with_scopes(resolved, scopes, 0)
+            && let Some(resolved) =
+                resolve_symbol(placeholder, scopes, &mut RecursionGuard::depth_only())
+            && let Some(replacement) =
+                expr_as_string_with_scopes(resolved, scopes, &mut RecursionGuard::depth_only())
         {
             result.push_str(&replacement);
         } else {
@@ -1618,7 +1647,12 @@ fn extract_default_nix_package(
                 );
             }
 
-            if let Some(resolved) = resolve_select(target, select_path, scopes, 0) {
+            if let Some(resolved) = resolve_select(
+                target,
+                select_path,
+                scopes,
+                &mut RecursionGuard::depth_only(),
+            ) {
                 return extract_default_nix_package(path, resolved, scopes, depth);
             }
 
@@ -1650,12 +1684,19 @@ fn build_default_package_from_attrset(
             .or_else(|| find_string_attr_with_scopes(derivation, &["description"], scopes));
     package.homepage_url = find_string_attr_with_scopes(derivation, &["meta", "homepage"], scopes)
         .or_else(|| find_string_attr_with_scopes(derivation, &["homepage"], scopes));
-    package.extracted_license_statement = find_attr(derivation, &["meta", "license"], 0)
-        .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
-        .or_else(|| {
-            find_attr(derivation, &["license"], 0)
-                .and_then(|expr| expr_to_scalar_string_with_scopes(expr, scopes, 0))
-        });
+    package.extracted_license_statement = find_attr(
+        derivation,
+        &["meta", "license"],
+        &mut RecursionGuard::depth_only(),
+    )
+    .and_then(|expr| {
+        expr_to_scalar_string_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+    })
+    .or_else(|| {
+        find_attr(derivation, &["license"], &mut RecursionGuard::depth_only()).and_then(|expr| {
+            expr_to_scalar_string_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+        })
+    });
     package.dependencies = [
         build_list_dependencies(derivation, "nativeBuildInputs", false, scopes),
         build_list_dependencies(derivation, "buildInputs", true, scopes),
@@ -1685,9 +1726,9 @@ fn try_follow_local_nix_application(
         return None;
     }
 
-    let local_path = parts
-        .get(1)
-        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
+    let local_path = parts.get(1).and_then(|expr| {
+        expr_as_symbol_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+    })?;
     if !is_local_nix_path(&local_path) {
         return None;
     }
@@ -1713,7 +1754,7 @@ fn try_follow_selected_local_import(
         find_attr(
             entries,
             &select_path.iter().map(String::as_str).collect::<Vec<_>>(),
-            0,
+            &mut RecursionGuard::depth_only(),
         )
     })?;
     Some((selected.clone(), imported_path))
@@ -1741,7 +1782,7 @@ fn extract_flake_compat_package_from_expr(
         Expr::Symbol(symbol) => {
             if let Some((head, rest)) = symbol.split_once('.') {
                 let select_path = rest.split('.').map(ToOwned::to_owned).collect::<Vec<_>>();
-                resolve_symbol(head, scopes, 0)
+                resolve_symbol(head, scopes, &mut RecursionGuard::depth_only())
                     .and_then(|resolved| {
                         extract_flake_compat_package_from_select(
                             path,
@@ -1762,14 +1803,20 @@ fn extract_flake_compat_package_from_expr(
                         )
                     })
                     .or_else(|| {
-                        resolve_symbol(symbol, scopes, 0).and_then(|resolved| {
-                            extract_flake_compat_package_from_expr(path, resolved, scopes, depth)
-                        })
+                        resolve_symbol(symbol, scopes, &mut RecursionGuard::depth_only()).and_then(
+                            |resolved| {
+                                extract_flake_compat_package_from_expr(
+                                    path, resolved, scopes, depth,
+                                )
+                            },
+                        )
                     })
             } else {
-                resolve_symbol(symbol, scopes, 0).and_then(|resolved| {
-                    extract_flake_compat_package_from_expr(path, resolved, scopes, depth)
-                })
+                resolve_symbol(symbol, scopes, &mut RecursionGuard::depth_only()).and_then(
+                    |resolved| {
+                        extract_flake_compat_package_from_expr(path, resolved, scopes, depth)
+                    },
+                )
             }
         }
         _ => None,
@@ -1815,9 +1862,10 @@ fn resolve_flake_compat_source_root(
 
     match target {
         Expr::Application(parts) => source_root_from_flake_compat_application(path, parts, scopes),
-        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, depth + 1).and_then(|resolved| {
-            resolve_flake_compat_source_root(path, resolved, scopes, depth + 1)
-        }),
+        Expr::Symbol(symbol) => resolve_symbol(symbol, scopes, &mut RecursionGuard::depth_only())
+            .and_then(|resolved| {
+                resolve_flake_compat_source_root(path, resolved, scopes, depth + 1)
+            }),
         Expr::Let { bindings, body } => {
             let scopes = extend_scopes(scopes, bindings);
             resolve_flake_compat_source_root(path, body, &scopes, depth + 1)
@@ -1825,9 +1873,13 @@ fn resolve_flake_compat_source_root(
         Expr::Select {
             target: inner_target,
             path: inner_path,
-        } => resolve_select(inner_target, inner_path, scopes, depth + 1).and_then(|resolved| {
-            resolve_flake_compat_source_root(path, resolved, scopes, depth + 1)
-        }),
+        } => resolve_select(
+            inner_target,
+            inner_path,
+            scopes,
+            &mut RecursionGuard::depth_only(),
+        )
+        .and_then(|resolved| resolve_flake_compat_source_root(path, resolved, scopes, depth + 1)),
         _ => None,
     }
 }
@@ -1842,16 +1894,18 @@ fn source_root_from_flake_compat_application(
         return None;
     }
 
-    let import_path = parts
-        .get(1)
-        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
+    let import_path = parts.get(1).and_then(|expr| {
+        expr_as_symbol_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+    })?;
     if !is_local_nix_path(&import_path) {
         return None;
     }
 
     let args = parts.iter().find_map(attrset_entries)?;
-    let src_value = find_attr(args, &["src"], 0)
-        .and_then(|expr| expr_as_symbol_with_scopes(expr, scopes, 0))?;
+    let src_value =
+        find_attr(args, &["src"], &mut RecursionGuard::depth_only()).and_then(|expr| {
+            expr_as_symbol_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
+        })?;
     if !is_local_path(&src_value) {
         return None;
     }

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -24,7 +24,8 @@ use crate::models::{
 };
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, npm_purl, parse_sri, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, npm_purl, parse_sri,
+    read_file_to_string, truncate_field,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -44,7 +45,6 @@ const FIELD_DEV: &str = "dev";
 const FIELD_OPTIONAL: &str = "optional";
 const FIELD_DEV_OPTIONAL: &str = "devOptional";
 const FIELD_LINK: &str = "link";
-const MAX_RECURSION_DEPTH: usize = 50;
 
 /// npm lockfile parser supporting package-lock.json v1, v2, and v3 formats.
 ///
@@ -365,15 +365,16 @@ fn parse_lockfile_v1(
 /// For v1 lockfiles, root dependencies are at nesting level 0 (direct children of the root
 /// "dependencies" object). Transitive dependencies are nested within parent dependencies.
 fn parse_dependencies_v1(dependencies_obj: &serde_json::Map<String, Value>) -> Vec<Dependency> {
-    parse_dependencies_v1_with_depth(dependencies_obj, 0)
+    let mut guard = RecursionGuard::<()>::depth_only();
+    parse_dependencies_v1_with_depth(dependencies_obj, &mut guard)
 }
 
 /// Recursively parse v1 dependencies with depth tracking
 fn parse_dependencies_v1_with_depth(
     dependencies_obj: &serde_json::Map<String, Value>,
-    depth: usize,
+    guard: &mut RecursionGuard<()>,
 ) -> Vec<Dependency> {
-    if depth >= MAX_RECURSION_DEPTH {
+    if guard.descend() {
         warn!(
             "Max recursion depth {} exceeded in v1 dependency parsing",
             MAX_RECURSION_DEPTH
@@ -412,10 +413,10 @@ fn parse_dependencies_v1_with_depth(
         let nested_deps = dep_data
             .get(FIELD_DEPENDENCIES)
             .and_then(|v| v.as_object())
-            .map(|nested| parse_dependencies_v1_with_depth(nested, depth + 1))
+            .map(|nested| parse_dependencies_v1_with_depth(nested, guard))
             .unwrap_or_default();
 
-        let is_direct = depth == 0;
+        let is_direct = guard.depth() == 1;
 
         let dependency = build_npm_dependency(
             package_name,
@@ -434,6 +435,7 @@ fn parse_dependencies_v1_with_depth(
         dependencies.push(dependency);
     }
 
+    guard.ascend();
     dependencies
 }
 

--- a/src/parsers/nuget.rs
+++ b/src/parsers/nuget.rs
@@ -597,6 +597,7 @@ fn default_package_data(datasource_id: Option<DatasourceId>) -> PackageData {
 const MAX_ARCHIVE_SIZE: u64 = 100 * 1024 * 1024; // 100MB
 const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50MB
 const MAX_COMPRESSION_RATIO: f64 = 100.0; // 100:1
+const MAX_UNCOMPRESSED_SIZE: u64 = 1024 * 1024 * 1024; // 1GB
 
 /// Parser for packages.lock.json (NuGet lock file)
 pub struct PackagesLockParser;
@@ -2622,6 +2623,8 @@ fn extract_nupkg_archive(path: &Path) -> Result<PackageData, String> {
     let mut archive =
         ZipArchive::new(file).map_err(|e| format!("Failed to read ZIP archive: {}", e))?;
 
+    let mut total_uncompressed: u64 = 0;
+
     for i in 0..archive.len() {
         let content = {
             let mut entry = archive
@@ -2629,11 +2632,24 @@ fn extract_nupkg_archive(path: &Path) -> Result<PackageData, String> {
                 .map_err(|e| format!("Failed to read ZIP entry: {}", e))?;
 
             let entry_name = entry.name().to_string();
+            let entry_size = entry.size();
+
+            total_uncompressed += entry_size;
+            if total_uncompressed > MAX_UNCOMPRESSED_SIZE {
+                warn!(
+                    "NuGet: total uncompressed size exceeds {} bytes for {:?}",
+                    MAX_UNCOMPRESSED_SIZE, path
+                );
+                return Err(format!(
+                    "Total uncompressed size exceeds limit: {} bytes (limit: {} bytes)",
+                    total_uncompressed, MAX_UNCOMPRESSED_SIZE
+                ));
+            }
+
             if !entry_name.ends_with(".nuspec") {
                 continue;
             }
 
-            let entry_size = entry.size();
             if entry_size > MAX_FILE_SIZE {
                 return Err(format!(
                     ".nuspec too large: {} bytes (limit: {} bytes)",
@@ -2684,6 +2700,14 @@ fn read_nupkg_license_file(
     archive: &mut zip::ZipArchive<File>,
     license_file: &str,
 ) -> Result<Option<String>, String> {
+    if license_file.split('/').any(|c| c == "..") || license_file.split('\\').any(|c| c == "..") {
+        warn!(
+            "NuGet: path traversal detected in license file path: {}",
+            license_file
+        );
+        return Ok(None);
+    }
+
     let normalized_target = license_file.replace('\\', "/");
 
     for i in 0..archive.len() {

--- a/src/parsers/nuget.rs
+++ b/src/parsers/nuget.rs
@@ -22,7 +22,7 @@
 //! - Graceful error handling with warn!()
 //! - No unwrap/expect in library code
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -36,9 +36,9 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 
 use super::PackageParser;
 use super::license_normalization::{empty_declared_license_data, normalize_spdx_declared_license};
-use super::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, read_file_to_string, truncate_field};
-
-const MAX_RECURSION_DEPTH: usize = 50;
+use super::utils::{
+    MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, RecursionGuard, read_file_to_string, truncate_field,
+};
 
 fn check_file_size(path: &Path) -> Result<(), String> {
     match fs::metadata(path) {
@@ -1759,18 +1759,17 @@ fn build_directory_packages_dependency(
 
 fn resolve_directory_packages_props(
     path: &Path,
-    visited: &mut HashSet<PathBuf>,
-    depth: usize,
+    guard: &mut RecursionGuard<PathBuf>,
 ) -> Result<CentralPackagePropsData, String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.exceeded() {
         return Err(format!(
-            "Recursion depth exceeded ({}) resolving Directory.Packages.props at {:?}",
-            depth, path
+            "Recursion depth exceeded resolving Directory.Packages.props at {:?}",
+            path
         ));
     }
 
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if !visited.insert(canonical.clone()) {
+    if guard.enter(canonical.clone()) {
         return Ok(CentralPackagePropsData::default());
     }
 
@@ -1783,7 +1782,7 @@ fn resolve_directory_packages_props(
         else {
             continue;
         };
-        let imported = resolve_directory_packages_props(&import_path, visited, depth + 1)?;
+        let imported = resolve_directory_packages_props(&import_path, guard)?;
         merge_central_package_props(&mut merged, imported);
     }
 
@@ -1826,23 +1825,23 @@ fn resolve_directory_packages_props(
         }
     }
 
+    guard.leave(canonical);
     Ok(merged)
 }
 
 fn resolve_directory_build_props(
     path: &Path,
-    visited: &mut HashSet<PathBuf>,
-    depth: usize,
+    guard: &mut RecursionGuard<PathBuf>,
 ) -> Result<BuildPropsData, String> {
-    if depth > MAX_RECURSION_DEPTH {
+    if guard.exceeded() {
         return Err(format!(
-            "Recursion depth exceeded ({}) resolving Directory.Build.props at {:?}",
-            depth, path
+            "Recursion depth exceeded resolving Directory.Build.props at {:?}",
+            path
         ));
     }
 
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if !visited.insert(canonical.clone()) {
+    if guard.enter(canonical.clone()) {
         return Ok(BuildPropsData::default());
     }
 
@@ -1855,7 +1854,7 @@ fn resolve_directory_build_props(
         else {
             continue;
         };
-        let imported = resolve_directory_build_props(&import_path, visited, depth + 1)?;
+        let imported = resolve_directory_build_props(&import_path, guard)?;
         merge_build_props_data(&mut merged, imported);
     }
 
@@ -1881,6 +1880,7 @@ fn resolve_directory_build_props(
         merged.central_package_version_override_enabled = Some(value);
     }
 
+    guard.leave(canonical);
     Ok(merged)
 }
 
@@ -2545,7 +2545,7 @@ impl PackageParser for DirectoryBuildPropsParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         vec![match (
-            resolve_directory_build_props(path, &mut HashSet::new(), 0),
+            resolve_directory_build_props(path, &mut RecursionGuard::new()),
             parse_directory_build_props_file(path),
         ) {
             (Ok(data), Ok(raw)) => build_directory_build_props_package_data(data, raw),
@@ -2566,7 +2566,7 @@ impl PackageParser for CentralPackageManagementPropsParser {
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
         vec![match (
-            resolve_directory_packages_props(path, &mut HashSet::new(), 0),
+            resolve_directory_packages_props(path, &mut RecursionGuard::new()),
             parse_directory_packages_props_file(path),
         ) {
             (Ok(data), Ok(raw)) => build_directory_packages_package_data(data, raw),

--- a/src/parsers/pylock_toml.rs
+++ b/src/parsers/pylock_toml.rs
@@ -13,7 +13,7 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
 
 use super::PackageParser;
 
@@ -39,7 +39,6 @@ const FIELD_WHEELS: &str = "wheels";
 const FIELD_HASHES: &str = "hashes";
 const FIELD_TOOL: &str = "tool";
 const FIELD_ATTESTATION_IDENTITIES: &str = "attestation-identities";
-const MAX_RECURSION_DEPTH: usize = 50;
 
 pub struct PylockTomlParser;
 
@@ -354,19 +353,20 @@ fn package_reference_matches(
     package_table: &TomlMap<String, TomlValue>,
     reference: &TomlMap<String, TomlValue>,
 ) -> bool {
+    let mut guard = RecursionGuard::depth_only();
     reference.iter().all(|(key, ref_value)| {
         package_table
             .get(key)
-            .is_some_and(|pkg_value| toml_values_match(pkg_value, ref_value, 0))
+            .is_some_and(|pkg_value| toml_values_match(pkg_value, ref_value, &mut guard))
     })
 }
 
-fn toml_values_match(left: &TomlValue, right: &TomlValue, depth: usize) -> bool {
-    if depth >= MAX_RECURSION_DEPTH {
+fn toml_values_match(left: &TomlValue, right: &TomlValue, guard: &mut RecursionGuard<()>) -> bool {
+    if guard.descend() {
         warn!("toml_values_match: recursion depth limit exceeded");
         return false;
     }
-    match (left, right) {
+    let result = match (left, right) {
         (TomlValue::String(left), TomlValue::String(right)) => left == right,
         (TomlValue::Integer(left), TomlValue::Integer(right)) => left == right,
         (TomlValue::Float(left), TomlValue::Float(right)) => left == right,
@@ -377,16 +377,18 @@ fn toml_values_match(left: &TomlValue, right: &TomlValue, depth: usize) -> bool 
                 && left
                     .iter()
                     .zip(right.iter())
-                    .all(|(left, right)| toml_values_match(left, right, depth + 1))
+                    .all(|(left, right)| toml_values_match(left, right, guard))
         }
         (TomlValue::Table(left), TomlValue::Table(right)) => {
             right.iter().all(|(key, right_value)| {
                 left.get(key)
-                    .is_some_and(|left_value| toml_values_match(left_value, right_value, depth + 1))
+                    .is_some_and(|left_value| toml_values_match(left_value, right_value, guard))
             })
         }
         _ => false,
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn build_incoming_counts(package_count: usize, dependency_indices: &[Vec<usize>]) -> Vec<usize> {

--- a/src/parsers/python.rs
+++ b/src/parsers/python.rs
@@ -1727,6 +1727,7 @@ pub fn parse_record_csv(content: &str) -> Vec<FileReference> {
 pub fn parse_installed_files_txt(content: &str) -> Vec<FileReference> {
     content
         .lines()
+        .take(MAX_ITERATION_COUNT)
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())
         .map(|path| FileReference {
@@ -1744,6 +1745,7 @@ pub fn parse_installed_files_txt(content: &str) -> Vec<FileReference> {
 pub fn parse_sources_txt(content: &str) -> Vec<FileReference> {
     content
         .lines()
+        .take(MAX_ITERATION_COUNT)
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(|path| FileReference {

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -22,7 +22,7 @@
 //! - Comments (lines starting with `#`) are skipped
 //! - Environment markers are preserved for dependency filtering
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::parser_warn as warn;
@@ -31,11 +31,11 @@ use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::pep508::{Pep508Requirement, parse_pep508_requirement};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 /// pip requirements.txt parser supporting PEP 508 dependency specifications.
 ///
@@ -110,7 +110,7 @@ struct ParseState {
     index_url: Option<String>,
     includes: Vec<String>,
     constraints: Vec<String>,
-    visited: HashSet<PathBuf>,
+    guard: RecursionGuard<PathBuf>,
 }
 
 fn extract_from_requirements_txt(path: &Path) -> PackageData {
@@ -120,12 +120,12 @@ fn extract_from_requirements_txt(path: &Path) -> PackageData {
         index_url: None,
         includes: Vec::new(),
         constraints: Vec::new(),
-        visited: HashSet::new(),
+        guard: RecursionGuard::new(),
     };
 
     let (scope, is_runtime) = scope_from_filename(path);
 
-    parse_requirements_with_includes(path, &mut state, &scope, is_runtime, 0);
+    parse_requirements_with_includes(path, &mut state, &scope, is_runtime);
 
     let mut extra_data = HashMap::new();
     if let Some(url) = state.index_url {
@@ -185,9 +185,8 @@ fn parse_requirements_with_includes(
     state: &mut ParseState,
     scope: &str,
     is_runtime: bool,
-    depth: usize,
 ) {
-    if depth > MAX_RECURSION_DEPTH {
+    if state.guard.exceeded() {
         warn!(
             "Maximum recursion depth ({}) exceeded for include: {:?}",
             MAX_RECURSION_DEPTH, path
@@ -203,12 +202,10 @@ fn parse_requirements_with_includes(
         }
     };
 
-    if state.visited.contains(&abs_path) {
+    if state.guard.enter(abs_path.clone()) {
         warn!("Circular include detected: {:?}", path);
         return;
     }
-
-    state.visited.insert(abs_path.clone());
 
     let content = match read_file_to_string(&abs_path, None) {
         Ok(c) => c,
@@ -248,13 +245,7 @@ fn parse_requirements_with_includes(
                 .join(&path_value);
 
             if included_path.exists() {
-                parse_requirements_with_includes(
-                    &included_path,
-                    state,
-                    scope,
-                    is_runtime,
-                    depth + 1,
-                );
+                parse_requirements_with_includes(&included_path, state, scope, is_runtime);
             } else {
                 warn!("Included file not found: {:?}", included_path);
             }
@@ -271,13 +262,7 @@ fn parse_requirements_with_includes(
                 .join(&path_value);
 
             if constraint_path.exists() {
-                parse_requirements_with_includes(
-                    &constraint_path,
-                    state,
-                    scope,
-                    is_runtime,
-                    depth + 1,
-                );
+                parse_requirements_with_includes(&constraint_path, state, scope, is_runtime);
             } else {
                 warn!("Constraint file not found: {:?}", constraint_path);
             }
@@ -302,6 +287,8 @@ fn parse_requirements_with_includes(
             state.dependencies.push(dependency);
         }
     }
+
+    state.guard.leave(abs_path);
 }
 
 fn default_package_data(

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -156,7 +156,7 @@ fn parse_rpm_database(
         ));
     }
 
-    let native_kind = native_kind_for_datasource(datasource_id);
+    let native_kind = native_kind_for_datasource(datasource_id)?;
     match read_installed_rpm_packages(path, native_kind) {
         Ok(packages) => Ok(packages
             .into_iter()
@@ -181,12 +181,14 @@ fn path_matches_any_suffix(path: &Path, suffixes: &[&str]) -> bool {
         .any(|suffix| path_matches_suffix(path, suffix))
 }
 
-fn native_kind_for_datasource(datasource_id: DatasourceId) -> InstalledRpmDbKind {
+fn native_kind_for_datasource(datasource_id: DatasourceId) -> Result<InstalledRpmDbKind, String> {
     match datasource_id {
-        DatasourceId::RpmInstalledDatabaseBdb => InstalledRpmDbKind::Bdb,
-        DatasourceId::RpmInstalledDatabaseNdb => InstalledRpmDbKind::Ndb,
-        DatasourceId::RpmInstalledDatabaseSqlite => InstalledRpmDbKind::Sqlite,
-        other => panic!("unexpected datasource for installed RPM DB: {other:?}"),
+        DatasourceId::RpmInstalledDatabaseBdb => Ok(InstalledRpmDbKind::Bdb),
+        DatasourceId::RpmInstalledDatabaseNdb => Ok(InstalledRpmDbKind::Ndb),
+        DatasourceId::RpmInstalledDatabaseSqlite => Ok(InstalledRpmDbKind::Sqlite),
+        other => Err(format!(
+            "unexpected datasource for installed RPM DB: {other:?}"
+        )),
     }
 }
 

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -40,8 +40,9 @@ use crate::parsers::utils::{
 
 use super::PackageParser;
 
-static RE_CONDITIONAL_MACRO: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"%\{\?[^}]+\}").unwrap());
+static RE_CONDITIONAL_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"%\{\?[^}]+\}").expect("valid regex: %{?...} pattern is a compile-time constant")
+});
 
 const PACKAGE_TYPE: PackageType = PackageType::Rpm;
 

--- a/src/parsers/sbt.rs
+++ b/src/parsers/sbt.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -8,9 +8,7 @@ use serde_json::json;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
-
-const MAX_RECURSION_DEPTH: usize = 50;
+use super::utils::{MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field};
 
 pub struct SbtParser;
 
@@ -410,10 +408,8 @@ fn resolve_string_aliases(statements: &[String]) -> HashMap<String, String> {
 
     let mut resolved = HashMap::new();
     for name in raw_aliases.keys() {
-        let mut visiting = HashSet::new();
-        if let Some(value) =
-            resolve_alias_value(name, &raw_aliases, &mut resolved, &mut visiting, 0)
-        {
+        let mut guard: RecursionGuard<String> = RecursionGuard::new();
+        if let Some(value) = resolve_alias_value(name, &raw_aliases, &mut resolved, &mut guard) {
             resolved.insert(name.clone(), value);
         }
     }
@@ -445,10 +441,9 @@ fn resolve_alias_value(
     name: &str,
     raw_aliases: &HashMap<String, AliasExpr>,
     resolved: &mut HashMap<String, String>,
-    visiting: &mut HashSet<String>,
-    depth: usize,
+    guard: &mut RecursionGuard<String>,
 ) -> Option<String> {
-    if depth >= MAX_RECURSION_DEPTH {
+    if guard.exceeded() {
         warn!(
             "Recursion depth exceeded in alias resolution for '{}'",
             name
@@ -460,18 +455,18 @@ fn resolve_alias_value(
         return Some(value.clone());
     }
 
-    if !visiting.insert(name.to_string()) {
+    if guard.enter(name.to_string()) {
         return None;
     }
 
     let value = match raw_aliases.get(name)? {
         AliasExpr::Literal(value) => Some(value.clone()),
         AliasExpr::Reference(reference) => {
-            resolve_alias_value(reference, raw_aliases, resolved, visiting, depth + 1)
+            resolve_alias_value(reference, raw_aliases, resolved, guard)
         }
     };
 
-    visiting.remove(name);
+    guard.leave(name.to_string());
     value
 }
 

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -12,18 +12,17 @@
 //! - Extracts full dependency graph with versions (beyond Python which only extracts name)
 //! - Spec: https://forums.swift.org/t/swiftpm-show-dependencies-without-fetching-dependencies/51154
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use crate::parser_warn as warn;
 use serde::{Deserialize, Serialize};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 const PACKAGE_TYPE: PackageType = PackageType::Swift;
 
@@ -113,8 +112,9 @@ fn flatten_dependencies(deps: &[SwiftDependency]) -> Vec<Dependency> {
     let mut result = Vec::new();
 
     for dep in deps {
-        let mut path = HashSet::new();
-        flatten_dependency(dep, true, &mut result, &mut path, 0);
+        let mut guard: RecursionGuard<String> = RecursionGuard::new();
+        let mut depth_guard = RecursionGuard::<()>::depth_only();
+        flatten_dependency(dep, true, &mut result, &mut guard, &mut depth_guard);
     }
 
     result
@@ -124,14 +124,11 @@ fn flatten_dependency(
     dep: &SwiftDependency,
     is_direct: bool,
     result: &mut Vec<Dependency>,
-    path: &mut HashSet<String>,
-    depth: usize,
+    guard: &mut RecursionGuard<String>,
+    depth_guard: &mut RecursionGuard<()>,
 ) {
-    if depth >= MAX_RECURSION_DEPTH {
-        warn!(
-            "Recursion depth exceeded in swift dependency flattening at depth {}",
-            depth
-        );
+    if guard.exceeded() || depth_guard.exceeded() {
+        warn!("Recursion depth exceeded in swift dependency flattening");
         return;
     }
 
@@ -145,29 +142,30 @@ fn flatten_dependency(
         .or(dep.name.as_deref())
         .unwrap_or("")
         .to_string();
-    if !dep_key.is_empty() && !path.insert(dep_key.clone()) {
+    if !dep_key.is_empty() && guard.enter(dep_key.clone()) {
         return;
     }
 
-    if let Some(dependency) = build_dependency(dep, is_direct, depth) {
+    if let Some(dependency) = build_dependency(dep, is_direct, depth_guard) {
         result.push(dependency);
     }
 
     for child in &dep.dependencies {
-        flatten_dependency(child, false, result, path, depth + 1);
+        flatten_dependency(child, false, result, guard, depth_guard);
     }
 
     if !dep_key.is_empty() {
-        path.remove(&dep_key);
+        guard.leave(dep_key);
     }
 }
 
-fn build_dependency(dep: &SwiftDependency, is_direct: bool, depth: usize) -> Option<Dependency> {
-    if depth >= MAX_RECURSION_DEPTH {
-        warn!(
-            "Recursion depth exceeded in swift dependency building at depth {}",
-            depth
-        );
+fn build_dependency(
+    dep: &SwiftDependency,
+    is_direct: bool,
+    guard: &mut RecursionGuard<()>,
+) -> Option<Dependency> {
+    if guard.descend() {
+        warn!("Recursion depth exceeded in swift dependency building");
         return None;
     }
 
@@ -178,8 +176,10 @@ fn build_dependency(dep: &SwiftDependency, is_direct: bool, depth: usize) -> Opt
         .dependencies
         .iter()
         .take(MAX_ITERATION_COUNT)
-        .filter_map(|child| build_dependency(child, true, depth + 1))
+        .filter_map(|child| build_dependency(child, true, guard))
         .collect();
+
+    guard.ascend();
 
     Some(Dependency {
         purl: Some(truncate_field(purl.clone())),

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -2,7 +2,9 @@
 ///
 /// This module provides common file I/O and parsing utilities
 /// used across multiple parser implementations.
+use std::collections::HashSet;
 use std::fs::{self, File};
+use std::hash::Hash;
 use std::io::Read;
 use std::path::Path;
 
@@ -18,6 +20,95 @@ pub const MAX_FIELD_LENGTH: usize = 10 * 1024 * 1024;
 
 /// Default maximum iteration count for loops processing items (100,000).
 pub const MAX_ITERATION_COUNT: usize = 100_000;
+
+/// Default maximum recursion depth for recursive parsing functions (50 levels).
+pub const MAX_RECURSION_DEPTH: usize = 50;
+
+/// A reusable guard that tracks recursion depth and detects cycles.
+///
+/// Use this in any recursive parser function to enforce the ADR 0004
+/// recursion depth limit (50 levels) and optionally detect circular
+/// references via a visited set keyed by `K`.
+///
+/// For depth-only tracking (no cycle detection), use `RecursionGuard<()>`
+/// — the unit type implements `Hash + Eq` as a singleton, so the visited
+/// set never grows and `enter`/`leave` are cheap no-ops.
+///
+/// # Type Parameters
+///
+/// * `K` — The key type for cycle detection (e.g., `usize` for package
+///   indices, `String` for dependency names, `PathBuf` for file paths,
+///   or `()` for depth-only tracking).
+///
+/// # Examples
+///
+/// ```no_run
+/// use provenant::parsers::utils::RecursionGuard;
+///
+/// fn walk_tree(idx: usize, guard: &mut RecursionGuard<usize>) {
+///     if guard.exceeded() { return; }
+///     if guard.enter(idx) { return; } // cycle detected
+///     // ... recurse into children ...
+///     walk_tree(idx + 1, guard);
+///     guard.leave(idx);
+/// }
+/// ```
+pub struct RecursionGuard<K: Hash + Eq> {
+    depth: usize,
+    visited: HashSet<K>,
+}
+
+impl<K: Hash + Eq> RecursionGuard<K> {
+    pub fn new() -> Self {
+        Self {
+            depth: 0,
+            visited: HashSet::new(),
+        }
+    }
+
+    pub fn exceeded(&self) -> bool {
+        self.depth > MAX_RECURSION_DEPTH
+    }
+
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
+    pub fn enter(&mut self, key: K) -> bool {
+        if self.visited.contains(&key) {
+            return true;
+        }
+        self.visited.insert(key);
+        self.depth += 1;
+        false
+    }
+
+    pub fn leave(&mut self, key: K) {
+        self.visited.remove(&key);
+        self.depth -= 1;
+    }
+}
+
+impl RecursionGuard<()> {
+    pub fn depth_only() -> Self {
+        Self::new()
+    }
+
+    pub fn descend(&mut self) -> bool {
+        self.depth += 1;
+        self.exceeded()
+    }
+
+    pub fn ascend(&mut self) {
+        self.depth -= 1;
+    }
+}
+
+impl<K: Hash + Eq> Default for RecursionGuard<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Truncates a string field value to [`MAX_FIELD_LENGTH`] bytes if it exceeds
 /// the limit, returning the truncated string. Returns the original string if

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -11,11 +11,9 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha256Digest,
 };
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
 
 use super::PackageParser;
-
-const MAX_RECURSION_DEPTH: usize = 50;
 
 const FIELD_PACKAGE: &str = "package";
 const FIELD_NAME: &str = "name";
@@ -930,19 +928,16 @@ fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
 }
 
 fn toml_value_to_json(value: &TomlValue) -> JsonValue {
-    toml_value_to_json_recursive(value, 0)
+    toml_value_to_json_recursive(value, &mut RecursionGuard::depth_only())
 }
 
-fn toml_value_to_json_recursive(value: &TomlValue, depth: usize) -> JsonValue {
-    if depth > MAX_RECURSION_DEPTH {
-        warn!(
-            "toml_value_to_json exceeded MAX_RECURSION_DEPTH ({})",
-            MAX_RECURSION_DEPTH
-        );
+fn toml_value_to_json_recursive(value: &TomlValue, guard: &mut RecursionGuard<()>) -> JsonValue {
+    if guard.descend() {
+        warn!("toml_value_to_json exceeded recursion depth limit");
         return JsonValue::Null;
     }
 
-    match value {
+    let result = match value {
         TomlValue::String(value) => JsonValue::String(value.clone()),
         TomlValue::Integer(value) => JsonValue::String(value.to_string()),
         TomlValue::Float(value) => JsonValue::String(value.to_string()),
@@ -951,16 +946,18 @@ fn toml_value_to_json_recursive(value: &TomlValue, depth: usize) -> JsonValue {
         TomlValue::Array(values) => JsonValue::Array(
             values
                 .iter()
-                .map(|v| toml_value_to_json_recursive(v, depth + 1))
+                .map(|v| toml_value_to_json_recursive(v, guard))
                 .collect(),
         ),
         TomlValue::Table(values) => JsonValue::Object(
             values
                 .iter()
-                .map(|(key, value)| (key.clone(), toml_value_to_json_recursive(value, depth + 1)))
+                .map(|(key, value)| (key.clone(), toml_value_to_json_recursive(value, guard)))
                 .collect(),
         ),
-    }
+    };
+    guard.ascend();
+    result
 }
 
 fn default_package_data() -> PackageData {


### PR DESCRIPTION
## Summary

Audited all ~90 parser source files against ADR 0004 (Security-First Parsing), remediated every divergence found, and extracted a shared `RecursionGuard<K>` utility now adopted across 17 parsers. Two parser families (Ruby/Cocoa/Haskell and Python/Conda/Pixi after fixes) were already fully compliant.

## Changes by Parser

### `bun_lockb.rs` — Recursion depth tracking + cycle detection (Critical)
- Introduced `RecursionGuard` struct encapsulating `depth` counter and `HashSet<usize>` visited set
- `build_dependencies_for_package` and `build_resolved_package` now accept `&mut RecursionGuard<usize>` instead of raw `depth`/`visited` params
- Both functions return early with `warn!()` when depth exceeds `MAX_RECURSION_DEPTH` (50)
- Cycle detection: before recursing into a package index, `guard.enter(pkg_idx)` checks if already visited; if so, skips with `warn!()` and returns `None`
- On return, `guard.leave(pkg_idx)` removes the index from visited, allowing diamond dependencies in different branches

### `clojure.rs` — Unbounded recursion in AST conversion (High)
- `form_to_json()` and `format_license()`: added depth tracking; return early with `warn!()` when depth exceeded
- Refactored to use shared `RecursionGuard<()>` via `descend()`/`ascend()` in struct and free functions

### `gradle.rs` — Unbounded nesting depth in delimiter matching (Low)
- Added depth cap checks in 5 bracket/paren/brace matching functions, logging `warn!()` and breaking with partial result

### `python.rs` / `conda.rs` — Unbounded iteration
- Added `.take(MAX_ITERATION_COUNT)` to iteration loops in `parse_installed_files_txt()`, `parse_sources_txt()`, and `extract_pip_dependencies()`

### `rpm_db.rs` — `panic!()` in library code
- Changed return type to `Result<..., String>`; replaced `panic!()` with `Err(...)`

### `rpm_specfile.rs` / `cpan_makefile_pl.rs` — `.unwrap()` on compile-time regexes
- Replaced `.unwrap()` with `.expect("valid regex: ...")`

### `nix.rs` — `.unwrap()` on `Vec::pop()`
- Replaced with `unwrap_or_else(|| Expr::Symbol(String::new()))`

### `nuget.rs` — Archive safety gaps
- Added path-traversal check in `read_nupkg_license_file`
- Added 1 GB uncompressed size accumulator in `extract_nupkg_archive`

## RecursionGuard Extraction (follow-up commit)

Extracted the `RecursionGuard` from `bun_lockb.rs` into `src/parsers/utils.rs` as a generic shared utility and adopted it across 17 parsers:

- **`RecursionGuard<K: Hash + Eq>`** — depth + cycle detection (keyed by `usize`, `String`, or `PathBuf`)
  - `guard.enter(key)` / `guard.leave(key)` — visited-set tracking + depth increment/decrement
  - `guard.exceeded()` — checks depth against `MAX_RECURSION_DEPTH` (50)
- **`RecursionGuard<()>`** — depth-only tracking (no cycle detection)
  - `guard.descend()` / `guard.ascend()` — lightweight increment/decrement, returns `true` if exceeded

**Parsers refactored to `RecursionGuard<K>` (depth + cycle detection):** `bun_lockb.rs` (`usize`), `nuget.rs` (`PathBuf`), `sbt.rs` (`String`), `swift_show_dependencies.rs` (`String` + `()`), `requirements_txt.rs` (`PathBuf`)

**Parsers refactored to `RecursionGuard<()>` (depth-only):** `dart.rs`, `bazel.rs`, `julia.rs`, `cargo.rs`, `uv_lock.rs`, `pylock_toml.rs`, `license_normalization.rs`, `npm_lock.rs`, `clojure.rs` (struct + free functions), `hex_lock.rs`, `meson.rs`, `nix.rs`

Removed 17 duplicate `MAX_RECURSION_DEPTH` constants; all parsers now use the shared `MAX_RECURSION_DEPTH` from `utils.rs`.

Skipped: `maven.rs`, `conan.rs`, `python.rs` — these have domain-specific extras (caches, node counts, resolution stacks) beyond simple depth+visited tracking.

## Skill file update

Updated `.opencode/skills/add-parser/SKILL.md` to document `RecursionGuard` in the security utilities section so future parser implementations use it from the start.

## Testing

- `cargo check` passes
- `cargo clippy` passes with zero warnings
- Pre-commit hooks (clippy, rustfmt, generate-supported-formats) all pass

## ADR Compliance

After this PR, all ~90 parser files comply with ADR 0004 across all 6 requirements:
1. No code execution
2. DoS protection (file size, recursion depth, iteration count, string length)
3. Archive safety (where applicable)
4. Input validation
5. Circular dependency detection (where applicable)
6. No `.unwrap()` in library code