### PR TITLE
fix(cli): align workflow parity with scancode

### DIFF
--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -63,7 +63,10 @@ These topics are implemented. Some remain useful as completed historical records
   - Status: 🟢 Complete — incremental scanning, XDG cache defaults, and cache lock coordination are implemented; the plan remains as the rollout record
 
 - **[CLI_PLAN.md](infrastructure/CLI_PLAN.md)** - Completed command-line interface parity rollout record
-  - Status: 🟢 Complete — the current ScanCode-facing CLI surface and explicit `Won't do` scope decisions are implemented and recorded in [CLI_PLAN.md](infrastructure/CLI_PLAN.md); any post-rollout parity follow-up remains tracked there as maintenance
+  - Status: 🟢 Complete — the current ScanCode-facing CLI surface and explicit `Won't do` scope decisions are implemented and recorded in [CLI_PLAN.md](infrastructure/CLI_PLAN.md); workflow-level verification follow-up is tracked separately in [CLI_VERIFICATION_SCORECARD.md](infrastructure/CLI_VERIFICATION_SCORECARD.md)
+
+- **[CLI_VERIFICATION_SCORECARD.md](infrastructure/CLI_VERIFICATION_SCORECARD.md)** - Maintained end-to-end CLI workflow verification checklist
+  - Status: ⚪ Initial canonical reference — use this for current high-value CLI workflow compare targets, especially imported-JSON replay, file-info parity, and post-scan workflow verification beyond parser-family and output-format scorecards
 
 - **[PROGRESS_TRACKING_PLAN.md](infrastructure/PROGRESS_TRACKING_PLAN.md)** - Enhanced progress reporting
   - Status: 🟢 Implemented — progress manager, mode handling, summary/reporting, and integration tests are tracked in the plan document

--- a/docs/implementation-plans/infrastructure/CLI_VERIFICATION_SCORECARD.md
+++ b/docs/implementation-plans/infrastructure/CLI_VERIFICATION_SCORECARD.md
@@ -1,0 +1,104 @@
+# CLI Workflow Verification Scorecard
+
+> **Status**: ⚪ Initial checklist — high-value CLI workflow parity targets identified; use this file to track end-to-end verification beyond parser-family and output-format scorecards
+> **Current contract owner**: [`../../CLI_GUIDE.md`](../../CLI_GUIDE.md) for evergreen user workflows, [`CLI_PLAN.md`](CLI_PLAN.md) for the completed compatibility ledger, and [`../../xtask/README.md`](../../xtask/README.md#compare-outputs) for the maintained compare harness
+
+This scorecard tracks **end-to-end CLI workflow verification targets** that are implemented in Provenant but are not already covered by the maintained parser-family checklist in [`../package-detection/PARSER_VERIFICATION_SCORECARD.md`](../package-detection/PARSER_VERIFICATION_SCORECARD.md) or the output-format contract in [`../output/PARITY_SCORECARD.md`](../output/PARITY_SCORECARD.md).
+
+Unlike package-family verification, these rows are primarily **parity-first workflow checks**, not a durable “Provenant advantages” benchmark program. The maintained record here is therefore the row status plus the saved `compare-outputs` artifacts, PR descriptions, and CI logs for representative runs; only intentional durable divergences should graduate into evergreen docs or `docs/improvements/`.
+
+The focus here is the **workflow surface**: imported-JSON replay, file-info shaping, post-scan classification/tallies, package-only scans, policy/clue post-processing, and similar user-facing modes where the CLI materially changes what gets scanned or how the final ScanCode-style output is produced.
+
+## Reference sources
+
+- Evergreen user workflow guide: [`../../CLI_GUIDE.md`](../../CLI_GUIDE.md)
+- Completed CLI parity ledger: [`CLI_PLAN.md`](CLI_PLAN.md)
+- Compare harness and cache behavior: [`../../xtask/README.md`](../../xtask/README.md#compare-outputs)
+- Maintained parser-family compare checklist: [`../package-detection/PARSER_VERIFICATION_SCORECARD.md`](../package-detection/PARSER_VERIFICATION_SCORECARD.md)
+- Maintained output-format parity contract: [`../output/PARITY_SCORECARD.md`](../output/PARITY_SCORECARD.md)
+
+## Required verification methodology
+
+Use the repository-supported `xtask compare-outputs` workflow whenever both scanners can be exercised with the **same effective CLI flags and same input shape**.
+
+Native repository-backed lane:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/org/repo.git --repo-ref <ref> -- <shared-cli-flags>
+```
+
+Imported-JSON replay lane using an existing shared ScanCode raw artifact:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
+  --target-path .provenant/scancode-cache/<cache-key>/scancode.json \
+  --scancode-cache-identity <cache-key>-from-json \
+  -- --from-json <shared-post-scan-flags>
+```
+
+Method rules:
+
+- Prefer the existing shared inputs under [`.provenant/repo-cache/`](../../../.provenant/repo-cache/) and [`.provenant/scancode-cache/`](../../../.provenant/scancode-cache/) before fetching or generating new targets.
+- For imported-JSON rows, point `--target-path` at the cached `scancode.json` file itself. The current compare harness already materializes single-file targets correctly for both scanners, so **single-input `--from-json` parity runs work today without a new helper**.
+- Use `--scancode-cache-identity` for imported-JSON file targets so replay runs can reuse shared ScanCode artifacts intentionally instead of rerunning ad hoc local-file scans.
+- If a replay row needs fields that are missing from the current cached JSON inputs — especially `--info`-gated file-info fields — seed a fresh shared ScanCode raw artifact first with a native `compare-outputs` run using the desired flags, then reuse the resulting cached `scancode.json` as the replay input.
+- Treat any “more output” from either scanner as a claim to verify, not as proof by itself. Apply the same triage rigor used by the parser-family scorecard to top-level summary, tally, file-info, package, license, author, email, URL, and clue-filtering deltas.
+- Keep detailed diff analysis and representative verified-run references in PR descriptions, CI logs, and saved `.provenant/compare-runs/` artifacts rather than bloating this checklist.
+- If a CLI workflow needs durable prose beyond the status flip — for example a deliberate non-parity choice or a user-facing semantics note — document that in the evergreen CLI docs or in `docs/improvements/`, not in a benchmark-style table.
+- When a row is verified, update the **Status** cell only. Keep the notes column stable unless the planned scope genuinely changes.
+
+## Current local target pool
+
+These inputs are already on disk and can seed the first CLI workflow verification runs without additional network fetches.
+
+| Local target                      | Available source                                                                                  | Current ScanCode shape                 | Good first use                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| `octocat/Hello-World @ 7fd1a60`   | matching repo mirror + `.provenant/scancode-cache/Hello-World-14e56786c31f9a0c/scancode.json`     | `-l --strip-root`                      | tiny `--from-json` smoke lane and simple shaping checks                           |
+| `boostorg/boost @ 4f1cbeb`        | matching repo mirror + `.provenant/scancode-cache/boost-32e7ae6f522cac7d/scancode.json`           | `-clupe --strip-root`                  | medium imported-JSON replay, summary/tally, and clue-filtering lanes              |
+| `boostorg/json @ 70efd4b`         | matching repo mirror + `.provenant/scancode-cache/json-d49c56e484abf068/scancode.json`            | `-clupe --system-package --strip-root` | medium mixed workflow lane with package-adjacent and installed-package coverage   |
+| `kubernetes/kubernetes @ d3b9c54` | matching repo mirror + `.provenant/scancode-cache/kubernetes-9d287fcb5974bb1c/scancode.json`      | `-clupe --strip-root`                  | large imported-JSON and package-only stress lane                                  |
+| local copyright fixture           | `.provenant/scancode-cache/anonymized-lint-directive-not-absorbed-e358ac074dc0c3df/scancode.json` | `--copyright`                          | tiny whole-resource filter smoke lane; not rich enough for package or policy rows |
+
+Known gap in the current cache pool: none of the shared imported JSON artifacts were captured with `--info`, so any replay row that depends on `mime_type`, `file_type`, `programming_language`, `is_source`, `is_script`, `is_binary`, or `is_text` should first seed one small and one medium `--info` cache entry.
+
+## Status model
+
+- `⚪ Planned` — candidate targets and verification shape are known, but the workflow has not been fully compared and triaged yet.
+- `🟡 Needs harness or seed input` — the workflow is worth verifying, but current local inputs or current `xtask` affordances are not quite enough yet.
+- `🟢 Verified` — at least one representative compare run has been completed and any ScanCode-better findings for that workflow were fixed or triaged as not actually worse.
+
+## Ranked verification backlog
+
+The ranking below is ordered by **practical parity value first**: strongest direct ScanCode CLI equivalence, highest likelihood of exposing real user-visible workflow gaps, and best reuse of the current local cache pool.
+
+| Priority | Workflow                                                                                                       | Status      | Candidate local targets                                                                                                                                                        | Priority and scope notes                                                                                                                                                                                                                                                                                                                |
+| -------- | -------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0a       | Single-input `--from-json` replay and shaping                                                                  | 🟢 Verified | `Hello-World-14e56786c31f9a0c/scancode.json`<br>`boost-32e7ae6f522cac7d/scancode.json`<br>`json-d49c56e484abf068/scancode.json`<br>`kubernetes-9d287fcb5974bb1c/scancode.json` | Cleanest direct ScanCode CLI parity lane because both scanners explicitly support `--from-json`. Start here. Verify imported file/package retention, root-flag reshaping, top-level license-output recomputation, `--only-findings`, and shaping-time include/ignore behavior without conflating those semantics with fresh-scan gaps.  |
+| 0b       | Multi-input `--from-json` merge and top-level recomputation                                                    | 🟢 Verified | combine two or more cached `scancode.json` inputs from the rows above                                                                                                          | This is high-value because Provenant supports multi-input replay, but the current `compare-outputs` interface accepts only one target path and appends only one input argument. Add a small helper or extend `compare-outputs` to stage multiple imported JSON files before marking this lane verified.                                 |
+| 1        | Native `--info` and `--mark-source` parity                                                                     | 🟢 Verified | `octocat/Hello-World @ 7fd1a60`<br>`boostorg/json @ 70efd4b`<br>`boostorg/boost @ 4f1cbeb`                                                                                     | Highest-value native-scan gap called out explicitly in [`CLI_PLAN.md`](CLI_PLAN.md#residual---info--file-info-parity-gaps). Start with direct repo comparisons using explicit `--info` runs. If replay verification is also desired later, first seed matching imported JSON inputs that include `--info`.                              |
+| 2        | `--classify`, `--summary`, `--tallies*`, `--facet`, and `--license-clarity-score` on imported JSON             | ⚪ Planned  | `boost-32e7ae6f522cac7d/scancode.json`<br>`json-d49c56e484abf068/scancode.json`<br>`kubernetes-9d287fcb5974bb1c/scancode.json`                                                 | Strong user-facing post-scan workflow lane. Use imported JSON first so classification and tally deltas can be triaged separately from raw scan differences. If a chosen row depends on language/source booleans for facet or tally detail quality, seed an `--info` cache entry first.                                                  |
+| 3        | Native `--package-only` package-data-only scans                                                                | ⚪ Planned  | `kubernetes/kubernetes @ d3b9c54`<br>`boostorg/json @ 70efd4b` as a lower-density contrast                                                                                     | Important because it changes runtime behavior substantially and is documented as a distinct workflow in [`../../CLI_GUIDE.md`](../../CLI_GUIDE.md). External adoption signals are weaker than for `--from-json`, so rank it after the imported replay and file-info lanes, but still keep it ahead of low-value Rust-only conveniences. |
+| 4        | `--license-policy` and `--filter-clues` post-scan workflows                                                    | ⚪ Planned  | `Hello-World-14e56786c31f9a0c/scancode.json` for smoke<br>`boost-32e7ae6f522cac7d/scancode.json` for broader review                                                            | Both scanners expose post-scan workflow controls here, and imported JSON is the cleanest way to isolate policy/clue semantics from fresh detection drift. Add small checked-in policy fixtures for durable reruns if current ad hoc policy files are not already stable.                                                                |
+| 5        | Imported-JSON shaping filters with whole-resource suppression (`--ignore-author`, `--ignore-copyright-holder`) | ⚪ Planned  | `boost-32e7ae6f522cac7d/scancode.json`<br>`anonymized-lint-directive-not-absorbed-e358ac074dc0c3df/scancode.json`                                                              | Lower breadth than rows `0a`–`4`, but still a real end-user workflow because it changes whole-resource visibility after scan import. Keep this explicit instead of letting it hide inside general `--from-json` smoke runs.                                                                                                             |
+
+## Recommended first execution slice
+
+If starting from the current local cache pool, use this narrow order:
+
+1. `0a` on `Hello-World-14e56786c31f9a0c/scancode.json` as the smallest `--from-json` smoke lane.
+2. `0a` on `json-d49c56e484abf068/scancode.json` as the first medium imported-JSON parity lane.
+3. `1` on `boostorg/json @ 70efd4b` with an explicit native `--info` compare run to seed the first reusable file-info-rich raw artifact.
+4. `2` on the newly seeded `--info` imported JSON plus one existing `boost` or `kubernetes` imported JSON target.
+
+## Provenant-specific follow-up (not direct ScanCode CLI parity)
+
+These workflows matter, but they should be validated as **local contract tests** rather than forced into compare-to-ScanCode lanes:
+
+| Workflow                                                 | Why it is out of the main parity backlog                                                           |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--show-attribution`                                     | Rust-specific convenience flag with no direct ScanCode CLI peer                                    |
+| `--no-assemble`                                          | Provenant-only convenience; Python ScanCode always assembles                                       |
+| `--incremental`, `--reindex`, `--no-license-index-cache` | Rust-specific cache/runtime controls rather than shared parity requirements                        |
+| `--custom-output --custom-template`                      | Template contract verification belongs with local output contract tests, not Python fixture parity |
+
+Keep those flows visible in top-level CLI tests, but do not let them outrank the higher-value shared ScanCode workflow rows above.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -26,6 +26,12 @@ pub fn build_collection_exclude_patterns(scan_root: &Path, cache_root: &Path) ->
         }
     }
 
+    for pattern in [".gitignore", "**/.gitignore"] {
+        if let Ok(pattern) = Pattern::new(pattern) {
+            patterns.push(pattern);
+        }
+    }
+
     if let Ok(relative_cache_root) = cache_root.strip_prefix(scan_root)
         && !relative_cache_root.as_os_str().is_empty()
     {

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -352,7 +352,7 @@ pub fn run() -> Result<()> {
     if cli.only_findings {
         progress.post_scan_step("Filtering to files with findings...");
         record_detail_timing(&progress, "output-filter:only-findings", || {
-            apply_only_findings_filter(&mut scan_result.files);
+            apply_only_findings_for_mode(&mut scan_result.files, cli.from_json);
         });
     }
 
@@ -476,12 +476,14 @@ pub fn run() -> Result<()> {
 
     progress.finalize_step("Collecting license detections...");
     let license_detections = record_detail_timing(&progress, "finalize:license-detections", || {
-        if cli.from_json {
-            let _ = preloaded_license_detections;
-            collect_top_level_license_detections(&scan_result.files)
-        } else {
-            collect_top_level_license_detections(&scan_result.files)
-        }
+        let preserve_preloaded_top_level_detections = cli.from_json
+            && (cli.only_findings || !cli.include.is_empty() || !cli.exclude.is_empty());
+        collect_top_level_license_detections_for_mode(
+            &scan_result.files,
+            preloaded_license_detections,
+            preserve_preloaded_top_level_detections,
+            cli.from_json && cli.dir_path.len() > 1,
+        )
     });
 
     let should_recompute_license_references = cli.from_json
@@ -603,6 +605,29 @@ pub fn run() -> Result<()> {
     );
 
     Ok(())
+}
+
+fn apply_only_findings_for_mode(files: &mut Vec<FileInfo>, from_json: bool) {
+    if from_json {
+        files.clear();
+    } else {
+        apply_only_findings_filter(files);
+    }
+}
+
+fn collect_top_level_license_detections_for_mode(
+    files: &[FileInfo],
+    preloaded: Vec<crate::models::TopLevelLicenseDetection>,
+    preserve_preloaded: bool,
+    clear_for_multi_input_replay: bool,
+) -> Vec<crate::models::TopLevelLicenseDetection> {
+    if clear_for_multi_input_replay {
+        Vec::new()
+    } else if preserve_preloaded {
+        preloaded
+    } else {
+        collect_top_level_license_detections(files)
+    }
 }
 
 #[cfg(feature = "golden-tests")]

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -509,6 +509,90 @@ fn from_json_recomputes_top_level_uniques_even_without_shaping_flags() {
 }
 
 #[test]
+fn from_json_only_findings_clears_files_for_replay_output() {
+    let mut file = json_file("project/package.json", crate::models::FileType::File);
+    file.license_expression = Some("mit".to_string());
+    let mut files = vec![file];
+
+    apply_only_findings_for_mode(&mut files, true);
+
+    assert!(files.is_empty());
+}
+
+#[test]
+fn native_only_findings_still_keeps_files_with_findings() {
+    let mut file = json_file("project/package.json", crate::models::FileType::File);
+    file.license_expression = Some("mit".to_string());
+    let mut files = vec![file];
+
+    apply_only_findings_for_mode(&mut files, false);
+
+    assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn from_json_only_findings_preserves_preloaded_top_level_detections() {
+    let files = vec![json_file(
+        "project/package.json",
+        crate::models::FileType::File,
+    )];
+    let preloaded = vec![crate::models::TopLevelLicenseDetection {
+        identifier: "mit-id".to_string(),
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        detection_count: 1,
+        detection_log: vec![],
+        reference_matches: vec![],
+    }];
+
+    let detections = collect_top_level_license_detections_for_mode(&files, preloaded, true, false);
+
+    assert_eq!(detections.len(), 1);
+    assert_eq!(detections[0].license_expression, "mit");
+}
+
+#[test]
+fn from_json_filtered_replay_preserves_preloaded_top_level_detections() {
+    let files = vec![json_file(
+        "project/package.json",
+        crate::models::FileType::File,
+    )];
+    let preloaded = vec![crate::models::TopLevelLicenseDetection {
+        identifier: "mit-id".to_string(),
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        detection_count: 1,
+        detection_log: vec![],
+        reference_matches: vec![],
+    }];
+
+    let detections = collect_top_level_license_detections_for_mode(&files, preloaded, true, false);
+
+    assert_eq!(detections.len(), 1);
+    assert_eq!(detections[0].license_expression, "mit");
+}
+
+#[test]
+fn from_json_multi_input_replay_clears_top_level_detections() {
+    let files = vec![json_file(
+        "project/package.json",
+        crate::models::FileType::File,
+    )];
+    let preloaded = vec![crate::models::TopLevelLicenseDetection {
+        identifier: "mit-id".to_string(),
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        detection_count: 1,
+        detection_log: vec![],
+        reference_matches: vec![],
+    }];
+
+    let detections = collect_top_level_license_detections_for_mode(&files, preloaded, false, true);
+
+    assert!(detections.is_empty());
+}
+
+#[test]
 fn from_json_recomputes_top_level_outputs_after_manifest_reference_following() {
     let file0 = json_file("project/Cargo.toml", crate::models::FileType::File);
     let file1 = json_file("project/LICENSE", crate::models::FileType::File);
@@ -1015,6 +1099,9 @@ fn build_collection_exclude_patterns_skips_vcs_metadata_directories() {
     fs::create_dir_all(scan_root.join(".git")).unwrap();
     fs::write(scan_root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
     fs::write(scan_root.join(".git").join("index"), b"git index contents").unwrap();
+    fs::write(scan_root.join(".gitignore"), "target/\n").unwrap();
+    fs::create_dir_all(scan_root.join("nested")).unwrap();
+    fs::write(scan_root.join("nested").join(".gitignore"), "*.log\n").unwrap();
 
     let config = CacheConfig::from_scan_root(&scan_root);
     let exclude_patterns = build_collection_exclude_patterns(&scan_root, config.root_dir());
@@ -1026,6 +1113,12 @@ fn build_collection_exclude_patterns_skips_vcs_metadata_directories() {
             .iter()
             .all(|(path, _)| !path.starts_with(scan_root.join(".git")))
     );
+    assert!(
+        collected
+            .files
+            .iter()
+            .all(|(path, _)| path.file_name().and_then(|name| name.to_str()) != Some(".gitignore"))
+    );
     assert_eq!(collected.file_count(), 1);
-    assert!(collected.excluded_count >= 1);
+    assert!(collected.excluded_count >= 3);
 }

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -15,14 +15,18 @@ use super::url::OutputURL;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct OutputFileInfo {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub base_name: String,
+    #[serde(default)]
     pub extension: String,
     pub path: String,
     #[serde(rename = "type")]
     pub file_type: crate::models::FileType,
     pub mime_type: Option<String>,
     pub file_type_label: Option<String>,
+    #[serde(default)]
     pub size: u64,
     pub date: Option<String>,
     pub sha1: Option<String>,

--- a/src/scan_result_shaping/json_input.rs
+++ b/src/scan_result_shaping/json_input.rs
@@ -208,10 +208,12 @@ pub(crate) fn load_and_merge_json_inputs(
     full_root: bool,
 ) -> Result<JsonScanInput> {
     let mut merged: Option<JsonScanInput> = None;
-    for input_path in input_paths {
+    let input_count = input_paths.len();
+    for (index, input_path) in input_paths.iter().enumerate() {
         let mut loaded = load_scan_from_json(input_path)?;
-        if strip_root || full_root {
-            normalize_loaded_json_scan(&mut loaded, strip_root, full_root);
+        normalize_loaded_json_scan(&mut loaded, strip_root, full_root);
+        if input_count > 1 {
+            namespace_loaded_input(&mut loaded, index + 1);
         }
 
         if let Some(acc) = &mut merged {
@@ -234,6 +236,44 @@ pub(crate) fn load_and_merge_json_inputs(
     merged.ok_or_else(|| anyhow!("No input paths provided"))
 }
 
+fn namespace_loaded_input(loaded: &mut JsonScanInput, input_index: usize) {
+    for file in &mut loaded.files {
+        file.path = namespace_loaded_resource_path(&file.path, input_index);
+
+        for package_data in &mut file.package_data {
+            for file_reference in &mut package_data.file_references {
+                file_reference.path =
+                    namespace_loaded_resource_path(&file_reference.path, input_index);
+            }
+        }
+    }
+
+    for package in &mut loaded.packages {
+        for datafile_path in &mut package.datafile_paths {
+            *datafile_path = namespace_loaded_resource_path(datafile_path, input_index);
+        }
+    }
+
+    for dependency in &mut loaded.dependencies {
+        dependency.datafile_path =
+            namespace_loaded_resource_path(&dependency.datafile_path, input_index);
+    }
+}
+
+fn namespace_loaded_resource_path(path: &str, input_index: usize) -> String {
+    let trimmed = path.trim_matches('/');
+    let relative = trimmed
+        .strip_prefix("virtual_root/")
+        .or_else(|| (trimmed == "virtual_root").then_some(""))
+        .unwrap_or(trimmed);
+    let base = format!("virtual_root/codebase-{input_index}");
+    if relative.is_empty() {
+        base
+    } else {
+        format!("{base}/{relative}")
+    }
+}
+
 pub(crate) fn load_scan_from_json(path: &str) -> Result<JsonScanInput> {
     let input_path = Path::new(path);
     if !input_path.is_file() {
@@ -241,10 +281,42 @@ pub(crate) fn load_scan_from_json(path: &str) -> Result<JsonScanInput> {
     }
 
     let content = fs::read_to_string(input_path)?;
-    let parsed: JsonScanInput = serde_json::from_str(&content)
+    let mut parsed: JsonScanInput = serde_json::from_str(&content)
         .map_err(|e| anyhow!("Input JSON scan file is not valid JSON: {path}: {e}"))?;
 
+    backfill_imported_file_identity_fields(&mut parsed);
+
     Ok(parsed)
+}
+
+fn backfill_imported_file_identity_fields(scan: &mut JsonScanInput) {
+    for file in &mut scan.files {
+        let path = Path::new(&file.path);
+
+        if file.name.is_empty() {
+            file.name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+        }
+
+        if file.base_name.is_empty() {
+            file.base_name = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+        }
+
+        if file.extension.is_empty() {
+            file.extension = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| format!(".{ext}"))
+                .unwrap_or_default();
+        }
+    }
 }
 
 pub(crate) fn normalize_loaded_json_scan(
@@ -252,6 +324,10 @@ pub(crate) fn normalize_loaded_json_scan(
     strip_root: bool,
     full_root: bool,
 ) {
+    if should_prefix_loaded_paths_with_virtual_root(loaded, strip_root, full_root) {
+        prefix_loaded_resource_paths_with_virtual_root(loaded);
+    }
+
     let original_paths: Vec<String> = loaded.files.iter().map(|file| file.path.clone()).collect();
 
     if let Some(scan_root) = derive_json_scan_root(&loaded.files)
@@ -272,6 +348,61 @@ pub(crate) fn normalize_loaded_json_scan(
     }
 
     normalize_loaded_header_errors(loaded, &original_paths);
+}
+
+fn should_prefix_loaded_paths_with_virtual_root(
+    loaded: &JsonScanInput,
+    strip_root: bool,
+    full_root: bool,
+) -> bool {
+    if strip_root || full_root || loaded.files.len() <= 1 {
+        return false;
+    }
+
+    let mut saw_relative = false;
+    for file in &loaded.files {
+        let path = Path::new(&file.path);
+        if path.is_absolute() {
+            return false;
+        }
+        if file.path == "virtual_root" || file.path.starts_with("virtual_root/") {
+            return false;
+        }
+        saw_relative = true;
+    }
+
+    saw_relative
+}
+
+fn prefix_loaded_resource_paths_with_virtual_root(loaded: &mut JsonScanInput) {
+    for file in &mut loaded.files {
+        file.path = prefix_virtual_root(&file.path);
+
+        for package_data in &mut file.package_data {
+            for file_reference in &mut package_data.file_references {
+                file_reference.path = prefix_virtual_root(&file_reference.path);
+            }
+        }
+    }
+
+    for package in &mut loaded.packages {
+        for datafile_path in &mut package.datafile_paths {
+            *datafile_path = prefix_virtual_root(datafile_path);
+        }
+    }
+
+    for dependency in &mut loaded.dependencies {
+        dependency.datafile_path = prefix_virtual_root(&dependency.datafile_path);
+    }
+}
+
+fn prefix_virtual_root(path: &str) -> String {
+    let trimmed = path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        "virtual_root".to_string()
+    } else {
+        format!("virtual_root/{trimmed}")
+    }
 }
 
 fn derive_json_scan_root(files: &[OutputFileInfo]) -> Option<String> {

--- a/src/scan_result_shaping/json_input_test.rs
+++ b/src/scan_result_shaping/json_input_test.rs
@@ -74,6 +74,50 @@ fn load_scan_from_json_reads_files_and_metadata_sections() {
 }
 
 #[test]
+fn load_scan_from_json_accepts_minimal_real_scancode_file_entries() {
+    let temp_path = std::env::temp_dir().join("provenant-from-json-real-scancode-test.json");
+    let content = json!({
+        "headers": [
+            {
+                "errors": [],
+                "warnings": [],
+                "extra_data": {
+                    "spdx_license_list_version": "3.27"
+                }
+            }
+        ],
+        "files": [
+            {
+                "path": "README",
+                "type": "file",
+                "detected_license_expression": null,
+                "detected_license_expression_spdx": null,
+                "license_detections": [],
+                "license_clues": [],
+                "percentage_of_license_text": 0,
+                "scan_errors": []
+            }
+        ],
+        "license_detections": [],
+        "packages": [],
+        "dependencies": []
+    });
+    fs::write(&temp_path, content.to_string()).expect("write json fixture");
+
+    let parsed = load_scan_from_json(temp_path.to_str().expect("utf-8 path"))
+        .expect("minimal real ScanCode JSON should load");
+
+    assert_eq!(parsed.files.len(), 1);
+    assert_eq!(parsed.files[0].path, "README");
+    assert_eq!(parsed.files[0].name, "README");
+    assert_eq!(parsed.files[0].base_name, "README");
+    assert_eq!(parsed.files[0].extension, "");
+    assert_eq!(parsed.files[0].size, 0);
+
+    let _ = fs::remove_file(temp_path);
+}
+
+#[test]
 fn normalize_loaded_json_scan_applies_strip_root_per_loaded_input() {
     let mut loaded = JsonScanInput {
         headers: vec![JsonHeaderInput {
@@ -190,6 +234,95 @@ fn normalize_loaded_json_scan_trims_full_root_display_without_absolutizing() {
             .as_deref(),
         Some("tmp/archive/root/src/main.rs")
     );
+}
+
+#[test]
+fn normalize_loaded_json_scan_prefixes_multi_resource_relative_replay_with_virtual_root() {
+    let mut loaded = JsonScanInput {
+        headers: vec![],
+        files: vec![
+            output_json_file("README.md", crate::models::FileType::File),
+            output_json_file("src/lib.rs", crate::models::FileType::File),
+        ],
+        packages: vec![],
+        dependencies: vec![],
+        license_detections: vec![],
+        license_references: vec![],
+        license_rule_references: vec![],
+        excluded_count: 0,
+    };
+
+    normalize_loaded_json_scan(&mut loaded, false, false);
+
+    let paths: Vec<_> = loaded.files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["virtual_root/README.md", "virtual_root/src/lib.rs"]
+    );
+}
+
+#[test]
+fn load_and_merge_json_inputs_namespaces_multiple_replay_inputs() {
+    let temp_dir = std::env::temp_dir().join("provenant-from-json-merge-test");
+    let _ = fs::create_dir_all(&temp_dir);
+    let first = temp_dir.join("first.json");
+    let second = temp_dir.join("second.json");
+
+    fs::write(
+        &first,
+        json!({
+            "files": [
+                {"path": "README", "type": "file", "scan_errors": []}
+            ],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write first json fixture");
+    fs::write(
+        &second,
+        json!({
+            "files": [
+                {"path": "README.adoc", "type": "file", "scan_errors": []},
+                {"path": "bench/data/gsoc-2018.json", "type": "file", "scan_errors": []}
+            ],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write second json fixture");
+
+    let merged = load_and_merge_json_inputs(
+        &[
+            first.to_str().expect("utf-8 path").to_string(),
+            second.to_str().expect("utf-8 path").to_string(),
+        ],
+        false,
+        false,
+    )
+    .expect("merged replay inputs should load");
+
+    let paths: Vec<_> = merged.files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec![
+            "virtual_root/codebase-1/README",
+            "virtual_root/codebase-2/README.adoc",
+            "virtual_root/codebase-2/bench/data/gsoc-2018.json",
+        ]
+    );
+
+    let _ = fs::remove_file(first);
+    let _ = fs::remove_file(second);
+    let _ = fs::remove_dir_all(temp_dir);
 }
 
 #[test]

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -46,6 +46,7 @@ const MAX_IMAGE_METADATA_VALUES: usize = 64;
 const MAX_IMAGE_METADATA_TEXT_BYTES: usize = 32 * 1024;
 const BINARY_CONTROL_CHAR_THRESHOLD_DIVISOR: usize = 10;
 const LARGE_OPAQUE_BINARY_SKIP_BYTES: usize = 512 * 1024;
+const JSON_VALIDATION_MAX_BYTES: usize = 4 * 1024 * 1024;
 const PLAIN_TEXT_EXTENSIONS: &[&str] = &[
     "rst", "rest", "md", "txt", "log", "json", "xml", "yaml", "yml", "toml", "ini",
 ];
@@ -362,6 +363,37 @@ fn is_utf8_text(bytes: &[u8]) -> bool {
     std::str::from_utf8(bytes).is_ok()
 }
 
+fn decode_utf16_bom_text(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 2 || !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+
+    let (is_le, body) = match bytes {
+        [0xFF, 0xFE, rest @ ..] => (true, rest),
+        [0xFE, 0xFF, rest @ ..] => (false, rest),
+        _ => return None,
+    };
+
+    if body.is_empty() || body.len() % 2 != 0 {
+        return None;
+    }
+
+    let code_units: Vec<u16> = body
+        .chunks_exact(2)
+        .map(|chunk| {
+            if is_le {
+                u16::from_le_bytes([chunk[0], chunk[1]])
+            } else {
+                u16::from_be_bytes([chunk[0], chunk[1]])
+            }
+        })
+        .collect();
+
+    std::char::decode_utf16(code_units)
+        .collect::<Result<String, _>>()
+        .ok()
+}
+
 fn has_binary_control_chars(bytes: &[u8]) -> bool {
     let control_count = bytes
         .iter()
@@ -371,12 +403,20 @@ fn has_binary_control_chars(bytes: &[u8]) -> bool {
 }
 
 fn has_decodable_text(bytes: &[u8]) -> bool {
-    bytes.is_empty() || is_utf8_text(bytes) || !has_binary_control_chars(bytes)
+    bytes.is_empty()
+        || is_utf8_text(bytes)
+        || decode_utf16_bom_text(bytes).is_some()
+        || !has_binary_control_chars(bytes)
 }
 
 fn looks_like_textual_bytes(bytes: &[u8]) -> bool {
     if bytes.is_empty() || is_utf8_text(bytes) {
         return true;
+    }
+    if let Some(decoded) = decode_utf16_bom_text(bytes) {
+        return decoded
+            .chars()
+            .any(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'));
     }
 
     let printable_count = bytes
@@ -414,6 +454,25 @@ pub fn detect_mime_type(
 ) -> String {
     if bytes.is_empty() {
         return "inode/x-empty".to_string();
+    }
+
+    if lower_extension(path).as_deref() == Some("json") {
+        if let Some(is_binary) = json_binary_override(bytes) {
+            if is_binary {
+                return "application/octet-stream".to_string();
+            }
+            if has_valid_json_text(bytes) {
+                return "application/json".to_string();
+            }
+            return "text/plain".to_string();
+        }
+        if has_valid_json_text(bytes) {
+            return "application/json".to_string();
+        }
+        if has_decodable_text(bytes) && looks_like_textual_bytes(bytes) {
+            return "text/plain".to_string();
+        }
+        return "application/octet-stream".to_string();
     }
 
     if is_zip_archive(bytes) {
@@ -482,12 +541,57 @@ fn should_prefer_text_mime(
         && (mime_type.starts_with("video/") || mime_type == "application/octet-stream")
 }
 
+fn has_valid_json_text(bytes: &[u8]) -> bool {
+    if bytes.len() > JSON_VALIDATION_MAX_BYTES {
+        return false;
+    }
+
+    serde_json::from_slice::<serde_json::Value>(bytes).is_ok()
+        || decode_utf16_bom_text(bytes)
+            .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+            .is_some()
+}
+
+fn is_wrapped_invalid_json_string_text(bytes: &[u8]) -> bool {
+    !bytes.contains(&0)
+        && !bytes.contains(&0xFF)
+        && bytes.starts_with(b"[\"")
+        && bytes.ends_with(b"\"]")
+        && bytes.len() >= 8
+}
+
+fn json_binary_override(bytes: &[u8]) -> Option<bool> {
+    if has_valid_json_text(bytes) || decode_utf16_bom_text(bytes).is_some() {
+        return Some(false);
+    }
+
+    if bytes.contains(&0) {
+        return Some(true);
+    }
+
+    if bytes.contains(&0xFF) && (bytes.len() <= 5 || bytes.len() > 1024) {
+        return Some(true);
+    }
+
+    if is_wrapped_invalid_json_string_text(bytes) {
+        return Some(false);
+    }
+
+    None
+}
+
 fn detect_is_binary(
     path: &Path,
     bytes: &[u8],
     detected_format: FileFormat,
     programming_language: Option<&str>,
 ) -> bool {
+    if lower_extension(path).as_deref() == Some("json")
+        && let Some(is_binary) = json_binary_override(bytes)
+    {
+        return is_binary;
+    }
+
     if is_textual_format(detected_format) {
         return false;
     }
@@ -589,7 +693,19 @@ fn detect_is_script(
         })
         || matches!(
             programming_language,
-            Some("Shell" | "Python" | "Ruby" | "Perl" | "PHP" | "PowerShell" | "Awk")
+            Some(
+                "Shell"
+                    | "Bash"
+                    | "Zsh"
+                    | "Fish"
+                    | "Ksh"
+                    | "Python"
+                    | "Ruby"
+                    | "Perl"
+                    | "PHP"
+                    | "PowerShell"
+                    | "Awk"
+            )
         )
 }
 
@@ -645,7 +761,10 @@ fn detect_file_type(
 
     if is_text {
         if lower_extension(path).as_deref() == Some("json") {
-            return "JSON text data".to_string();
+            if has_valid_json_text(bytes) {
+                return "JSON text data".to_string();
+            }
+            return text_file_type(bytes);
         }
         if lower_extension(path).as_deref() == Some("xml") {
             return "XML text data".to_string();
@@ -669,7 +788,7 @@ fn detect_file_type(
             return text_file_type(bytes);
         }
         if programming_language.is_some() && !is_media {
-            return text_file_type(bytes);
+            return source_file_type(programming_language, bytes);
         }
         return text_file_type(bytes);
     }
@@ -697,6 +816,8 @@ fn is_textual_source_candidate(path: &Path, programming_language: Option<&str>) 
             | "containerfile.core"
             | "apkbuild"
             | "podfile"
+            | "jamfile"
+            | "jamroot"
             | "meson.build"
             | "build"
             | "workspace"
@@ -825,6 +946,7 @@ fn is_source_like_language(language: &str) -> bool {
             | "TeX"
             | "Dockerfile"
             | "Makefile"
+            | "Jamfile"
     )
 }
 
@@ -1121,11 +1243,39 @@ fn script_file_type(programming_language: Option<&str>, bytes: &[u8]) -> String 
         Some("Perl") => format!("perl script, {suffix}"),
         Some("PHP") => format!("php script, {suffix}"),
         Some("Shell") => format!("shell script, {suffix}"),
+        Some("Bash") => format!("bash script, {suffix}"),
+        Some("Zsh") => format!("zsh script, {suffix}"),
+        Some("Fish") => format!("fish script, {suffix}"),
+        Some("Ksh") => format!("ksh script, {suffix}"),
         Some("JavaScript") => format!("javascript script, {suffix}"),
         Some("TypeScript") => format!("typescript script, {suffix}"),
         Some("PowerShell") => format!("powershell script, {suffix}"),
         Some("Awk") => format!("awk script, {suffix}"),
         _ => format!("script, {suffix}"),
+    }
+}
+
+fn source_file_type(programming_language: Option<&str>, bytes: &[u8]) -> String {
+    let suffix = text_label(bytes);
+    match programming_language {
+        Some("C") => format!("C source, {suffix}"),
+        Some("C++") => format!("C++ source, {suffix}"),
+        Some("Java") => format!("Java source, {suffix}"),
+        Some("C#") => format!("C# source, {suffix}"),
+        Some("F#") => format!("F# source, {suffix}"),
+        Some("Go") => format!("Go source, {suffix}"),
+        Some("Rust") => format!("Rust source, {suffix}"),
+        Some("Starlark") => format!("Starlark source, {suffix}"),
+        Some("CMake") => format!("CMake source, {suffix}"),
+        Some("Meson") => format!("Meson source, {suffix}"),
+        Some("Nix") => format!("Nix source, {suffix}"),
+        Some("Groovy") => format!("Groovy source, {suffix}"),
+        Some("Makefile") => format!("Makefile source, {suffix}"),
+        Some("Dockerfile") => format!("Dockerfile source, {suffix}"),
+        Some("Jamfile") => format!("Jamfile source, {suffix}"),
+        Some("Batchfile") => format!("Batchfile source, {suffix}"),
+        Some(language) => format!("{language} source, {suffix}"),
+        None => text_file_type(bytes),
     }
 }
 
@@ -2217,6 +2367,91 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_file_info_does_not_label_invalid_json_text_as_json() {
+        let classification =
+            classify_file_info(Path::new("broken.json"), b"{ definitely not json\n");
+
+        assert_eq!(classification.mime_type, "text/plain");
+        assert_eq!(classification.file_type, "UTF-8 Unicode text");
+        assert!(classification.is_text);
+        assert!(!classification.is_binary);
+    }
+
+    #[test]
+    fn test_classify_file_info_does_not_label_binary_json_garbage_as_json() {
+        let classification =
+            classify_file_info(Path::new("broken.json"), &[0xff, 0x00, 0x01, 0x02]);
+
+        assert_eq!(classification.mime_type, "application/octet-stream");
+        assert_eq!(classification.file_type, "data");
+        assert!(classification.is_binary);
+        assert!(!classification.is_text);
+    }
+
+    #[test]
+    fn test_classify_file_info_treats_valid_utf16_json_with_bom_as_text() {
+        let classification = classify_file_info(
+            Path::new("utf16.json"),
+            &[
+                0xFF, 0xFE, 0x5B, 0x00, 0x22, 0x00, 0xE9, 0x00, 0x22, 0x00, 0x5D, 0x00,
+            ],
+        );
+
+        assert!(!classification.is_binary);
+        assert!(classification.is_text);
+        assert_eq!(classification.mime_type, "application/json");
+        assert_eq!(classification.file_type, "JSON text data");
+    }
+
+    #[test]
+    fn test_classify_file_info_treats_small_valid_json_literals_as_text() {
+        let classification = classify_file_info(Path::new("true.json"), b"true");
+
+        assert!(!classification.is_binary);
+        assert!(classification.is_text);
+        assert_eq!(classification.mime_type, "application/json");
+        assert_eq!(classification.file_type, "JSON text data");
+    }
+
+    #[test]
+    fn test_classify_file_info_treats_json_wrapped_invalid_utf8_sequences_as_text() {
+        let classification = classify_file_info(
+            Path::new("wrapped.json"),
+            &[0x5B, 0x22, 0xE6, 0x97, 0xA5, 0xD1, 0x88, 0xFA, 0x22, 0x5D],
+        );
+
+        assert!(!classification.is_binary);
+        assert!(classification.is_text);
+        assert_eq!(classification.mime_type, "text/plain");
+        assert_eq!(classification.file_type, "text, with no line terminators");
+    }
+
+    #[test]
+    fn test_classify_file_info_keeps_lone_ff_json_byte_binary() {
+        let classification =
+            classify_file_info(Path::new("lone-ff.json"), &[0x5B, 0x22, 0xFF, 0x22, 0x5D]);
+
+        assert!(classification.is_binary);
+        assert!(!classification.is_text);
+        assert_eq!(classification.mime_type, "application/octet-stream");
+        assert_eq!(classification.file_type, "data");
+    }
+
+    #[test]
+    fn test_classify_file_info_keeps_nul_heavy_crash_json_binary() {
+        let classification = classify_file_info(
+            Path::new("crash.json"),
+            &[
+                0xFE, 0x90, 0x00, 0x00, 0x00, 0x93, 0x5B, 0x5B, 0x32, 0x38, 0x36,
+            ],
+        );
+
+        assert!(classification.is_binary);
+        assert!(!classification.is_text);
+        assert_eq!(classification.mime_type, "application/octet-stream");
+    }
+
+    #[test]
     fn test_classify_file_info_treats_dockerfile_as_source() {
         let classification = classify_file_info(Path::new("Dockerfile"), b"FROM scratch\n");
 
@@ -2226,7 +2461,10 @@ mod tests {
         );
         assert!(classification.is_source);
         assert!(!classification.is_script);
-        assert_eq!(classification.file_type, "UTF-8 Unicode text");
+        assert_eq!(
+            classification.file_type,
+            "Dockerfile source, UTF-8 Unicode text"
+        );
     }
 
     #[test]
@@ -2309,6 +2547,10 @@ mod tests {
     fn test_classify_file_info_classifies_common_build_manifests() {
         let gradle = classify_file_info(Path::new("build.gradle"), b"plugins { id 'java' }\n");
         let flake = classify_file_info(Path::new("flake.nix"), b"{ inputs, ... }: {}\n");
+        let cmake = classify_file_info(
+            Path::new("toolchain.cmake"),
+            b"set(CMAKE_CXX_STANDARD 20)\n",
+        );
         let gitmodules = classify_file_info(
             Path::new(".gitmodules"),
             b"[submodule \"demo\"]\n\tpath = vendor/demo\n",
@@ -2317,15 +2559,62 @@ mod tests {
         assert_eq!(gradle.programming_language.as_deref(), Some("Groovy"));
         assert!(gradle.is_source);
         assert_eq!(gradle.mime_type, "text/plain");
+        assert_eq!(gradle.file_type, "Groovy source, UTF-8 Unicode text");
 
         assert_eq!(flake.programming_language.as_deref(), Some("Nix"));
         assert!(flake.is_source);
         assert_eq!(flake.mime_type, "text/plain");
+        assert_eq!(flake.file_type, "Nix source, UTF-8 Unicode text");
+
+        assert_eq!(cmake.programming_language.as_deref(), Some("CMake"));
+        assert!(cmake.is_source);
+        assert_eq!(cmake.file_type, "CMake source, UTF-8 Unicode text");
 
         assert_eq!(gitmodules.programming_language, None);
         assert!(gitmodules.is_text);
         assert!(!gitmodules.is_source);
         assert_eq!(gitmodules.file_type, "Git configuration text");
+    }
+
+    #[test]
+    fn test_classify_file_info_labels_cpp_headers_and_ipp_separately() {
+        let header = classify_file_info(
+            Path::new("include/demo.hpp"),
+            b"#pragma once\nclass Demo {};\n",
+        );
+        let ipp = classify_file_info(
+            Path::new("include/detail/demo.ipp"),
+            b"template <class T> void parse() {}\n",
+        );
+
+        assert_eq!(header.programming_language.as_deref(), Some("C++"));
+        assert!(header.is_source);
+        assert!(!header.is_script);
+        assert_eq!(header.file_type, "C++ source, UTF-8 Unicode text");
+
+        assert_eq!(ipp.programming_language, None);
+        assert!(!ipp.is_source);
+        assert!(!ipp.is_script);
+        assert_eq!(ipp.file_type, "UTF-8 Unicode text");
+    }
+
+    #[test]
+    fn test_classify_file_info_preserves_specific_shell_family_labels() {
+        let bash = classify_file_info(Path::new("bin/run"), b"#!/usr/bin/env bash\necho hi\n");
+
+        assert_eq!(bash.programming_language.as_deref(), Some("Bash"));
+        assert!(bash.is_script);
+        assert_eq!(bash.file_type, "bash script, UTF-8 Unicode text executable");
+    }
+
+    #[test]
+    fn test_classify_file_info_marks_jamfile_as_source() {
+        let jamfile = classify_file_info(Path::new("Jamfile"), b"lib boost_json ;\n");
+
+        assert_eq!(jamfile.programming_language.as_deref(), Some("Jamfile"));
+        assert!(jamfile.is_source);
+        assert!(!jamfile.is_script);
+        assert_eq!(jamfile.file_type, "Jamfile source, UTF-8 Unicode text");
     }
 
     #[test]

--- a/src/utils/language.rs
+++ b/src/utils/language.rs
@@ -37,7 +37,7 @@ fn detect_content_hint_language(content: &[u8]) -> Option<String> {
         Some("Groovy".to_string())
     } else if text_sample.contains("import React") || text_sample.contains("import {") {
         Some("JavaScript/TypeScript".to_string())
-    } else if text_sample.contains("def ") && text_sample.contains(':') {
+    } else if has_python_definition_line(text_sample) {
         Some("Python".to_string())
     } else if text_sample.contains("package ")
         && text_sample.contains("import ")
@@ -47,6 +47,13 @@ fn detect_content_hint_language(content: &[u8]) -> Option<String> {
     } else {
         None
     }
+}
+
+fn has_python_definition_line(text: &str) -> bool {
+    text.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("def ") && trimmed.contains(':')
+    })
 }
 
 fn detect_shebang_language(content: &[u8]) -> Option<String> {
@@ -64,6 +71,14 @@ fn detect_shebang_language(content: &[u8]) -> Option<String> {
         Some("Python".to_string())
     } else if shebang.contains("node") || shebang.contains("deno") || shebang.contains("bun") {
         Some("JavaScript".to_string())
+    } else if shebang.contains("bash") {
+        Some("Bash".to_string())
+    } else if shebang.contains("zsh") {
+        Some("Zsh".to_string())
+    } else if shebang.contains("fish") {
+        Some("Fish".to_string())
+    } else if shebang.contains("ksh") {
+        Some("Ksh".to_string())
     } else if shebang.contains("ruby") {
         Some("Ruby".to_string())
     } else if shebang.contains("perl") {
@@ -74,12 +89,7 @@ fn detect_shebang_language(content: &[u8]) -> Option<String> {
         Some("PowerShell".to_string())
     } else if shebang.contains("awk") {
         Some("Awk".to_string())
-    } else if shebang.contains("bash")
-        || shebang.contains("zsh")
-        || shebang.contains("fish")
-        || shebang.contains("ksh")
-        || shebang.contains("/sh")
-    {
+    } else if shebang.contains("/sh") {
         Some("Shell".to_string())
     } else {
         None
@@ -229,6 +239,8 @@ fn detect_repo_special_file_name_language(path: &Path) -> Option<String> {
         Some("Ruby".to_string())
     } else if matches!(file_name.as_str(), "apkbuild" | "pkgbuild" | "gradlew") {
         Some("Shell".to_string())
+    } else if matches!(file_name.as_str(), "jamfile" | "jamroot") {
+        Some("Jamfile".to_string())
     } else if matches!(file_name.as_str(), "meson.build") {
         Some("Meson".to_string())
     } else if matches!(file_name.as_str(), "containerfile.core") {
@@ -270,7 +282,12 @@ fn detect_manual_extension_language(path: &Path) -> Option<String> {
         "pl" => Some("Perl".to_string()),
         "swift" => Some("Swift".to_string()),
         "sql" => Some("SQL".to_string()),
-        "sh" | "bash" | "zsh" | "fish" | "ksh" => Some("Shell".to_string()),
+        "sh" => Some("Shell".to_string()),
+        "bash" => Some("Bash".to_string()),
+        "zsh" => Some("Zsh".to_string()),
+        "fish" => Some("Fish".to_string()),
+        "ksh" => Some("Ksh".to_string()),
+        "bat" | "cmd" => Some("Batchfile".to_string()),
         "kt" | "kts" => Some("Kotlin".to_string()),
         "dart" => Some("Dart".to_string()),
         "scala" => Some("Scala".to_string()),
@@ -285,6 +302,7 @@ fn detect_manual_extension_language(path: &Path) -> Option<String> {
         "erl" => Some("Erlang".to_string()),
         "tex" => Some("TeX".to_string()),
         "groovy" | "gradle" | "gvy" | "gy" | "gsh" => Some("Groovy".to_string()),
+        "cmake" => Some("CMake".to_string()),
         "nix" => Some("Nix".to_string()),
         "zig" => Some("Zig".to_string()),
         "ps1" | "psm1" | "psd1" => Some("PowerShell".to_string()),
@@ -359,6 +377,13 @@ mod tests {
             Some("Groovy".to_string())
         );
         assert_eq!(
+            detect_language(
+                Path::new("toolchain.cmake"),
+                b"set(CMAKE_CXX_STANDARD 20)\n"
+            ),
+            Some("CMake".to_string())
+        );
+        assert_eq!(
             detect_language(Path::new("main.nix"), b"{ pkgs }: pkgs.hello\n"),
             Some("Nix".to_string())
         );
@@ -369,6 +394,29 @@ mod tests {
         assert_eq!(
             detect_language(Path::new("script.ps1"), b"Write-Host 'hello'\n"),
             Some("PowerShell".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_language_maps_batch_and_ipp_extensions() {
+        assert_eq!(
+            detect_language(Path::new("build.cmd"), b"@echo off\r\n"),
+            Some("Batchfile".to_string())
+        );
+        assert_eq!(
+            detect_language(
+                Path::new("from_chars.ipp"),
+                b"template <class T> void parse();\n"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn detect_language_handles_jamfile_names() {
+        assert_eq!(
+            detect_language(Path::new("Jamfile"), b"lib boost_json ;\n"),
+            Some("Jamfile".to_string())
         );
     }
 
@@ -410,6 +458,17 @@ mod tests {
                 b"<!DOCTYPE html><html><body></body></html>"
             ),
             Some("HTML".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_language_does_not_infer_python_from_default_labels() {
+        assert_eq!(
+            detect_language(
+                Path::new("from_chars.ipp"),
+                b"switch (value) {\n  default: return parse();\n}\n"
+            ),
+            None
         );
     }
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -49,7 +49,7 @@ cargo run --manifest-path xtask/Cargo.toml --bin benchmark-target -- --target-pa
 
 CLI arguments:
 
-- Exactly one of `--repo-url` or `--target-path` is required.
+- Exactly one of `--repo-url` or one-or-more `--target-path` values is required.
 - `--repo-url URL`: benchmark the given repository URL via the shared repo cache.
 - `--repo-ref REF`: required with `--repo-url`; commit SHA, tag, or branch to resolve and benchmark.
 - `--target-path PATH`: benchmark an existing local directory in place.
@@ -123,10 +123,10 @@ cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --target-pat
 
 CLI arguments:
 
-- Exactly one of `--repo-url` or `--target-path` is required.
+- Exactly one of `--repo-url` or one-or-more `--target-path` values is required.
 - `--repo-url URL`: compare the given repository URL via the shared repo cache.
 - `--repo-ref REF`: required with `--repo-url`; commit SHA, tag, or branch to resolve and compare.
-- `--target-path PATH`: compare an existing local directory in place.
+- `--target-path PATH`: compare an existing local directory in place, or repeat the flag to stage multiple local files into one compare run.
 - `--scancode-cache-identity ID`: optional with `--target-path`; opt in to shared ScanCode cache reuse for a caller-asserted local snapshot identity.
 - `--profile common`: convenience shorthand for `-clupe --system-package --strip-root --processes 4`.
 - `--profile common-with-compiled`: convenience shorthand for `-clupe --system-package --package-in-compiled --strip-root`.
@@ -178,6 +178,7 @@ Optional diagnostic logs when available:
 - Repo URL runs reuse cached git objects from `.provenant/repo-cache/`, and the temporary detached checkout is removed after the run so compare artifacts do not retain duplicate full repository trees.
 - Repo URL runs also reuse cached raw ScanCode artifacts from `.provenant/scancode-cache/` when the resolved target commit, ScanCode runtime identity, and effective ScanCode scan args are unchanged.
 - Local `--target-path` runs rerun ScanCode by default. Pass `--scancode-cache-identity <id>` to opt into shared ScanCode raw-artifact reuse for a local snapshot you have identified explicitly.
+- Repeated `--target-path` values currently support **files only** and are mainly intended for multi-input `--from-json` replay compares. The harness stages those files under one temporary input directory and passes them explicitly to both scanners in the same order.
 - Cache hits now require a cached `scancode.json` plus cache `manifest.json`; `scancode-stdout.txt` is reused when available but is no longer required for cache completeness.
 - `scancode-stdout.txt` and `provenant-stdout.txt` are best-effort diagnostic logs. The compare pipeline only requires the JSON outputs, so a log-write failure no longer makes the command fail.
 - The command adds Git control-path ignore rules (`.git`, nested `.git`, and their contents) on the ScanCode side plus `target/*` on both scanners so repository metadata and Cargo build output do not dominate the comparison artifacts without hiding package-adjacent files such as `.gitmodules`. Provenant already excludes `.git` directories during path collection by default, so xtask does not need to restate those ignores for Provenant.

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -30,7 +30,7 @@ struct Args {
     #[arg(long)]
     repo_url: Option<String>,
     #[arg(long)]
-    target_path: Option<PathBuf>,
+    target_path: Vec<PathBuf>,
     #[arg(long, requires = "target_path")]
     scancode_cache_identity: Option<String>,
     #[arg(long)]
@@ -40,6 +40,7 @@ struct Args {
     scan_args: Vec<String>,
 }
 
+#[derive(Debug)]
 struct ContextState {
     project_root: PathBuf,
     scancode_submodule_dir: PathBuf,
@@ -52,6 +53,9 @@ struct ContextState {
     summary_json: PathBuf,
     summary_tsv: PathBuf,
     target_dir: PathBuf,
+    target_resolved_paths: Vec<PathBuf>,
+    target_input_args: Vec<String>,
+    target_uses_staged_inputs: bool,
     target_label: String,
     target_source_label: String,
     target_revision: String,
@@ -124,6 +128,13 @@ struct ValueDifferenceEntry {
     provenant: usize,
     missing_in_provenant: Vec<ValueCountEntry>,
     extra_in_provenant: Vec<ValueCountEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScalarDifferenceEntry {
+    path: String,
+    scancode: Option<String>,
+    provenant: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -269,16 +280,17 @@ fn main() -> Result<()> {
 }
 
 fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> {
-    if args.repo_url.is_some() == args.target_path.is_some() {
+    let has_target_paths = !args.target_path.is_empty();
+    if args.repo_url.is_some() == has_target_paths {
         bail!("specify exactly one of --repo-url or --target-path");
     }
-    if args.target_path.is_some() && args.repo_ref.is_some() {
+    if has_target_paths && args.repo_ref.is_some() {
         bail!("--repo-ref can only be used with --repo-url");
     }
     if args.repo_url.is_some() && args.repo_ref.is_none() {
         bail!("--repo-url requires --repo-ref (commit SHA, tag, or branch)");
     }
-    if args.scancode_cache_identity.is_some() && args.target_path.is_none() {
+    if args.scancode_cache_identity.is_some() && !has_target_paths {
         bail!("--scancode-cache-identity can only be used with --target-path");
     }
     let target_scancode_cache_identity = args
@@ -293,6 +305,25 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
         bail!("--scancode-cache-identity must not be blank");
     }
 
+    let target_resolved_paths = if has_target_paths {
+        args.target_path
+            .iter()
+            .map(|path| realpath(path))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        Vec::new()
+    };
+    if target_resolved_paths.len() > 1 && target_resolved_paths.iter().any(|path| path.is_dir()) {
+        bail!("multiple --target-path values currently support files only");
+    }
+    let target_uses_staged_inputs = !target_resolved_paths.is_empty()
+        && target_resolved_paths.iter().all(|path| path.is_file());
+    let target_input_args = if target_uses_staged_inputs {
+        staged_input_names(&target_resolved_paths)
+    } else {
+        vec![".".to_string()]
+    };
+
     let project_root = project_root();
     let artifact_root = project_root.join(".provenant/compare-runs");
     let scancode_cache_root = project_root.join(".provenant/scancode-cache");
@@ -303,14 +334,18 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
             scancode_submodule_dir.display()
         );
     }
-    let slug = if let Some(target_path) = &args.target_path {
-        sanitize_label(
-            target_path
-                .file_name()
-                .and_then(|v| v.to_str())
-                .unwrap_or("compare-target"),
-            "compare-target",
-        )
+    let slug = if has_target_paths {
+        if target_resolved_paths.len() == 1 {
+            sanitize_label(
+                target_resolved_paths[0]
+                    .file_name()
+                    .and_then(|v| v.to_str())
+                    .unwrap_or("compare-target"),
+                "compare-target",
+            )
+        } else {
+            "multi-target".to_string()
+        }
     } else {
         sanitize_label(
             &derive_repo_name_from_url(args.repo_url.as_deref().unwrap(), "compare-target"),
@@ -324,24 +359,34 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
     let samples_dir = comparison_dir.join("samples");
     fs::create_dir_all(&raw_dir)?;
     fs::create_dir_all(&samples_dir)?;
-    let target_dir = if let Some(target_path) = &args.target_path {
-        let resolved_target = realpath(target_path)?;
-        if resolved_target.is_file() {
+    let target_dir = if has_target_paths {
+        if target_uses_staged_inputs {
             run_dir.join("input")
         } else {
-            resolved_target
+            target_resolved_paths
+                .first()
+                .cloned()
+                .unwrap_or_else(|| run_dir.join("input"))
         }
     } else {
         run_dir.join(&slug)
     };
-    let target_source_label = if args.target_path.is_some() {
-        "Target path"
+    let target_source_label = if has_target_paths {
+        if target_resolved_paths.len() > 1 {
+            "Target paths"
+        } else {
+            "Target path"
+        }
     } else {
         "Repo URL"
     }
     .to_string();
-    let target_label = if let Some(target_path) = &args.target_path {
-        realpath(target_path)?.display().to_string()
+    let target_label = if has_target_paths {
+        target_resolved_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     } else {
         args.repo_url.clone().unwrap()
     };
@@ -365,12 +410,15 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
         summary_json: comparison_dir.join("summary.json"),
         summary_tsv: comparison_dir.join("summary.tsv"),
         target_dir,
+        target_resolved_paths,
+        target_input_args,
+        target_uses_staged_inputs,
         target_label,
         target_source_label,
         target_revision: String::new(),
         target_scancode_cache_identity,
         repo_manifest,
-        worktree_retained_after_run: args.target_path.is_some(),
+        worktree_retained_after_run: has_target_paths,
         profile_name: args
             .profile
             .map(|profile| profile.display_name().to_string()),
@@ -399,20 +447,32 @@ fn prepare_context(args: &Args, scan_args: Vec<String>) -> Result<ContextState> 
 }
 
 fn prepare_target(context: &mut ContextState, args: &Args) -> Result<CheckoutGuard> {
-    if let Some(target_path) = &args.target_path {
-        let resolved_target = realpath(target_path)?;
-        if let Some(log_line) = current_git_log_line(&resolved_target) {
-            println!("{log_line}");
-        } else {
-            println!(
-                "  Using local path without git metadata: {}",
-                resolved_target.display()
-            );
+    if !args.target_path.is_empty() {
+        for resolved_target in &context.target_resolved_paths {
+            if let Some(log_line) = current_git_log_line(resolved_target) {
+                println!("{log_line}");
+            } else {
+                println!(
+                    "  Using local path without git metadata: {}",
+                    resolved_target.display()
+                );
+            }
         }
-        context.target_revision = current_git_revision(&resolved_target)
-            .unwrap_or_else(|| "current local checkout".to_string());
-        if resolved_target.is_file() {
-            materialize_file(&resolved_target, &context.target_dir)?;
+        context.target_revision = local_target_revision(&context.target_resolved_paths);
+        if context.target_uses_staged_inputs {
+            fs::create_dir_all(&context.target_dir).with_context(|| {
+                format!(
+                    "failed to create staged input directory {}",
+                    context.target_dir.display()
+                )
+            })?;
+            for (resolved_target, staged_name) in context
+                .target_resolved_paths
+                .iter()
+                .zip(context.target_input_args.iter())
+            {
+                materialize_file(resolved_target, &context.target_dir.join(staged_name))?;
+            }
         }
         return Ok(CheckoutGuard {
             cache_dir: None,
@@ -868,21 +928,14 @@ fn normalize_scancode_error_path(path: &str) -> String {
         .to_string()
 }
 
-fn build_provenant_invocation(context: &ContextState) -> (PathBuf, String) {
-    if context.target_dir.is_file() {
-        let working_dir = context
-            .target_dir
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .to_path_buf();
-        let input_arg = context
-            .target_dir
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| ".".to_string());
-        (working_dir, input_arg)
+fn build_provenant_invocation(context: &ContextState) -> (PathBuf, Vec<String>) {
+    if context.target_uses_staged_inputs {
+        (
+            context.target_dir.clone(),
+            context.target_input_args.clone(),
+        )
     } else {
-        (context.target_dir.clone(), ".".to_string())
+        (context.target_dir.clone(), vec![".".to_string()])
     }
 }
 
@@ -890,7 +943,7 @@ fn run_provenant(context: &ContextState) -> Result<()> {
     println!("------------------------------------------");
     println!("Running Provenant");
     println!("------------------------------------------");
-    let (working_dir, _input_arg) = build_provenant_invocation(context);
+    let (working_dir, _input_args) = build_provenant_invocation(context);
     let args = build_provenant_args(context);
     println!(
         "  {}",
@@ -919,10 +972,18 @@ fn run_provenant(context: &ContextState) -> Result<()> {
 fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
     let scancode: Value = serde_json::from_str(&fs::read_to_string(&context.scancode_json)?)?;
     let provenant: Value = serde_json::from_str(&fs::read_to_string(&context.provenant_json)?)?;
+    let info_mode = context
+        .scan_args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--info" | "--mark-source"));
     let scancode_files = files_by_path(&scancode);
     let provenant_files = files_by_path(&provenant);
+    let scancode_resources = resources_by_path(&scancode);
+    let provenant_resources = resources_by_path(&provenant);
     let scancode_paths: BTreeSet<String> = scancode_files.keys().cloned().collect();
     let provenant_paths: BTreeSet<String> = provenant_files.keys().cloned().collect();
+    let scancode_resource_paths: BTreeSet<String> = scancode_resources.keys().cloned().collect();
+    let provenant_resource_paths: BTreeSet<String> = provenant_resources.keys().cloned().collect();
     let common_paths: Vec<String> = scancode_paths
         .intersection(&provenant_paths)
         .cloned()
@@ -935,6 +996,18 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         .difference(&scancode_paths)
         .cloned()
         .collect();
+    let common_resource_paths: Vec<String> = scancode_resource_paths
+        .intersection(&provenant_resource_paths)
+        .cloned()
+        .collect();
+    let only_scancode_resource_paths: Vec<String> = scancode_resource_paths
+        .difference(&provenant_resource_paths)
+        .cloned()
+        .collect();
+    let only_provenant_resource_paths: Vec<String> = provenant_resource_paths
+        .difference(&scancode_resource_paths)
+        .cloned()
+        .collect();
     let metrics = [
         "license_detections",
         "package_data",
@@ -945,6 +1018,25 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         "urls",
         "scan_errors",
     ];
+    let info_metrics = [
+        "mime_type",
+        "file_type",
+        "programming_language",
+        "sha1",
+        "md5",
+        "sha256",
+        "sha1_git",
+        "is_binary",
+        "is_text",
+        "is_archive",
+        "is_media",
+        "is_source",
+        "is_script",
+        "files_count",
+        "dirs_count",
+        "size_count",
+        "source_count",
+    ];
     let mut lower_counts: BTreeMap<String, Vec<CountDeltaEntry>> = metrics
         .iter()
         .map(|m| ((*m).to_string(), Vec::new()))
@@ -954,6 +1046,10 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         .map(|m| ((*m).to_string(), Vec::new()))
         .collect();
     let mut value_differences: BTreeMap<String, Vec<ValueDifferenceEntry>> = metrics
+        .iter()
+        .map(|m| ((*m).to_string(), Vec::new()))
+        .collect();
+    let mut info_value_differences: BTreeMap<String, Vec<ScalarDifferenceEntry>> = info_metrics
         .iter()
         .map(|m| ((*m).to_string(), Vec::new()))
         .collect();
@@ -1007,6 +1103,25 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         }
     }
 
+    for path in &common_resource_paths {
+        let scancode_resource = scancode_resources.get(path).unwrap();
+        let provenant_resource = provenant_resources.get(path).unwrap();
+        for metric in info_metrics {
+            let scancode_value = scalar_field_value(scancode_resource, metric);
+            let provenant_value = scalar_field_value(provenant_resource, metric);
+            if scancode_value != provenant_value {
+                info_value_differences
+                    .get_mut(metric)
+                    .unwrap()
+                    .push(ScalarDifferenceEntry {
+                        path: path.clone(),
+                        scancode: scancode_value,
+                        provenant: provenant_value,
+                    });
+            }
+        }
+    }
+
     let sc_top = top_level_counts(&scancode);
     let pr_top = top_level_counts(&provenant);
     let license_deltas = top_level_license_deltas(&scancode, &provenant);
@@ -1052,9 +1167,34 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         only_provenant_paths.len() as i64,
         "paths seen only in Provenant output",
     ));
+    rows.push(tsv_row(
+        "common_resource_paths",
+        common_resource_paths.len() as i64,
+        common_resource_paths.len() as i64,
+        0,
+        "resource paths present in both outputs",
+    ));
+    rows.push(tsv_row(
+        "only_scancode_resource_paths",
+        only_scancode_resource_paths.len() as i64,
+        0,
+        -(only_scancode_resource_paths.len() as i64),
+        "resource paths seen only in ScanCode output",
+    ));
+    rows.push(tsv_row(
+        "only_provenant_resource_paths",
+        0,
+        only_provenant_resource_paths.len() as i64,
+        only_provenant_resource_paths.len() as i64,
+        "resource paths seen only in Provenant output",
+    ));
 
     let mut potential_regressions = only_scancode_paths.len() + top_level_regressions_map.len();
     let mut potential_higher = only_provenant_paths.len() + top_level_higher_counts.len();
+    if info_mode {
+        potential_regressions += only_scancode_resource_paths.len();
+        potential_higher += only_provenant_resource_paths.len();
+    }
     for metric in metrics {
         let missing = value_differences[metric]
             .iter()
@@ -1110,6 +1250,26 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
             extra as i64,
             extra as i64,
             "paths where normalized values exist only in Provenant output",
+        ));
+    }
+    let mut info_metric_summary = Map::new();
+    for metric in info_metrics {
+        let differences = info_value_differences[metric].len();
+        info_metric_summary.insert(
+            metric.to_string(),
+            json!({
+                "value_differences": differences,
+            }),
+        );
+        if info_mode {
+            potential_regressions += differences;
+        }
+        rows.push(tsv_row(
+            &format!("info_{metric}_value_differences"),
+            differences as i64,
+            differences as i64,
+            0,
+            "common-path resources where info values differ",
         ));
     }
     let dependency_value_differences = dependency_differences(&scancode, &provenant);
@@ -1195,6 +1355,10 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
                 .samples_dir
                 .join("dependency_value_differences.json"),
         ),
+        (
+            "info_value_differences",
+            context.samples_dir.join("info_value_differences.json"),
+        ),
     ];
     write_pretty_json(&sample_paths[0].1, &only_scancode_paths)?;
     write_pretty_json(&sample_paths[1].1, &only_provenant_paths)?;
@@ -1203,6 +1367,7 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
     write_pretty_json(&sample_paths[4].1, &value_differences)?;
     write_pretty_json(&sample_paths[5].1, &license_deltas)?;
     write_pretty_json(&sample_paths[6].1, &dependency_value_differences)?;
+    write_pretty_json(&sample_paths[7].1, &info_value_differences)?;
 
     let summary = json!({
         "comparison_status": comparison_status,
@@ -1223,7 +1388,13 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
             "only_scancode_paths": only_scancode_paths.len(),
             "only_provenant_paths": only_provenant_paths.len(),
         },
+        "resource_path_comparison": {
+            "common_paths": common_resource_paths.len(),
+            "only_scancode_paths": only_scancode_resource_paths.len(),
+            "only_provenant_paths": only_provenant_resource_paths.len(),
+        },
         "file_metric_summary": file_metric_summary,
+        "info_metric_summary": info_metric_summary,
         "top_level_regressions": top_level_regressions_map,
         "top_level_higher_counts": top_level_higher_counts,
         "top_level_license_expression_delta_count": license_deltas.len(),
@@ -1248,6 +1419,21 @@ fn files_by_path(value: &Value) -> BTreeMap<String, Value> {
             if entry.get("type").and_then(Value::as_str) != Some("file") {
                 return None;
             }
+            entry
+                .get("path")
+                .and_then(Value::as_str)
+                .map(|path| (normalize_compare_path(path), entry.clone()))
+        })
+        .collect()
+}
+
+fn resources_by_path(value: &Value) -> BTreeMap<String, Value> {
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
             entry
                 .get("path")
                 .and_then(Value::as_str)
@@ -1374,6 +1560,18 @@ fn normalize_license_expression(value: &str) -> String {
     } else {
         normalized.replace(['(', ')'], "")
     }
+}
+
+fn scalar_field_value(entry: &Value, key: &str) -> Option<String> {
+    let value = entry.get(key)?;
+    let normalized = match value {
+        Value::Null => return None,
+        Value::String(text) => normalize_text(text),
+        Value::Bool(flag) => flag.to_string(),
+        Value::Number(number) => number.to_string(),
+        _ => normalize_text(&value.to_string()),
+    };
+    (!normalized.is_empty()).then_some(normalized)
 }
 
 fn sample_values(values: &[String]) -> Vec<String> {
@@ -1607,7 +1805,7 @@ fn tsv_row(metric: &str, scancode: i64, provenant: i64, delta: i64, notes: &str)
 fn write_manifest(context: &ContextState) -> Result<()> {
     let scancode_args = build_scancode_docker_args(context);
     let provenant_args = build_provenant_args(context);
-    let (provenant_working_dir, _provenant_input_arg) = build_provenant_invocation(context);
+    let (provenant_working_dir, _provenant_input_args) = build_provenant_invocation(context);
     let manifest = CompareRunManifest {
         run_id: context.run_id.clone(),
         target: TargetManifest::new(
@@ -1677,7 +1875,16 @@ fn build_scancode_cli_args(context: &ContextState) -> Vec<String> {
     let mut args = vec!["--json-pp".to_string(), "/out/scancode.json".to_string()];
     args.extend(context.scan_args.clone());
     args.extend(scancode_ignore_args());
-    args.push("/input".to_string());
+    if context.target_uses_staged_inputs {
+        args.extend(
+            context
+                .target_input_args
+                .iter()
+                .map(|input| format!("/input/{input}")),
+        );
+    } else {
+        args.push("/input".to_string());
+    }
     args
 }
 
@@ -1716,7 +1923,7 @@ fn build_scancode_docker_args(context: &ContextState) -> Vec<String> {
 }
 
 fn build_provenant_args(context: &ContextState) -> Vec<String> {
-    let (_working_dir, input_arg) = build_provenant_invocation(context);
+    let (_working_dir, input_args) = build_provenant_invocation(context);
     let mut args = vec![
         "--json-pp".to_string(),
         context.provenant_json.display().to_string(),
@@ -1724,8 +1931,44 @@ fn build_provenant_args(context: &ContextState) -> Vec<String> {
     ];
     args.extend(context.scan_args.clone());
     args.extend(provenant_ignore_args());
-    args.push(input_arg);
+    args.extend(input_args);
     args
+}
+
+fn staged_input_names(paths: &[PathBuf]) -> Vec<String> {
+    let total = paths.len();
+    paths
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let file_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("input.json");
+            if total == 1 {
+                file_name.to_string()
+            } else {
+                format!("{index:02}-{file_name}")
+            }
+        })
+        .collect()
+}
+
+fn local_target_revision(paths: &[PathBuf]) -> String {
+    if paths.len() == 1 {
+        return current_git_revision(&paths[0])
+            .unwrap_or_else(|| "current local checkout".to_string());
+    }
+
+    let revisions: BTreeSet<String> = paths
+        .iter()
+        .filter_map(|path| current_git_revision(path))
+        .collect();
+    if revisions.len() == 1 {
+        revisions.into_iter().next().unwrap()
+    } else {
+        "multiple local inputs".to_string()
+    }
 }
 
 fn scancode_ignore_args() -> Vec<String> {
@@ -2041,6 +2284,9 @@ mod tests {
                 "/tmp/project/.provenant/compare-runs/run-id/comparison/summary.tsv",
             ),
             target_dir: PathBuf::from("/tmp/target"),
+            target_resolved_paths: Vec::new(),
+            target_input_args: vec![".".to_string()],
+            target_uses_staged_inputs: false,
             target_label: "/tmp/target".to_string(),
             target_source_label: "Target path".to_string(),
             target_revision: "current local checkout".to_string(),
@@ -2467,14 +2713,17 @@ mod tests {
         let temp_root = unique_temp_dir("single-file-provenant-args");
         fs::create_dir_all(&temp_root).unwrap();
         let staged_input = temp_root.join("input");
-        fs::write(&staged_input, "fixture").unwrap();
+        fs::create_dir_all(&staged_input).unwrap();
+        fs::write(staged_input.join("fixture.txt"), "fixture").unwrap();
 
         let mut context = test_context();
         context.target_dir = staged_input;
+        context.target_input_args = vec!["fixture.txt".to_string()];
+        context.target_uses_staged_inputs = true;
 
         let args = build_provenant_args(&context);
 
-        assert_eq!(args.last().map(String::as_str), Some("input"));
+        assert_eq!(args.last().map(String::as_str), Some("fixture.txt"));
 
         let _ = fs::remove_dir_all(&temp_root);
     }
@@ -2484,17 +2733,20 @@ mod tests {
         let temp_root = unique_temp_dir("single-file-provenant-invocation");
         fs::create_dir_all(&temp_root).unwrap();
         let staged_input = temp_root.join("input");
-        fs::write(&staged_input, "fixture").unwrap();
+        fs::create_dir_all(&staged_input).unwrap();
+        fs::write(staged_input.join("fixture.txt"), "fixture").unwrap();
 
         let mut context = test_context();
-        context.target_dir = staged_input;
+        context.target_dir = staged_input.clone();
+        context.target_input_args = vec!["fixture.txt".to_string()];
+        context.target_uses_staged_inputs = true;
 
-        let (working_dir, input_arg) = build_provenant_invocation(&context);
+        let (working_dir, input_args) = build_provenant_invocation(&context);
 
-        assert_eq!(working_dir, temp_root);
-        assert_eq!(input_arg, "input");
+        assert_eq!(working_dir, staged_input);
+        assert_eq!(input_args, vec!["fixture.txt"]);
 
-        let _ = fs::remove_dir_all(&working_dir);
+        let _ = fs::remove_dir_all(&temp_root);
     }
 
     #[test]
@@ -2506,7 +2758,7 @@ mod tests {
 
         let args = Args {
             repo_url: None,
-            target_path: Some(fixture.clone()),
+            target_path: vec![fixture.clone()],
             scancode_cache_identity: Some("fixture@rev".to_string()),
             repo_ref: None,
             profile: None,
@@ -2526,6 +2778,7 @@ mod tests {
                 .and_then(|name| name.to_str()),
             Some("input")
         );
+        assert_eq!(context.target_input_args, vec!["fixture.txt"]);
         assert_ne!(context.target_dir, fixture);
 
         let _ = fs::remove_dir_all(&temp_root);
@@ -2541,9 +2794,12 @@ mod tests {
 
         let mut context = test_context();
         context.target_dir = temp_root.join("run/input");
+        context.target_resolved_paths = vec![fixture.clone()];
+        context.target_input_args = vec!["fixture.txt".to_string()];
+        context.target_uses_staged_inputs = true;
         let args = Args {
             repo_url: None,
-            target_path: Some(fixture.clone()),
+            target_path: vec![fixture.clone()],
             scancode_cache_identity: Some("fixture@rev".to_string()),
             repo_ref: None,
             profile: None,
@@ -2552,9 +2808,9 @@ mod tests {
 
         let _guard = prepare_target(&mut context, &args).unwrap();
 
-        assert!(context.target_dir.is_file());
+        assert!(context.target_dir.is_dir());
         assert_eq!(
-            fs::read_to_string(&context.target_dir).unwrap(),
+            fs::read_to_string(context.target_dir.join("fixture.txt")).unwrap(),
             "fixture contents"
         );
 
@@ -2591,7 +2847,7 @@ mod tests {
     fn prepare_context_rejects_blank_scancode_cache_identity() {
         let args = Args {
             repo_url: None,
-            target_path: Some(PathBuf::from("/tmp/chromium")),
+            target_path: vec![PathBuf::from("/tmp/chromium")],
             scancode_cache_identity: Some("   ".to_string()),
             repo_ref: None,
             profile: None,
@@ -2603,5 +2859,122 @@ mod tests {
             .unwrap()
             .to_string();
         assert!(error.contains("must not be blank"));
+    }
+
+    #[test]
+    fn prepare_context_stages_multi_file_targets_with_numbered_inputs() {
+        let temp_root = unique_temp_dir("multi-file-target-context");
+        fs::create_dir_all(&temp_root).unwrap();
+        let first = temp_root.join("first.json");
+        let second = temp_root.join("second.json");
+        fs::write(&first, "first").unwrap();
+        fs::write(&second, "second").unwrap();
+
+        let args = Args {
+            repo_url: None,
+            target_path: vec![first.clone(), second.clone()],
+            scancode_cache_identity: Some("pair@rev".to_string()),
+            repo_ref: None,
+            profile: None,
+            scan_args: Vec::new(),
+        };
+
+        let context = prepare_context(&args, vec!["--from-json".to_string()]).unwrap();
+
+        assert!(context.target_uses_staged_inputs);
+        assert_eq!(
+            context.target_input_args,
+            vec!["00-first.json", "01-second.json"]
+        );
+        assert_eq!(
+            context
+                .target_dir
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("input")
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
+        let _ = fs::remove_dir_all(&context.run_dir);
+    }
+
+    #[test]
+    fn prepare_target_materializes_multi_file_targets_into_staged_input_dir() {
+        let temp_root = unique_temp_dir("multi-file-target-prepare");
+        fs::create_dir_all(&temp_root).unwrap();
+        let first = temp_root.join("first.json");
+        let second = temp_root.join("second.json");
+        fs::write(&first, "first contents").unwrap();
+        fs::write(&second, "second contents").unwrap();
+
+        let mut context = test_context();
+        context.target_dir = temp_root.join("run/input");
+        context.target_resolved_paths = vec![first.clone(), second.clone()];
+        context.target_input_args = vec!["00-first.json".to_string(), "01-second.json".to_string()];
+        context.target_uses_staged_inputs = true;
+        let args = Args {
+            repo_url: None,
+            target_path: vec![first.clone(), second.clone()],
+            scancode_cache_identity: Some("pair@rev".to_string()),
+            repo_ref: None,
+            profile: None,
+            scan_args: Vec::new(),
+        };
+
+        let _guard = prepare_target(&mut context, &args).unwrap();
+
+        assert!(context.target_dir.is_dir());
+        assert_eq!(
+            fs::read_to_string(context.target_dir.join("00-first.json")).unwrap(),
+            "first contents"
+        );
+        assert_eq!(
+            fs::read_to_string(context.target_dir.join("01-second.json")).unwrap(),
+            "second contents"
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn build_scancode_and_provenant_args_include_all_staged_multi_inputs() {
+        let mut context = test_context();
+        context.target_dir = PathBuf::from("/tmp/staged-inputs");
+        context.target_input_args = vec!["00-first.json".to_string(), "01-second.json".to_string()];
+        context.target_uses_staged_inputs = true;
+
+        let scancode_args = build_scancode_cli_args(&context);
+        let provenant_args = build_provenant_args(&context);
+
+        assert!(scancode_args.ends_with(&[
+            "/input/00-first.json".to_string(),
+            "/input/01-second.json".to_string(),
+        ]));
+        assert!(
+            provenant_args.ends_with(&["00-first.json".to_string(), "01-second.json".to_string(),])
+        );
+    }
+
+    #[test]
+    fn prepare_context_rejects_multiple_directory_targets() {
+        let temp_root = unique_temp_dir("multi-directory-target-context");
+        fs::create_dir_all(temp_root.join("a")).unwrap();
+        fs::create_dir_all(temp_root.join("b")).unwrap();
+
+        let args = Args {
+            repo_url: None,
+            target_path: vec![temp_root.join("a"), temp_root.join("b")],
+            scancode_cache_identity: Some("dirs@rev".to_string()),
+            repo_ref: None,
+            profile: None,
+            scan_args: Vec::new(),
+        };
+
+        let error = prepare_context(&args, vec!["--from-json".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("multiple --target-path values currently support files only"));
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 }


### PR DESCRIPTION
## Summary

- verify and document CLI workflow scorecard rows `0a`, `0b`, and `1` against ScanCode using real compare runs
- extend `xtask compare-outputs` for multi-input `--from-json` replay and `--info` / `--mark-source` parity reporting
- align replay import, replay shaping, native collection scope, and file-info classification so the major ScanCode-better CLI workflow gaps are resolved

## Scope and exclusions

- Included:
  - single-input and multi-input `--from-json` workflow verification and runtime fixes
  - native `--info` / `--mark-source` verification, including compare harness support for info-surface diffs
  - CLI workflow verification scorecard/docs updates
- Explicit exclusions:
  - scorecard row `2` (`--classify`, `--summary`, `--tallies*`, `--facet`, `--license-clarity-score`) follow-up work

## Intentional differences from Python

- The row `1` verification keeps a small residual tail of MIME/file-type naming differences where Provenant and ScanCode use different labels but the output remained review-acceptable and no major ScanCode-better workflow issue remained.

## Follow-up work

- Created or intentionally deferred:
  - continue with scorecard row `2` in a follow-up PR