### PR TITLE
refactor(license-detection): replace rmp_serde with postcard for embedded artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +953,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -2786,6 +2807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,12 +2921,12 @@ dependencies = [
  "packageurl",
  "pdf_oxide",
  "pep508_rs",
+ "postcard",
  "quick-xml",
  "rancor",
  "rayon",
  "regex",
  "rkyv",
- "rmp-serde",
  "rpm",
  "rusqlite",
  "rustc_version_runtime",
@@ -2925,10 +2958,10 @@ dependencies = [
  "anyhow",
  "clap",
  "inventory",
+ "postcard",
  "provenant-cli",
  "rayon",
  "regex",
- "rmp-serde",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3201,25 +3234,6 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rmp"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
-dependencies = [
- "rmp",
- "serde",
-]
 
 [[package]]
 name = "rpm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ pre-release-commit-message = "chore: release"
 anyhow = "1.0.102"
 clap = { version = "4.6.0", features = ["derive"] }
 inventory = "0.3.24"
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 rayon = "1.11.0"
 regex = "1.12.3"
-rmp-serde = "1.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 tempfile = "3.27.0"
@@ -118,12 +118,12 @@ os_info = "3.14.0"
 packageurl = "0.6.0"
 pdf_oxide = "0.3.30"
 pep508_rs = "0.9.2"
+postcard = { workspace = true }
 quick-xml = "0.39.2"
 rancor = "0.1.1"
 rayon = { workspace = true }
 regex = { workspace = true }
 rkyv = { version = "0.8.15", features = ["smallvec-1"] }
-rmp-serde = { workspace = true }
 rpm = { version = "0.20.0", default-features = false, features = ["gzip-compression", "xz-compression", "zstd-compression", "bzip2-compression"] }
 ruff_python_ast = { version = "0.15.8", package = "rustpython-ruff_python_ast" }
 ruff_python_parser = { version = "0.15.8", package = "rustpython-ruff_python_parser" }

--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -33,7 +33,7 @@ pub fn load_loader_snapshot_from_bytes(
         SerializationError(format!("Failed to decompress embedded artifact: {}", e))
     })?;
 
-    let snapshot: EmbeddedLoaderSnapshot = rmp_serde::from_slice(&decompressed).map_err(|e| {
+    let snapshot: EmbeddedLoaderSnapshot = postcard::from_bytes(&decompressed).map_err(|e| {
         SerializationError(format!("Failed to deserialize embedded artifact: {}", e))
     })?;
 
@@ -88,11 +88,11 @@ mod tests {
             licenses,
         };
 
-        let msgpack = rmp_serde::to_vec(&snapshot).map_err(|e| {
+        let postcard_bytes = postcard::to_allocvec(&snapshot).map_err(|e| {
             SerializationError(format!("Failed to serialize embedded artifact: {}", e))
         })?;
 
-        zstd::encode_all(&msgpack[..], 0)
+        zstd::encode_all(&postcard_bytes[..], 0)
             .map_err(|e| SerializationError(format!("Failed to compress embedded artifact: {}", e)))
     }
 

--- a/src/license_detection/embedded/schema.rs
+++ b/src/license_detection/embedded/schema.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::license_detection::models::{LoadedLicense, LoadedRule};
 
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EmbeddedArtifactMetadata {

--- a/src/license_detection/embedded_test.rs
+++ b/src/license_detection/embedded_test.rs
@@ -93,8 +93,8 @@ fn serialize_loader_snapshot_to_bytes(
         licenses,
     };
 
-    let msgpack = rmp_serde::to_vec(&snapshot).map_err(|e| e.to_string())?;
-    zstd::encode_all(&msgpack[..], 0).map_err(|e| e.to_string())
+    let postcard_bytes = postcard::to_allocvec(&snapshot).map_err(|e| e.to_string())?;
+    zstd::encode_all(&postcard_bytes[..], 0).map_err(|e| e.to_string())
 }
 
 mod engine_loading {
@@ -200,8 +200,8 @@ mod failure_handling {
             rules: vec![create_test_loaded_rule()],
             licenses: vec![create_test_loaded_license()],
         };
-        let msgpack = rmp_serde::to_vec(&snapshot).unwrap();
-        let bytes = zstd::encode_all(&msgpack[..], 0).unwrap();
+        let postcard_bytes = postcard::to_allocvec(&snapshot).unwrap();
+        let bytes = zstd::encode_all(&postcard_bytes[..], 0).unwrap();
 
         let error = load_embedded_license_index_from_bytes(&bytes)
             .map(|loaded| loaded.index)
@@ -231,7 +231,7 @@ mod packaging {
     fn test_embedded_artifact_schema_version() {
         let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         let decompressed = zstd::decode_all(&artifact_bytes[..]).unwrap();
-        let snapshot: EmbeddedLoaderSnapshot = rmp_serde::from_slice(&decompressed).unwrap();
+        let snapshot: EmbeddedLoaderSnapshot = postcard::from_bytes(&decompressed).unwrap();
 
         assert_eq!(snapshot.schema_version, SCHEMA_VERSION);
     }
@@ -240,7 +240,7 @@ mod packaging {
     fn test_embedded_artifact_has_non_empty_rules_and_licenses() {
         let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         let decompressed = zstd::decode_all(&artifact_bytes[..]).unwrap();
-        let snapshot: EmbeddedLoaderSnapshot = rmp_serde::from_slice(&decompressed).unwrap();
+        let snapshot: EmbeddedLoaderSnapshot = postcard::from_bytes(&decompressed).unwrap();
 
         assert!(!snapshot.rules.is_empty());
         assert!(!snapshot.licenses.is_empty());
@@ -250,7 +250,7 @@ mod packaging {
     fn test_embedded_artifact_metadata_has_spdx_license_list_version() {
         let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         let decompressed = zstd::decode_all(&artifact_bytes[..]).unwrap();
-        let snapshot: EmbeddedLoaderSnapshot = rmp_serde::from_slice(&decompressed).unwrap();
+        let snapshot: EmbeddedLoaderSnapshot = postcard::from_bytes(&decompressed).unwrap();
 
         assert!(!snapshot.metadata.spdx_license_list_version.is_empty());
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -41,10 +41,10 @@ path = "src/bin/compare_outputs.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 inventory = { workspace = true }
+postcard = { workspace = true }
 provenant = { path = "..", package = "provenant-cli", features = ["golden-tests"] }
 rayon = { workspace = true }
 regex = { workspace = true }
-rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11.0"

--- a/xtask/src/bin/generate_index_artifact.rs
+++ b/xtask/src/bin/generate_index_artifact.rs
@@ -69,9 +69,10 @@ fn main() -> Result<()> {
     };
 
     println!("Serializing...");
-    let msgpack = rmp_serde::to_vec(&snapshot).context("Failed to serialize embedded artifact")?;
+    let postcard_bytes =
+        postcard::to_allocvec(&snapshot).context("Failed to serialize embedded artifact")?;
     let bytes =
-        zstd::encode_all(&msgpack[..], 0).context("Failed to compress embedded artifact")?;
+        zstd::encode_all(&postcard_bytes[..], 0).context("Failed to compress embedded artifact")?;
 
     println!("Total artifact size: {} bytes", bytes.len());
 


### PR DESCRIPTION
## Summary

- Replace `rmp_serde` with `postcard` for the embedded license artifact (`license_index.zst`) serialization
- Bump `SCHEMA_VERSION` 3 → 4 (artifact format change)
- Remove `rmp-serde` from workspace dependencies; add `postcard` with `alloc` feature

## Motivation

`postcard` is a simpler and more efficient serde-based serialization format than MessagePack (`rmp_serde`). It uses varint encoding with no self-describing overhead, producing smaller output. It also has a lighter dependency footprint — `postcard` depends only on `serde` (already in tree) and `cobs`, removing the `rmp-serde` / `rmp` / `num-traits` / `autocfg` chain entirely.

Net dependency change: removes 4 crates (`rmp-serde`, `rmp`, `num-traits`, `autocfg`), adds 2 (`postcard`, `cobs`).

Artifact size: 6.54 MB (postcard+zstd) vs 6.58 MB (rmp_serde+zstd) — ~0.5% smaller.

## How I Tested

- `cargo check` — compiles cleanly
- `cargo clippy` — no warnings
- `cargo test --lib license_detection::embedded::index` — 3/3 pass
- `cargo test --lib license_cache` — 4/4 pass
- `cargo test --lib embedded` — 20/20 pass
- Pre-commit hooks (clippy, rustfmt, cargo-sort) — pass
- Regenerated artifact via `cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact`