### PR TITLE
fix(scanner): enforce license-stage timeout deadlines

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -15,6 +15,7 @@ use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::QueryRun;
 use crate::models::LineNumber;
 use crate::models::MatchScore;
+use std::time::Instant;
 
 pub const MATCH_AHO: MatcherKind = MatcherKind::Aho;
 
@@ -61,7 +62,16 @@ fn byte_pos_to_token_pos(byte_pos: usize) -> usize {
 ///
 /// Corresponds to Python: `exact_match()` (lines 84-138)
 pub fn aho_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatch> {
-    aho_match_with_extra_matchables(index, query_run, None)
+    aho_match_with_extra_matchables(index, query_run, None, None)
+        .expect("Aho matching without deadline should not time out")
+}
+
+pub(crate) fn aho_match_with_deadline(
+    index: &LicenseIndex,
+    query_run: &QueryRun,
+    deadline: Option<Instant>,
+) -> anyhow::Result<Vec<LicenseMatch>> {
+    aho_match_with_extra_matchables(index, query_run, None, deadline)
 }
 
 /// Perform Aho-Corasick exact matching with temporary extra matchable positions.
@@ -73,12 +83,13 @@ pub fn aho_match_with_extra_matchables(
     index: &LicenseIndex,
     query_run: &QueryRun,
     extra_matchable_positions: Option<&PositionSet>,
-) -> Vec<LicenseMatch> {
+    deadline: Option<Instant>,
+) -> anyhow::Result<Vec<LicenseMatch>> {
     let mut matches = Vec::new();
 
     let query_tokens = query_run.tokens();
     if query_tokens.is_empty() {
-        return matches;
+        return Ok(matches);
     }
 
     let encoded_query = tokens_to_bytes(query_tokens);
@@ -88,7 +99,11 @@ pub fn aho_match_with_extra_matchables(
 
     let automaton = &index.rules_automaton;
 
-    for ac_match in automaton.find_overlapping_iter(&encoded_query) {
+    for (match_index, ac_match) in automaton.find_overlapping_iter(&encoded_query).enumerate() {
+        if match_index.is_multiple_of(1024) {
+            crate::license_detection::ensure_within_deadline(deadline)?;
+        }
+
         let pattern_id = ac_match.pattern;
         let byte_start = ac_match.start;
         let byte_end = ac_match.end;
@@ -194,6 +209,7 @@ pub fn aho_match_with_extra_matchables(
     }
 
     if let Some(extra_matchables) = extra_matchable_positions {
+        crate::license_detection::ensure_within_deadline(deadline)?;
         let live_matchables = query_run.matchables(true);
         matches = matches
             .iter()
@@ -227,7 +243,7 @@ pub fn aho_match_with_extra_matchables(
             .collect();
     }
 
-    matches
+    Ok(matches)
 }
 
 #[cfg(test)]
@@ -511,7 +527,8 @@ mod tests {
 
         let extra_matchables: PositionSet = [1usize].into_iter().collect();
         let matches =
-            aho_match_with_extra_matchables(run.get_index(), &run, Some(&extra_matchables));
+            aho_match_with_extra_matchables(run.get_index(), &run, Some(&extra_matchables), None)
+                .expect("Aho matching with extra matchables should succeed");
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].start_token, 0);
@@ -565,7 +582,8 @@ mod tests {
         let run = query.whole_query_run();
         let extra_matchables: PositionSet = [0usize, 1].into_iter().collect();
         let matches =
-            aho_match_with_extra_matchables(run.get_index(), &run, Some(&extra_matchables));
+            aho_match_with_extra_matchables(run.get_index(), &run, Some(&extra_matchables), None)
+                .expect("Aho matching with extra matchables should succeed");
 
         assert_eq!(matches.len(), 1);
         assert_eq!(

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -77,6 +77,7 @@ pub const SCANCODE_LICENSES_LICENSES_PATH: &str =
 pub const SCANCODE_LICENSES_DATA_PATH: &str = "reference/scancode-toolkit/src/licensedcode/data";
 
 pub const DEFAULT_LICENSEDB_URL_TEMPLATE: &str = "https://scancode-licensedb.aboutcode.org/{}";
+pub(crate) const LICENSE_DETECTION_TIMEOUT_MESSAGE: &str = "license detection timed out";
 
 pub(crate) use detection::{
     LicenseDetection, group_matches_by_region, post_process_detections, sort_matches_by_line,
@@ -95,7 +96,10 @@ pub use token_multiset::TokenMultiset;
 pub use token_set::TokenSet;
 pub use unknown_match::unknown_match;
 
-use self::seq_match::{MAX_NEAR_DUPE_CANDIDATES, select_seq_candidates, seq_match_with_candidates};
+use self::seq_match::{
+    MAX_NEAR_DUPE_CANDIDATES, select_seq_candidates_with_deadline,
+    seq_match_with_candidates_and_deadline,
+};
 
 /// License detection engine that orchestrates the detection pipeline.
 ///
@@ -113,6 +117,18 @@ const MAX_DETECTION_SIZE: usize = 10 * 1024 * 1024; // 10MB
 const MAX_REGULAR_SEQ_CANDIDATES: usize = 70;
 const MAX_REDUNDANT_SEQ_CONTAINER_BOUNDARY_GAP: usize = 8;
 const MAX_REDUNDANT_SEQ_CONTAINER_UNMATCHED_GAP: usize = 2;
+
+pub(crate) fn deadline_exceeded(deadline: Option<Instant>) -> bool {
+    deadline.is_some_and(|deadline| Instant::now() >= deadline)
+}
+
+pub(crate) fn ensure_within_deadline(deadline: Option<Instant>) -> Result<()> {
+    if deadline_exceeded(deadline) {
+        Err(anyhow::anyhow!(LICENSE_DETECTION_TIMEOUT_MESSAGE))
+    } else {
+        Ok(())
+    }
+}
 
 fn truncate_detection_text(clean_text: &str) -> &str {
     if clean_text.len() <= MAX_DETECTION_SIZE {
@@ -384,16 +400,34 @@ fn collect_whole_query_exact_followup_matches(
     query: &mut Query<'_>,
     matched_qspans: &mut Vec<models::PositionSpan>,
     whole_run: &query::QueryRun<'_>,
-) -> Vec<LicenseMatch> {
+    deadline: Option<Instant>,
+) -> Result<Vec<LicenseMatch>> {
     let mut seq_all_matches = Vec::new();
 
     if whole_run.is_matchable(false, matched_qspans) {
-        let near_dupe_candidates =
-            select_seq_candidates(index, whole_run, true, MAX_NEAR_DUPE_CANDIDATES);
+        let near_dupe_candidates = if deadline.is_some() {
+            select_seq_candidates_with_deadline(
+                index,
+                whole_run,
+                true,
+                MAX_NEAR_DUPE_CANDIDATES,
+                deadline,
+            )?
+        } else {
+            self::seq_match::select_seq_candidates(index, whole_run, true, MAX_NEAR_DUPE_CANDIDATES)
+        };
 
         if !near_dupe_candidates.is_empty() {
-            let near_dupe_matches =
-                seq_match_with_candidates(index, whole_run, &near_dupe_candidates);
+            let near_dupe_matches = if deadline.is_some() {
+                seq_match_with_candidates_and_deadline(
+                    index,
+                    whole_run,
+                    &near_dupe_candidates,
+                    deadline,
+                )?
+            } else {
+                self::seq_match::seq_match_with_candidates(index, whole_run, &near_dupe_candidates)
+            };
 
             for m in &near_dupe_matches {
                 if !m.query_span().is_empty() {
@@ -407,7 +441,7 @@ fn collect_whole_query_exact_followup_matches(
         }
     }
 
-    seq_all_matches
+    Ok(seq_all_matches)
 }
 
 fn collect_regular_seq_matches(
@@ -415,18 +449,41 @@ fn collect_regular_seq_matches(
     query: &Query<'_>,
     matched_qspans: &[models::PositionSpan],
     candidate_contained_matches: &[LicenseMatch],
-) -> Vec<LicenseMatch> {
+    deadline: Option<Instant>,
+) -> Result<Vec<LicenseMatch>> {
     let mut seq_all_matches = Vec::new();
 
-    for query_run in query.query_runs() {
+    for (query_run_index, query_run) in query.query_runs().into_iter().enumerate() {
+        if query_run_index % 8 == 0 {
+            ensure_within_deadline(deadline)?;
+        }
+
         if !query_run.is_matchable(false, matched_qspans) {
             continue;
         }
 
-        let candidates =
-            select_seq_candidates(index, &query_run, false, MAX_REGULAR_SEQ_CANDIDATES);
+        let candidates = if deadline.is_some() {
+            select_seq_candidates_with_deadline(
+                index,
+                &query_run,
+                false,
+                MAX_REGULAR_SEQ_CANDIDATES,
+                deadline,
+            )?
+        } else {
+            self::seq_match::select_seq_candidates(
+                index,
+                &query_run,
+                false,
+                MAX_REGULAR_SEQ_CANDIDATES,
+            )
+        };
         if !candidates.is_empty() {
-            let matches = seq_match_with_candidates(index, &query_run, &candidates);
+            let matches = if deadline.is_some() {
+                seq_match_with_candidates_and_deadline(index, &query_run, &candidates, deadline)?
+            } else {
+                self::seq_match::seq_match_with_candidates(index, &query_run, &candidates)
+            };
             seq_all_matches.extend(matches);
         }
     }
@@ -434,10 +491,10 @@ fn collect_regular_seq_matches(
     let merged_seq = merge_overlapping_matches(&seq_all_matches);
     let filtered_same_expression =
         filter_redundant_same_expression_seq_containers(merged_seq, candidate_contained_matches);
-    filter_redundant_low_coverage_composite_seq_wrappers(
+    Ok(filter_redundant_low_coverage_composite_seq_wrappers(
         filtered_same_expression,
         candidate_contained_matches,
-    )
+    ))
 }
 
 impl LicenseDetectionEngine {
@@ -458,6 +515,11 @@ impl LicenseDetectionEngine {
             spdx_mapping,
             spdx_license_list_version,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_index(index: index::LicenseIndex) -> Self {
+        Self::from_index(index, None).expect("test index should build license engine")
     }
 
     /// Create a new license detection engine from the embedded license index.
@@ -644,7 +706,13 @@ impl LicenseDetectionEngine {
         unknown_licenses: bool,
         binary_derived: bool,
     ) -> Result<Vec<LicenseDetection>> {
-        self.detect_with_kind_with_score(text, unknown_licenses, binary_derived, 0.0)
+        self.detect_with_kind_with_score_and_deadline(
+            text,
+            unknown_licenses,
+            binary_derived,
+            0.0,
+            None,
+        )
     }
 
     pub fn detect_with_kind_with_score(
@@ -654,11 +722,39 @@ impl LicenseDetectionEngine {
         binary_derived: bool,
         min_score: f32,
     ) -> Result<Vec<LicenseDetection>> {
+        self.detect_with_kind_with_score_and_deadline(
+            text,
+            unknown_licenses,
+            binary_derived,
+            min_score,
+            None,
+        )
+    }
+
+    pub(crate) fn detect_with_kind_with_score_and_deadline(
+        &self,
+        text: &str,
+        unknown_licenses: bool,
+        binary_derived: bool,
+        min_score: f32,
+        deadline: Option<Instant>,
+    ) -> Result<Vec<LicenseDetection>> {
+        ensure_within_deadline(deadline)?;
         let clean_text = strip_utf8_bom_str(text);
 
         let content = truncate_detection_text(clean_text);
 
-        let mut query = Query::from_extracted_text(content, &self.index, binary_derived)?;
+        ensure_within_deadline(deadline)?;
+        let mut query = if deadline.is_some() {
+            Query::from_extracted_text_with_deadline(
+                content,
+                &self.index,
+                binary_derived,
+                deadline,
+            )?
+        } else {
+            Query::from_extracted_text(content, &self.index, binary_derived)?
+        };
         let whole_query_run = query.whole_query_run();
 
         let mut all_matches = Vec::new();
@@ -669,6 +765,7 @@ impl LicenseDetectionEngine {
         // Phase 1a: Hash matching
         // Python returns immediately if hash matches found (index.py:987-991)
         {
+            ensure_within_deadline(deadline)?;
             let hash_matches = hash_match(&self.index, &whole_query_run);
 
             if !hash_matches.is_empty() {
@@ -696,6 +793,7 @@ impl LicenseDetectionEngine {
 
         // Phase 1b: SPDX-LID matching
         {
+            ensure_within_deadline(deadline)?;
             let spdx_matches = spdx_lid_match(&self.index, &query);
             subtract_spdx_match_qspans(
                 &mut query,
@@ -708,14 +806,29 @@ impl LicenseDetectionEngine {
 
         // Phase 1c: Aho-Corasick matching
         {
+            ensure_within_deadline(deadline)?;
             let aho_matches = if aho_extra_matchables.is_empty() {
-                aho_match(&self.index, &whole_query_run)
+                if deadline.is_some() {
+                    aho_match::aho_match_with_deadline(&self.index, &whole_query_run, deadline)?
+                } else {
+                    aho_match(&self.index, &whole_query_run)
+                }
             } else {
-                aho_match::aho_match_with_extra_matchables(
-                    &self.index,
-                    &whole_query_run,
-                    Some(&aho_extra_matchables),
-                )
+                if deadline.is_some() {
+                    aho_match::aho_match_with_extra_matchables(
+                        &self.index,
+                        &whole_query_run,
+                        Some(&aho_extra_matchables),
+                        deadline,
+                    )?
+                } else {
+                    aho_match::aho_match_with_extra_matchables(
+                        &self.index,
+                        &whole_query_run,
+                        Some(&aho_extra_matchables),
+                        None,
+                    )?
+                }
             };
 
             // Python's get_exact_matches() calls refine_matches with merge=False
@@ -735,7 +848,8 @@ impl LicenseDetectionEngine {
                 &mut query,
                 &mut matched_qspans,
                 &whole_query_run,
-            );
+                deadline,
+            )?;
             all_matches.extend(whole_query_followup);
 
             let merged_seq = collect_regular_seq_matches(
@@ -743,12 +857,14 @@ impl LicenseDetectionEngine {
                 &query,
                 &matched_qspans,
                 &candidate_contained_matches,
-            );
+                deadline,
+            )?;
             all_matches.extend(merged_seq);
         }
 
         // Step 1: Initial refine WITHOUT false positive filtering
         // Python: refine_matches with filter_false_positive=False (index.py:1073-1080)
+        ensure_within_deadline(deadline)?;
         let merged_matches =
             refine_matches_without_false_positive_filter(&self.index, all_matches, &query);
 
@@ -774,6 +890,7 @@ impl LicenseDetectionEngine {
         };
 
         // Step 5: Final refine WITH false positive filtering - Python: index.py:1130-1145
+        ensure_within_deadline(deadline)?;
         let refined = refine_matches(&self.index, refined_matches, &query);
 
         let mut sorted = refined;
@@ -797,6 +914,7 @@ impl LicenseDetectionEngine {
 
         let detections = post_process_detections(detections, min_score);
 
+        ensure_within_deadline(deadline)?;
         Ok(detections)
     }
 
@@ -807,7 +925,30 @@ impl LicenseDetectionEngine {
         binary_derived: bool,
         source_path: &str,
     ) -> Result<Vec<LicenseDetection>> {
-        let mut detections = self.detect_with_kind(text, unknown_licenses, binary_derived)?;
+        self.detect_with_kind_and_source_with_deadline(
+            text,
+            unknown_licenses,
+            binary_derived,
+            source_path,
+            None,
+        )
+    }
+
+    pub(crate) fn detect_with_kind_and_source_with_deadline(
+        &self,
+        text: &str,
+        unknown_licenses: bool,
+        binary_derived: bool,
+        source_path: &str,
+        deadline: Option<Instant>,
+    ) -> Result<Vec<LicenseDetection>> {
+        let mut detections = self.detect_with_kind_with_score_and_deadline(
+            text,
+            unknown_licenses,
+            binary_derived,
+            0.0,
+            deadline,
+        )?;
         attach_source_path_to_detections(&mut detections, source_path);
         Ok(detections)
     }
@@ -822,6 +963,26 @@ impl LicenseDetectionEngine {
     ) -> Result<Vec<LicenseDetection>> {
         let mut detections =
             self.detect_with_kind_with_score(text, unknown_licenses, binary_derived, min_score)?;
+        attach_source_path_to_detections(&mut detections, source_path);
+        Ok(detections)
+    }
+
+    pub(crate) fn detect_with_kind_and_source_with_score_and_deadline(
+        &self,
+        text: &str,
+        unknown_licenses: bool,
+        binary_derived: bool,
+        source_path: &str,
+        min_score: f32,
+        deadline: Option<Instant>,
+    ) -> Result<Vec<LicenseDetection>> {
+        let mut detections = self.detect_with_kind_with_score_and_deadline(
+            text,
+            unknown_licenses,
+            binary_derived,
+            min_score,
+            deadline,
+        )?;
         attach_source_path_to_detections(&mut detections, source_path);
         Ok(detections)
     }
@@ -881,7 +1042,8 @@ impl LicenseDetectionEngine {
                     &self.index,
                     &whole_query_run,
                     Some(&aho_extra_matchables),
-                )
+                    None,
+                )?
             };
             let refined_aho = match_refine::refine_aho_matches(&self.index, aho_matches, &query);
             candidate_contained_matches.extend(refined_aho.clone());
@@ -898,7 +1060,8 @@ impl LicenseDetectionEngine {
                 &mut query,
                 &mut matched_qspans,
                 &whole_query_run,
-            );
+                None,
+            )?;
             all_matches.extend(whole_query_followup);
 
             let merged_seq = collect_regular_seq_matches(
@@ -906,7 +1069,8 @@ impl LicenseDetectionEngine {
                 &query,
                 &matched_qspans,
                 &candidate_contained_matches,
-            );
+                None,
+            )?;
             all_matches.extend(merged_seq);
         }
 

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use std::cell::{OnceCell, RefCell};
 use std::collections::HashMap;
 use std::sync::LazyLock;
+use std::time::Instant;
 
 static QUERY_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[^_\W]+\+?[^_\W]*").expect("valid query regex"));
@@ -441,13 +442,22 @@ impl<'a> Query<'a> {
         index: &'a LicenseIndex,
         binary_derived: bool,
     ) -> Result<Self, anyhow::Error> {
+        Self::from_extracted_text_with_deadline(text, index, binary_derived, None)
+    }
+
+    pub fn from_extracted_text_with_deadline(
+        text: &str,
+        index: &'a LicenseIndex,
+        binary_derived: bool,
+        deadline: Option<Instant>,
+    ) -> Result<Self, anyhow::Error> {
         let line_threshold = if binary_derived {
             Self::BINARY_LINE_THRESHOLD
         } else {
             Self::TEXT_LINE_THRESHOLD
         };
 
-        Self::with_source_options(text, index, line_threshold, Some(binary_derived))
+        Self::with_source_options(text, index, line_threshold, Some(binary_derived), deadline)
     }
 
     /// Iterate over query runs.
@@ -465,7 +475,9 @@ impl<'a> Query<'a> {
         index: &'a LicenseIndex,
         line_threshold: usize,
         binary_derived: Option<bool>,
+        deadline: Option<Instant>,
     ) -> Result<Self, anyhow::Error> {
+        crate::license_detection::ensure_within_deadline(deadline)?;
         let is_binary = match binary_derived {
             Some(is_binary) => is_binary,
             None => Self::detect_binary(text)?,
@@ -485,7 +497,11 @@ impl<'a> Query<'a> {
 
         let mut tokens_by_line: Vec<Vec<Option<KnownToken>>> = Vec::new();
 
-        for line in text.lines() {
+        for (line_index, line) in text.lines().enumerate() {
+            if line_index.is_multiple_of(128) {
+                crate::license_detection::ensure_within_deadline(deadline)?;
+            }
+
             let line_trimmed = line.trim();
             let mut line_tokens: Vec<Option<KnownToken>> = Vec::new();
 
@@ -548,6 +564,8 @@ impl<'a> Query<'a> {
             tokens_by_line.push(line_tokens);
             current_line += 1;
         }
+
+        crate::license_detection::ensure_within_deadline(deadline)?;
 
         let high_matchables: PositionSet = tokens
             .iter()

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -20,7 +20,7 @@ mod tests {
         text: &str,
         index: &'a LicenseIndex,
     ) -> anyhow::Result<Query<'a>> {
-        Query::with_source_options(text, index, Query::TEXT_LINE_THRESHOLD, None)
+        Query::with_source_options(text, index, Query::TEXT_LINE_THRESHOLD, None, None)
     }
 
     fn build_query_with_threshold<'a>(
@@ -28,7 +28,7 @@ mod tests {
         index: &'a LicenseIndex,
         line_threshold: usize,
     ) -> anyhow::Result<Query<'a>> {
-        Query::with_source_options(text, index, line_threshold, None)
+        Query::with_source_options(text, index, line_threshold, None, None)
     }
 
     fn query_unknown_count_after(query: &Query<'_>, pos: Option<usize>) -> usize {

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -7,6 +7,7 @@ use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::models::Rule;
 use crate::license_detection::query::QueryRun;
 use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
 use super::HIGH_RESEMBLANCE_THRESHOLD_TENTHS;
 
@@ -366,6 +367,7 @@ fn find_set_candidates<'a>(
     index: &'a LicenseIndex,
     query_data: &QueryData,
     high_resemblance: bool,
+    deadline: Option<Instant>,
 ) -> Vec<Candidate<'a>> {
     let candidate_rids: HashSet<usize> = query_data
         .query_high_set
@@ -376,7 +378,11 @@ fn find_set_candidates<'a>(
 
     let mut candidates = Vec::new();
 
-    for rid in candidate_rids {
+    for (rid_index, rid) in candidate_rids.into_iter().enumerate() {
+        if rid_index.is_multiple_of(128) && crate::license_detection::deadline_exceeded(deadline) {
+            return candidates;
+        }
+
         let Some(rule) = index.rules_by_rid.get(rid) else {
             continue;
         };
@@ -428,10 +434,17 @@ fn rescore_candidates_with_multisets<'a>(
     query_data: &QueryData,
     shortlisted: Vec<Candidate<'a>>,
     high_resemblance: bool,
+    deadline: Option<Instant>,
 ) -> Vec<Candidate<'a>> {
     let mut candidates = Vec::new();
 
-    for candidate in shortlisted {
+    for (candidate_index, candidate) in shortlisted.into_iter().enumerate() {
+        if candidate_index.is_multiple_of(64)
+            && crate::license_detection::deadline_exceeded(deadline)
+        {
+            return candidates;
+        }
+
         let Some(rule_mset) = index.msets_by_rid.get(&candidate.rid) else {
             continue;
         };
@@ -546,16 +559,29 @@ pub(crate) fn select_seq_candidates<'a>(
     high_resemblance: bool,
     top_n: usize,
 ) -> Vec<Candidate<'a>> {
+    select_seq_candidates_with_deadline(index, query_run, high_resemblance, top_n, None)
+        .expect("Sequence candidate selection without deadline should not time out")
+}
+
+pub(crate) fn select_seq_candidates_with_deadline<'a>(
+    index: &'a LicenseIndex,
+    query_run: &QueryRun,
+    high_resemblance: bool,
+    top_n: usize,
+    deadline: Option<Instant>,
+) -> anyhow::Result<Vec<Candidate<'a>>> {
+    crate::license_detection::ensure_within_deadline(deadline)?;
     let Some(query_data) = QueryData::new(index, query_run) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
-    let mut candidates = find_set_candidates(index, &query_data, high_resemblance);
+    let mut candidates = find_set_candidates(index, &query_data, high_resemblance, deadline);
 
     if candidates.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
+    crate::license_detection::ensure_within_deadline(deadline)?;
     candidates.sort_by(|a, b| {
         compare_candidate_rank(
             &b.score_vec_rounded,
@@ -569,15 +595,21 @@ pub(crate) fn select_seq_candidates<'a>(
 
     candidates.truncate(top_n * 10);
 
-    let mut candidates =
-        rescore_candidates_with_multisets(index, &query_data, candidates, high_resemblance);
+    let mut candidates = rescore_candidates_with_multisets(
+        index,
+        &query_data,
+        candidates,
+        high_resemblance,
+        deadline,
+    );
 
+    crate::license_detection::ensure_within_deadline(deadline)?;
     candidates = filter_dupes(candidates);
 
     candidates.sort_by(|a, b| b.cmp(a));
     candidates.truncate(top_n);
 
-    candidates
+    Ok(candidates)
 }
 
 #[cfg(test)]

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -9,9 +9,19 @@ use crate::models::LineNumber;
 use crate::models::MatchScore;
 use bit_set::BitSet;
 use std::collections::HashMap;
+use std::time::Instant;
 
 use super::MATCH_SEQ;
 use super::candidates::Candidate;
+
+struct MatchSearchContext<'a> {
+    query_tokens: &'a [TokenId],
+    rule_tokens: &'a [TokenId],
+    high_postings: &'a HashMap<TokenId, Vec<usize>>,
+    len_legalese: usize,
+    matchables: &'a BitSet,
+    deadline: Option<Instant>,
+}
 
 /// Find the longest matching block between query and rule token sequences.
 ///
@@ -34,31 +44,31 @@ use super::candidates::Candidate;
 /// # Returns
 ///
 /// Tuple of (query_start, rule_start, match_length)
-#[allow(clippy::too_many_arguments, clippy::needless_range_loop)]
-pub(super) fn find_longest_match(
-    query_tokens: &[TokenId],
-    rule_tokens: &[TokenId],
+#[allow(clippy::needless_range_loop)]
+fn find_longest_match_impl(
+    context: &MatchSearchContext<'_>,
     query_lo: usize,
     query_hi: usize,
     rule_lo: usize,
     rule_hi: usize,
-    high_postings: &HashMap<TokenId, Vec<usize>>,
-    len_legalese: usize,
-    matchables: &BitSet,
-) -> (usize, usize, usize) {
+) -> anyhow::Result<(usize, usize, usize)> {
     let mut best_i = query_lo;
     let mut best_j = rule_lo;
     let mut best_size = 0;
 
     let mut j2len: HashMap<usize, usize> = HashMap::new();
 
-    for i in query_lo..query_hi {
-        let mut new_j2len: HashMap<usize, usize> = HashMap::new();
-        let cur_a = query_tokens[i];
+    for (offset, i) in (query_lo..query_hi).enumerate() {
+        if offset.is_multiple_of(256) {
+            crate::license_detection::ensure_within_deadline(context.deadline)?;
+        }
 
-        if cur_a.as_usize() < len_legalese
-            && matchables.contains(i)
-            && let Some(positions) = high_postings.get(&cur_a)
+        let mut new_j2len: HashMap<usize, usize> = HashMap::new();
+        let cur_a = context.query_tokens[i];
+
+        if cur_a.as_usize() < context.len_legalese
+            && context.matchables.contains(i)
+            && let Some(positions) = context.high_postings.get(&cur_a)
         {
             for &j in positions {
                 if j < rule_lo {
@@ -89,8 +99,8 @@ pub(super) fn find_longest_match(
     if best_size > 0 {
         while best_i > query_lo
             && best_j > rule_lo
-            && query_tokens[best_i - 1] == rule_tokens[best_j - 1]
-            && matchables.contains(best_i - 1)
+            && context.query_tokens[best_i - 1] == context.rule_tokens[best_j - 1]
+            && context.matchables.contains(best_i - 1)
         {
             best_i -= 1;
             best_j -= 1;
@@ -99,14 +109,14 @@ pub(super) fn find_longest_match(
 
         while best_i + best_size < query_hi
             && best_j + best_size < rule_hi
-            && query_tokens[best_i + best_size] == rule_tokens[best_j + best_size]
-            && matchables.contains(best_i + best_size)
+            && context.query_tokens[best_i + best_size] == context.rule_tokens[best_j + best_size]
+            && context.matchables.contains(best_i + best_size)
         {
             best_size += 1;
         }
     }
 
-    (best_i, best_j, best_size)
+    Ok((best_i, best_j, best_size))
 }
 
 /// Find all matching blocks between query and rule token sequences using divide-and-conquer.
@@ -129,35 +139,27 @@ pub(super) fn find_longest_match(
 /// # Returns
 ///
 /// Vector of matching blocks as (query_pos, rule_pos, length)
-pub(super) fn match_blocks(
-    query_tokens: &[TokenId],
-    rule_tokens: &[TokenId],
+fn match_blocks_impl(
+    context: &MatchSearchContext<'_>,
     query_start: usize,
     query_end: usize,
-    high_postings: &HashMap<TokenId, Vec<usize>>,
-    len_legalese: usize,
-    matchables: &BitSet,
-) -> Vec<(usize, usize, usize)> {
-    if query_tokens.is_empty() || rule_tokens.is_empty() {
-        return Vec::new();
+) -> anyhow::Result<Vec<(usize, usize, usize)>> {
+    if context.query_tokens.is_empty() || context.rule_tokens.is_empty() {
+        return Ok(Vec::new());
     }
 
     let mut queue: Vec<(usize, usize, usize, usize)> =
-        vec![(query_start, query_end, 0, rule_tokens.len())];
+        vec![(query_start, query_end, 0, context.rule_tokens.len())];
     let mut matching_blocks: Vec<(usize, usize, usize)> = Vec::new();
 
+    let mut loop_count = 0usize;
     while let Some((alo, ahi, blo, bhi)) = queue.pop() {
-        let (i, j, k) = find_longest_match(
-            query_tokens,
-            rule_tokens,
-            alo,
-            ahi,
-            blo,
-            bhi,
-            high_postings,
-            len_legalese,
-            matchables,
-        );
+        if loop_count.is_multiple_of(32) {
+            crate::license_detection::ensure_within_deadline(context.deadline)?;
+        }
+        loop_count += 1;
+
+        let (i, j, k) = find_longest_match_impl(context, alo, ahi, blo, bhi)?;
 
         if k > 0 {
             matching_blocks.push((i, j, k));
@@ -195,7 +197,7 @@ pub(super) fn match_blocks(
         non_adjacent.push((i1, j1, k1));
     }
 
-    non_adjacent
+    Ok(non_adjacent)
 }
 
 /// Sequence matching against pre-selected candidates.
@@ -217,9 +219,23 @@ pub(crate) fn seq_match_with_candidates(
     query_run: &QueryRun,
     candidates: &[Candidate<'_>],
 ) -> Vec<LicenseMatch> {
+    seq_match_with_candidates_and_deadline(index, query_run, candidates, None)
+        .expect("Sequence matching without deadline should not time out")
+}
+
+pub(crate) fn seq_match_with_candidates_and_deadline(
+    index: &LicenseIndex,
+    query_run: &QueryRun,
+    candidates: &[Candidate<'_>],
+    deadline: Option<Instant>,
+) -> anyhow::Result<Vec<LicenseMatch>> {
     let mut matches = Vec::new();
 
-    for candidate in candidates {
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        if candidate_index.is_multiple_of(8) {
+            crate::license_detection::ensure_within_deadline(deadline)?;
+        }
+
         let rid = candidate.rid;
         let rule_tokens = index.tids_by_rid.get(rid);
         let high_postings: HashMap<TokenId, Vec<usize>> = index
@@ -245,23 +261,29 @@ pub(crate) fn seq_match_with_candidates(
                 .iter()
                 .map(|pos| pos - query_run.start)
                 .collect();
+            let context = MatchSearchContext {
+                query_tokens,
+                rule_tokens,
+                high_postings: &high_postings,
+                len_legalese,
+                matchables: &matchables,
+                deadline,
+            };
 
             let mut qstart = qbegin;
+            let mut loop_count = 0usize;
 
             while qstart <= qfinish {
+                if loop_count.is_multiple_of(32) {
+                    crate::license_detection::ensure_within_deadline(deadline)?;
+                }
+                loop_count += 1;
+
                 let has_remaining_matchables = matchables.iter().any(|pos| pos >= qstart);
                 if !has_remaining_matchables {
                     break;
                 }
-                let blocks = match_blocks(
-                    query_tokens,
-                    rule_tokens,
-                    qstart,
-                    qfinish + 1,
-                    &high_postings,
-                    len_legalese,
-                    &matchables,
-                );
+                let blocks = match_blocks_impl(&context, qstart, qfinish + 1)?;
 
                 if blocks.is_empty() {
                     break;
@@ -352,16 +374,64 @@ pub(crate) fn seq_match_with_candidates(
         }
     }
 
-    matches
+    Ok(matches)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::license_detection::index::dictionary::{TokenId, tid};
+    use std::ops::Range;
 
     fn tids(values: &[u16]) -> Vec<TokenId> {
         values.iter().copied().map(tid).collect()
+    }
+
+    fn find_longest_match_for_test(
+        query_tokens: &[TokenId],
+        rule_tokens: &[TokenId],
+        query_range: Range<usize>,
+        rule_range: Range<usize>,
+        high_postings: &HashMap<TokenId, Vec<usize>>,
+        len_legalese: usize,
+        matchables: &BitSet,
+    ) -> (usize, usize, usize) {
+        let context = MatchSearchContext {
+            query_tokens,
+            rule_tokens,
+            high_postings,
+            len_legalese,
+            matchables,
+            deadline: None,
+        };
+        find_longest_match_impl(
+            &context,
+            query_range.start,
+            query_range.end,
+            rule_range.start,
+            rule_range.end,
+        )
+        .expect("Sequence matching without deadline should not time out")
+    }
+
+    fn match_blocks_for_test(
+        query_tokens: &[TokenId],
+        rule_tokens: &[TokenId],
+        query_range: Range<usize>,
+        high_postings: &HashMap<TokenId, Vec<usize>>,
+        len_legalese: usize,
+        matchables: &BitSet,
+    ) -> Vec<(usize, usize, usize)> {
+        let context = MatchSearchContext {
+            query_tokens,
+            rule_tokens,
+            high_postings,
+            len_legalese,
+            matchables,
+            deadline: None,
+        };
+        match_blocks_impl(&context, query_range.start, query_range.end)
+            .expect("Sequence block matching without deadline should not time out")
     }
 
     #[test]
@@ -376,13 +446,11 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
-            0,
-            rule_tokens.len(),
+            0..query_tokens.len(),
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -403,13 +471,11 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
-            0,
-            rule_tokens.len(),
+            0..query_tokens.len(),
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -436,13 +502,11 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
-            0,
-            rule_tokens.len(),
+            0..query_tokens.len(),
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -462,13 +526,11 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
-            0,
-            rule_tokens.len(),
+            0..query_tokens.len(),
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -492,13 +554,11 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            3,
-            6,
-            0,
-            rule_tokens.len(),
+            3..6,
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -522,13 +582,11 @@ mod tests {
 
         let matchables: BitSet = [0, 2].into_iter().collect();
 
-        let result = find_longest_match(
+        let result = find_longest_match_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
-            0,
-            rule_tokens.len(),
+            0..query_tokens.len(),
+            0..rule_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -552,11 +610,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -577,11 +634,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -603,11 +659,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -623,11 +678,10 @@ mod tests {
         let high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
         let matchables: BitSet = BitSet::new();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -648,11 +702,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -672,11 +725,10 @@ mod tests {
         let high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -697,11 +749,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -725,11 +776,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            3,
+            0..3,
             &high_postings,
             5,
             &matchables,
@@ -742,11 +792,10 @@ mod tests {
         );
         assert_eq!(blocks[0], (0, 0, 3));
 
-        let blocks2 = match_blocks(
+        let blocks2 = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            4,
-            query_tokens.len(),
+            4..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -766,11 +815,10 @@ mod tests {
 
         let matchables: BitSet = (0..query_tokens.len()).collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,
@@ -794,11 +842,10 @@ mod tests {
 
         let matchables: BitSet = [0, 1, 2].into_iter().collect();
 
-        let blocks = match_blocks(
+        let blocks = match_blocks_for_test(
             &query_tokens,
             &rule_tokens,
-            0,
-            query_tokens.len(),
+            0..query_tokens.len(),
             &high_postings,
             5,
             &matchables,

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -22,8 +22,8 @@ mod matching;
 #[cfg(test)]
 mod gfdl_debug_test;
 
-pub(crate) use candidates::select_seq_candidates;
-pub(crate) use matching::seq_match_with_candidates;
+pub(crate) use candidates::{select_seq_candidates, select_seq_candidates_with_deadline};
+pub(crate) use matching::{seq_match_with_candidates, seq_match_with_candidates_and_deadline};
 
 use crate::license_detection::models::MatcherKind;
 

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use std::sync::{LazyLock, Once};
+use std::time::{Duration, Instant};
 
 use crate::license_detection::models::{MatchCoordinates, position_span::PositionSpan};
+use crate::license_detection::test_utils::create_test_index_default;
 use crate::models::LineNumber;
 use crate::models::MatchScore;
 
@@ -180,6 +182,23 @@ fn test_engine_detect_spdx_identifier() {
         !detections.is_empty(),
         "Should detect license from SPDX identifier"
     );
+}
+
+#[test]
+fn test_engine_detect_with_deadline_times_out_when_already_expired() {
+    let engine = LicenseDetectionEngine::from_test_index(create_test_index_default());
+
+    let error = engine
+        .detect_with_kind_with_score_and_deadline(
+            "Permission is hereby granted, free of charge, to any person obtaining a copy",
+            false,
+            false,
+            0.0,
+            Some(Instant::now() - Duration::from_millis(1)),
+        )
+        .expect_err("expired deadline should abort license detection");
+
+    assert_eq!(error.to_string(), LICENSE_DETECTION_TIMEOUT_MESSAGE);
 }
 
 #[test]

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -8,21 +8,57 @@ use crate::scanner::LicenseScanOptions;
 use anyhow::Error;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
+
+pub(super) struct LicenseExtractionInput<'a> {
+    pub(super) path: &'a Path,
+    pub(super) text_content: String,
+    pub(super) license_engine: Option<Arc<LicenseDetectionEngine>>,
+    pub(super) license_options: LicenseScanOptions,
+    pub(super) from_binary_strings: bool,
+    pub(super) timeout_seconds: f64,
+    pub(super) deadline: Option<Instant>,
+}
 
 pub(super) fn extract_license_information(
     file_info_builder: &mut FileInfoBuilder,
     scan_errors: &mut Vec<String>,
-    path: &Path,
-    text_content: String,
-    license_engine: Option<Arc<LicenseDetectionEngine>>,
-    license_options: LicenseScanOptions,
-    from_binary_strings: bool,
+    input: LicenseExtractionInput<'_>,
 ) -> Result<(), Error> {
+    let LicenseExtractionInput {
+        path,
+        text_content,
+        license_engine,
+        license_options,
+        from_binary_strings,
+        timeout_seconds,
+        deadline,
+    } = input;
+
     let Some(engine) = license_engine else {
         return Ok(());
     };
 
-    let detection_result = if license_options.min_score == 0 {
+    let detection_result = if deadline.is_some() {
+        if license_options.min_score == 0 {
+            engine.detect_with_kind_and_source_with_deadline(
+                &text_content,
+                license_options.unknown_licenses,
+                from_binary_strings,
+                &path.to_string_lossy(),
+                deadline,
+            )
+        } else {
+            engine.detect_with_kind_and_source_with_score_and_deadline(
+                &text_content,
+                license_options.unknown_licenses,
+                from_binary_strings,
+                &path.to_string_lossy(),
+                f32::from(license_options.min_score),
+                deadline,
+            )
+        }
+    } else if license_options.min_score == 0 {
         engine.detect_with_kind_and_source(
             &text_content,
             license_options.unknown_licenses,
@@ -41,8 +77,22 @@ pub(super) fn extract_license_information(
 
     match detection_result {
         Ok(detections) => {
-            let query =
-                Query::from_extracted_text(&text_content, engine.index(), from_binary_strings).ok();
+            let query = match if deadline.is_some() {
+                Query::from_extracted_text_with_deadline(
+                    &text_content,
+                    engine.index(),
+                    from_binary_strings,
+                    deadline,
+                )
+            } else {
+                Query::from_extracted_text(&text_content, engine.index(), from_binary_strings)
+            } {
+                Ok(query) => Some(query),
+                Err(error) if is_license_detection_timeout_error(&error) => {
+                    return Err(timeout_during_license_scan(timeout_seconds));
+                }
+                Err(_) => None,
+            };
             let mut model_detections = Vec::new();
             let mut model_clues = Vec::new();
 
@@ -84,12 +134,26 @@ pub(super) fn extract_license_information(
                     .map(|query| compute_percentage_of_license_text(query, &detections)),
             );
         }
+        Err(e) if is_license_detection_timeout_error(&e) => {
+            return Err(timeout_during_license_scan(timeout_seconds));
+        }
         Err(e) => {
             scan_errors.push(format!("License detection failed: {}", e));
         }
     }
 
     Ok(())
+}
+
+fn is_license_detection_timeout_error(error: &Error) -> bool {
+    error.to_string() == crate::license_detection::LICENSE_DETECTION_TIMEOUT_MESSAGE
+}
+
+fn timeout_during_license_scan(timeout_seconds: f64) -> Error {
+    Error::msg(format!(
+        "Timeout during license scan (> {:.2}s)",
+        timeout_seconds
+    ))
 }
 
 fn convert_detection_to_model(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -1,12 +1,30 @@
-use super::{compute_percentage_of_license_text, convert_detection_to_model};
+use super::{
+    LicenseExtractionInput, compute_percentage_of_license_text, convert_detection_to_model,
+    extract_license_information,
+};
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
+use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenDictionary;
 use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleKind};
 use crate::license_detection::query::Query;
-use crate::models::{LineNumber, MatchScore};
+use crate::models::{FileInfoBuilder, LineNumber, MatchScore};
 use crate::scanner::LicenseScanOptions;
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+static TEST_ENGINE: LazyLock<Arc<LicenseDetectionEngine>> = LazyLock::new(|| {
+    Arc::new(LicenseDetectionEngine::from_test_index(create_test_index(
+        &[
+            ("mit", 0),
+            ("license", 1),
+            ("permission", 2),
+            ("granted", 3),
+        ],
+        4,
+    )))
+});
 
 fn make_internal_match(rule_url: &str) -> LicenseMatch {
     LicenseMatch {
@@ -237,4 +255,30 @@ fn test_compute_percentage_of_license_text_counts_unknown_tokens() {
     let percentage = compute_percentage_of_license_text(&query, &[detection]);
 
     assert_eq!(percentage, 33.33);
+}
+
+#[test]
+fn test_extract_license_information_maps_timeout_to_stage_error() {
+    let mut file_info_builder = FileInfoBuilder::default();
+    let mut scan_errors = Vec::new();
+
+    let error = extract_license_information(
+        &mut file_info_builder,
+        &mut scan_errors,
+        LicenseExtractionInput {
+            path: std::path::Path::new("timeout.txt"),
+            text_content:
+                "Permission is hereby granted, free of charge, to any person obtaining a copy"
+                    .to_string(),
+            license_engine: Some(TEST_ENGINE.clone()),
+            license_options: LicenseScanOptions::default(),
+            from_binary_strings: false,
+            timeout_seconds: 1.0,
+            deadline: Some(Instant::now() - Duration::from_millis(1)),
+        },
+    )
+    .expect_err("expired deadline should map to stage-specific timeout");
+
+    assert!(scan_errors.is_empty());
+    assert_eq!(error.to_string(), "Timeout during license scan (> 1.00s)");
 }

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -1,6 +1,6 @@
 use super::contacts::extract_email_url_information;
 use super::copyright::extract_copyright_information;
-use super::license::extract_license_information;
+use super::license::{LicenseExtractionInput, extract_license_information};
 use super::special_cases::{is_go_non_production_source, should_skip_text_detection};
 use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{DatasourceId, FileInfo, FileInfoBuilder, FileType, Sha256Digest};
@@ -25,7 +25,7 @@ use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 const LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES: usize = 128 * 1024;
 
@@ -265,27 +265,44 @@ fn extract_information_from_content(
     let text_content_for_license_detection =
         prepare_license_detection_text(path, &classification, text_content);
 
+    if is_timeout_exceeded(started, text_options.timeout_seconds) {
+        return Err(Error::msg(format!(
+            "Timeout during license scan (> {:.2}s)",
+            text_options.timeout_seconds
+        )));
+    }
+
+    let license_deadline = deadline_from_start(started, text_options.timeout_seconds);
+
     if license_enabled {
         let started = Instant::now();
         extract_license_information(
             file_info_builder,
             scan_errors,
-            &filesystem_path,
-            text_content_for_license_detection.clone(),
-            license_engine,
-            license_options,
-            from_binary_strings,
+            LicenseExtractionInput {
+                path: &filesystem_path,
+                text_content: text_content_for_license_detection.clone(),
+                license_engine,
+                license_options,
+                from_binary_strings,
+                timeout_seconds: text_options.timeout_seconds,
+                deadline: license_deadline,
+            },
         )?;
         progress.record_detail_timing("scan:licenses", started.elapsed().as_secs_f64());
     } else {
         extract_license_information(
             file_info_builder,
             scan_errors,
-            &filesystem_path,
-            text_content_for_license_detection,
-            license_engine,
-            license_options,
-            from_binary_strings,
+            LicenseExtractionInput {
+                path: &filesystem_path,
+                text_content: text_content_for_license_detection,
+                license_engine,
+                license_options,
+                from_binary_strings,
+                timeout_seconds: text_options.timeout_seconds,
+                deadline: license_deadline,
+            },
         )?;
     }
 
@@ -335,6 +352,15 @@ fn is_timeout_exceeded(started: Instant, timeout_seconds: f64) -> bool {
     timeout_seconds.is_finite()
         && timeout_seconds > 0.0
         && started.elapsed().as_secs_f64() > timeout_seconds
+}
+
+fn deadline_from_start(started: Instant, timeout_seconds: f64) -> Option<Instant> {
+    if !timeout_seconds.is_finite() || timeout_seconds <= 0.0 {
+        return None;
+    }
+
+    let remaining_seconds = (timeout_seconds - started.elapsed().as_secs_f64()).max(0.0);
+    Instant::now().checked_add(Duration::from_secs_f64(remaining_seconds))
 }
 
 fn maybe_record_processing_timeout(


### PR DESCRIPTION
## Summary

- propagate the remaining per-file timeout budget into license detection instead of only checking timeout before and after the license stage
- add deadline-aware checkpoints in query building, Aho matching, and sequence matching so pathological license-only scans can stop inside the heavy matcher loops
- add focused regressions for expired license deadlines and keep the existing pipeline timeout de-duplication behavior intact

## Issues

- Covers: timeout enforcement for license-only scans on pathological large inputs
- Closes: 

## Scope and exclusions

- Included: license-detection deadline plumbing, scanner timeout mapping, and targeted regression coverage
- Explicit exclusions: no new large-text sampling heuristics, no manifest-size policy changes, no expected-output fixture updates

## Intentional differences from Python

- None intended; this only makes Provenant honor its documented per-file timeout more consistently during license detection

## Follow-up work

- Created or intentionally deferred: benchmark additional real-world pathological license-only fixtures if we want finer-grained deadline checkpoints later

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no golden or expected-output fixtures changed for this fix