### PR TITLE
chore: roll out SPDX license headers

### DIFF
--- a/.github/actions/verify-embedded-license-index/action.yml
+++ b/.github/actions/verify-embedded-license-index/action.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Verify embedded license index
 description: Regenerate and verify the checked-in embedded license index artifact
 inputs:

--- a/.github/actions/verify-scancode-output-format-version/action.yml
+++ b/.github/actions/verify-scancode-output-format-version/action.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Verify ScanCode output format version sync
 description: Verify that Provenant's output format version matches the pinned ScanCode submodule
 runs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI
 
 on:
@@ -73,6 +76,9 @@ jobs:
 
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Check SPDX-style license headers
+        run: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check
 
       - name: Check release version sync
         run: ./scripts/check_release_version_sync.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 on:

--- a/.license-headers.toml
+++ b/.license-headers.toml
@@ -1,0 +1,25 @@
+# SPDX license header scope rules.
+
+[license_headers]
+include = [
+  "build.rs",
+  "lefthook.yml",
+  "release.sh",
+  "setup.sh",
+  "src/**/*.rs",
+  "tests/**/*.rs",
+  "xtask/src/**/*.rs",
+  "build_support/**/*.rs",
+  "scripts/**/*.sh",
+  ".github/workflows/**/*.yml",
+  ".github/workflows/**/*.yaml",
+  ".github/actions/**/*.yml",
+  ".github/actions/**/*.yaml",
+]
+
+exclude = [
+  "reference/**",
+  "testdata/**",
+  "resources/license_detection/**",
+  "docs/SUPPORTED_FORMATS.md",
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This guide provides essential information for AI coding agents working on the `P
 ## Documentation Map
 
 - **Architecture & Design Decisions**: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) - System design, components, principles
+- **Contributor Workflow & Compliance**: [`CONTRIBUTING.md`](CONTRIBUTING.md) - Canonical contributor expectations including DCO sign-off and SPDX header policy
 - **Documentation Index**: [`docs/DOCUMENTATION_INDEX.md`](docs/DOCUMENTATION_INDEX.md) - Best entry point for navigating the broader docs set
 - **How-To Guides**: [`docs/HOW_TO_ADD_A_PARSER.md`](docs/HOW_TO_ADD_A_PARSER.md) - Step-by-step guide for adding new parsers
 - **Architectural Decision Records**: [`docs/adr/`](docs/adr/) - Index of accepted design decisions and contributor guidance
@@ -46,6 +47,7 @@ When an upstream test fixture is needed for Provenant tests, copy it into Proven
 Treat the executable sources of truth as canonical:
 
 - [`README.md`](README.md) for local setup, bootstrap, and routine developer commands
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor policy, DCO requirements, and license-header workflow
 - [`package.json`](package.json) for documentation formatting/lint scripts
 - [`xtask/README.md`](xtask/README.md) for maintainer workflows such as benchmarking, compare runs, golden maintenance, and generated artifacts
 - [`docs/TESTING_STRATEGY.md`](docs/TESTING_STRATEGY.md) for test-layer definitions and current command guidance
@@ -98,6 +100,13 @@ Canonical hook and CI definitions live in [`lefthook.yml`](lefthook.yml), [`pack
 - Use [`.github/pull_request_template.md`](.github/pull_request_template.md) for every agent-authored PR. The final PR body should follow its section structure, complete the applicable sections, and omit sections that do not apply.
 - With `gh`, use `--template .github/pull_request_template.md` only for interactive/editor-driven PR creation. When supplying `--body` or `--body-file`, do **not** combine them with `--template`; instead, render the template structure manually into the provided body.
 - Keep PR scope disciplined. For ecosystem/parser work, prefer one ecosystem family per PR and do not hide unrelated refactors inside the same review unit.
+
+### Contributor Compliance Metadata
+
+- Inbound contributions use the Developer Certificate of Origin (DCO) 1.1. Agent-authored commits should include a matching sign-off via `git commit -s`, and rewritten commits must preserve that trailer. See [`DCO`](DCO) and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the canonical policy text.
+- First-party code and automation files in the repo's allowlisted rollout carry SPDX-style headers using `SPDX-FileCopyrightText: Provenant contributors` and `SPDX-License-Identifier: Apache-2.0`.
+- Header scope is configured centrally in [`.license-headers.toml`](.license-headers.toml). Do not add headers to excluded paths such as `reference/**`, `testdata/**`, `resources/license_detection/**`, or generated docs unless the policy is intentionally expanded.
+- Use the xtask command documented in [`xtask/README.md`](xtask/README.md) to check or repair headers. Lefthook checks staged in-scope files without mutating them; CI verifies the full configured scope.
 
 ## Performance and Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,14 @@ The header intentionally omits a year so maintainers do not have to rewrite the
 entire tree every calendar year just to keep boilerplate current.
 
 The current rollout intentionally covers repo-owned, comment-friendly files such
-as Rust sources, selected shell and Python scripts, and GitHub workflow/action
-YAML. It intentionally does **not** rewrite paths where prepended text would be
+as Rust sources, selected shell scripts, and GitHub workflow/action YAML. It
+intentionally does **not** rewrite paths where prepended text would be
 misleading or risky, including `reference/**`, `testdata/**`,
 `resources/license_detection/**`, and generated docs such as
 `docs/SUPPORTED_FORMATS.md`.
+
+The scope lives in `.license-headers.toml` using explicit `include` and
+`exclude` lists so the checker and hooks share one source of truth.
 
 To backfill or repair headers manually, run:
 
@@ -104,11 +107,17 @@ To backfill or repair headers manually, run:
 cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix
 ```
 
-Lefthook auto-adds missing headers for staged in-scope files, and CI verifies
+Lefthook checks staged in-scope files without rewriting them, and CI verifies
 the full allowlist with:
 
 ```sh
 cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check
+```
+
+If the hook reports a missing header, repair it explicitly with:
+
+```sh
+cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix
 ```
 
 ## Testing and validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,35 @@ If you rewrite or squash commits before merge, make sure the resulting commits
 still carry the sign-off. The local git hook can catch missing sign-offs early,
 and the GitHub DCO app enforces PR-level compliance.
 
+## License headers
+
+Provenant's first-party code and automation files carry SPDX-style license
+headers using the Apache-2.0 expression and a `Provenant contributors`
+copyright line.
+
+The header intentionally omits a year so maintainers do not have to rewrite the
+entire tree every calendar year just to keep boilerplate current.
+
+The current rollout intentionally covers repo-owned, comment-friendly files such
+as Rust sources, selected shell and Python scripts, and GitHub workflow/action
+YAML. It intentionally does **not** rewrite paths where prepended text would be
+misleading or risky, including `reference/**`, `testdata/**`,
+`resources/license_detection/**`, and generated docs such as
+`docs/SUPPORTED_FORMATS.md`.
+
+To backfill or repair headers manually, run:
+
+```sh
+cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix
+```
+
+Lefthook auto-adds missing headers for staged in-scope files, and CI verifies
+the full allowlist with:
+
+```sh
+cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check
+```
+
 ## Testing and validation
 
 Keep local validation tightly scoped. This repository has many slow and specialized tests, so the default is the smallest command that proves your change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "glob",
  "inventory",
  "postcard",
  "provenant-cli",
@@ -2995,6 +2996,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "toml",
  "url",
  "yaml_serde",
  "zstd",

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;

--- a/build_support/version_format.rs
+++ b/build_support/version_format.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub const MAX_BUILD_VERSION_LEN: usize = 128;
 
 pub fn sanitize_build_version(value: &str) -> Option<String> {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,6 +7,34 @@ commit-msg:
 
 pre-commit:
   commands:
+    license-headers:
+      glob:
+        - build.rs
+        - release.sh
+        - setup.sh
+        - "src/*.rs"
+        - "src/**/*.rs"
+        - "tests/*.rs"
+        - "tests/**/*.rs"
+        - "xtask/src/*.rs"
+        - "xtask/src/**/*.rs"
+        - "build_support/*.rs"
+        - "build_support/**/*.rs"
+        - "scripts/*.sh"
+        - "scripts/**/*.sh"
+        - "scripts/*.py"
+        - "scripts/**/*.py"
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+        - ".github/workflows/**/*.yml"
+        - ".github/workflows/**/*.yaml"
+        - ".github/actions/*.yml"
+        - ".github/actions/*.yaml"
+        - ".github/actions/**/*.yml"
+        - ".github/actions/**/*.yaml"
+      run: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix {staged_files}
+      stage_fixed: true
+
     cargo-sort:
       glob:
         - Cargo.toml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 glob_matcher: doublestar
 
 commit-msg:
@@ -8,32 +11,7 @@ commit-msg:
 pre-commit:
   commands:
     license-headers:
-      glob:
-        - build.rs
-        - release.sh
-        - setup.sh
-        - "src/*.rs"
-        - "src/**/*.rs"
-        - "tests/*.rs"
-        - "tests/**/*.rs"
-        - "xtask/src/*.rs"
-        - "xtask/src/**/*.rs"
-        - "build_support/*.rs"
-        - "build_support/**/*.rs"
-        - "scripts/*.sh"
-        - "scripts/**/*.sh"
-        - "scripts/*.py"
-        - "scripts/**/*.py"
-        - ".github/workflows/*.yml"
-        - ".github/workflows/*.yaml"
-        - ".github/workflows/**/*.yml"
-        - ".github/workflows/**/*.yaml"
-        - ".github/actions/*.yml"
-        - ".github/actions/*.yaml"
-        - ".github/actions/**/*.yml"
-        - ".github/actions/**/*.yaml"
-      run: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix {staged_files}
-      stage_fixed: true
+      run: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check {staged_files}
 
     cargo-sort:
       glob:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "setup": "npm install && cargo install --locked cargo-sort cargo-machete cargo-deny && ./setup.sh",
     "hooks:install": "lefthook install",
     "hooks:run": "lefthook run pre-commit --all-files",
+    "headers:fix": "cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix",
+    "headers:check": "cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check",
     "format": "git ls-files -z -- '*.yml' '*.yaml' '*.json' '*.md' | xargs -0 npx prettier --write",
     "format:check": "git ls-files -z -- '*.yml' '*.yaml' '*.json' '*.md' | xargs -0 npx prettier --check",
     "format:manifests": "./scripts/cargo_sort_manifests.sh",

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 # Release script that updates license data before releasing
 # Usage: ./release.sh <patch|minor|major> [--execute]

--- a/scripts/cargo_sort_manifests.sh
+++ b/scripts/cargo_sort_manifests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_crate_size.sh
+++ b/scripts/check_crate_size.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_dco_signoff.sh
+++ b/scripts/check_dco_signoff.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_dependency_policy.sh
+++ b/scripts/check_dependency_policy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_release_version_sync.sh
+++ b/scripts/check_release_version_sync.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_scancode_output_format_sync.sh
+++ b/scripts/check_scancode_output_format_sync.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/check_unused_deps.sh
+++ b/scripts/check_unused_deps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 if ! command -v cargo-machete &> /dev/null; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Setup script for Provenant development
 #

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::models::PackageType;

--- a/src/assembly/assembly_golden_test.rs
+++ b/src/assembly/assembly_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod tests {
     use std::fs;

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::assemble;

--- a/src/assembly/bazel_merge.rs
+++ b/src/assembly/bazel_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{FileInfo, Package, TopLevelDependency};
 
 use super::{AssemblerConfig, DirectoryMergeOutput, sibling_merge};

--- a/src/assembly/bazel_prune.rs
+++ b/src/assembly/bazel_prune.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::models::{FileInfo, Package, PackageType, PackageUid, TopLevelDependency};

--- a/src/assembly/cargo_resource_assign.rs
+++ b/src/assembly/cargo_resource_assign.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::{Path, PathBuf};
 
 use crate::models::{FileInfo, Package, PackageType, PackageUid};

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/src/assembly/composer_resource_assign.rs
+++ b/src/assembly/composer_resource_assign.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::{Path, PathBuf};
 
 use crate::cache::DEFAULT_CACHE_DIR_NAME;

--- a/src/assembly/conda_rootfs_merge.rs
+++ b/src/assembly/conda_rootfs_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};

--- a/src/assembly/debian_source_merge.rs
+++ b/src/assembly/debian_source_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeSet;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::str::FromStr;

--- a/src/assembly/file_ref_resolve_test.rs
+++ b/src/assembly/file_ref_resolve_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::{
     DependencyUid, FileReference, FileType, Md5Digest, PackageData, PackageType, PackageUid,

--- a/src/assembly/hackage_merge.rs
+++ b/src/assembly/hackage_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
 struct HackageSource<'a> {

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod assemblers;
 #[cfg(all(test, feature = "golden-tests"))]
 mod assembly_golden_test;

--- a/src/assembly/nested_merge.rs
+++ b/src/assembly/nested_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 

--- a/src/assembly/nested_merge_test.rs
+++ b/src/assembly/nested_merge_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use std::path::Path;
 

--- a/src/assembly/nix_flake_compat_merge.rs
+++ b/src/assembly/nix_flake_compat_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/src/assembly/npm_resource_assign.rs
+++ b/src/assembly/npm_resource_assign.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! npm/pnpm workspace assembly for monorepos.
 //!
 //! This module implements a post-processing pass that detects npm/pnpm workspace

--- a/src/assembly/nuget_cpm_resolve.rs
+++ b/src/assembly/nuget_cpm_resolve.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 

--- a/src/assembly/python_requirements_assign.rs
+++ b/src/assembly/python_requirements_assign.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageType, PackageUid, TopLevelDependency};

--- a/src/assembly/ruby_resource_assign.rs
+++ b/src/assembly/ruby_resource_assign.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::{Path, PathBuf};
 
 use crate::cache::DEFAULT_CACHE_DIR_NAME;

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::path::Path;
 

--- a/src/assembly/swift_merge.rs
+++ b/src/assembly/swift_merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;

--- a/src/assembly/topology.rs
+++ b/src/assembly/topology.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 

--- a/src/bin/provenant.rs
+++ b/src/bin/provenant.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     if let Err(err) = provenant::cli::run() {
         eprintln!("Error: {}", err);

--- a/src/cache/config.rs
+++ b/src/cache/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/src/cache/incremental.rs
+++ b/src/cache/incremental.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;

--- a/src/cache/io.rs
+++ b/src/cache/io.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};

--- a/src/cache/locking.rs
+++ b/src/cache/locking.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use glob::Pattern;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod run;
 
 pub use run::run;

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::assembly;
 use crate::cache::{
     CACHE_DIR_ENV_VAR, CacheConfig, IncrementalManifest, IncrementalManifestEntry,

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::cli::ProcessMode;
 use crate::models::{LineNumber, MatchScore};

--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Candidate line selection and grouping for copyright detection.
 //!
 //! Identifies lines that may contain copyright statements and groups them

--- a/src/copyright/credits.rs
+++ b/src/copyright/credits.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Linux CREDITS file detection and parsing.
 //!
 //! Detects structured `N:/E:/W:` format used by Linux kernel, LLVM, Botan, u-boot, etc.

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::sync::LazyLock;
 

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Copyright detection orchestrator.
 //!
 //! Runs the full detection pipeline: text → numbered lines → candidate groups

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::copyright::line_tracking::PreparedLineCache;
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 use std::time::Instant;

--- a/src/copyright/detector/primary_phase.rs
+++ b/src/copyright/detector/primary_phase.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::copyright::line_tracking::{LineNumberIndex, PreparedLineCache};
 use crate::copyright::types::{CopyrightDetection, HolderDetection};
 

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::postprocess_transforms::{
     drop_shadowed_c_sign_variants, drop_shadowed_year_only_copyright_prefixes_same_start_line,
 };

--- a/src/copyright/detector/token_utils.rs
+++ b/src/copyright/detector/token_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::sync::LazyLock;
 

--- a/src/copyright/detector/tree_walk.rs
+++ b/src/copyright/detector/tree_walk.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::LazyLock;
 
 use regex::Regex;

--- a/src/copyright/detector_input_normalization.rs
+++ b/src/copyright/detector_input_normalization.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::borrow::Cow;
 use std::sync::LazyLock;
 

--- a/src/copyright/golden_test.rs
+++ b/src/copyright/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Golden tests for copyright detection.
 //!
 //! These tests load YAML expected outputs (copied from the Python ScanCode test

--- a/src/copyright/golden_utils.rs
+++ b/src/copyright/golden_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/src/copyright/grammar/mod.rs
+++ b/src/copyright/grammar/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Grammar facade for copyright parse tree construction.
 //!
 //! Types and rule data are split into dedicated submodules to keep this module

--- a/src/copyright/grammar/rules.rs
+++ b/src/copyright/grammar/rules.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Grammar rule data for copyright parse tree construction.
 
 use super::types::{GrammarRule, TagMatcher};

--- a/src/copyright/grammar/tests.rs
+++ b/src/copyright/grammar/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::copyright::types::TreeLabel;
 

--- a/src/copyright/grammar/types.rs
+++ b/src/copyright/grammar/types.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Grammar rules for copyright parse tree construction.
 //!
 //! Rules are applied bottom-up to a sequence of POS-tagged tokens.

--- a/src/copyright/hints.rs
+++ b/src/copyright/hints.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Copyright hint markers and year detection.
 //!
 //! Provides functions to identify lines that may contain copyright information

--- a/src/copyright/lexer.rs
+++ b/src/copyright/lexer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Lexer (tokenizer + POS tagger) for copyright detection.
 //!
 //! Splits prepared text lines into tokens, then assigns each token a

--- a/src/copyright/lexer_test.rs
+++ b/src/copyright/lexer_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::LineNumber;
 

--- a/src/copyright/line_tracking.rs
+++ b/src/copyright/line_tracking.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::prepare::prepare_text_line;
 use crate::models::LineNumber;
 

--- a/src/copyright/mod.rs
+++ b/src/copyright/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Copyright detection module.
 //!
 //! Detects copyright statements, holder names, and author information

--- a/src/copyright/parser.rs
+++ b/src/copyright/parser.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Bottom-up grammar parser for copyright detection.
 //!
 //! Applies grammar rules to a sequence of POS-tagged tokens, building

--- a/src/copyright/parser_test.rs
+++ b/src/copyright/parser_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::copyright::types::{PosTag, TreeLabel};
 use crate::models::LineNumber;

--- a/src/copyright/patterns.rs
+++ b/src/copyright/patterns.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! POS tag regex patterns for copyright token classification.
 //!
 //! Contains ~1100 ordered regex patterns that map tokens to POS tags.

--- a/src/copyright/patterns_test.rs
+++ b/src/copyright/patterns_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 
 #[test]

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Text preparation and normalization for copyright detection.
 //!
 //! Normalizes raw text lines before copyright detection:

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 
 /// Refine a detected author name. Returns `None` if junk or empty.

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Refinement and cleanup functions for detected copyright strings.
 //!
 //! After the parser produces raw detection text from parse tree nodes,

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 
 // ── debug tests ──────────────────────────────────────────────────

--- a/src/copyright/refiner/utils.rs
+++ b/src/copyright/refiner/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 
 /// Refine a name string (shared logic for holders and authors).

--- a/src/copyright/types.rs
+++ b/src/copyright/types.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Core types for copyright detection.
 //!
 //! This module defines:

--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use regex::Regex;
 use std::sync::LazyLock;
 

--- a/src/finder/golden_test.rs
+++ b/src/finder/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod tests {
     use std::fs;

--- a/src/finder/host.rs
+++ b/src/finder/host.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::net::IpAddr;
 
 use url::Url;

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 const JUNK_EMAILS: &[&str] = &[
     "test@test.com",
     "exmaple.com",

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod emails;
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_test;

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use regex::Regex;
 use std::sync::LazyLock;
 

--- a/src/golden_maintenance.rs
+++ b/src/golden_maintenance.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! # Provenant
 //!
 //! `provenant` is the library crate behind the `provenant` CLI. It

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Aho-Corasick exact matching for license detection.
 //!
 //! This module implements Aho-Corasick multi-pattern matching for license detection.

--- a/src/license_detection/automaton.rs
+++ b/src/license_detection/automaton.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Aho-Corasick automaton wrapper using daachorse.
 //!
 //! This module provides a `DoubleArrayAhoCorasick`-based automaton that is

--- a/src/license_detection/build_policy.rs
+++ b/src/license_detection/build_policy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 

--- a/src/license_detection/dataset.rs
+++ b/src/license_detection/dataset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Write as _;
 use std::path::Path;
 

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Detection analysis and heuristics.
 
 use super::types::LicenseDetection;

--- a/src/license_detection/detection/grouping.rs
+++ b/src/license_detection/detection/grouping.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Match grouping functions.
 
 use super::LINES_THRESHOLD;

--- a/src/license_detection/detection/identifier.rs
+++ b/src/license_detection/detection/identifier.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Detection identifier computation.
 
 use super::types::LicenseDetection;

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License detection assembly and grouping logic.
 //!
 //! This module implements Phase 6 of the license detection pipeline:

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Core detection data structures.
 
 use crate::license_detection::models::LicenseMatch;

--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::schema::{EmbeddedArtifactMetadata, EmbeddedLoaderSnapshot, SCHEMA_VERSION};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::build_index_from_loaded;

--- a/src/license_detection/embedded/mod.rs
+++ b/src/license_detection/embedded/mod.rs
@@ -1,2 +1,5 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod index;
 pub mod schema;

--- a/src/license_detection/embedded/schema.rs
+++ b/src/license_detection/embedded/schema.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::license_detection::models::{LoadedLicense, LoadedRule};

--- a/src/license_detection/embedded_test.rs
+++ b/src/license_detection/embedded_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::license_detection::embedded::index::load_embedded_license_index_from_bytes;
 use crate::license_detection::embedded::schema::{

--- a/src/license_detection/expression/mod.rs
+++ b/src/license_detection/expression/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License expression parsing and manipulation.
 //!
 //! This module provides a parser for ScanCode license expressions, supporting:

--- a/src/license_detection/expression/parse.rs
+++ b/src/license_detection/expression/parse.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License expression parsing implementation.
 
 use super::{LicenseExpression, ParseError};

--- a/src/license_detection/expression/parse_test.rs
+++ b/src/license_detection/expression/parse_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::{LicenseExpression, expression_to_string};
 use super::*;
 

--- a/src/license_detection/expression/simplify.rs
+++ b/src/license_detection/expression/simplify.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License expression simplification and utilities.
 
 use std::collections::HashSet;

--- a/src/license_detection/golden_test.rs
+++ b/src/license_detection/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Golden tests for license detection against Python ScanCode reference.
 //!
 //! These tests validate that the Rust license detection engine produces

--- a/src/license_detection/golden_utils.rs
+++ b/src/license_detection/golden_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::Path;
 

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Hash-based exact matching for license detection.
 //!
 //! This module implements the hash matching strategy which computes a hash of the

--- a/src/license_detection/hash_match_test.rs
+++ b/src/license_detection/hash_match_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::license_detection::index::IndexedRuleMetadata;
 use crate::license_detection::index::dictionary::TokenId;

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License index builder.
 //!
 //! This module implements the `build_index()` and `build_index_from_loaded()`

--- a/src/license_detection/index/builder/tests.rs
+++ b/src/license_detection/index/builder/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod test_cases {
     use crate::license_detection::index::LicenseIndex;

--- a/src/license_detection/index/dictionary.rs
+++ b/src/license_detection/index/dictionary.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Token string to integer ID mapping.
 //!
 //! TokenDictionary maps token strings to unique integer IDs. This enables

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License index construction and querying.
 
 pub mod builder;

--- a/src/license_detection/license_cache.rs
+++ b/src/license_detection/license_cache.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! False positive detection for license matches.
 //!
 //! This module contains functions for detecting and filtering false positive

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Low quality match filtering functions.
 //!
 //! This module contains functions for filtering matches based on quality criteria

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Overlap handling for license matches.
 //!
 //! This module contains functions for detecting and resolving overlapping matches

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Match merging functions.
 //!
 //! This module contains functions for merging overlapping and adjacent matches,

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Match refinement - merge, filter, and finalize license matches.
 //!
 //! This module implements the final phase of license matching where raw matches

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License Detection Engine
 
 pub mod aho_match;

--- a/src/license_detection/models/license.rs
+++ b/src/license_detection/models/license.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License metadata loaded from .LICENSE files.
 
 use rkyv::Archive;

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! License match result from a matching strategy.
 
 use serde::Serialize;

--- a/src/license_detection/models/loaded_license.rs
+++ b/src/license_detection/models/loaded_license.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Loader-stage license type.
 //!
 //! This module defines `LoadedLicense`, which represents a parsed and normalized

--- a/src/license_detection/models/loaded_rule.rs
+++ b/src/license_detection/models/loaded_rule.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Loader-stage rule type.
 //!
 //! This module defines `LoadedRule`, which represents a parsed and normalized

--- a/src/license_detection/models/mod.rs
+++ b/src/license_detection/models/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Core data structures for license detection.
 
 pub mod license;

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::license_detection::index::LicenseIndex;

--- a/src/license_detection/models/position_span.rs
+++ b/src/license_detection/models/position_span.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Position span types for license detection.
 
 use crate::license_detection::position_set::PositionSet;

--- a/src/license_detection/models/rule.rs
+++ b/src/license_detection/models/rule.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Rule metadata loaded from .LICENSE and .RULE files.
 
 use std::collections::HashMap;

--- a/src/license_detection/position_set.rs
+++ b/src/license_detection/position_set.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use bit_set::BitSet;
 
 use crate::license_detection::models::position_span::PositionSpan;

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Query processing - tokenized input for license matching.
 
 use crate::license_detection::index::LicenseIndex;

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for query module.
 
 #[cfg(test)]

--- a/src/license_detection/rules/legalese.rs
+++ b/src/license_detection/rules/legalese.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Common license-specific word dictionary (legalese).
 //!
 //! This module defines legalese tokens - common words specific to licenses

--- a/src/license_detection/rules/loader.rs
+++ b/src/license_detection/rules/loader.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parse .LICENSE and .RULE files.
 //!
 //! This module provides two-stage loading:

--- a/src/license_detection/rules/loader_test.rs
+++ b/src/license_detection/rules/loader_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for rule/license file parsing.
 //!
 //! Tests for YAML frontmatter parsing edge cases including:

--- a/src/license_detection/rules/mod.rs
+++ b/src/license_detection/rules/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Rule loading and orchestration.
 
 pub mod legalese;

--- a/src/license_detection/rules/thresholds.rs
+++ b/src/license_detection/rules/thresholds.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Compute match thresholds for license detection rules.
 
 /// Minimum match length for token-based matching.

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Candidate selection using set and multiset similarity.
 
 use crate::license_detection::TokenMultiset;

--- a/src/license_detection/seq_match/gfdl_debug_test.rs
+++ b/src/license_detection/seq_match/gfdl_debug_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Debug test for GFDL-1.1 selection issue.
 
 #[cfg(test)]

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Sequence matching algorithms for finding matching blocks.
 
 use crate::license_detection::index::LicenseIndex;

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Approximate sequence matching for license detection.
 //!
 //! This module implements sequence-based matching using set similarity for

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -1,4 +1,6 @@
-//! SPDX-License-Identifier detection and parsing.
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //!
 //! This module handles detection of SPDX license identifier tags in source code,
 //! such as "SPDX-License-Identifier: MIT" or variations with different comment

--- a/src/license_detection/spdx_lid/test.rs
+++ b/src/license_detection/spdx_lid/test.rs
@@ -1,4 +1,5 @@
-//! Tests for SPDX-License-Identifier detection.
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]
 mod tests {

--- a/src/license_detection/spdx_mapping/mod.rs
+++ b/src/license_detection/spdx_mapping/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! SPDX license key mapping for license expressions.
 //!
 //! This module provides mapping between ScanCode license keys and SPDX license

--- a/src/license_detection/spdx_mapping/test.rs
+++ b/src/license_detection/spdx_mapping/test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for SPDX license key mapping.
 
 #[cfg(test)]

--- a/src/license_detection/test_utils.rs
+++ b/src/license_detection/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared test utilities for license detection tests.
 //!
 //! This module provides common helper functions used across multiple test modules

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use std::sync::{LazyLock, Once};
 use std::time::{Duration, Instant};

--- a/src/license_detection/token_multiset.rs
+++ b/src/license_detection/token_multiset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::ops::Deref;
 

--- a/src/license_detection/token_set.rs
+++ b/src/license_detection/token_set.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::ops::Deref;

--- a/src/license_detection/tokenize.rs
+++ b/src/license_detection/tokenize.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Text tokenization and normalization.
 //!
 //! Tokenization converts text into a sequence of tokens that can be matched

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Unknown license detection using ngram matching.
 
 use crate::license_detection::automaton::Automaton;

--- a/src/models/datasource_id.rs
+++ b/src/models/datasource_id.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Datasource identifiers for package parsers.
 //!
 //! Each variant uniquely identifies the type of package data source (file format)

--- a/src/models/dependency_uid.rs
+++ b/src/models/dependency_uid.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;

--- a/src/models/diagnostic.rs
+++ b/src/models/diagnostic.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/models/digest.rs
+++ b/src/models/digest.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use derive_builder::Builder;
 use packageurl::PackageUrl;
 use serde::{Deserialize, Serialize};

--- a/src/models/line_number.rs
+++ b/src/models/line_number.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::num::NonZeroUsize;
 use std::ops::{Add, AddAssign, Sub};
 

--- a/src/models/match_score.rs
+++ b/src/models/match_score.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt;
 
 use serde::{Deserialize, Serialize};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod datasource_id;
 mod dependency_uid;
 mod diagnostic;

--- a/src/models/output.rs
+++ b/src/models/output.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{FileInfo, Match, Package, TopLevelDependency};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};

--- a/src/models/package_type.rs
+++ b/src/models/package_type.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Package type identifiers for package parsers.
 //!
 //! Each variant uniquely identifies the package ecosystem/registry type.

--- a/src/models/package_uid.rs
+++ b/src/models/package_uid.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::io::{self, Write};
 

--- a/src/output/debian.rs
+++ b/src/output/debian.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::io::{self, Write};
 

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 

--- a/src/output/jsonl.rs
+++ b/src/output/jsonl.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io::{self, Write};
 
 use crate::output_schema::Output;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 

--- a/src/output/public_serialize.rs
+++ b/src/output/public_serialize.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use serde::ser::{SerializeMap, SerializeSeq};

--- a/src/output/shared.rs
+++ b/src/output/shared.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io;
 
 use crate::output_schema::OutputFileInfo;

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::PathBuf;

--- a/src/output/template.rs
+++ b/src/output/template.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::io::{self, Write};
 

--- a/src/output_schema/author.rs
+++ b/src/output_schema/author.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/copyright.rs
+++ b/src/output_schema/copyright.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/dependency.rs
+++ b/src/output_schema/dependency.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/email.rs
+++ b/src/output_schema/email.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/extra_data.rs
+++ b/src/output_schema/extra_data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::license_index_provenance::OutputLicenseIndexProvenance;

--- a/src/output_schema/facet_tallies.rs
+++ b/src/output_schema/facet_tallies.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::tallies::OutputTallies;

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Map;
 

--- a/src/output_schema/file_reference.rs
+++ b/src/output_schema/file_reference.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/header.rs
+++ b/src/output_schema/header.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 

--- a/src/output_schema/holder.rs
+++ b/src/output_schema/holder.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/license_clarity_score.rs
+++ b/src/output_schema/license_clarity_score.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/src/output_schema/license_detection.rs
+++ b/src/output_schema/license_detection.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::license_match::OutputMatch;

--- a/src/output_schema/license_index_provenance.rs
+++ b/src/output_schema/license_index_provenance.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/license_match.rs
+++ b/src/output_schema/license_match.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::MatchScore;
 use serde::{Deserialize, Serialize};
 

--- a/src/output_schema/license_policy_entry.rs
+++ b/src/output_schema/license_policy_entry.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/src/output_schema/license_reference.rs
+++ b/src/output_schema/license_reference.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/license_rule_reference.rs
+++ b/src/output_schema/license_rule_reference.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/mod.rs
+++ b/src/output_schema/mod.rs
@@ -1,4 +1,6 @@
 #![allow(unused_imports)]
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod author;
 pub mod copyright;

--- a/src/output_schema/output.rs
+++ b/src/output_schema/output.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::facet_tallies::OutputFacetTallies;

--- a/src/output_schema/package.rs
+++ b/src/output_schema/package.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/package_data.rs
+++ b/src/output_schema/package_data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/party.rs
+++ b/src/output_schema/party.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/resolved_package.rs
+++ b/src/output_schema/resolved_package.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/serde_helpers.rs
+++ b/src/output_schema/serde_helpers.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::ser::Error as SerError;
 use serde::{Serialize, Serializer};
 use serde_json::{Map, Value};

--- a/src/output_schema/summary.rs
+++ b/src/output_schema/summary.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::license_clarity_score::OutputLicenseClarityScore;

--- a/src/output_schema/system_environment.rs
+++ b/src/output_schema/system_environment.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/output_schema/tallies.rs
+++ b/src/output_schema/tallies.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::tally_entry::OutputTallyEntry;

--- a/src/output_schema/tally_entry.rs
+++ b/src/output_schema/tally_entry.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/src/output_schema/top_level_dependency.rs
+++ b/src/output_schema/top_level_dependency.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/output_schema/top_level_license_detection.rs
+++ b/src/output_schema/top_level_license_detection.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use super::license_match::OutputMatch;

--- a/src/output_schema/url.rs
+++ b/src/output_schema/url.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/parsers/about.rs
+++ b/src/parsers/about.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for AboutCode .ABOUT metadata files.
 //!
 //! Extracts package metadata from AboutCode .ABOUT YAML files which describe

--- a/src/parsers/about_golden_test.rs
+++ b/src/parsers/about_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/about_scan_test.rs
+++ b/src/parsers/about_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/about_test.rs
+++ b/src/parsers/about_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Alpine Linux package metadata files.
 //!
 //! Extracts installed package metadata from Alpine Linux package database files

--- a/src/parsers/alpine_golden_test.rs
+++ b/src/parsers/alpine_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/alpine_scan_test.rs
+++ b/src/parsers/alpine_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/android.rs
+++ b/src/parsers/android.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{Cursor, Read};

--- a/src/parsers/android_golden_test.rs
+++ b/src/parsers/android_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::fs;

--- a/src/parsers/android_test.rs
+++ b/src/parsers/android_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/arch.rs
+++ b/src/parsers/arch.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/parsers/arch_golden_test.rs
+++ b/src/parsers/arch_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/arch_scan_test.rs
+++ b/src/parsers/arch_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/arch_test.rs
+++ b/src/parsers/arch_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{DatasourceId, PackageType};
 use std::path::PathBuf;
 

--- a/src/parsers/autotools.rs
+++ b/src/parsers/autotools.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Autotools configure scripts.
 //!
 //! Extracts basic package metadata from Autotools configure files by using

--- a/src/parsers/autotools_golden_test.rs
+++ b/src/parsers/autotools_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/autotools_test.rs
+++ b/src/parsers/autotools_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for Autotools configure script parser.
 
 use crate::models::PackageType;

--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Bazel BUILD file parser
 //!
 //! Extracts package metadata from Bazel BUILD files using Starlark (Python-like) syntax.

--- a/src/parsers/bazel_golden_test.rs
+++ b/src/parsers/bazel_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/bazel_module_golden_test.rs
+++ b/src/parsers/bazel_module_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/bazel_module_test.rs
+++ b/src/parsers/bazel_module_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/bazel_test.rs
+++ b/src/parsers/bazel_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for Bazel BUILD parser
 
 use crate::models::PackageType;

--- a/src/parsers/bitbake.rs
+++ b/src/parsers/bitbake.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/bitbake_golden_test.rs
+++ b/src/parsers/bitbake_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/bitbake_scan_test.rs
+++ b/src/parsers/bitbake_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/bitbake_test.rs
+++ b/src/parsers/bitbake_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PackageParser;
 use super::bitbake::BitbakeRecipeParser;
 use crate::models::{DatasourceId, PackageType, Sha256Digest};

--- a/src/parsers/bower.rs
+++ b/src/parsers/bower.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Bower package manifests (bower.json).
 //!
 //! Extracts package metadata, dependencies, and license information from

--- a/src/parsers/bower_golden_test.rs
+++ b/src/parsers/bower_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/bower_scan_test.rs
+++ b/src/parsers/bower_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/bower_test.rs
+++ b/src/parsers/bower_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Buck BUILD and METADATA.bzl parsers
 //!
 //! Extracts package metadata from Buck build system files using Starlark (Python-like) syntax.

--- a/src/parsers/buck_golden_test.rs
+++ b/src/parsers/buck_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for Buck BUILD and METADATA.bzl parsers
 
 use crate::models::{PackageType, Sha1Digest};

--- a/src/parsers/bun_lock.rs
+++ b/src/parsers/bun_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/bun_lock_golden_test.rs
+++ b/src/parsers/bun_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/bun_lock_test.rs
+++ b/src/parsers/bun_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::{DatasourceId, PackageType};

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/bun_lockb_golden_test.rs
+++ b/src/parsers/bun_lockb_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use base64::Engine;

--- a/src/parsers/bun_lockb_test.rs
+++ b/src/parsers/bun_lockb_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use base64::Engine;

--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Cargo.toml manifest files.
 //!
 //! Extracts package metadata, dependencies, and license information from

--- a/src/parsers/cargo_golden_test.rs
+++ b/src/parsers/cargo_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Cargo.lock lockfiles.
 //!
 //! Extracts resolved dependency information including exact versions and

--- a/src/parsers/cargo_lock_test.rs
+++ b/src/parsers/cargo_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::PackageType;
 use std::path::PathBuf;

--- a/src/parsers/cargo_scan_test.rs
+++ b/src/parsers/cargo_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::PackageType;

--- a/src/parsers/carthage.rs
+++ b/src/parsers/carthage.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};

--- a/src/parsers/carthage_golden_test.rs
+++ b/src/parsers/carthage_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/carthage_scan_test.rs
+++ b/src/parsers/carthage_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/carthage_test.rs
+++ b/src/parsers/carthage_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PackageParser;
 use super::carthage::{CarthageCartfileParser, CarthageCartfileResolvedParser};
 use crate::models::{DatasourceId, PackageType};

--- a/src/parsers/chef.rs
+++ b/src/parsers/chef.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Chef cookbook metadata files (JSON and Ruby).
 //!
 //! Extracts package metadata, dependencies, and maintainer information from

--- a/src/parsers/chef_golden_test.rs
+++ b/src/parsers/chef_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/chef_scan_test.rs
+++ b/src/parsers/chef_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/chef_test.rs
+++ b/src/parsers/chef_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for Chef metadata.json and metadata.rb parsers.
 
 use crate::models::{DatasourceId, PackageType};

--- a/src/parsers/citation.rs
+++ b/src/parsers/citation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};

--- a/src/parsers/citation_golden_test.rs
+++ b/src/parsers/citation_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/citation_test.rs
+++ b/src/parsers/citation_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/clojure_golden_test.rs
+++ b/src/parsers/clojure_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/clojure_test.rs
+++ b/src/parsers/clojure_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use std::fs;
     use std::path::PathBuf;

--- a/src/parsers/cocoapods_golden_test.rs
+++ b/src/parsers/cocoapods_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Golden tests for CocoaPods parsers.
 
 #[cfg(all(test, feature = "golden-tests"))]

--- a/src/parsers/cocoapods_scan_test.rs
+++ b/src/parsers/cocoapods_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/compiled_binary.rs
+++ b/src/parsers/compiled_binary.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io::Read;
 #[cfg(test)]
 use std::path::Path;

--- a/src/parsers/compiled_binary_golden_test.rs
+++ b/src/parsers/compiled_binary_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::fs;

--- a/src/parsers/composer.rs
+++ b/src/parsers/composer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //!
 //! Extracts package metadata and dependencies from PHP Composer manifests
 //! (composer.json) and lockfiles (composer.lock).

--- a/src/parsers/composer_golden_test.rs
+++ b/src/parsers/composer_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/composer_scan_test.rs
+++ b/src/parsers/composer_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/composer_test.rs
+++ b/src/parsers/composer_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use crate::models::{Dependency, PackageType, Sha1Digest};
     use crate::parsers::{ComposerJsonParser, ComposerLockParser, PackageParser};

--- a/src/parsers/conan.rs
+++ b/src/parsers/conan.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Conan C/C++ package manager manifests.
 //!
 //! Extracts package metadata and dependencies from Conan manifest files.

--- a/src/parsers/conan_data.rs
+++ b/src/parsers/conan_data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Conan conandata.yml files.
 //!
 //! Extracts package metadata from `conandata.yml` files which contain

--- a/src/parsers/conan_data_test.rs
+++ b/src/parsers/conan_data_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/conan_golden_test.rs
+++ b/src/parsers/conan_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/conan_scan_test.rs
+++ b/src/parsers/conan_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/conan_test.rs
+++ b/src/parsers/conan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Unit tests for Conan parsers (conanfile.py, conanfile.txt, conan.lock)
 
 use crate::models::{DatasourceId, PackageType};

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Conda/Anaconda package manifest files.
 //!
 //! Extracts package metadata and dependencies from Conda ecosystem manifest files

--- a/src/parsers/conda_golden_test.rs
+++ b/src/parsers/conda_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/conda_meta_json.rs
+++ b/src/parsers/conda_meta_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Conda metadata JSON files.
 //!
 //! Extracts package metadata from `conda-meta/*.json` files which contain

--- a/src/parsers/conda_meta_json_test.rs
+++ b/src/parsers/conda_meta_json_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/conda_scan_test.rs
+++ b/src/parsers/conda_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/cpan.rs
+++ b/src/parsers/cpan.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CPAN Perl package manifests.
 //!
 //! Extracts package metadata, dependencies, and author information from

--- a/src/parsers/cpan_dist_ini.rs
+++ b/src/parsers/cpan_dist_ini.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CPAN dist.ini files.
 //!
 //! Extracts Perl package metadata from `dist.ini` files used by Dist::Zilla.

--- a/src/parsers/cpan_dist_ini_test.rs
+++ b/src/parsers/cpan_dist_ini_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/cpan_golden_test.rs
+++ b/src/parsers/cpan_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/cpan_makefile_pl.rs
+++ b/src/parsers/cpan_makefile_pl.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CPAN Perl Makefile.PL files.
 //!
 //! Extracts Perl package metadata from `Makefile.PL` files used by ExtUtils::MakeMaker.

--- a/src/parsers/cpan_makefile_pl_test.rs
+++ b/src/parsers/cpan_makefile_pl_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/cpan_scan_test.rs
+++ b/src/parsers/cpan_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/cpan_test.rs
+++ b/src/parsers/cpan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::{CpanManifestParser, CpanMetaJsonParser, CpanMetaYmlParser, PackageParser};

--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CRAN R package DESCRIPTION files.
 //!
 //! Extracts package metadata and dependencies from R package DESCRIPTION files

--- a/src/parsers/cran_golden_test.rs
+++ b/src/parsers/cran_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/cran_scan_test.rs
+++ b/src/parsers/cran_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/cran_test.rs
+++ b/src/parsers/cran_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/dart.rs
+++ b/src/parsers/dart.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Dart/Flutter pubspec.yaml and pubspec.lock files.
 //!
 //! Extracts package metadata and dependencies from Dart/Flutter project manifest

--- a/src/parsers/dart_golden_test.rs
+++ b/src/parsers/dart_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/dart_scan_test.rs
+++ b/src/parsers/dart_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/dart_test.rs
+++ b/src/parsers/dart_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use crate::models::Dependency;
     use crate::models::PackageType;

--- a/src/parsers/debian/control.rs
+++ b/src/parsers/debian/control.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/debian/copyright.rs
+++ b/src/parsers/debian/copyright.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/debian/deb.rs
+++ b/src/parsers/debian/deb.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType};

--- a/src/parsers/debian/deb_extra_test.rs
+++ b/src/parsers/debian/deb_extra_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::deb::extract_package_name_from_deb_path;

--- a/src/parsers/debian/dsc.rs
+++ b/src/parsers/debian/dsc.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/debian/file_list.rs
+++ b/src/parsers/debian/file_list.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, FileReference, Md5Digest, PackageData, PackageType};

--- a/src/parsers/debian/golden_test.rs
+++ b/src/parsers/debian/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::models::PackageData;

--- a/src/parsers/debian/mod.rs
+++ b/src/parsers/debian/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Debian package metadata files.
 //!
 //! Extracts package metadata from Debian package management files using RFC 822

--- a/src/parsers/debian/scan_test.rs
+++ b/src/parsers/debian/scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/debian/tarball.rs
+++ b/src/parsers/debian/tarball.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType};

--- a/src/parsers/debian/utils.rs
+++ b/src/parsers/debian/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use packageurl::PackageUrl;

--- a/src/parsers/deno.rs
+++ b/src/parsers/deno.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/deno_golden_test.rs
+++ b/src/parsers/deno_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/deno_lock.rs
+++ b/src/parsers/deno_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/parsers/deno_lock_test.rs
+++ b/src/parsers/deno_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/deno_scan_test.rs
+++ b/src/parsers/deno_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/deno_test.rs
+++ b/src/parsers/deno_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/docker.rs
+++ b/src/parsers/docker.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/docker_golden_test.rs
+++ b/src/parsers/docker_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/docker_scan_test.rs
+++ b/src/parsers/docker_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/docker_test.rs
+++ b/src/parsers/docker_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/freebsd.rs
+++ b/src/parsers/freebsd.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for FreeBSD package manifest files.
 //!
 //! Extracts package metadata from FreeBSD compact manifest files (+COMPACT_MANIFEST)

--- a/src/parsers/freebsd_golden_test.rs
+++ b/src/parsers/freebsd_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/freebsd_scan_test.rs
+++ b/src/parsers/freebsd_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/freebsd_test.rs
+++ b/src/parsers/freebsd_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::PackageType;
 use std::path::PathBuf;
 

--- a/src/parsers/gitmodules.rs
+++ b/src/parsers/gitmodules.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Git submodule manifest files (`.gitmodules`).
 //!
 //! Extracts submodule dependencies from `.gitmodules` files, treating

--- a/src/parsers/gitmodules_golden_test.rs
+++ b/src/parsers/gitmodules_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/gitmodules_scan_test.rs
+++ b/src/parsers/gitmodules_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Go ecosystem dependency files.
 //!
 //! Extracts package metadata and dependencies from Go module management files

--- a/src/parsers/go_golden_test.rs
+++ b/src/parsers/go_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/go_mod_graph.rs
+++ b/src/parsers/go_mod_graph.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::path::Path;
 

--- a/src/parsers/go_scan_test.rs
+++ b/src/parsers/go_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/go_test.rs
+++ b/src/parsers/go_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/go_work_test.rs
+++ b/src/parsers/go_work_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/golden_test.rs
+++ b/src/parsers/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[path = "about_golden_test.rs"]
 mod about_golden_test;
 #[path = "alpine_golden_test.rs"]

--- a/src/parsers/golden_test_utils.rs
+++ b/src/parsers/golden_test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 use crate::models::PackageData;
 #[cfg(all(test, feature = "golden-tests"))]

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Gradle build files (Groovy and Kotlin DSL).
 //!
 //! Extracts dependencies from Gradle build scripts using a custom token-based

--- a/src/parsers/gradle_golden_test.rs
+++ b/src/parsers/gradle_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/gradle_lock.rs
+++ b/src/parsers/gradle_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for gradle.lockfile dependency lock files.
 //!
 //! Extracts resolved dependency information from Gradle's gradle.lockfile format.

--- a/src/parsers/gradle_lock_test.rs
+++ b/src/parsers/gradle_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::PackageType;
 // Tests for gradle.lockfile parser
 

--- a/src/parsers/gradle_module.rs
+++ b/src/parsers/gradle_module.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/parsers/gradle_module_golden_test.rs
+++ b/src/parsers/gradle_module_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::golden_test_utils::compare_package_data_parser_only;

--- a/src/parsers/gradle_module_scan_test.rs
+++ b/src/parsers/gradle_module_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/gradle_module_test.rs
+++ b/src/parsers/gradle_module_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/gradle_scan_test.rs
+++ b/src/parsers/gradle_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/hackage.rs
+++ b/src/parsers/hackage.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/parsers/hackage_golden_test.rs
+++ b/src/parsers/hackage_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/hackage_scan_test.rs
+++ b/src/parsers/hackage_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/hackage_test.rs
+++ b/src/parsers/hackage_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/haxe.rs
+++ b/src/parsers/haxe.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Haxe package manifests (haxelib.json).
 //!
 //! Extracts package metadata and dependencies from Haxe haxelib.json files.

--- a/src/parsers/haxe_golden_test.rs
+++ b/src/parsers/haxe_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod tests {
     use crate::parsers::golden_test_utils::compare_package_data_parser_only;

--- a/src/parsers/haxe_scan_test.rs
+++ b/src/parsers/haxe_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/haxe_test.rs
+++ b/src/parsers/haxe_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/helm_golden_test.rs
+++ b/src/parsers/helm_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/helm_scan_test.rs
+++ b/src/parsers/helm_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/helm_test.rs
+++ b/src/parsers/helm_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use std::fs;
     use std::path::PathBuf;

--- a/src/parsers/hex_lock.rs
+++ b/src/parsers/hex_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/hex_lock_golden_test.rs
+++ b/src/parsers/hex_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/hex_lock_test.rs
+++ b/src/parsers/hex_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 use crate::models::{DatasourceId, PackageType, Sha256Digest};

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Julia Project.toml and Manifest.toml files.
 //!
 //! Extracts package metadata, dependencies, and license information from

--- a/src/parsers/julia_golden_test.rs
+++ b/src/parsers/julia_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/julia_test.rs
+++ b/src/parsers/julia_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{DatasourceId, PackageType};
 use crate::parsers::PackageParser;
 use crate::parsers::julia::{JuliaManifestTomlParser, JuliaProjectTomlParser};

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::{Arc, LazyLock};
 
 #[cfg(test)]

--- a/src/parsers/maven.rs
+++ b/src/parsers/maven.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Apache Maven pom.xml files.
 //!
 //! Extracts package metadata, dependencies, and license information from

--- a/src/parsers/maven_golden_test.rs
+++ b/src/parsers/maven_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/maven_scan_test.rs
+++ b/src/parsers/maven_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/maven_test.rs
+++ b/src/parsers/maven_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/meson.rs
+++ b/src/parsers/meson.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/meson_golden_test.rs
+++ b/src/parsers/meson_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/meson_scan_test.rs
+++ b/src/parsers/meson_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/meson_test.rs
+++ b/src/parsers/meson_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/metadata.rs
+++ b/src/parsers/metadata.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /// Parser metadata for auto-generating documentation.
 ///
 /// This module provides infrastructure for registering parser metadata

--- a/src/parsers/microsoft_update_manifest.rs
+++ b/src/parsers/microsoft_update_manifest.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Microsoft Update Manifest (.mum) files.
 //!
 //! Extracts Windows Update package metadata from .mum XML manifest files.

--- a/src/parsers/microsoft_update_manifest_golden_test.rs
+++ b/src/parsers/microsoft_update_manifest_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/microsoft_update_manifest_test.rs
+++ b/src/parsers/microsoft_update_manifest_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/misc.rs
+++ b/src/parsers/misc.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! File type recognizers for various package archives and binary formats.
 //!
 //! This module contains simple file-type recognizers that identify packages by

--- a/src/parsers/misc_test.rs
+++ b/src/parsers/misc_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for file type recognizers in misc.rs
 
 use crate::models::PackageType;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod about;
 #[cfg(test)]
 mod about_scan_test;

--- a/src/parsers/nix.rs
+++ b/src/parsers/nix.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/nix_golden_test.rs
+++ b/src/parsers/nix_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/nix_scan_test.rs
+++ b/src/parsers/nix_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/nix_test.rs
+++ b/src/parsers/nix_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/npm.rs
+++ b/src/parsers/npm.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for npm package.json manifests.
 //!
 //! Extracts package metadata, dependencies, and license information from

--- a/src/parsers/npm_golden_test.rs
+++ b/src/parsers/npm_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for npm package-lock.json and npm-shrinkwrap.json lockfiles.
 //!
 //! Extracts resolved dependency information including exact versions, integrity hashes,

--- a/src/parsers/npm_lock_test.rs
+++ b/src/parsers/npm_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::PackageType;

--- a/src/parsers/npm_scan_test.rs
+++ b/src/parsers/npm_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use base64::Engine;

--- a/src/parsers/npm_test.rs
+++ b/src/parsers/npm_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::{DatasourceId, PackageType, Sha1Digest, Sha256Digest, Sha512Digest};

--- a/src/parsers/npm_workspace.rs
+++ b/src/parsers/npm_workspace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for npm/pnpm workspace configuration files.
 //!
 //! Extracts workspace package patterns and monorepo structure from workspace

--- a/src/parsers/npm_workspace_test.rs
+++ b/src/parsers/npm_workspace_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::PackageType;

--- a/src/parsers/nuget/deps_json.rs
+++ b/src/parsers/nuget/deps_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};

--- a/src/parsers/nuget/directory_props.rs
+++ b/src/parsers/nuget/directory_props.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;

--- a/src/parsers/nuget/mod.rs
+++ b/src/parsers/nuget/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for NuGet package manifests and configuration files.
 //!
 //! Extracts package metadata and dependencies from .NET/NuGet ecosystem files:

--- a/src/parsers/nuget/nuget_golden_test.rs
+++ b/src/parsers/nuget/nuget_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/nuget/nuget_scan_test.rs
+++ b/src/parsers/nuget/nuget_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/nuget/nuget_test.rs
+++ b/src/parsers/nuget/nuget_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::super::PackageParser;

--- a/src/parsers/nuget/nupkg.rs
+++ b/src/parsers/nuget/nupkg.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;

--- a/src/parsers/nuget/nuspec.rs
+++ b/src/parsers/nuget/nuspec.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;

--- a/src/parsers/nuget/packages_config.rs
+++ b/src/parsers/nuget/packages_config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;

--- a/src/parsers/nuget/packages_lock.rs
+++ b/src/parsers/nuget/packages_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};

--- a/src/parsers/nuget/project_file.rs
+++ b/src/parsers/nuget/project_file.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;

--- a/src/parsers/nuget/project_json.rs
+++ b/src/parsers/nuget/project_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};

--- a/src/parsers/nuget/utils.rs
+++ b/src/parsers/nuget/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 pub(super) fn resolve_string_property_reference(

--- a/src/parsers/opam.rs
+++ b/src/parsers/opam.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for OCaml OPAM package manager manifests.
 //!
 //! Extracts package metadata and dependencies from OPAM files used by the

--- a/src/parsers/opam_golden_test.rs
+++ b/src/parsers/opam_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/opam_scan_test.rs
+++ b/src/parsers/opam_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/os_release.rs
+++ b/src/parsers/os_release.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Linux OS release metadata files.
 //!
 //! Extracts distribution information from `/etc/os-release` and `/usr/lib/os-release`

--- a/src/parsers/os_release_golden_test.rs
+++ b/src/parsers/os_release_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/os_release_test.rs
+++ b/src/parsers/os_release_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/osgi_test.rs
+++ b/src/parsers/osgi_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PackageParser;
 use super::maven::*;
 use crate::models::DatasourceId;

--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::parser_warn as warn;
 use crate::parsers::utils::{MAX_FIELD_LENGTH, MAX_ITERATION_COUNT, truncate_field};
 

--- a/src/parsers/pip_inspect_deplock.rs
+++ b/src/parsers/pip_inspect_deplock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for pip inspect deplock files.
 //!
 //! Extracts package metadata from `pip-inspect.deplock` files which contain

--- a/src/parsers/pip_inspect_deplock_golden_test.rs
+++ b/src/parsers/pip_inspect_deplock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/pip_inspect_deplock_test.rs
+++ b/src/parsers/pip_inspect_deplock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/pipfile_lock.rs
+++ b/src/parsers/pipfile_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Pipfile.lock lockfiles.
 //!
 //! Extracts resolved dependency information from Pipfile.lock files which store

--- a/src/parsers/pipfile_lock_golden_test.rs
+++ b/src/parsers/pipfile_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::models::Sha256Digest;

--- a/src/parsers/pipfile_lock_test.rs
+++ b/src/parsers/pipfile_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::parsers::{PackageParser, PipfileLockParser};

--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/pixi_golden_test.rs
+++ b/src/parsers/pixi_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/pixi_scan_test.rs
+++ b/src/parsers/pixi_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/pixi_test.rs
+++ b/src/parsers/pixi_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use std::fs;
     use std::path::PathBuf;

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for pnpm-lock.yaml lockfiles.
 //!
 //! Extracts resolved dependency information from pnpm lockfiles supporting

--- a/src/parsers/pnpm_lock_golden_test.rs
+++ b/src/parsers/pnpm_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/pnpm_lock_test.rs
+++ b/src/parsers/pnpm_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::pnpm_lock::*;
 use crate::models::PackageType;
 use crate::parsers::PackageParser;

--- a/src/parsers/podfile.rs
+++ b/src/parsers/podfile.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CocoaPods Podfile manifest files.
 //!
 //! Extracts dependency declarations from Podfile using regex-based Ruby Domain-Specific

--- a/src/parsers/podfile_lock.rs
+++ b/src/parsers/podfile_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CocoaPods Podfile.lock lockfiles.
 //!
 //! Extracts resolved dependency information from Podfile.lock files which maintain

--- a/src/parsers/podfile_lock_test.rs
+++ b/src/parsers/podfile_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CocoaPods .podspec manifest files.
 //!
 //! Extracts package metadata and dependencies from .podspec files which define

--- a/src/parsers/podspec_json.rs
+++ b/src/parsers/podspec_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for CocoaPods .podspec.json manifests.
 //!
 //! Extracts package metadata and dependencies from .podspec.json files used by

--- a/src/parsers/podspec_json_test.rs
+++ b/src/parsers/podspec_json_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/poetry_lock.rs
+++ b/src/parsers/poetry_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Poetry poetry.lock lockfiles.
 //!
 //! Extracts resolved dependency information from Poetry lockfiles which use TOML format

--- a/src/parsers/poetry_lock_golden_test.rs
+++ b/src/parsers/poetry_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::golden_test_utils::compare_package_data_parser_only;

--- a/src/parsers/poetry_lock_test.rs
+++ b/src/parsers/poetry_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::parsers::{PackageParser, PoetryLockParser};

--- a/src/parsers/publiccode.rs
+++ b/src/parsers/publiccode.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party};

--- a/src/parsers/publiccode_golden_test.rs
+++ b/src/parsers/publiccode_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/publiccode_test.rs
+++ b/src/parsers/publiccode_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/pylock_toml.rs
+++ b/src/parsers/pylock_toml.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 

--- a/src/parsers/pylock_toml_golden_test.rs
+++ b/src/parsers/pylock_toml_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/pylock_toml_test.rs
+++ b/src/parsers/pylock_toml_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/python/archive.rs
+++ b/src/parsers/python/archive.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PythonParser;
 use super::utils::{
     build_pypi_urls, calculate_file_checksums, default_package_data, normalize_python_package_name,

--- a/src/parsers/python/mod.rs
+++ b/src/parsers/python/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Python package manifests and metadata files.
 //!
 //! Comprehensive parser supporting multiple Python packaging formats including

--- a/src/parsers/python/pypi_json.rs
+++ b/src/parsers/python/pypi_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::license_normalization::normalize_spdx_declared_license;
 use super::PythonParser;
 use super::setup_py::package_data_to_resolved;

--- a/src/parsers/python/pyproject.rs
+++ b/src/parsers/python/pyproject.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::license_normalization::normalize_spdx_declared_license;
 use super::PythonParser;
 use super::rfc822_meta::{build_extracted_license_statement, split_classifiers};

--- a/src/parsers/python/rfc822_meta.rs
+++ b/src/parsers/python/rfc822_meta.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_spdx_declared_license,
     normalize_spdx_expression,

--- a/src/parsers/python/scan_test.rs
+++ b/src/parsers/python/scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/python/setup_cfg.rs
+++ b/src/parsers/python/setup_cfg.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PythonParser;
 use super::utils::{
     ProjectUrls, apply_project_url_mappings, build_python_dependency_purl, default_package_data,

--- a/src/parsers/python/setup_py.rs
+++ b/src/parsers/python/setup_py.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::license_normalization::normalize_spdx_declared_license;
 use super::PythonParser;
 use super::utils::{

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::PackageType;

--- a/src/parsers/python/utils.rs
+++ b/src/parsers/python/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::PythonParser;
 use super::archive::is_likely_python_sdist_filename;
 use crate::models::{DatasourceId, Dependency, PackageData, Sha256Digest};

--- a/src/parsers/python_golden_test.rs
+++ b/src/parsers/python_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::golden_test_utils::compare_package_data_parser_only;

--- a/src/parsers/readme.rs
+++ b/src/parsers/readme.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for third-party attribution README files.
 //!
 //! Extracts package metadata from semi-structured README files used to document

--- a/src/parsers/readme_golden_test.rs
+++ b/src/parsers/readme_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/readme_test.rs
+++ b/src/parsers/readme_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for pip requirements.txt files.
 //!
 //! Extracts Python package dependencies from requirements.txt files using PEP 508

--- a/src/parsers/requirements_txt_golden_test.rs
+++ b/src/parsers/requirements_txt_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::golden_test_utils::compare_package_data_parser_only;

--- a/src/parsers/requirements_txt_test.rs
+++ b/src/parsers/requirements_txt_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod tests {
     use std::fs;
     use std::path::PathBuf;

--- a/src/parsers/rfc822.rs
+++ b/src/parsers/rfc822.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared RFC822-style metadata parser.
 //!
 //! This module provides a reusable parser for RFC822/RFC2822-like metadata formats

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for RPM database files.
 //!
 //! Extracts installed package metadata from the RPM database maintained by the

--- a/src/parsers/rpm_db_native/bdb.rs
+++ b/src/parsers/rpm_db_native/bdb.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;

--- a/src/parsers/rpm_db_native/entry.rs
+++ b/src/parsers/rpm_db_native/entry.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::io::Cursor;

--- a/src/parsers/rpm_db_native/mod.rs
+++ b/src/parsers/rpm_db_native/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod bdb;
 mod entry;
 mod ndb;

--- a/src/parsers/rpm_db_native/ndb.rs
+++ b/src/parsers/rpm_db_native/ndb.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs::{self, File};
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;

--- a/src/parsers/rpm_db_native/package.rs
+++ b/src/parsers/rpm_db_native/package.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Result, anyhow};
 
 use crate::parser_warn as warn;

--- a/src/parsers/rpm_db_native/sqlite.rs
+++ b/src/parsers/rpm_db_native/sqlite.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::fs::File;
 use std::io::Read;

--- a/src/parsers/rpm_db_native/tags.rs
+++ b/src/parsers/rpm_db_native/tags.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub(crate) const RPMTAG_HEADERIMAGE: u32 = 61;
 pub(crate) const RPMTAG_HEADERSIGNATURES: u32 = 62;
 pub(crate) const RPMTAG_HEADERIMMUTABLE: u32 = 63;

--- a/src/parsers/rpm_db_scan_test.rs
+++ b/src/parsers/rpm_db_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::scan_test_utils::scan_and_assemble;

--- a/src/parsers/rpm_golden_test.rs
+++ b/src/parsers/rpm_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::models::{DatasourceId, PackageType};

--- a/src/parsers/rpm_license_files.rs
+++ b/src/parsers/rpm_license_files.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for RPM license files in /usr/share/licenses/ directories.
 //!
 //! Identifies packages from their license files installed in the standard

--- a/src/parsers/rpm_license_files_test.rs
+++ b/src/parsers/rpm_license_files_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for RPM license files parser.
 
 use super::PackageParser;

--- a/src/parsers/rpm_mariner_manifest.rs
+++ b/src/parsers/rpm_mariner_manifest.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for RPM Mariner container manifest files.
 //!
 //! Extracts package metadata from `container-manifest-2` files which contain

--- a/src/parsers/rpm_mariner_manifest_test.rs
+++ b/src/parsers/rpm_mariner_manifest_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/rpm_parser.rs
+++ b/src/parsers/rpm_parser.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for RPM package archives.
 //!
 //! Extracts package metadata and dependencies from binary RPM package (.rpm) files

--- a/src/parsers/rpm_scan_test.rs
+++ b/src/parsers/rpm_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for RPM .spec files.
 //!
 //! Extracts package metadata from RPM specfiles, which define how RPM packages

--- a/src/parsers/rpm_specfile_test.rs
+++ b/src/parsers/rpm_specfile_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::PackageType;
 use std::fs;
 use std::path::PathBuf;

--- a/src/parsers/rpm_yumdb.rs
+++ b/src/parsers/rpm_yumdb.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::Path;
 

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Ruby/RubyGems package manifests.
 //!
 //! Extracts package metadata, dependencies, and platform information from

--- a/src/parsers/ruby_golden_test.rs
+++ b/src/parsers/ruby_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/ruby_scan_test.rs
+++ b/src/parsers/ruby_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/ruby_test.rs
+++ b/src/parsers/ruby_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tests for Ruby/RubyGems parser (Gemfile and Gemfile.lock).
 //!
 //! Following TDD approach - tests written first (RED phase).

--- a/src/parsers/sbt.rs
+++ b/src/parsers/sbt.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/sbt_golden_test.rs
+++ b/src/parsers/sbt_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/sbt_test.rs
+++ b/src/parsers/sbt_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/scan_test_utils.rs
+++ b/src/parsers/scan_test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 use std::sync::Arc;
 

--- a/src/parsers/swift_golden_test.rs
+++ b/src/parsers/swift_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Golden tests for Swift Package Manager parsers.
 
 #[cfg(all(test, feature = "golden-tests"))]

--- a/src/parsers/swift_manifest_json.rs
+++ b/src/parsers/swift_manifest_json.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/swift_manifest_json_test.rs
+++ b/src/parsers/swift_manifest_json_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::DatasourceId;

--- a/src/parsers/swift_resolved.rs
+++ b/src/parsers/swift_resolved.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Swift Package.resolved lockfiles (v1, v2, v3).
 //!
 //! Format differences:

--- a/src/parsers/swift_resolved_test.rs
+++ b/src/parsers/swift_resolved_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::PackageType;
 use std::path::PathBuf;

--- a/src/parsers/swift_scan_test.rs
+++ b/src/parsers/swift_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Swift show-dependencies deplock files.
 //!
 //! Extracts dependency information from `swift-show-dependencies.deplock` files

--- a/src/parsers/swift_show_dependencies_test.rs
+++ b/src/parsers/swift_show_dependencies_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use super::super::PackageParser;

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /// Shared utility functions for package parsers
 ///
 /// This module provides common file I/O and parsing utilities

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 

--- a/src/parsers/uv_lock_golden_test.rs
+++ b/src/parsers/uv_lock_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/uv_lock_test.rs
+++ b/src/parsers/uv_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/parsers/vcpkg.rs
+++ b/src/parsers/vcpkg.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/parsers/vcpkg_golden_test.rs
+++ b/src/parsers/vcpkg_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use crate::parsers::PackageParser;

--- a/src/parsers/vcpkg_scan_test.rs
+++ b/src/parsers/vcpkg_scan_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/parsers/vcpkg_test.rs
+++ b/src/parsers/vcpkg_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{DatasourceId, PackageType};
 use std::path::PathBuf;
 

--- a/src/parsers/windows_executable.rs
+++ b/src/parsers/windows_executable.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;

--- a/src/parsers/windows_executable_golden_test.rs
+++ b/src/parsers/windows_executable_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::fs;

--- a/src/parsers/yarn_lock.rs
+++ b/src/parsers/yarn_lock.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parser for Yarn yarn.lock lockfiles.
 //!
 //! Extracts resolved dependency information from Yarn lockfiles supporting both

--- a/src/parsers/yarn_lock_test.rs
+++ b/src/parsers/yarn_lock_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use crate::models::PackageType;

--- a/src/parsers/yarn_pnp.rs
+++ b/src/parsers/yarn_pnp.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/parsers/yarn_pnp_golden_test.rs
+++ b/src/parsers/yarn_pnp_golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod golden_tests {
     use std::path::PathBuf;

--- a/src/parsers/yarn_pnp_test.rs
+++ b/src/parsers/yarn_pnp_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/post_processing/classification.rs
+++ b/src/post_processing/classification.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::FileInfo;
 #[cfg(test)]
 use crate::models::Package;

--- a/src/post_processing/classify_test.rs
+++ b/src/post_processing/classify_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 
 use super::test_utils::{dir, file, package, scan_and_assemble_with_keyfiles};

--- a/src/post_processing/facet_test.rs
+++ b/src/post_processing/facet_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::test_utils::{dir, file};
 use super::*;
 use crate::models::{FileInfo, Tallies, TallyEntry};

--- a/src/post_processing/font_policy.rs
+++ b/src/post_processing/font_policy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 const FONT_ASSET_EXTENSIONS: &[&str] = &["ttf", "otf", "woff", "woff2", "eot"];

--- a/src/post_processing/generated_test.rs
+++ b/src/post_processing/generated_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::test_utils::{dir, file};
 use super::*;
 use std::path::Path;

--- a/src/post_processing/golden_test.rs
+++ b/src/post_processing/golden_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(all(test, feature = "golden-tests"))]
 mod tests {
     use std::fs;

--- a/src/post_processing/license_policy.rs
+++ b/src/post_processing/license_policy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;

--- a/src/post_processing/license_references.rs
+++ b/src/post_processing/license_references.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{BTreeSet, HashMap};
 
 use crate::license_detection::expression::parse_expression;

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};

--- a/src/post_processing/output_indexes.rs
+++ b/src/post_processing/output_indexes.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::models::FileInfo;

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{TimeZone, Timelike, Utc};
 use std::collections::HashMap;
 

--- a/src/post_processing/package_file_index.rs
+++ b/src/post_processing/package_file_index.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 

--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{FileInfo, Package};
 
 use super::PackageIx;

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/post_processing/summary/index.rs
+++ b/src/post_processing/summary/index.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::models::{FileInfo, FileType, Package};

--- a/src/post_processing/summary/mod.rs
+++ b/src/post_processing/summary/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 mod index;

--- a/src/post_processing/summary/test.rs
+++ b/src/post_processing/summary/test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::super::classification::{apply_file_classification, classify_key_files};
 use super::super::output_indexes::{OutputIndexMode, OutputIndexes};
 use super::super::package_file_index::PackageFileIndex;

--- a/src/post_processing/summary_helpers.rs
+++ b/src/post_processing/summary_helpers.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::license_detection::expression::{

--- a/src/post_processing/tallies.rs
+++ b/src/post_processing/tallies.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/src/post_processing/tallies_test.rs
+++ b/src/post_processing/tallies_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::test_utils::{dir, file};
 use super::*;
 use crate::models::{

--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(feature = "golden-tests")]
 use std::fs;
 use std::path::Path;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::env;
 use std::io::IsTerminal;

--- a/src/scan_result_shaping/core_test.rs
+++ b/src/scan_result_shaping/core_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::{
     Author, Copyright, DatasourceId, Dependency, FileReference, LineNumber, MatchScore,

--- a/src/scan_result_shaping/directory_tree.rs
+++ b/src/scan_result_shaping/directory_tree.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/scan_result_shaping/json_input.rs
+++ b/src/scan_result_shaping/json_input.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Result, anyhow};
 use serde::Deserialize;
 use std::collections::HashSet;

--- a/src/scan_result_shaping/json_input_test.rs
+++ b/src/scan_result_shaping/json_input_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use crate::models::MatchScore;
 use crate::output_schema::{OutputMatch, OutputTopLevelLicenseDetection};

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod core_test;
 mod directory_tree;

--- a/src/scan_result_shaping/selection.rs
+++ b/src/scan_result_shaping/selection.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Result, anyhow};
 use glob::Pattern;
 use std::collections::HashSet;

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use std::fs;
 use std::path::PathBuf;

--- a/src/scan_result_shaping/test_fixtures.rs
+++ b/src/scan_result_shaping/test_fixtures.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::models::{FileInfo, FileType};

--- a/src/scanner/collect.rs
+++ b/src/scanner/collect.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use glob::Pattern;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod collect;
 mod process;
 

--- a/src/scanner/process/binary_text.rs
+++ b/src/scanner/process/binary_text.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::finder::{self, DetectionConfig};
 use crate::parsers::utils::split_name_email;
 

--- a/src/scanner/process/binary_text_test.rs
+++ b/src/scanner/process/binary_text_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{
     extract_named_author_from_binary_line, is_binary_string_author_candidate,
     is_binary_string_email_candidate, is_binary_string_url_candidate, normalize_binary_string_url,

--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::binary_text::{is_binary_string_email_candidate, normalize_binary_string_url};
 use crate::finder::{self, DetectionConfig};
 use crate::models::{FileInfoBuilder, OutputEmail, OutputURL};

--- a/src/scanner/process/contacts_test.rs
+++ b/src/scanner/process/contacts_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::extract_email_url_information;
 use crate::models::{FileInfoBuilder, FileType};
 use crate::scanner::TextDetectionOptions;

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::binary_text::{
     extract_named_author_from_binary_line, has_binary_name_like_shape, has_excessive_at_noise,
     has_sufficient_alphabetic_content, is_binary_string_author_candidate, is_company_like_suffix,

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{
     extract_comment_author_supplements, extract_patch_header_author_supplements,
     is_binary_string_copyright_candidate,

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::PositionSet;

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{
     LicenseExtractionInput, compute_percentage_of_license_text, convert_detection_to_model,
     extract_license_information,

--- a/src/scanner/process/mod.rs
+++ b/src/scanner/process/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod binary_text;
 mod contacts;
 mod copyright;

--- a/src/scanner/process/orchestrator.rs
+++ b/src/scanner/process/orchestrator.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::pipeline::process_file;
 use super::special_cases::process_directory;
 use super::spill::{FileInfoSpillStore, MemoryMode, retain_or_spill_chunk};

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::contacts::extract_email_url_information;
 use super::copyright::extract_copyright_information;
 use super::license::{LicenseExtractionInput, extract_license_information};

--- a/src/scanner/process/pipeline_test.rs
+++ b/src/scanner/process/pipeline_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{
     LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES, cap_non_source_json_license_text,
     maybe_record_processing_timeout, process_file,

--- a/src/scanner/process/special_cases.rs
+++ b/src/scanner/process/special_cases.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::{FileInfo, FileType};
 use std::fs;
 use std::path::Path;

--- a/src/scanner/process/special_cases_test.rs
+++ b/src/scanner/process/special_cases_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::is_go_non_production_source;
 use std::fs;
 use tempfile::tempdir;

--- a/src/scanner/process/spill.rs
+++ b/src/scanner/process/spill.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::models::FileInfo;
 use std::fs::{self, File};
 use std::io::{Read, Write};

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Datelike, Timelike, Utc};
 
 pub(crate) fn format_scancode_timestamp(timestamp: &DateTime<Utc>) -> String {

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fs;

--- a/src/utils/font.rs
+++ b/src/utils/font.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeSet;
 use std::path::Path;
 

--- a/src/utils/generated.rs
+++ b/src/utils/generated.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 use std::fs;
 #[cfg(test)]

--- a/src/utils/hash.rs
+++ b/src/utils/hash.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use md5::{Digest as Md5Digest, Md5};
 use sha1::Sha1;
 use sha2::Sha256;

--- a/src/utils/language.rs
+++ b/src/utils/language.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::path::Path;
 

--- a/src/utils/magic.rs
+++ b/src/utils/magic.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! File magic byte detection utilities.
 //!
 //! Provides low-level file format detection by reading and checking magic bytes

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod file;
 pub mod font;
 pub mod generated;

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub(crate) fn parent_dir(path: &str) -> &str {
     path.rsplit_once('/').map_or("", |(parent, _)| parent)
 }

--- a/src/utils/sourcemap.rs
+++ b/src/utils/sourcemap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Source map file processing for license detection.
 //!
 //! Source map files (.js.map, .css.map) are JSON files containing embedded

--- a/src/utils/spdx.rs
+++ b/src/utils/spdx.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 
 use crate::license_detection::expression::{

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 const UTF8_BOM_CHAR: char = '\u{FEFF}';

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
 
 const ISO_UTC_TIMESTAMP_FALLBACK: &str = "1970-01-01T00:00:00Z";

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::OnceLock;
 
 pub const BUILD_VERSION: &str = match option_env!("PROVENANT_BUILD_VERSION") {

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use provenant::models::{
     Copyright, DatasourceId, DependencyUid, ExtraData, FacetTallies, FileInfo, FileType, Header,
     Holder, LineNumber, MatchScore, Md5Digest, Output, Package, PackageData, PackageType,

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::process::Command;
 

--- a/tests/scanner_copyright_credits.rs
+++ b/tests/scanner_copyright_credits.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use glob::Pattern;
 use provenant::progress::{ProgressMode, ScanProgress};
 use provenant::scanner::LicenseScanOptions;

--- a/tests/scanner_integration.rs
+++ b/tests/scanner_integration.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use glob::Pattern;
 use provenant::license_detection::LicenseDetectionEngine;
 use provenant::models::{LineNumber, PackageType};

--- a/tests/version_format_unit.rs
+++ b/tests/version_format_unit.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #[path = "../build_support/version_format.rs"]
 mod version_format;
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -45,6 +45,10 @@ path = "src/bin/generate_benchmark_chart.rs"
 name = "generate-legalese-artifact"
 path = "src/bin/generate_legalese_artifact/main.rs"
 
+[[bin]]
+name = "check-license-headers"
+path = "src/bin/check_license_headers.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -52,6 +52,7 @@ path = "src/bin/check_license_headers.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+glob = "0.3.3"
 inventory = { workspace = true }
 postcard = { workspace = true }
 provenant = { path = "..", package = "provenant-cli", features = ["golden-tests"] }
@@ -61,6 +62,7 @@ rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+toml = "1.1.2"
 url = { workspace = true }
 yaml_serde = { workspace = true }
 zstd = { workspace = true }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -319,10 +319,16 @@ This command is informational in CI and does not block PRs.
 for first-party code and automation files.
 
 The current rollout intentionally covers repo-owned, comment-friendly files
-such as Rust sources, selected shell and Python scripts, and GitHub
-workflow/action YAML. It intentionally excludes `reference/**`, `testdata/**`,
+such as Rust sources, selected shell scripts, and GitHub workflow/action YAML.
+It intentionally excludes `reference/**`, `testdata/**`,
 `resources/license_detection/**`, and generated docs such as
 `docs/SUPPORTED_FORMATS.md`.
+
+Scope rules live in `.license-headers.toml` with explicit `include` and
+`exclude` lists over repo-root-relative glob patterns.
+
+Lefthook checks staged in-scope files without rewriting them. If a header is
+missing, repair it explicitly with the `--fix` form below.
 
 The header intentionally uses a holder-only copyright line:
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -17,6 +17,7 @@ cargo run --manifest-path xtask/Cargo.toml --bin <command> -- ...
 | `update-copyright-golden`    | Maintain copyright golden YAML fixtures with parity-gated or Rust-owned update modes.          |
 | `update-license-golden`      | Maintain license golden YAML fixtures with parity-gated or Rust-owned update modes.            |
 | `validate-urls`              | Validate URLs in production docs and Rust docstrings.                                          |
+| `check-license-headers`      | Check or repair SPDX-style headers on the repo's allowlisted first-party files.                |
 | `generate-supported-formats` | Regenerate `docs/SUPPORTED_FORMATS.md` from parser metadata.                                   |
 | `generate-benchmark-chart`   | Regenerate the benchmark duration-vs-files SVG from timing rows in `docs/BENCHMARKS.md`.       |
 | `generate-index-artifact`    | Regenerate the embedded license index artifact from ScanCode rules and licenses.               |
@@ -311,6 +312,34 @@ Exit codes:
 - `1`: some URLs failed validation
 
 This command is informational in CI and does not block PRs.
+
+## `check-license-headers`
+
+`check-license-headers` checks or repairs the repo's SPDX-style header rollout
+for first-party code and automation files.
+
+The current rollout intentionally covers repo-owned, comment-friendly files
+such as Rust sources, selected shell and Python scripts, and GitHub
+workflow/action YAML. It intentionally excludes `reference/**`, `testdata/**`,
+`resources/license_detection/**`, and generated docs such as
+`docs/SUPPORTED_FORMATS.md`.
+
+The header intentionally uses a holder-only copyright line:
+
+```text
+SPDX-FileCopyrightText: Provenant contributors
+SPDX-License-Identifier: Apache-2.0
+```
+
+This avoids pointless repo-wide churn from updating years every calendar year.
+
+Examples:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin check-license-headers -- --check
+cargo run --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix
+cargo run --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix src/lib.rs .github/workflows/check.yml
+```
 
 ## `generate-supported-formats`
 

--- a/xtask/src/bin/benchmark_target.rs
+++ b/xtask/src/bin/benchmark_target.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/xtask/src/bin/check_license_headers.rs
+++ b/xtask/src/bin/check_license_headers.rs
@@ -4,12 +4,16 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use glob::Pattern;
+use serde::Deserialize;
 
 const COPYRIGHT_LINE: &str = "SPDX-FileCopyrightText: Provenant contributors";
 const LICENSE_LINE: &str = "SPDX-License-Identifier: Apache-2.0";
+const SCOPE_CONFIG_PATH: &str = ".license-headers.toml";
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -25,15 +29,104 @@ struct Args {
     paths: Vec<PathBuf>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct ScopePatterns {
+    #[serde(default)]
+    include: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ScopeConfigFile {
+    #[serde(default)]
+    license_headers: ScopePatterns,
+}
+
+#[derive(Debug)]
+struct CompiledScopePatterns {
+    include: Vec<Pattern>,
+    exclude: Vec<Pattern>,
+}
+
+#[derive(Debug)]
+struct ScopeConfig {
+    patterns: CompiledScopePatterns,
+}
+
+impl ScopeConfig {
+    fn load(repo_root: &Path) -> Result<Self> {
+        let config_path = repo_root.join(SCOPE_CONFIG_PATH);
+        let contents = fs::read_to_string(&config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?;
+        let parsed: ScopeConfigFile = toml::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+        let include = compile_patterns(&config_path, "include", parsed.license_headers.include)?;
+        let exclude = compile_patterns(&config_path, "exclude", parsed.license_headers.exclude)?;
+
+        anyhow::ensure!(
+            !include.is_empty(),
+            "{} must define at least one include pattern",
+            config_path.display()
+        );
+
+        Ok(Self {
+            patterns: CompiledScopePatterns { include, exclude },
+        })
+    }
+
+    fn includes(&self, relative_path: &str) -> bool {
+        let path = Path::new(relative_path);
+        self.patterns
+            .include
+            .iter()
+            .any(|pattern| pattern.matches_path(path))
+            && !self
+                .patterns
+                .exclude
+                .iter()
+                .any(|pattern| pattern.matches_path(path))
+    }
+}
+
+fn compile_patterns(
+    config_path: &Path,
+    kind: &'static str,
+    patterns: Vec<String>,
+) -> Result<Vec<Pattern>> {
+    patterns
+        .into_iter()
+        .map(|pattern| {
+            let normalized = pattern.trim().trim_start_matches('/').to_string();
+            anyhow::ensure!(
+                !normalized.is_empty(),
+                "{} contains an empty {} pattern",
+                config_path.display(),
+                kind
+            );
+            Pattern::new(&normalized).with_context(|| {
+                format!(
+                    "invalid {} pattern {:?} in {}",
+                    kind,
+                    normalized,
+                    config_path.display()
+                )
+            })
+        })
+        .collect()
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
     anyhow::ensure!(args.check || args.fix, "pass either --check or --fix");
 
     let repo_root = provenant_xtask::common::project_root();
+    let scope = ScopeConfig::load(&repo_root)?;
     let candidates = if args.paths.is_empty() {
-        collect_all_candidates(&repo_root)?
+        collect_all_candidates(&repo_root, &scope)?
     } else {
-        collect_requested_candidates(&repo_root, &args.paths)?
+        collect_requested_candidates(&repo_root, &scope, &args.paths)?
     };
 
     if args.fix {
@@ -80,42 +173,28 @@ fn main() -> Result<()> {
         eprintln!("  {path}");
     }
     eprintln!();
+    eprintln!("Scope rules live in {SCOPE_CONFIG_PATH}.");
     eprintln!(
         "Fix them with: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix"
     );
     anyhow::bail!("license header check failed");
 }
 
-fn collect_all_candidates(repo_root: &Path) -> Result<Vec<PathBuf>> {
+fn collect_all_candidates(repo_root: &Path, scope: &ScopeConfig) -> Result<Vec<PathBuf>> {
     let mut candidates = BTreeSet::new();
-    walk_dir(repo_root, repo_root, &mut candidates)?;
-    Ok(candidates.into_iter().collect())
-}
-
-fn walk_dir(repo_root: &Path, dir: &Path, candidates: &mut BTreeSet<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .with_context(|| format!("failed to stat {}", path.display()))?;
-
-        if file_type.is_dir() {
-            if should_skip_dir(repo_root, &path)? {
-                continue;
-            }
-            walk_dir(repo_root, &path, candidates)?;
-            continue;
-        }
-
-        if file_type.is_file() && is_in_scope(repo_root, &path)? {
+    for path in git_tracked_files(repo_root)? {
+        if is_in_scope(repo_root, scope, &path)? {
             candidates.insert(path);
         }
     }
-    Ok(())
+    Ok(candidates.into_iter().collect())
 }
 
-fn collect_requested_candidates(repo_root: &Path, raw_paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+fn collect_requested_candidates(
+    repo_root: &Path,
+    scope: &ScopeConfig,
+    raw_paths: &[PathBuf],
+) -> Result<Vec<PathBuf>> {
     let mut candidates = BTreeSet::new();
     for raw_path in raw_paths {
         let path = normalize_requested_path(raw_path)?;
@@ -125,11 +204,39 @@ fn collect_requested_candidates(repo_root: &Path, raw_paths: &[PathBuf]) -> Resu
         if !path.starts_with(repo_root) {
             continue;
         }
-        if is_in_scope(repo_root, &path)? {
+        if is_in_scope(repo_root, scope, &path)? {
             candidates.insert(path);
         }
     }
     Ok(candidates.into_iter().collect())
+}
+
+fn git_tracked_files(repo_root: &Path) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("ls-files")
+        .arg("-z")
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to enumerate tracked files in {}",
+                repo_root.display()
+            )
+        })?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "git ls-files failed for {}",
+        repo_root.display()
+    );
+
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|bytes| !bytes.is_empty())
+        .map(|bytes| repo_root.join(String::from_utf8_lossy(bytes).into_owned()))
+        .collect())
 }
 
 fn normalize_requested_path(raw_path: &Path) -> Result<PathBuf> {
@@ -149,48 +256,15 @@ fn rel_path(repo_root: &Path, path: &Path) -> Result<String> {
         .replace('\\', "/"))
 }
 
-fn should_skip_dir(repo_root: &Path, path: &Path) -> Result<bool> {
+fn is_in_scope(repo_root: &Path, scope: &ScopeConfig, path: &Path) -> Result<bool> {
     let relative = rel_path(repo_root, path)?;
-    Ok(matches!(
-        relative.as_str(),
-        ".git"
-            | "node_modules"
-            | "reference"
-            | "resources"
-            | "target"
-            | "testdata"
-            | ".provenant"
-            | ".sisyphus"
-    ))
-}
-
-fn is_in_scope(repo_root: &Path, path: &Path) -> Result<bool> {
-    let relative = rel_path(repo_root, path)?;
-
-    if matches!(relative.as_str(), "build.rs" | "release.sh" | "setup.sh") {
-        return Ok(true);
-    }
-
-    if relative == "docs/SUPPORTED_FORMATS.md" {
-        return Ok(false);
-    }
-
-    let ext = path.extension().and_then(|value| value.to_str());
-
-    Ok((relative.starts_with("src/") && ext == Some("rs"))
-        || (relative.starts_with("tests/") && ext == Some("rs"))
-        || (relative.starts_with("xtask/src/") && ext == Some("rs"))
-        || (relative.starts_with("build_support/") && ext == Some("rs"))
-        || (relative.starts_with("scripts/") && matches!(ext, Some("sh") | Some("py")))
-        || (relative.starts_with(".github/workflows/")
-            && matches!(ext, Some("yml") | Some("yaml")))
-        || (relative.starts_with(".github/actions/") && matches!(ext, Some("yml") | Some("yaml"))))
+    Ok(scope.includes(&relative))
 }
 
 fn comment_prefix(path: &Path) -> Option<&'static str> {
     match path.extension().and_then(|value| value.to_str()) {
         Some("rs") => Some("//"),
-        Some("sh") | Some("py") | Some("yml") | Some("yaml") => Some("#"),
+        Some("sh") | Some("yml") | Some("yaml") => Some("#"),
         _ if path.file_name().and_then(|value| value.to_str()) == Some("build.rs") => Some("//"),
         _ => None,
     }

--- a/xtask/src/bin/check_license_headers.rs
+++ b/xtask/src/bin/check_license_headers.rs
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+const COPYRIGHT_LINE: &str = "SPDX-FileCopyrightText: Provenant contributors";
+const LICENSE_LINE: &str = "SPDX-License-Identifier: Apache-2.0";
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Fail if any in-scope file lacks the expected header.
+    #[arg(long, conflicts_with = "fix")]
+    check: bool,
+
+    /// Insert or normalize headers in in-scope files.
+    #[arg(long, conflicts_with = "check")]
+    fix: bool,
+
+    /// Optional file paths to restrict processing; defaults to all in-scope files.
+    paths: Vec<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    anyhow::ensure!(args.check || args.fix, "pass either --check or --fix");
+
+    let repo_root = provenant_xtask::common::project_root();
+    let candidates = if args.paths.is_empty() {
+        collect_all_candidates(&repo_root)?
+    } else {
+        collect_requested_candidates(&repo_root, &args.paths)?
+    };
+
+    if args.fix {
+        let mut updated = Vec::new();
+        for path in candidates {
+            let original = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            let rewritten = rewrite_with_header(&path, &original)?;
+            if rewritten != original {
+                fs::write(&path, rewritten)
+                    .with_context(|| format!("failed to write {}", path.display()))?;
+                updated.push(rel_path(&repo_root, &path)?);
+            }
+        }
+
+        if updated.is_empty() {
+            println!("All in-scope files already have the expected license header.");
+        } else {
+            println!("Updated license headers:");
+            for path in updated {
+                println!("  {path}");
+            }
+        }
+        return Ok(());
+    }
+
+    let mut missing = Vec::new();
+    for path in candidates {
+        let original = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let rewritten = rewrite_with_header(&path, &original)?;
+        if rewritten != original {
+            missing.push(rel_path(&repo_root, &path)?);
+        }
+    }
+
+    if missing.is_empty() {
+        println!("All in-scope files have the expected license header.");
+        return Ok(());
+    }
+
+    eprintln!("Files missing the expected license header:");
+    for path in missing {
+        eprintln!("  {path}");
+    }
+    eprintln!();
+    eprintln!(
+        "Fix them with: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin check-license-headers -- --fix"
+    );
+    anyhow::bail!("license header check failed");
+}
+
+fn collect_all_candidates(repo_root: &Path) -> Result<Vec<PathBuf>> {
+    let mut candidates = BTreeSet::new();
+    walk_dir(repo_root, repo_root, &mut candidates)?;
+    Ok(candidates.into_iter().collect())
+}
+
+fn walk_dir(repo_root: &Path, dir: &Path, candidates: &mut BTreeSet<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to stat {}", path.display()))?;
+
+        if file_type.is_dir() {
+            if should_skip_dir(repo_root, &path)? {
+                continue;
+            }
+            walk_dir(repo_root, &path, candidates)?;
+            continue;
+        }
+
+        if file_type.is_file() && is_in_scope(repo_root, &path)? {
+            candidates.insert(path);
+        }
+    }
+    Ok(())
+}
+
+fn collect_requested_candidates(repo_root: &Path, raw_paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut candidates = BTreeSet::new();
+    for raw_path in raw_paths {
+        let path = normalize_requested_path(raw_path)?;
+        if !path.is_file() {
+            continue;
+        }
+        if !path.starts_with(repo_root) {
+            continue;
+        }
+        if is_in_scope(repo_root, &path)? {
+            candidates.insert(path);
+        }
+    }
+    Ok(candidates.into_iter().collect())
+}
+
+fn normalize_requested_path(raw_path: &Path) -> Result<PathBuf> {
+    if raw_path.is_absolute() {
+        return Ok(raw_path.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .context("failed to resolve current working directory")?
+        .join(raw_path))
+}
+
+fn rel_path(repo_root: &Path, path: &Path) -> Result<String> {
+    Ok(path
+        .strip_prefix(repo_root)
+        .with_context(|| format!("{} is outside {}", path.display(), repo_root.display()))?
+        .to_string_lossy()
+        .replace('\\', "/"))
+}
+
+fn should_skip_dir(repo_root: &Path, path: &Path) -> Result<bool> {
+    let relative = rel_path(repo_root, path)?;
+    Ok(matches!(
+        relative.as_str(),
+        ".git"
+            | "node_modules"
+            | "reference"
+            | "resources"
+            | "target"
+            | "testdata"
+            | ".provenant"
+            | ".sisyphus"
+    ))
+}
+
+fn is_in_scope(repo_root: &Path, path: &Path) -> Result<bool> {
+    let relative = rel_path(repo_root, path)?;
+
+    if matches!(relative.as_str(), "build.rs" | "release.sh" | "setup.sh") {
+        return Ok(true);
+    }
+
+    if relative == "docs/SUPPORTED_FORMATS.md" {
+        return Ok(false);
+    }
+
+    let ext = path.extension().and_then(|value| value.to_str());
+
+    Ok((relative.starts_with("src/") && ext == Some("rs"))
+        || (relative.starts_with("tests/") && ext == Some("rs"))
+        || (relative.starts_with("xtask/src/") && ext == Some("rs"))
+        || (relative.starts_with("build_support/") && ext == Some("rs"))
+        || (relative.starts_with("scripts/") && matches!(ext, Some("sh") | Some("py")))
+        || (relative.starts_with(".github/workflows/")
+            && matches!(ext, Some("yml") | Some("yaml")))
+        || (relative.starts_with(".github/actions/") && matches!(ext, Some("yml") | Some("yaml"))))
+}
+
+fn comment_prefix(path: &Path) -> Option<&'static str> {
+    match path.extension().and_then(|value| value.to_str()) {
+        Some("rs") => Some("//"),
+        Some("sh") | Some("py") | Some("yml") | Some("yaml") => Some("#"),
+        _ if path.file_name().and_then(|value| value.to_str()) == Some("build.rs") => Some("//"),
+        _ => None,
+    }
+}
+
+fn expected_header(prefix: &str) -> [String; 2] {
+    [
+        format!("{prefix} {COPYRIGHT_LINE}"),
+        format!("{prefix} {LICENSE_LINE}"),
+    ]
+}
+
+fn rewrite_with_header(path: &Path, original: &str) -> Result<String> {
+    let prefix = comment_prefix(path)
+        .with_context(|| format!("no comment prefix configured for {}", path.display()))?;
+    let expected = expected_header(prefix);
+    let mut lines: Vec<&str> = original.lines().collect();
+
+    let mut output = Vec::new();
+    let mut index = 0;
+    if lines.first().is_some_and(|line| line.starts_with("#!")) {
+        output.push(lines[0].to_string());
+        index = 1;
+    }
+
+    while lines.get(index).is_some_and(|line| line.trim().is_empty()) {
+        index += 1;
+    }
+
+    while lines.get(index).is_some_and(|line| line.contains("SPDX-")) {
+        index += 1;
+    }
+
+    while lines.get(index).is_some_and(|line| line.trim().is_empty()) {
+        index += 1;
+    }
+
+    output.extend(expected);
+    if index < lines.len() {
+        output.push(String::new());
+        output.extend(lines.drain(index..).map(ToOwned::to_owned));
+    }
+
+    Ok(output.join("\n") + "\n")
+}

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{self, File};
 use std::io::BufReader;

--- a/xtask/src/bin/generate_benchmark_chart.rs
+++ b/xtask/src/bin/generate_benchmark_chart.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::Path;
 

--- a/xtask/src/bin/generate_index_artifact.rs
+++ b/xtask/src/bin/generate_index_artifact.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/xtask/src/bin/generate_legalese_artifact/main.rs
+++ b/xtask/src/bin/generate_legalese_artifact/main.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;

--- a/xtask/src/bin/generate_supported_formats.rs
+++ b/xtask/src/bin/generate_supported_formats.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::Path;
 

--- a/xtask/src/bin/update_copyright_golden.rs
+++ b/xtask/src/bin/update_copyright_golden.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/xtask/src/bin/update_license_golden.rs
+++ b/xtask/src/bin/update_license_golden.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/xtask/src/bin/update_parser_golden.rs
+++ b/xtask/src/bin/update_parser_golden.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/xtask/src/bin/validate_urls.rs
+++ b/xtask/src/bin/validate_urls.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/xtask/src/common.rs
+++ b/xtask/src/common.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod common;
 pub mod manifests;
 pub mod repo_cache;

--- a/xtask/src/manifests.rs
+++ b/xtask/src/manifests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 use serde::Serialize;

--- a/xtask/src/repo_cache.rs
+++ b/xtask/src/repo_cache.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;


### PR DESCRIPTION
## Summary

- add SPDX-style Apache-2.0 headers to the repo's phase-1 allowlist of first-party Rust, shell, and GitHub automation files while explicitly excluding risky paths like `testdata/**`, `reference/**`, `resources/license_detection/**`, and generated docs
- move license-header enforcement into a Rust xtask command and configure scope centrally in `.license-headers.toml` with explicit `include` and `exclude` lists
- use a yearless `SPDX-FileCopyrightText: Provenant contributors` line and a non-mutating lefthook check so headers stay machine-readable without annual churn or partial-staging surprises

## Issues

- Covers: Linux Foundation license best-practice gap around per-file license headers
- Closes:

## Scope and exclusions

- Included: xtask-based header enforcement, `.license-headers.toml` scope config, contributor documentation, CI/hook wiring, and header backfill for the phase-1 allowlist of repo-owned comment-friendly files
- Explicit exclusions: `reference/**`, `testdata/**`, `resources/license_detection/**`, and generated docs such as `docs/SUPPORTED_FORMATS.md`

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: phase-2 decisions on whether to extend coverage to additional docs or use REUSE sidecar metadata for non-commentable first-party files

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no golden or expected-output fixtures were modified