### PR TITLE
fix(license-detection): curate downstream ScanCode rule overlays

### DIFF
--- a/resources/license_detection/index_build_policy.toml
+++ b/resources/license_detection/index_build_policy.toml
@@ -16,6 +16,8 @@
 ignored_rules = [
   # Android-generated header boilerplate says this text contains no copyrightable information; see ScanCode PR #4683.
   "gpl-2.0_and-unknown-license-reference_1.RULE",
+  # Bare freertos.org URL references such as a00127.html false-positive as GPL-2.0+ WITH FreeRTOS exception; see ScanCode issues #4147 and #4441.
+  "gpl-2.0-plus_with_freertos-exception-2.0_1.RULE",
 ]
 
 ignored_licenses = []

--- a/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_1.RULE
+++ b/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_1.RULE
@@ -1,0 +1,14 @@
+---
+license_expression: apache-2.0 AND lgpl-2.1
+is_license_notice: yes
+relevance: 100
+referenced_filenames:
+    - COPYING.LGPL
+    - COPYING.ASL2
+---
+
+distributed pursuant to the terms of two different licenses.
+The user interface (located in ui/ in this distribution) is governed by
+the {{Apache License version 2.0}}.  The rest of this distribution is
+governed by the {{GNU Lesser General Public License version 2.1}}.
+See COPYING.LGPL and COPYING.ASL2.

--- a/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_2.RULE
+++ b/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_2.RULE
@@ -1,0 +1,25 @@
+---
+license_expression: apache-2.0 AND lgpl-2.1
+is_license_notice: yes
+relevance: 90
+referenced_filenames:
+    - /usr/share/common-licenses/Apache-2.0
+notes: this is likely some typo See https://salsa.debian.org/owncloud-team/nextcloud-desktop/-/merge_requests/9#note_256687
+ignorable_urls:
+    - http://www.apache.org/licenses/LICENSE-2.0
+---
+
+Licensed under the {{Apache License, Version 2.0}} (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems a full copy of the {{LGPL 2.1}} can be found at
+ /usr/share/common-licenses/Apache-2.0

--- a/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_4.RULE
+++ b/resources/license_detection/overlay/rules/apache-2.0_and_lgpl-2.1_4.RULE
@@ -1,0 +1,26 @@
+---
+license_expression: apache-2.0 AND lgpl-2.1
+is_license_notice: yes
+relevance: 99
+minimum_coverage: 95
+referenced_filenames:
+    - /usr/share/common-licenses/Apache-2.0
+notes: this is likely some typo See https://salsa.debian.org/owncloud-team/nextcloud-desktop/-/merge_requests/9#note_256687
+ignorable_urls:
+    - http://www.apache.org/licenses/LICENSE-2.0
+---
+
+Licensed under the {{Apache License, Version 2.0}} (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian GNU/Linux systems a full copy of the {{LGPL 2.1}} can be found at
+ /usr/share/common-licenses/Apache-2.0

--- a/resources/license_detection/overlay/rules/gpl-3.0_with_gcc-exception-3.1_16.RULE
+++ b/resources/license_detection/overlay/rules/gpl-3.0_with_gcc-exception-3.1_16.RULE
@@ -1,0 +1,7 @@
+---
+license_expression: gpl-3.0 WITH gcc-exception-3.1
+is_license_reference: yes
+relevance: 100
+---
+
+{{GPL 3.0}} with {{GCC Runtime Library Exception 3.1}}

--- a/resources/license_detection/overlay/rules/stable-diffusion-2022-08-22_required_phrase_1.RULE
+++ b/resources/license_detection/overlay/rules/stable-diffusion-2022-08-22_required_phrase_1.RULE
@@ -1,0 +1,9 @@
+---
+license_expression: stable-diffusion-2022-08-22
+is_license_reference: yes
+is_required_phrase: yes
+relevance: 100
+---
+
+CreativeML Open RAIL-M
+dated August 22, 2022


### PR DESCRIPTION
## Summary

- tighten downstream Apache/LGPL overlay replacements to avoid known ScanCode false positives while keeping the embedded dataset in sync
- add downstream overlay coverage for a missing `gpl-3.0 WITH gcc-exception-3.1` short reference and a dated CreativeML Open RAIL-M reference
- ignore the overbroad FreeRTOS URL-only rule and regenerate the embedded license index artifact after each curation step

## Issues

- Covers: aboutcode-org/scancode-toolkit#3933, aboutcode-org/scancode-toolkit#4147, aboutcode-org/scancode-toolkit#4320, aboutcode-org/scancode-toolkit#4441, aboutcode-org/scancode-toolkit#4599, aboutcode-org/scancode-toolkit#4597, aboutcode-org/scancode-toolkit#4611
- Closes: #716, #717, #718, #719

## Scope and exclusions

- Included:
  - three Apache/LGPL replacement overlays under `resources/license_detection/overlay/rules/`
  - one GCC exception overlay and one CreativeML dated-reference overlay
  - one additional ignored ScanCode rule in `resources/license_detection/index_build_policy.toml`
  - regenerated `resources/license_detection/license_index.zst`
- Explicit exclusions:
  - no parser or scanner-engine code changes
  - no broader renaming of the `stable-diffusion-2022-08-22` key
  - no attempt to solve unrelated upstream rule-family issues beyond the ones evidenced here

## Follow-up work

- Created or intentionally deferred:
  - remove the Apache/LGPL overlays once Provenant picks up an upstream ScanCode dataset with an equivalent fix
  - remove the FreeRTOS ignore once the upstream URL-only rule is deleted or narrowed enough to stop false positives
  - revisit the CreativeML overlay once upstream improves naming/aliasing and short-reference coverage for that license family
  - remove the GCC exception overlay once upstream ships equivalent rule coverage