### PR TITLE
fix(post-processing): follow explicit source-tree root licenses

### DIFF
--- a/docs/LICENSE_DETECTION_ARCHITECTURE.md
+++ b/docs/LICENSE_DETECTION_ARCHITECTURE.md
@@ -450,6 +450,22 @@ The current public JSON output still omits `file_region`, but it does preserve
 }
 ```
 
+### Local File Reference Following
+
+After raw license detection, `src/post_processing/reference_following.rs` may merge detections from
+referenced local files such as `LICENSE`, `COPYING`, or manifest-adjacent sidecars.
+
+The default lookup stays conservative: current directory, package-manifest directories, then the
+current scan root / repo root.
+
+For notices that explicitly say the license file lives in the **root directory of this source
+tree** or equivalent project-root language, Provenant also allows a bounded ancestor lookup within
+the current scan root. Plain `See LICENSE` notices stay on the conservative path, and incompatible
+ancestor targets are rejected.
+
+This is an intentional product-quality difference from current ScanCode behavior, not a schema
+change.
+
 ## Related Documentation
 
 - [CLI_GUIDE.md](CLI_GUIDE.md) - user-facing workflows for the public license flags documented here

--- a/docs/SCANCODE_COMPARISON.md
+++ b/docs/SCANCODE_COMPARISON.md
@@ -62,6 +62,11 @@ nullable and omitted values. Provenant therefore keeps these fields unset when t
 not actually prove them, rather than coercing output to common ScanCode defaults and overstating
 dependency intent.
 
+Another intentional difference is local license-reference following. Provenant keeps the same
+conservative default for vague notices such as plain `See LICENSE`, but it allows a bounded
+ancestor lookup for explicit **root directory of this source tree** / project-root notices so
+vendored or nested source trees can resolve their own root `LICENSE` files.
+
 ## Related Docs
 
 - [README](../README.md) for installation, usage, and positioning

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1490,6 +1490,46 @@ fn apply_package_reference_following_prefers_intermediate_ancestor_for_source_tr
 }
 
 #[test]
+fn reference_root_language_accepts_project_scope_but_not_bare_root_directory() {
+    let project_root_notice = Match {
+        license_expression: "unknown-license-reference".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+        from_file: Some("project/src/file.c".to_string()),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+        matcher: Some("2-aho".to_string()),
+        score: MatchScore::MAX,
+        matched_length: Some(10),
+        match_coverage: Some(100.0),
+        rule_relevance: Some(100),
+        rule_identifier: Some("unknown-license-reference_see-license_1.RULE".to_string()),
+        rule_url: None,
+        matched_text: Some(
+            "This source code is licensed under the BSD-style license found in the LICENSE file in the root directory of this project.".to_string(),
+        ),
+        referenced_filenames: Some(vec!["LICENSE".to_string()]),
+        matched_text_diagnostics: None,
+    };
+    assert!(
+        super::reference_following::detection_match_explicitly_mentions_reference_root(
+            &project_root_notice
+        )
+    );
+
+    let bare_root_notice = Match {
+        matched_text: Some(
+            "This source code is licensed under the BSD-style license found in the LICENSE file in the root directory.".to_string(),
+        ),
+        ..project_root_notice
+    };
+    assert!(
+        !super::reference_following::detection_match_explicitly_mentions_reference_root(
+            &bare_root_notice
+        )
+    );
+}
+
+#[test]
 fn apply_package_reference_following_falls_back_past_nested_root_to_repo_root() {
     let mut root_license = file("LICENSE");
     root_license.license_expression = Some("mit".to_string());

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1223,6 +1223,7 @@ fn apply_package_reference_following_resolves_absolute_rootfs_license_reference(
     let snapshot = super::build_reference_follow_snapshot(&files, &packages);
     let resolved = super::resolve_referenced_resource(
         "/usr/share/common-licenses/GPL-2",
+        &files[5].license_detections[0],
         "usr/sbin/service",
         &[],
         &snapshot,
@@ -1331,47 +1332,21 @@ fn apply_package_reference_following_falls_back_to_root_when_package_missing() {
 }
 
 #[test]
-fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermediate_ancestor() {
+fn apply_package_reference_following_prefers_intermediate_ancestor_for_source_tree_root_notice() {
     let mut repo_root_license = file("project/LICENSE");
-    repo_root_license.license_expression = Some("mit".to_string());
+    repo_root_license.license_expression = Some("apache-2.0".to_string());
     repo_root_license.license_detections = vec![crate::models::LicenseDetection {
-        license_expression: "mit".to_string(),
-        license_expression_spdx: "MIT".to_string(),
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
         matches: vec![Match {
-            license_expression: "mit".to_string(),
-            license_expression_spdx: "MIT".to_string(),
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
             from_file: Some("project/LICENSE".to_string()),
             start_line: LineNumber::ONE,
             end_line: LineNumber::new(10).unwrap(),
             matcher: Some("1-hash".to_string()),
             score: MatchScore::MAX,
             matched_length: Some(50),
-            match_coverage: Some(100.0),
-            rule_relevance: Some(100),
-            rule_identifier: Some("mit.LICENSE".to_string()),
-            rule_url: None,
-            matched_text: None,
-            referenced_filenames: None,
-            matched_text_diagnostics: None,
-        }],
-        detection_log: vec![],
-        identifier: Some("mit-root".to_string()),
-    }];
-
-    let mut nested_license = file("project/java/LICENSE");
-    nested_license.license_expression = Some("apache-2.0".to_string());
-    nested_license.license_detections = vec![crate::models::LicenseDetection {
-        license_expression: "apache-2.0".to_string(),
-        license_expression_spdx: "Apache-2.0".to_string(),
-        matches: vec![Match {
-            license_expression: "apache-2.0".to_string(),
-            license_expression_spdx: "Apache-2.0".to_string(),
-            from_file: Some("project/java/LICENSE".to_string()),
-            start_line: LineNumber::ONE,
-            end_line: LineNumber::new(17).unwrap(),
-            matcher: Some("1-hash".to_string()),
-            score: MatchScore::MAX,
-            matched_length: Some(120),
             match_coverage: Some(100.0),
             rule_relevance: Some(100),
             rule_identifier: Some("apache-2.0.LICENSE".to_string()),
@@ -1381,7 +1356,33 @@ fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermed
             matched_text_diagnostics: None,
         }],
         detection_log: vec![],
-        identifier: Some("apache-java".to_string()),
+        identifier: Some("apache-root".to_string()),
+    }];
+
+    let mut nested_license = file("project/java/LICENSE");
+    nested_license.license_expression = Some("mit".to_string());
+    nested_license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("project/java/LICENSE".to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(17).unwrap(),
+            matcher: Some("1-hash".to_string()),
+            score: MatchScore::MAX,
+            matched_length: Some(120),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("mit.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("mit-java".to_string()),
     }];
 
     let mut source = file("project/java/src/com/example/Callback.java");
@@ -1403,7 +1404,9 @@ fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermed
                 rule_relevance: Some(100),
                 rule_identifier: Some("mit_101.RULE".to_string()),
                 rule_url: None,
-                matched_text: Some("licensed under the MIT license".to_string()),
+                matched_text: Some(
+                    "This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.".to_string(),
+                ),
                 referenced_filenames: Some(vec!["LICENSE".to_string()]),
                 matched_text_diagnostics: None,
             }],
@@ -1450,12 +1453,13 @@ fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermed
     let snapshot = super::build_reference_follow_snapshot(&files, &packages);
     let resolved = super::resolve_referenced_resource(
         "LICENSE",
+        &files[7].license_detections[0],
         "project/java/src/com/example/Callback.java",
         &[],
         &snapshot,
     )
-    .expect("repo root LICENSE should resolve");
-    assert_eq!(resolved.path, "project/LICENSE");
+    .expect("nested source-tree LICENSE should resolve");
+    assert_eq!(resolved.path, "project/java/LICENSE");
 
     apply_package_reference_following(&mut files, &mut packages);
 
@@ -1481,7 +1485,7 @@ fn apply_package_reference_following_falls_back_to_repo_root_instead_of_intermed
             .any(|detection| detection.license_expression_spdx == "Apache-2.0")
     );
     assert!(followed.matches.iter().any(|detection_match| {
-        detection_match.from_file.as_deref() == Some("project/LICENSE")
+        detection_match.from_file.as_deref() == Some("project/java/LICENSE")
     }));
 }
 
@@ -1513,6 +1517,32 @@ fn apply_package_reference_following_falls_back_past_nested_root_to_repo_root() 
         identifier: Some("mit-root".to_string()),
     }];
 
+    let mut nested_license = file("docs/LICENSE");
+    nested_license.license_expression = Some("apache-2.0".to_string());
+    nested_license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some("docs/LICENSE".to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(20).unwrap(),
+            matcher: Some("1-hash".to_string()),
+            score: MatchScore::MAX,
+            matched_length: Some(100),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("apache-2.0.LICENSE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: Some("apache-docs".to_string()),
+    }];
+
     let mut manpage = file("docs/man-xlate/nmap-id.1");
     manpage.license_expression = Some("unknown-license-reference".to_string());
     manpage.license_detections = vec![crate::models::LicenseDetection {
@@ -1539,7 +1569,13 @@ fn apply_package_reference_following_falls_back_past_nested_root_to_repo_root() 
         identifier: Some("manpage-ref".to_string()),
     }];
 
-    let mut files = vec![dir("docs"), dir("docs/man-xlate"), root_license, manpage];
+    let mut files = vec![
+        dir("docs"),
+        dir("docs/man-xlate"),
+        root_license,
+        nested_license,
+        manpage,
+    ];
     let mut packages = Vec::new();
     apply_package_reference_following(&mut files, &mut packages);
 

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1068,17 +1068,27 @@ fn detection_match_targets_reference(detection_match: &Match, referenced_filenam
         })
 }
 
-fn detection_match_explicitly_mentions_reference_root(detection_match: &Match) -> bool {
+pub(super) fn detection_match_explicitly_mentions_reference_root(detection_match: &Match) -> bool {
     let Some(matched_text) = detection_match.matched_text.as_deref() else {
         return false;
     };
     let lower = matched_text.to_ascii_lowercase();
 
-    lower.contains("root directory of this source tree")
+    mentions_named_root_reference(&lower, "source tree")
+        || mentions_named_root_reference(&lower, "project")
+        || mentions_named_root_reference(&lower, "repository")
         || lower.contains("project root")
+        || lower.contains("repository root")
         || lower.contains("root of the program")
         || lower.contains("root opencv directory")
         || lower.contains("at the project root")
+}
+
+fn mentions_named_root_reference(text: &str, scope: &str) -> bool {
+    text.contains(&format!("root directory of this {scope}"))
+        || text.contains(&format!("root directory of the {scope}"))
+        || text.contains(&format!("root of this {scope}"))
+        || text.contains(&format!("root of the {scope}"))
 }
 
 fn should_accept_ancestor_reference_target(

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -710,6 +710,7 @@ fn apply_reference_following_to_detection(
             .filter_map(|referenced_filename| {
                 resolve_referenced_resource(
                     referenced_filename,
+                    detection,
                     current_path,
                     package_uids,
                     snapshot,
@@ -918,6 +919,7 @@ fn sanitize_referenced_filename(name: &str) -> String {
 
 pub(super) fn resolve_referenced_resource(
     referenced_filename: &str,
+    detection: &LicenseDetection,
     current_path: &str,
     package_uids: &[PackageUid],
     snapshot: &ReferenceFollowSnapshot,
@@ -928,33 +930,53 @@ pub(super) fn resolve_referenced_resource(
         return None;
     }
 
+    let search_ancestors =
+        should_search_ancestor_reference_candidates(detection, &referenced_filename);
+    let prefer_ancestors = prefers_ancestor_reference_candidates(detection, &referenced_filename);
+
     let mut candidates = Vec::new();
     if is_absolute {
-        candidates.push(referenced_filename.clone());
+        candidates.push((referenced_filename.clone(), false));
     }
     if let Some(base) = current_reference_base(current_path) {
-        candidates.push(join_reference_candidate(&base, &referenced_filename));
+        candidates.push((join_reference_candidate(&base, &referenced_filename), false));
     }
 
     for package_uid in package_uids {
         if let Some(dirs) = snapshot.package_manifest_dirs_by_uid.get(package_uid) {
             for dir in dirs {
-                candidates.push(join_reference_candidate(dir, &referenced_filename));
+                candidates.push((join_reference_candidate(dir, &referenced_filename), false));
             }
         }
     }
 
+    if search_ancestors && prefer_ancestors {
+        for base in bounded_ancestor_reference_bases(current_path, snapshot) {
+            candidates.push((join_reference_candidate(&base, &referenced_filename), true));
+        }
+    }
+
     if let Some(root) = explicit_reference_root(snapshot) {
-        candidates.push(join_reference_candidate(root, &referenced_filename));
+        candidates.push((join_reference_candidate(root, &referenced_filename), false));
+    }
+
+    if search_ancestors && !prefer_ancestors {
+        for base in bounded_ancestor_reference_bases(current_path, snapshot) {
+            candidates.push((join_reference_candidate(&base, &referenced_filename), true));
+        }
     }
 
     let mut seen = HashSet::new();
-    for candidate in candidates {
+    for (candidate, is_ancestor_candidate) in candidates {
         if !seen.insert(candidate.clone()) {
             continue;
         }
 
         if let Some(target) = snapshot.files_by_path.get(&candidate) {
+            if is_ancestor_candidate && !should_accept_ancestor_reference_target(detection, target)
+            {
+                continue;
+            }
             return Some(target.clone());
         }
 
@@ -970,6 +992,125 @@ fn current_reference_base(current_path: &str) -> Option<String> {
     Path::new(current_path)
         .parent()
         .map(|path| path.to_string_lossy().replace('\\', "/"))
+}
+
+fn bounded_ancestor_reference_bases(
+    current_path: &str,
+    snapshot: &ReferenceFollowSnapshot,
+) -> Vec<String> {
+    let Some(root) = nearest_reference_root(current_path, snapshot) else {
+        return Vec::new();
+    };
+
+    let mut bases = Vec::new();
+    let mut current = Path::new(current_path).parent().and_then(Path::parent);
+
+    while let Some(path) = current {
+        let normalized = path.to_string_lossy().replace('\\', "/");
+        if normalized.is_empty() || normalized == root || !path_is_within_root(&normalized, root) {
+            break;
+        }
+        bases.push(normalized.clone());
+        current = path.parent();
+    }
+
+    bases
+}
+
+fn nearest_reference_root<'a>(
+    current_path: &str,
+    snapshot: &'a ReferenceFollowSnapshot,
+) -> Option<&'a str> {
+    snapshot
+        .root_paths
+        .iter()
+        .filter(|root| !root.is_empty() && path_is_within_root(current_path, root))
+        .max_by_key(|root| root.len())
+        .map(|root| root.as_str())
+}
+
+fn should_search_ancestor_reference_candidates(
+    detection: &LicenseDetection,
+    referenced_filename: &str,
+) -> bool {
+    has_concrete_reference_expression(detection)
+        || detection.matches.iter().any(|detection_match| {
+            detection_match_targets_reference(detection_match, referenced_filename)
+                && detection_match_explicitly_mentions_reference_root(detection_match)
+        })
+}
+
+fn prefers_ancestor_reference_candidates(
+    detection: &LicenseDetection,
+    referenced_filename: &str,
+) -> bool {
+    detection.matches.iter().any(|detection_match| {
+        detection_match_targets_reference(detection_match, referenced_filename)
+            && detection_match_explicitly_mentions_reference_root(detection_match)
+    })
+}
+
+fn has_concrete_reference_expression(detection: &LicenseDetection) -> bool {
+    !matches!(
+        detection.license_expression.as_str(),
+        "unknown-license-reference" | "free-unknown"
+    )
+}
+
+fn detection_match_targets_reference(detection_match: &Match, referenced_filename: &str) -> bool {
+    detection_match
+        .referenced_filenames
+        .as_ref()
+        .is_some_and(|filenames| {
+            filenames
+                .iter()
+                .any(|filename| normalize_referenced_filename(filename) == referenced_filename)
+        })
+}
+
+fn detection_match_explicitly_mentions_reference_root(detection_match: &Match) -> bool {
+    let Some(matched_text) = detection_match.matched_text.as_deref() else {
+        return false;
+    };
+    let lower = matched_text.to_ascii_lowercase();
+
+    lower.contains("root directory of this source tree")
+        || lower.contains("project root")
+        || lower.contains("root of the program")
+        || lower.contains("root opencv directory")
+        || lower.contains("at the project root")
+}
+
+fn should_accept_ancestor_reference_target(
+    detection: &LicenseDetection,
+    target: &ResolvedReferenceTarget,
+) -> bool {
+    if !has_concrete_reference_expression(detection) {
+        return true;
+    }
+
+    if detection.license_expression.contains(" OR ") {
+        return false;
+    }
+
+    let Some(referenced_expression) = combine_detection_expressions(&target.detections) else {
+        return false;
+    };
+
+    let current_keys: HashSet<_> = parse_expression(&detection.license_expression)
+        .ok()
+        .map(|expr| expr.license_keys())
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    let referenced_keys: HashSet<_> = parse_expression(&referenced_expression)
+        .ok()
+        .map(|expr| expr.license_keys())
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
+    !referenced_keys.is_empty() && referenced_keys.is_subset(&current_keys)
 }
 
 fn explicit_reference_root(snapshot: &ReferenceFollowSnapshot) -> Option<&str> {


### PR DESCRIPTION
## Summary

- add a bounded ancestor lookup path for local license references so explicit source-tree-root notices can resolve a subtree `LICENSE` before falling back to the repo root
- keep vague local references conservative by preserving repo-root fallback behavior for plain `See LICENSE`-style notices while still rejecting incompatible ancestor targets
- extend `post_processing::output_test` to cover both the positive source-tree-root case and the negative vague-reference case with a nearer ancestor `LICENSE`

## Scope and exclusions

- Included: `src/post_processing/reference_following.rs` heuristic changes and the paired `src/post_processing/output_test.rs` regressions
- Explicit exclusions: no CI workflow changes, no golden expected output changes, and no broader redesign of package-context reference following

## Intentional differences from Python

- Prefer Provenant's bounded subtree-root heuristic for explicit source-tree-root notices even though ScanCode remains more conservative about ancestor traversal.

## Follow-up work

- Created or intentionally deferred: if this heuristic proves useful beyond local file references, we can later teach it more explicit root-language variants without widening vague `See LICENSE` behavior.