### PR TITLE
fix(post-processing): stop resolving local references via ancestors

### DIFF
--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1242,11 +1242,11 @@ fn apply_package_reference_following_resolves_absolute_rootfs_license_reference(
         .expect("service file should exist");
     assert_eq!(
         service.license_expression.as_deref(),
-        Some("gpl-2.0-plus AND gpl-2.0")
+        Some("gpl-2.0 AND gpl-2.0-plus")
     );
     assert_eq!(
         service.license_detections[0].license_expression_spdx,
-        "GPL-2.0-or-later AND GPL-2.0-only"
+        "GPL-2.0-only AND GPL-2.0-or-later"
     );
     assert_eq!(service.license_detections[0].matches.len(), 2);
     assert_eq!(
@@ -1331,7 +1331,7 @@ fn apply_package_reference_following_falls_back_to_root_when_package_missing() {
 }
 
 #[test]
-fn apply_package_reference_following_prefers_nearest_ancestor_license_file() {
+fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermediate_ancestor() {
     let mut repo_root_license = file("project/LICENSE");
     repo_root_license.license_expression = Some("mit".to_string());
     repo_root_license.license_detections = vec![crate::models::LicenseDetection {
@@ -1454,8 +1454,8 @@ fn apply_package_reference_following_prefers_nearest_ancestor_license_file() {
         &[],
         &snapshot,
     )
-    .expect("nearest ancestor LICENSE should resolve");
-    assert_eq!(resolved.path, "project/java/LICENSE");
+    .expect("repo root LICENSE should resolve");
+    assert_eq!(resolved.path, "project/LICENSE");
 
     apply_package_reference_following(&mut files, &mut packages);
 
@@ -1468,20 +1468,20 @@ fn apply_package_reference_following_prefers_nearest_ancestor_license_file() {
         Some("apache-2.0 AND mit")
     );
     assert_eq!(source.license_detections.len(), 2);
-    let combined = source
+    let followed = source
         .license_detections
         .iter()
-        .find(|detection| detection.license_expression_spdx == "Apache-2.0 AND MIT")
-        .expect("combined followed detection should exist");
-    assert_eq!(combined.detection_log, ["unknown-reference-to-local-file"]);
+        .find(|detection| detection.license_expression_spdx == "MIT")
+        .expect("followed MIT detection should exist");
+    assert_eq!(followed.detection_log, ["unknown-reference-to-local-file"]);
     assert!(
         source
             .license_detections
             .iter()
             .any(|detection| detection.license_expression_spdx == "Apache-2.0")
     );
-    assert!(combined.matches.iter().any(|detection_match| {
-        detection_match.from_file.as_deref() == Some("project/java/LICENSE")
+    assert!(followed.matches.iter().any(|detection_match| {
+        detection_match.from_file.as_deref() == Some("project/LICENSE")
     }));
 }
 

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -932,7 +932,7 @@ pub(super) fn resolve_referenced_resource(
     if is_absolute {
         candidates.push(referenced_filename.clone());
     }
-    for base in ancestor_reference_bases(current_path) {
+    if let Some(base) = current_reference_base(current_path) {
         candidates.push(join_reference_candidate(&base, &referenced_filename));
     }
 
@@ -966,22 +966,10 @@ pub(super) fn resolve_referenced_resource(
     None
 }
 
-fn ancestor_reference_bases(current_path: &str) -> Vec<String> {
-    let mut bases = Vec::new();
-    let mut current = Path::new(current_path).parent();
-
-    while let Some(path) = current {
-        let normalized = path.to_string_lossy().replace('\\', "/");
-        bases.push(normalized.clone());
-
-        if normalized.is_empty() {
-            break;
-        }
-
-        current = path.parent();
-    }
-
-    bases
+fn current_reference_base(current_path: &str) -> Option<String> {
+    Path::new(current_path)
+        .parent()
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
 }
 
 fn explicit_reference_root(snapshot: &ReferenceFollowSnapshot) -> Option<&str> {


### PR DESCRIPTION
## Summary

- make local license reference resolution match ScanCode by checking the current file directory, package context, and scan root instead of walking every ancestor directory
- update the regression covering nested `LICENSE` lookup so deep files now fall back to the repo root rather than an intermediate ancestor
- keep absolute-path and manifest-origin reference-following behavior covered by targeted unit tests

## Scope and exclusions

- Included: `src/post_processing/reference_following.rs` lookup narrowing and the paired `src/post_processing/output_test.rs` assertions
- Explicit exclusions: no changes to package-context reference following, rule metadata, or golden expected outputs

## Intentional differences from Python

- None. This change restores ScanCode parity for local-file reference lookup.