### PR TITLE
fix(android-parser): handle textproto adjacent string concatenation

### DIFF
--- a/src/parsers/android.rs
+++ b/src/parsers/android.rs
@@ -964,9 +964,15 @@ impl TextProtoParser {
 
     fn expect_scalar(&mut self) -> Result<String, String> {
         match self.next() {
-            Some(TextProtoToken::Identifier(value)) | Some(TextProtoToken::String(value)) => {
+            Some(TextProtoToken::String(mut value)) => {
+                while matches!(self.peek(), Some(TextProtoToken::String(_))) {
+                    if let Some(TextProtoToken::String(next)) = self.next() {
+                        value.push_str(&next);
+                    }
+                }
                 Ok(value)
             }
+            Some(TextProtoToken::Identifier(value)) => Ok(value),
             other => Err(format!("Expected scalar value, found {:?}", other)),
         }
     }

--- a/src/parsers/android_test.rs
+++ b/src/parsers/android_test.rs
@@ -279,6 +279,33 @@ third_party {
     }
 
     #[test]
+    fn test_parse_soong_metadata_string_concatenation() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let metadata_path = temp_dir.path().join("METADATA");
+        fs::write(
+            &metadata_path,
+            r#"
+name: "nlohmann_json"
+description: "SPM builds, making it impossible to use directly "
+             "in those environments."
+third_party {
+  version: "3.11.2"
+}
+"#,
+        )
+        .expect("write METADATA");
+
+        let package = AndroidSoongMetadataParser::extract_first_package(&metadata_path);
+
+        assert_eq!(package.name.as_deref(), Some("nlohmann_json"));
+        assert_eq!(package.version.as_deref(), Some("3.11.2"));
+        assert_eq!(
+            package.description.as_deref(),
+            Some("SPM builds, making it impossible to use directly in those environments.")
+        );
+    }
+
+    #[test]
     fn test_parse_text_android_manifest_fixture() {
         let package = AndroidManifestParser::extract_first_package(&PathBuf::from(
             "testdata/android/manifest/AndroidManifest.xml",


### PR DESCRIPTION
## Summary
- Fix parsing of Android Soong METADATA files that use adjacent string concatenation (a standard textproto feature where consecutive quoted strings like `"foo " "bar"` are implicitly joined)
- The parser previously emitted `Unexpected token in textproto: String(...)` warnings for these files
- `expect_scalar()` now consumes and concatenates consecutive `String` tokens

## Test plan
- [x] Added `test_parse_soong_metadata_string_concatenation` covering multi-line concatenated strings
- [x] All existing soong/METADATA tests continue to pass