### PR TITLE
fix(license-detection): add downstream CAL and MIT rule curations

### DIFF
--- a/resources/license_detection/index_build_policy.toml
+++ b/resources/license_detection/index_build_policy.toml
@@ -18,6 +18,8 @@ ignored_rules = [
   "gpl-2.0_and-unknown-license-reference_1.RULE",
   # Bare freertos.org URL references such as a00127.html false-positive as GPL-2.0+ WITH FreeRTOS exception; see ScanCode issues #4147 and #4441.
   "gpl-2.0-plus_with_freertos-exception-2.0_1.RULE",
+  # Bare CAL-1.0 tokenization false-positives on calibration macros; see ScanCode issue #4740 and PR #4759.
+  "cal-1.0_10.RULE",
 ]
 
 ignored_licenses = []

--- a/resources/license_detection/overlay/rules/mit_attribution_no_endorsement.RULE
+++ b/resources/license_detection/overlay/rules/mit_attribution_no_endorsement.RULE
@@ -1,0 +1,41 @@
+---
+license_expression: mit
+is_license_text: yes
+relevance: 100
+minimum_coverage: 98
+ignorable_copyrights:
+  - Copyright 2025 Sinusoidal Systems AB
+ignorable_holders:
+  - Sinusoidal Systems AB
+ignorable_authors:
+  - Sinusoidal Systems AB
+---
+Copyright 2025 Sinusoidal Systems AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+2. Redistributions of the Software in source or binary form must include an
+   attribution notice stating that the Software was originally developed by
+   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
+   endorses or is affiliated with the redistribution or derivative work without
+   prior written permission.
+
+3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
+   used to endorse or promote products derived from this Software without specific
+   prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- ignore the overbroad `cal-1.0_10.RULE` so bare calibration-macro tokenization no longer produces CAL-1.0 false positives
- add a downstream `mit_attribution_no_endorsement.RULE` overlay so the Sinusoidal Systems MIT variant detects as MIT instead of `proprietary-license`
- regenerate the embedded license dataset artifact after each curation and verify the final artifact matches source inputs

## Issues

- Covers: aboutcode-org/scancode-toolkit#4740, aboutcode-org/scancode-toolkit#4759, aboutcode-org/scancode-toolkit#4710, aboutcode-org/scancode-toolkit#4721
- Closes: #722, #723

## Scope and exclusions

- Included:
  - `resources/license_detection/index_build_policy.toml`
  - `resources/license_detection/overlay/rules/mit_attribution_no_endorsement.RULE`
  - regenerated `resources/license_detection/license_index.zst`
- Explicit exclusions:
  - no scanner-engine or parser changes
  - no downstream MPL badge override, because the current embedded ScanCode snapshot does not contain the upstream problematic `mpl-2.0_url_badge.RULE` and the ISC badge repro already scans correctly here

## Follow-up work

- Created or intentionally deferred:
  - issue #721 was investigated and closed separately after confirming the current embedded dataset does not reproduce the upstream MPL badge false positive
  - remove the CAL ignore once Provenant updates to an upstream ScanCode snapshot where that bad short-token rule is gone
  - remove the MIT overlay once Provenant updates to an upstream ScanCode snapshot containing equivalent MIT variant coverage