### PR TITLE
fix(output): preserve hoisted SPDX license data

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -355,6 +355,28 @@ mod tests {
     }
 
     #[test]
+    fn test_detected_license_expression_spdx_prefers_detection_spdx_values() {
+        let mut internal = sample_internal_output();
+        internal.files[0].license_expression = Some("mit".to_string());
+
+        let schema_file = OutputFileInfo::from(&internal.files[0]);
+        let schema_value = serde_json::to_value(&schema_file).expect("file info serializes");
+        assert_eq!(schema_value["detected_license_expression_spdx"], "MIT");
+
+        let output = Output::from(&internal);
+        let mut bytes = Vec::new();
+        writer_for_format(OutputFormat::Json)
+            .write(&output, &mut bytes, &OutputWriteConfig::default())
+            .expect("json write should succeed");
+
+        let rendered: Value = serde_json::from_slice(&bytes).expect("json output should parse");
+        assert_eq!(
+            rendered["files"][0]["detected_license_expression_spdx"],
+            "MIT"
+        );
+    }
+
+    #[test]
     fn test_json_lines_writer_sorts_files_by_path_for_reproducibility() {
         let mut internal = sample_internal_output();
         internal.files.reverse();

--- a/src/output/public_serialize.rs
+++ b/src/output/public_serialize.rs
@@ -675,7 +675,10 @@ impl Serialize for PublicFileInfo<'_> {
         }
 
         map.serialize_entry("package_data", &PublicPackageDataSeq(&file.package_data))?;
-        map.serialize_entry("detected_license_expression_spdx", &file.license_expression)?;
+        map.serialize_entry(
+            "detected_license_expression_spdx",
+            &file.detected_license_expression_spdx(),
+        )?;
         map.serialize_entry("license_detections", &file.license_detections)?;
         if file.should_serialize_license_surface() {
             map.serialize_entry("license_clues", &file.license_clues)?;

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -109,6 +109,29 @@ impl OutputFileInfo {
             || !self.license_clues.is_empty()
             || self.percentage_of_license_text.is_some()
     }
+
+    pub(crate) fn detected_license_expression_spdx(&self) -> Option<String> {
+        crate::utils::spdx::combine_license_expressions(
+            self.license_detections
+                .iter()
+                .filter(|detection| !detection.license_expression_spdx.is_empty())
+                .map(|detection| detection.license_expression_spdx.clone()),
+        )
+        .or_else(|| {
+            crate::utils::spdx::combine_license_expressions(
+                self.package_data
+                    .iter()
+                    .flat_map(|package_data| package_data.license_detections.iter())
+                    .filter(|detection| !detection.license_expression_spdx.is_empty())
+                    .map(|detection| detection.license_expression_spdx.clone()),
+            )
+        })
+        .or_else(|| {
+            self.license_expression
+                .clone()
+                .filter(|expression| !expression.is_empty())
+        })
+    }
 }
 
 impl Serialize for OutputFileInfo {
@@ -148,7 +171,7 @@ impl Serialize for OutputFileInfo {
         insert_json(
             &mut map,
             "detected_license_expression_spdx",
-            &self.license_expression,
+            self.detected_license_expression_spdx(),
         )?;
         insert_json(&mut map, "license_detections", &self.license_detections)?;
         if self.should_serialize_license_surface() {

--- a/src/parsers/debian.rs
+++ b/src/parsers/debian.rs
@@ -2100,6 +2100,26 @@ fn merge_debian_copyright_into_package(target: &mut PackageData, copyright: &Pac
         target.extracted_license_statement = copyright.extracted_license_statement.clone();
     }
 
+    if target.declared_license_expression.is_none() {
+        target.declared_license_expression = copyright.declared_license_expression.clone();
+    }
+    if target.declared_license_expression_spdx.is_none() {
+        target.declared_license_expression_spdx =
+            copyright.declared_license_expression_spdx.clone();
+    }
+    if target.license_detections.is_empty() {
+        target.license_detections = copyright.license_detections.clone();
+    }
+    if target.other_license_expression.is_none() {
+        target.other_license_expression = copyright.other_license_expression.clone();
+    }
+    if target.other_license_expression_spdx.is_none() {
+        target.other_license_expression_spdx = copyright.other_license_expression_spdx.clone();
+    }
+    if target.other_license_detections.is_empty() {
+        target.other_license_detections = copyright.other_license_detections.clone();
+    }
+
     for party in &copyright.parties {
         if !target.parties.iter().any(|existing| {
             existing.r#type == party.r#type
@@ -3696,6 +3716,40 @@ Copyright (C) 2015-2018 Example Corp";
         assert_eq!(pkg.name, Some("test".to_string()));
         assert!(pkg.parties.is_empty());
         assert!(pkg.extracted_license_statement.is_none());
+    }
+
+    #[test]
+    fn test_merge_debian_copyright_into_package_preserves_license_fields() {
+        let copyright = parse_copyright_file(
+            "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n\
+             Upstream-Name: demo\n\n\
+             Files: *\n\
+             Copyright: 2024 Example\n\
+             License: MIT\n\n\
+             Files: debian/*\n\
+             Copyright: 2024 Debian Example\n\
+             License: Apache-2.0\n",
+            Some("demo"),
+        );
+        let mut target = default_package_data(DatasourceId::DebianDeb);
+
+        merge_debian_copyright_into_package(&mut target, &copyright);
+
+        assert_eq!(target.declared_license_expression.as_deref(), Some("mit"));
+        assert_eq!(
+            target.declared_license_expression_spdx.as_deref(),
+            Some("MIT")
+        );
+        assert_eq!(
+            target.other_license_expression.as_deref(),
+            Some("apache-2.0")
+        );
+        assert_eq!(
+            target.other_license_expression_spdx.as_deref(),
+            Some("Apache-2.0")
+        );
+        assert_eq!(target.license_detections.len(), 1);
+        assert_eq!(target.other_license_detections.len(), 1);
     }
 
     #[test]

--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -789,6 +789,9 @@ pub(crate) fn project_package_fields(value: &Value) -> Value {
                     "version": package.get("version").cloned().unwrap_or(Value::Null),
                     "purl": package.get("purl").cloned().unwrap_or(Value::Null),
                     "declared_license_expression": package.get("declared_license_expression").cloned().unwrap_or(Value::Null),
+                    "declared_license_expression_spdx": package.get("declared_license_expression_spdx").cloned().unwrap_or(Value::Null),
+                    "other_license_expression": package.get("other_license_expression").cloned().unwrap_or(Value::Null),
+                    "other_license_expression_spdx": package.get("other_license_expression_spdx").cloned().unwrap_or(Value::Null),
                     "datafile_paths": package.get("datafile_paths").cloned().unwrap_or_else(|| json!([])),
                     "datasource_ids": package.get("datasource_ids").cloned().unwrap_or_else(|| json!([])),
                 })
@@ -979,6 +982,7 @@ pub(crate) fn project_reference_follow_fields(value: &Value) -> Value {
                 "declared_license_expression": package.get("declared_license_expression").cloned().unwrap_or(Value::Null),
                 "declared_license_expression_spdx": package.get("declared_license_expression_spdx").cloned().unwrap_or(Value::Null),
                 "other_license_expression": package.get("other_license_expression").cloned().unwrap_or(Value::Null),
+                "other_license_expression_spdx": package.get("other_license_expression_spdx").cloned().unwrap_or(Value::Null),
                 "datafile_paths": package.get("datafile_paths").cloned().unwrap_or_else(|| json!([])),
                 "license_detections": package
                     .get("license_detections")
@@ -1043,6 +1047,7 @@ pub(crate) fn project_reference_follow_fields(value: &Value) -> Value {
                             "declared_license_expression": package_data.get("declared_license_expression").cloned().unwrap_or(Value::Null),
                             "declared_license_expression_spdx": package_data.get("declared_license_expression_spdx").cloned().unwrap_or(Value::Null),
                             "other_license_expression": package_data.get("other_license_expression").cloned().unwrap_or(Value::Null),
+                            "other_license_expression_spdx": package_data.get("other_license_expression_spdx").cloned().unwrap_or(Value::Null),
                             "license_detections": package_data
                                 .get("license_detections")
                                 .and_then(Value::as_array)
@@ -1146,6 +1151,89 @@ pub(crate) fn assert_package_fixture_matches_expected(fixture_dir: &str, expecte
             error,
             serde_json::to_string_pretty(&actual_normalized).unwrap_or_default(),
             serde_json::to_string_pretty(&expected_normalized).unwrap_or_default()
+        );
+    }
+}
+
+#[cfg(all(test, feature = "golden-tests"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_projection_helpers_keep_other_license_expression_spdx() {
+        let package_projection = project_package_fields(&json!({
+            "packages": [
+                {
+                    "type": "deb",
+                    "name": "demo",
+                    "declared_license_expression": "mit",
+                    "declared_license_expression_spdx": "MIT",
+                    "other_license_expression": "apache-2.0",
+                    "other_license_expression_spdx": "Apache-2.0",
+                    "datafile_paths": [],
+                    "datasource_ids": []
+                }
+            ],
+            "dependencies": []
+        }));
+        assert_eq!(
+            package_projection["packages"][0]["other_license_expression_spdx"],
+            json!("Apache-2.0")
+        );
+
+        let reference_projection = project_reference_follow_fields(&json!({
+            "packages": [
+                {
+                    "type": "deb",
+                    "name": "demo",
+                    "declared_license_expression": "mit",
+                    "declared_license_expression_spdx": "MIT",
+                    "other_license_expression": "apache-2.0",
+                    "other_license_expression_spdx": "Apache-2.0",
+                    "datafile_paths": [],
+                    "license_detections": [],
+                    "other_license_detections": []
+                }
+            ],
+            "files": [
+                {
+                    "path": "demo/copyright",
+                    "type": "file",
+                    "is_top_level": true,
+                    "is_key_file": true,
+                    "is_manifest": true,
+                    "detected_license_expression": null,
+                    "detected_license_expression_spdx": null,
+                    "license_detections": [],
+                    "package_data": [
+                        {
+                            "type": "deb",
+                            "name": "demo",
+                            "version": "1.0.0",
+                            "declared_license_expression": "mit",
+                            "declared_license_expression_spdx": "MIT",
+                            "other_license_expression": "apache-2.0",
+                            "other_license_expression_spdx": "Apache-2.0",
+                            "license_detections": [],
+                            "other_license_detections": []
+                        }
+                    ]
+                }
+            ],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": [],
+            "summary": null,
+            "tallies": null,
+            "tallies_of_key_files": null
+        }));
+        assert_eq!(
+            reference_projection["packages"][0]["other_license_expression_spdx"],
+            json!("Apache-2.0")
+        );
+        assert_eq!(
+            reference_projection["files"][0]["package_data"][0]["other_license_expression_spdx"],
+            json!("Apache-2.0")
         );
     }
 }

--- a/testdata/summarycode-golden/reference_following-expected/root_license_preferred_over_top_level_sibling.expected.json
+++ b/testdata/summarycode-golden/reference_following-expected/root_license_preferred_over_top_level_sibling.expected.json
@@ -247,7 +247,7 @@
       "is_key_file": false,
       "is_manifest": false,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "mit",
+      "detected_license_expression_spdx": "MIT",
       "license_detections": [
         {
           "license_expression": "mit",

--- a/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
+++ b/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
@@ -231,7 +231,7 @@
       "is_key_file": false,
       "is_manifest": false,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "bsd-new",
+      "detected_license_expression_spdx": "BSD-3-Clause",
       "license_detections": [
         {
           "license_expression": "bsd-new",

--- a/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
+++ b/testdata/summarycode-golden/reference_following/license_beside_manifest/expected.json
@@ -307,7 +307,7 @@
       "is_key_file": true,
       "is_manifest": true,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "mit",
+      "detected_license_expression_spdx": "MIT",
       "license_detections": [
         {
           "license_expression": "mit",

--- a/testdata/summarycode-golden/reference_following/manifest_origin_local_file/expected.json
+++ b/testdata/summarycode-golden/reference_following/manifest_origin_local_file/expected.json
@@ -219,7 +219,7 @@
       "is_key_file": true,
       "is_manifest": true,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "mit",
+      "detected_license_expression_spdx": "MIT",
       "license_detections": [
         {
           "license_expression": "mit",

--- a/testdata/summarycode-golden/reference_following/readme_mit_see_license/expected.json
+++ b/testdata/summarycode-golden/reference_following/readme_mit_see_license/expected.json
@@ -190,7 +190,7 @@
       "is_key_file": true,
       "is_manifest": false,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "mit",
+      "detected_license_expression_spdx": "MIT",
       "license_detections": [
         {
           "license_expression": "mit",

--- a/testdata/summarycode-golden/reference_following/root_fallback_no_package/expected.json
+++ b/testdata/summarycode-golden/reference_following/root_fallback_no_package/expected.json
@@ -210,7 +210,7 @@
       "is_key_file": false,
       "is_manifest": false,
       "detected_license_expression": null,
-      "detected_license_expression_spdx": "mit",
+      "detected_license_expression_spdx": "MIT",
       "license_detections": [
         {
           "license_expression": "mit",

--- a/testdata/summarycode-golden/tallies/packages/expected.json
+++ b/testdata/summarycode-golden/tallies/packages/expected.json
@@ -25,15 +25,15 @@
       "copyright": null,
       "holder": null,
       "declared_license_expression": "public-domain",
-      "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
+      "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
       "license_detections": [
         {
           "license_expression": "public-domain",
-          "license_expression_spdx": "LicenseRef-scancode-public-domain",
+          "license_expression_spdx": "LicenseRef-provenant-public-domain",
           "matches": [
             {
               "license_expression": "public-domain",
-              "license_expression_spdx": "LicenseRef-scancode-public-domain",
+              "license_expression_spdx": "LicenseRef-provenant-public-domain",
               "from_file": "scan/aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
               "start_line": 1,
               "end_line": 1,
@@ -1199,15 +1199,15 @@
           "copyright": null,
           "holder": null,
           "declared_license_expression": "public-domain",
-          "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
+          "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
           "license_detections": [
             {
               "license_expression": "public-domain",
-              "license_expression_spdx": "LicenseRef-scancode-public-domain",
+              "license_expression_spdx": "LicenseRef-provenant-public-domain",
               "matches": [
                 {
                   "license_expression": "public-domain",
-                  "license_expression_spdx": "LicenseRef-scancode-public-domain",
+                  "license_expression_spdx": "LicenseRef-provenant-public-domain",
                   "from_file": "scan/aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
                   "start_line": 1,
                   "end_line": 1,


### PR DESCRIPTION
## Summary

- derive `detected_license_expression_spdx` from SPDX-bearing detections instead of the overloaded internal file field
- preserve Debian copyright license expressions, SPDX siblings, and detections when merging parsed copyright metadata into package data
- include `other_license_expression_spdx` in golden package/reference-follow projections so sibling hoist regressions stay visible

## Scope and exclusions

- Included: file-level SPDX output serialization, Debian package license merge behavior, golden projection coverage for package SPDX sibling fields
- Explicit exclusions: broader internal model renaming or storage cleanup for ScanCode-vs-SPDX license fields

## Intentional differences from Python

- None; this aligns hoisted SPDX output with ScanCode semantics and preserves Debian package license metadata that was already parsed but previously dropped during merge

## Follow-up work

- Created or intentionally deferred: consider separating internal ScanCode and SPDX storage fields to reduce future hoisting ambiguity