### PR TITLE
perf(scan-result-shaping): replace O(D×N) directory scans with O(N) bottom-up tree traversal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ use crate::scan_result_shaping::{
     apply_cli_path_selection_filter, apply_ignore_resource_filter, apply_mark_source,
     apply_only_findings_filter, apply_user_path_filters_to_collected, filter_redundant_clues,
     filter_redundant_clues_with_rules, load_and_merge_json_inputs, normalize_paths,
-    normalize_top_level_output_paths, prepare_filter_clue_rule_lookup, resolve_native_scan_inputs,
-    trim_preloaded_assembly_to_files,
+    normalize_top_level_output_paths, populate_info_resource_counts,
+    prepare_filter_clue_rule_lookup, resolve_native_scan_inputs, trim_preloaded_assembly_to_files,
 };
 use crate::scanner::{
     LicenseScanOptions, TextDetectionOptions, collect_paths, process_collected_with_memory_limit,
@@ -893,44 +893,6 @@ fn should_include_info_surface(files: &[crate::models::FileInfo], cli: &Cli) -> 
                 || file.dirs_count.is_some()
                 || file.size_count.is_some()
         })
-}
-
-fn populate_info_resource_counts(files: &mut [crate::models::FileInfo]) {
-    let snapshot: Vec<(String, crate::models::FileType, u64)> = files
-        .iter()
-        .map(|file| (file.path.clone(), file.file_type.clone(), file.size))
-        .collect();
-
-    for file in files {
-        match file.file_type {
-            crate::models::FileType::Directory => {
-                let prefix = format!("{}/", file.path);
-                let mut files_count = 0usize;
-                let mut dirs_count = 0usize;
-                let mut size_count = 0u64;
-                for (path, file_type, size) in &snapshot {
-                    if !path.starts_with(&prefix) {
-                        continue;
-                    }
-                    match file_type {
-                        crate::models::FileType::Directory => dirs_count += 1,
-                        crate::models::FileType::File => {
-                            files_count += 1;
-                            size_count += *size;
-                        }
-                    }
-                }
-                file.files_count = Some(files_count);
-                file.dirs_count = Some(dirs_count);
-                file.size_count = Some(size_count);
-            }
-            crate::models::FileType::File => {
-                file.files_count = Some(0);
-                file.dirs_count = Some(0);
-                file.size_count = Some(0);
-            }
-        }
-    }
 }
 
 fn record_detail_timing<T, F>(progress: &Arc<ScanProgress>, name: impl Into<String>, f: F) -> T

--- a/src/scan_result_shaping/directory_tree.rs
+++ b/src/scan_result_shaping/directory_tree.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::models::{FileInfo, FileType};
+
+pub(crate) struct DirectoryTree {
+    child_dirs: HashMap<String, Vec<String>>,
+    dirs_deepest_first: Vec<String>,
+}
+
+impl DirectoryTree {
+    pub(crate) fn build(files: &[FileInfo]) -> Self {
+        let mut child_dirs: HashMap<String, Vec<String>> = HashMap::new();
+        let mut dir_paths: Vec<String> = Vec::new();
+
+        for entry in files {
+            if entry.file_type == FileType::Directory {
+                dir_paths.push(entry.path.clone());
+            }
+            if let Some(parent) = Path::new(&entry.path).parent().and_then(|p| p.to_str())
+                && !parent.is_empty()
+                && entry.file_type == FileType::Directory
+            {
+                child_dirs
+                    .entry(parent.to_string())
+                    .or_default()
+                    .push(entry.path.clone());
+            }
+        }
+
+        dir_paths.sort_by_key(|path| usize::MAX - Path::new(path).components().count());
+
+        DirectoryTree {
+            child_dirs,
+            dirs_deepest_first: dir_paths,
+        }
+    }
+
+    pub(crate) fn dirs_deepest_first(&self) -> &[String] {
+        &self.dirs_deepest_first
+    }
+
+    pub(crate) fn child_dirs(&self, dir_path: &str) -> &[String] {
+        self.child_dirs.get(dir_path).map_or(&[], |v| v)
+    }
+}

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod core_test;
+mod directory_tree;
 pub(crate) mod json_input;
 pub(crate) mod selection;
 #[cfg(test)]
@@ -32,11 +33,32 @@ where
         .map(|entry| entry.path.clone())
         .collect();
 
+    let tree = directory_tree::DirectoryTree::build(files);
+
+    let mut dir_has_kept_file: HashSet<String> = HashSet::new();
+    for path in &kept_file_paths {
+        if let Some(parent) = Path::new(path).parent().and_then(|p| p.to_str())
+            && !parent.is_empty()
+        {
+            dir_has_kept_file.insert(parent.to_string());
+        }
+    }
+
+    let mut dir_has_kept_descendant: HashSet<String> = HashSet::new();
+    for dir_path in tree.dirs_deepest_first() {
+        let has_direct = dir_has_kept_file.contains(dir_path);
+        let has_child_descendant = tree
+            .child_dirs(dir_path)
+            .iter()
+            .any(|child| dir_has_kept_descendant.contains(child));
+        if has_direct || has_child_descendant {
+            dir_has_kept_descendant.insert(dir_path.clone());
+        }
+    }
+
     files.retain(|entry| match entry.file_type {
         crate::models::FileType::File => kept_file_paths.contains(&entry.path),
-        crate::models::FileType::Directory => kept_file_paths
-            .iter()
-            .any(|path| Path::new(path).starts_with(Path::new(&entry.path))),
+        crate::models::FileType::Directory => dir_has_kept_descendant.contains(&entry.path),
     });
 }
 
@@ -45,6 +67,60 @@ where
     F: FnMut(&FileInfo) -> bool,
 {
     retain_matching_files_with_ancestor_dirs(files, keep_file);
+}
+
+pub(crate) fn populate_info_resource_counts(files: &mut [FileInfo]) {
+    let tree = directory_tree::DirectoryTree::build(files);
+
+    let mut direct_counts: HashMap<String, (usize, usize, u64)> = HashMap::new();
+    for file in files.iter() {
+        if let Some(parent) = Path::new(&file.path).parent().and_then(|p| p.to_str()) {
+            if parent.is_empty() {
+                continue;
+            }
+            let counts = direct_counts.entry(parent.to_string()).or_insert((0, 0, 0));
+            match file.file_type {
+                crate::models::FileType::File => {
+                    counts.0 += 1;
+                    counts.2 += file.size;
+                }
+                crate::models::FileType::Directory => {
+                    counts.1 += 1;
+                }
+            }
+        }
+    }
+
+    let mut descendant_counts: HashMap<String, (usize, usize, u64)> = HashMap::new();
+    for dir_path in tree.dirs_deepest_first() {
+        let (mut f, mut d, mut s) = direct_counts.get(dir_path).copied().unwrap_or((0, 0, 0));
+        for child in tree.child_dirs(dir_path) {
+            let (cf, cd, cs) = descendant_counts.get(child).copied().unwrap_or((0, 0, 0));
+            f += cf;
+            d += cd;
+            s += cs;
+        }
+        descendant_counts.insert(dir_path.clone(), (f, d, s));
+    }
+
+    for entry in files.iter_mut() {
+        match entry.file_type {
+            crate::models::FileType::Directory => {
+                let (f, d, s) = descendant_counts
+                    .get(&entry.path)
+                    .copied()
+                    .unwrap_or((0, 0, 0));
+                entry.files_count = Some(f);
+                entry.dirs_count = Some(d);
+                entry.size_count = Some(s);
+            }
+            crate::models::FileType::File => {
+                entry.files_count = Some(0);
+                entry.dirs_count = Some(0);
+                entry.size_count = Some(0);
+            }
+        }
+    }
 }
 
 fn has_findings(file: &FileInfo) -> bool {
@@ -585,36 +661,24 @@ pub(crate) fn apply_mark_source(files: &mut [FileInfo]) {
         entry.source_count = Some(0);
     }
 
-    let mut dir_paths = files
-        .iter()
-        .filter(|entry| entry.file_type == crate::models::FileType::Directory)
-        .map(|entry| entry.path.clone())
-        .collect::<Vec<_>>();
-    dir_paths.sort_by_key(|path| usize::MAX - Path::new(path).components().count());
+    let tree = directory_tree::DirectoryTree::build(files);
 
     let mut direct_file_count = HashMap::<String, usize>::new();
     let mut direct_source_file_count = HashMap::<String, usize>::new();
-    let mut child_dirs = HashMap::<String, Vec<String>>::new();
 
     for entry in files.iter() {
-        if let Some(parent) = Path::new(&entry.path).parent().and_then(|p| p.to_str()) {
+        if let Some(parent) = Path::new(&entry.path).parent().and_then(|p| p.to_str())
+            && entry.file_type == crate::models::FileType::File
+        {
+            let excluded_go_non_production = entry.programming_language.as_deref() == Some("Go")
+                && entry.is_source == Some(false);
+            if excluded_go_non_production {
+                continue;
+            }
             let parent_key = parent.to_string();
-            if entry.file_type == crate::models::FileType::File {
-                let excluded_go_non_production = entry.programming_language.as_deref()
-                    == Some("Go")
-                    && entry.is_source == Some(false);
-                if excluded_go_non_production {
-                    continue;
-                }
-                *direct_file_count.entry(parent_key.clone()).or_insert(0) += 1;
-                if entry.is_source.unwrap_or(false) {
-                    *direct_source_file_count.entry(parent_key).or_insert(0) += 1;
-                }
-            } else {
-                child_dirs
-                    .entry(parent_key)
-                    .or_default()
-                    .push(entry.path.clone());
+            *direct_file_count.entry(parent_key.clone()).or_insert(0) += 1;
+            if entry.is_source.unwrap_or(false) {
+                *direct_source_file_count.entry(parent_key).or_insert(0) += 1;
             }
         }
     }
@@ -622,20 +686,18 @@ pub(crate) fn apply_mark_source(files: &mut [FileInfo]) {
     let mut descendant_file_count = HashMap::<String, usize>::new();
     let mut descendant_source_count = HashMap::<String, usize>::new();
 
-    for dir_path in dir_paths {
-        let mut total_files = *direct_file_count.get(&dir_path).unwrap_or(&0);
-        let mut source_files = *direct_source_file_count.get(&dir_path).unwrap_or(&0);
+    for dir_path in tree.dirs_deepest_first() {
+        let mut total_files = *direct_file_count.get(dir_path).unwrap_or(&0);
+        let mut source_files = *direct_source_file_count.get(dir_path).unwrap_or(&0);
 
-        if let Some(children) = child_dirs.get(&dir_path) {
-            for child in children {
-                total_files += descendant_file_count.get(child).copied().unwrap_or(0);
-                source_files += descendant_source_count.get(child).copied().unwrap_or(0);
-            }
+        for child in tree.child_dirs(dir_path) {
+            total_files += descendant_file_count.get(child).copied().unwrap_or(0);
+            source_files += descendant_source_count.get(child).copied().unwrap_or(0);
         }
 
         let qualifies = total_files > 0 && (source_files as f64 / total_files as f64) >= 0.9;
 
-        if let Some(idx) = index_by_path.get(&dir_path)
+        if let Some(idx) = index_by_path.get(dir_path)
             && let Some(entry) = files.get_mut(*idx)
         {
             if qualifies && source_files > 0 {
@@ -648,7 +710,7 @@ pub(crate) fn apply_mark_source(files: &mut [FileInfo]) {
         }
 
         descendant_file_count.insert(dir_path.clone(), total_files);
-        descendant_source_count.insert(dir_path, if qualifies { source_files } else { 0 });
+        descendant_source_count.insert(dir_path.clone(), if qualifies { source_files } else { 0 });
     }
 }
 


### PR DESCRIPTION
## Summary

Replace quadratic directory-ancestor checks in post-scan operations with an O(N) bottom-up tree traversal, eliminating a ~2-hour bottleneck on large scans.

## Symptom

On a scan of 441,295 files across 114,863 directories with `--only-findings`, the post-scan phase took 7107 seconds — 92% of total runtime. The timing breakdown showed that `output-filter:only-findings` alone consumed 7097 seconds of that:

```
post-scan: 7106.72s
  output-filter:only-findings: 7097.17s    ← 99.8% of post-scan
  post-scan:license-provenance: 0.03s
  post-scan:path-normalization: 0.72s
  post-scan:package-reference-following: 8.78s
```

## Root Cause

Two functions used a brute-force pattern to answer "does this directory have any descendant matching files?" — iterating **all kept file paths** for **every directory entry** using `Path::starts_with()`:

1. **`retain_matching_files_with_ancestor_dirs`** — O(D × F) where D = directories, F = kept files. With 114k dirs × 441k files, this is ~50 billion `starts_with()` comparisons, each also allocating temporary `Path` wrappers.

2. **`populate_info_resource_counts`** — Same O(D × N) pattern. For each directory, iterates the entire file snapshot with `starts_with`. Not yet observed on a large scan (requires `--info`), but would be equally catastrophic.

## Fix

Extract a `DirectoryTree` struct that encapsulates the bottom-up tree traversal pattern already proven in `apply_mark_source`. The approach:

1. **Build a child-dir map** in a single O(N) pass: `HashMap<String, Vec<String>>` mapping each parent directory to its immediate child directories
2. **Sort directories deepest-first** (by path component count, descending)
3. **Walk bottom-up**, accumulating from already-computed children via memoized `HashSet`/`HashMap` lookups instead of scanning all file paths per directory

This turns O(D × F) inner loops into O(1) lookups per child directory.

### Changes

- **New `src/scan_result_shaping/directory_tree.rs`** — `DirectoryTree` struct with `build()`, `dirs_deepest_first()`, `child_dirs()`
- **Rewrite `retain_matching_files_with_ancestor_dirs`** — Uses `dir_has_kept_file` + bottom-up `dir_has_kept_descendant` `HashSet` instead of quadratic `starts_with` scan
- **Rewrite `populate_info_resource_counts`** — Moved from `main.rs` into `scan_result_shaping/`, uses `DirectoryTree` + bottom-up `(files, dirs, size)` accumulation instead of quadratic scan
- **Refactor `apply_mark_source`** — Delegates tree building to `DirectoryTree::build()` instead of its hand-rolled `child_dirs`/`dir_paths` construction

### Expected Impact

| Operation | Before | After | Speedup |
|-----------|--------|-------|---------|
| `output-filter:only-findings` | 7097s | <1s | ~7000× |
| `post-scan:info-resource-counts` | O(D×N) unmeasured | <1s | similar |
| Total scan (7664s) | — | ~566s | ~13× |

## Test plan

- [x] `cargo check` and `cargo clippy` pass with zero warnings
- [x] All 24 `scan_result_shaping::core_test` tests pass (covers `only_findings`, `mark_source`, `ignore_resource`, `path_selection`)
- [ ] Run with `--only-findings --verbose` on a sample directory and verify identical output
- [ ] Run with `--info` and verify resource counts on directory entries match the quadratic version