### PR TITLE
fix(buck): stop defaulting METADATA.bzl package types

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -942,7 +942,14 @@ mod tests {
         assert_eq!(package.package_type, None);
         assert_eq!(package.name.as_deref(), Some("example"));
         assert_eq!(package.version.as_deref(), Some("0.0.1"));
+        assert!(!package.package_uid.is_empty());
+        assert!(
+            package
+                .package_uid
+                .starts_with("generated-package:buck_metadata/example@0.0.1?uuid=")
+        );
         assert!(package.datasource_ids.contains(&DatasourceId::BuckMetadata));
+        assert_eq!(files[0].for_packages, vec![package.package_uid.clone()]);
     }
 
     #[test]

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -925,6 +925,27 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_creates_package_for_buck_metadata_without_package_type() {
+        let mut files = vec![create_test_file_info(
+            "repo/METADATA.bzl",
+            DatasourceId::BuckMetadata,
+            None,
+            Some("example"),
+            Some("0.0.1"),
+            vec![],
+        )];
+
+        let result = assemble(&mut files);
+
+        assert_eq!(result.packages.len(), 1);
+        let package = &result.packages[0];
+        assert_eq!(package.package_type, None);
+        assert_eq!(package.name.as_deref(), Some("example"));
+        assert_eq!(package.version.as_deref(), Some("0.0.1"));
+        assert!(package.datasource_ids.contains(&DatasourceId::BuckMetadata));
+    }
+
+    #[test]
     fn test_assemble_nuget_cpm_prefers_version_override_when_enabled() {
         let mut props_file = create_test_file_info(
             "repo/Directory.Packages.props",

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -477,7 +477,10 @@ fn normalized_identity_value(value: Option<&str>) -> Option<&str> {
 }
 
 fn has_assemblable_identity(pkg_data: &PackageData) -> bool {
-    pkg_data.package_type.is_some() && normalized_identity_value(pkg_data.name.as_deref()).is_some()
+    let has_name = normalized_identity_value(pkg_data.name.as_deref()).is_some();
+    has_name
+        && (pkg_data.package_type.is_some()
+            || pkg_data.datasource_id == Some(DatasourceId::BuckMetadata))
 }
 
 fn should_skip_python_uv_lock_merge(package: &Package, pkg_data: &PackageData) -> bool {

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -911,19 +911,14 @@ pub struct Package {
 impl Package {
     /// Create a `Package` from a `PackageData` and its source file path.
     ///
-    /// Generates a unique `package_uid` by appending a UUID qualifier to the PURL.
-    /// If the `PackageData` has no PURL, the package_uid will be an empty string.
+    /// Generates a unique `package_uid` from the package PURL when available.
+    /// For packages without a PURL but with enough manifest identity to assemble,
+    /// falls back to an opaque UID derived from datasource/name/version.
     pub fn from_package_data(package_data: &PackageData, datafile_path: String) -> Self {
         let mut package_data = package_data.clone();
         enrich_package_data_license_provenance(&mut package_data, &datafile_path);
 
-        let package_uid = package_data
-            .purl
-            .as_ref()
-            .map(|p| PackageUid::new(p))
-            .unwrap_or_else(PackageUid::empty);
-
-        Package {
+        let mut package = Package {
             package_type: package_data.package_type,
             namespace: package_data.namespace.clone(),
             name: package_data.name.clone(),
@@ -963,14 +958,21 @@ impl Package {
             repository_download_url: package_data.repository_download_url.clone(),
             api_data_url: package_data.api_data_url.clone(),
             purl: package_data.purl.clone(),
-            package_uid,
+            package_uid: PackageUid::empty(),
             datafile_paths: vec![datafile_path],
             datasource_ids: if let Some(dsid) = package_data.datasource_id {
                 vec![dsid]
             } else {
                 vec![]
             },
+        };
+
+        package.refresh_identity();
+        if package.package_uid.is_empty() {
+            package.package_uid = package.fallback_package_uid();
         }
+
+        package
     }
 
     /// Update this package with data from another `PackageData`.
@@ -1100,6 +1102,28 @@ impl Package {
         }
 
         self.purl = Some(next_purl);
+    }
+
+    fn fallback_package_uid(&self) -> PackageUid {
+        let name = self
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("unknown");
+        let version = self
+            .version
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("unknown");
+        let datasource = self
+            .datasource_ids
+            .first()
+            .map(DatasourceId::as_str)
+            .unwrap_or("unknown");
+
+        PackageUid::new_opaque(&format!("generated-package:{datasource}/{name}@{version}"))
     }
 
     fn build_current_purl(&self) -> Option<String> {

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1127,6 +1127,22 @@ impl Package {
     }
 
     fn build_current_purl(&self) -> Option<String> {
+        if let Some(existing_purl) = self.purl.as_deref() {
+            let mut purl = PackageUrl::from_str(existing_purl).ok()?;
+
+            if let Some(version) = self
+                .version
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                purl.with_version(version).ok()?;
+            } else {
+                purl.without_version();
+            }
+
+            return Some(purl.to_string());
+        }
+
         if let (Some(package_type), Some(name)) = (
             self.package_type.as_ref(),
             self.name
@@ -1172,21 +1188,7 @@ impl Package {
 
             return Some(purl.to_string());
         }
-
-        let existing_purl = self.purl.as_deref()?;
-        let mut purl = PackageUrl::from_str(existing_purl).ok()?;
-
-        if let Some(version) = self
-            .version
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-        {
-            purl.with_version(version).ok()?;
-        } else {
-            purl.without_version();
-        }
-
-        Some(purl.to_string())
+        None
     }
 }
 
@@ -1323,6 +1325,30 @@ mod tests {
             Some("parser-declared-license")
         );
         assert!(package.license_detections[0].identifier.is_some());
+    }
+
+    #[test]
+    fn package_from_package_data_preserves_existing_purl_qualifiers() {
+        let package_data = PackageData {
+            package_type: Some(PackageType::Alpine),
+            namespace: Some("alpine".to_string()),
+            name: Some("busybox".to_string()),
+            version: Some("1.35.0-r17".to_string()),
+            purl: Some("pkg:alpine/busybox@1.35.0-r17?arch=x86_64".to_string()),
+            ..PackageData::default()
+        };
+
+        let package = Package::from_package_data(&package_data, "lib/apk/db/installed".to_string());
+
+        assert_eq!(
+            package.purl.as_deref(),
+            Some("pkg:alpine/busybox@1.35.0-r17?arch=x86_64")
+        );
+        assert!(
+            package
+                .package_uid
+                .starts_with("pkg:alpine/busybox@1.35.0-r17?arch=x86_64&uuid=")
+        );
     }
 }
 

--- a/src/models/package_uid.rs
+++ b/src/models/package_uid.rs
@@ -16,10 +16,20 @@ impl PackageUid {
     /// Creates a new `PackageUid` by appending a UUID to the given purl.
     pub fn new(purl: &str) -> Self {
         let uuid = Uuid::new_v4();
-        if purl.contains('?') {
-            PackageUid(format!("{}&uuid={}", purl, uuid))
+        Self::with_uuid_suffix(purl, uuid)
+    }
+
+    /// Creates a new `PackageUid` from a non-purl base string.
+    pub fn new_opaque(base: &str) -> Self {
+        let uuid = Uuid::new_v4();
+        Self::with_uuid_suffix(base, uuid)
+    }
+
+    fn with_uuid_suffix(base: &str, uuid: Uuid) -> Self {
+        if base.contains('?') {
+            PackageUid(format!("{}&uuid={}", base, uuid))
         } else {
-            PackageUid(format!("{}?uuid={}", purl, uuid))
+            PackageUid(format!("{}?uuid={}", base, uuid))
         }
     }
 

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -81,7 +81,6 @@ impl PackageParser for BuckMetadataBzlParser {
             Err(e) => {
                 warn!("Failed to parse Buck METADATA.bzl {:?}: {}", path, e);
                 PackageData {
-                    package_type: Some(Self::PACKAGE_TYPE),
                     datasource_id: Some(DatasourceId::BuckMetadata),
                     ..Default::default()
                 }
@@ -125,7 +124,6 @@ fn parse_metadata_bzl(path: &Path) -> Result<PackageData, String> {
 
     // No METADATA found
     Ok(PackageData {
-        package_type: Some(BuckMetadataBzlParser::PACKAGE_TYPE),
         datasource_id: Some(DatasourceId::BuckMetadata),
         ..Default::default()
     })
@@ -311,7 +309,6 @@ fn insert_license_reference_extra_data(
 /// Build PackageData from extracted metadata fields
 fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> PackageData {
     let mut pkg = PackageData {
-        package_type: Some(BuckMetadataBzlParser::PACKAGE_TYPE),
         datasource_id: Some(DatasourceId::BuckMetadata),
         ..Default::default()
     };

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -3,7 +3,7 @@
 
 //! Tests for Buck BUILD and METADATA.bzl parsers
 
-use crate::models::{PackageType, Sha1Digest};
+use crate::models::{DatasourceId, PackageType, Sha1Digest};
 
 use std::path::PathBuf;
 
@@ -158,7 +158,8 @@ fn test_parse_metadata_bzl_basic() {
     let path = PathBuf::from("testdata/buck/metadata/METADATA.bzl");
     let pkg = BuckMetadataBzlParser::extract_first_package(&path);
 
-    assert_eq!(pkg.package_type, Some(PackageType::Buck));
+    assert_eq!(pkg.package_type, None);
+    assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
     assert_eq!(pkg.name, Some("example".to_string()));
     assert_eq!(pkg.version, Some("0.0.1".to_string()));
     assert_eq!(
@@ -321,7 +322,8 @@ fn test_metadata_bzl_empty_file() {
     std::fs::write(&metadata_path, content).unwrap();
 
     let pkg = BuckMetadataBzlParser::extract_first_package(&metadata_path);
-    assert_eq!(pkg.package_type, Some(PackageType::Buck));
+    assert_eq!(pkg.package_type, None);
+    assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
     assert_eq!(pkg.name, None);
 }
 
@@ -337,7 +339,8 @@ OTHER_VAR = {
     std::fs::write(&metadata_path, content).unwrap();
 
     let pkg = BuckMetadataBzlParser::extract_first_package(&metadata_path);
-    assert_eq!(pkg.package_type, Some(PackageType::Buck));
+    assert_eq!(pkg.package_type, None);
+    assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
     assert_eq!(pkg.name, None);
 }
 
@@ -351,7 +354,8 @@ METADATA = {{{
     std::fs::write(&metadata_path, content).unwrap();
 
     let pkg = BuckMetadataBzlParser::extract_first_package(&metadata_path);
-    assert_eq!(pkg.package_type, Some(PackageType::Buck));
+    assert_eq!(pkg.package_type, None);
+    assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
 }
 
 #[test]
@@ -539,5 +543,6 @@ METADATA = {
 
     let pkg = BuckMetadataBzlParser::extract_first_package(&metadata_path);
 
-    assert_eq!(pkg.package_type, Some(PackageType::Buck));
+    assert_eq!(pkg.package_type, None);
+    assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
 }

--- a/testdata/buck/metadata/METADATA.bzl.expected.json
+++ b/testdata/buck/metadata/METADATA.bzl.expected.json
@@ -1,6 +1,5 @@
 [
   {
-    "type": "buck",
     "name": "example",
     "version": "0.0.1",
     "parties": [


### PR DESCRIPTION
## Summary

- stop defaulting `METADATA.bzl` packages to `type: buck` when the file does not declare an ecosystem or package URL
- keep `buck_metadata` as the source identity, preserve explicit `ecosystem`/`type`/`package_type` and `package_url` overrides, and still assemble a top-level package
- generate opaque internal `package_uid` values for assembled typeless packages so `for_packages` linkage stays populated without inventing a fake PURL type

## Scope and exclusions

- Included: Buck metadata parser behavior, Buck metadata assembly eligibility, and internal package UID fallback for assembled packages without PURLs
- Explicit exclusions: BUCK build-file parsing semantics and any broader `PackageType` taxonomy cleanup outside Buck metadata

## Intentional differences from Python

- Upstream ScanCode treats `METADATA.bzl` as `type: buck` by default. This branch intentionally leaves `type` unset unless the metadata declares a real ecosystem or `package_url`, while preserving `buck_metadata` as the datasource identity.
- Because typeless assembled packages no longer have a PURL-derived UID, this branch assigns an opaque internal `package_uid` so top-level package linkage still works.

## Expected-output fixture changes

- Files changed: `testdata/buck/metadata/METADATA.bzl.expected.json`
- Why the new expected output is correct: the fixture no longer emits `"type": "buck"` because the parser now distinguishes Buck file ownership from declared package ecosystem, while still preserving `datasource_id: "buck_metadata"` and producing an assembled package with a non-empty internal UID at scan time.