### PR TITLE
fix(conda): preserve environment build strings separately

### DIFF
--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -591,6 +591,28 @@ fn parse_environment_string_dependency(dep_str: &str) -> Option<Dependency> {
     create_conda_dependency(namespace, channel_url, dep_without_ns, "dependencies")
 }
 
+fn parse_conda_exact_requirement(req_no_space: &str) -> (Option<String>, Option<String>) {
+    let exact = req_no_space
+        .strip_prefix("==")
+        .or_else(|| req_no_space.strip_prefix('='));
+
+    let Some(exact) = exact else {
+        return (None, None);
+    };
+
+    if exact.is_empty() {
+        return (None, None);
+    }
+
+    match exact.split_once('=') {
+        Some((version, build_string)) if !version.is_empty() => (
+            Some(truncate_field(version.to_string())),
+            (!build_string.is_empty()).then(|| truncate_field(build_string.to_string())),
+        ),
+        _ => (Some(truncate_field(exact.to_string())), None),
+    }
+}
+
 fn parse_conda_channel_prefix(dep_str: &str) -> (Option<&str>, Option<&str>, &str) {
     if let Some((ns, rest)) = dep_str.rsplit_once("::") {
         if ns.contains('/') || ns.contains(':') {
@@ -620,24 +642,20 @@ fn create_conda_dependency(
     let name = name_match.as_str().trim();
     let rest = dep[name_match.end()..].trim();
 
-    let (version, is_pinned, extracted_requirement) = if rest.is_empty() {
-        (None, false, Some(String::new()))
+    let (version, build_string, is_pinned, extracted_requirement) = if rest.is_empty() {
+        (None, None, false, Some(String::new()))
     } else {
         let req_no_space = rest.replace(' ', "");
         let is_exact = req_no_space.starts_with("=") || req_no_space.starts_with("==");
-        let parsed_version = if is_exact {
-            Some(truncate_field(
-                req_no_space
-                    .trim_start_matches('=')
-                    .trim_start_matches('=')
-                    .to_string(),
-            ))
+        let (parsed_version, parsed_build_string) = if is_exact {
+            parse_conda_exact_requirement(&req_no_space)
         } else {
-            None
+            (None, None)
         };
 
         (
             parsed_version,
+            parsed_build_string,
             is_exact,
             Some(truncate_field(rest.to_string())),
         )
@@ -668,6 +686,9 @@ fn create_conda_dependency(
             "channel_url".to_string(),
             serde_json::json!(truncate_field(channel_url.to_string())),
         );
+    }
+    if let Some(build_string) = build_string {
+        extra_data.insert("build_string".to_string(), serde_json::json!(build_string));
     }
 
     Some(Dependency {

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -285,6 +285,70 @@ dependencies:
     }
 
     #[test]
+    fn test_environment_top_level_dependencies_preserve_build_string_separately() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_path = temp_dir.path().join("environment.yml");
+        fs::write(
+            &env_path,
+            r#"
+name: test-env
+channels:
+  - defaults
+dependencies:
+  - bzip2=1.0.8=h4bc722e_7
+  - defaults::openssl=3.4.0=h7b32b05_1
+"#,
+        )
+        .unwrap();
+
+        let package_data = CondaEnvironmentYmlParser::extract_first_package(&env_path);
+
+        let bzip2 = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some("pkg:conda/bzip2@1.0.8"))
+            .expect("conda bzip2 dependency missing");
+        assert_eq!(
+            bzip2.extracted_requirement.as_deref(),
+            Some("=1.0.8=h4bc722e_7")
+        );
+        assert_eq!(
+            bzip2
+                .extra_data
+                .as_ref()
+                .and_then(|m| m.get("build_string"))
+                .and_then(|v| v.as_str()),
+            Some("h4bc722e_7")
+        );
+
+        let openssl = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some("pkg:conda/defaults/openssl@3.4.0"))
+            .expect("conda openssl dependency missing");
+        assert_eq!(
+            openssl.extracted_requirement.as_deref(),
+            Some("=3.4.0=h7b32b05_1")
+        );
+        assert_eq!(
+            openssl
+                .extra_data
+                .as_ref()
+                .and_then(|m| m.get("channel"))
+                .and_then(|v| v.as_str()),
+            Some("defaults")
+        );
+        assert_eq!(
+            openssl
+                .extra_data
+                .as_ref()
+                .and_then(|m| m.get("build_string"))
+                .and_then(|v| v.as_str()),
+            Some("h7b32b05_1")
+        );
+    }
+
+    #[test]
     fn test_environment_yaml_without_conda_structure_returns_no_packages() {
         let temp_dir = TempDir::new().unwrap();
         let env_path = temp_dir.path().join("pod-with-api-env.yaml");


### PR DESCRIPTION
## Summary

- keep Conda environment dependency PURLs pinned to the package version even when the requirement also includes a build string
- preserve Conda environment build strings in dependency `extra_data.build_string`
- add regression coverage for exact `name=version=build` environment entries, including channel-qualified dependencies

## Scope and exclusions

- Included: `src/parsers/conda.rs` environment dependency parsing and `src/parsers/conda_test.rs` regression coverage
- Explicit exclusions: no output schema changes and no changes to `meta.yaml` recipe dependency parsing

## Intentional differences from Python

- preserve Conda environment build strings as explicit dependency metadata instead of folding them into the generated dependency version field

## Follow-up work

- Created or intentionally deferred: add end-to-end serialized-output coverage for `extra_data.build_string` if we want golden fixtures for this field