### PR TITLE
fix(copyright): stop directive absorption and support single-file compare targets

### DIFF
--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -277,6 +277,18 @@ fn is_tabular_noise_line(line: &str) -> bool {
     false
 }
 
+fn is_noncopyright_at_directive_line(prepared: &str) -> bool {
+    let trimmed = prepared.trim_start();
+    let mut chars = trimmed.chars();
+    let starts_with_lowercase_directive =
+        matches!(chars.next(), Some('@')) && chars.next().is_some_and(|c| c.is_ascii_lowercase());
+
+    starts_with_lowercase_directive
+        && !hints::has_year(trimmed)
+        && !trimmed.contains("://")
+        && !has_copyright_indicators(trimmed)
+}
+
 /// A numbered line: (1-based line number, prepared text).
 pub type NumberedLine = (usize, String);
 
@@ -405,6 +417,16 @@ where
             }
 
             let prepared = prepare_text_line(line);
+            if is_noncopyright_at_directive_line(&prepared) {
+                if !candidates.is_empty() {
+                    groups.push(std::mem::take(&mut candidates));
+                }
+                in_copyright = 0;
+                previous_chars = None;
+                prev_prepared_is_copy_start_with_year = false;
+                continue;
+            }
+
             let prepared_chars = chars_only(&prepared);
 
             let prepared_is_copy_start_with_year = is_copy_marker_start(prepared.trim_start());
@@ -477,6 +499,16 @@ where
             let prepared = prepare_text_line(line);
             let trimmed = prepared.trim_start();
             let lower = trimmed.to_ascii_lowercase();
+
+            if is_noncopyright_at_directive_line(trimmed) {
+                if !candidates.is_empty() {
+                    groups.push(std::mem::take(&mut candidates));
+                }
+                in_copyright = 0;
+                previous_chars = None;
+                prev_prepared_is_copy_start_with_year = false;
+                continue;
+            }
 
             let is_author_header = (lower == "authors"
                 || lower.starts_with("authors:")
@@ -928,6 +960,41 @@ mod tests {
         // line 3 is end-of-statement → yields group.
         assert_eq!(groups.len(), 1, "groups: {groups:?}");
         assert_eq!(groups[0].len(), 3);
+    }
+
+    #[test]
+    fn test_noncopyright_at_directive_line_detection() {
+        assert!(is_noncopyright_at_directive_line(
+            "@lint-ignore-every FBOBJCIMPORTORDER1 METHOD_BRACKETSMETHOD_BRACKETS"
+        ));
+        assert!(!is_noncopyright_at_directive_line("@author Jane Doe"));
+        assert!(!is_noncopyright_at_directive_line(
+            "@copyright 2024 Example Corp."
+        ));
+        assert!(!is_noncopyright_at_directive_line("@History:"));
+    }
+
+    #[test]
+    fn test_collect_breaks_before_noncopyright_at_directive_line() {
+        let lines = vec![
+            (
+                1,
+                "// (c) Example Corp. and affiliates. Confidential and proprietary.".to_string(),
+            ),
+            (
+                2,
+                "// @lint-ignore-every FBOBJCIMPORTORDER1 METHOD_BRACKETSMETHOD_BRACKETS"
+                    .to_string(),
+            ),
+        ];
+
+        let groups = collect_candidate_lines(lines);
+        assert_eq!(groups.len(), 1, "groups: {groups:?}");
+        assert_eq!(groups[0].len(), 1, "groups: {groups:?}");
+        assert_eq!(
+            groups[0][0].1,
+            "(c) Example Corp. and affiliates. Confidential and proprietary."
+        );
     }
 
     #[test]

--- a/src/copyright/detector.rs
+++ b/src/copyright/detector.rs
@@ -11825,6 +11825,31 @@ fn is_same_line_holder_suffix_prefix(tree: &[ParseNode], idx: usize, line: LineN
     })
 }
 
+fn has_same_line_confidential_proprietary_suffix(
+    copyright_node: &ParseNode,
+    tree: &[ParseNode],
+    start: usize,
+    line: LineNumber,
+) -> bool {
+    let node_has_confidential = collect_all_leaves(copyright_node)
+        .iter()
+        .any(|t| t.start_line == line && t.value.eq_ignore_ascii_case("Confidential"));
+    if !node_has_confidential {
+        return false;
+    }
+
+    let end = std::cmp::min(start + 6, tree.len());
+    tree[start + 1..end].iter().any(|node| {
+        collect_all_leaves(node).iter().any(|token| {
+            token.start_line == line
+                && token
+                    .value
+                    .trim_end_matches(|c: char| c.is_ascii_punctuation())
+                    .eq_ignore_ascii_case("proprietary")
+        })
+    })
+}
+
 fn is_orphan_copy_name_match(node: &ParseNode) -> bool {
     match node.label() {
         Some(TreeLabel::NameYear) | Some(TreeLabel::NameEmail) | Some(TreeLabel::Company) => true,
@@ -12081,7 +12106,16 @@ fn should_start_absorbing(copyright_node: &ParseNode, tree: &[ParseNode], start:
             tree[start + 1..end].iter().enumerate().any(|(offset, _)| {
                 is_same_line_holder_suffix_prefix(tree, start + 1 + offset, token.start_line)
             });
-        if has_expected_continuation || has_holder_suffix_prefix {
+        let has_confidential_proprietary_suffix = has_same_line_confidential_proprietary_suffix(
+            copyright_node,
+            tree,
+            start,
+            token.start_line,
+        );
+        if has_expected_continuation
+            || has_holder_suffix_prefix
+            || has_confidential_proprietary_suffix
+        {
             return true;
         }
     }

--- a/src/copyright/detector_test.rs
+++ b/src/copyright/detector_test.rs
@@ -818,6 +818,41 @@ fn test_copyright_span_does_not_absorb_following_author_line() {
 }
 
 #[test]
+fn test_copyright_span_does_not_absorb_following_lint_directive_line() {
+    let input = concat!(
+        "// (c) Example Corp. and affiliates. Confidential and proprietary.\n",
+        "// @lint-ignore-every FBOBJCIMPORTORDER1 METHOD_BRACKETSMETHOD_BRACKETS\n",
+    );
+
+    let (copyrights, _holders, _authors) = detect_copyrights_from_text(input);
+    let values: Vec<String> = copyrights.into_iter().map(|c| c.copyright).collect();
+
+    assert!(
+        values
+            .iter()
+            .any(|c| c == "(c) Example Corp. and affiliates. Confidential and proprietary"),
+        "copyrights: {values:#?}"
+    );
+    assert!(
+        !values.iter().any(|c| c.contains("@lint-ignore-every")),
+        "copyrights: {values:#?}"
+    );
+}
+
+#[test]
+fn test_history_written_by_fixture_keeps_following_author() {
+    let path = PathBuf::from("testdata/copyright-golden/copyrights/misco4/more-linux/multi.txt");
+    let content = fs::read_to_string(&path).expect("read fixture");
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(&content);
+
+    let values: Vec<String> = authors.into_iter().map(|a| a.author).collect();
+    assert!(
+        values.iter().any(|a| a == "Ben Dooks <ben@simtec.co.uk>"),
+        "authors: {values:#?}"
+    );
+}
+
+#[test]
 fn test_multilines_fixture_detects_split_copyright_by_holder() {
     let path = PathBuf::from("testdata/copyright-golden/copyrights/misco4/linux4/multilines.txt");
     let content = fs::read_to_string(&path).expect("read fixture");
@@ -3074,6 +3109,45 @@ fn test_detect_copyright_holder_suffix_the_respective_contributors() {
         h
     );
     assert!(a.is_empty(), "Unexpected authors detected: {:?}", a);
+}
+
+#[test]
+fn test_collect_trailing_orphan_tokens_keeps_confidential_and_proprietary_phrase() {
+    let text = "(c) Example Corp. and affiliates. Confidential and proprietary.";
+    let prepared = super::super::prepare::prepare_text_line(text);
+    let tokens = get_tokens(&[(1, prepared)]);
+    let tree = parse(tokens);
+    let (copyright_idx, copyright_node) = tree
+        .iter()
+        .enumerate()
+        .find(|(_i, n)| {
+            matches!(
+                n.label(),
+                Some(TreeLabel::Copyright) | Some(TreeLabel::Copyright2)
+            )
+        })
+        .expect("Should parse a COPYRIGHT node");
+    let start = copyright_idx + 1;
+
+    assert!(
+        should_start_absorbing(copyright_node, &tree, start),
+        "Should absorb trailing confidentiality phrase; tree={:?}",
+        tree
+    );
+
+    let (trailing, _skip) = collect_trailing_orphan_tokens(copyright_node, &tree, start);
+    let trailing_values: Vec<&str> = trailing.iter().map(|t| t.value.as_str()).collect();
+
+    assert!(
+        trailing_values.contains(&"and"),
+        "Trailing tokens should include trailing conjunction, got: {:?}",
+        trailing_values
+    );
+    assert!(
+        trailing_values.contains(&"proprietary."),
+        "Trailing tokens should include 'proprietary.', got: {:?}",
+        trailing_values
+    );
 }
 
 #[test]

--- a/src/copyright/refiner_test.rs
+++ b/src/copyright/refiner_test.rs
@@ -428,6 +428,16 @@ fn test_refine_copyright_empty() {
 }
 
 #[test]
+fn test_refine_copyright_keeps_confidential_and_proprietary_phrase() {
+    let result =
+        refine_copyright("(c) Example Corp. and affiliates. Confidential and proprietary.");
+    assert_eq!(
+        result,
+        Some("(c) Example Corp. and affiliates. Confidential and proprietary".to_string())
+    );
+}
+
+#[test]
 fn test_refine_copyright_strips_junk_prefix() {
     let result = refine_copyright("by Copyright 2024 Acme");
     assert_eq!(result, Some("Copyright 2024 Acme".to_string()));

--- a/testdata/copyright-golden/copyrights/copytest/anonymized_lint_directive_not_absorbed.txt
+++ b/testdata/copyright-golden/copyrights/copytest/anonymized_lint_directive_not_absorbed.txt
@@ -1,0 +1,2 @@
+// (c) Example Corp. and affiliates. Confidential and proprietary.
+// @lint-ignore-every FBOBJCIMPORTORDER1 METHOD_BRACKETSMETHOD_BRACKETS

--- a/testdata/copyright-golden/copyrights/copytest/anonymized_lint_directive_not_absorbed.txt.yml
+++ b/testdata/copyright-golden/copyrights/copytest/anonymized_lint_directive_not_absorbed.txt.yml
@@ -1,0 +1,4 @@
+what:
+  - copyrights
+copyrights:
+  - (c) Example Corp. and affiliates. Confidential and proprietary

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -316,7 +316,12 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
     fs::create_dir_all(&raw_dir)?;
     fs::create_dir_all(&samples_dir)?;
     let target_dir = if let Some(target_path) = &args.target_path {
-        realpath(target_path)?
+        let resolved_target = realpath(target_path)?;
+        if resolved_target.is_file() {
+            run_dir.join("input")
+        } else {
+            resolved_target
+        }
     } else {
         run_dir.join(&slug)
     };
@@ -383,16 +388,20 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
 
 fn prepare_target(context: &mut ContextState, args: &Args) -> Result<CheckoutGuard> {
     if let Some(target_path) = &args.target_path {
-        if let Some(log_line) = current_git_log_line(&realpath(target_path)?) {
+        let resolved_target = realpath(target_path)?;
+        if let Some(log_line) = current_git_log_line(&resolved_target) {
             println!("{log_line}");
         } else {
             println!(
-                "  Using local directory without git metadata: {}",
-                context.target_dir.display()
+                "  Using local path without git metadata: {}",
+                resolved_target.display()
             );
         }
-        context.target_revision = current_git_revision(&context.target_dir)
+        context.target_revision = current_git_revision(&resolved_target)
             .unwrap_or_else(|| "current local checkout".to_string());
+        if resolved_target.is_file() {
+            materialize_file(&resolved_target, &context.target_dir)?;
+        }
         return Ok(CheckoutGuard {
             cache_dir: None,
             target_dir: context.target_dir.clone(),
@@ -766,10 +775,29 @@ fn normalize_scancode_error_path(path: &str) -> String {
         .to_string()
 }
 
+fn build_provenant_invocation(context: &ContextState) -> (PathBuf, String) {
+    if context.target_dir.is_file() {
+        let working_dir = context
+            .target_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        let input_arg = context
+            .target_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| ".".to_string());
+        (working_dir, input_arg)
+    } else {
+        (context.target_dir.clone(), ".".to_string())
+    }
+}
+
 fn run_provenant(context: &ContextState) -> Result<()> {
     println!("------------------------------------------");
     println!("Running Provenant");
     println!("------------------------------------------");
+    let (working_dir, _input_arg) = build_provenant_invocation(context);
     let args = build_provenant_args(context);
     println!(
         "  {}",
@@ -782,7 +810,7 @@ fn run_provenant(context: &ContextState) -> Result<()> {
     let (combined, log_warning) = run_and_capture_optional_log(
         context.provenant_bin.to_str().unwrap(),
         &args,
-        Some(&context.target_dir),
+        Some(&working_dir),
         &context.provenant_stdout,
     )?;
     if let Some(log_warning) = log_warning {
@@ -1486,6 +1514,7 @@ fn tsv_row(metric: &str, scancode: i64, provenant: i64, delta: i64, notes: &str)
 fn write_manifest(context: &ContextState) -> Result<()> {
     let scancode_args = build_scancode_docker_args(context);
     let provenant_args = build_provenant_args(context);
+    let (provenant_working_dir, _provenant_input_arg) = build_provenant_invocation(context);
     let manifest = CompareRunManifest {
         run_id: context.run_id.clone(),
         target: TargetManifest::new(
@@ -1493,7 +1522,7 @@ fn write_manifest(context: &ContextState) -> Result<()> {
             context.target_label.clone(),
             context.target_revision.clone(),
             if context.target_source_label == "Target path" {
-                Some(context.target_dir.clone())
+                Some(PathBuf::from(&context.target_label))
             } else {
                 None
             },
@@ -1522,7 +1551,7 @@ fn write_manifest(context: &ContextState) -> Result<()> {
                         .chain(provenant_args.iter().cloned())
                         .collect::<Vec<_>>(),
                 ),
-                working_directory: Some(context.target_dir.clone()),
+                working_directory: Some(provenant_working_dir),
             },
         },
         provenant: ProvenantManifest {
@@ -1580,6 +1609,7 @@ fn build_scancode_docker_args(context: &ContextState) -> Vec<String> {
 }
 
 fn build_provenant_args(context: &ContextState) -> Vec<String> {
+    let (_working_dir, input_arg) = build_provenant_invocation(context);
     let mut args = vec![
         "--json-pp".to_string(),
         context.provenant_json.display().to_string(),
@@ -1587,7 +1617,7 @@ fn build_provenant_args(context: &ContextState) -> Vec<String> {
     ];
     args.extend(context.scan_args.clone());
     args.extend(provenant_ignore_args());
-    args.push(".".to_string());
+    args.push(input_arg);
     args
 }
 
@@ -2230,6 +2260,105 @@ mod tests {
         let args = build_provenant_args(&context);
 
         assert!(args.iter().any(|arg| arg == "--no-license-index-cache"));
+    }
+
+    #[test]
+    fn build_provenant_args_uses_staged_input_file_for_single_file_targets() {
+        let temp_root = unique_temp_dir("single-file-provenant-args");
+        fs::create_dir_all(&temp_root).unwrap();
+        let staged_input = temp_root.join("input");
+        fs::write(&staged_input, "fixture").unwrap();
+
+        let mut context = test_context();
+        context.target_dir = staged_input;
+
+        let args = build_provenant_args(&context);
+
+        assert_eq!(args.last().map(String::as_str), Some("input"));
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn build_provenant_invocation_uses_parent_dir_for_single_file_targets() {
+        let temp_root = unique_temp_dir("single-file-provenant-invocation");
+        fs::create_dir_all(&temp_root).unwrap();
+        let staged_input = temp_root.join("input");
+        fs::write(&staged_input, "fixture").unwrap();
+
+        let mut context = test_context();
+        context.target_dir = staged_input;
+
+        let (working_dir, input_arg) = build_provenant_invocation(&context);
+
+        assert_eq!(working_dir, temp_root);
+        assert_eq!(input_arg, "input");
+
+        let _ = fs::remove_dir_all(&working_dir);
+    }
+
+    #[test]
+    fn prepare_context_stages_single_file_targets_as_input() {
+        let temp_root = unique_temp_dir("single-file-target-context");
+        fs::create_dir_all(&temp_root).unwrap();
+        let fixture = temp_root.join("fixture.txt");
+        fs::write(&fixture, "fixture").unwrap();
+
+        let args = Args {
+            repo_url: None,
+            target_path: Some(fixture.clone()),
+            scancode_cache_identity: Some("fixture@rev".to_string()),
+            repo_ref: None,
+            profile: None,
+            scan_args: Vec::new(),
+        };
+
+        let context = prepare_context(&args, vec!["--copyright".to_string()]).unwrap();
+
+        assert_eq!(
+            context.target_label,
+            realpath(&fixture).unwrap().display().to_string()
+        );
+        assert_eq!(
+            context
+                .target_dir
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("input")
+        );
+        assert_ne!(context.target_dir, fixture);
+
+        let _ = fs::remove_dir_all(&temp_root);
+        let _ = fs::remove_dir_all(&context.run_dir);
+    }
+
+    #[test]
+    fn prepare_target_materializes_single_file_target_into_staged_input() {
+        let temp_root = unique_temp_dir("single-file-target-prepare");
+        fs::create_dir_all(&temp_root).unwrap();
+        let fixture = temp_root.join("fixture.txt");
+        fs::write(&fixture, "fixture contents").unwrap();
+
+        let mut context = test_context();
+        context.target_dir = temp_root.join("run/input");
+        let args = Args {
+            repo_url: None,
+            target_path: Some(fixture.clone()),
+            scancode_cache_identity: Some("fixture@rev".to_string()),
+            repo_ref: None,
+            profile: None,
+            scan_args: Vec::new(),
+        };
+
+        let _guard = prepare_target(&mut context, &args).unwrap();
+
+        assert!(context.target_dir.is_file());
+        assert_eq!(
+            fs::read_to_string(&context.target_dir).unwrap(),
+            "fixture contents"
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stop copyright detections from absorbing lowercase trailing directive comment lines such as `@lint-ignore-every` while preserving the full `Confidential and proprietary` notice text
- add focused detector/refiner regressions plus an anonymized copyright golden fixture for the reported case and the `@History:` author follow-up case
- fix `xtask compare-outputs` for single-file `--target-path` runs by staging file inputs consistently so ScanCode and Provenant compare the same logical path

## Issues

- Covers: reported copyright false positive on trailing directive lines and the follow-up single-file `compare-outputs` failure
- Closes:

## Scope and exclusions

- Included: copyright candidate grouping and same-line suffix handling, regression tests/golden coverage, and the xtask single-file compare workflow
- Explicit exclusions: broader heuristic tightening for other theoretical multiline marker classes beyond the reproduced cases

## Intentional differences from Python

- For the reproduced two-line fixture, Provenant now drops the trailing directive line but preserves `Confidential and proprietary`; current ScanCode avoids the directive append too, but truncates the notice earlier at `Confidential`

## Follow-up work

- Created or intentionally deferred: broader investigation of other weak multiline marker classes (for example URL-follow-up lines or author-like prose) was deferred because this branch closes the reproduced bugs without new failing fixtures

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/copytest/anonymized_lint_directive_not_absorbed.txt` and `.yml`
- Why the new expected output is correct: the trailing `@lint-ignore-every` line is scanner metadata rather than copyright text, while the full first-line notice `Confidential and proprietary` should remain part of the extracted copyright