### PR TITLE
chore: adopt DCO contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,33 @@ Repo-specific expectations:
 - Do not add dependencies lightly; make sure they clearly justify their maintenance cost.
 - Keep PR scope disciplined. For ecosystem or parser work, prefer one ecosystem family per PR.
 
+## Inbound licensing policy
+
+Provenant uses the Developer Certificate of Origin (DCO) 1.1 for inbound
+contributions. The DCO text is stored in [`DCO`](DCO).
+
+Unless a path says otherwise, contributions are accepted under the same license
+terms that already apply to the material you are changing in this repository.
+For the main project code that is Apache-2.0. Third-party and reference
+material kept in-tree continues to use its existing notices and licenses.
+
+Every commit you author must include a `Signed-off-by:` trailer that matches
+your commit author identity. The easiest way to do that is to use:
+
+```sh
+git commit -s
+```
+
+If you forgot to sign off the latest commit, fix it with:
+
+```sh
+git commit --amend -s --no-edit
+```
+
+If you rewrite or squash commits before merge, make sure the resulting commits
+still carry the sign-off. The local git hook can catch missing sign-offs early,
+and the GitHub DCO app enforces PR-level compliance.
+
 ## Testing and validation
 
 Keep local validation tightly scoped. This repository has many slow and specialized tests, so the default is the smallest command that proves your change.
@@ -85,6 +112,7 @@ That guide covers parser invariants, registration, datasource wiring, assembly i
 
 - Write commit messages in Conventional Commits format: `type(scope): short summary` when a scope helps, or `type: short summary` otherwise.
 - Use the same Conventional Commits format for pull request titles.
+- Sign off every commit with `git commit -s` so the branch satisfies the DCO policy.
 - Follow the structure in [`.github/pull_request_template.md`](.github/pull_request_template.md) and omit sections that do not apply.
 - Keep summaries focused on why the change exists, not just what changed.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ include = [
     "/ACKNOWLEDGEMENTS.md",
     "/README.md",
     "/CITATION.cff",
+    "/DCO",
     "/LICENSE",
     "/NOTICE",
     "/SECURITY.md",

--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ Output architecture and compatibility approach are documented in:
 Contributions are welcome. Please feel free to submit a pull request.
 
 For contributor workflow, start with [CONTRIBUTING.md](CONTRIBUTING.md).
+Inbound contributions use the Developer Certificate of Origin (DCO) 1.1, so
+commits should be signed off with `git commit -s`. See [`DCO`](DCO) and
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the policy details.
 
 For deeper contributor documentation, see the [Documentation Index](docs/DOCUMENTATION_INDEX.md), [How to Add a Parser](docs/HOW_TO_ADD_A_PARSER.md), and [Testing Strategy](docs/TESTING_STRATEGY.md).
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,10 @@
 glob_matcher: doublestar
 
+commit-msg:
+  commands:
+    dco-signoff:
+      run: ./scripts/check_dco_signoff.sh --commit-msg-file {1}
+
 pre-commit:
   commands:
     cargo-sort:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,6 +40,17 @@ Example:
 ./scripts/check_dependency_policy.sh
 ```
 
+## `check_dco_signoff.sh`
+
+Validate that a commit message includes a Developer Certificate of Origin (DCO)
+sign-off trailer.
+
+Examples:
+
+```bash
+./scripts/check_dco_signoff.sh --commit-msg-file .git/COMMIT_EDITMSG
+```
+
 ## `check_crate_size.sh`
 
 Package the crate locally and fail if the resulting `.crate` archive exceeds the

--- a/scripts/check_dco_signoff.sh
+++ b/scripts/check_dco_signoff.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  ./scripts/check_dco_signoff.sh --commit-msg-file <path>
+EOF
+    exit 1
+}
+
+check_commit_msg_file() {
+    local commit_msg_file="$1"
+
+    if [[ ! -f "$commit_msg_file" ]]; then
+        echo "Commit message file not found: $commit_msg_file" >&2
+        exit 1
+    fi
+
+    if ! grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+>$' "$commit_msg_file"; then
+        echo "Commit message is missing a DCO sign-off." >&2
+        echo "Add one with: git commit --amend -s --no-edit" >&2
+        exit 1
+    fi
+}
+
+case "${1:-}" in
+    --commit-msg-file)
+        [[ $# -eq 2 ]] || usage
+        check_commit_msg_file "$2"
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary

- adopt the Developer Certificate of Origin (DCO) 1.1 as the repo's inbound contribution policy and document it in contributor-facing docs
- include the `DCO` file in packaged crate metadata so downstream source distributions carry the policy text
- add a local `commit-msg` hook plus a small helper script so contributors catch missing sign-offs before the GitHub DCO app checks the PR

## Issues

- Covers: Linux Foundation license best-practice gap around inbound contribution policy
- Closes:

## Scope and exclusions

- Included: policy text, contributor docs, packaged metadata, and local sign-off enforcement
- Explicit exclusions: no custom PR-side DCO GitHub Actions check because the GitHub DCO app now handles PR enforcement

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: branch protection should require the GitHub DCO app's status check instead of any removed custom DCO workflow check

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no golden or expected-output fixtures were changed