### PR TITLE
refactor(copyright): streamline detector helpers and speed up scans

### DIFF
--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -226,77 +226,65 @@ fn extract_dash_bullet_attribution_author(line: &str) -> Option<String> {
 pub(super) fn extract_dash_bullet_attribution_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
 ) -> Vec<AuthorDetection> {
-    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return authors;
+        return Vec::new();
     }
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(raw_line) = prepared_cache.raw_by_index(idx) else {
-            continue;
-        };
-        let trimmed = raw_line.trim_start();
-        if !trimmed.starts_with("- ") {
-            continue;
-        }
-        let Some(author) = extract_dash_bullet_attribution_author(trimmed) else {
-            continue;
-        };
-        authors.push(AuthorDetection {
-            author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
-        });
-    }
-
-    authors
+    (0..prepared_cache.len())
+        .filter_map(|idx| {
+            let ln = idx + 1;
+            let raw_line = prepared_cache.raw_by_index(idx)?;
+            let trimmed = raw_line.trim_start();
+            if !trimmed.starts_with("- ") {
+                return None;
+            }
+            let author = extract_dash_bullet_attribution_author(trimmed)?;
+            Some(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            })
+        })
+        .collect()
 }
 
 pub(super) fn extract_name_contributed_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
 ) -> Vec<AuthorDetection> {
-    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return authors;
+        return Vec::new();
     }
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(raw_line) = prepared_cache.raw_by_index(idx) else {
-            continue;
-        };
-        let trimmed = raw_line.trim();
-        let Some((who, _)) = trimmed.split_once(" contributed") else {
-            continue;
-        };
-        let words: Vec<&str> = who.split_whitespace().collect();
-        if !(2..=4).contains(&words.len()) {
-            continue;
-        }
-        if !words
-            .iter()
-            .all(|word| looks_like_contributed_person_name_token(word))
-        {
-            continue;
-        }
-        if words
-            .iter()
-            .any(|word| is_contributed_non_person_token(word))
-        {
-            continue;
-        }
-        let Some(author) = refine_author(who) else {
-            continue;
-        };
-        authors.push(AuthorDetection {
-            author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
-        });
-    }
-
-    authors
+    (0..prepared_cache.len())
+        .filter_map(|idx| {
+            let ln = idx + 1;
+            let raw_line = prepared_cache.raw_by_index(idx)?;
+            let trimmed = raw_line.trim();
+            let (who, _) = trimmed.split_once(" contributed")?;
+            let words: Vec<&str> = who.split_whitespace().collect();
+            if !(2..=4).contains(&words.len()) {
+                return None;
+            }
+            if !words
+                .iter()
+                .all(|word| looks_like_contributed_person_name_token(word))
+            {
+                return None;
+            }
+            if words
+                .iter()
+                .any(|word| is_contributed_non_person_token(word))
+            {
+                return None;
+            }
+            let author = refine_author(who)?;
+            Some(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            })
+        })
+        .collect()
 }
 
 fn looks_like_contributed_person_name_token(word: &str) -> bool {
@@ -336,9 +324,8 @@ fn is_contributed_non_person_token(word: &str) -> bool {
 pub(super) fn extract_rst_field_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
 ) -> Vec<AuthorDetection> {
-    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return authors;
+        return Vec::new();
     }
 
     static RST_FIELD_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -350,36 +337,30 @@ pub(super) fn extract_rst_field_authors(
             .unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
+    (0..prepared_cache.len())
+        .filter_map(|idx| {
+            let ln = idx + 1;
+            let prepared = prepared_cache.get_by_index(idx)?;
+            let line = prepared.trim();
+            if line.is_empty() {
+                return None;
+            }
 
-        let Some(cap) = RST_FIELD_AUTHOR_RE.captures(line) else {
-            continue;
-        };
-        let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
-        if tail.is_empty() {
-            continue;
-        }
-        let stripped_tail = ATTRIBUTION_PREFIX_RE.replace(tail, "");
-        let trimmed = trim_attribution_tail(stripped_tail.as_ref());
-        let Some(author) = refine_author(&trimmed) else {
-            continue;
-        };
-        authors.push(AuthorDetection {
-            author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
-        });
-    }
-
-    authors
+            let cap = RST_FIELD_AUTHOR_RE.captures(line)?;
+            let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
+            if tail.is_empty() {
+                return None;
+            }
+            let stripped_tail = ATTRIBUTION_PREFIX_RE.replace(tail, "");
+            let trimmed = trim_attribution_tail(stripped_tail.as_ref());
+            let author = refine_author(&trimmed)?;
+            Some(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            })
+        })
+        .collect()
 }
 
 fn extract_author_colon_bullet_roster(
@@ -685,9 +666,8 @@ pub(super) fn drop_merged_dash_bullet_attribution_authors(authors: &mut Vec<Auth
 }
 
 pub(super) fn extract_json_excerpt_developed_by_authors(content: &str) -> Vec<AuthorDetection> {
-    let mut authors = Vec::new();
     if content.is_empty() {
-        return authors;
+        return Vec::new();
     }
 
     static JSON_DEVELOPED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -697,27 +677,26 @@ pub(super) fn extract_json_excerpt_developed_by_authors(content: &str) -> Vec<Au
         .unwrap()
     });
 
-    for cap in JSON_DEVELOPED_BY_RE.captures_iter(content) {
-        let who = cap
-            .name("who")
-            .map(|m| m.as_str())
-            .unwrap_or("")
-            .trim()
-            .trim_end_matches(&['.', ';', ','][..]);
-        if who.is_empty() {
-            continue;
-        }
-        let Some(author) = refine_author(who) else {
-            continue;
-        };
-        authors.push(AuthorDetection {
-            author,
-            start_line: LineNumber::ONE,
-            end_line: LineNumber::ONE,
-        });
-    }
-
-    authors
+    JSON_DEVELOPED_BY_RE
+        .captures_iter(content)
+        .filter_map(|cap| {
+            let who = cap
+                .name("who")
+                .map(|m| m.as_str())
+                .unwrap_or("")
+                .trim()
+                .trim_end_matches(&['.', ';', ','][..]);
+            if who.is_empty() {
+                return None;
+            }
+            let author = refine_author(who)?;
+            Some(AuthorDetection {
+                author,
+                start_line: LineNumber::ONE,
+                end_line: LineNumber::ONE,
+            })
+        })
+        .collect()
 }
 
 pub(super) fn extract_modified_portion_developed_by_authors(content: &str) -> Vec<AuthorDetection> {
@@ -2398,16 +2377,15 @@ pub(super) fn drop_shadowed_prefix_authors(authors: &mut Vec<AuthorDetection>) {
     if authors.len() < 2 {
         return;
     }
-    let mut drop: Vec<bool> = vec![false; authors.len()];
-    for i in 0..authors.len() {
-        let a = authors[i].author.trim();
+    let originals = authors.clone();
+
+    authors.retain(|author| {
+        let a = author.author.trim();
         if a.is_empty() {
-            continue;
+            return true;
         }
-        for (j, other) in authors.iter().enumerate() {
-            if i == j {
-                continue;
-            }
+
+        for other in &originals {
             let b = other.author.trim();
             if b.len() <= a.len() {
                 continue;
@@ -2427,12 +2405,10 @@ pub(super) fn drop_shadowed_prefix_authors(authors: &mut Vec<AuthorDetection>) {
                     if a.chars().all(|c| c.is_ascii_lowercase()) {
                         continue;
                     }
-                    drop[i] = true;
-                    break;
+                    return false;
                 }
                 if !a_has_email && b_has_email && boundary {
-                    drop[i] = true;
-                    break;
+                    return false;
                 }
                 if boundary {
                     let tail_lower = tail.to_ascii_lowercase();
@@ -2445,23 +2421,14 @@ pub(super) fn drop_shadowed_prefix_authors(authors: &mut Vec<AuthorDetection>) {
                         || tail_lower.starts_with("and")
                         || tail_lower.starts_with("author-email")
                     {
-                        drop[i] = true;
-                        break;
+                        return false;
                     }
                 }
             }
         }
-    }
-    if drop.iter().all(|d| !*d) {
-        return;
-    }
-    let mut kept = Vec::with_capacity(authors.len());
-    for (i, a) in authors.iter().cloned().enumerate() {
-        if !drop[i] {
-            kept.push(a);
-        }
-    }
-    *authors = kept;
+
+        true
+    });
 }
 
 pub(super) fn drop_shadowed_compound_email_authors(authors: &mut Vec<AuthorDetection>) {

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -1535,21 +1535,12 @@ pub(super) fn extract_debian_maintainer_authors(
         Regex::new(r"(?i)^maintained\s+by\s+(?P<who>.+?)(?:\s+on\b|\s+since\b|\s*$)").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let who_raw = if let Some(cap) = CO_MAINTAINER_RE.captures(line) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let who_raw = if let Some(cap) = CO_MAINTAINER_RE.captures(prepared_line.prepared) {
             cap.name("who").map(|m| m.as_str()).unwrap_or("")
-        } else if let Some(cap) = DEBIANIZED_BY_RE.captures(line) {
+        } else if let Some(cap) = DEBIANIZED_BY_RE.captures(prepared_line.prepared) {
             cap.name("who").map(|m| m.as_str()).unwrap_or("")
-        } else if let Some(cap) = MAINTAINED_BY_RE.captures(line) {
+        } else if let Some(cap) = MAINTAINED_BY_RE.captures(prepared_line.prepared) {
             cap.name("who").map(|m| m.as_str()).unwrap_or("")
         } else {
             ""
@@ -1566,8 +1557,8 @@ pub(super) fn extract_debian_maintainer_authors(
 
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
     }
 
@@ -1587,12 +1578,8 @@ pub(super) fn extract_maintainers_label_authors(
     static GITREPO_SUFFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s+GitRepo\s+https?://\S+.*$").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim().trim_start_matches('*').trim_start();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let line = prepared_line.prepared.trim_start_matches('*').trim_start();
         if line.is_empty() {
             continue;
         }
@@ -1615,8 +1602,8 @@ pub(super) fn extract_maintainers_label_authors(
 
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
     }
 
@@ -1634,17 +1621,13 @@ pub(super) fn extract_created_by_project_author(
     static CREATED_BY_PROJECT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bcreated\s+by\s+the\s+project\b").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        if CREATED_BY_PROJECT_RE.is_match(prepared.trim()) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if CREATED_BY_PROJECT_RE.is_match(prepared_line.prepared) {
             let author = "the Project".to_string();
             authors.push(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
             break;
         }
@@ -1664,17 +1647,8 @@ pub(super) fn extract_created_by_authors(
     static CREATED_BY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\s*created\s+by\s+(?P<who>.+?)\s*$").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Some(cap) = CREATED_BY_RE.captures(line) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = CREATED_BY_RE.captures(prepared_line.prepared) else {
             continue;
         };
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1694,11 +1668,16 @@ pub(super) fn extract_created_by_authors(
         };
         authors.push(AuthorDetection {
             author: author.clone(),
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
 
-        authors.retain(|a| !(author.starts_with(&a.author) && a.author.len() < author.len()));
+        authors.retain(|a| {
+            !(a.start_line == prepared_line.line_number
+                && a.end_line == prepared_line.line_number
+                && author.starts_with(&a.author)
+                && a.author.len() < author.len())
+        });
     }
 }
 
@@ -1778,17 +1757,8 @@ pub(super) fn extract_written_by_comma_and_copyright_authors(
         Regex::new(r"(?i)\bwritten\s+by\s+(?P<who>.+?),\s+and\s+copyright\b").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Some(cap) = WRITTEN_BY_AND_COPYRIGHT_RE.captures(line) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = WRITTEN_BY_AND_COPYRIGHT_RE.captures(prepared_line.prepared) else {
             continue;
         };
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1798,11 +1768,13 @@ pub(super) fn extract_written_by_comma_and_copyright_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        authors.retain(|a| !(a.start_line.get() == ln && a.end_line.get() == ln));
+        authors.retain(|a| {
+            !(a.start_line == prepared_line.line_number && a.end_line == prepared_line.line_number)
+        });
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
     }
 }
@@ -1825,17 +1797,8 @@ pub(super) fn extract_package_comment_named_authors(
         Regex::new(r"^(?P<name>[A-Z][^<>@]+?)\s*<(?P<email>[^>\s]+@[^>\s]+)>$").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        for cap in COMMENT_AUTHOR_RE.captures_iter(line) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        for cap in COMMENT_AUTHOR_RE.captures_iter(prepared_line.prepared) {
             let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
             if who.is_empty() || who.to_ascii_lowercase().starts_with("the ") {
                 continue;
@@ -1852,8 +1815,8 @@ pub(super) fn extract_package_comment_named_authors(
             if let Some(author) = author {
                 authors.push(AuthorDetection {
                     author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
         }
@@ -1873,17 +1836,8 @@ pub(super) fn extract_developed_by_sentence_authors(
     static DEVELOPED_BY_PREFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\s*developed\s+by\s+(?P<rest>.+)$").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Some(cap) = DEVELOPED_BY_PREFIX_RE.captures(line) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = DEVELOPED_BY_PREFIX_RE.captures(prepared_line.prepared) else {
             continue;
         };
         let rest = cap.name("rest").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1913,8 +1867,8 @@ pub(super) fn extract_developed_by_sentence_authors(
 
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
     }
 
@@ -1933,17 +1887,8 @@ pub(super) fn extract_developed_by_phrase_authors(
         Regex::new(r"(?i)\bdeveloped\s+by\s+(?P<who>.+?)\s+and\s+to\s+credit\b").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        for cap in DEVELOPED_BY_PHRASE_RE.captures_iter(line) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        for cap in DEVELOPED_BY_PHRASE_RE.captures_iter(prepared_line.prepared) {
             let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
             if who.is_empty() {
                 continue;
@@ -1960,8 +1905,8 @@ pub(super) fn extract_developed_by_phrase_authors(
 
             authors.push(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -1984,29 +1929,24 @@ pub(super) fn extract_developed_by_contributors_authors(
         .unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(line) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if !line.to_ascii_lowercase().contains("developed by") {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if !prepared_line
+            .prepared
+            .to_ascii_lowercase()
+            .contains("developed by")
+        {
             continue;
         }
 
-        let mut window = line.clone();
-        let mut end_line = ln;
+        let mut window = prepared_line.prepared.to_string();
+        let mut end_line = prepared_line.line_number;
         if !window.to_ascii_lowercase().contains("contributors")
-            && let Some(next) = prepared_cache
-                .get_by_index(idx + 1)
-                .map(|p| p.trim().to_string())
-            && !next.is_empty()
+            && let Some(next) = prepared_cache.line(prepared_line.line_number + 1usize)
+            && !next.prepared.is_empty()
         {
             window.push(' ');
-            window.push_str(&next);
-            end_line = idx + 2;
+            window.push_str(next.prepared);
+            end_line = next.line_number;
         }
 
         let Some(cap) = DEVELOPED_BY_CONTRIBUTORS_RE.captures(&window) else {
@@ -2023,8 +1963,8 @@ pub(super) fn extract_developed_by_contributors_authors(
 
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(end_line).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line,
         });
     }
 
@@ -2077,16 +2017,8 @@ pub(super) fn extract_maintained_by_authors(
         Regex::new(r"(?i)\bmaintained\s+by\s+(?P<who>.+?)(?:\s+(?:on|since|for)\b|$)").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        for cap in MAINTAINED_BY_RE.captures_iter(line) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        for cap in MAINTAINED_BY_RE.captures_iter(prepared_line.prepared) {
             let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
             if who.is_empty() {
                 continue;
@@ -2099,8 +2031,8 @@ pub(super) fn extract_maintained_by_authors(
             };
             authors.push(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -2124,12 +2056,8 @@ pub(super) fn extract_converted_to_by_authors(
     static CONVERTED_TO_VERSION_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bconverted\s+to\s+\d+\.\d+\b").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim().trim_start_matches('*').trim_start();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let line = prepared_line.prepared.trim_start_matches('*').trim_start();
         if line.is_empty() {
             continue;
         }
@@ -2161,15 +2089,15 @@ pub(super) fn extract_converted_to_by_authors(
         };
         authors.push(AuthorDetection {
             author: author.clone(),
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
         if add_converted_variant {
             let converted = format!("{author} Converted");
             authors.push(AuthorDetection {
                 author: converted,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -2189,12 +2117,8 @@ pub(super) fn extract_various_bugfixes_and_enhancements_by_authors(
         Regex::new(r"(?i)^\s*various\s+bugfixes\s+and\s+enhancements\s+by\s+(?P<who>.+)$").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim().trim_start_matches('*').trim_start();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let line = prepared_line.prepared.trim_start_matches('*').trim_start();
         if line.is_empty() {
             continue;
         }
@@ -2213,8 +2137,8 @@ pub(super) fn extract_various_bugfixes_and_enhancements_by_authors(
         };
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
     }
 
@@ -2768,24 +2692,15 @@ pub(super) fn drop_written_by_authors_preceded_by_copyright(
     }
 
     let mut to_drop: HashSet<String> = HashSet::new();
-    for i in 1..prepared_cache.len() {
-        let Some(line) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            continue;
-        };
-        let Some(cap) = WRITTEN_BY_RE.captures(&line) else {
+    for (prev, line) in prepared_cache.adjacent_pairs() {
+        let Some(cap) = WRITTEN_BY_RE.captures(line.prepared) else {
             continue;
         };
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
         if who.is_empty() {
             continue;
         }
-        let Some(prev) = prepared_cache
-            .get_by_index(i - 1)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if !COPYRIGHT_HINT_RE.is_match(&prev) {
+        if !COPYRIGHT_HINT_RE.is_match(prev.prepared) {
             continue;
         }
         if let Some(author) = refine_author(who) {

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -499,14 +499,14 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 || lower.contains(" written by "));
 
         if !is_start {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let mut block_lines: Vec<(LineNumber, String)> = Vec::new();
         block_lines.push((prepared_line.line_number, line.to_string()));
 
-        let mut next_line_number = prepared_line.line_number + 1usize;
+        let mut next_line_number = prepared_line.line_number.next();
         while let Some(next_line) = prepared_cache.line(next_line_number) {
             let next_line = next_line.prepared;
             if next_line.is_empty() {
@@ -530,11 +530,11 @@ pub(super) fn extract_multiline_written_by_author_blocks(
             }
 
             block_lines.push((next_line_number, next_line.to_string()));
-            next_line_number += 1usize;
+            next_line_number = next_line_number.next();
         }
 
         if block_lines.len() < 2 {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
@@ -797,24 +797,24 @@ pub(super) fn extract_was_developed_by_author_blocks(
     let mut line_number = LineNumber::ONE;
     while let Some(line) = prepared_cache.line(line_number) {
         if line.prepared.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let Some(cap) = WAS_DEVELOPED_BY_RE.captures(line.prepared) else {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         };
         let mut parts: Vec<String> = Vec::new();
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
         if who.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
         parts.push(who.to_string());
 
         let mut end_line = line.line_number;
-        let mut next_line_number = line.line_number + 1usize;
+        let mut next_line_number = line.line_number.next();
         while let Some(next_line) = prepared_cache.line(next_line_number) {
             if next_line.prepared.is_empty() {
                 break;
@@ -841,19 +841,19 @@ pub(super) fn extract_was_developed_by_author_blocks(
                 break;
             }
 
-            next_line_number += 1usize;
+            next_line_number = next_line_number.next();
         }
 
         let joined = parts.join(" ");
         let joined = joined.split_whitespace().collect::<Vec<_>>().join(" ");
         if joined.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let author = refine_author(&joined).unwrap_or(joined);
         if author.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
@@ -863,7 +863,7 @@ pub(super) fn extract_was_developed_by_author_blocks(
             end_line,
         });
 
-        line_number += 1usize;
+        line_number = line_number.next();
     }
 
     authors
@@ -891,19 +891,19 @@ pub(super) fn extract_author_colon_blocks(
     while let Some(prepared_line) = prepared_cache.line(line_number) {
         let line = trim_author_label_prefix(prepared_line.prepared);
         if line.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let Some(cap) = AUTHOR_COLON_RE.captures(&line) else {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         };
 
         let mut skip = false;
         let mut prev_line_number = prepared_line.line_number;
         while prev_line_number > LineNumber::ONE {
-            prev_line_number = LineNumber::new(prev_line_number.get() - 1).expect("valid");
+            prev_line_number = prev_line_number.prev().expect("valid");
             let Some(prev) = prepared_cache.line(prev_line_number) else {
                 break;
             };
@@ -916,7 +916,7 @@ pub(super) fn extract_author_colon_blocks(
             break;
         }
         if skip {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
@@ -938,19 +938,19 @@ pub(super) fn extract_author_colon_blocks(
             && label_raw.chars().any(|c| c.is_ascii_uppercase())
             && !label_raw.chars().any(|c| c.is_ascii_lowercase());
         if label_is_all_caps {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let mut segments: Vec<String> = Vec::new();
         if !tail.is_empty() {
             let Some(initial_tail) = sanitize_author_colon_tail(tail) else {
-                line_number += 1usize;
+                line_number = line_number.next();
                 continue;
             };
             segments.push(initial_tail);
         }
-        let mut next_line_number = prepared_line.line_number + 1usize;
+        let mut next_line_number = prepared_line.line_number.next();
         let mut added = 0usize;
         if !single_line_original_or_primary || collect_following_original_authors {
             loop {
@@ -1000,7 +1000,7 @@ pub(super) fn extract_author_colon_blocks(
                 if include {
                     segments.push(next_line.to_string());
                     added += 1;
-                    next_line_number += 1usize;
+                    next_line_number = next_line_number.next();
                     if added >= 4 {
                         break;
                     }
@@ -1015,15 +1015,15 @@ pub(super) fn extract_author_colon_blocks(
         }
 
         if segments.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let start_line = prepared_line.line_number;
-        let end_line = if next_line_number == prepared_line.line_number + 1usize {
+        let end_line = if next_line_number == prepared_line.line_number.next() {
             start_line
         } else {
-            LineNumber::new(next_line_number.get() - 1).expect("valid")
+            next_line_number.prev().expect("valid")
         };
         let bullet_results = extract_author_colon_bullet_roster(&segments, start_line.get());
         if !bullet_results.is_empty() {
@@ -1059,7 +1059,7 @@ pub(super) fn extract_author_colon_blocks(
         }
         let combined_raw = segments.join(" ");
         let Some(combined) = refine_author_with_optional_handle_suffix(&combined_raw) else {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         };
 
@@ -1205,16 +1205,16 @@ pub(super) fn extract_code_written_by_author_blocks(
     while let Some(prepared_line) = prepared_cache.line(line_number) {
         let line = prepared_line.prepared;
         if line.is_empty() {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
         if !HEADER_RE.is_match(line) {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let mut combined = line.to_string();
-        let mut next_line_number = prepared_line.line_number + 1usize;
+        let mut next_line_number = prepared_line.line_number.next();
         while let Some(next_prepared) = prepared_cache.line(next_line_number) {
             let next = next_prepared.prepared;
             if next.is_empty() {
@@ -1228,7 +1228,7 @@ pub(super) fn extract_code_written_by_author_blocks(
             if combined.len() > 800 {
                 break;
             }
-            next_line_number += 1usize;
+            next_line_number = next_line_number.next();
         }
 
         let Some(cap) = BODY_RE.captures(&combined) else {
@@ -1256,7 +1256,7 @@ pub(super) fn extract_code_written_by_author_blocks(
         authors.push(AuthorDetection {
             author,
             start_line: prepared_line.line_number,
-            end_line: LineNumber::new(next_line_number.get() - 1).expect("valid"),
+            end_line: next_line_number.prev().expect("valid"),
         });
 
         line_number = next_line_number;
@@ -1307,7 +1307,7 @@ pub(super) fn extract_developed_and_created_by_authors(
                 parts.push(piece);
             }
             end_line = line_number;
-            line_number += 1usize;
+            line_number = line_number.next();
         }
 
         if parts.is_empty() {
@@ -1427,7 +1427,7 @@ pub(super) fn merge_metadata_author_and_email_lines(
             continue;
         }
 
-        let mut next_line_number = prepared_line.line_number + 1usize;
+        let mut next_line_number = prepared_line.line_number.next();
         while let Some(email_line) = prepared_cache.line(next_line_number) {
             let email_line = email_line.prepared;
             if email_line.is_empty() {
@@ -1438,7 +1438,7 @@ pub(super) fn merge_metadata_author_and_email_lines(
             }
 
             if !email_line.to_ascii_lowercase().starts_with("author-email") {
-                next_line_number += 1usize;
+                next_line_number = next_line_number.next();
                 continue;
             }
             let Some((_, email_raw)) = email_line.split_once(':') else {
@@ -1906,7 +1906,7 @@ pub(super) fn extract_developed_by_contributors_authors(
         let mut window = prepared_line.prepared.to_string();
         let mut end_line = prepared_line.line_number;
         if !window.to_ascii_lowercase().contains("contributors")
-            && let Some(next) = prepared_cache.line(prepared_line.line_number + 1usize)
+            && let Some(next) = prepared_cache.line(prepared_line.line_number.next())
             && !next.prepared.is_empty()
         {
             window.push(' ');
@@ -2164,37 +2164,45 @@ pub(super) fn drop_authors_from_copyright_by_lines(
     });
 
     authors.retain(|author| {
-        let start = author.start_line.get();
-        let end = author.end_line.get();
-        (start..=end).all(|line_no| {
-            let Some(raw) = prepared_cache.raw_by_index(line_no - 1) else {
+        let author_lower = author.author.to_ascii_lowercase();
+        let mut line_number = author.start_line;
+
+        loop {
+            let Some(raw) = prepared_cache.line(line_number).map(|line| line.raw) else {
                 return true;
             };
             let lower = raw.to_ascii_lowercase();
             if INLINE_ATTRIBUTION_PARENS_RE.is_match(raw) {
-                return true;
+                if line_number == author.end_line {
+                    return true;
+                }
+                line_number = line_number.next();
+                continue;
             }
             if lower.trim_start().starts_with("copyright")
                 && lower.contains(" by ")
-                && lower.contains(&author.author.to_ascii_lowercase())
+                && lower.contains(&author_lower)
             {
                 return false;
             }
 
-            if line_no > 1
-                && let Some(prev) = prepared_cache.raw_by_index(line_no - 2)
+            if let Some(prev_line_number) = line_number.prev()
+                && let Some(prev) = prepared_cache.line(prev_line_number).map(|line| line.raw)
             {
                 let prev_lower = prev.to_ascii_lowercase();
                 if prev_lower.contains("copyright")
                     && YEAR_PREFIX_BY_RE.is_match(raw)
-                    && lower.contains(&author.author.to_ascii_lowercase())
+                    && lower.contains(&author_lower)
                 {
                     return false;
                 }
             }
 
-            true
-        })
+            if line_number == author.end_line {
+                return true;
+            }
+            line_number = line_number.next();
+        }
     });
 }
 
@@ -2218,13 +2226,14 @@ pub(super) fn drop_author_colon_lines_absorbed_into_year_only_copyrights(
     });
 
     authors.retain(|author| {
-        let start_line = author.start_line.get();
-        let end_line = author.end_line.get();
-        if start_line != end_line || start_line <= 1 {
+        if author.start_line != author.end_line {
             return true;
         }
+        let Some(previous_line_number) = author.start_line.prev() else {
+            return true;
+        };
 
-        let Some(raw_line) = prepared_cache.raw_by_index(start_line - 1) else {
+        let Some(raw_line) = prepared_cache.line(author.start_line).map(|line| line.raw) else {
             return true;
         };
         let normalized_line = raw_line.trim().trim_start_matches('*').trim_start();
@@ -2233,8 +2242,8 @@ pub(super) fn drop_author_colon_lines_absorbed_into_year_only_copyrights(
         }
 
         copyrights.iter().all(|copyright| {
-            if copyright.start_line.get() != start_line - 1
-                || copyright.end_line.get() != start_line
+            if copyright.start_line != previous_line_number
+                || copyright.end_line != author.start_line
             {
                 return true;
             }

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -439,11 +439,12 @@ pub(super) fn extract_multiline_written_by_author_blocks(
         .unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(raw_line) = prepared_cache.raw_by_index(idx) else {
+    for prepared_line in prepared_cache.iter() {
+        let raw_line = prepared_line.raw;
+        let ln = prepared_line.line_number;
+        if raw_line.is_empty() {
             continue;
-        };
+        }
         let line = strip_leading_dash_bullet(raw_line.trim());
         if line.is_empty() {
             continue;
@@ -476,21 +477,16 @@ pub(super) fn extract_multiline_written_by_author_blocks(
             if let Some(author) = refine_author(who) {
                 authors.push(AuthorDetection {
                     author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
+                    start_line: ln,
+                    end_line: ln,
                 });
             }
         }
     }
 
-    let mut i = 0;
-    while i < prepared_cache.len() {
-        let ln = i + 1;
-        let Some(prepared) = prepared_cache.get_by_index(i) else {
-            i += 1;
-            continue;
-        };
-        let line = prepared.trim();
+    let mut line_number = LineNumber::ONE;
+    while let Some(prepared_line) = prepared_cache.line(line_number) {
+        let line = prepared_line.prepared;
         let normalized_line = strip_leading_dash_bullet(line);
         let lower = normalized_line.to_ascii_lowercase();
 
@@ -503,20 +499,16 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 || lower.contains(" written by "));
 
         if !is_start {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
-        let mut block_lines: Vec<(usize, String)> = Vec::new();
-        block_lines.push((ln, line.to_string()));
+        let mut block_lines: Vec<(LineNumber, String)> = Vec::new();
+        block_lines.push((prepared_line.line_number, line.to_string()));
 
-        let mut j = i + 1;
-        while j < prepared_cache.len() {
-            let next_ln = j + 1;
-            let Some(next_prepared) = prepared_cache.get_by_index(j) else {
-                break;
-            };
-            let next_line = next_prepared.trim();
+        let mut next_line_number = prepared_line.line_number + 1usize;
+        while let Some(next_line) = prepared_cache.line(next_line_number) {
+            let next_line = next_line.prepared;
             if next_line.is_empty() {
                 break;
             }
@@ -537,17 +529,23 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 break;
             }
 
-            block_lines.push((next_ln, next_line.to_string()));
-            j += 1;
+            block_lines.push((next_line_number, next_line.to_string()));
+            next_line_number += 1usize;
         }
 
         if block_lines.len() < 2 {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
-        let start_line = block_lines.first().map(|(l, _)| *l).unwrap_or(ln);
-        let end_line = block_lines.last().map(|(l, _)| *l).unwrap_or(ln);
+        let start_line = block_lines
+            .first()
+            .map(|(line_number, _)| *line_number)
+            .unwrap_or(prepared_line.line_number);
+        let end_line = block_lines
+            .last()
+            .map(|(line_number, _)| *line_number)
+            .unwrap_or(prepared_line.line_number);
 
         let prefer_combined_block = block_lines.iter().skip(1).any(|(_, raw_line)| {
             let lower = raw_line.trim().to_ascii_lowercase();
@@ -575,13 +573,13 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 .trim_end_matches('.')
                 .trim();
             if let Some(combined) = refine_author(combined_candidate) {
-                authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
+                authors.retain(|a| a.start_line < start_line || a.end_line > end_line);
                 authors.push(AuthorDetection {
                     author: combined,
-                    start_line: LineNumber::new(start_line).expect("valid"),
-                    end_line: LineNumber::new(end_line).expect("valid"),
+                    start_line,
+                    end_line,
                 });
-                i = j;
+                line_number = next_line_number;
                 continue;
             }
         }
@@ -600,8 +598,8 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                         if let Some(author) = refine_author(who) {
                             authors.push(AuthorDetection {
                                 author,
-                                start_line: LineNumber::new(start_line).expect("valid"),
-                                end_line: LineNumber::new(end_line).expect("valid"),
+                                start_line,
+                                end_line,
                             });
                         }
                         extracted_any = true;
@@ -625,16 +623,16 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 .trim_end_matches('.')
                 .trim();
             if let Some(combined) = refine_author(combined_candidate) {
-                authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
+                authors.retain(|a| a.start_line < start_line || a.end_line > end_line);
                 authors.push(AuthorDetection {
                     author: combined,
-                    start_line: LineNumber::new(start_line).expect("valid"),
-                    end_line: LineNumber::new(end_line).expect("valid"),
+                    start_line,
+                    end_line,
                 });
             }
         }
 
-        i = j;
+        line_number = next_line_number;
     }
 }
 
@@ -889,43 +887,36 @@ pub(super) fn extract_author_colon_blocks(
         Regex::new(r"(?i)^copyright\s+\(c\)\s*(?:\d{4}(?:\s*,\s*\d{4})*|\d{4}-\d{4})\s*$").unwrap()
     });
 
-    let mut i = 0;
-    while i < prepared_cache.len() {
-        let ln = i + 1;
-        let Some(line) = prepared_cache.get_by_index(i).map(trim_author_label_prefix) else {
-            i += 1;
-            continue;
-        };
+    let mut line_number = LineNumber::ONE;
+    while let Some(prepared_line) = prepared_cache.line(line_number) {
+        let line = trim_author_label_prefix(prepared_line.prepared);
         if line.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
         let Some(cap) = AUTHOR_COLON_RE.captures(&line) else {
-            i += 1;
+            line_number += 1usize;
             continue;
         };
 
         let mut skip = false;
-        let mut prev_idx = i;
-        while prev_idx > 0 {
-            prev_idx -= 1;
-            let Some(prev) = prepared_cache
-                .get_by_index(prev_idx)
-                .map(|p| p.trim().to_string())
-            else {
+        let mut prev_line_number = prepared_line.line_number;
+        while prev_line_number > LineNumber::ONE {
+            prev_line_number = LineNumber::new(prev_line_number.get() - 1).expect("valid");
+            let Some(prev) = prepared_cache.line(prev_line_number) else {
                 break;
             };
-            if prev.is_empty() {
+            if prev.prepared.is_empty() {
                 continue;
             }
-            if YEAR_ONLY_COPY_RE.is_match(&prev) {
+            if YEAR_ONLY_COPY_RE.is_match(prev.prepared) {
                 skip = true;
             }
             break;
         }
         if skip {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
@@ -947,93 +938,97 @@ pub(super) fn extract_author_colon_blocks(
             && label_raw.chars().any(|c| c.is_ascii_uppercase())
             && !label_raw.chars().any(|c| c.is_ascii_lowercase());
         if label_is_all_caps {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
         let mut segments: Vec<String> = Vec::new();
         if !tail.is_empty() {
             let Some(initial_tail) = sanitize_author_colon_tail(tail) else {
-                i += 1;
+                line_number += 1usize;
                 continue;
             };
             segments.push(initial_tail);
         }
-        let mut j = i + 1;
+        let mut next_line_number = prepared_line.line_number + 1usize;
         let mut added = 0usize;
-        while (!single_line_original_or_primary || collect_following_original_authors)
-            && j < prepared_cache.len()
-        {
-            let Some(next_prepared) = prepared_cache.get_by_index(j) else {
-                break;
-            };
-            let next_line_buf = trim_author_label_prefix(next_prepared);
-            let next_line = next_line_buf.as_str();
-            if next_line.is_empty() {
-                break;
-            }
-            let next_lower = next_line.to_ascii_lowercase();
-            if is_author_metadata_line(next_line) {
-                break;
-            }
-            if next_lower.starts_with("copyright") {
-                break;
-            }
-            if next_lower.starts_with("fixed") || next_lower.starts_with("software") {
-                break;
-            }
-            if next_lower.starts_with("updated")
-                || next_lower.starts_with("date")
-                || next_lower.starts_with("borrows")
-                || next_lower.starts_with("files")
-            {
-                break;
-            }
-            if next_lower.starts_with("et al") {
-                break;
-            }
-
-            if next_line.contains(':') {
-                break;
-            }
-
-            let mut include = false;
-            if !include {
-                include = next_line.contains('@')
-                    || next_line.contains('<')
-                    || next_line.contains(',')
-                    || next_line
-                        .chars()
-                        .find(|c| !c.is_whitespace())
-                        .is_some_and(|c| c.is_ascii_uppercase());
-            }
-            if include {
-                segments.push(next_line.to_string());
-                added += 1;
-                j += 1;
-                if added >= 4 {
+        if !single_line_original_or_primary || collect_following_original_authors {
+            loop {
+                let Some(next_prepared) = prepared_cache.line(next_line_number) else {
+                    break;
+                };
+                let next_line_buf = trim_author_label_prefix(next_prepared.prepared);
+                let next_line = next_line_buf.as_str();
+                if next_line.is_empty() {
                     break;
                 }
-                let combined_len: usize = segments.iter().map(|s| s.len()).sum();
-                if combined_len > 320 {
+                let next_lower = next_line.to_ascii_lowercase();
+                if is_author_metadata_line(next_line) {
                     break;
                 }
-                continue;
+                if next_lower.starts_with("copyright") {
+                    break;
+                }
+                if next_lower.starts_with("fixed") || next_lower.starts_with("software") {
+                    break;
+                }
+                if next_lower.starts_with("updated")
+                    || next_lower.starts_with("date")
+                    || next_lower.starts_with("borrows")
+                    || next_lower.starts_with("files")
+                {
+                    break;
+                }
+                if next_lower.starts_with("et al") {
+                    break;
+                }
+
+                if next_line.contains(':') {
+                    break;
+                }
+
+                let mut include = false;
+                if !include {
+                    include = next_line.contains('@')
+                        || next_line.contains('<')
+                        || next_line.contains(',')
+                        || next_line
+                            .chars()
+                            .find(|c| !c.is_whitespace())
+                            .is_some_and(|c| c.is_ascii_uppercase());
+                }
+                if include {
+                    segments.push(next_line.to_string());
+                    added += 1;
+                    next_line_number += 1usize;
+                    if added >= 4 {
+                        break;
+                    }
+                    let combined_len: usize = segments.iter().map(|s| s.len()).sum();
+                    if combined_len > 320 {
+                        break;
+                    }
+                    continue;
+                }
+                break;
             }
-            break;
         }
 
         if segments.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
-        let start_line = ln;
-        let end_line = if j == i + 1 { start_line } else { j };
-        let bullet_results = extract_author_colon_bullet_roster(&segments, start_line);
+        let start_line = prepared_line.line_number;
+        let end_line = if next_line_number == prepared_line.line_number + 1usize {
+            start_line
+        } else {
+            LineNumber::new(next_line_number.get() - 1).expect("valid")
+        };
+        let bullet_results = extract_author_colon_bullet_roster(&segments, start_line.get());
         if !bullet_results.is_empty() {
             authors.extend(bullet_results);
-            i = j;
+            line_number = next_line_number;
             continue;
         }
         if collect_following_original_authors {
@@ -1044,38 +1039,38 @@ pub(super) fn extract_author_colon_blocks(
                 };
                 authors.push(AuthorDetection {
                     author,
-                    start_line: LineNumber::new(start_line).expect("valid"),
-                    end_line: LineNumber::new(end_line).expect("valid"),
+                    start_line,
+                    end_line,
                 });
                 extracted_any = true;
             }
             if extracted_any {
-                i = j;
+                line_number = next_line_number;
                 continue;
             }
         }
         if segments.len() == 1 {
-            let inline_results = extract_author_colon_inline_roster(&segments[0], start_line);
+            let inline_results = extract_author_colon_inline_roster(&segments[0], start_line.get());
             if !inline_results.is_empty() {
                 authors.extend(inline_results);
-                i = j;
+                line_number = next_line_number;
                 continue;
             }
         }
         let combined_raw = segments.join(" ");
         let Some(combined) = refine_author_with_optional_handle_suffix(&combined_raw) else {
-            i += 1;
+            line_number += 1usize;
             continue;
         };
 
-        authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
+        authors.retain(|a| a.start_line < start_line || a.end_line > end_line);
         authors.push(AuthorDetection {
             author: combined,
-            start_line: LineNumber::new(start_line).expect("valid"),
-            end_line: LineNumber::new(end_line).expect("valid"),
+            start_line,
+            end_line,
         });
 
-        i = j;
+        line_number = next_line_number;
     }
 }
 
@@ -1206,30 +1201,22 @@ pub(super) fn extract_code_written_by_author_blocks(
         Regex::new(r"(?is)(?P<prefix>.+?\bDonald\s+wrote\s+the\s+SMC\s+91c92\s+code)\b").unwrap()
     });
 
-    let mut i = 0;
-    while i < prepared_cache.len() {
-        let ln = i + 1;
-        let Some(prepared) = prepared_cache.get_by_index(i) else {
-            i += 1;
-            continue;
-        };
-        let line = prepared.trim();
+    let mut line_number = LineNumber::ONE;
+    while let Some(prepared_line) = prepared_cache.line(line_number) {
+        let line = prepared_line.prepared;
         if line.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
         if !HEADER_RE.is_match(line) {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
         let mut combined = line.to_string();
-        let mut j = i + 1;
-        while j < prepared_cache.len() {
-            let Some(next_prepared) = prepared_cache.get_by_index(j) else {
-                break;
-            };
-            let next = next_prepared.trim();
+        let mut next_line_number = prepared_line.line_number + 1usize;
+        while let Some(next_prepared) = prepared_cache.line(next_line_number) {
+            let next = next_prepared.prepared;
             if next.is_empty() {
                 break;
             }
@@ -1241,16 +1228,16 @@ pub(super) fn extract_code_written_by_author_blocks(
             if combined.len() > 800 {
                 break;
             }
-            j += 1;
+            next_line_number += 1usize;
         }
 
         let Some(cap) = BODY_RE.captures(&combined) else {
-            i = j;
+            line_number = next_line_number;
             continue;
         };
         let body = cap.name("body").map(|m| m.as_str()).unwrap_or("").trim();
         if body.is_empty() {
-            i = j;
+            line_number = next_line_number;
             continue;
         }
 
@@ -1263,16 +1250,16 @@ pub(super) fn extract_code_written_by_author_blocks(
         }
 
         let Some(author) = refine_author(&candidate) else {
-            i = j;
+            line_number = next_line_number;
             continue;
         };
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(j).expect("invalid line number"),
+            start_line: prepared_line.line_number,
+            end_line: LineNumber::new(next_line_number.get() - 1).expect("valid"),
         });
 
-        i = j;
+        line_number = next_line_number;
     }
 
     authors
@@ -1293,22 +1280,17 @@ pub(super) fn extract_developed_and_created_by_authors(
         return;
     }
 
-    for start_idx in 0..prepared_cache.len() {
-        let Some(prepared0) = prepared_cache.get_by_index(start_idx) else {
-            continue;
-        };
-        if !PREFIX_RE.is_match(prepared0.trim()) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if !PREFIX_RE.is_match(prepared_line.prepared) {
             continue;
         }
 
         let mut parts: Vec<String> = Vec::new();
-        let mut end_idx = start_idx;
+        let mut line_number = prepared_line.line_number;
+        let mut end_line = prepared_line.line_number;
 
-        for idx in start_idx..prepared_cache.len() {
-            let Some(prepared) = prepared_cache.get_by_index(idx) else {
-                break;
-            };
-            let line = prepared.trim();
+        while let Some(current_line) = prepared_cache.line(line_number) {
+            let line = current_line.prepared;
             if line.is_empty() {
                 break;
             }
@@ -1316,7 +1298,7 @@ pub(super) fn extract_developed_and_created_by_authors(
                 break;
             }
 
-            let piece = if idx == start_idx {
+            let piece = if line_number == prepared_line.line_number {
                 PREFIX_RE.replace(line, "").to_string()
             } else {
                 line.to_string()
@@ -1324,7 +1306,8 @@ pub(super) fn extract_developed_and_created_by_authors(
             if !piece.trim().is_empty() {
                 parts.push(piece);
             }
-            end_idx = idx;
+            end_line = line_number;
+            line_number += 1usize;
         }
 
         if parts.is_empty() {
@@ -1346,8 +1329,8 @@ pub(super) fn extract_developed_and_created_by_authors(
         };
         authors.push(AuthorDetection {
             author: author.clone(),
-            start_line: LineNumber::from_0_indexed(start_idx),
-            end_line: LineNumber::from_0_indexed(end_idx),
+            start_line: prepared_line.line_number,
+            end_line,
         });
 
         authors.retain(|a| !(author.starts_with(&a.author) && a.author.len() < author.len()));
@@ -1362,16 +1345,8 @@ pub(super) fn extract_with_additional_hacking_by_authors(
         Regex::new(r"(?i)^\s*with\s+additional\s+hacking\s+by\s+(?P<who>.+?)\s*$").unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some(cap) = RE.captures(line) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = RE.captures(prepared_line.prepared) else {
             continue;
         };
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1381,8 +1356,8 @@ pub(super) fn extract_with_additional_hacking_by_authors(
         if let Some(author) = refine_author(who) {
             authors.push(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -1428,24 +1403,16 @@ pub(super) fn merge_metadata_author_and_email_lines(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
-    let has_metadata = (0..prepared_cache.len()).any(|idx| {
-        prepared_cache
-            .get_by_index(idx)
-            .is_some_and(|l| l.trim_start().starts_with("Metadata-Version:"))
-    });
+    let has_metadata = prepared_cache
+        .iter()
+        .any(|line| line.prepared.trim_start().starts_with("Metadata-Version:"));
 
     if !has_metadata {
         return;
     }
 
-    for idx in 0..prepared_cache.len() {
-        let author_ln = idx + 1;
-        let Some(author_line) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let author_line = prepared_line.prepared;
         if author_line.is_empty() {
             continue;
         }
@@ -1460,12 +1427,9 @@ pub(super) fn merge_metadata_author_and_email_lines(
             continue;
         }
 
-        for j in (idx + 1)..prepared_cache.len() {
-            let email_ln = j + 1;
-            let Some(email_line) = prepared_cache.get_by_index(j).map(|p| p.trim().to_string())
-            else {
-                break;
-            };
+        let mut next_line_number = prepared_line.line_number + 1usize;
+        while let Some(email_line) = prepared_cache.line(next_line_number) {
+            let email_line = email_line.prepared;
             if email_line.is_empty() {
                 break;
             }
@@ -1474,6 +1438,7 @@ pub(super) fn merge_metadata_author_and_email_lines(
             }
 
             if !email_line.to_ascii_lowercase().starts_with("author-email") {
+                next_line_number += 1usize;
                 continue;
             }
             let Some((_, email_raw)) = email_line.split_once(':') else {
@@ -1489,19 +1454,19 @@ pub(super) fn merge_metadata_author_and_email_lines(
 
             authors.push(AuthorDetection {
                 author: combined,
-                start_line: LineNumber::new(author_ln).expect("invalid line number"),
-                end_line: LineNumber::new(email_ln).expect("invalid line number"),
+                start_line: prepared_line.line_number,
+                end_line: next_line_number,
             });
 
             authors.retain(|a| {
-                if a.start_line.get() == author_ln
-                    && a.end_line.get() == author_ln
+                if a.start_line == prepared_line.line_number
+                    && a.end_line == prepared_line.line_number
                     && a.author == name
                 {
                     return false;
                 }
-                if a.start_line.get() == email_ln
-                    && a.end_line.get() == email_ln
+                if a.start_line == next_line_number
+                    && a.end_line == next_line_number
                     && a.author.to_ascii_lowercase() == format!("author-email {email}")
                 {
                     return false;
@@ -2726,22 +2691,15 @@ pub(super) fn extract_dense_name_email_author_lists(
         Regex::new(r"^(?P<name>[^<\n]{2,120})\s*<(?P<email>[^>\s]+@[^>\s]+)>\s*$").unwrap()
     });
 
-    let mut non_empty_lines: Vec<(usize, String)> = Vec::new();
-    for idx in 0..prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        non_empty_lines.push((idx + 1, line.to_string()));
-    }
+    let non_empty_lines: Vec<(LineNumber, String)> = prepared_cache
+        .iter_non_empty()
+        .map(|line| (line.line_number, line.prepared.to_string()))
+        .collect();
     if non_empty_lines.len() < 2 {
         return authors;
     }
 
-    let mut matched: Vec<(usize, String)> = Vec::new();
+    let mut matched: Vec<(LineNumber, String)> = Vec::new();
     for (ln, line) in &non_empty_lines {
         let Some(cap) = NAME_EMAIL_LINE_RE.captures(line) else {
             continue;
@@ -2775,8 +2733,8 @@ pub(super) fn extract_dense_name_email_author_lists(
         };
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
+            start_line: ln,
+            end_line: ln,
         });
     }
 

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -225,13 +225,11 @@ fn extract_dash_bullet_attribution_author(line: &str) -> Option<String> {
 
 pub(super) fn extract_dash_bullet_attribution_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -245,25 +243,23 @@ pub(super) fn extract_dash_bullet_attribution_authors(
         let Some(author) = extract_dash_bullet_attribution_author(trimmed) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_name_contributed_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -293,14 +289,14 @@ pub(super) fn extract_name_contributed_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 fn looks_like_contributed_person_name_token(word: &str) -> bool {
@@ -339,10 +335,10 @@ fn is_contributed_non_person_token(word: &str) -> bool {
 
 pub(super) fn extract_rst_field_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static RST_FIELD_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -353,8 +349,6 @@ pub(super) fn extract_rst_field_authors(
         Regex::new(r"(?i)^(?:written|updated|authored|created|developed|maintained)\s+by\s+")
             .unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -378,34 +372,33 @@ pub(super) fn extract_rst_field_authors(
         let Some(author) = refine_author(&trimmed) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 fn extract_author_colon_bullet_roster(
     segments: &[String],
     start_line: usize,
-    authors: &mut Vec<AuthorDetection>,
-    seen: &mut HashSet<String>,
-) -> bool {
+) -> Vec<AuthorDetection> {
     static BARE_EMAIL_AUTHOR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^(?P<who>.+?<[^>\s]*@[^>\s]*>)\s*,?$").unwrap());
+
+    let mut authors = Vec::new();
 
     if segments.is_empty()
         || !segments
             .iter()
             .any(|segment| segment.trim_start().starts_with('-'))
     {
-        return false;
+        return authors;
     }
 
-    let mut extracted_any = false;
     for (offset, segment) in segments.iter().enumerate() {
         let trimmed = segment.trim();
         let line_no = start_line + offset;
@@ -415,18 +408,15 @@ fn extract_author_colon_bullet_roster(
             if lower.starts_with("with the help of ") {
                 continue;
             }
-            return false;
+            return authors;
         }
 
         if let Some(author) = extract_dash_bullet_attribution_author(trimmed) {
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(line_no).expect("valid"),
-                    end_line: LineNumber::new(line_no).expect("valid"),
-                });
-            }
-            extracted_any = true;
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(line_no).expect("valid"),
+                end_line: LineNumber::new(line_no).expect("valid"),
+            });
             continue;
         }
 
@@ -441,17 +431,14 @@ fn extract_author_colon_bullet_roster(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(line_no).expect("valid"),
-                end_line: LineNumber::new(line_no).expect("valid"),
-            });
-        }
-        extracted_any = true;
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(line_no).expect("valid"),
+            end_line: LineNumber::new(line_no).expect("valid"),
+        });
     }
 
-    extracted_any
+    authors
 }
 
 pub(super) fn extract_multiline_written_by_author_blocks(
@@ -478,8 +465,6 @@ pub(super) fn extract_multiline_written_by_author_blocks(
         )
         .unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -515,9 +500,7 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 who
             };
 
-            if let Some(author) = refine_author(who)
-                && seen.insert(author.clone())
-            {
+            if let Some(author) = refine_author(who) {
                 authors.push(AuthorDetection {
                     author,
                     start_line: LineNumber::new(ln).expect("invalid line number"),
@@ -618,9 +601,7 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 .unwrap_or(combined_raw.as_str())
                 .trim_end_matches('.')
                 .trim();
-            if let Some(combined) = refine_author(combined_candidate)
-                && seen.insert(combined.clone())
-            {
+            if let Some(combined) = refine_author(combined_candidate) {
                 authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
                 authors.push(AuthorDetection {
                     author: combined,
@@ -643,9 +624,7 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 if !who.is_empty() {
                     let who = who.trim_end_matches('.').trim();
                     if !who.to_ascii_lowercase().starts_with("the ") {
-                        if let Some(author) = refine_author(who)
-                            && seen.insert(author.clone())
-                        {
+                        if let Some(author) = refine_author(who) {
                             authors.push(AuthorDetection {
                                 author,
                                 start_line: LineNumber::new(start_line).expect("valid"),
@@ -672,9 +651,7 @@ pub(super) fn extract_multiline_written_by_author_blocks(
                 .unwrap_or(combined_raw.as_str())
                 .trim_end_matches('.')
                 .trim();
-            if let Some(combined) = refine_author(combined_candidate)
-                && seen.insert(combined.clone())
-            {
+            if let Some(combined) = refine_author(combined_candidate) {
                 authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
                 authors.push(AuthorDetection {
                     author: combined,
@@ -707,12 +684,10 @@ pub(super) fn drop_merged_dash_bullet_attribution_authors(authors: &mut Vec<Auth
     });
 }
 
-pub(super) fn extract_json_excerpt_developed_by_authors(
-    content: &str,
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(super) fn extract_json_excerpt_developed_by_authors(content: &str) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if content.is_empty() {
-        return;
+        return authors;
     }
 
     static JSON_DEVELOPED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -722,7 +697,6 @@ pub(super) fn extract_json_excerpt_developed_by_authors(
         .unwrap()
     });
 
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
     for cap in JSON_DEVELOPED_BY_RE.captures_iter(content) {
         let who = cap
             .name("who")
@@ -736,22 +710,20 @@ pub(super) fn extract_json_excerpt_developed_by_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::ONE,
-                end_line: LineNumber::ONE,
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        });
     }
+
+    authors
 }
 
-pub(super) fn extract_modified_portion_developed_by_authors(
-    content: &str,
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(super) fn extract_modified_portion_developed_by_authors(content: &str) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if content.is_empty() {
-        return;
+        return authors;
     }
 
     static MODIFIED_PORTION_DEVELOPED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -760,8 +732,6 @@ pub(super) fn extract_modified_portion_developed_by_authors(
         )
         .unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for cap in MODIFIED_PORTION_DEVELOPED_BY_RE.captures_iter(content) {
         let Some(full) = cap.get(0) else {
@@ -781,36 +751,40 @@ pub(super) fn extract_modified_portion_developed_by_authors(
             author.push(')');
         }
 
-        if seen.insert(author.clone()) {
-            let start_line = line_number_for_offset(content, full.start());
-            let end_line = line_number_for_offset(content, full.end());
-            authors.push(AuthorDetection {
-                author,
-                start_line,
-                end_line,
-            });
-        }
+        let start_line = line_number_for_offset(content, full.start());
+        let end_line = line_number_for_offset(content, full.end());
+        authors.push(AuthorDetection {
+            author,
+            start_line,
+            end_line,
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_module_author_macros(
     content: &str,
     copyrights: &[CopyrightDetection],
     holders: &[HolderDetection],
-    authors: &mut Vec<AuthorDetection>,
+) -> (
+    Vec<CopyrightDetection>,
+    Vec<HolderDetection>,
+    Vec<AuthorDetection>,
 ) {
+    let authors = Vec::new();
     if content.is_empty() {
-        return;
+        return (Vec::new(), Vec::new(), authors);
     }
-    if !copyrights.is_empty() || !holders.is_empty() || !authors.is_empty() {
-        return;
+    if !copyrights.is_empty() || !holders.is_empty() {
+        return (Vec::new(), Vec::new(), authors);
     }
 
     static MODULE_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"(?i)MODULE_AUTHOR\s*\(\s*\"(?P<who>[^\"]+)\"\s*\)"#).unwrap()
     });
 
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
+    let mut authors = Vec::new();
     for (idx, raw) in content.lines().enumerate() {
         let ln = idx + 1;
         let line = raw.trim();
@@ -827,31 +801,29 @@ pub(super) fn extract_module_author_macros(
             let Some(author) = refine_author(&who) else {
                 continue;
             };
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            });
         }
     }
+
+    (Vec::new(), Vec::new(), authors)
 }
 
 pub(super) fn extract_was_developed_by_author_blocks(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static WAS_DEVELOPED_BY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bwas\s+developed\s+by\s+(?P<who>.+)$").unwrap());
     static WITH_PARTICIPATION_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bwith\s+participation\b").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     let mut i = 0;
     while i < prepared_cache.len() {
@@ -927,16 +899,16 @@ pub(super) fn extract_was_developed_by_author_blocks(
             continue;
         }
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(end_ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(end_ln).expect("invalid line number"),
+        });
 
         i += 1;
     }
+
+    authors
 }
 
 pub(super) fn extract_author_colon_blocks(
@@ -956,8 +928,6 @@ pub(super) fn extract_author_colon_blocks(
     static YEAR_ONLY_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^copyright\s+\(c\)\s*(?:\d{4}(?:\s*,\s*\d{4})*|\d{4}-\d{4})\s*$").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     let mut i = 0;
     while i < prepared_cache.len() {
@@ -1100,7 +1070,9 @@ pub(super) fn extract_author_colon_blocks(
 
         let start_line = ln;
         let end_line = if j == i + 1 { start_line } else { j };
-        if extract_author_colon_bullet_roster(&segments, start_line, authors, &mut seen) {
+        let bullet_results = extract_author_colon_bullet_roster(&segments, start_line);
+        if !bullet_results.is_empty() {
+            authors.extend(bullet_results);
             i = j;
             continue;
         }
@@ -1110,25 +1082,25 @@ pub(super) fn extract_author_colon_blocks(
                 let Some(author) = refine_author_with_optional_handle_suffix(segment) else {
                     continue;
                 };
-                if seen.insert(author.clone()) {
-                    authors.push(AuthorDetection {
-                        author,
-                        start_line: LineNumber::new(start_line).expect("valid"),
-                        end_line: LineNumber::new(end_line).expect("valid"),
-                    });
-                    extracted_any = true;
-                }
+                authors.push(AuthorDetection {
+                    author,
+                    start_line: LineNumber::new(start_line).expect("valid"),
+                    end_line: LineNumber::new(end_line).expect("valid"),
+                });
+                extracted_any = true;
             }
             if extracted_any {
                 i = j;
                 continue;
             }
         }
-        if segments.len() == 1
-            && extract_author_colon_inline_roster(&segments[0], start_line, authors, &mut seen)
-        {
-            i = j;
-            continue;
+        if segments.len() == 1 {
+            let inline_results = extract_author_colon_inline_roster(&segments[0], start_line);
+            if !inline_results.is_empty() {
+                authors.extend(inline_results);
+                i = j;
+                continue;
+            }
         }
         let combined_raw = segments.join(" ");
         let Some(combined) = refine_author_with_optional_handle_suffix(&combined_raw) else {
@@ -1136,42 +1108,32 @@ pub(super) fn extract_author_colon_blocks(
             continue;
         };
 
-        if seen.insert(combined.clone()) {
-            authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
-            authors.push(AuthorDetection {
-                author: combined,
-                start_line: LineNumber::new(start_line).expect("valid"),
-                end_line: LineNumber::new(end_line).expect("valid"),
-            });
-        }
+        authors.retain(|a| a.start_line.get() < start_line || a.end_line.get() > end_line);
+        authors.push(AuthorDetection {
+            author: combined,
+            start_line: LineNumber::new(start_line).expect("valid"),
+            end_line: LineNumber::new(end_line).expect("valid"),
+        });
 
         i = j;
     }
 }
 
-fn extract_author_colon_inline_roster(
-    tail: &str,
-    line_number: usize,
-    authors: &mut Vec<AuthorDetection>,
-    seen: &mut HashSet<String>,
-) -> bool {
-    let mut extracted_any = false;
+fn extract_author_colon_inline_roster(tail: &str, line_number: usize) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
 
     for candidate in tail.split(" - ") {
         let Some(author) = refine_author_with_optional_handle_suffix(candidate) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(line_number).expect("valid"),
-                end_line: LineNumber::new(line_number).expect("valid"),
-            });
-            extracted_any = true;
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(line_number).expect("valid"),
+            end_line: LineNumber::new(line_number).expect("valid"),
+        });
     }
 
-    extracted_any
+    authors
 }
 
 fn refine_author_with_optional_handle_suffix(candidate: &str) -> Option<String> {
@@ -1270,10 +1232,10 @@ fn trim_author_label_prefix(line: &str) -> String {
 
 pub(super) fn extract_code_written_by_author_blocks(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static HEADER_RE: LazyLock<Regex> =
@@ -1283,8 +1245,6 @@ pub(super) fn extract_code_written_by_author_blocks(
     static STOP_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?is)(?P<prefix>.+?\bDonald\s+wrote\s+the\s+SMC\s+91c92\s+code)\b").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     let mut i = 0;
     while i < prepared_cache.len() {
@@ -1346,16 +1306,16 @@ pub(super) fn extract_code_written_by_author_blocks(
             i = j;
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(j).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(j).expect("invalid line number"),
+        });
 
         i = j;
     }
+
+    authors
 }
 
 pub(super) fn extract_developed_and_created_by_authors(
@@ -1372,8 +1332,6 @@ pub(super) fn extract_developed_and_created_by_authors(
     if prepared_cache.is_empty() {
         return;
     }
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for start_idx in 0..prepared_cache.len() {
         let Some(prepared0) = prepared_cache.get_by_index(start_idx) else {
@@ -1426,13 +1384,11 @@ pub(super) fn extract_developed_and_created_by_authors(
         let Some(author) = refine_author(&combined) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author: author.clone(),
-                start_line: LineNumber::from_0_indexed(start_idx),
-                end_line: LineNumber::from_0_indexed(end_idx),
-            });
-        }
+        authors.push(AuthorDetection {
+            author: author.clone(),
+            start_line: LineNumber::from_0_indexed(start_idx),
+            end_line: LineNumber::from_0_indexed(end_idx),
+        });
 
         authors.retain(|a| !(author.starts_with(&a.author) && a.author.len() < author.len()));
     }
@@ -1440,13 +1396,11 @@ pub(super) fn extract_developed_and_created_by_authors(
 
 pub(super) fn extract_with_additional_hacking_by_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     static RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*with\s+additional\s+hacking\s+by\s+(?P<who>.+?)\s*$").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1464,9 +1418,7 @@ pub(super) fn extract_with_additional_hacking_by_authors(
         if who.is_empty() {
             continue;
         }
-        if let Some(author) = refine_author(who)
-            && seen.insert(author.clone())
-        {
+        if let Some(author) = refine_author(who) {
             authors.push(AuthorDetection {
                 author,
                 start_line: LineNumber::new(ln).expect("invalid line number"),
@@ -1474,20 +1426,18 @@ pub(super) fn extract_with_additional_hacking_by_authors(
             });
         }
     }
+
+    authors
 }
 
-pub(super) fn extract_parenthesized_inline_by_authors(
-    raw_lines: &[&str],
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(super) fn extract_parenthesized_inline_by_authors(raw_lines: &[&str]) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     static RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\s*copyright\b.*\((?:written|authored|created|developed)\s+by\s+(?P<who>[^)]+)\)",
         )
         .unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for (idx, raw) in raw_lines.iter().enumerate() {
         let ln = idx + 1;
@@ -1502,9 +1452,7 @@ pub(super) fn extract_parenthesized_inline_by_authors(
         if who.is_empty() {
             continue;
         }
-        if let Some(author) = refine_author(who)
-            && seen.insert(author.clone())
-        {
+        if let Some(author) = refine_author(who) {
             authors.push(AuthorDetection {
                 author,
                 start_line: LineNumber::new(ln).expect("invalid line number"),
@@ -1512,6 +1460,8 @@ pub(super) fn extract_parenthesized_inline_by_authors(
             });
         }
     }
+
+    authors
 }
 
 pub(super) fn merge_metadata_author_and_email_lines(
@@ -1527,8 +1477,6 @@ pub(super) fn merge_metadata_author_and_email_lines(
     if !has_metadata {
         return;
     }
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let author_ln = idx + 1;
@@ -1579,13 +1527,11 @@ pub(super) fn merge_metadata_author_and_email_lines(
             let combined_raw = format!("{name} Author-email {email}");
             let combined = normalize_whitespace(&combined_raw);
 
-            if seen.insert(combined.clone()) {
-                authors.push(AuthorDetection {
-                    author: combined,
-                    start_line: LineNumber::new(author_ln).expect("invalid line number"),
-                    end_line: LineNumber::new(email_ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author: combined,
+                start_line: LineNumber::new(author_ln).expect("invalid line number"),
+                end_line: LineNumber::new(email_ln).expect("invalid line number"),
+            });
 
             authors.retain(|a| {
                 if a.start_line.get() == author_ln
@@ -1610,10 +1556,10 @@ pub(super) fn merge_metadata_author_and_email_lines(
 
 pub(super) fn extract_debian_maintainer_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static DEBIANIZED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1628,8 +1574,6 @@ pub(super) fn extract_debian_maintainer_authors(
     static MAINTAINED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^maintained\s+by\s+(?P<who>.+?)(?:\s+on\b|\s+since\b|\s*$)").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1660,30 +1604,28 @@ pub(super) fn extract_debian_maintainer_authors(
             continue;
         };
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_maintainers_label_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static MAINTAINERS_LABEL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^maintainers?\s*:?[ \t]+(?P<who>.+)$").unwrap());
     static GITREPO_SUFFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s+GitRepo\s+https?://\S+.*$").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1711,28 +1653,26 @@ pub(super) fn extract_maintainers_label_authors(
             continue;
         }
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_created_by_project_author(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static CREATED_BY_PROJECT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bcreated\s+by\s+the\s+project\b").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1741,16 +1681,16 @@ pub(super) fn extract_created_by_project_author(
         };
         if CREATED_BY_PROJECT_RE.is_match(prepared.trim()) {
             let author = "the Project".to_string();
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            });
             break;
         }
     }
+
+    authors
 }
 
 pub(super) fn extract_created_by_authors(
@@ -1763,8 +1703,6 @@ pub(super) fn extract_created_by_authors(
 
     static CREATED_BY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\s*created\s+by\s+(?P<who>.+?)\s*$").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1794,32 +1732,26 @@ pub(super) fn extract_created_by_authors(
         let Some(author) = refine_author_with_optional_handle_suffix(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author: author.clone(),
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author: author.clone(),
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
 
         authors.retain(|a| !(author.starts_with(&a.author) && a.author.len() < author.len()));
     }
 }
 
-pub(super) fn extract_toml_author_assignment_authors(
-    raw_lines: &[&str],
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(super) fn extract_toml_author_assignment_authors(raw_lines: &[&str]) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if raw_lines.is_empty() {
-        return;
+        return authors;
     }
 
     static TOML_AUTHOR_ASSIGNMENT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"(?i)^\s*authors?\s*=\s*(?P<rhs>.+?)\s*$"#).unwrap());
     static QUOTED_VALUE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"\"(?P<value>(?:\\.|[^\"])*)\""#).unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for (idx, raw_line) in raw_lines.iter().enumerate() {
         let ln = idx + 1;
@@ -1863,15 +1795,15 @@ pub(super) fn extract_toml_author_assignment_authors(
             let Some(author) = refine_author_with_optional_handle_suffix(&candidate) else {
                 continue;
             };
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            });
         }
     }
+
+    authors
 }
 
 pub(super) fn extract_written_by_comma_and_copyright_authors(
@@ -1885,8 +1817,6 @@ pub(super) fn extract_written_by_comma_and_copyright_authors(
     static WRITTEN_BY_AND_COPYRIGHT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bwritten\s+by\s+(?P<who>.+?),\s+and\s+copyright\b").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1908,23 +1838,21 @@ pub(super) fn extract_written_by_comma_and_copyright_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.retain(|a| !(a.start_line.get() == ln && a.end_line.get() == ln));
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.retain(|a| !(a.start_line.get() == ln && a.end_line.get() == ln));
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
 }
 
 pub(super) fn extract_package_comment_named_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static COMMENT_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1936,8 +1864,6 @@ pub(super) fn extract_package_comment_named_authors(
     static RAW_ANGLE_EMAIL_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"^(?P<name>[A-Z][^<>@]+?)\s*<(?P<email>[^>\s]+@[^>\s]+)>$").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1963,9 +1889,7 @@ pub(super) fn extract_package_comment_named_authors(
                 refine_author(who)
             };
 
-            if let Some(author) = author
-                && seen.insert(author.clone())
-            {
+            if let Some(author) = author {
                 authors.push(AuthorDetection {
                     author,
                     start_line: LineNumber::new(ln).expect("invalid line number"),
@@ -1974,20 +1898,20 @@ pub(super) fn extract_package_comment_named_authors(
             }
         }
     }
+
+    authors
 }
 
 pub(super) fn extract_developed_by_sentence_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static DEVELOPED_BY_PREFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\s*developed\s+by\s+(?P<rest>.+)$").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2027,29 +1951,27 @@ pub(super) fn extract_developed_by_sentence_authors(
             continue;
         }
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_developed_by_phrase_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static DEVELOPED_BY_PHRASE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bdeveloped\s+by\s+(?P<who>.+?)\s+and\s+to\s+credit\b").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2076,23 +1998,23 @@ pub(super) fn extract_developed_by_phrase_authors(
                 continue;
             }
 
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            });
         }
     }
+
+    authors
 }
 
 pub(super) fn extract_developed_by_contributors_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static DEVELOPED_BY_CONTRIBUTORS_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -2101,8 +2023,6 @@ pub(super) fn extract_developed_by_contributors_authors(
         )
         .unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2141,25 +2061,21 @@ pub(super) fn extract_developed_by_contributors_authors(
             continue;
         };
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(end_line).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(end_line).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
-pub(super) fn extract_json_author_object_authors(
-    raw_lines: &[&str],
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(super) fn extract_json_author_object_authors(raw_lines: &[&str]) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if raw_lines.is_empty() {
-        return;
+        return authors;
     }
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for (idx, line) in raw_lines.iter().enumerate() {
         if !line.contains("\"author\"") {
@@ -2179,29 +2095,27 @@ pub(super) fn extract_json_author_object_authors(
             continue;
         };
 
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(idx + 1).expect("invalid line number"),
-                end_line: LineNumber::new(end).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(idx + 1).expect("invalid line number"),
+            end_line: LineNumber::new(end).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn extract_maintained_by_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static MAINTAINED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bmaintained\s+by\s+(?P<who>.+?)(?:\s+(?:on|since|for)\b|$)").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2223,23 +2137,23 @@ pub(super) fn extract_maintained_by_authors(
             let Some(author) = refine_author(who) else {
                 continue;
             };
-            if seen.insert(author.clone()) {
-                authors.push(AuthorDetection {
-                    author,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
+            authors.push(AuthorDetection {
+                author,
+                start_line: LineNumber::new(ln).expect("invalid line number"),
+                end_line: LineNumber::new(ln).expect("invalid line number"),
+            });
         }
     }
+
+    authors
 }
 
 pub(super) fn extract_converted_to_by_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static CONVERTED_BY_RE: LazyLock<Regex> =
@@ -2249,8 +2163,6 @@ pub(super) fn extract_converted_to_by_authors(
     });
     static CONVERTED_TO_VERSION_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bconverted\s+to\s+\d+\.\d+\b").unwrap());
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2287,39 +2199,35 @@ pub(super) fn extract_converted_to_by_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
+        authors.push(AuthorDetection {
+            author: author.clone(),
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
+        if add_converted_variant {
+            let converted = format!("{author} Converted");
             authors.push(AuthorDetection {
-                author: author.clone(),
+                author: converted,
                 start_line: LineNumber::new(ln).expect("invalid line number"),
                 end_line: LineNumber::new(ln).expect("invalid line number"),
             });
         }
-        if add_converted_variant {
-            let converted = format!("{author} Converted");
-            if seen.insert(converted.clone()) {
-                authors.push(AuthorDetection {
-                    author: converted,
-                    start_line: LineNumber::new(ln).expect("invalid line number"),
-                    end_line: LineNumber::new(ln).expect("invalid line number"),
-                });
-            }
-        }
     }
+
+    authors
 }
 
 pub(super) fn extract_various_bugfixes_and_enhancements_by_authors(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static VARIOUS_BUGFIXES_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*various\s+bugfixes\s+and\s+enhancements\s+by\s+(?P<who>.+)$").unwrap()
     });
-
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2343,14 +2251,14 @@ pub(super) fn extract_various_bugfixes_and_enhancements_by_authors(
         let Some(author) = refine_author(who) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }
 
 pub(super) fn drop_authors_embedded_in_copyrights(
@@ -2945,10 +2853,10 @@ pub(super) fn drop_written_by_authors_preceded_by_copyright(
 
 pub(super) fn extract_dense_name_email_author_lists(
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
     if prepared_cache.is_empty() {
-        return;
+        return authors;
     }
 
     static NAME_EMAIL_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -2967,7 +2875,7 @@ pub(super) fn extract_dense_name_email_author_lists(
         non_empty_lines.push((idx + 1, line.to_string()));
     }
     if non_empty_lines.len() < 2 {
-        return;
+        return authors;
     }
 
     let mut matched: Vec<(usize, String)> = Vec::new();
@@ -2992,23 +2900,22 @@ pub(super) fn extract_dense_name_email_author_lists(
     }
 
     if matched.len() < 2 {
-        return;
+        return authors;
     }
     if matched.len() * 2 < non_empty_lines.len() {
-        return;
+        return authors;
     }
 
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
     for (ln, candidate) in matched {
         let Some(author) = refine_author(&candidate) else {
             continue;
         };
-        if seen.insert(author.clone()) {
-            authors.push(AuthorDetection {
-                author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
-            });
-        }
+        authors.push(AuthorDetection {
+            author,
+            start_line: LineNumber::new(ln).expect("invalid line number"),
+            end_line: LineNumber::new(ln).expect("invalid line number"),
+        });
     }
+
+    authors
 }

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use super::token_utils::normalize_whitespace;
-use crate::copyright::line_tracking::PreparedLineCache;
+use crate::copyright::line_tracking::PreparedLines;
 use crate::copyright::prepare::prepare_text_line;
 use crate::copyright::refiner::{looks_like_name_with_parenthesized_url, refine_author};
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
@@ -224,7 +224,7 @@ fn extract_dash_bullet_attribution_author(line: &str) -> Option<String> {
 }
 
 pub(super) fn extract_dash_bullet_attribution_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     if prepared_cache.is_empty() {
         return Vec::new();
@@ -249,7 +249,7 @@ pub(super) fn extract_dash_bullet_attribution_authors(
 }
 
 pub(super) fn extract_name_contributed_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     if prepared_cache.is_empty() {
         return Vec::new();
@@ -322,7 +322,7 @@ fn is_contributed_non_person_token(word: &str) -> bool {
 }
 
 pub(super) fn extract_rst_field_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     if prepared_cache.is_empty() {
         return Vec::new();
@@ -423,7 +423,7 @@ fn extract_author_colon_bullet_roster(
 }
 
 pub(super) fn extract_multiline_written_by_author_blocks(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if prepared_cache.is_empty() {
@@ -792,7 +792,7 @@ pub(super) fn extract_module_author_macros(
 }
 
 pub(super) fn extract_was_developed_by_author_blocks(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -891,7 +891,7 @@ pub(super) fn extract_was_developed_by_author_blocks(
 }
 
 pub(super) fn extract_author_colon_blocks(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if prepared_cache.is_empty() {
@@ -1210,7 +1210,7 @@ fn trim_author_label_prefix(line: &str) -> String {
 }
 
 pub(super) fn extract_code_written_by_author_blocks(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1298,7 +1298,7 @@ pub(super) fn extract_code_written_by_author_blocks(
 }
 
 pub(super) fn extract_developed_and_created_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     static PREFIX_RE: LazyLock<Regex> =
@@ -1374,7 +1374,7 @@ pub(super) fn extract_developed_and_created_by_authors(
 }
 
 pub(super) fn extract_with_additional_hacking_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     static RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1444,7 +1444,7 @@ pub(super) fn extract_parenthesized_inline_by_authors(raw_lines: &[&str]) -> Vec
 }
 
 pub(super) fn merge_metadata_author_and_email_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     let has_metadata = (0..prepared_cache.len()).any(|idx| {
@@ -1534,7 +1534,7 @@ pub(super) fn merge_metadata_author_and_email_lines(
 }
 
 pub(super) fn extract_debian_maintainer_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1594,7 +1594,7 @@ pub(super) fn extract_debian_maintainer_authors(
 }
 
 pub(super) fn extract_maintainers_label_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1643,7 +1643,7 @@ pub(super) fn extract_maintainers_label_authors(
 }
 
 pub(super) fn extract_created_by_project_author(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1673,7 +1673,7 @@ pub(super) fn extract_created_by_project_author(
 }
 
 pub(super) fn extract_created_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if prepared_cache.is_empty() {
@@ -1786,7 +1786,7 @@ pub(super) fn extract_toml_author_assignment_authors(raw_lines: &[&str]) -> Vec<
 }
 
 pub(super) fn extract_written_by_comma_and_copyright_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if prepared_cache.is_empty() {
@@ -1827,7 +1827,7 @@ pub(super) fn extract_written_by_comma_and_copyright_authors(
 }
 
 pub(super) fn extract_package_comment_named_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1882,7 +1882,7 @@ pub(super) fn extract_package_comment_named_authors(
 }
 
 pub(super) fn extract_developed_by_sentence_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1941,7 +1941,7 @@ pub(super) fn extract_developed_by_sentence_authors(
 }
 
 pub(super) fn extract_developed_by_phrase_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -1989,7 +1989,7 @@ pub(super) fn extract_developed_by_phrase_authors(
 }
 
 pub(super) fn extract_developed_by_contributors_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -2085,7 +2085,7 @@ pub(super) fn extract_json_author_object_authors(raw_lines: &[&str]) -> Vec<Auth
 }
 
 pub(super) fn extract_maintained_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -2128,7 +2128,7 @@ pub(super) fn extract_maintained_by_authors(
 }
 
 pub(super) fn extract_converted_to_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -2197,7 +2197,7 @@ pub(super) fn extract_converted_to_by_authors(
 }
 
 pub(super) fn extract_various_bugfixes_and_enhancements_by_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {
@@ -2276,7 +2276,7 @@ pub(super) fn drop_authors_embedded_in_copyrights(
 }
 
 pub(super) fn drop_authors_from_copyright_by_lines(
-    prepared_cache: &PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if authors.is_empty() || prepared_cache.is_empty() {
@@ -2329,7 +2329,7 @@ pub(super) fn drop_authors_from_copyright_by_lines(
 }
 
 pub(super) fn drop_author_colon_lines_absorbed_into_year_only_copyrights(
-    prepared_cache: &PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &[CopyrightDetection],
     authors: &mut Vec<AuthorDetection>,
 ) {
@@ -2770,7 +2770,7 @@ fn json_window_contains_developed_by(window: &str, author: &str) -> bool {
 }
 
 pub(super) fn drop_written_by_authors_preceded_by_copyright(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if authors.is_empty() {
@@ -2819,7 +2819,7 @@ pub(super) fn drop_written_by_authors_preceded_by_copyright(
 }
 
 pub(super) fn extract_dense_name_email_author_lists(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     let mut authors = Vec::new();
     if prepared_cache.is_empty() {

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -230,19 +230,18 @@ pub(super) fn extract_dash_bullet_attribution_authors(
         return Vec::new();
     }
 
-    (0..prepared_cache.len())
-        .filter_map(|idx| {
-            let ln = idx + 1;
-            let raw_line = prepared_cache.raw_by_index(idx)?;
-            let trimmed = raw_line.trim_start();
+    prepared_cache
+        .iter()
+        .filter_map(|line| {
+            let trimmed = line.raw.trim_start();
             if !trimmed.starts_with("- ") {
                 return None;
             }
             let author = extract_dash_bullet_attribution_author(trimmed)?;
             Some(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: line.line_number,
+                end_line: line.line_number,
             })
         })
         .collect()
@@ -255,11 +254,10 @@ pub(super) fn extract_name_contributed_authors(
         return Vec::new();
     }
 
-    (0..prepared_cache.len())
-        .filter_map(|idx| {
-            let ln = idx + 1;
-            let raw_line = prepared_cache.raw_by_index(idx)?;
-            let trimmed = raw_line.trim();
+    prepared_cache
+        .iter()
+        .filter_map(|line| {
+            let trimmed = line.raw.trim();
             let (who, _) = trimmed.split_once(" contributed")?;
             let words: Vec<&str> = who.split_whitespace().collect();
             if !(2..=4).contains(&words.len()) {
@@ -280,8 +278,8 @@ pub(super) fn extract_name_contributed_authors(
             let author = refine_author(who)?;
             Some(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: line.line_number,
+                end_line: line.line_number,
             })
         })
         .collect()
@@ -337,16 +335,10 @@ pub(super) fn extract_rst_field_authors(
             .unwrap()
     });
 
-    (0..prepared_cache.len())
-        .filter_map(|idx| {
-            let ln = idx + 1;
-            let prepared = prepared_cache.get_by_index(idx)?;
-            let line = prepared.trim();
-            if line.is_empty() {
-                return None;
-            }
-
-            let cap = RST_FIELD_AUTHOR_RE.captures(line)?;
+    prepared_cache
+        .iter_non_empty()
+        .filter_map(|line| {
+            let cap = RST_FIELD_AUTHOR_RE.captures(line.prepared)?;
             let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
             if tail.is_empty() {
                 return None;
@@ -356,8 +348,8 @@ pub(super) fn extract_rst_field_authors(
             let author = refine_author(&trimmed)?;
             Some(AuthorDetection {
                 author,
-                start_line: LineNumber::new(ln).expect("invalid line number"),
-                end_line: LineNumber::new(ln).expect("invalid line number"),
+                start_line: line.line_number,
+                end_line: line.line_number,
             })
         })
         .collect()
@@ -804,87 +796,76 @@ pub(super) fn extract_was_developed_by_author_blocks(
     static WITH_PARTICIPATION_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bwith\s+participation\b").unwrap());
 
-    let mut i = 0;
-    while i < prepared_cache.len() {
-        let ln = i + 1;
-        let Some(prepared) = prepared_cache.get_by_index(i) else {
-            i += 1;
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            i += 1;
+    let mut line_number = LineNumber::ONE;
+    while let Some(line) = prepared_cache.line(line_number) {
+        if line.prepared.is_empty() {
+            line_number += 1usize;
             continue;
         }
 
-        let Some(cap) = WAS_DEVELOPED_BY_RE.captures(line) else {
-            i += 1;
+        let Some(cap) = WAS_DEVELOPED_BY_RE.captures(line.prepared) else {
+            line_number += 1usize;
             continue;
         };
         let mut parts: Vec<String> = Vec::new();
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
         if who.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
         parts.push(who.to_string());
 
-        let mut end_ln = ln;
-        let mut j = i + 1;
-        while j < prepared_cache.len() {
-            let next_ln = j + 1;
-            let Some(next_prepared) = prepared_cache.get_by_index(j) else {
-                break;
-            };
-            let next_line = next_prepared.trim();
-            if next_line.is_empty() {
+        let mut end_line = line.line_number;
+        let mut next_line_number = line.line_number + 1usize;
+        while let Some(next_line) = prepared_cache.line(next_line_number) {
+            if next_line.prepared.is_empty() {
                 break;
             }
 
-            let next_lower = next_line.to_ascii_lowercase();
+            let next_lower = next_line.prepared.to_ascii_lowercase();
             if next_lower.starts_with("copyright") {
                 break;
             }
 
-            if let Some(m) = WITH_PARTICIPATION_RE.find(next_line) {
-                let prefix = next_line[..m.start()].trim_end();
+            if let Some(m) = WITH_PARTICIPATION_RE.find(next_line.prepared) {
+                let prefix = next_line.prepared[..m.start()].trim_end();
                 if !prefix.is_empty() {
                     parts.push(prefix.to_string());
-                    end_ln = next_ln;
+                    end_line = next_line.line_number;
                 }
                 break;
             }
 
-            parts.push(next_line.to_string());
-            end_ln = next_ln;
+            parts.push(next_line.prepared.to_string());
+            end_line = next_line.line_number;
 
-            if end_ln.saturating_sub(ln) >= 3 {
+            if end_line.get().saturating_sub(line.line_number.get()) >= 3 {
                 break;
             }
 
-            j += 1;
+            next_line_number += 1usize;
         }
 
         let joined = parts.join(" ");
         let joined = joined.split_whitespace().collect::<Vec<_>>().join(" ");
         if joined.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
         let author = refine_author(&joined).unwrap_or(joined);
         if author.is_empty() {
-            i += 1;
+            line_number += 1usize;
             continue;
         }
 
         authors.push(AuthorDetection {
             author,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(end_ln).expect("invalid line number"),
+            start_line: line.line_number,
+            end_line,
         });
 
-        i += 1;
+        line_number += 1usize;
     }
 
     authors

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -116,7 +116,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     let allow_not_copyrighted_prefix = NOT_COPYRIGHTED_RE.find_iter(content).count() == 1;
 
     let raw_lines: Vec<&str> = content.lines().collect();
-    let mut prepared_cache = PreparedLineCache::new(&raw_lines);
+    let prepared_cache = PreparedLineCache::new(&raw_lines);
 
     if raw_lines.is_empty() {
         return (copyrights, holders, authors);
@@ -296,11 +296,13 @@ pub fn detect_copyrights_from_text_with_deadline(
         return (copyrights, holders, authors);
     }
 
+    let prepared_lines = prepared_cache.materialize();
+
     primary_phase::run_phase_primary_extractions(
         content,
         &groups,
         &line_number_index,
-        &mut prepared_cache,
+        &prepared_lines,
         &mut copyrights,
         &mut holders,
         &mut seen,
@@ -309,7 +311,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     postprocess_phase::run_phase_postprocess(
         content,
         &raw_lines,
-        &mut prepared_cache,
+        &prepared_lines,
         did_expand_href,
         &mut copyrights,
         &mut holders,

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -28,9 +28,11 @@ use super::line_tracking::{LineNumberIndex, PreparedLineCache};
 use super::parser::{parse, parse_with_deadline};
 #[cfg(test)]
 use super::refiner::{refine_copyright, refine_holder_in_copyright_context};
-use super::types::{AuthorDetection, CopyrightDetection, HolderDetection, PosTag, TreeLabel};
 #[cfg(test)]
-use super::types::{ParseNode, Token};
+use super::types::Token;
+use super::types::{
+    AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, TreeLabel,
+};
 
 const NON_COPYRIGHT_LABELS: &[TreeLabel] = &[];
 const NON_HOLDER_LABELS: &[TreeLabel] = &[TreeLabel::YrRange, TreeLabel::YrAnd];
@@ -78,6 +80,55 @@ const NON_COPYRIGHT_POS_TAGS: &[PosTag] = &[];
 
 static NOT_COPYRIGHTED_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)\bnot\s+copyrighted\b").unwrap());
+
+#[derive(Default)]
+struct TreeAnalysis {
+    has_copy_like_token: bool,
+    has_authorish_boundary_token: bool,
+    has_year_token: bool,
+    single_line: Option<usize>,
+    is_single_line_group: bool,
+}
+
+fn analyze_tree(nodes: &[ParseNode]) -> TreeAnalysis {
+    fn visit(node: &ParseNode, analysis: &mut TreeAnalysis) {
+        match node {
+            ParseNode::Leaf(token) => {
+                analysis.has_copy_like_token |=
+                    matches!(token.tag, PosTag::Copy | PosTag::SpdxContrib);
+                analysis.has_authorish_boundary_token |= matches!(
+                    token.tag,
+                    PosTag::Auths | PosTag::AuthDot | PosTag::Contributors | PosTag::Commit
+                );
+                analysis.has_year_token |=
+                    matches!(token.tag, PosTag::Yr | PosTag::YrPlus | PosTag::BareYr);
+
+                let line = token.start_line.get();
+                match analysis.single_line {
+                    Some(existing) if existing != line => analysis.is_single_line_group = false,
+                    None => analysis.single_line = Some(line),
+                    _ => {}
+                }
+            }
+            ParseNode::Tree { children, .. } => {
+                for child in children {
+                    visit(child, analysis);
+                }
+            }
+        }
+    }
+
+    let mut analysis = TreeAnalysis {
+        is_single_line_group: true,
+        ..TreeAnalysis::default()
+    };
+
+    for node in nodes {
+        visit(node, &mut analysis);
+    }
+
+    analysis
+}
 
 /// Returns a tuple of (copyrights, holders, authors).
 pub fn detect_copyrights_from_text(
@@ -153,6 +204,7 @@ pub fn detect_copyrights_from_text_with_deadline(
                 Some(TreeLabel::Copyright) | Some(TreeLabel::Copyright2) | Some(TreeLabel::Author)
             )
         });
+        let analysis = analyze_tree(&tree);
 
         if has_top_level_nodes {
             let (new_c, new_h, new_a) =
@@ -171,38 +223,10 @@ pub fn detect_copyrights_from_text_with_deadline(
                 authors.push(det);
             }
 
-            let has_copy_like_token = tree
-                .iter()
-                .flat_map(collect_all_leaves)
-                .any(|t| matches!(t.tag, PosTag::Copy | PosTag::SpdxContrib));
-
-            let has_authorish_boundary_token = tree.iter().flat_map(collect_all_leaves).any(|t| {
-                matches!(
-                    t.tag,
-                    PosTag::Auths | PosTag::AuthDot | PosTag::Contributors | PosTag::Commit
-                )
-            });
-
-            let is_single_line_group = {
-                let mut line: Option<usize> = None;
-                let mut ok = true;
-                for t in tree.iter().flat_map(collect_all_leaves) {
-                    if let Some(existing) = line {
-                        if existing != t.start_line.get() {
-                            ok = false;
-                            break;
-                        }
-                    } else {
-                        line = Some(t.start_line.get());
-                    }
-                }
-                ok
-            };
-
             if copyrights.len() == copyrights_before
-                && has_copy_like_token
-                && has_authorish_boundary_token
-                && is_single_line_group
+                && analysis.has_copy_like_token
+                && analysis.has_authorish_boundary_token
+                && analysis.is_single_line_group
             {
                 let (new_c, new_h) = extract_bare_copyrights(&tree);
                 seen.register_copyrights(&new_c);
@@ -217,11 +241,10 @@ pub fn detect_copyrights_from_text_with_deadline(
                 holders.extend(new_h);
             }
 
-            let has_year_token = tree
-                .iter()
-                .flat_map(collect_all_leaves)
-                .any(|t| matches!(t.tag, PosTag::Yr | PosTag::YrPlus | PosTag::BareYr));
-            if copyrights.len() == copyrights_before && has_copy_like_token && has_year_token {
+            if copyrights.len() == copyrights_before
+                && analysis.has_copy_like_token
+                && analysis.has_year_token
+            {
                 let (new_c, new_h) =
                     extract_copyrights_from_spans(&tree, allow_not_copyrighted_prefix);
                 seen.register_copyrights(&new_c);
@@ -364,9 +387,9 @@ use postprocess_transforms::{
     extend_w3c_registered_org_list_suffixes, refine_final_copyrights,
     restore_linux_foundation_copyrights_from_raw_lines,
 };
+pub(super) use token_utils::collect_all_leaves;
 use token_utils::{
-    apply_written_by_for_markers, collect_all_leaves,
-    drop_path_fragment_holders_from_bare_c_code_lines,
+    apply_written_by_for_markers, drop_path_fragment_holders_from_bare_c_code_lines,
     drop_scan_only_holders_from_copyright_scan_lines,
     extract_original_author_additional_contributors,
 };

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -14,7 +14,6 @@
 //!   collect spans heuristically.
 
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
@@ -126,6 +125,8 @@ pub fn detect_copyrights_from_text_with_deadline(
     let groups =
         collect_candidate_lines(raw_lines.iter().enumerate().map(|(i, line)| (i + 1, *line)));
 
+    let mut seen = seen_text::SeenTextSets::from_existing(&copyrights, &holders, &authors);
+
     for group in &groups {
         if deadline_exceeded(deadline) {
             break;
@@ -154,19 +155,18 @@ pub fn detect_copyrights_from_text_with_deadline(
         });
 
         if has_top_level_nodes {
+            let (new_c, new_h, new_a) =
+                extract_from_tree_nodes(&tree, allow_not_copyrighted_prefix);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            seen.register_authors(&new_a);
             let copyrights_before = copyrights.len();
-            extract_from_tree_nodes(
-                &tree,
-                &mut copyrights,
-                &mut holders,
-                &mut authors,
-                allow_not_copyrighted_prefix,
-            );
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            authors.extend(new_a);
 
             if let Some(det) = extract_original_author_additional_contributors(&tree)
-                && !authors
-                    .iter()
-                    .any(|a| a.author == det.author && a.start_line.get() == det.start_line.get())
+                && seen.authors.insert(det.author.clone())
             {
                 authors.push(det);
             }
@@ -204,13 +204,17 @@ pub fn detect_copyrights_from_text_with_deadline(
                 && has_authorish_boundary_token
                 && is_single_line_group
             {
-                extract_bare_copyrights(&tree, &mut copyrights, &mut holders);
-                extract_copyrights_from_spans(
-                    &tree,
-                    &mut copyrights,
-                    &mut holders,
-                    allow_not_copyrighted_prefix,
-                );
+                let (new_c, new_h) = extract_bare_copyrights(&tree);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
+                let (new_c, new_h) =
+                    extract_copyrights_from_spans(&tree, allow_not_copyrighted_prefix);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
             }
 
             let has_year_token = tree
@@ -218,28 +222,32 @@ pub fn detect_copyrights_from_text_with_deadline(
                 .flat_map(collect_all_leaves)
                 .any(|t| matches!(t.tag, PosTag::Yr | PosTag::YrPlus | PosTag::BareYr));
             if copyrights.len() == copyrights_before && has_copy_like_token && has_year_token {
-                extract_copyrights_from_spans(
-                    &tree,
-                    &mut copyrights,
-                    &mut holders,
-                    allow_not_copyrighted_prefix,
-                );
+                let (new_c, new_h) =
+                    extract_copyrights_from_spans(&tree, allow_not_copyrighted_prefix);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
             }
         } else {
-            extract_bare_copyrights(&tree, &mut copyrights, &mut holders);
-            extract_from_spans(
-                &tree,
-                &mut copyrights,
-                &mut holders,
-                &mut authors,
-                allow_not_copyrighted_prefix,
-            );
-            extract_orphaned_by_authors(&tree, &mut authors);
+            let (new_c, new_h) = extract_bare_copyrights(&tree);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            let (new_c, new_h, new_a) = extract_from_spans(&tree, allow_not_copyrighted_prefix);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            seen.register_authors(&new_a);
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            authors.extend(new_a);
+            let mut new_a = extract_orphaned_by_authors(&tree);
+            seen.dedup_new_authors(&mut new_a, 0);
+            authors.extend(new_a);
 
             if let Some(det) = extract_original_author_additional_contributors(&tree)
-                && !authors
-                    .iter()
-                    .any(|a| a.author == det.author && a.start_line.get() == det.start_line.get())
+                && seen.authors.insert(det.author.clone())
             {
                 authors.push(det);
             }
@@ -248,7 +256,12 @@ pub fn detect_copyrights_from_text_with_deadline(
         // Run after each group is processed so it can fix authors detected
         // through any extraction path.
         fix_truncated_contributors_authors(&tree, &mut authors);
-        extract_holder_is_name(&tree, &mut copyrights, &mut holders);
+        seen.rebuild_authors_from(&authors);
+        let (mut new_c, mut new_h) = extract_holder_is_name(&tree);
+        seen.dedup_new_copyrights(&mut new_c, 0);
+        seen.dedup_new_holders(&mut new_h, 0);
+        copyrights.extend(new_c);
+        holders.extend(new_h);
         apply_written_by_for_markers(group, &mut copyrights, &mut holders);
         extend_multiline_copyright_c_year_holder_continuations(
             group,
@@ -264,23 +277,16 @@ pub fn detect_copyrights_from_text_with_deadline(
         extend_software_in_the_public_interest_holder(group, &mut copyrights, &mut holders);
     }
 
-    if copyrights.is_empty() {
-        copyrights.extend(fallback_year_only_copyrights(&groups));
-    } else {
-        let fallback = fallback_year_only_copyrights(&groups);
-        let existing_set: HashSet<&str> = copyrights.iter().map(|c| c.copyright.as_str()).collect();
-        let to_add: Vec<CopyrightDetection> = fallback
-            .into_iter()
-            .filter(|det| {
-                !existing_set.contains(det.copyright.as_str())
-                    && !existing_set.iter().any(|e| {
-                        e.to_ascii_lowercase()
-                            .contains(&det.copyright.to_ascii_lowercase())
-                    })
-            })
-            .collect();
-        copyrights.extend(to_add);
-    }
+    let mut fallback = fallback_year_only_copyrights(&groups);
+    seen.dedup_new_copyrights(&mut fallback, 0);
+    fallback.retain(|det| {
+        !copyrights.iter().any(|c| {
+            c.copyright
+                .to_ascii_lowercase()
+                .contains(&det.copyright.to_ascii_lowercase())
+        })
+    });
+    copyrights.extend(fallback);
 
     if deadline_exceeded(deadline) {
         refine_final_copyrights(&mut copyrights);
@@ -297,6 +303,7 @@ pub fn detect_copyrights_from_text_with_deadline(
         &mut prepared_cache,
         &mut copyrights,
         &mut holders,
+        &mut seen,
     );
 
     postprocess_phase::run_phase_postprocess(
@@ -307,6 +314,7 @@ pub fn detect_copyrights_from_text_with_deadline(
         &mut copyrights,
         &mut holders,
         &mut authors,
+        &mut seen,
     );
 
     refine_final_copyrights(&mut copyrights);
@@ -334,6 +342,7 @@ mod pattern_extract;
 mod postprocess_phase;
 mod postprocess_transforms;
 mod primary_phase;
+mod seen_text;
 mod token_utils;
 mod tree_walk;
 

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -328,7 +328,11 @@ pub fn detect_copyrights_from_text_with_deadline(
     }
     restore_linux_foundation_copyrights_from_raw_lines(&raw_lines, &mut copyrights);
 
-    add_missing_holders_for_bare_c_name_year_suffixes(&copyrights, &mut holders);
+    holders.extend(add_missing_holders_for_bare_c_name_year_suffixes(
+        &copyrights,
+    ));
+
+    dedupe_exact_span_holders(&mut holders);
 
     dedupe_exact_span_copyrights(&mut copyrights);
     dedupe_exact_span_holders(&mut holders);

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -838,15 +838,8 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        let Some(cap) = COPY_YEARS_BY_NAME_RE.captures(&prepared) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = COPY_YEARS_BY_NAME_RE.captures(prepared_line.prepared) else {
             continue;
         };
 
@@ -862,7 +855,7 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
             .unwrap_or("")
             .trim()
             .to_string();
-        let matched = cap.get(0).map(|m| m.as_str()).unwrap_or("").to_string();
+        let matched = cap.get(0).map(|m| m.as_str()).unwrap_or("");
         if years.is_empty() || name.is_empty() {
             continue;
         }
@@ -873,59 +866,48 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
             continue;
         }
 
-        let mut j = idx + 1;
-        while j < prepared_cache.len() {
-            let next_ln = j + 1;
-            let Some(next_trimmed) = prepared_cache.get_by_index(j).map(|p| p.trim().to_string())
-            else {
-                break;
-            };
-            if next_trimmed.is_empty() {
-                j += 1;
-                continue;
-            }
+        let Some(next_line) = prepared_cache.next_non_empty_line(prepared_line.line_number) else {
+            continue;
+        };
 
-            let Some(email_cap) = LEADING_PAREN_EMAIL_RE.captures(&next_trimmed) else {
-                break;
-            };
-            let email = email_cap
-                .name("email")
-                .map(|m| m.as_str())
-                .unwrap_or("")
-                .trim();
-            if email.is_empty() {
-                break;
-            }
+        let Some(email_cap) = LEADING_PAREN_EMAIL_RE.captures(next_line.prepared) else {
+            continue;
+        };
+        let email = email_cap
+            .name("email")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        if email.is_empty() {
+            continue;
+        }
 
-            let full_raw = format!("{} ({email})", matched.trim_end());
-            if let Some(full) = refine_copyright(&full_raw)
-                && seen_copyrights.insert(full.to_ascii_lowercase())
-            {
-                copyrights.push(CopyrightDetection {
-                    copyright: full,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(next_ln).expect("valid"),
-                });
-            }
+        let full_raw = format!("{} ({email})", matched.trim_end());
+        if let Some(full) = refine_copyright(&full_raw)
+            && seen_copyrights.insert(full.to_ascii_lowercase())
+        {
+            copyrights.push(CopyrightDetection {
+                copyright: full,
+                start_line: prepared_line.line_number,
+                end_line: next_line.line_number,
+            });
+        }
 
-            let year_only_raw = format!("copyright {years}");
-            if let Some(year_only) = refine_copyright(&year_only_raw) {
-                copyrights.retain(|c| {
-                    !(c.start_line.get() == ln
-                        && c.end_line.get() == ln
-                        && c.copyright == year_only)
-                });
-            }
+        let year_only_raw = format!("copyright {years}");
+        if let Some(year_only) = refine_copyright(&year_only_raw) {
+            copyrights.retain(|c| {
+                !(c.start_line == prepared_line.line_number
+                    && c.end_line == prepared_line.line_number
+                    && c.copyright == year_only)
+            });
+        }
 
-            if let Some(holder) = refine_holder_in_copyright_context(&name) {
-                holders.push(HolderDetection {
-                    holder,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
-                });
-            }
-
-            break;
+        if let Some(holder) = refine_holder_in_copyright_context(&name) {
+            holders.push(HolderDetection {
+                holder,
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
+            });
         }
     }
 }
@@ -2635,30 +2617,15 @@ pub fn extract_name_before_rewrited_by_copyrights(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for idx in 0..prepared_cache.len().saturating_sub(1) {
-        let ln1 = idx + 1;
-        let ln2 = idx + 2;
-
-        let Some(l1) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        let Some(l2) = prepared_cache
-            .get_by_index(idx + 1)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if l1.is_empty() || l2.is_empty() {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        if first.prepared.is_empty() || second.prepared.is_empty() {
             continue;
         }
 
-        let Some(cap1) = NAME_EMAIL_YEARS_RE.captures(&l1) else {
+        let Some(cap1) = NAME_EMAIL_YEARS_RE.captures(first.prepared) else {
             continue;
         };
-        let Some(cap2) = REWRITED_BY_RE.captures(&l2) else {
+        let Some(cap2) = REWRITED_BY_RE.captures(second.prepared) else {
             continue;
         };
 
@@ -2686,8 +2653,8 @@ pub fn extract_name_before_rewrited_by_copyrights(
         if let Some(refined) = refine_copyright(&combined_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
@@ -2695,8 +2662,8 @@ pub fn extract_name_before_rewrited_by_copyrights(
         if let Some(holder) = refine_holder(&holder_raw) {
             holders.push(HolderDetection {
                 holder,
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -2721,19 +2688,25 @@ pub fn extract_developed_at_software_copyrights(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx).map(|p| p.to_string()) else {
-            continue;
-        };
-        let mut candidates: Vec<(usize, String)> = vec![(ln, prepared.clone())];
-        if let Some(next) = prepared_cache.get_by_index(idx + 1)
-            && !next.trim().is_empty()
+    for prepared_line in prepared_cache.iter() {
+        let mut candidates: Vec<(LineNumber, String)> = vec![(
+            prepared_line.line_number,
+            prepared_line.prepared.to_string(),
+        )];
+        if let Some(next) = prepared_cache.line(prepared_line.line_number + 1usize)
+            && !next.prepared.is_empty()
         {
-            candidates.push((ln, format!("{} {}", prepared.trim_end(), next.trim_start())));
+            candidates.push((
+                prepared_line.line_number,
+                format!(
+                    "{} {}",
+                    prepared_line.prepared.trim_end(),
+                    next.prepared.trim_start()
+                ),
+            ));
         }
 
-        for (_ln, candidate) in candidates {
+        for (line_number, candidate) in candidates {
             for cap in DEVELOPED_AT_RE.captures_iter(&candidate) {
                 let holder = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
                 let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -2743,14 +2716,14 @@ pub fn extract_developed_at_software_copyrights(
                 let cr = format!("at {holder} copyright (c) {year}");
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line_number,
+                    end_line: line_number,
                 });
                 let h = holder.to_string();
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line_number,
+                    end_line: line_number,
                 });
             }
         }

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -180,12 +180,8 @@ pub fn extract_added_the_copyright_year_for_lines(
         .map(|h| (h.holder.clone(), h.start_line.get()))
         .collect();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let Some(cap) = ADDED_COPYRIGHT_YEAR_RE.captures(prepared) else {
+    for line in prepared_cache.iter_non_empty() {
+        let Some(cap) = ADDED_COPYRIGHT_YEAR_RE.captures(line.prepared) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("");
@@ -198,15 +194,15 @@ pub fn extract_added_the_copyright_year_for_lines(
         let cr = format!("Copyright year ({year}) for {holder}");
         copyrights.push(CopyrightDetection {
             copyright: cr,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: line.line_number,
+            end_line: line.line_number,
         });
 
-        if seen_h.insert((holder.clone(), ln)) {
+        if seen_h.insert((holder.clone(), line.line_number.get())) {
             holders.push(HolderDetection {
                 holder,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
     }
@@ -1681,18 +1677,11 @@ pub fn extract_are_c_year_holder_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
+    for line in prepared_cache.iter_non_empty() {
+        if !line.prepared.to_ascii_lowercase().contains("(c)") {
             continue;
         }
-        if !line.to_ascii_lowercase().contains("(c)") {
-            continue;
-        }
-        for cap in ARE_C_YEAR_HOLDER_RE.captures_iter(line) {
+        for cap in ARE_C_YEAR_HOLDER_RE.captures_iter(line.prepared) {
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             let mut holder_raw = cap
                 .name("holder")
@@ -1711,21 +1700,21 @@ pub fn extract_are_c_year_holder_lines(
             let Some(refined) = refine_copyright(&raw) else {
                 continue;
             };
-            if seen_cr.insert((ln, refined.clone())) {
+            if seen_cr.insert((line.line_number.get(), refined.clone())) {
                 copyrights.push(CopyrightDetection {
                     copyright: refined,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line.line_number,
+                    end_line: line.line_number,
                 });
             }
 
             if let Some(h) = refine_holder_in_copyright_context(&holder_raw)
-                && seen_h.insert((ln, h.clone()))
+                && seen_h.insert((line.line_number.get(), h.clone()))
             {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line.line_number,
+                    end_line: line.line_number,
                 });
             }
         }
@@ -1758,15 +1747,8 @@ pub fn extract_bare_c_by_holder_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some(cap) = C_BY_RE.captures(line) else {
+    for line in prepared_cache.iter_non_empty() {
+        let Some(cap) = C_BY_RE.captures(line.prepared) else {
             continue;
         };
         let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1777,20 +1759,20 @@ pub fn extract_bare_c_by_holder_lines(
         let Some(refined) = refine_copyright(&raw) else {
             continue;
         };
-        if seen_cr.insert((ln, refined.clone())) {
+        if seen_cr.insert((line.line_number.get(), refined.clone())) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
         if let Some(h) = refine_holder_in_copyright_context(holder_raw)
-            && seen_h.insert((ln, h.clone()))
+            && seen_h.insert((line.line_number.get(), h.clone()))
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
     }
@@ -1824,15 +1806,8 @@ pub fn extract_all_rights_reserved_by_holder_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some(cap) = RESERVED_BY_RE.captures(line) else {
+    for line in prepared_cache.iter_non_empty() {
+        let Some(cap) = RESERVED_BY_RE.captures(line.prepared) else {
             continue;
         };
         let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1844,21 +1819,21 @@ pub fn extract_all_rights_reserved_by_holder_lines(
         let Some(refined) = refine_copyright(&raw) else {
             continue;
         };
-        if seen_cr.insert((ln, refined.clone())) {
+        if seen_cr.insert((line.line_number.get(), refined.clone())) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
 
         if let Some(h) = refine_holder_in_copyright_context(holder_raw)
-            && seen_h.insert((ln, h.clone()))
+            && seen_h.insert((line.line_number.get(), h.clone()))
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
     }
@@ -1894,15 +1869,8 @@ pub fn extract_holder_is_name_paren_email_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        for cap in HOLDER_IS_RE.captures_iter(line) {
+    for line in prepared_cache.iter_non_empty() {
+        for cap in HOLDER_IS_RE.captures_iter(line.prepared) {
             let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
             let email = cap.name("email").map(|m| m.as_str()).unwrap_or("").trim();
             if name.is_empty() || email.is_empty() {
@@ -1912,21 +1880,21 @@ pub fn extract_holder_is_name_paren_email_lines(
             let Some(cr) = refine_copyright(&raw) else {
                 continue;
             };
-            if seen_c.insert((ln, cr.clone())) {
+            if seen_c.insert((line.line_number.get(), cr.clone())) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line.line_number,
+                    end_line: line.line_number,
                 });
             }
 
             if let Some(h) = refine_holder_in_copyright_context(name)
-                && seen_h.insert((ln, h.clone()))
+                && seen_h.insert((line.line_number.get(), h.clone()))
             {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: line.line_number,
+                    end_line: line.line_number,
                 });
             }
         }

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -16,22 +16,18 @@ use crate::models::LineNumber;
 
 use super::token_utils::normalize_whitespace;
 
-pub fn extract_glide_3dfx_copyright_notice(
-    content: &str,
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+pub fn extract_glide_3dfx_copyright_notice(content: &str) -> Vec<CopyrightDetection> {
     static GLIDE_3DFX_COPYRIGHT_NOTICE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bcopyright\s+notice\s*\(3dfx\s+interactive,\s+inc\.\s+1999\)").unwrap()
     });
 
-    let mut seen: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
+    let mut copyrights = Vec::new();
+
     for (idx, line) in content.lines().enumerate() {
         let ln = idx + 1;
         if let Some(m) = GLIDE_3DFX_COPYRIGHT_NOTICE_RE.find(line) {
             let raw = m.as_str();
-            if let Some(refined) = refine_copyright(raw)
-                && seen.insert(refined.clone())
-            {
+            if let Some(refined) = refine_copyright(raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: refined,
                     start_line: LineNumber::new(ln).unwrap(),
@@ -40,19 +36,22 @@ pub fn extract_glide_3dfx_copyright_notice(
             }
         }
     }
+
+    copyrights
 }
 
 pub fn extract_spdx_filecopyrighttext_c_without_year(
     content: &str,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static SPDX_COPYRIGHT_C_NO_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bSPDX-FileCopyrightText:\s*Copyright\s*\(c\)\s+(.+?)\s*$").unwrap()
     });
 
-    let mut seen_cr: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<(String, usize)> = holders
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    let mut seen_h: HashSet<(String, usize)> = existing_holders
         .iter()
         .map(|h| (h.holder.clone(), h.start_line.get()))
         .collect();
@@ -69,9 +68,7 @@ pub fn extract_spdx_filecopyrighttext_c_without_year(
         }
 
         let raw = format!("Copyright (c) {tail}");
-        if let Some(refined) = refine_copyright(&raw)
-            && seen_cr.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -89,13 +86,14 @@ pub fn extract_spdx_filecopyrighttext_c_without_year(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_html_meta_name_copyright_content(
     content: &str,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static META_COPYRIGHT_CONTENT_DQ_NAME_CONTENT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"(?i)<meta\s+[^>]*\bname\s*=\s*"copyright"[^>]*\bcontent\s*=\s*"([^"]+)""#)
             .unwrap()
@@ -113,8 +111,10 @@ pub fn extract_html_meta_name_copyright_content(
             .unwrap()
     });
 
-    let mut seen_cr: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<(String, usize)> = holders
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    let mut seen_h: HashSet<(String, usize)> = existing_holders
         .iter()
         .map(|h| (h.holder.clone(), h.start_line.get()))
         .collect();
@@ -138,9 +138,7 @@ pub fn extract_html_meta_name_copyright_content(
             continue;
         }
 
-        if let Some(refined) = refine_copyright(raw)
-            && seen_cr.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined.clone(),
                 start_line: LineNumber::new(ln).unwrap(),
@@ -159,13 +157,14 @@ pub fn extract_html_meta_name_copyright_content(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_added_the_copyright_year_for_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static ADDED_COPYRIGHT_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\s*added\s+the\s+copyright\s+year\s*\(\s*(?P<year>\d{4})\s*\)\s+for\s+(?P<holder>.+?)\s*$",
@@ -173,8 +172,10 @@ pub fn extract_added_the_copyright_year_for_lines(
         .unwrap()
     });
 
-    let mut seen_cr: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<(String, usize)> = holders
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    let mut seen_h: HashSet<(String, usize)> = existing_holders
         .iter()
         .map(|h| (h.holder.clone(), h.start_line.get()))
         .collect();
@@ -195,13 +196,11 @@ pub fn extract_added_the_copyright_year_for_lines(
         let holder = refine_holder(holder_raw).unwrap_or_else(|| holder_raw.trim().to_string());
 
         let cr = format!("Copyright year ({year}) for {holder}");
-        if seen_cr.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
 
         if seen_h.insert((holder.clone(), ln)) {
             holders.push(HolderDetection {
@@ -211,18 +210,21 @@ pub fn extract_added_the_copyright_year_for_lines(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_changelog_timestamp_copyrights_from_content(
     content: &str,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static CHANGELOG_TS_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})\s+(.+?)\s*$").unwrap());
 
-    let mut seen_cr: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<(String, usize)> = holders
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    let mut seen_h: HashSet<(String, usize)> = existing_holders
         .iter()
         .map(|h| (h.holder.clone(), h.start_line.get()))
         .collect();
@@ -247,14 +249,12 @@ pub fn extract_changelog_timestamp_copyrights_from_content(
     }
 
     if matches.len() < 2 {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     let (ln, dt, tail) = &matches[0];
     let raw = format!("copyright {dt} {tail}");
-    if let Some(refined) = refine_copyright(&raw)
-        && seen_cr.insert(refined.clone())
-    {
+    if let Some(refined) = refine_copyright(&raw) {
         copyrights.push(CopyrightDetection {
             copyright: refined,
             start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -271,6 +271,8 @@ pub fn extract_changelog_timestamp_copyrights_from_content(
             end_line: LineNumber::new(*ln).expect("invalid line number"),
         });
     }
+
+    (copyrights, holders)
 }
 
 pub fn drop_arch_floppy_h_bare_1995(content: &str, copyrights: &mut Vec<CopyrightDetection>) {
@@ -316,10 +318,7 @@ pub fn is_lppl_license_document(content: &str) -> bool {
     content.to_ascii_lowercase().contains("lppl version")
 }
 
-pub fn extract_common_year_only_lines(
-    groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+pub fn extract_common_year_only_lines(groups: &[Vec<(usize, String)>]) -> Vec<CopyrightDetection> {
     const MIN_YEAR_ONLY_LINES: usize = 3;
     const MAX_YEAR: u32 = 2020;
 
@@ -336,6 +335,7 @@ pub fn extract_common_year_only_lines(
         .unwrap()
     });
 
+    let mut copyrights = Vec::new();
     let mut matches: Vec<(usize, String)> = Vec::new();
     for group in groups {
         for (idx, (ln, line)) in group.iter().enumerate() {
@@ -372,25 +372,24 @@ pub fn extract_common_year_only_lines(
     }
 
     if matches.len() < MIN_YEAR_ONLY_LINES {
-        return;
+        return Vec::new();
     }
 
-    let mut seen: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
     for (ln, refined) in matches {
-        if seen.insert(refined.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: refined,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: refined,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
     }
+
+    copyrights
 }
 
 pub fn extract_embedded_bare_c_year_suffixes(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     const MAX_YEAR: u32 = 2099;
 
     static EMBEDDED_BARE_C_YEAR_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -400,7 +399,8 @@ pub fn extract_embedded_bare_c_year_suffixes(
         .unwrap()
     });
 
-    let mut seen: HashSet<String> = copyrights
+    let mut copyrights = Vec::new();
+    let mut seen: HashSet<String> = existing_copyrights
         .iter()
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
@@ -474,18 +474,19 @@ pub fn extract_embedded_bare_c_year_suffixes(
             }
         }
     }
+
+    copyrights
 }
 
 pub fn extract_trailing_bare_c_year_range_suffixes(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+) -> Vec<CopyrightDetection> {
     static TRAILING_BARE_C_RANGE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\(c\)\s*(?:19\d{2}|20\d{2})\s*[-–]\s*(?:19\d{2}|20\d{2})\s*\.?\s*$")
             .unwrap()
     });
 
-    let mut seen: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
+    let mut copyrights = Vec::new();
 
     for group in groups {
         for (idx, (ln, line)) in group.iter().enumerate() {
@@ -514,9 +515,7 @@ pub fn extract_trailing_bare_c_year_range_suffixes(
             }
 
             let suffix = trimmed[m.start()..m.end()].trim();
-            if let Some(cr) = refine_copyright(suffix)
-                && seen.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(suffix) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -525,12 +524,13 @@ pub fn extract_trailing_bare_c_year_range_suffixes(
             }
         }
     }
+
+    copyrights
 }
 
 pub fn extract_repeated_embedded_bare_c_year_suffixes(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+) -> Vec<CopyrightDetection> {
     const MIN_REPEATS: usize = 2;
     const MAX_YEAR: u32 = 2020;
 
@@ -541,6 +541,7 @@ pub fn extract_repeated_embedded_bare_c_year_suffixes(
         .unwrap()
     });
 
+    let mut copyrights = Vec::new();
     let mut license_counts: std::collections::HashMap<String, (usize, usize)> =
         std::collections::HashMap::new();
     let mut copyright_line_sets: std::collections::HashMap<String, (HashSet<String>, usize)> =
@@ -582,15 +583,11 @@ pub fn extract_repeated_embedded_bare_c_year_suffixes(
         }
     }
 
-    let mut seen: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-
     for (bare, (count, first_ln)) in license_counts {
         if count < MIN_REPEATS {
             continue;
         }
-        if let Some(refined) = refine_copyright(&bare)
-            && seen.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&bare) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: LineNumber::new(first_ln).expect("valid"),
@@ -603,9 +600,7 @@ pub fn extract_repeated_embedded_bare_c_year_suffixes(
         if lines.len() < MIN_REPEATS {
             continue;
         }
-        if let Some(refined) = refine_copyright(&bare)
-            && seen.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&bare) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: LineNumber::new(first_ln).expect("valid"),
@@ -613,13 +608,13 @@ pub fn extract_repeated_embedded_bare_c_year_suffixes(
             });
         }
     }
+
+    copyrights
 }
 
 pub fn extract_lowercase_username_angle_email_copyrights(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static USER_EMAIL_COPYRIGHT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"^[Cc]opyright\s*(?:\([Cc]\)\s*)?(19\d{2}|20\d{2})\s+([a-z0-9][a-z0-9_\-]{2,63})\s*<\s*([^>\s]+@[^>\s]+)\s*>\s*[\.,;:]*\s*$",
@@ -627,9 +622,8 @@ pub fn extract_lowercase_username_angle_email_copyrights(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -646,9 +640,7 @@ pub fn extract_lowercase_username_angle_email_copyrights(
             }
 
             let cr_raw = format!("Copyright (c) {year} {user} <{email}>");
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -656,22 +648,20 @@ pub fn extract_lowercase_username_angle_email_copyrights(
                 });
             }
 
-            if seen_holders.insert(user.to_string()) {
-                holders.push(HolderDetection {
-                    holder: user.to_string(),
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
-            }
+            holders.push(HolderDetection {
+                holder: user.to_string(),
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_lowercase_username_paren_email_copyrights(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static USER_EMAIL_PARENS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"\b[Cc]opyright\s*(?:\([Cc]\)\s*)?(19\d{2}|20\d{2})\s+([a-z0-9][a-z0-9_\-]{2,63})\s*\(\s*([^\)\s]+@[^\)\s]+)\s*\)",
@@ -679,9 +669,8 @@ pub fn extract_lowercase_username_paren_email_copyrights(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -694,9 +683,7 @@ pub fn extract_lowercase_username_paren_email_copyrights(
                 }
 
                 let cr_raw = format!("copyright {year} {user} ({email})");
-                if let Some(cr) = refine_copyright(&cr_raw)
-                    && seen_copyrights.insert(cr.clone())
-                {
+                if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
                         start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -704,23 +691,21 @@ pub fn extract_lowercase_username_paren_email_copyrights(
                     });
                 }
 
-                if seen_holders.insert(user.to_string()) {
-                    holders.push(HolderDetection {
-                        holder: user.to_string(),
-                        start_line: LineNumber::new(*ln).expect("invalid line number"),
-                        end_line: LineNumber::new(*ln).expect("invalid line number"),
-                    });
-                }
+                holders.push(HolderDetection {
+                    holder: user.to_string(),
+                    start_line: LineNumber::new(*ln).expect("invalid line number"),
+                    end_line: LineNumber::new(*ln).expect("invalid line number"),
+                });
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_c_year_range_by_name_comma_email_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static C_BY_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\(c\)\s+(?P<years>\d{4}(?:\s*[-–]\s*(?:\d{4}|\d{2}))?)\s+by\s+(?P<name>[^,]+),\s*(?P<email>[^\s,]+@[^\s,]+)\s*$",
@@ -728,9 +713,8 @@ pub fn extract_c_year_range_by_name_comma_email_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -747,9 +731,7 @@ pub fn extract_c_year_range_by_name_comma_email_lines(
             }
 
             let cr_raw = format!("(c) {years} by {name}, {email}");
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -757,9 +739,7 @@ pub fn extract_c_year_range_by_name_comma_email_lines(
                 });
             }
 
-            if let Some(h) = refine_holder(name)
-                && seen_holders.insert(h.clone())
-            {
+            if let Some(h) = refine_holder(name) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -768,6 +748,8 @@ pub fn extract_c_year_range_by_name_comma_email_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copyright_years_by_name_paren_email_lines(
@@ -786,7 +768,6 @@ pub fn extract_copyright_years_by_name_paren_email_lines(
         .iter()
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
 
     for group in groups {
         for (ln, line) in group {
@@ -810,13 +791,15 @@ pub fn extract_copyright_years_by_name_paren_email_lines(
                     continue;
                 };
 
-                if seen_copyrights.insert(full.to_ascii_lowercase()) {
-                    copyrights.push(CopyrightDetection {
-                        copyright: full.clone(),
-                        start_line: LineNumber::new(*ln).expect("invalid line number"),
-                        end_line: LineNumber::new(*ln).expect("invalid line number"),
-                    });
+                if !seen_copyrights.insert(full.to_ascii_lowercase()) {
+                    continue;
                 }
+
+                copyrights.push(CopyrightDetection {
+                    copyright: full.clone(),
+                    start_line: LineNumber::new(*ln).expect("invalid line number"),
+                    end_line: LineNumber::new(*ln).expect("invalid line number"),
+                });
 
                 let year_only_raw = format!("copyright {years}");
                 if let Some(year_only) = refine_copyright(&year_only_raw) {
@@ -828,9 +811,7 @@ pub fn extract_copyright_years_by_name_paren_email_lines(
                     });
                 }
 
-                if let Some(holder) = refine_holder_in_copyright_context(name)
-                    && seen_holders.insert(holder.clone())
-                {
+                if let Some(holder) = refine_holder_in_copyright_context(name) {
                     holders.push(HolderDetection {
                         holder,
                         start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -860,7 +841,6 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
         .iter()
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -941,9 +921,7 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
                 });
             }
 
-            if let Some(holder) = refine_holder_in_copyright_context(&name)
-                && seen_holders.insert(holder.clone())
-            {
+            if let Some(holder) = refine_holder_in_copyright_context(&name) {
                 holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(ln).unwrap(),
@@ -958,9 +936,7 @@ pub fn extract_copyright_years_by_name_then_paren_email_next_line(
 
 pub fn extract_copyright_year_name_with_of_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_YEAR_OF_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^Copyright\s*\(c\)\s+(?P<year>19\d{2}|20\d{2})\s+(?P<holder>[A-Z][A-Za-z0-9.'\-]*(?:\s+of\s+[A-Z][A-Za-z0-9.'\-]*)+)\s*$",
@@ -968,9 +944,8 @@ pub fn extract_copyright_year_name_with_of_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -986,9 +961,7 @@ pub fn extract_copyright_year_name_with_of_lines(
             }
 
             let cr_raw = format!("Copyright (c) {year} {holder_raw}");
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -996,9 +969,7 @@ pub fn extract_copyright_year_name_with_of_lines(
                 });
             }
 
-            if let Some(h) = refine_holder(holder_raw)
-                && seen_holders.insert(h.clone())
-            {
+            if let Some(h) = refine_holder(holder_raw) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -1007,6 +978,8 @@ pub fn extract_copyright_year_name_with_of_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn drop_url_extended_prefix_duplicates(copyrights: &mut Vec<CopyrightDetection>) {
@@ -1060,9 +1033,8 @@ pub fn drop_url_extended_prefix_duplicates(copyrights: &mut Vec<CopyrightDetecti
 
 pub fn extract_standalone_c_holder_year_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static STANDALONE_C_HOLDER_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"^\(c\)\s+(?P<holder>[A-Z0-9][A-Za-z0-9 ,&'\-\.]*?)\s+(?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*)\s*\.?\s*(?:[Aa]ll\s+[Rr]ights\s+[Rr]eserved)?\s*$",
@@ -1078,9 +1050,8 @@ pub fn extract_standalone_c_holder_year_lines(
     static EMAIL_ONLY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^[^\s@]+@[^\s@]+$").unwrap());
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for idx in 0..group.len() {
@@ -1114,7 +1085,7 @@ pub fn extract_standalone_c_holder_year_lines(
                 continue;
             }
 
-            let already_covered = copyrights.iter().any(|c| {
+            let already_covered = existing_copyrights.iter().any(|c| {
                 c.start_line.get() <= *ln
                     && c.end_line.get() >= *ln
                     && c.copyright.contains(&yearish)
@@ -1153,9 +1124,7 @@ pub fn extract_standalone_c_holder_year_lines(
             } else {
                 format!("(c) {holder_raw} {yearish}")
             };
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -1172,9 +1141,7 @@ pub fn extract_standalone_c_holder_year_lines(
                 });
             }
 
-            if let Some(h) = refine_holder(holder_raw)
-                && seen_holders.insert(h.clone())
-            {
+            if let Some(h) = refine_holder(holder_raw) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -1183,14 +1150,14 @@ pub fn extract_standalone_c_holder_year_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_c_holder_without_year_lines(
     content: &str,
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static STRING_NAME_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)<\s*string\b[^>]*\bname\s*=").unwrap());
     static C_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\(c\)\s*\d{4}").unwrap());
@@ -1204,12 +1171,11 @@ pub fn extract_c_holder_without_year_lines(
     });
 
     if !STRING_NAME_RE.is_match(content) || !C_YEAR_RE.is_match(content) {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -1236,9 +1202,7 @@ pub fn extract_c_holder_without_year_lines(
             }
 
             let cr_raw = format!("(c) {holder_raw}");
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -1246,9 +1210,7 @@ pub fn extract_c_holder_without_year_lines(
                 });
             }
 
-            if let Some(holder) = refine_holder_in_copyright_context(holder_raw)
-                && seen_holders.insert(holder.clone())
-            {
+            if let Some(holder) = refine_holder_in_copyright_context(holder_raw) {
                 holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -1257,21 +1219,26 @@ pub fn extract_c_holder_without_year_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_versioned_project_c_holder_banner_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
-    let mut seen_c: HashSet<(usize, String)> = copyrights
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    let mut seen_c: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -1320,21 +1287,26 @@ pub fn extract_versioned_project_c_holder_banner_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_c_years_then_holder_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -1396,13 +1368,15 @@ pub fn extract_c_years_then_holder_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copyright_c_years_holder_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_C_YEARS_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^copyright\s*\(c\)\s*(?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*?)\s+(?P<holder>.+?)\s*$",
@@ -1410,14 +1384,17 @@ pub fn extract_copyright_c_years_holder_lines(
         .unwrap()
     });
 
-    let mut seen_c: HashSet<(usize, String)> = copyrights
+    let mut seen_c: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -1459,29 +1436,34 @@ pub fn extract_copyright_c_years_holder_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_three_digit_copyright_year_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static COPYRIGHT_C_3DIGIT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*copyright\s*\(c\)\s*(?P<year>\d{3})\s+(?P<tail>.+)$").unwrap()
     });
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1526,29 +1508,34 @@ pub fn extract_three_digit_copyright_year_lines(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copyrighted_by_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static COPYRIGHTED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bcopyrighted\s+by\s+(?P<who>(?-i:[\p{Lu}][^\.\,\;\)]+))").unwrap()
     });
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1597,29 +1584,34 @@ pub fn extract_copyrighted_by_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_c_word_year_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static C_WORD_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\(c\)\s+(?P<who>[\p{L}]{2,20})\s+(?P<year>(?:19\d{2}|20\d{2}))\b").unwrap()
     });
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -1674,15 +1666,17 @@ pub fn extract_c_word_year_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_are_c_year_holder_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static ARE_C_YEAR_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1692,14 +1686,17 @@ pub fn extract_are_c_year_holder_lines(
     static TRAILING_UNDER_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s+under\b.*$").unwrap());
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for ln in 1..=prepared_cache.len() {
         let Some(prepared) = prepared_cache.get(ln) else {
@@ -1750,28 +1747,33 @@ pub fn extract_are_c_year_holder_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_bare_c_by_holder_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static C_BY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\(c\)\s*by\s+(?P<holder>[A-Z][^\n]+)$").unwrap());
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for ln in 1..=prepared_cache.len() {
         let Some(prepared) = prepared_cache.get(ln) else {
@@ -1809,15 +1811,17 @@ pub fn extract_bare_c_by_holder_lines(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_all_rights_reserved_by_holder_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static RESERVED_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1825,14 +1829,17 @@ pub fn extract_all_rights_reserved_by_holder_lines(
             .unwrap()
     });
 
-    let mut seen_cr: HashSet<(usize, String)> = copyrights
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for ln in 1..=prepared_cache.len() {
         let Some(prepared) = prepared_cache.get(ln) else {
@@ -1872,15 +1879,17 @@ pub fn extract_all_rights_reserved_by_holder_lines(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_holder_is_name_paren_email_lines(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static HOLDER_IS_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1890,14 +1899,17 @@ pub fn extract_holder_is_name_paren_email_lines(
         .unwrap()
     });
 
-    let mut seen_c: HashSet<(usize, String)> = copyrights
+    let mut seen_c: HashSet<(usize, String)> = existing_copyrights
         .iter()
         .map(|c| (c.start_line.get(), c.copyright.clone()))
         .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
         .iter()
         .map(|h| (h.start_line.get(), h.holder.clone()))
         .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for ln in 1..=prepared_cache.len() {
         let Some(prepared) = prepared_cache.get(ln) else {
@@ -1936,6 +1948,8 @@ pub fn extract_holder_is_name_paren_email_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copr_lines(
@@ -1952,10 +1966,6 @@ pub fn extract_copr_lines(
     static TRAILING_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"\s+(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?\s*$").unwrap()
     });
-
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
 
     for group in groups {
         for (ln, line) in group {
@@ -2039,13 +2049,11 @@ pub fn extract_copr_lines(
                 !(cr.starts_with(&c.copyright) && cr.len() > c.copyright.len())
             });
 
-            if seen_copyrights.insert(cr.clone()) {
-                copyrights.push(CopyrightDetection {
-                    copyright: cr.clone(),
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
-            }
+            copyrights.push(CopyrightDetection {
+                copyright: cr.clone(),
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
 
             let mut holder_raw = holder_candidate;
             holder_raw = LEADING_YEAR_RE.replace(&holder_raw, "").to_string();
@@ -2069,13 +2077,11 @@ pub fn extract_copr_lines(
                 });
             }
 
-            if seen_holders.insert(h.clone()) {
-                holders.push(HolderDetection {
-                    holder: h,
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
-            }
+            holders.push(HolderDetection {
+                holder: h,
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
         }
     }
 }
@@ -2204,8 +2210,6 @@ pub fn extract_html_entity_year_range_copyrights(
         Regex::new(r"(?i)\bare\s+copyright\s*\(c\)\s*(\d{4}\s*[-–]\s*\d{4})\s*\.").unwrap()
     });
 
-    let mut seen: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-
     let is_terminator = |s: &str| {
         let tail = s.trim_start();
         if tail.is_empty() {
@@ -2230,9 +2234,7 @@ pub fn extract_html_entity_year_range_copyrights(
             continue;
         }
         let raw = format!("Copyright (c) {range}");
-        if let Some(refined) = refine_copyright(&raw)
-            && seen.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: ln,
@@ -2257,9 +2259,7 @@ pub fn extract_html_entity_year_range_copyrights(
             continue;
         }
         let raw = format!("(c) {range}");
-        if let Some(refined) = refine_copyright(&raw)
-            && seen.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: ln,
@@ -2281,9 +2281,7 @@ pub fn extract_html_entity_year_range_copyrights(
             continue;
         }
         let raw = format!("Copyright (c) {range}");
-        if let Some(refined) = refine_copyright(&raw)
-            && seen.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: ln,
@@ -2516,16 +2514,15 @@ pub fn fallback_year_only_copyrights(groups: &[Vec<(usize, String)>]) -> Vec<Cop
 
 pub fn extract_copyright_c_year_comma_name_angle_email_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    existing_copyrights: &[CopyrightDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     let has_copyright_label_lines = groups.iter().flatten().any(|(_, l)| {
         l.trim_start()
             .to_ascii_lowercase()
             .starts_with("copyright:")
     });
     if !has_copyright_label_lines {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static COPY_C_YEAR_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -2535,11 +2532,12 @@ pub fn extract_copyright_c_year_comma_name_angle_email_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> = copyrights
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+    let mut seen_copyrights: HashSet<String> = existing_copyrights
         .iter()
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
 
     for group in groups {
         for (ln, line) in group {
@@ -2559,17 +2557,17 @@ pub fn extract_copyright_c_year_comma_name_angle_email_lines(
                 continue;
             };
 
-            if seen_copyrights.insert(cr.to_ascii_lowercase()) {
-                copyrights.push(CopyrightDetection {
-                    copyright: cr,
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
+            if !seen_copyrights.insert(cr.to_ascii_lowercase()) {
+                continue;
             }
 
-            if let Some(holder) = refine_holder_in_copyright_context(name)
-                && seen_holders.insert(holder.clone())
-            {
+            copyrights.push(CopyrightDetection {
+                copyright: cr,
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
+
+            if let Some(holder) = refine_holder_in_copyright_context(name) {
                 holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -2578,6 +2576,8 @@ pub fn extract_copyright_c_year_comma_name_angle_email_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extend_software_in_the_public_interest_holder(
@@ -2663,9 +2663,7 @@ pub fn strip_trailing_c_year_suffix_from_comma_and_others(copyrights: &mut [Copy
 
 pub fn extract_name_before_rewrited_by_copyrights(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static NAME_EMAIL_YEARS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"^(?P<name>[^<>]+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s+(?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?)\s*$",
@@ -2680,12 +2678,11 @@ pub fn extract_name_before_rewrited_by_copyrights(
     });
 
     if prepared_cache.len() < 2 {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for idx in 0..prepared_cache.len().saturating_sub(1) {
         let ln1 = idx + 1;
@@ -2735,9 +2732,7 @@ pub fn extract_name_before_rewrited_by_copyrights(
 
         let combined_raw =
             format!("{name1} <{email1}> {years1} {prefix2} {name2} <{email2}> (c) {year2}");
-        if let Some(refined) = refine_copyright(&combined_raw)
-            && seen_copyrights.insert(refined.clone())
-        {
+        if let Some(refined) = refine_copyright(&combined_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: LineNumber::new(ln1).expect("valid"),
@@ -2746,9 +2741,7 @@ pub fn extract_name_before_rewrited_by_copyrights(
         }
 
         let holder_raw = format!("{name1} {prefix2} {name2}");
-        if let Some(holder) = refine_holder(&holder_raw)
-            && seen_holders.insert(holder.clone())
-        {
+        if let Some(holder) = refine_holder(&holder_raw) {
             holders.push(HolderDetection {
                 holder,
                 start_line: LineNumber::new(ln1).expect("valid"),
@@ -2756,13 +2749,13 @@ pub fn extract_name_before_rewrited_by_copyrights(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_developed_at_software_copyrights(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static DEVELOPED_AT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)\bat\s+(?P<holder>[^\n,]+,\s*inc\.,\s*software)\s+copyright\s*\(c\)\s+(?P<year>(?:19\d{2}|20\d{2}))\b",
@@ -2771,12 +2764,11 @@ pub fn extract_developed_at_software_copyrights(
     });
 
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -2798,24 +2790,22 @@ pub fn extract_developed_at_software_copyrights(
                     continue;
                 }
                 let cr = format!("at {holder} copyright (c) {year}");
-                if seen_copyrights.insert(cr.clone()) {
-                    copyrights.push(CopyrightDetection {
-                        copyright: cr,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln).unwrap(),
-                    });
-                }
+                copyrights.push(CopyrightDetection {
+                    copyright: cr,
+                    start_line: LineNumber::new(ln).unwrap(),
+                    end_line: LineNumber::new(ln).unwrap(),
+                });
                 let h = holder.to_string();
-                if seen_holders.insert(h.clone()) {
-                    holders.push(HolderDetection {
-                        holder: h,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln).unwrap(),
-                    });
-                }
+                holders.push(HolderDetection {
+                    holder: h,
+                    start_line: LineNumber::new(ln).unwrap(),
+                    end_line: LineNumber::new(ln).unwrap(),
+                });
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_confidential_proprietary_copyrights(
@@ -2852,10 +2842,6 @@ pub fn extract_confidential_proprietary_copyrights(
         return;
     }
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
         let Some(line) = prepared_cache
@@ -2873,18 +2859,14 @@ pub fn extract_confidential_proprietary_copyrights(
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             if !holder.is_empty() && !year.is_empty() {
                 let cr = format!("{holder} (c) Copyright {year}");
-                if let Some(refined) = refine_copyright(&cr)
-                    && seen_copyrights.insert(refined.clone())
-                {
+                if let Some(refined) = refine_copyright(&cr) {
                     copyrights.push(CopyrightDetection {
                         copyright: refined,
                         start_line: LineNumber::new(ln).unwrap(),
                         end_line: LineNumber::new(ln).unwrap(),
                     });
                 }
-                if let Some(h) = refine_holder_in_copyright_context(holder)
-                    && seen_holders.insert(h.clone())
-                {
+                if let Some(h) = refine_holder_in_copyright_context(holder) {
                     holders.push(HolderDetection {
                         holder: h,
                         start_line: LineNumber::new(ln).unwrap(),
@@ -2914,9 +2896,7 @@ pub fn extract_confidential_proprietary_copyrights(
             };
             if !next_clean.is_empty() && CONFIDENTIAL_RE.is_match(&next_clean) {
                 let cr_raw = format!("COPYRIGHT {year} {tag} {next_clean}");
-                if let Some(cr) = refine_copyright(&cr_raw)
-                    && seen_copyrights.insert(cr.clone())
-                {
+                if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
                         start_line: LineNumber::new(ln).unwrap(),
@@ -2924,9 +2904,7 @@ pub fn extract_confidential_proprietary_copyrights(
                     });
                 }
                 let holder_raw = format!("{tag} {next_clean}");
-                if let Some(h) = refine_holder_in_copyright_context(&holder_raw)
-                    && seen_holders.insert(h.clone())
-                {
+                if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
                     holders.push(HolderDetection {
                         holder: h,
                         start_line: LineNumber::new(ln).unwrap(),
@@ -2951,9 +2929,7 @@ pub fn extract_confidential_proprietary_copyrights(
             };
             if !next_clean.is_empty() && CONFIDENTIAL_RE.is_match(&next_clean) {
                 let cr_raw = format!("Copyright {year} (c), {base_holder} - {next_clean}");
-                if let Some(cr) = refine_copyright(&cr_raw)
-                    && seen_copyrights.insert(cr.clone())
-                {
+                if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
                         start_line: LineNumber::new(ln).unwrap(),
@@ -2967,9 +2943,7 @@ pub fn extract_confidential_proprietary_copyrights(
                 }
 
                 let holder_raw = format!("{base_holder} - {next_clean}");
-                if let Some(h) = refine_holder_in_copyright_context(&holder_raw)
-                    && seen_holders.insert(h.clone())
-                {
+                if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
                     holders.push(HolderDetection {
                         holder: h,
                         start_line: LineNumber::new(ln).unwrap(),
@@ -3026,9 +3000,7 @@ pub fn truncate_stichting_mathematisch_centrum_amsterdam_netherlands(
 
 pub fn extract_copyright_year_c_holder_mid_sentence_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_YEAR_C_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\s*copyright\s+(?P<year>19\d{2}|20\d{2})\s+\(c\)\s+(?P<holder>.+?)\s+is\s+licensed\b",
@@ -3036,9 +3008,8 @@ pub fn extract_copyright_year_c_holder_mid_sentence_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3066,9 +3037,7 @@ pub fn extract_copyright_year_c_holder_mid_sentence_lines(
             }
 
             let raw = format!("Copyright {year} (c) {holder}");
-            if let Some(cr) = refine_copyright(&raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3076,9 +3045,7 @@ pub fn extract_copyright_year_c_holder_mid_sentence_lines(
                 });
             }
 
-            if let Some(h) = refine_holder_in_copyright_context(holder)
-                && seen_holders.insert(h.clone())
-            {
+            if let Some(h) = refine_holder_in_copyright_context(holder) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3087,13 +3054,13 @@ pub fn extract_copyright_year_c_holder_mid_sentence_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_javadoc_author_copyright_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static JAVADOC_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\s*@author\s+(?P<name>.+?)\s*,?\s*\(\s*c\s*\)\s*(?P<year>(?:19|20)\d{2})\b",
@@ -3101,8 +3068,8 @@ pub fn extract_javadoc_author_copyright_lines(
         .unwrap()
     });
 
-    let mut seen_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3127,9 +3094,7 @@ pub fn extract_javadoc_author_copyright_lines(
             }
 
             let cr_raw = format!("{name}, (c) {year}");
-            if let Some(cr) = refine_copyright(&cr_raw)
-                && seen_c.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3137,9 +3102,7 @@ pub fn extract_javadoc_author_copyright_lines(
                 });
             }
 
-            if let Some(h) = refine_holder_in_copyright_context(&name)
-                && seen_h.insert(h.clone())
-            {
+            if let Some(h) = refine_holder_in_copyright_context(&name) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3148,6 +3111,8 @@ pub fn extract_javadoc_author_copyright_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_xml_copyright_tag_c_lines(
@@ -3167,10 +3132,6 @@ pub fn extract_xml_copyright_tag_c_lines(
         LazyLock::new(|| Regex::new(r"(?i)\(c\)\s*(?P<body>.+)").unwrap());
     static ALL_RIGHTS_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i),?\s*all\s+rights\s+reserved\.?\s*$").unwrap());
-
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
 
     for cap in BLOCK_RE.captures_iter(content) {
         let ln = cap
@@ -3221,9 +3182,7 @@ pub fn extract_xml_copyright_tag_c_lines(
             .map(|b| format!("(c) {b}"))
             .collect::<Vec<_>>()
             .join(" ");
-        if let Some(cr) = refine_copyright(&combined)
-            && seen_copyrights.insert(cr.clone())
-        {
+        if let Some(cr) = refine_copyright(&combined) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
                 start_line: ln,
@@ -3232,9 +3191,7 @@ pub fn extract_xml_copyright_tag_c_lines(
         }
 
         let combined_holder = bodies.join(" ");
-        if let Some(h) = refine_holder_in_copyright_context(&combined_holder)
-            && seen_holders.insert(h.clone())
-        {
+        if let Some(h) = refine_holder_in_copyright_context(&combined_holder) {
             holders.push(HolderDetection {
                 holder: h,
                 start_line: ln,
@@ -3253,15 +3210,12 @@ pub fn extract_xml_copyright_tag_c_lines(
 
 pub fn extract_copyright_its_authors_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static ITS_AUTHORS_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bcopyright\s+its\s+authors\b(?P<tail>.*)$").unwrap());
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3281,40 +3235,35 @@ pub fn extract_copyright_its_authors_lines(
             }
 
             let cr = "copyright its authors".to_string();
-            if seen_copyrights.insert(cr.clone()) {
-                copyrights.push(CopyrightDetection {
-                    copyright: cr,
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
-            }
+            copyrights.push(CopyrightDetection {
+                copyright: cr,
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
 
             let holder = "its authors".to_string();
-            if seen_holders.insert(holder.clone()) {
-                holders.push(HolderDetection {
-                    holder,
-                    start_line: LineNumber::new(*ln).expect("invalid line number"),
-                    end_line: LineNumber::new(*ln).expect("invalid line number"),
-                });
-            }
+            holders.push(HolderDetection {
+                holder,
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_us_government_year_placeholder_copyrights(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*copyright\b.*\bYEAR\b.*\bUnited\s+States\s+Government\b").unwrap()
     });
     static HAS_DIGIT_YEAR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\b(?:19\d{2}|20\d{2})\b").unwrap());
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3330,9 +3279,7 @@ pub fn extract_us_government_year_placeholder_copyrights(
             }
 
             let raw = "Copyright YEAR United States Government";
-            if let Some(cr) = refine_copyright(raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3341,9 +3288,7 @@ pub fn extract_us_government_year_placeholder_copyrights(
             }
 
             let holder_raw = "United States Government";
-            if let Some(holder) = refine_holder_in_copyright_context(holder_raw)
-                && seen_holders.insert(holder.clone())
-            {
+            if let Some(holder) = refine_holder_in_copyright_context(holder_raw) {
                 holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3352,13 +3297,13 @@ pub fn extract_us_government_year_placeholder_copyrights(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copyright_notice_paren_year_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)\bcopyright\s+notice\s*\(\s*(?P<year>\d{4})\s*\)\s+(?P<holder>[^\n]+?)\s*$",
@@ -3366,9 +3311,8 @@ pub fn extract_copyright_notice_paren_year_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3386,9 +3330,7 @@ pub fn extract_copyright_notice_paren_year_lines(
             }
 
             let raw = format!("Copyright Notice ({year}) {holder_raw}");
-            if let Some(cr) = refine_copyright(&raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3396,9 +3338,7 @@ pub fn extract_copyright_notice_paren_year_lines(
                 });
             }
 
-            if let Some(holder) = refine_holder_in_copyright_context(holder_raw)
-                && seen_holders.insert(holder.clone())
-            {
+            if let Some(holder) = refine_holder_in_copyright_context(holder_raw) {
                 holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3407,6 +3347,8 @@ pub fn extract_copyright_notice_paren_year_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn drop_shadowed_bare_c_holders_with_year_prefixed_copyrights(
@@ -3442,8 +3384,7 @@ pub fn drop_shadowed_bare_c_holders_with_year_prefixed_copyrights(
 
 pub fn extract_initials_holders_from_copyrights(
     copyrights: &[CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> Vec<HolderDetection> {
     static INITIALS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^copyright\s+\(c\)\s+(?:19\d{2}|20\d{2})\s*,?\s+(?P<holder>[A-Z](?:\s+[A-Z]){1,2})$",
@@ -3451,7 +3392,7 @@ pub fn extract_initials_holders_from_copyrights(
         .unwrap()
     });
 
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut holders = Vec::new();
 
     for det in copyrights {
         let Some(cap) = INITIALS_RE.captures(&det.copyright) else {
@@ -3461,9 +3402,7 @@ pub fn extract_initials_holders_from_copyrights(
         if holder_raw.is_empty() {
             continue;
         }
-        if let Some(holder) = refine_holder_in_copyright_context(holder_raw)
-            && seen_holders.insert(holder.clone())
-        {
+        if let Some(holder) = refine_holder_in_copyright_context(holder_raw) {
             holders.push(HolderDetection {
                 holder,
                 start_line: det.start_line,
@@ -3471,16 +3410,16 @@ pub fn extract_initials_holders_from_copyrights(
             });
         }
     }
+
+    holders
 }
 
 pub fn extract_html_anchor_copyright_url(
     content: &str,
     line_number_index: &LineNumberIndex,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if !content.to_ascii_lowercase().contains("href=") {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static A_HREF_COPYRIGHT_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -3496,9 +3435,8 @@ pub fn extract_html_anchor_copyright_url(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for cap in A_HREF_COPYRIGHT_RE.captures_iter(content) {
         let start_line = cap
@@ -3519,22 +3457,18 @@ pub fn extract_html_anchor_copyright_url(
         }
 
         let cr = format!("copyright {url}");
-        if seen_copyrights.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line,
-                end_line,
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line,
+            end_line,
+        });
 
         let holder = url.to_string();
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line,
-                end_line,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line,
+            end_line,
+        });
     }
 
     for cap in COPY_SYMBOL_A_HREF_RE.captures_iter(content) {
@@ -3557,30 +3491,28 @@ pub fn extract_html_anchor_copyright_url(
         }
 
         let cr = format!("(c) {url} {holder}");
-        if seen_copyrights.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line,
-                end_line,
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line,
+            end_line,
+        });
 
         let holder = holder.to_string();
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line,
-                end_line,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line,
+            end_line,
+        });
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_angle_bracket_year_name_copyrights(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &mut [CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_C_ANGLE_YEAR_ANGLE_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^copyright\s*\(c\)\s*<\s*(?P<years>[^>]+?)\s*>\s*<\s*(?P<name>[A-Z][A-Za-z'\.-]+(?:\s+[A-Z][A-Za-z'\.-]+){1,2})\s*>\s*$",
@@ -3592,10 +3524,13 @@ pub fn extract_angle_bracket_year_name_copyrights(
         .iter()
         .map(|c| c.copyright.to_ascii_lowercase())
         .collect();
-    let mut seen_holders: HashSet<String> = holders
+    let mut seen_holders: HashSet<String> = existing_holders
         .iter()
         .map(|h| h.holder.to_ascii_lowercase())
         .collect();
+
+    let mut new_copyrights = Vec::new();
+    let mut new_holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3618,7 +3553,7 @@ pub fn extract_angle_bracket_year_name_copyrights(
                 }) {
                     existing.copyright = full.clone();
                 } else {
-                    copyrights.push(CopyrightDetection {
+                    new_copyrights.push(CopyrightDetection {
                         copyright: full.clone(),
                         start_line: LineNumber::new(*ln).expect("invalid line number"),
                         end_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3631,7 +3566,7 @@ pub fn extract_angle_bracket_year_name_copyrights(
                 refine_holder_in_copyright_context(name).unwrap_or_else(|| name.to_string());
             let holder_lower = holder.to_ascii_lowercase();
             if seen_holders.insert(holder_lower) {
-                holders.push(HolderDetection {
+                new_holders.push(HolderDetection {
                     holder,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
                     end_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3639,6 +3574,8 @@ pub fn extract_angle_bracket_year_name_copyrights(
             }
         }
     }
+
+    (new_copyrights, new_holders)
 }
 
 pub fn extract_html_icon_class_copyrights(
@@ -3671,10 +3608,6 @@ pub fn extract_html_icon_class_copyrights(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for cap in FA_AUTHORS_RE.captures_iter(content) {
         let ln = cap
             .get(0)
@@ -3685,21 +3618,17 @@ pub fn extract_html_icon_class_copyrights(
             continue;
         }
         let cr = format!("Copyright fa-copyright {year} by the authors");
-        if seen_copyrights.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: ln,
+            end_line: ln,
+        });
         let holder = "fa-copyright by the authors".to_string();
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: ln,
+            end_line: ln,
+        });
 
         let simple = format!("Copyright {year} by the authors");
         copyrights.retain(|c| c.copyright != simple);
@@ -3721,21 +3650,17 @@ pub fn extract_html_icon_class_copyrights(
         }
 
         let cr = format!("Copyright glyphicon-copyright-mark {url}");
-        if seen_copyrights.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: ln,
+            end_line: ln,
+        });
         let holder = "glyphicon-copyright-mark".to_string();
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: ln,
+            end_line: ln,
+        });
 
         copyrights.retain(|c| c.copyright != "Copyright Dalegroup");
         holders.retain(|h| h.holder != "Dalegroup");
@@ -3751,22 +3676,18 @@ pub fn extract_html_icon_class_copyrights(
             continue;
         }
         let cr = format!("Copyright glyphicon-copyright-mark {years} Rubix");
-        if seen_copyrights.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: ln,
+            end_line: ln,
+        });
 
         let holder = "glyphicon-copyright-mark Rubix".to_string();
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: ln,
-                end_line: ln,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: ln,
+            end_line: ln,
+        });
 
         let simple = format!("Copyright {years} Rubix");
         copyrights.retain(|c| c.copyright != simple);
@@ -3776,9 +3697,7 @@ pub fn extract_html_icon_class_copyrights(
 
 pub fn extract_copyright_year_c_name_angle_email_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_YEAR_C_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^copyright\s+(?P<year>19\d{2}|20\d{2})\s+\(c\)\s+(?P<name>.+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s*$",
@@ -3786,9 +3705,8 @@ pub fn extract_copyright_year_c_name_angle_email_lines(
         .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         for (ln, line) in group {
@@ -3807,9 +3725,7 @@ pub fn extract_copyright_year_c_name_angle_email_lines(
             }
 
             let raw = format!("Copyright {year} (c) {name} <{email}>");
-            if let Some(cr) = refine_copyright(&raw)
-                && seen_copyrights.insert(cr.clone())
-            {
+            if let Some(cr) = refine_copyright(&raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3817,9 +3733,7 @@ pub fn extract_copyright_year_c_name_angle_email_lines(
                 });
             }
 
-            if let Some(h) = refine_holder_in_copyright_context(name)
-                && seen_holders.insert(h.clone())
-            {
+            if let Some(h) = refine_holder_in_copyright_context(name) {
                 holders.push(HolderDetection {
                     holder: h,
                     start_line: LineNumber::new(*ln).expect("invalid line number"),
@@ -3828,21 +3742,20 @@ pub fn extract_copyright_year_c_name_angle_email_lines(
             }
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_copyright_by_without_year_lines(
     groups: &[Vec<(usize, String)>],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPYRIGHT_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)\bcopyright\s+by\s+(?P<who>.+?)(?:\s+all\s+rights\s+reserved\b|\.|$)")
             .unwrap()
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
 
     for group in groups {
         if group.is_empty() {
@@ -3873,19 +3786,15 @@ pub fn extract_copyright_by_without_year_lines(
             continue;
         }
         let cr = format!("copyright by {who}");
-        if seen_copyrights.insert(cr.clone()) {
-            let start_line = group.first().map(|(n, _)| *n).unwrap_or(1);
-            let end_line = group.last().map(|(n, _)| *n).unwrap_or(start_line);
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: LineNumber::new(start_line).expect("valid"),
-                end_line: LineNumber::new(end_line).expect("valid"),
-            });
-        }
+        let start_line = group.first().map(|(n, _)| *n).unwrap_or(1);
+        let end_line = group.last().map(|(n, _)| *n).unwrap_or(start_line);
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: LineNumber::new(start_line).expect("valid"),
+            end_line: LineNumber::new(end_line).expect("valid"),
+        });
 
-        if let Some(holder) = refine_holder_in_copyright_context(who)
-            && seen_holders.insert(holder.clone())
-        {
+        if let Some(holder) = refine_holder_in_copyright_context(who) {
             let start_line = group.first().map(|(n, _)| *n).unwrap_or(1);
             let end_line = group.last().map(|(n, _)| *n).unwrap_or(start_line);
             holders.push(HolderDetection {
@@ -3895,6 +3804,8 @@ pub fn extract_copyright_by_without_year_lines(
             });
         }
     }
+
+    (copyrights, holders)
 }
 
 pub fn drop_shadowed_and_or_holders(holders: &mut Vec<HolderDetection>) {

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -2673,7 +2673,7 @@ pub fn extract_developed_at_software_copyrights(
             prepared_line.line_number,
             prepared_line.prepared.to_string(),
         )];
-        if let Some(next) = prepared_cache.line(prepared_line.line_number + 1usize)
+        if let Some(next) = prepared_cache.line(prepared_line.line_number.next())
             && !next.prepared.is_empty()
         {
             candidates.push((
@@ -2782,14 +2782,13 @@ pub fn extract_confidential_proprietary_copyrights(
             if year.is_empty() || tag.is_empty() {
                 continue;
             }
-            let Some(next_clean) =
-                prepared_cache
-                    .line(prepared_line.line_number + 1usize)
-                    .map(|p| {
-                        p.prepared
-                            .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
-                            .to_string()
-                    })
+            let Some(next_clean) = prepared_cache
+                .line(prepared_line.line_number.next())
+                .map(|p| {
+                    p.prepared
+                        .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+                        .to_string()
+                })
             else {
                 continue;
             };
@@ -2799,7 +2798,7 @@ pub fn extract_confidential_proprietary_copyrights(
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
                         start_line: prepared_line.line_number,
-                        end_line: prepared_line.line_number + 1usize,
+                        end_line: prepared_line.line_number.next(),
                     });
                 }
                 let holder_raw = format!("{tag} {next_clean}");
@@ -2807,7 +2806,7 @@ pub fn extract_confidential_proprietary_copyrights(
                     holders.push(HolderDetection {
                         holder: h,
                         start_line: prepared_line.line_number,
-                        end_line: prepared_line.line_number + 1usize,
+                        end_line: prepared_line.line_number.next(),
                     });
                 }
             }
@@ -2819,14 +2818,13 @@ pub fn extract_confidential_proprietary_copyrights(
             if year.is_empty() || base_holder.is_empty() {
                 continue;
             }
-            let Some(next_clean) =
-                prepared_cache
-                    .line(prepared_line.line_number + 1usize)
-                    .map(|p| {
-                        p.prepared
-                            .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
-                            .to_string()
-                    })
+            let Some(next_clean) = prepared_cache
+                .line(prepared_line.line_number.next())
+                .map(|p| {
+                    p.prepared
+                        .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+                        .to_string()
+                })
             else {
                 continue;
             };
@@ -2836,7 +2834,7 @@ pub fn extract_confidential_proprietary_copyrights(
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
                         start_line: prepared_line.line_number,
-                        end_line: prepared_line.line_number + 1usize,
+                        end_line: prepared_line.line_number.next(),
                     });
                 }
 
@@ -2850,7 +2848,7 @@ pub fn extract_confidential_proprietary_copyrights(
                     holders.push(HolderDetection {
                         holder: h,
                         start_line: prepared_line.line_number,
-                        end_line: prepared_line.line_number + 1usize,
+                        end_line: prepared_line.line_number.next(),
                     });
                 }
             }

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use crate::copyright::candidates::versioned_banner_holder_from_prepared;
-use crate::copyright::line_tracking::{LineNumberIndex, PreparedLineCache};
+use crate::copyright::line_tracking::{LineNumberIndex, PreparedLines};
 use crate::copyright::refiner::{
     refine_copyright, refine_holder, refine_holder_in_copyright_context,
 };
@@ -162,7 +162,7 @@ pub fn extract_html_meta_name_copyright_content(
 }
 
 pub fn extract_added_the_copyright_year_for_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static ADDED_COPYRIGHT_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -824,7 +824,7 @@ pub fn extract_copyright_years_by_name_paren_email_lines(
 }
 
 pub fn extract_copyright_years_by_name_then_paren_email_next_line(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -1424,7 +1424,7 @@ pub fn extract_copyright_c_years_holder_lines(
 }
 
 pub fn extract_three_digit_copyright_year_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1496,7 +1496,7 @@ pub fn extract_three_digit_copyright_year_lines(
 }
 
 pub fn extract_copyrighted_by_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1572,7 +1572,7 @@ pub fn extract_copyrighted_by_lines(
 }
 
 pub fn extract_c_word_year_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1654,7 +1654,7 @@ pub fn extract_c_word_year_lines(
 }
 
 pub fn extract_are_c_year_holder_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1735,7 +1735,7 @@ pub fn extract_are_c_year_holder_lines(
 }
 
 pub fn extract_bare_c_by_holder_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1799,7 +1799,7 @@ pub fn extract_bare_c_by_holder_lines(
 }
 
 pub fn extract_all_rights_reserved_by_holder_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -1867,7 +1867,7 @@ pub fn extract_all_rights_reserved_by_holder_lines(
 }
 
 pub fn extract_holder_is_name_paren_email_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
@@ -2645,7 +2645,7 @@ pub fn strip_trailing_c_year_suffix_from_comma_and_others(copyrights: &mut [Copy
 }
 
 pub fn extract_name_before_rewrited_by_copyrights(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static NAME_EMAIL_YEARS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -2737,7 +2737,7 @@ pub fn extract_name_before_rewrited_by_copyrights(
 }
 
 pub fn extract_developed_at_software_copyrights(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static DEVELOPED_AT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -2792,7 +2792,7 @@ pub fn extract_developed_at_software_copyrights(
 }
 
 pub fn extract_confidential_proprietary_copyrights(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -14,7 +14,7 @@ use crate::copyright::refiner::{
 use crate::copyright::types::{CopyrightDetection, HolderDetection};
 use crate::models::LineNumber;
 
-use super::token_utils::normalize_whitespace;
+use super::token_utils::{group_by, normalize_whitespace};
 
 pub fn extract_glide_3dfx_copyright_notice(content: &str) -> Vec<CopyrightDetection> {
     static GLIDE_3DFX_COPYRIGHT_NOTICE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -3813,32 +3813,32 @@ pub fn drop_shadowed_and_or_holders(holders: &mut Vec<HolderDetection>) {
         return;
     }
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .push(h.holder.clone());
-    }
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let short = h.holder.as_str();
+                let shadow_prefix = format!("{short} and/or ");
 
-    holders.retain(|h| {
-        let Some(group) = by_span.get(&(h.start_line.get(), h.end_line.get())) else {
-            return true;
-        };
+                let is_shadowed = group_texts.iter().any(|other| {
+                    other.len() > short.len()
+                        && other.starts_with(&shadow_prefix)
+                        && other[shadow_prefix.len()..]
+                            .to_lowercase()
+                            .starts_with("its ")
+                });
 
-        let short = h.holder.as_str();
-        let shadow_prefix = format!("{short} and/or ");
-
-        let is_shadowed = group.iter().any(|other| {
-            other.len() > short.len()
-                && other.starts_with(&shadow_prefix)
-                && other[shadow_prefix.len()..]
-                    .to_lowercase()
-                    .starts_with("its ")
-        });
-
-        !is_shadowed
-    });
+                !is_shadowed
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_prefix_holders(holders: &mut Vec<HolderDetection>) {
@@ -3846,72 +3846,72 @@ pub fn drop_shadowed_prefix_holders(holders: &mut Vec<HolderDetection>) {
         return;
     }
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .push(h.holder.clone());
-    }
-
-    holders.retain(|h| {
-        let Some(group) = by_span.get(&(h.start_line.get(), h.end_line.get())) else {
-            return true;
-        };
-
-        let short = h.holder.trim();
-        let is_short_acronym =
-            (2..=3).contains(&short.len()) && short.chars().all(|c| c.is_ascii_uppercase());
-        if short.len() < 4 && !is_short_acronym {
-            return true;
-        }
-
-        let mut shadowed = false;
-
-        if !short.contains(',') {
-            let shadow_prefix = format!("{short}, ");
-            shadowed = group
-                .iter()
-                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix));
-        }
-
-        if !shadowed {
-            shadowed = group.iter().any(|other| {
-                other.len() > short.len()
-                    && other.starts_with(short)
-                    && other
-                        .as_bytes()
-                        .get(short.len())
-                        .is_some_and(|b| *b == b',')
-            });
-        }
-
-        if !shadowed {
-            shadowed = group.iter().any(|other| {
-                if other.len() <= short.len() {
-                    return false;
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let short = h.holder.trim();
+                let is_short_acronym =
+                    (2..=3).contains(&short.len()) && short.chars().all(|c| c.is_ascii_uppercase());
+                if short.len() < 4 && !is_short_acronym {
+                    return true;
                 }
-                if !other.starts_with(short) {
-                    return false;
+
+                let mut shadowed = false;
+
+                if !short.contains(',') {
+                    let shadow_prefix = format!("{short}, ");
+                    shadowed = group_texts.iter().any(|other| {
+                        other.len() > short.len() && other.starts_with(&shadow_prefix)
+                    });
                 }
-                let tail = other.get(short.len()..).unwrap_or("");
-                let tail = tail.trim_start();
-                tail.starts_with('-') || tail.starts_with('(')
-            });
-        }
 
-        if !shadowed
-            && short.split_whitespace().count() == 1
-            && short.chars().all(|c| c.is_ascii_lowercase())
-        {
-            let shadow_prefix = format!("{short} ");
-            shadowed = group
-                .iter()
-                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix));
-        }
+                if !shadowed {
+                    shadowed = group_texts.iter().any(|other| {
+                        other.len() > short.len()
+                            && other.starts_with(short)
+                            && other
+                                .as_bytes()
+                                .get(short.len())
+                                .is_some_and(|b| *b == b',')
+                    });
+                }
 
-        !shadowed
-    });
+                if !shadowed {
+                    shadowed = group_texts.iter().any(|other| {
+                        if other.len() <= short.len() {
+                            return false;
+                        }
+                        if !other.starts_with(short) {
+                            return false;
+                        }
+                        let tail = other.get(short.len()..).unwrap_or("");
+                        let tail = tail.trim_start();
+                        tail.starts_with('-') || tail.starts_with('(')
+                    });
+                }
+
+                if !shadowed
+                    && short.split_whitespace().count() == 1
+                    && short.chars().all(|c| c.is_ascii_lowercase())
+                {
+                    let shadow_prefix = format!("{short} ");
+                    shadowed = group_texts.iter().any(|other| {
+                        other.len() > short.len() && other.starts_with(&shadow_prefix)
+                    });
+                }
+
+                !shadowed
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_prefix_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
@@ -3919,98 +3919,99 @@ pub fn drop_shadowed_prefix_copyrights(copyrights: &mut Vec<CopyrightDetection>)
         return;
     }
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .push(c.copyright.clone());
-    }
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let group_texts: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                let short = c.copyright.as_str();
+                if short.len() < 10 {
+                    return true;
+                }
 
-    copyrights.retain(|c| {
-        let Some(group) = by_span.get(&(c.start_line.get(), c.end_line.get())) else {
-            return true;
-        };
-        let short = c.copyright.as_str();
-        if short.len() < 10 {
-            return true;
-        }
+                if group_texts.iter().any(|other| {
+                    if other.len() <= short.len() {
+                        return false;
+                    }
+                    if !other.starts_with(short) {
+                        return false;
+                    }
+                    let tail = other.get(short.len()..).unwrap_or("");
+                    let tail = tail.trim_start();
+                    tail.starts_with('-')
+                }) {
+                    return false;
+                }
 
-        if group.iter().any(|other| {
-            if other.len() <= short.len() {
-                return false;
-            }
-            if !other.starts_with(short) {
-                return false;
-            }
-            let tail = other.get(short.len()..).unwrap_or("");
-            let tail = tail.trim_start();
-            tail.starts_with('-')
-        }) {
-            return false;
-        }
+                if group_texts.iter().any(|other| {
+                    other.len() > short.len()
+                        && other.starts_with(short)
+                        && other
+                            .as_bytes()
+                            .get(short.len())
+                            .is_some_and(|b| *b == b',')
+                }) {
+                    return false;
+                }
+                let words: Vec<&str> = short.split_whitespace().collect();
+                if words.is_empty() {
+                    return true;
+                }
+                if !words[0].eq_ignore_ascii_case("copyright") {
+                    return true;
+                }
 
-        if group.iter().any(|other| {
-            other.len() > short.len()
-                && other.starts_with(short)
-                && other
-                    .as_bytes()
-                    .get(short.len())
-                    .is_some_and(|b| *b == b',')
-        }) {
-            return false;
-        }
-        let words: Vec<&str> = short.split_whitespace().collect();
-        if words.is_empty() {
-            return true;
-        }
-        if !words[0].eq_ignore_ascii_case("copyright") {
-            return true;
-        }
+                if words.len() == 2 {
+                    let tail = words[1];
+                    let is_acronym = (2..=10).contains(&tail.len())
+                        && tail.chars().all(|c| c.is_ascii_uppercase());
+                    if !is_acronym {
+                        return true;
+                    }
+                    let shadow_prefix_comma = format!("{short},");
+                    return !group_texts.iter().any(|other| {
+                        other.len() > short.len() && other.starts_with(&shadow_prefix_comma)
+                    });
+                }
 
-        if words.len() == 2 {
-            let tail = words[1];
-            let is_acronym =
-                (2..=10).contains(&tail.len()) && tail.chars().all(|c| c.is_ascii_uppercase());
-            if !is_acronym {
-                return true;
-            }
-            let shadow_prefix_comma = format!("{short},");
-            return !group
-                .iter()
-                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix_comma));
-        }
+                if group_texts.iter().any(|other| {
+                    if other.len() <= short.len() {
+                        return false;
+                    }
+                    if !other.starts_with(short) {
+                        return false;
+                    }
+                    let tail = other.get(short.len()..).unwrap_or("");
+                    let tail = tail.trim_start();
+                    tail.starts_with('(')
+                }) {
+                    return false;
+                }
 
-        if group.iter().any(|other| {
-            if other.len() <= short.len() {
-                return false;
-            }
-            if !other.starts_with(short) {
-                return false;
-            }
-            let tail = other.get(short.len()..).unwrap_or("");
-            let tail = tail.trim_start();
-            tail.starts_with('(')
-        }) {
-            return false;
-        }
+                if words.len() != 3 {
+                    return true;
+                }
+                if !words[2].chars().all(|c| c.is_ascii_lowercase()) {
+                    return true;
+                }
 
-        if words.len() != 3 {
-            return true;
-        }
-        if !words[2].chars().all(|c| c.is_ascii_lowercase()) {
-            return true;
-        }
-
-        !group.iter().any(|other| {
-            other.len() > short.len()
-                && other.starts_with(short)
-                && other
-                    .as_bytes()
-                    .get(short.len())
-                    .is_some_and(|b| *b == b' ')
-        })
-    });
+                !group_texts.iter().any(|other| {
+                    other.len() > short.len()
+                        && other.starts_with(short)
+                        && other
+                            .as_bytes()
+                            .get(short.len())
+                            .is_some_and(|b| *b == b' ')
+                })
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_bare_c_copyrights_same_span(copyrights: &mut Vec<CopyrightDetection>) {

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -1426,16 +1426,8 @@ pub fn extract_three_digit_copyright_year_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some(cap) = COPYRIGHT_C_3DIGIT_RE.captures(line) else {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let Some(cap) = COPYRIGHT_C_3DIGIT_RE.captures(prepared_line.prepared) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1451,21 +1443,21 @@ pub fn extract_three_digit_copyright_year_lines(
         let Some(refined) = refine_copyright(&raw) else {
             continue;
         };
-        if seen_cr.insert((ln, refined.clone())) {
+        if seen_cr.insert((prepared_line.line_number.get(), refined.clone())) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
 
         if let Some(h) = refine_holder_in_copyright_context(tail)
-            && seen_h.insert((ln, h.clone()))
+            && seen_h.insert((prepared_line.line_number.get(), h.clone()))
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -1498,19 +1490,15 @@ pub fn extract_copyrighted_by_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if line.to_ascii_lowercase().contains("not copyrighted") {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if prepared_line
+            .prepared
+            .to_ascii_lowercase()
+            .contains("not copyrighted")
+        {
             continue;
         }
-        for cap in COPYRIGHTED_BY_RE.captures_iter(line) {
+        for cap in COPYRIGHTED_BY_RE.captures_iter(prepared_line.prepared) {
             let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
             if who.is_empty() {
                 continue;
@@ -1526,21 +1514,21 @@ pub fn extract_copyrighted_by_lines(
             let Some(refined) = refine_copyright(&raw) else {
                 continue;
             };
-            if seen_cr.insert((ln, refined.clone())) {
+            if seen_cr.insert((prepared_line.line_number.get(), refined.clone())) {
                 copyrights.push(CopyrightDetection {
                     copyright: refined,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
 
             if let Some(h) = refine_holder_in_copyright_context(who)
-                && seen_h.insert((ln, h.clone()))
+                && seen_h.insert((prepared_line.line_number.get(), h.clone()))
             {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
         }
@@ -1574,19 +1562,11 @@ pub fn extract_c_word_year_lines(
     let mut copyrights = Vec::new();
     let mut holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if !prepared_line.prepared.to_ascii_lowercase().contains("(c)") {
             continue;
         }
-        if !line.to_ascii_lowercase().contains("(c)") {
-            continue;
-        }
-        for cap in C_WORD_YEAR_RE.captures_iter(line) {
+        for cap in C_WORD_YEAR_RE.captures_iter(prepared_line.prepared) {
             let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             if who.is_empty() || year.is_empty() {
@@ -1608,21 +1588,21 @@ pub fn extract_c_word_year_lines(
             let Some(refined) = refine_copyright(&raw) else {
                 continue;
             };
-            if seen_cr.insert((ln, refined.clone())) {
+            if seen_cr.insert((prepared_line.line_number.get(), refined.clone())) {
                 copyrights.push(CopyrightDetection {
                     copyright: refined,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
 
             if let Some(h) = refine_holder_in_copyright_context(who)
-                && seen_h.insert((ln, h.clone()))
+                && seen_h.insert((prepared_line.line_number.get(), h.clone()))
             {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
         }
@@ -2766,19 +2746,10 @@ pub fn extract_confidential_proprietary_copyrights(
         return;
     }
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(line) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if line.is_empty() {
-            continue;
-        }
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let line = prepared_line.prepared;
 
-        if let Some(cap) = HOLDER_C_COPYRIGHT_YEAR_RE.captures(&line) {
+        if let Some(cap) = HOLDER_C_COPYRIGHT_YEAR_RE.captures(line) {
             let holder = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             if !holder.is_empty() && !year.is_empty() {
@@ -2786,15 +2757,15 @@ pub fn extract_confidential_proprietary_copyrights(
                 if let Some(refined) = refine_copyright(&cr) {
                     copyrights.push(CopyrightDetection {
                         copyright: refined,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln).unwrap(),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number,
                     });
                 }
                 if let Some(h) = refine_holder_in_copyright_context(holder) {
                     holders.push(HolderDetection {
                         holder: h,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln).unwrap(),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number,
                     });
                 }
 
@@ -2805,17 +2776,21 @@ pub fn extract_confidential_proprietary_copyrights(
             }
         }
 
-        if let Some(cap) = ABC_LINE_RE.captures(&line) {
+        if let Some(cap) = ABC_LINE_RE.captures(line) {
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             let tag = cap.name("tag").map(|m| m.as_str()).unwrap_or("").trim();
             if year.is_empty() || tag.is_empty() {
                 continue;
             }
-            let Some(next_clean) = prepared_cache.get_by_index(idx + 1).map(|p| {
-                p.trim()
-                    .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
-                    .to_string()
-            }) else {
+            let Some(next_clean) =
+                prepared_cache
+                    .line(prepared_line.line_number + 1usize)
+                    .map(|p| {
+                        p.prepared
+                            .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+                            .to_string()
+                    })
+            else {
                 continue;
             };
             if !next_clean.is_empty() && CONFIDENTIAL_RE.is_match(&next_clean) {
@@ -2823,32 +2798,36 @@ pub fn extract_confidential_proprietary_copyrights(
                 if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number + 1usize,
                     });
                 }
                 let holder_raw = format!("{tag} {next_clean}");
                 if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
                     holders.push(HolderDetection {
                         holder: h,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number + 1usize,
                     });
                 }
             }
         }
 
-        if let Some(cap) = MOTOROLA_RE.captures(&line) {
+        if let Some(cap) = MOTOROLA_RE.captures(line) {
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             let base_holder = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
             if year.is_empty() || base_holder.is_empty() {
                 continue;
             }
-            let Some(next_clean) = prepared_cache.get_by_index(idx + 1).map(|p| {
-                p.trim()
-                    .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
-                    .to_string()
-            }) else {
+            let Some(next_clean) =
+                prepared_cache
+                    .line(prepared_line.line_number + 1usize)
+                    .map(|p| {
+                        p.prepared
+                            .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+                            .to_string()
+                    })
+            else {
                 continue;
             };
             if !next_clean.is_empty() && CONFIDENTIAL_RE.is_match(&next_clean) {
@@ -2856,8 +2835,8 @@ pub fn extract_confidential_proprietary_copyrights(
                 if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number + 1usize,
                     });
                 }
 
@@ -2870,8 +2849,8 @@ pub fn extract_confidential_proprietary_copyrights(
                 if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
                     holders.push(HolderDetection {
                         holder: h,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                        start_line: prepared_line.line_number,
+                        end_line: prepared_line.line_number + 1usize,
                     });
                 }
             }

--- a/src/copyright/detector/pattern_extract.rs
+++ b/src/copyright/detector/pattern_extract.rs
@@ -989,46 +989,29 @@ pub fn drop_url_extended_prefix_duplicates(copyrights: &mut Vec<CopyrightDetecti
 
     let has_url = |s: &str| s.contains("http://") || s.contains("https://");
 
-    let mut drop = vec![false; copyrights.len()];
-    for i in 0..copyrights.len() {
-        let shorter = &copyrights[i];
-        if has_url(&shorter.copyright) {
-            continue;
+    let with_url: Vec<_> = copyrights
+        .iter()
+        .filter(|c| has_url(&c.copyright))
+        .cloned()
+        .collect();
+
+    copyrights.retain(|c| {
+        if has_url(&c.copyright) {
+            return true;
         }
 
-        for (j, longer) in copyrights.iter().enumerate() {
-            if i == j {
-                continue;
+        with_url.iter().all(|longer| {
+            if c.start_line != longer.start_line || c.end_line > longer.end_line {
+                return true;
             }
-            if !has_url(&longer.copyright) {
-                continue;
-            }
-            if shorter.start_line != longer.start_line || shorter.end_line > longer.end_line {
-                continue;
-            }
-            if !longer.copyright.starts_with(&shorter.copyright) {
-                continue;
+            if !longer.copyright.starts_with(&c.copyright) {
+                return true;
             }
 
-            let tail = longer.copyright[shorter.copyright.len()..].trim_start();
-            if tail.starts_with('-') || tail.starts_with("http") {
-                drop[i] = true;
-                break;
-            }
-        }
-    }
-
-    if drop.iter().all(|d| !*d) {
-        return;
-    }
-
-    let mut kept = Vec::with_capacity(copyrights.len());
-    for (i, c) in copyrights.iter().cloned().enumerate() {
-        if !drop[i] {
-            kept.push(c);
-        }
-    }
-    *copyrights = kept;
+            let tail = longer.copyright[c.copyright.len()..].trim_start();
+            !tail.starts_with('-') && !tail.starts_with("http")
+        })
+    });
 }
 
 pub fn extract_standalone_c_holder_year_lines(
@@ -3813,32 +3796,27 @@ pub fn drop_shadowed_and_or_holders(holders: &mut Vec<HolderDetection>) {
         return;
     }
 
-    *holders = group_by(std::mem::take(holders), |h| {
-        (h.start_line.get(), h.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
-        group
+    let by_span: HashMap<(usize, usize), Vec<String>> =
+        group_by(holders.clone(), |h| (h.start_line.get(), h.end_line.get()))
             .into_iter()
-            .filter(|h| {
-                let short = h.holder.as_str();
-                let shadow_prefix = format!("{short} and/or ");
+            .map(|(span, group)| (span, group.into_iter().map(|h| h.holder).collect()))
+            .collect();
 
-                let is_shadowed = group_texts.iter().any(|other| {
-                    other.len() > short.len()
-                        && other.starts_with(&shadow_prefix)
-                        && other[shadow_prefix.len()..]
-                            .to_lowercase()
-                            .starts_with("its ")
-                });
+    holders.retain(|h| {
+        let short = h.holder.as_str();
+        let shadow_prefix = format!("{short} and/or ");
+        let span = (h.start_line.get(), h.end_line.get());
 
-                !is_shadowed
+        !by_span.get(&span).is_some_and(|group_texts| {
+            group_texts.iter().any(|other| {
+                other.len() > short.len()
+                    && other.starts_with(&shadow_prefix)
+                    && other[shadow_prefix.len()..]
+                        .to_lowercase()
+                        .starts_with("its ")
             })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+        })
+    });
 }
 
 pub fn drop_shadowed_prefix_holders(holders: &mut Vec<HolderDetection>) {
@@ -3846,72 +3824,67 @@ pub fn drop_shadowed_prefix_holders(holders: &mut Vec<HolderDetection>) {
         return;
     }
 
-    *holders = group_by(std::mem::take(holders), |h| {
-        (h.start_line.get(), h.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
-        group
+    let by_span: HashMap<(usize, usize), Vec<String>> =
+        group_by(holders.clone(), |h| (h.start_line.get(), h.end_line.get()))
             .into_iter()
-            .filter(|h| {
-                let short = h.holder.trim();
-                let is_short_acronym =
-                    (2..=3).contains(&short.len()) && short.chars().all(|c| c.is_ascii_uppercase());
-                if short.len() < 4 && !is_short_acronym {
-                    return true;
+            .map(|(span, group)| (span, group.into_iter().map(|h| h.holder).collect()))
+            .collect();
+
+    holders.retain(|h| {
+        let short = h.holder.trim();
+        let is_short_acronym =
+            (2..=3).contains(&short.len()) && short.chars().all(|c| c.is_ascii_uppercase());
+        if short.len() < 4 && !is_short_acronym {
+            return true;
+        }
+
+        let span = (h.start_line.get(), h.end_line.get());
+        let Some(group_texts) = by_span.get(&span) else {
+            return true;
+        };
+
+        let mut shadowed = false;
+
+        if !short.contains(',') {
+            let shadow_prefix = format!("{short}, ");
+            shadowed = group_texts
+                .iter()
+                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix));
+        }
+
+        if !shadowed {
+            shadowed = group_texts.iter().any(|other| {
+                other.len() > short.len()
+                    && other.starts_with(short)
+                    && other
+                        .as_bytes()
+                        .get(short.len())
+                        .is_some_and(|b| *b == b',')
+            });
+        }
+
+        if !shadowed {
+            shadowed = group_texts.iter().any(|other| {
+                if other.len() <= short.len() || !other.starts_with(short) {
+                    return false;
                 }
+                let tail = other.get(short.len()..).unwrap_or("").trim_start();
+                tail.starts_with('-') || tail.starts_with('(')
+            });
+        }
 
-                let mut shadowed = false;
+        if !shadowed
+            && short.split_whitespace().count() == 1
+            && short.chars().all(|c| c.is_ascii_lowercase())
+        {
+            let shadow_prefix = format!("{short} ");
+            shadowed = group_texts
+                .iter()
+                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix));
+        }
 
-                if !short.contains(',') {
-                    let shadow_prefix = format!("{short}, ");
-                    shadowed = group_texts.iter().any(|other| {
-                        other.len() > short.len() && other.starts_with(&shadow_prefix)
-                    });
-                }
-
-                if !shadowed {
-                    shadowed = group_texts.iter().any(|other| {
-                        other.len() > short.len()
-                            && other.starts_with(short)
-                            && other
-                                .as_bytes()
-                                .get(short.len())
-                                .is_some_and(|b| *b == b',')
-                    });
-                }
-
-                if !shadowed {
-                    shadowed = group_texts.iter().any(|other| {
-                        if other.len() <= short.len() {
-                            return false;
-                        }
-                        if !other.starts_with(short) {
-                            return false;
-                        }
-                        let tail = other.get(short.len()..).unwrap_or("");
-                        let tail = tail.trim_start();
-                        tail.starts_with('-') || tail.starts_with('(')
-                    });
-                }
-
-                if !shadowed
-                    && short.split_whitespace().count() == 1
-                    && short.chars().all(|c| c.is_ascii_lowercase())
-                {
-                    let shadow_prefix = format!("{short} ");
-                    shadowed = group_texts.iter().any(|other| {
-                        other.len() > short.len() && other.starts_with(&shadow_prefix)
-                    });
-                }
-
-                !shadowed
-            })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+        !shadowed
+    });
 }
 
 pub fn drop_shadowed_prefix_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
@@ -3919,99 +3892,86 @@ pub fn drop_shadowed_prefix_copyrights(copyrights: &mut Vec<CopyrightDetection>)
         return;
     }
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| {
+    let by_span: HashMap<(usize, usize), Vec<String>> = group_by(copyrights.clone(), |c| {
         (c.start_line.get(), c.end_line.get())
     })
     .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let group_texts: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
-        group
-            .into_iter()
-            .filter(|c| {
-                let short = c.copyright.as_str();
-                if short.len() < 10 {
-                    return true;
-                }
-
-                if group_texts.iter().any(|other| {
-                    if other.len() <= short.len() {
-                        return false;
-                    }
-                    if !other.starts_with(short) {
-                        return false;
-                    }
-                    let tail = other.get(short.len()..).unwrap_or("");
-                    let tail = tail.trim_start();
-                    tail.starts_with('-')
-                }) {
-                    return false;
-                }
-
-                if group_texts.iter().any(|other| {
-                    other.len() > short.len()
-                        && other.starts_with(short)
-                        && other
-                            .as_bytes()
-                            .get(short.len())
-                            .is_some_and(|b| *b == b',')
-                }) {
-                    return false;
-                }
-                let words: Vec<&str> = short.split_whitespace().collect();
-                if words.is_empty() {
-                    return true;
-                }
-                if !words[0].eq_ignore_ascii_case("copyright") {
-                    return true;
-                }
-
-                if words.len() == 2 {
-                    let tail = words[1];
-                    let is_acronym = (2..=10).contains(&tail.len())
-                        && tail.chars().all(|c| c.is_ascii_uppercase());
-                    if !is_acronym {
-                        return true;
-                    }
-                    let shadow_prefix_comma = format!("{short},");
-                    return !group_texts.iter().any(|other| {
-                        other.len() > short.len() && other.starts_with(&shadow_prefix_comma)
-                    });
-                }
-
-                if group_texts.iter().any(|other| {
-                    if other.len() <= short.len() {
-                        return false;
-                    }
-                    if !other.starts_with(short) {
-                        return false;
-                    }
-                    let tail = other.get(short.len()..).unwrap_or("");
-                    let tail = tail.trim_start();
-                    tail.starts_with('(')
-                }) {
-                    return false;
-                }
-
-                if words.len() != 3 {
-                    return true;
-                }
-                if !words[2].chars().all(|c| c.is_ascii_lowercase()) {
-                    return true;
-                }
-
-                !group_texts.iter().any(|other| {
-                    other.len() > short.len()
-                        && other.starts_with(short)
-                        && other
-                            .as_bytes()
-                            .get(short.len())
-                            .is_some_and(|b| *b == b' ')
-                })
-            })
-            .collect::<Vec<_>>()
-    })
+    .map(|(span, group)| (span, group.into_iter().map(|c| c.copyright).collect()))
     .collect();
+
+    copyrights.retain(|c| {
+        let short = c.copyright.as_str();
+        if short.len() < 10 {
+            return true;
+        }
+
+        let span = (c.start_line.get(), c.end_line.get());
+        let Some(group_texts) = by_span.get(&span) else {
+            return true;
+        };
+
+        if group_texts.iter().any(|other| {
+            if other.len() <= short.len() || !other.starts_with(short) {
+                return false;
+            }
+            let tail = other.get(short.len()..).unwrap_or("").trim_start();
+            tail.starts_with('-')
+        }) {
+            return false;
+        }
+
+        if group_texts.iter().any(|other| {
+            other.len() > short.len()
+                && other.starts_with(short)
+                && other
+                    .as_bytes()
+                    .get(short.len())
+                    .is_some_and(|b| *b == b',')
+        }) {
+            return false;
+        }
+
+        let words: Vec<&str> = short.split_whitespace().collect();
+        if words.is_empty() || !words[0].eq_ignore_ascii_case("copyright") {
+            return true;
+        }
+
+        if words.len() == 2 {
+            let tail = words[1];
+            let is_acronym =
+                (2..=10).contains(&tail.len()) && tail.chars().all(|c| c.is_ascii_uppercase());
+            if !is_acronym {
+                return true;
+            }
+            let shadow_prefix_comma = format!("{short},");
+            return !group_texts
+                .iter()
+                .any(|other| other.len() > short.len() && other.starts_with(&shadow_prefix_comma));
+        }
+
+        if group_texts.iter().any(|other| {
+            if other.len() <= short.len() || !other.starts_with(short) {
+                return false;
+            }
+            let tail = other.get(short.len()..).unwrap_or("").trim_start();
+            tail.starts_with('(')
+        }) {
+            return false;
+        }
+
+        if words.len() != 3 || !words[2].chars().all(|c| c.is_ascii_lowercase()) {
+            return true;
+        }
+
+        !group_texts.iter().any(|other| {
+            other.len() > short.len()
+                && other.starts_with(short)
+                && other
+                    .as_bytes()
+                    .get(short.len())
+                    .is_some_and(|b| *b == b' ')
+        })
+    });
 }
 
 pub fn drop_shadowed_bare_c_copyrights_same_span(copyrights: &mut Vec<CopyrightDetection>) {

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::copyright::line_tracking::PreparedLineCache;
+use crate::copyright::line_tracking::PreparedLines;
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 
 use super::seen_text::SeenTextSets;
@@ -10,7 +10,7 @@ use super::seen_text::SeenTextSets;
 pub(super) fn run_phase_postprocess(
     content: &str,
     raw_lines: &[&str],
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     did_expand_href: bool,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -34,9 +34,11 @@ pub(super) fn run_phase_postprocess(
     seen.rebuild_holders_from(holders);
 
     super::postprocess_transforms::split_embedded_copyright_detections(copyrights, holders);
-    super::postprocess_transforms::add_missing_holders_from_email_bearing_copyrights(
-        copyrights, holders,
+    let new_h = super::postprocess_transforms::add_missing_holders_from_email_bearing_copyrights(
+        &copyrights[..],
+        &holders[..],
     );
+    holders.extend(new_h);
     super::postprocess_transforms::extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
         prepared_cache,
         copyrights,
@@ -45,9 +47,11 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::replace_holders_with_embedded_c_year_markers(
         copyrights, holders,
     );
-    super::postprocess_transforms::add_missing_holders_for_debian_modifications(
-        content, copyrights, holders,
+    let new_h = super::postprocess_transforms::add_missing_holders_for_debian_modifications(
+        content,
+        &copyrights[..],
     );
+    holders.extend(new_h);
     super::postprocess_transforms::fix_sundry_contributors_truncation(
         prepared_cache,
         copyrights,
@@ -411,7 +415,13 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::drop_shadowed_year_prefixed_holders(holders);
 
     super::postprocess_transforms::truncate_lonely_svox_baslerstr_address(copyrights, holders);
-    super::postprocess_transforms::add_short_svox_baslerstr_variants(copyrights, holders);
+    let (new_c, new_h) = super::postprocess_transforms::add_short_svox_baslerstr_variants(
+        &copyrights[..],
+        &holders[..],
+        seen,
+    );
+    copyrights.extend(new_c);
+    holders.extend(new_h);
 
     super::postprocess_transforms::drop_shadowed_year_only_copyright_prefixes_same_start_line(
         copyrights,
@@ -422,34 +432,64 @@ pub(super) fn run_phase_postprocess(
         copyrights,
     );
 
-    super::postprocess_transforms::add_embedded_copyright_clause_variants(copyrights);
-    super::postprocess_transforms::add_found_at_short_variants(copyrights, holders);
+    let new_c =
+        super::postprocess_transforms::add_embedded_copyright_clause_variants(&copyrights[..]);
+    copyrights.extend(new_c);
+    let (new_c, new_h) =
+        super::postprocess_transforms::add_found_at_short_variants(&copyrights[..], &holders[..]);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
     super::postprocess_transforms::drop_shadowed_linux_foundation_holder_copyrights_same_line(
         copyrights,
     );
-    super::postprocess_transforms::add_bare_email_variants_for_escaped_angle_lines(
-        raw_lines, copyrights,
+    let new_c = super::postprocess_transforms::add_bare_email_variants_for_escaped_angle_lines(
+        raw_lines,
+        &copyrights[..],
     );
+    copyrights.extend(new_c);
     super::postprocess_transforms::drop_comma_holders_shadowed_by_space_version_same_span(holders);
     super::postprocess_transforms::normalize_company_suffix_period_holder_variants(holders);
-    super::postprocess_transforms::add_confidential_short_variants_late(copyrights, holders);
-    super::postprocess_transforms::add_karlsruhe_university_short_variants(copyrights, holders);
-    super::postprocess_transforms::add_intel_and_sun_non_portions_variants(
-        prepared_cache,
-        copyrights,
+    let (new_c, new_h) = super::postprocess_transforms::add_confidential_short_variants_late(
+        &copyrights[..],
+        &holders[..],
     );
-    super::postprocess_transforms::add_pipe_read_parenthetical_variants(prepared_cache, copyrights);
-    super::postprocess_transforms::add_from_url_parenthetical_copyright_variants(
-        prepared_cache,
-        copyrights,
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+    let (new_c, new_h) = super::postprocess_transforms::add_karlsruhe_university_short_variants(
+        &copyrights[..],
+        &holders[..],
     );
-    super::postprocess_transforms::add_at_affiliation_short_variants(copyrights, holders);
-    super::postprocess_transforms::add_but_suffix_short_variants(copyrights);
-    super::postprocess_transforms::add_missing_copyrights_for_holder_lines_with_emails(
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+    let new_c = super::postprocess_transforms::add_intel_and_sun_non_portions_variants(
         prepared_cache,
-        copyrights,
-        holders,
+        &copyrights[..],
     );
+    copyrights.extend(new_c);
+    let new_c = super::postprocess_transforms::add_pipe_read_parenthetical_variants(
+        prepared_cache,
+        &copyrights[..],
+    );
+    copyrights.extend(new_c);
+    let new_c = super::postprocess_transforms::add_from_url_parenthetical_copyright_variants(
+        prepared_cache,
+        &copyrights[..],
+    );
+    copyrights.extend(new_c);
+    let (new_c, new_h) = super::postprocess_transforms::add_at_affiliation_short_variants(
+        &copyrights[..],
+        &holders[..],
+    );
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+    let new_c = super::postprocess_transforms::add_but_suffix_short_variants(&copyrights[..]);
+    copyrights.extend(new_c);
+    let new_c = super::postprocess_transforms::add_missing_copyrights_for_holder_lines_with_emails(
+        prepared_cache,
+        &copyrights[..],
+        &holders[..],
+    );
+    copyrights.extend(new_c);
     super::postprocess_transforms::extend_inline_obfuscated_angle_email_suffixes(
         prepared_cache,
         copyrights,
@@ -457,10 +497,15 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::strip_lone_obfuscated_angle_email_user_tokens(
         raw_lines, copyrights, holders,
     );
-    super::postprocess_transforms::add_at_domain_variants_for_short_net_angle_emails(
+    let new_c = super::postprocess_transforms::add_at_domain_variants_for_short_net_angle_emails(
         prepared_cache,
-        copyrights,
+        &copyrights[..],
     );
+    copyrights.extend(new_c);
+
+    super::postprocess_transforms::dedupe_exact_span_copyrights(copyrights);
+    super::postprocess_transforms::dedupe_exact_span_holders(holders);
+
     super::postprocess_transforms::normalize_french_support_disclaimer_copyrights(
         copyrights, holders,
     );
@@ -481,13 +526,22 @@ pub(super) fn run_phase_postprocess(
         copyrights,
         holders,
     );
-    super::postprocess_transforms::add_first_angle_email_only_variants(copyrights);
+    let new_c = super::postprocess_transforms::add_first_angle_email_only_variants(&copyrights[..]);
+    copyrights.extend(new_c);
     super::postprocess_transforms::drop_shadowed_angle_email_prefix_copyrights_same_span(
         copyrights,
     );
     super::postprocess_transforms::drop_shadowed_quote_before_email_variants_same_span(copyrights);
     super::postprocess_transforms::drop_url_embedded_suffix_variants_same_span(copyrights, holders);
-    super::postprocess_transforms::add_missing_holder_from_single_copyright(copyrights, holders);
+    if let Some(h) = super::postprocess_transforms::add_missing_holder_from_single_copyright(
+        &copyrights[..],
+        &holders[..],
+    ) {
+        holders.push(h);
+    }
+
+    super::postprocess_transforms::dedupe_exact_span_copyrights(copyrights);
+    super::postprocess_transforms::dedupe_exact_span_holders(holders);
 
     super::postprocess_transforms::drop_shadowed_acronym_location_suffix_copyrights_same_span(
         copyrights,

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -76,9 +76,8 @@ pub(super) fn run_phase_postprocess(
 
     let a_before_markup = authors.len();
     super::author_heuristics::extract_markup_authors(content, authors);
-    for a in &authors[a_before_markup..] {
-        seen.authors.insert(a.author.clone());
-    }
+    seen.authors
+        .extend(authors[a_before_markup..].iter().map(|a| a.author.clone()));
 
     let mut new_a = super::author_heuristics::extract_rst_field_authors(prepared_cache);
     seen.dedup_new_authors(&mut new_a, 0);

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -4,6 +4,9 @@
 use crate::copyright::line_tracking::PreparedLineCache;
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 
+use super::seen_text::SeenTextSets;
+
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_phase_postprocess(
     content: &str,
     raw_lines: &[&str],
@@ -12,12 +15,14 @@ pub(super) fn run_phase_postprocess(
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
     authors: &mut Vec<AuthorDetection>,
+    seen: &mut SeenTextSets,
 ) {
-    super::postprocess_transforms::extract_question_mark_year_copyrights(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
+    let (mut new_c, mut new_h) =
+        super::postprocess_transforms::extract_question_mark_year_copyrights(prepared_cache);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
 
     if super::pattern_extract::is_lppl_license_document(content) {
         holders.retain(|h| h.holder != "M. Y.");
@@ -25,6 +30,8 @@ pub(super) fn run_phase_postprocess(
 
     super::pattern_extract::drop_arch_floppy_h_bare_1995(content, copyrights);
     super::pattern_extract::drop_batman_adv_contributors_copyright(content, copyrights, holders);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
 
     super::postprocess_transforms::split_embedded_copyright_detections(copyrights, holders);
     super::postprocess_transforms::add_missing_holders_from_email_bearing_copyrights(
@@ -54,45 +61,158 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::drop_url_embedded_c_symbol_false_positive_holders(
         content, holders,
     );
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::recover_template_literal_year_range_copyrights(
         content, copyrights, holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
 
+    let a_before_markup = authors.len();
     super::author_heuristics::extract_markup_authors(content, authors);
-    super::author_heuristics::extract_rst_field_authors(prepared_cache, authors);
-    super::author_heuristics::extract_toml_author_assignment_authors(raw_lines, authors);
+    for a in &authors[a_before_markup..] {
+        seen.authors.insert(a.author.clone());
+    }
+
+    let mut new_a = super::author_heuristics::extract_rst_field_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_toml_author_assignment_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let a_before = authors.len();
     super::author_heuristics::merge_metadata_author_and_email_lines(prepared_cache, authors);
-    super::author_heuristics::extract_debian_maintainer_authors(prepared_cache, authors);
-    super::author_heuristics::extract_maintainers_label_authors(prepared_cache, authors);
-    super::author_heuristics::extract_maintained_by_authors(prepared_cache, authors);
-    super::author_heuristics::extract_package_comment_named_authors(prepared_cache, authors);
-    super::author_heuristics::extract_created_by_project_author(prepared_cache, authors);
+    seen.dedup_new_authors(authors, a_before);
+
+    let mut new_a = super::author_heuristics::extract_debian_maintainer_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_maintainers_label_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_maintained_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_package_comment_named_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_created_by_project_author(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let a_before = authors.len();
     super::author_heuristics::extract_created_by_authors(prepared_cache, authors);
+    seen.dedup_new_authors(authors, a_before);
+    seen.rebuild_authors_from(authors);
+
+    let a_before = authors.len();
     super::author_heuristics::extract_written_by_comma_and_copyright_authors(
         prepared_cache,
         authors,
     );
+    seen.dedup_new_authors(authors, a_before);
+    seen.rebuild_authors_from(authors);
+
+    let a_before = authors.len();
     super::author_heuristics::extract_multiline_written_by_author_blocks(prepared_cache, authors);
-    super::author_heuristics::extract_name_contributed_authors(prepared_cache, authors);
-    super::author_heuristics::extract_dash_bullet_attribution_authors(prepared_cache, authors);
-    super::author_heuristics::extract_json_excerpt_developed_by_authors(content, authors);
-    super::author_heuristics::extract_modified_portion_developed_by_authors(content, authors);
-    super::author_heuristics::extract_was_developed_by_author_blocks(prepared_cache, authors);
-    super::author_heuristics::extract_developed_by_sentence_authors(prepared_cache, authors);
-    super::author_heuristics::extract_developed_by_phrase_authors(prepared_cache, authors);
-    super::author_heuristics::extract_developed_by_contributors_authors(prepared_cache, authors);
-    super::author_heuristics::extract_with_additional_hacking_by_authors(prepared_cache, authors);
-    super::author_heuristics::extract_parenthesized_inline_by_authors(raw_lines, authors);
+    seen.dedup_new_authors(authors, a_before);
+    seen.rebuild_authors_from(authors);
+
+    let mut new_a = super::author_heuristics::extract_name_contributed_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_dash_bullet_attribution_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_json_excerpt_developed_by_authors(content);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_modified_portion_developed_by_authors(content);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_was_developed_by_author_blocks(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_developed_by_sentence_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_developed_by_phrase_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_developed_by_contributors_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_with_additional_hacking_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_parenthesized_inline_by_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let a_before = authors.len();
     super::author_heuristics::extract_developed_and_created_by_authors(prepared_cache, authors);
+    seen.dedup_new_authors(authors, a_before);
+    seen.rebuild_authors_from(authors);
+
+    let a_before = authors.len();
     super::author_heuristics::extract_author_colon_blocks(prepared_cache, authors);
-    super::author_heuristics::extract_module_author_macros(content, copyrights, holders, authors);
-    super::author_heuristics::extract_code_written_by_author_blocks(prepared_cache, authors);
-    super::author_heuristics::extract_converted_to_by_authors(prepared_cache, authors);
-    super::author_heuristics::extract_various_bugfixes_and_enhancements_by_authors(
-        prepared_cache,
-        authors,
+    seen.dedup_new_authors(authors, a_before);
+    seen.rebuild_authors_from(authors);
+
+    let (mut new_c, mut new_h, mut new_a) = super::author_heuristics::extract_module_author_macros(
+        content,
+        &copyrights[..],
+        &holders[..],
     );
-    super::author_heuristics::extract_dense_name_email_author_lists(prepared_cache, authors);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    seen.dedup_new_authors(&mut new_a, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_code_written_by_author_blocks(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_converted_to_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+    seen.rebuild_authors_from(authors);
+
+    let mut new_a = super::author_heuristics::extract_various_bugfixes_and_enhancements_by_authors(
+        prepared_cache,
+    );
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+    seen.rebuild_authors_from(authors);
+
+    let mut new_a = super::author_heuristics::extract_dense_name_email_author_lists(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     super::author_heuristics::drop_author_colon_lines_absorbed_into_year_only_copyrights(
         prepared_cache,
         copyrights,
@@ -101,12 +221,14 @@ pub(super) fn run_phase_postprocess(
     super::author_heuristics::drop_authors_embedded_in_copyrights(copyrights, authors);
     super::author_heuristics::drop_authors_from_copyright_by_lines(prepared_cache, authors);
     super::author_heuristics::drop_merged_dash_bullet_attribution_authors(authors);
+    seen.rebuild_authors_from(authors);
     super::postprocess_transforms::drop_created_by_camelcase_identifier_authors(
         prepared_cache,
         authors,
     );
     super::author_heuristics::drop_shadowed_compound_email_authors(authors);
     super::author_heuristics::drop_shadowed_prefix_authors(authors);
+    seen.rebuild_authors_from(authors);
 
     super::postprocess_transforms::merge_implemented_by_lines(
         prepared_cache,
@@ -125,16 +247,26 @@ pub(super) fn run_phase_postprocess(
         authors,
     );
     super::author_heuristics::drop_ref_markup_authors(authors);
-    super::author_heuristics::extract_json_author_object_authors(raw_lines, authors);
-    super::author_heuristics::normalize_json_blob_authors(raw_lines, authors);
+    seen.rebuild_authors_from(authors);
 
-    super::postprocess_transforms::extract_following_authors_holders(
-        raw_lines,
-        prepared_cache,
-        authors,
-    );
+    let mut new_a = super::author_heuristics::extract_json_author_object_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    super::author_heuristics::normalize_json_blob_authors(raw_lines, authors);
+    seen.authors = authors.iter().map(|a| a.author.clone()).collect();
+
+    let mut new_a =
+        super::postprocess_transforms::extract_following_authors_holders(raw_lines, prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     super::author_heuristics::drop_json_code_example_authors(raw_lines, authors);
-    super::author_heuristics::extract_name_contributed_authors(prepared_cache, authors);
+    seen.rebuild_authors_from(authors);
+
+    let mut new_a = super::author_heuristics::extract_name_contributed_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
 
     super::postprocess_transforms::merge_multiline_copyrighted_by_with_trailing_copyright_clause(
         did_expand_href,
@@ -152,13 +284,29 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::drop_symbol_year_only_copyrights(content, copyrights);
 
     super::postprocess_transforms::drop_from_source_attribution_copyrights(copyrights, holders);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
 
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::fix_shm_inline_copyrights(prepared_cache, copyrights, holders);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::fix_n_tty_linus_torvalds_written_by_clause(
         content, copyrights, holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
 
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::merge_freebird_c_inc_urls(prepared_cache, copyrights, holders);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
     super::postprocess_transforms::merge_debugging390_best_viewed_suffix(
         prepared_cache,
         copyrights,
@@ -166,35 +314,67 @@ pub(super) fn run_phase_postprocess(
     );
     super::postprocess_transforms::merge_fsf_gdb_notice_lines(prepared_cache, copyrights, holders);
     super::postprocess_transforms::merge_axis_ethereal_suffix(prepared_cache, copyrights, holders);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::merge_kirkwood_converted_to(prepared_cache, copyrights, holders);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
+    let a_before = authors.len();
     super::postprocess_transforms::split_reworked_by_suffixes(
         content, copyrights, holders, authors,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.dedup_new_authors(authors, a_before);
+
     super::postprocess_transforms::drop_static_char_string_copyrights(content, copyrights, holders);
     super::postprocess_transforms::drop_combined_period_holders(holders);
     super::pattern_extract::drop_shadowed_prefix_holders(holders);
     super::pattern_extract::strip_trailing_c_year_suffix_from_comma_and_others(copyrights);
     super::pattern_extract::drop_bare_c_shadowed_by_non_copyright_prefixes(copyrights);
-    super::pattern_extract::extract_name_before_rewrited_by_copyrights(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
-    super::pattern_extract::extract_developed_at_software_copyrights(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_name_before_rewrited_by_copyrights(prepared_cache);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_developed_at_software_copyrights(prepared_cache);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_confidential_proprietary_copyrights(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
     super::pattern_extract::drop_shadowed_bare_c_holders_with_year_prefixed_copyrights(
         copyrights, holders,
     );
     super::pattern_extract::drop_shadowed_dashless_holders(holders);
-    super::pattern_extract::extract_initials_holders_from_copyrights(copyrights, holders);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let mut new_h =
+        super::pattern_extract::extract_initials_holders_from_copyrights(&copyrights[..]);
+    seen.dedup_new_holders(&mut new_h, 0);
+    holders.extend(new_h);
+
     super::pattern_extract::strip_trailing_the_source_suffixes(copyrights);
     super::pattern_extract::truncate_stichting_mathematisch_centrum_amsterdam_netherlands(
         copyrights, holders,

--- a/src/copyright/detector/postprocess_phase.rs
+++ b/src/copyright/detector/postprocess_phase.rs
@@ -509,9 +509,12 @@ pub(super) fn run_phase_postprocess(
     super::postprocess_transforms::normalize_french_support_disclaimer_copyrights(
         copyrights, holders,
     );
-    super::postprocess_transforms::drop_shadowed_email_org_location_suffixes_same_span(
-        copyrights, holders,
-    );
+    super::postprocess_transforms::drop_shadowed_inria_location_copyrights_same_span(copyrights);
+    let extra_holders =
+        super::postprocess_transforms::add_email_holders_from_leading_email_comma_holders(holders);
+    holders.extend(extra_holders);
+    super::postprocess_transforms::dedupe_exact_span_holders(holders);
+    super::postprocess_transforms::drop_shadowed_email_comma_holders_same_span(holders);
     super::postprocess_transforms::drop_shadowed_plain_email_prefix_copyrights_same_span(
         copyrights,
     );

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -3764,12 +3764,8 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
     let mut new_copyrights = Vec::new();
     let mut new_holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let trimmed = prepared.trim();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let trimmed = prepared_line.prepared;
 
         let lower = trimmed.to_ascii_lowercase();
         if !lower.contains("fix") {
@@ -3797,16 +3793,16 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
 
         new_copyrights.push(CopyrightDetection {
             copyright: cr,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
 
         let holder_raw = format!("{holder} {prefix}");
         if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
             new_holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -5354,26 +5350,17 @@ pub fn extract_following_authors_holders(
 
     let mut new_authors = Vec::new();
 
-    let mut i = 0;
-    while i < raw_lines.len() {
-        let Some(header) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            i += 1;
-            continue;
-        };
-        if header.is_empty() {
-            i += 1;
-            continue;
-        }
-        if !HEADER_RE.is_match(&header) {
-            i += 1;
+    let mut line_number = LineNumber::ONE;
+    while let Some(header_line) = prepared_cache.line(line_number) {
+        if header_line.prepared.is_empty() || !HEADER_RE.is_match(header_line.prepared) {
+            line_number += 1usize;
             continue;
         }
 
         let mut extracted_any = false;
-        let mut j = i + 1;
-        while j < raw_lines.len() {
-            let next_ln = j + 1;
-            let raw = raw_lines[j];
+        let mut next_line_number = header_line.line_number + 1usize;
+        while let Some(next_line) = prepared_cache.line(next_line_number) {
+            let raw = next_line.raw;
             if raw.trim().is_empty() {
                 break;
             }
@@ -5387,15 +5374,19 @@ pub fn extract_following_authors_holders(
             {
                 new_authors.push(AuthorDetection {
                     author,
-                    start_line: LineNumber::new(next_ln).unwrap(),
-                    end_line: LineNumber::new(next_ln).unwrap(),
+                    start_line: next_line.line_number,
+                    end_line: next_line.line_number,
                 });
                 extracted_any = true;
             }
-            j += 1;
+            next_line_number += 1usize;
         }
 
-        i = if extracted_any { j } else { i + 1 };
+        line_number = if extracted_any {
+            next_line_number
+        } else {
+            header_line.line_number + 1usize
+        };
     }
 
     new_authors
@@ -5477,17 +5468,11 @@ pub fn merge_implemented_by_lines(
     static EMAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?P<email>[^\s<>]+@[^\s<>]+)").unwrap());
 
-    let mut merged: Vec<(usize, String, String, HashSet<String>)> = Vec::new();
+    let mut merged: Vec<(LineNumber, String, String, HashSet<String>)> = Vec::new();
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln = i + 1;
-        let Some(line) = prepared_cache
-            .get_by_index(i)
-            .map(|p| p.trim().trim_start_matches('*').trim_start().to_string())
-        else {
-            continue;
-        };
-        let Some(cap) = COPY_RE.captures(&line) else {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        let line = first.prepared.trim().trim_start_matches('*').trim_start();
+        let Some(cap) = COPY_RE.captures(line) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -5496,13 +5481,8 @@ pub fn merge_implemented_by_lines(
             continue;
         }
 
-        let Some(next) = prepared_cache
-            .get_by_index(i + 1)
-            .map(|p| p.trim().trim_start_matches('*').trim_start().to_string())
-        else {
-            continue;
-        };
-        let Some(cap2) = IMPLEMENTED_RE.captures(&next) else {
+        let next = second.prepared.trim().trim_start_matches('*').trim_start();
+        let Some(cap2) = IMPLEMENTED_RE.captures(next) else {
             continue;
         };
         let tail = cap2.name("tail").map(|m| m.as_str()).unwrap_or("");
@@ -5521,14 +5501,14 @@ pub fn merge_implemented_by_lines(
 
         let cr = format!("Copyright (c) {year}, {holder_raw} Implemented by {first_email}");
         let holder = format!("{holder_raw} Implemented by");
-        merged.push((ln, cr, holder, email_set));
+        merged.push((first.line_number, cr, holder, email_set));
     }
 
     if merged.is_empty() {
         return;
     }
 
-    for (ln, cr_raw, holder_raw, emails) in merged {
+    for (line_number, cr_raw, holder_raw, emails) in merged {
         let Some(cr) = refine_copyright(&cr_raw) else {
             continue;
         };
@@ -5536,7 +5516,7 @@ pub fn merge_implemented_by_lines(
         let cr_first = cr.split_whitespace().next().unwrap_or("");
 
         for det in copyrights.iter_mut() {
-            if det.start_line.get() == ln
+            if det.start_line == line_number
                 && det.copyright.starts_with("Copyright (c)")
                 && det.copyright.contains(",")
                 && det.copyright.contains(cr_first)
@@ -5547,24 +5527,24 @@ pub fn merge_implemented_by_lines(
         if !copyrights.iter().any(|c| c.copyright == cr) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: line_number,
+                end_line: line_number + 1usize,
             });
         }
 
         holders.retain(|h| {
-            !(h.start_line.get() == ln
+            !(h.start_line == line_number
                 && h.holder == holder_raw.trim_end_matches(" Implemented by"))
         });
         if let Some(h) = refine_holder(&holder_raw)
             && !holders
                 .iter()
-                .any(|x| x.holder == h && x.start_line.get() == ln)
+                .any(|x| x.holder == h && x.start_line == line_number)
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: line_number,
+                end_line: line_number + 1usize,
             });
         }
 
@@ -5590,16 +5570,8 @@ pub fn split_written_by_copyrights_into_holder_prefixed_clauses(
     });
 
     let mut added_any = false;
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        for cap in WRITTEN_BY_COPY_RE.captures_iter(line) {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        for cap in WRITTEN_BY_COPY_RE.captures_iter(prepared_line.prepared) {
             let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
             let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
             if name.is_empty() || years.is_empty() {
@@ -5611,14 +5583,14 @@ pub fn split_written_by_copyrights_into_holder_prefixed_clauses(
             };
             copyrights.push(CopyrightDetection {
                 copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
             if let Some(h) = refine_holder(name) {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
             added_any = true;
@@ -5655,16 +5627,11 @@ pub fn fix_shm_inline_copyrights(
             .unwrap()
     });
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        if !prepared.contains("/proc/sysvipc/shm") {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if !prepared_line.prepared.contains("/proc/sysvipc/shm") {
             continue;
         }
-        let line = prepared.trim();
-        let Some(cap) = INLINE_RE.captures(line) else {
+        let Some(cap) = INLINE_RE.captures(prepared_line.prepared) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -5680,15 +5647,15 @@ pub fn fix_shm_inline_copyrights(
         };
         copyrights.push(CopyrightDetection {
             copyright: cr,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: prepared_line.line_number,
+            end_line: prepared_line.line_number,
         });
 
         if let Some(holder) = refine_holder(name) {
             holders.push(HolderDetection {
                 holder,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
         break;
@@ -5747,21 +5714,23 @@ pub fn fix_sundry_contributors_truncation(
         .unwrap()
     });
 
-    let mut matched: Option<(usize, String, String, String)> = None;
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        if let Some(cap) = COPYRIGHT_SUNDRY_CONTRIBUTORS_RE.captures(prepared.trim()) {
+    let mut matched: Option<(LineNumber, String, String, String)> = None;
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if let Some(cap) = COPYRIGHT_SUNDRY_CONTRIBUTORS_RE.captures(prepared_line.prepared) {
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
             let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
-            matched = Some((ln, year.to_string(), name.to_string(), tail.to_string()));
+            matched = Some((
+                prepared_line.line_number,
+                year.to_string(),
+                name.to_string(),
+                tail.to_string(),
+            ));
             break;
         }
     }
 
-    let Some((ln, year, name, tail)) = matched else {
+    let Some((line_number, year, name, tail)) = matched else {
         return;
     };
 
@@ -5801,15 +5770,15 @@ pub fn fix_sundry_contributors_truncation(
     if !copyrights.iter().any(|c| c.copyright == full_cr) {
         copyrights.push(CopyrightDetection {
             copyright: full_cr,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: line_number,
+            end_line: line_number,
         });
     }
     if !holders.iter().any(|h| h.holder == full_holder) {
         holders.push(HolderDetection {
             holder: full_holder,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: line_number,
+            end_line: line_number,
         });
     }
 }
@@ -5960,20 +5929,18 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
     static C_YEAR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\(c\)\s*(?P<year>(?:19\d{2}|20\d{2}))\b").unwrap());
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if line.to_ascii_lowercase().matches("(c)").count() < 2 {
+    for prepared_line in prepared_cache.iter_non_empty() {
+        if prepared_line
+            .prepared
+            .to_ascii_lowercase()
+            .matches("(c)")
+            .count()
+            < 2
+        {
             continue;
         }
 
-        for m in C_YEAR_RE.captures_iter(line) {
+        for m in C_YEAR_RE.captures_iter(prepared_line.prepared) {
             let year = m.name("year").map(|m| m.as_str()).unwrap_or("").trim();
             if year.is_empty() {
                 continue;
@@ -5982,7 +5949,7 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
             let Some(start) = m.get(0).map(|mm| mm.start()) else {
                 continue;
             };
-            let tail = line.get(start..).unwrap_or("").trim();
+            let tail = prepared_line.prepared.get(start..).unwrap_or("").trim();
             if tail.len() <= short.len() {
                 continue;
             }
@@ -5992,7 +5959,9 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
 
             let mut did_replace = false;
             for det in copyrights.iter_mut() {
-                if det.start_line.get() == ln && det.end_line.get() == ln && det.copyright == short
+                if det.start_line == prepared_line.line_number
+                    && det.end_line == prepared_line.line_number
+                    && det.copyright == short
                 {
                     det.copyright = extended.clone();
                     did_replace = true;
@@ -6005,12 +5974,12 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
             if let Some(holder) = derive_holder_from_simple_copyright_string(&extended)
                 && !holders
                     .iter()
-                    .any(|h| h.start_line.get() == ln && h.holder == holder)
+                    .any(|h| h.start_line == prepared_line.line_number && h.holder == holder)
             {
                 holders.push(HolderDetection {
                     holder,
-                    start_line: LineNumber::new(ln).unwrap(),
-                    end_line: LineNumber::new(ln).unwrap(),
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
                 });
             }
         }

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -2633,7 +2633,9 @@ pub fn add_missing_holders_from_preceding_name_lines(
         if seen_h.insert(holder_key) {
             holders.push(HolderDetection {
                 holder,
-                start_line: LineNumber::new(copyright.start_line.get() - 1)
+                start_line: copyright
+                    .start_line
+                    .prev()
                     .expect("valid preceding line number"),
                 end_line: copyright.end_line,
             });
@@ -2840,7 +2842,7 @@ pub fn extend_copyrights_with_next_line_parenthesized_obfuscated_email(
         };
 
         c.copyright = refined;
-        c.end_line += 1usize;
+        c.end_line = c.end_line.next();
     }
 }
 
@@ -2889,7 +2891,7 @@ pub fn extend_copyrights_with_following_all_rights_reserved_line(
         } else {
             merged_normalized
         };
-        c.end_line += 1usize;
+        c.end_line = c.end_line.next();
     }
 }
 
@@ -5353,12 +5355,12 @@ pub fn extract_following_authors_holders(
     let mut line_number = LineNumber::ONE;
     while let Some(header_line) = prepared_cache.line(line_number) {
         if header_line.prepared.is_empty() || !HEADER_RE.is_match(header_line.prepared) {
-            line_number += 1usize;
+            line_number = line_number.next();
             continue;
         }
 
         let mut extracted_any = false;
-        let mut next_line_number = header_line.line_number + 1usize;
+        let mut next_line_number = header_line.line_number.next();
         while let Some(next_line) = prepared_cache.line(next_line_number) {
             let raw = next_line.raw;
             if raw.trim().is_empty() {
@@ -5379,13 +5381,13 @@ pub fn extract_following_authors_holders(
                 });
                 extracted_any = true;
             }
-            next_line_number += 1usize;
+            next_line_number = next_line_number.next();
         }
 
         line_number = if extracted_any {
             next_line_number
         } else {
-            header_line.line_number + 1usize
+            header_line.line_number.next()
         };
     }
 
@@ -5528,7 +5530,7 @@ pub fn merge_implemented_by_lines(
             copyrights.push(CopyrightDetection {
                 copyright: cr,
                 start_line: line_number,
-                end_line: line_number + 1usize,
+                end_line: line_number.next(),
             });
         }
 
@@ -5544,7 +5546,7 @@ pub fn merge_implemented_by_lines(
             holders.push(HolderDetection {
                 holder: h,
                 start_line: line_number,
-                end_line: line_number + 1usize,
+                end_line: line_number.next(),
             });
         }
 

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use regex::Regex;
 
 use crate::copyright::candidates::is_raw_versioned_project_banner_line;
-use crate::copyright::line_tracking::{LineNumberIndex, PreparedLineCache};
+use crate::copyright::line_tracking::{LineNumberIndex, PreparedLines};
 use crate::copyright::refiner::{
     refine_author, refine_copyright, refine_holder, refine_holder_in_copyright_context,
 };
@@ -340,7 +340,7 @@ pub fn drop_shadowed_year_only_copyright_prefixes_same_start_line(
 
 pub fn drop_year_only_copyrights_shadowed_by_previous_software_copyright_line(
     raw_lines: &[&str],
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
 ) {
     if raw_lines.is_empty() || copyrights.is_empty() {
@@ -380,7 +380,7 @@ pub fn drop_year_only_copyrights_shadowed_by_previous_software_copyright_line(
 }
 
 pub fn merge_multiline_person_year_copyright_continuations(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -1105,7 +1105,7 @@ pub fn add_karlsruhe_university_short_variants(
 }
 
 pub fn add_intel_and_sun_non_portions_variants(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &[CopyrightDetection],
 ) -> Vec<CopyrightDetection> {
     if prepared_cache.is_empty() || copyrights.is_empty() {
@@ -1403,7 +1403,7 @@ pub fn add_at_affiliation_short_variants(
 }
 
 pub fn add_missing_copyrights_for_holder_lines_with_emails(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &[CopyrightDetection],
     holders: &[HolderDetection],
 ) -> Vec<CopyrightDetection> {
@@ -1460,7 +1460,7 @@ pub fn add_missing_copyrights_for_holder_lines_with_emails(
 }
 
 pub fn extend_inline_obfuscated_angle_email_suffixes(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
 ) {
     if copyrights.is_empty() {
@@ -1618,7 +1618,7 @@ pub fn strip_lone_obfuscated_angle_email_user_tokens(
 }
 
 pub fn add_at_domain_variants_for_short_net_angle_emails(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &[CopyrightDetection],
 ) -> Vec<CopyrightDetection> {
     if copyrights.is_empty() {
@@ -1945,7 +1945,7 @@ pub fn drop_shadowed_email_comma_holders_same_span(holders: &mut Vec<HolderDetec
 }
 
 pub fn add_pipe_read_parenthetical_variants(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &[CopyrightDetection],
 ) -> Vec<CopyrightDetection> {
     if prepared_cache.len() < 2 || copyrights.is_empty() {
@@ -1988,7 +1988,7 @@ pub fn add_pipe_read_parenthetical_variants(
 }
 
 pub fn add_from_url_parenthetical_copyright_variants(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     _copyrights: &[CopyrightDetection],
 ) -> Vec<CopyrightDetection> {
     if prepared_cache.is_empty() {
@@ -2419,7 +2419,7 @@ pub fn expand_portions_copyright_variants(copyrights: &mut [CopyrightDetection])
 }
 
 pub fn expand_year_only_copyrights_with_by_name_prefix(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -2485,7 +2485,7 @@ pub fn expand_year_only_copyrights_with_by_name_prefix(
 }
 
 pub fn add_missing_holders_from_preceding_name_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -2662,7 +2662,7 @@ pub fn add_missing_holders_from_preceding_name_lines(
 }
 
 pub fn expand_year_only_copyrights_with_read_the_suffix(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -2730,7 +2730,7 @@ pub fn expand_year_only_copyrights_with_read_the_suffix(
 }
 
 pub fn merge_multiline_obfuscated_name_year_copyright_pairs(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -2824,7 +2824,7 @@ pub fn merge_multiline_obfuscated_name_year_copyright_pairs(
 }
 
 pub fn extend_copyrights_with_next_line_parenthesized_obfuscated_email(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
 ) {
     if copyrights.is_empty() {
@@ -2924,7 +2924,7 @@ pub fn extend_copyrights_with_following_all_rights_reserved_line(
 }
 
 pub fn add_modify_suffix_holders(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     holders: &[HolderDetection],
 ) -> Vec<HolderDetection> {
     if prepared_cache.is_empty() || holders.is_empty() {
@@ -3247,7 +3247,7 @@ pub fn replace_holders_with_embedded_c_year_markers(
 }
 
 pub fn extend_year_only_copyrights_with_trailing_text(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -3312,7 +3312,7 @@ pub fn extend_year_only_copyrights_with_trailing_text(
 }
 
 pub fn extract_licensed_material_of_company_bare_c_year_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -3387,7 +3387,7 @@ pub fn extract_licensed_material_of_company_bare_c_year_lines(
 }
 
 pub fn merge_year_only_copyrights_with_following_author_colon_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -3491,7 +3491,7 @@ pub fn merge_year_only_copyrights_with_following_author_colon_lines(
 }
 
 pub fn extract_question_mark_year_copyrights(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
         return (Vec::new(), Vec::new());
@@ -3592,7 +3592,7 @@ pub fn contains_year_placeholder(lower: &str) -> bool {
 }
 
 pub fn extend_copyrights_with_authors_blocks(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -3797,7 +3797,7 @@ pub fn apply_openoffice_org_report_builder_bin_normalizations(
 }
 
 pub fn extract_midline_c_year_holder_with_leading_acronym(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static MIDLINE_C_YEAR_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -4699,7 +4699,7 @@ pub fn drop_from_source_attribution_copyrights(
 }
 
 pub fn merge_freebird_c_inc_urls(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -4771,7 +4771,7 @@ pub fn merge_freebird_c_inc_urls(
 }
 
 pub fn merge_debugging390_best_viewed_suffix(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -4834,7 +4834,7 @@ pub fn merge_debugging390_best_viewed_suffix(
 }
 
 pub fn merge_fsf_gdb_notice_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -4891,7 +4891,7 @@ pub fn merge_fsf_gdb_notice_lines(
 }
 
 pub fn merge_axis_ethereal_suffix(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -4944,7 +4944,7 @@ pub fn merge_axis_ethereal_suffix(
 }
 
 pub fn merge_kirkwood_converted_to(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -5089,7 +5089,7 @@ pub fn drop_combined_period_holders(holders: &mut Vec<HolderDetection>) {
 }
 
 pub fn extract_line_ending_copyright_then_by_holder(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     existing_holders: &[HolderDetection],
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     let mut new_copyrights = Vec::new();
@@ -5159,7 +5159,7 @@ pub fn extract_line_ending_copyright_then_by_holder(
 }
 
 pub fn drop_trailing_software_line_from_holders(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     holders: &mut [HolderDetection],
 ) {
     for h in holders.iter_mut() {
@@ -5463,7 +5463,7 @@ pub fn drop_url_embedded_suffix_variants_same_span(
 
 pub fn extract_following_authors_holders(
     raw_lines: &[&str],
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
     if raw_lines.is_empty() {
         return Vec::new();
@@ -5524,7 +5524,7 @@ pub fn extract_following_authors_holders(
 }
 
 pub fn drop_created_by_camelcase_identifier_authors(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
     if prepared_cache.is_empty() || authors.is_empty() {
@@ -5582,7 +5582,7 @@ pub fn drop_created_by_camelcase_identifier_authors(
 }
 
 pub fn merge_implemented_by_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
     authors: &mut Vec<AuthorDetection>,
@@ -5698,7 +5698,7 @@ pub fn merge_implemented_by_lines(
 }
 
 pub fn split_written_by_copyrights_into_holder_prefixed_clauses(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
     authors: &mut Vec<AuthorDetection>,
@@ -5764,7 +5764,7 @@ pub fn split_written_by_copyrights_into_holder_prefixed_clauses(
 }
 
 pub fn fix_shm_inline_copyrights(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -5861,7 +5861,7 @@ pub fn fix_n_tty_linus_torvalds_written_by_clause(
 }
 
 pub fn fix_sundry_contributors_truncation(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
@@ -6074,7 +6074,7 @@ pub fn split_embedded_copyright_detections(
 }
 
 pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut [CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -2727,29 +2727,15 @@ pub fn merge_multiline_obfuscated_name_year_copyright_pairs(
             .unwrap()
     });
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let Some(prepared) = prepared_cache.get_by_index(i) else {
-            continue;
-        };
-        if !(prepared.contains("Copyright") || prepared.contains("copyright")) {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        if !(first.prepared.contains("Copyright") || first.prepared.contains("copyright")) {
             continue;
         }
 
-        let ln1 = i + 1;
-        let ln2 = i + 2;
-
-        let Some(l1p) = prepared_cache.get(ln1).map(|s| s.to_string()) else {
+        let Some(c1) = FIRST_RE.captures(first.prepared) else {
             continue;
         };
-        let Some(l2p) = prepared_cache.get(ln2).map(|s| s.to_string()) else {
-            continue;
-        };
-        let l1 = l1p.trim();
-        let l2 = l2p.trim();
-        let Some(c1) = FIRST_RE.captures(l1) else {
-            continue;
-        };
-        let Some(c2) = SECOND_RE.captures(l2) else {
+        let Some(c2) = SECOND_RE.captures(second.prepared) else {
             continue;
         };
 
@@ -2767,9 +2753,12 @@ pub fn merge_multiline_obfuscated_name_year_copyright_pairs(
         };
         let mut updated = false;
         for c in copyrights.iter_mut() {
-            if c.start_line.get() == ln1 && c.end_line.get() == ln1 && c.copyright.contains(name1) {
+            if c.start_line == first.line_number
+                && c.end_line == first.line_number
+                && c.copyright.contains(name1)
+            {
                 c.copyright = refined.clone();
-                c.end_line = LineNumber::new(ln2).expect("valid");
+                c.end_line = second.line_number;
                 updated = true;
                 break;
             }
@@ -2777,26 +2766,27 @@ pub fn merge_multiline_obfuscated_name_year_copyright_pairs(
         if !updated {
             copyrights.push(CopyrightDetection {
                 copyright: refined.clone(),
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
         let combined_holder_raw = format!("{name1}, {name2}");
         if let Some(h) = refine_holder_in_copyright_context(&combined_holder_raw) {
             holders.retain(|x| {
-                !(x.start_line.get() == ln1
-                    && x.end_line.get() == ln1
+                !(x.start_line == first.line_number
+                    && x.end_line == first.line_number
                     && (x.holder == name1 || x.holder.contains(name1)))
             });
-            if !holders
-                .iter()
-                .any(|x| x.start_line.get() == ln1 && x.end_line.get() == ln2 && x.holder == h)
-            {
+            if !holders.iter().any(|x| {
+                x.start_line == first.line_number
+                    && x.end_line == second.line_number
+                    && x.holder == h
+            }) {
                 holders.push(HolderDetection {
                     holder: h,
-                    start_line: LineNumber::new(ln1).expect("valid"),
-                    end_line: LineNumber::new(ln2).expect("valid"),
+                    start_line: first.line_number,
+                    end_line: second.line_number,
                 });
             }
         }
@@ -5004,18 +4994,8 @@ pub fn extract_line_ending_copyright_then_by_holder(
     let mut new_copyrights = Vec::new();
     let mut new_holders = Vec::new();
 
-    for idx in 0..prepared_cache.len() {
-        let ln = idx + 1;
-        let Some(prepared) = prepared_cache
-            .get_by_index(idx)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if prepared.is_empty() {
-            continue;
-        }
-        let lower = prepared.to_ascii_lowercase();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let lower = prepared_line.prepared.to_ascii_lowercase();
         if !lower.ends_with("copyright") {
             continue;
         }
@@ -5026,18 +5006,8 @@ pub fn extract_line_ending_copyright_then_by_holder(
             continue;
         }
 
-        let mut j = idx + 1;
-        while j < prepared_cache.len() {
-            let next_ln = j + 1;
-            let Some(next_prepared) = prepared_cache.get_by_index(j).map(|p| p.trim().to_string())
-            else {
-                break;
-            };
-            if next_prepared.is_empty() {
-                j += 1;
-                continue;
-            }
-
+        if let Some(next_line) = prepared_cache.next_non_empty_line(prepared_line.line_number) {
+            let next_prepared = next_line.prepared;
             let next_lower = next_prepared.to_ascii_lowercase();
             if next_lower.starts_with("by ") {
                 let holder_raw = next_prepared[3..].trim();
@@ -5045,8 +5015,8 @@ pub fn extract_line_ending_copyright_then_by_holder(
                 if let Some(copyright_text) = refine_copyright(&copyright_raw) {
                     new_copyrights.push(CopyrightDetection {
                         copyright: copyright_text,
-                        start_line: LineNumber::new(ln).unwrap(),
-                        end_line: LineNumber::new(next_ln).expect("valid"),
+                        start_line: prepared_line.line_number,
+                        end_line: next_line.line_number,
                     });
                 }
 
@@ -5055,12 +5025,11 @@ pub fn extract_line_ending_copyright_then_by_holder(
                 {
                     new_holders.push(HolderDetection {
                         holder,
-                        start_line: LineNumber::new(next_ln).expect("valid"),
-                        end_line: LineNumber::new(next_ln).expect("valid"),
+                        start_line: next_line.line_number,
+                        end_line: next_line.line_number,
                     });
                 }
             }
-            break;
         }
     }
 

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -1861,19 +1861,13 @@ pub fn normalize_french_support_disclaimer_copyrights(
     });
 }
 
-pub fn drop_shadowed_email_org_location_suffixes_same_span(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
-    if copyrights.len() < 2 && holders.len() < 2 {
+pub fn drop_shadowed_inria_location_copyrights_same_span(copyrights: &mut Vec<CopyrightDetection>) {
+    if copyrights.len() < 2 {
         return;
     }
 
     static INRIA_LOC_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"^(?P<prefix>.+\bINRIA)\s+(?P<loc>[A-Z][a-z]{2,64})$").unwrap()
-    });
-    static LEADING_EMAIL_COMMA_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)^(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\s*,\s+.+$").unwrap()
     });
 
     let mut exact_c_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
@@ -1902,6 +1896,18 @@ pub fn drop_shadowed_email_org_location_suffixes_same_span(
         }
         !set.contains(prefix)
     });
+}
+
+pub fn add_email_holders_from_leading_email_comma_holders(
+    holders: &[HolderDetection],
+) -> Vec<HolderDetection> {
+    if holders.len() < 2 {
+        return Vec::new();
+    }
+
+    static LEADING_EMAIL_COMMA_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\s*,\s+.+$").unwrap()
+    });
 
     let mut exact_h_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
     for h in holders.iter() {
@@ -1911,7 +1917,7 @@ pub fn drop_shadowed_email_org_location_suffixes_same_span(
             .insert(h.holder.clone());
     }
 
-    let mut to_add_h = Vec::new();
+    let mut to_add = Vec::new();
     for h in holders.iter() {
         let Some(cap) = LEADING_EMAIL_COMMA_RE.captures(h.holder.trim()) else {
             continue;
@@ -1923,24 +1929,41 @@ pub fn drop_shadowed_email_org_location_suffixes_same_span(
         let Some(refined_email) = refine_holder_in_copyright_context(email) else {
             continue;
         };
-        let key = (h.start_line.get(), h.end_line.get(), refined_email.clone());
         if exact_h_by_span
             .get(&(h.start_line.get(), h.end_line.get()))
             .is_some_and(|set| set.contains(&refined_email))
         {
             continue;
         }
-        to_add_h.push(HolderDetection {
+        exact_h_by_span
+            .entry((h.start_line.get(), h.end_line.get()))
+            .or_default()
+            .insert(refined_email.clone());
+        to_add.push(HolderDetection {
             holder: refined_email,
             start_line: h.start_line,
             end_line: h.end_line,
         });
+    }
+    to_add
+}
+
+pub fn drop_shadowed_email_comma_holders_same_span(holders: &mut Vec<HolderDetection>) {
+    if holders.len() < 2 {
+        return;
+    }
+
+    static LEADING_EMAIL_COMMA_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\s*,\s+.+$").unwrap()
+    });
+
+    let mut exact_h_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
+    for h in holders.iter() {
         exact_h_by_span
             .entry((h.start_line.get(), h.end_line.get()))
             .or_default()
-            .insert(key.2);
+            .insert(h.holder.clone());
     }
-    holders.extend(to_add_h);
 
     holders.retain(|h| {
         let span = (h.start_line.get(), h.end_line.get());

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -16,6 +16,7 @@ use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetecti
 use crate::models::LineNumber;
 
 use super::seen_text::SeenTextSets;
+use super::token_utils::group_by;
 
 pub fn refine_final_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
     if copyrights.is_empty() {
@@ -789,26 +790,25 @@ pub fn drop_comma_holders_shadowed_by_space_version_same_span(holders: &mut Vec<
         return;
     }
 
-    use std::collections::{HashMap, HashSet};
-
-    let mut by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .insert(h.holder.clone());
-    }
-
-    holders.retain(|h| {
-        let Some(set) = by_span.get(&(h.start_line.get(), h.end_line.get())) else {
-            return true;
-        };
-        if !h.holder.contains(',') {
-            return true;
-        }
-        let no_comma = super::token_utils::normalize_whitespace(&h.holder.replace(',', ""));
-        !(no_comma != h.holder && set.contains(&no_comma))
-    });
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                if !h.holder.contains(',') {
+                    return true;
+                }
+                let no_comma = super::token_utils::normalize_whitespace(&h.holder.replace(',', ""));
+                !(no_comma != h.holder && set.contains(&no_comma))
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn normalize_company_suffix_period_holder_variants(holders: &mut Vec<HolderDetection>) {
@@ -1239,44 +1239,44 @@ pub fn drop_shadowed_angle_email_prefix_copyrights_same_span(
         .unwrap()
     });
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .push(c.copyright.clone());
-    }
-
-    copyrights.retain(|c| {
-        let span = (c.start_line.get(), c.end_line.get());
-        let Some(all) = by_span.get(&span) else {
-            return true;
-        };
-        let s = c.copyright.trim();
-        if !s.ends_with('>') {
-            return true;
-        }
-        let mut has_longer = false;
-        let mut has_email_only_extension = false;
-        for other in all {
-            let o = other.trim();
-            if o == s {
-                continue;
-            }
-            if let Some(tail) = o.strip_prefix(s) {
-                has_longer = true;
-                let tail = tail.trim_end();
-                if EMAIL_TAIL_ONLY_RE.is_match(tail) {
-                    has_email_only_extension = true;
-                    break;
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let texts: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                let s = c.copyright.trim();
+                if !s.ends_with('>') {
+                    return true;
                 }
-            }
-        }
-        if !has_longer {
-            return true;
-        }
-        has_email_only_extension
-    });
+                let mut has_longer = false;
+                let mut has_email_only_extension = false;
+                for other in &texts {
+                    let o = other.trim();
+                    if o == s {
+                        continue;
+                    }
+                    if let Some(tail) = o.strip_prefix(s) {
+                        has_longer = true;
+                        let tail = tail.trim_end();
+                        if EMAIL_TAIL_ONLY_RE.is_match(tail) {
+                            has_email_only_extension = true;
+                            break;
+                        }
+                    }
+                }
+                if !has_longer {
+                    return true;
+                }
+                has_email_only_extension
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_quote_before_email_variants_same_span(
@@ -1286,8 +1286,6 @@ pub fn drop_shadowed_quote_before_email_variants_same_span(
         return;
     }
 
-    use std::collections::{HashMap, HashSet};
-
     static QUOTED_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)'\s+(<[^>\s]*@[^>\s]+>|[^\s<>]*@[^\s<>]+)").unwrap());
 
@@ -1295,28 +1293,28 @@ pub fn drop_shadowed_quote_before_email_variants_same_span(
         super::token_utils::normalize_whitespace(&QUOTED_RE.replace_all(s, " $1"))
     }
 
-    let mut exact_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        exact_by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .insert(c.copyright.clone());
-    }
-
-    copyrights.retain(|c| {
-        if !c.copyright.contains('\'') || !c.copyright.contains('@') {
-            return true;
-        }
-        let span = (c.start_line.get(), c.end_line.get());
-        let Some(exact) = exact_by_span.get(&span) else {
-            return true;
-        };
-        let canon = canonical(&c.copyright);
-        if canon == c.copyright {
-            return true;
-        }
-        !exact.contains(&canon)
-    });
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                if !c.copyright.contains('\'') || !c.copyright.contains('@') {
+                    return true;
+                }
+                let canon = canonical(&c.copyright);
+                if canon == c.copyright {
+                    return true;
+                }
+                !set.contains(&canon)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn add_missing_holder_from_single_copyright(
@@ -1695,17 +1693,15 @@ pub fn drop_shadowed_plain_email_prefix_copyrights_same_span(
             .unwrap()
     });
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .push(c.copyright.clone());
-    }
-
-    let mut to_drop: HashSet<(usize, usize, String)> = HashSet::new();
-    for (span, all) in &by_span {
-        for s in all {
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let all: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        let mut to_drop: HashSet<String> = HashSet::new();
+        for s in &all {
             let s_trim = s.trim();
             let Some(cap) = TRAILING_EMAIL_RE.captures(s_trim) else {
                 continue;
@@ -1714,7 +1710,7 @@ pub fn drop_shadowed_plain_email_prefix_copyrights_same_span(
             if prefix.is_empty() {
                 continue;
             }
-            for other in all {
+            for other in &all {
                 let o = other.trim();
                 if o == prefix {
                     continue;
@@ -1723,15 +1719,16 @@ pub fn drop_shadowed_plain_email_prefix_copyrights_same_span(
                     && o[prefix.len()..].trim_start().starts_with(',')
                     && !o[prefix.len()..].contains('@')
                 {
-                    to_drop.insert((span.0, span.1, other.clone()));
+                    to_drop.insert(other.clone());
                 }
             }
         }
-    }
-
-    copyrights.retain(|c| {
-        !to_drop.contains(&(c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-    });
+        group
+            .into_iter()
+            .filter(|c| !to_drop.contains(&c.copyright))
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_single_line_copyrights_shadowed_by_multiline_same_start(
@@ -1870,32 +1867,32 @@ pub fn drop_shadowed_inria_location_copyrights_same_span(copyrights: &mut Vec<Co
         Regex::new(r"^(?P<prefix>.+\bINRIA)\s+(?P<loc>[A-Z][a-z]{2,64})$").unwrap()
     });
 
-    let mut exact_c_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        exact_c_by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .insert(c.copyright.clone());
-    }
-
-    copyrights.retain(|c| {
-        let span = (c.start_line.get(), c.end_line.get());
-        let Some(set) = exact_c_by_span.get(&span) else {
-            return true;
-        };
-        let Some(cap) = INRIA_LOC_RE.captures(c.copyright.trim()) else {
-            return true;
-        };
-        let prefix = cap
-            .name("prefix")
-            .map(|m| m.as_str())
-            .unwrap_or("")
-            .trim_end();
-        if prefix.is_empty() {
-            return true;
-        }
-        !set.contains(prefix)
-    });
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                let Some(cap) = INRIA_LOC_RE.captures(c.copyright.trim()) else {
+                    return true;
+                };
+                let prefix = cap
+                    .name("prefix")
+                    .map(|m| m.as_str())
+                    .unwrap_or("")
+                    .trim_end();
+                if prefix.is_empty() {
+                    return true;
+                }
+                !set.contains(prefix)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn add_email_holders_from_leading_email_comma_holders(
@@ -1957,32 +1954,32 @@ pub fn drop_shadowed_email_comma_holders_same_span(holders: &mut Vec<HolderDetec
         Regex::new(r"(?i)^(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\s*,\s+.+$").unwrap()
     });
 
-    let mut exact_h_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for h in holders.iter() {
-        exact_h_by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .insert(h.holder.clone());
-    }
-
-    holders.retain(|h| {
-        let span = (h.start_line.get(), h.end_line.get());
-        let Some(set) = exact_h_by_span.get(&span) else {
-            return true;
-        };
-        let trimmed = h.holder.trim();
-        let Some(cap) = LEADING_EMAIL_COMMA_RE.captures(trimmed) else {
-            return true;
-        };
-        let email = cap.name("email").map(|m| m.as_str()).unwrap_or("").trim();
-        if email.is_empty() {
-            return true;
-        }
-        if trimmed.eq_ignore_ascii_case(email) {
-            return true;
-        }
-        !set.contains(email)
-    });
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let trimmed = h.holder.trim();
+                let Some(cap) = LEADING_EMAIL_COMMA_RE.captures(trimmed) else {
+                    return true;
+                };
+                let email = cap.name("email").map(|m| m.as_str()).unwrap_or("").trim();
+                if email.is_empty() {
+                    return true;
+                }
+                if trimmed.eq_ignore_ascii_case(email) {
+                    return true;
+                }
+                !set.contains(email)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn add_pipe_read_parenthetical_variants(
@@ -2079,35 +2076,35 @@ pub fn drop_shadowed_acronym_location_suffix_copyrights_same_span(
         Regex::new(r"(?P<prefix>.+\b(?P<acr>[A-Z]{2,10}))\s+(?P<loc>[A-Z][a-z]{2,})\s*$").unwrap()
     });
 
-    let mut by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .insert(c.copyright.clone());
-    }
-
-    copyrights.retain(|c| {
-        let span = (c.start_line.get(), c.end_line.get());
-        let Some(set) = by_span.get(&span) else {
-            return true;
-        };
-        let Some(cap) = ACR_LOC_RE.captures(c.copyright.trim()) else {
-            return true;
-        };
-        let prefix = cap
-            .name("prefix")
-            .map(|m| m.as_str())
-            .unwrap_or("")
-            .trim_end();
-        if prefix.is_empty() {
-            return true;
-        }
-        if !prefix.contains('@') {
-            return true;
-        }
-        !set.contains(prefix)
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
     })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                let Some(cap) = ACR_LOC_RE.captures(c.copyright.trim()) else {
+                    return true;
+                };
+                let prefix = cap
+                    .name("prefix")
+                    .map(|m| m.as_str())
+                    .unwrap_or("")
+                    .trim_end();
+                if prefix.is_empty() {
+                    return true;
+                }
+                if !prefix.contains('@') {
+                    return true;
+                }
+                !set.contains(prefix)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_copyright_like_holders(holders: &mut Vec<HolderDetection>) {
@@ -3010,8 +3007,6 @@ pub fn drop_shadowed_c_sign_variants(copyrights: &mut Vec<CopyrightDetection>) {
         return;
     }
 
-    use std::collections::{HashMap, HashSet};
-
     fn contains_c_sign(s: &str) -> bool {
         s.to_ascii_lowercase().contains("(c)")
     }
@@ -3021,44 +3016,34 @@ pub fn drop_shadowed_c_sign_variants(copyrights: &mut Vec<CopyrightDetection>) {
         super::token_utils::normalize_whitespace(&C_SIGN_RE.replace_all(s, " "))
     }
 
-    let mut with_c_by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        if contains_c_sign(&c.copyright) {
-            with_c_by_span
-                .entry((c.start_line.get(), c.end_line.get()))
-                .or_default()
-                .insert(canonical_without_c_sign(&c.copyright));
-        }
-    }
-    if with_c_by_span.is_empty() {
-        return;
-    }
-
-    copyrights.retain(|c| {
-        if contains_c_sign(&c.copyright) {
-            return true;
-        }
-        let Some(set) = with_c_by_span.get(&(c.start_line.get(), c.end_line.get())) else {
-            return true;
-        };
-        let canon = canonical_without_c_sign(&c.copyright);
-        !set.contains(&canon)
-    });
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let with_c_set: HashSet<String> = group
+            .iter()
+            .filter(|c| contains_c_sign(&c.copyright))
+            .map(|c| canonical_without_c_sign(&c.copyright))
+            .collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                if contains_c_sign(&c.copyright) {
+                    return true;
+                }
+                let canon = canonical_without_c_sign(&c.copyright);
+                !with_c_set.contains(&canon)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_year_prefixed_holders(holders: &mut Vec<HolderDetection>) {
     if holders.len() < 2 {
         return;
-    }
-
-    use std::collections::{HashMap, HashSet};
-
-    let mut by_span: HashMap<(usize, usize), HashSet<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .insert(super::token_utils::normalize_whitespace(&h.holder));
     }
 
     fn strip_leading_year_token(s: &str) -> Option<String> {
@@ -3076,16 +3061,28 @@ pub fn drop_shadowed_year_prefixed_holders(holders: &mut Vec<HolderDetection>) {
         Some(super::token_utils::normalize_whitespace(rest))
     }
 
-    holders.retain(|h| {
-        let Some(set) = by_span.get(&(h.start_line.get(), h.end_line.get())) else {
-            return true;
-        };
-        let normalized = super::token_utils::normalize_whitespace(&h.holder);
-        let Some(stripped) = strip_leading_year_token(&normalized) else {
-            return true;
-        };
-        !set.contains(&stripped)
-    });
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let set: HashSet<String> = group
+            .iter()
+            .map(|h| super::token_utils::normalize_whitespace(&h.holder))
+            .collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let normalized = super::token_utils::normalize_whitespace(&h.holder);
+                let Some(stripped) = strip_leading_year_token(&normalized) else {
+                    return true;
+                };
+                !set.contains(&stripped)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_for_clause_holders_with_email_copyrights(
@@ -3096,8 +3093,6 @@ pub fn drop_shadowed_for_clause_holders_with_email_copyrights(
         return;
     }
 
-    use std::collections::{HashMap, HashSet};
-
     let spans_with_email: HashSet<(usize, usize)> = copyrights
         .iter()
         .filter(|c| c.copyright.contains('@'))
@@ -3107,52 +3102,50 @@ pub fn drop_shadowed_for_clause_holders_with_email_copyrights(
         return;
     }
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .push(h.holder.clone());
-    }
-
-    holders.retain(|h| {
-        let span = (h.start_line.get(), h.end_line.get());
-        if !spans_with_email.contains(&span) {
-            return true;
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        if !spans_with_email.contains(&(group[0].start_line.get(), group[0].end_line.get())) {
+            return group;
         }
+        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let holder = h.holder.as_str();
+                let lower = holder.to_ascii_lowercase();
+                let Some((head, _tail)) = lower.rsplit_once(" for ") else {
+                    return true;
+                };
+                let head = holder[..head.len()].trim_end();
+                if head.is_empty() {
+                    return true;
+                }
 
-        let holder = h.holder.as_str();
-        let lower = holder.to_ascii_lowercase();
-        let Some((head, _tail)) = lower.rsplit_once(" for ") else {
-            return true;
-        };
-        let head = holder[..head.len()].trim_end();
-        if head.is_empty() {
-            return true;
-        }
+                let words: Vec<&str> = head.split_whitespace().collect();
+                if words.len() < 2 {
+                    return true;
+                }
+                let looks_like_person = words.iter().all(|w| {
+                    let w = w.trim_matches(|c: char| c.is_ascii_punctuation());
+                    let mut chars = w.chars();
+                    let Some(first) = chars.next() else {
+                        return false;
+                    };
+                    first.is_alphabetic() && first.is_uppercase()
+                });
+                if !looks_like_person {
+                    return true;
+                }
 
-        let words: Vec<&str> = head.split_whitespace().collect();
-        if words.len() < 2 {
-            return true;
-        }
-        let looks_like_person = words.iter().all(|w| {
-            let w = w.trim_matches(|c: char| c.is_ascii_punctuation());
-            let mut chars = w.chars();
-            let Some(first) = chars.next() else {
-                return false;
-            };
-            first.is_alphabetic() && first.is_uppercase()
-        });
-        if !looks_like_person {
-            return true;
-        }
-
-        let Some(group) = by_span.get(&span) else {
-            return true;
-        };
-        let has_short = group.iter().any(|other| other.trim() == head);
-        !has_short
-    });
+                !group_texts.iter().any(|other| other.trim() == head)
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_multiline_prefix_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
@@ -3160,31 +3153,38 @@ pub fn drop_shadowed_multiline_prefix_copyrights(copyrights: &mut Vec<CopyrightD
         return;
     }
 
-    let all: Vec<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
+    *copyrights = group_by(std::mem::take(copyrights), |c| (c.start_line.get(),))
+        .into_iter()
+        .map(|(_, v)| v)
+        .flat_map(|group| {
+            let group_data: Vec<(usize, usize, String)> = group
+                .iter()
+                .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
+                .collect();
+            group
+                .into_iter()
+                .filter(|c| {
+                    if c.start_line.get() != c.end_line.get() {
+                        return true;
+                    }
+                    let short = c.copyright.as_str();
+                    if short.len() < 10 {
+                        return true;
+                    }
 
-    copyrights.retain(|c| {
-        if c.start_line.get() != c.end_line.get() {
-            return true;
-        }
-        let short = c.copyright.as_str();
-        if short.len() < 10 {
-            return true;
-        }
-
-        !all.iter().any(|(s, e, other)| {
-            *s == c.start_line.get()
-                && *e > c.end_line.get()
-                && other.len() > short.len()
-                && other.starts_with(short)
-                && other
-                    .as_bytes()
-                    .get(short.len())
-                    .is_some_and(|b| b.is_ascii_whitespace() || b.is_ascii_punctuation())
+                    !group_data.iter().any(|(s, e, other)| {
+                        *s == c.start_line.get()
+                            && *e > c.end_line.get()
+                            && other.len() > short.len()
+                            && other.starts_with(short)
+                            && other.as_bytes().get(short.len()).is_some_and(|b| {
+                                b.is_ascii_whitespace() || b.is_ascii_punctuation()
+                            })
+                    })
+                })
+                .collect::<Vec<_>>()
         })
-    });
+        .collect();
 }
 
 pub fn drop_shadowed_multiline_prefix_holders(holders: &mut Vec<HolderDetection>) {
@@ -3192,35 +3192,42 @@ pub fn drop_shadowed_multiline_prefix_holders(holders: &mut Vec<HolderDetection>
         return;
     }
 
-    let all: Vec<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
+    *holders = group_by(std::mem::take(holders), |h| (h.start_line.get(),))
+        .into_iter()
+        .map(|(_, v)| v)
+        .flat_map(|group| {
+            let group_data: Vec<(usize, usize, String)> = group
+                .iter()
+                .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
+                .collect();
+            group
+                .into_iter()
+                .filter(|h| {
+                    if h.start_line.get() != h.end_line.get() {
+                        return true;
+                    }
+                    let short = h.holder.as_str();
+                    if short.len() < 3 {
+                        return true;
+                    }
 
-    holders.retain(|h| {
-        if h.start_line.get() != h.end_line.get() {
-            return true;
-        }
-        let short = h.holder.as_str();
-        if short.len() < 3 {
-            return true;
-        }
-
-        !all.iter().any(|(s, e, other)| {
-            *s == h.start_line.get()
-                && *e > h.end_line.get()
-                && other.len() > short.len()
-                && other.starts_with(short)
-                && {
-                    let tail = other.get(short.len()..).unwrap_or("").trim_start();
-                    !tail.to_ascii_lowercase().starts_with("modify ")
-                }
-                && other
-                    .as_bytes()
-                    .get(short.len())
-                    .is_some_and(|b| b.is_ascii_whitespace() || b.is_ascii_punctuation())
+                    !group_data.iter().any(|(s, e, other)| {
+                        *s == h.start_line.get()
+                            && *e > h.end_line.get()
+                            && other.len() > short.len()
+                            && other.starts_with(short)
+                            && {
+                                let tail = other.get(short.len()..).unwrap_or("").trim_start();
+                                !tail.to_ascii_lowercase().starts_with("modify ")
+                            }
+                            && other.as_bytes().get(short.len()).is_some_and(|b| {
+                                b.is_ascii_whitespace() || b.is_ascii_punctuation()
+                            })
+                    })
+                })
+                .collect::<Vec<_>>()
         })
-    });
+        .collect();
 }
 
 pub fn replace_holders_with_embedded_c_year_markers(
@@ -3915,38 +3922,40 @@ pub fn drop_shadowed_prefix_bare_c_copyrights_same_span(copyrights: &mut Vec<Cop
         return;
     }
 
-    use std::collections::HashMap;
+    *copyrights = group_by(std::mem::take(copyrights), |c| {
+        (c.start_line.get(), c.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let texts: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
+        group
+            .into_iter()
+            .filter(|c| {
+                let short = c.copyright.trim();
+                if !short.to_ascii_lowercase().starts_with("(c) ") {
+                    return true;
+                }
+                if short.contains(',')
+                    || short.contains('<')
+                    || short.contains('>')
+                    || short.contains('@')
+                {
+                    return true;
+                }
 
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for c in copyrights.iter() {
-        by_span
-            .entry((c.start_line.get(), c.end_line.get()))
-            .or_default()
-            .push(c.copyright.clone());
-    }
-
-    copyrights.retain(|c| {
-        let Some(group) = by_span.get(&(c.start_line.get(), c.end_line.get())) else {
-            return true;
-        };
-        let short = c.copyright.trim();
-        if !short.to_ascii_lowercase().starts_with("(c) ") {
-            return true;
-        }
-        if short.contains(',') || short.contains('<') || short.contains('>') || short.contains('@')
-        {
-            return true;
-        }
-
-        !group.iter().any(|other| {
-            other.len() > short.len()
-                && other.starts_with(short)
-                && other
-                    .as_bytes()
-                    .get(short.len())
-                    .is_some_and(|b| *b == b',')
-        })
-    });
+                !texts.iter().any(|other| {
+                    other.len() > short.len()
+                        && other.starts_with(short)
+                        && other
+                            .as_bytes()
+                            .get(short.len())
+                            .is_some_and(|b| *b == b',')
+                })
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn drop_shadowed_acronym_extended_holders(holders: &mut Vec<HolderDetection>) {
@@ -3954,50 +3963,50 @@ pub fn drop_shadowed_acronym_extended_holders(holders: &mut Vec<HolderDetection>
         return;
     }
 
-    use std::collections::HashMap;
-    let mut by_span: HashMap<(usize, usize), Vec<String>> = HashMap::new();
-    for h in holders.iter() {
-        by_span
-            .entry((h.start_line.get(), h.end_line.get()))
-            .or_default()
-            .push(h.holder.clone());
-    }
+    *holders = group_by(std::mem::take(holders), |h| {
+        (h.start_line.get(), h.end_line.get())
+    })
+    .into_iter()
+    .map(|(_, v)| v)
+    .flat_map(|group| {
+        let group_texts: Vec<String> = group.iter().map(|h| h.holder.clone()).collect();
+        group
+            .into_iter()
+            .filter(|h| {
+                let candidate = h.holder.trim();
 
-    holders.retain(|h| {
-        let Some(group) = by_span.get(&(h.start_line.get(), h.end_line.get())) else {
-            return true;
-        };
-        let candidate = h.holder.trim();
+                for base in &group_texts {
+                    let base = base.trim();
+                    if base == candidate {
+                        continue;
+                    }
+                    let prefix = format!("{base} ");
+                    if !candidate.starts_with(&prefix) {
+                        continue;
+                    }
 
-        for base in group {
-            let base = base.trim();
-            if base == candidate {
-                continue;
-            }
-            let prefix = format!("{base} ");
-            if !candidate.starts_with(&prefix) {
-                continue;
-            }
+                    let base_last = base.split_whitespace().last().unwrap_or("");
+                    let base_last_trim = base_last.trim_matches(|c: char| c.is_ascii_punctuation());
+                    let base_is_acronym = (2..=6).contains(&base_last_trim.len())
+                        && base_last_trim.chars().all(|c| c.is_ascii_uppercase());
+                    if !base_is_acronym {
+                        continue;
+                    }
 
-            let base_last = base.split_whitespace().last().unwrap_or("");
-            let base_last_trim = base_last.trim_matches(|c: char| c.is_ascii_punctuation());
-            let base_is_acronym = (2..=6).contains(&base_last_trim.len())
-                && base_last_trim.chars().all(|c| c.is_ascii_uppercase());
-            if !base_is_acronym {
-                continue;
-            }
+                    let tail = candidate[prefix.len()..].trim();
+                    let tail_has_lower = tail
+                        .split_whitespace()
+                        .any(|w| w.chars().any(|c| c.is_ascii_lowercase()));
+                    if tail_has_lower {
+                        return false;
+                    }
+                }
 
-            let tail = candidate[prefix.len()..].trim();
-            let tail_has_lower = tail
-                .split_whitespace()
-                .any(|w| w.chars().any(|c| c.is_ascii_lowercase()));
-            if tail_has_lower {
-                return false;
-            }
-        }
-
-        true
-    });
+                true
+            })
+            .collect::<Vec<_>>()
+    })
+    .collect();
 }
 
 pub fn extend_multiline_copyright_c_no_year_names(

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -23,18 +23,17 @@ pub fn refine_final_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
         return;
     }
 
-    let mut refined: Vec<CopyrightDetection> = Vec::with_capacity(copyrights.len());
-    for c in copyrights.drain(..) {
-        let Some(text) = refine_copyright(&c.copyright) else {
-            continue;
-        };
-        refined.push(CopyrightDetection {
-            copyright: text,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    *copyrights = refined;
+    *copyrights = copyrights
+        .iter()
+        .filter_map(|c| {
+            let text = refine_copyright(&c.copyright)?;
+            Some(CopyrightDetection {
+                copyright: text,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect();
 }
 
 fn strip_trailing_license_tail(s: &str) -> Option<String> {
@@ -170,39 +169,34 @@ pub fn add_missing_holders_for_bare_c_name_year_suffixes(
         Regex::new(r"(?ix)^\(c\)\s+(?P<name>.+?)\s+(?P<year>(?:19\d{2}|20\d{2}))\s*$").unwrap()
     });
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let trimmed = c.copyright.trim();
-        let Some(cap) = BARE_C_NAME_YEAR_RE.captures(trimmed) else {
-            continue;
-        };
-        let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
-        if name.is_empty() {
-            continue;
-        }
-        if name.split_whitespace().count() != 1 {
-            continue;
-        }
-        if !name
-            .chars()
-            .all(|ch| ch.is_alphabetic() || ch == '\'' || ch == '’' || ch == '-')
-        {
-            continue;
-        }
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let trimmed = c.copyright.trim();
+            let cap = BARE_C_NAME_YEAR_RE.captures(trimmed)?;
+            let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
+            if name.is_empty() || name.split_whitespace().count() != 1 {
+                return None;
+            }
+            if !name
+                .chars()
+                .all(|ch| ch.is_alphabetic() || ch == '\'' || ch == '’' || ch == '-')
+            {
+                return None;
+            }
 
-        let Some(holder) = refine_holder_in_copyright_context(name) else {
-            continue;
-        };
-        if holder.is_empty() {
-            continue;
-        }
-        result.push(HolderDetection {
-            holder,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    result
+            let holder = refine_holder_in_copyright_context(name)?;
+            if holder.is_empty() {
+                return None;
+            }
+
+            Some(HolderDetection {
+                holder,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn truncate_lonely_svox_baslerstr_address(
@@ -493,35 +487,32 @@ pub fn add_embedded_copyright_clause_variants(
         return Vec::new();
     }
 
-    let mut to_add = Vec::new();
-    for c in copyrights {
-        let lower = c.copyright.to_ascii_lowercase();
-        if !lower.starts_with("portions created by the initial developer are ") {
-            continue;
-        }
-        let Some(pos) = lower.find(" copyright") else {
-            continue;
-        };
-        let embedded = c.copyright[pos + 1..].trim();
-        if embedded.is_empty() {
-            continue;
-        }
-        let Some(refined) = refine_copyright(embedded) else {
-            continue;
-        };
-        if refined
-            .to_ascii_lowercase()
-            .contains("the initial developer")
-        {
-            continue;
-        }
-        to_add.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    to_add
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let lower = c.copyright.to_ascii_lowercase();
+            if !lower.starts_with("portions created by the initial developer are ") {
+                return None;
+            }
+            let pos = lower.find(" copyright")?;
+            let embedded = c.copyright[pos + 1..].trim();
+            if embedded.is_empty() {
+                return None;
+            }
+            let refined = refine_copyright(embedded)?;
+            if refined
+                .to_ascii_lowercase()
+                .contains("the initial developer")
+            {
+                return None;
+            }
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn add_found_at_short_variants(
@@ -573,36 +564,32 @@ pub fn add_missing_holders_from_email_bearing_copyrights(
         .unwrap()
     });
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let Some(cap) = COPYRIGHT_NAME_EMAIL_RE.captures(c.copyright.trim()) else {
-            continue;
-        };
-        let raw_name = cap.name("name").map(|m| m.as_str()).unwrap_or("");
-        let cleaned_name = normalize_email_copyright_holder_candidate(raw_name);
-        if cleaned_name.is_empty() {
-            continue;
-        }
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let cap = COPYRIGHT_NAME_EMAIL_RE.captures(c.copyright.trim())?;
+            let raw_name = cap.name("name").map(|m| m.as_str()).unwrap_or("");
+            let cleaned_name = normalize_email_copyright_holder_candidate(raw_name);
+            if cleaned_name.is_empty() {
+                return None;
+            }
 
-        let Some(name) = refine_holder_in_copyright_context(&cleaned_name) else {
-            continue;
-        };
-        let domain_only = name.contains('.')
-            && name
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'));
-        if domain_only {
-            continue;
-        }
+            let name = refine_holder_in_copyright_context(&cleaned_name)?;
+            let domain_only = name.contains('.')
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'));
+            if domain_only {
+                return None;
+            }
 
-        result.push(HolderDetection {
-            holder: name,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-
-    result
+            Some(HolderDetection {
+                holder: name,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn normalize_email_copyright_holder_candidate(raw_name: &str) -> String {
@@ -671,15 +658,17 @@ pub fn drop_shadowed_linux_foundation_holder_copyrights_same_line(
             .unwrap()
     });
 
-    let mut years_by_line: HashSet<(usize, String)> = HashSet::new();
-    for c in copyrights.iter() {
-        if let Some(cap) = WITH_C_RE.captures(c.copyright.trim()) {
+    let years_by_line: HashSet<(usize, String)> = copyrights
+        .iter()
+        .filter_map(|c| {
+            let cap = WITH_C_RE.captures(c.copyright.trim())?;
             let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
-            if !years.is_empty() {
-                years_by_line.insert((c.start_line.get(), years.to_string()));
+            if years.is_empty() {
+                return None;
             }
-        }
-    }
+            Some((c.start_line.get(), years.to_string()))
+        })
+        .collect();
 
     copyrights.retain(|c| {
         let Some(cap) = WITH_HOLDER_RE.captures(c.copyright.trim()) else {
@@ -790,25 +779,23 @@ pub fn drop_comma_holders_shadowed_by_space_version_same_span(holders: &mut Vec<
         return;
     }
 
-    *holders = group_by(std::mem::take(holders), |h| {
-        (h.start_line.get(), h.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let set: HashSet<String> = group.iter().map(|h| h.holder.clone()).collect();
-        group
+    let by_span: HashMap<(usize, usize), HashSet<String>> =
+        group_by(holders.clone(), |h| (h.start_line.get(), h.end_line.get()))
             .into_iter()
-            .filter(|h| {
-                if !h.holder.contains(',') {
-                    return true;
-                }
-                let no_comma = super::token_utils::normalize_whitespace(&h.holder.replace(',', ""));
-                !(no_comma != h.holder && set.contains(&no_comma))
-            })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+            .map(|(span, group)| (span, group.into_iter().map(|h| h.holder).collect()))
+            .collect();
+
+    holders.retain(|h| {
+        if !h.holder.contains(',') {
+            return true;
+        }
+        let no_comma = super::token_utils::normalize_whitespace(&h.holder.replace(',', ""));
+        let span = (h.start_line.get(), h.end_line.get());
+        !(no_comma != h.holder
+            && by_span
+                .get(&span)
+                .is_some_and(|set| set.contains(&no_comma)))
+    });
 }
 
 pub fn normalize_company_suffix_period_holder_variants(holders: &mut Vec<HolderDetection>) {
@@ -1203,26 +1190,23 @@ pub fn add_first_angle_email_only_variants(
         Regex::new(r"^(?P<prefix>Copyright\b.*?<[^>\s]*@[^>\s]+>)(?:\s*,\s*.+)$").unwrap()
     });
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let trimmed = c.copyright.trim();
-        let Some(cap) = MULTI_EMAIL_RE.captures(trimmed) else {
-            continue;
-        };
-        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
-        if prefix.is_empty() {
-            continue;
-        }
-        let Some(refined) = refine_copyright(prefix) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    result
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let trimmed = c.copyright.trim();
+            let cap = MULTI_EMAIL_RE.captures(trimmed)?;
+            let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+            if prefix.is_empty() {
+                return None;
+            }
+            let refined = refine_copyright(prefix)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn drop_shadowed_angle_email_prefix_copyrights_same_span(
@@ -1293,28 +1277,24 @@ pub fn drop_shadowed_quote_before_email_variants_same_span(
         super::token_utils::normalize_whitespace(&QUOTED_RE.replace_all(s, " $1"))
     }
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| {
+    let by_span: HashMap<(usize, usize), HashSet<String>> = group_by(copyrights.clone(), |c| {
         (c.start_line.get(), c.end_line.get())
     })
     .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let set: HashSet<String> = group.iter().map(|c| c.copyright.clone()).collect();
-        group
-            .into_iter()
-            .filter(|c| {
-                if !c.copyright.contains('\'') || !c.copyright.contains('@') {
-                    return true;
-                }
-                let canon = canonical(&c.copyright);
-                if canon == c.copyright {
-                    return true;
-                }
-                !set.contains(&canon)
-            })
-            .collect::<Vec<_>>()
-    })
+    .map(|(span, group)| (span, group.into_iter().map(|c| c.copyright).collect()))
     .collect();
+
+    copyrights.retain(|c| {
+        if !c.copyright.contains('\'') || !c.copyright.contains('@') {
+            return true;
+        }
+        let canon = canonical(&c.copyright);
+        if canon == c.copyright {
+            return true;
+        }
+        let span = (c.start_line.get(), c.end_line.get());
+        !by_span.get(&span).is_some_and(|set| set.contains(&canon))
+    });
 }
 
 pub fn add_missing_holder_from_single_copyright(
@@ -1352,27 +1332,23 @@ pub fn add_but_suffix_short_variants(copyrights: &[CopyrightDetection]) -> Vec<C
     static BUT_SUFFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^(?P<prefix>.+?),\s*but\s*$").unwrap());
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let trimmed = c.copyright.trim();
-        let Some(cap) = BUT_SUFFIX_RE.captures(trimmed) else {
-            continue;
-        };
-        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
-        if prefix.is_empty() {
-            continue;
-        }
-        let Some(refined) = refine_copyright(prefix) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-
-    result
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let trimmed = c.copyright.trim();
+            let cap = BUT_SUFFIX_RE.captures(trimmed)?;
+            let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+            if prefix.is_empty() {
+                return None;
+            }
+            let refined = refine_copyright(prefix)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn add_at_affiliation_short_variants(
@@ -1745,25 +1721,23 @@ pub fn drop_single_line_copyrights_shadowed_by_multiline_same_start(
         .unwrap()
     });
 
-    let mut multi_keys: HashSet<(usize, String, String)> = HashSet::new();
-    for c in copyrights.iter() {
-        if c.end_line.get() <= c.start_line.get() {
-            continue;
-        }
-        let Some(cap) = YEARS_EMAIL_RE.captures(c.copyright.trim()) else {
-            continue;
-        };
-        let years = cap.name("years").map(|m| m.as_str()).unwrap_or("");
-        let email = cap.name("email").map(|m| m.as_str()).unwrap_or("");
-        let years_norm = years
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .collect::<String>();
-        if years_norm.is_empty() || email.is_empty() {
-            continue;
-        }
-        multi_keys.insert((c.start_line.get(), years_norm, email.to_ascii_lowercase()));
-    }
+    let multi_keys: HashSet<(usize, String, String)> = copyrights
+        .iter()
+        .filter(|c| c.end_line.get() > c.start_line.get())
+        .filter_map(|c| {
+            let cap = YEARS_EMAIL_RE.captures(c.copyright.trim())?;
+            let years = cap.name("years").map(|m| m.as_str()).unwrap_or("");
+            let email = cap.name("email").map(|m| m.as_str()).unwrap_or("");
+            let years_norm = years
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect::<String>();
+            if years_norm.is_empty() || email.is_empty() {
+                return None;
+            }
+            Some((c.start_line.get(), years_norm, email.to_ascii_lowercase()))
+        })
+        .collect();
 
     if multi_keys.is_empty() {
         return;
@@ -1867,32 +1841,28 @@ pub fn drop_shadowed_inria_location_copyrights_same_span(copyrights: &mut Vec<Co
         Regex::new(r"^(?P<prefix>.+\bINRIA)\s+(?P<loc>[A-Z][a-z]{2,64})$").unwrap()
     });
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| {
+    let by_span: HashMap<(usize, usize), HashSet<String>> = group_by(copyrights.clone(), |c| {
         (c.start_line.get(), c.end_line.get())
     })
     .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let set: HashSet<String> = group.iter().map(|c| c.copyright.clone()).collect();
-        group
-            .into_iter()
-            .filter(|c| {
-                let Some(cap) = INRIA_LOC_RE.captures(c.copyright.trim()) else {
-                    return true;
-                };
-                let prefix = cap
-                    .name("prefix")
-                    .map(|m| m.as_str())
-                    .unwrap_or("")
-                    .trim_end();
-                if prefix.is_empty() {
-                    return true;
-                }
-                !set.contains(prefix)
-            })
-            .collect::<Vec<_>>()
-    })
+    .map(|(span, group)| (span, group.into_iter().map(|c| c.copyright).collect()))
     .collect();
+
+    copyrights.retain(|c| {
+        let Some(cap) = INRIA_LOC_RE.captures(c.copyright.trim()) else {
+            return true;
+        };
+        let prefix = cap
+            .name("prefix")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim_end();
+        if prefix.is_empty() {
+            return true;
+        }
+        let span = (c.start_line.get(), c.end_line.get());
+        !by_span.get(&span).is_some_and(|set| set.contains(prefix))
+    });
 }
 
 pub fn add_email_holders_from_leading_email_comma_holders(
@@ -1954,32 +1924,24 @@ pub fn drop_shadowed_email_comma_holders_same_span(holders: &mut Vec<HolderDetec
         Regex::new(r"(?i)^(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\s*,\s+.+$").unwrap()
     });
 
-    *holders = group_by(std::mem::take(holders), |h| {
-        (h.start_line.get(), h.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let set: HashSet<String> = group.iter().map(|h| h.holder.clone()).collect();
-        group
+    let by_span: HashMap<(usize, usize), HashSet<String>> =
+        group_by(holders.clone(), |h| (h.start_line.get(), h.end_line.get()))
             .into_iter()
-            .filter(|h| {
-                let trimmed = h.holder.trim();
-                let Some(cap) = LEADING_EMAIL_COMMA_RE.captures(trimmed) else {
-                    return true;
-                };
-                let email = cap.name("email").map(|m| m.as_str()).unwrap_or("").trim();
-                if email.is_empty() {
-                    return true;
-                }
-                if trimmed.eq_ignore_ascii_case(email) {
-                    return true;
-                }
-                !set.contains(email)
-            })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+            .map(|(span, group)| (span, group.into_iter().map(|h| h.holder).collect()))
+            .collect();
+
+    holders.retain(|h| {
+        let trimmed = h.holder.trim();
+        let Some(cap) = LEADING_EMAIL_COMMA_RE.captures(trimmed) else {
+            return true;
+        };
+        let email = cap.name("email").map(|m| m.as_str()).unwrap_or("").trim();
+        if email.is_empty() || trimmed.eq_ignore_ascii_case(email) {
+            return true;
+        }
+        let span = (h.start_line.get(), h.end_line.get());
+        !by_span.get(&span).is_some_and(|set| set.contains(email))
+    });
 }
 
 pub fn add_pipe_read_parenthetical_variants(
@@ -3016,29 +2978,33 @@ pub fn drop_shadowed_c_sign_variants(copyrights: &mut Vec<CopyrightDetection>) {
         super::token_utils::normalize_whitespace(&C_SIGN_RE.replace_all(s, " "))
     }
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| {
-        (c.start_line.get(), c.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let with_c_set: HashSet<String> = group
-            .iter()
-            .filter(|c| contains_c_sign(&c.copyright))
-            .map(|c| canonical_without_c_sign(&c.copyright))
-            .collect();
-        group
-            .into_iter()
-            .filter(|c| {
-                if contains_c_sign(&c.copyright) {
-                    return true;
-                }
-                let canon = canonical_without_c_sign(&c.copyright);
-                !with_c_set.contains(&canon)
-            })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+    let with_c_by_span: HashMap<(usize, usize), HashSet<String>> =
+        group_by(copyrights.clone(), |c| {
+            (c.start_line.get(), c.end_line.get())
+        })
+        .into_iter()
+        .map(|(span, group)| {
+            (
+                span,
+                group
+                    .into_iter()
+                    .filter(|c| contains_c_sign(&c.copyright))
+                    .map(|c| canonical_without_c_sign(&c.copyright))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    copyrights.retain(|c| {
+        if contains_c_sign(&c.copyright) {
+            return true;
+        }
+        let canon = canonical_without_c_sign(&c.copyright);
+        let span = (c.start_line.get(), c.end_line.get());
+        !with_c_by_span
+            .get(&span)
+            .is_some_and(|set| set.contains(&canon))
+    });
 }
 
 pub fn drop_shadowed_year_prefixed_holders(holders: &mut Vec<HolderDetection>) {
@@ -3061,28 +3027,30 @@ pub fn drop_shadowed_year_prefixed_holders(holders: &mut Vec<HolderDetection>) {
         Some(super::token_utils::normalize_whitespace(rest))
     }
 
-    *holders = group_by(std::mem::take(holders), |h| {
-        (h.start_line.get(), h.end_line.get())
-    })
-    .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let set: HashSet<String> = group
-            .iter()
-            .map(|h| super::token_utils::normalize_whitespace(&h.holder))
-            .collect();
-        group
+    let by_span: HashMap<(usize, usize), HashSet<String>> =
+        group_by(holders.clone(), |h| (h.start_line.get(), h.end_line.get()))
             .into_iter()
-            .filter(|h| {
-                let normalized = super::token_utils::normalize_whitespace(&h.holder);
-                let Some(stripped) = strip_leading_year_token(&normalized) else {
-                    return true;
-                };
-                !set.contains(&stripped)
+            .map(|(span, group)| {
+                (
+                    span,
+                    group
+                        .into_iter()
+                        .map(|h| super::token_utils::normalize_whitespace(&h.holder))
+                        .collect(),
+                )
             })
-            .collect::<Vec<_>>()
-    })
-    .collect();
+            .collect();
+
+    holders.retain(|h| {
+        let normalized = super::token_utils::normalize_whitespace(&h.holder);
+        let Some(stripped) = strip_leading_year_token(&normalized) else {
+            return true;
+        };
+        let span = (h.start_line.get(), h.end_line.get());
+        !by_span
+            .get(&span)
+            .is_some_and(|set| set.contains(&stripped))
+    });
 }
 
 pub fn drop_shadowed_for_clause_holders_with_email_copyrights(
@@ -3153,38 +3121,40 @@ pub fn drop_shadowed_multiline_prefix_copyrights(copyrights: &mut Vec<CopyrightD
         return;
     }
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| (c.start_line.get(),))
-        .into_iter()
-        .map(|(_, v)| v)
-        .flat_map(|group| {
-            let group_data: Vec<(usize, usize, String)> = group
-                .iter()
-                .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-                .collect();
-            group
-                .into_iter()
-                .filter(|c| {
-                    if c.start_line.get() != c.end_line.get() {
-                        return true;
-                    }
-                    let short = c.copyright.as_str();
-                    if short.len() < 10 {
-                        return true;
-                    }
+    let by_start: HashMap<usize, Vec<(usize, String)>> =
+        group_by(copyrights.clone(), |c| (c.start_line.get(),))
+            .into_iter()
+            .map(|((start,), group)| {
+                (
+                    start,
+                    group
+                        .into_iter()
+                        .map(|c| (c.end_line.get(), c.copyright))
+                        .collect(),
+                )
+            })
+            .collect();
 
-                    !group_data.iter().any(|(s, e, other)| {
-                        *s == c.start_line.get()
-                            && *e > c.end_line.get()
-                            && other.len() > short.len()
-                            && other.starts_with(short)
-                            && other.as_bytes().get(short.len()).is_some_and(|b| {
-                                b.is_ascii_whitespace() || b.is_ascii_punctuation()
-                            })
-                    })
-                })
-                .collect::<Vec<_>>()
+    copyrights.retain(|c| {
+        if c.start_line.get() != c.end_line.get() {
+            return true;
+        }
+        let short = c.copyright.as_str();
+        if short.len() < 10 {
+            return true;
+        }
+        !by_start.get(&c.start_line.get()).is_some_and(|group| {
+            group.iter().any(|(end, other)| {
+                *end > c.end_line.get()
+                    && other.len() > short.len()
+                    && other.starts_with(short)
+                    && other
+                        .as_bytes()
+                        .get(short.len())
+                        .is_some_and(|b| b.is_ascii_whitespace() || b.is_ascii_punctuation())
+            })
         })
-        .collect();
+    });
 }
 
 pub fn drop_shadowed_multiline_prefix_holders(holders: &mut Vec<HolderDetection>) {
@@ -3192,42 +3162,45 @@ pub fn drop_shadowed_multiline_prefix_holders(holders: &mut Vec<HolderDetection>
         return;
     }
 
-    *holders = group_by(std::mem::take(holders), |h| (h.start_line.get(),))
-        .into_iter()
-        .map(|(_, v)| v)
-        .flat_map(|group| {
-            let group_data: Vec<(usize, usize, String)> = group
-                .iter()
-                .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-                .collect();
-            group
-                .into_iter()
-                .filter(|h| {
-                    if h.start_line.get() != h.end_line.get() {
-                        return true;
-                    }
-                    let short = h.holder.as_str();
-                    if short.len() < 3 {
-                        return true;
-                    }
+    let by_start: HashMap<usize, Vec<(usize, String)>> =
+        group_by(holders.clone(), |h| (h.start_line.get(),))
+            .into_iter()
+            .map(|((start,), group)| {
+                (
+                    start,
+                    group
+                        .into_iter()
+                        .map(|h| (h.end_line.get(), h.holder))
+                        .collect(),
+                )
+            })
+            .collect();
 
-                    !group_data.iter().any(|(s, e, other)| {
-                        *s == h.start_line.get()
-                            && *e > h.end_line.get()
-                            && other.len() > short.len()
-                            && other.starts_with(short)
-                            && {
-                                let tail = other.get(short.len()..).unwrap_or("").trim_start();
-                                !tail.to_ascii_lowercase().starts_with("modify ")
-                            }
-                            && other.as_bytes().get(short.len()).is_some_and(|b| {
-                                b.is_ascii_whitespace() || b.is_ascii_punctuation()
-                            })
-                    })
-                })
-                .collect::<Vec<_>>()
+    holders.retain(|h| {
+        if h.start_line.get() != h.end_line.get() {
+            return true;
+        }
+        let short = h.holder.as_str();
+        if short.len() < 3 {
+            return true;
+        }
+
+        !by_start.get(&h.start_line.get()).is_some_and(|group| {
+            group.iter().any(|(end, other)| {
+                *end > h.end_line.get()
+                    && other.len() > short.len()
+                    && other.starts_with(short)
+                    && {
+                        let tail = other.get(short.len()..).unwrap_or("").trim_start();
+                        !tail.to_ascii_lowercase().starts_with("modify ")
+                    }
+                    && other
+                        .as_bytes()
+                        .get(short.len())
+                        .is_some_and(|b| b.is_ascii_whitespace() || b.is_ascii_punctuation())
+            })
         })
-        .collect();
+    });
 }
 
 pub fn replace_holders_with_embedded_c_year_markers(
@@ -3922,40 +3895,35 @@ pub fn drop_shadowed_prefix_bare_c_copyrights_same_span(copyrights: &mut Vec<Cop
         return;
     }
 
-    *copyrights = group_by(std::mem::take(copyrights), |c| {
+    let by_span: HashMap<(usize, usize), Vec<String>> = group_by(copyrights.clone(), |c| {
         (c.start_line.get(), c.end_line.get())
     })
     .into_iter()
-    .map(|(_, v)| v)
-    .flat_map(|group| {
-        let texts: Vec<String> = group.iter().map(|c| c.copyright.clone()).collect();
-        group
-            .into_iter()
-            .filter(|c| {
-                let short = c.copyright.trim();
-                if !short.to_ascii_lowercase().starts_with("(c) ") {
-                    return true;
-                }
-                if short.contains(',')
-                    || short.contains('<')
-                    || short.contains('>')
-                    || short.contains('@')
-                {
-                    return true;
-                }
-
-                !texts.iter().any(|other| {
-                    other.len() > short.len()
-                        && other.starts_with(short)
-                        && other
-                            .as_bytes()
-                            .get(short.len())
-                            .is_some_and(|b| *b == b',')
-                })
-            })
-            .collect::<Vec<_>>()
-    })
+    .map(|(span, group)| (span, group.into_iter().map(|c| c.copyright).collect()))
     .collect();
+
+    copyrights.retain(|c| {
+        let short = c.copyright.trim();
+        if !short.to_ascii_lowercase().starts_with("(c) ") {
+            return true;
+        }
+        if short.contains(',') || short.contains('<') || short.contains('>') || short.contains('@')
+        {
+            return true;
+        }
+
+        let span = (c.start_line.get(), c.end_line.get());
+        !by_span.get(&span).is_some_and(|texts| {
+            texts.iter().any(|other| {
+                other.len() > short.len()
+                    && other.starts_with(short)
+                    && other
+                        .as_bytes()
+                        .get(short.len())
+                        .is_some_and(|b| *b == b',')
+            })
+        })
+    });
 }
 
 pub fn drop_shadowed_acronym_extended_holders(holders: &mut Vec<HolderDetection>) {
@@ -5983,18 +5951,17 @@ pub fn add_missing_holders_for_debian_modifications(
         return Vec::new();
     }
 
-    let mut result = Vec::new();
-    for cr in copyrights {
-        let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
-            continue;
-        };
-        result.push(HolderDetection {
-            holder,
-            start_line: cr.start_line,
-            end_line: cr.end_line,
-        });
-    }
-    result
+    copyrights
+        .iter()
+        .filter_map(|cr| {
+            let holder = derive_holder_from_simple_copyright_string(&cr.copyright)?;
+            Some(HolderDetection {
+                holder,
+                start_line: cr.start_line,
+                end_line: cr.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn split_embedded_copyright_detections(
@@ -6178,18 +6145,17 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
 pub fn add_missing_holders_derived_from_split_copyrights(
     copyrights: &[CopyrightDetection],
 ) -> Vec<HolderDetection> {
-    let mut result = Vec::new();
-    for cr in copyrights {
-        let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
-            continue;
-        };
-        result.push(HolderDetection {
-            holder,
-            start_line: cr.start_line,
-            end_line: cr.end_line,
-        });
-    }
-    result
+    copyrights
+        .iter()
+        .filter_map(|cr| {
+            let holder = derive_holder_from_simple_copyright_string(&cr.copyright)?;
+            Some(HolderDetection {
+                holder,
+                start_line: cr.start_line,
+                end_line: cr.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -15,6 +15,8 @@ use crate::copyright::refiner::{
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 use crate::models::LineNumber;
 
+use super::seen_text::SeenTextSets;
+
 pub fn refine_final_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
     if copyrights.is_empty() {
         return;
@@ -162,12 +164,12 @@ pub fn deadline_exceeded(deadline: Option<Instant>) -> bool {
 
 pub fn add_missing_holders_for_bare_c_name_year_suffixes(
     copyrights: &[CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> Vec<HolderDetection> {
     static BARE_C_NAME_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?ix)^\(c\)\s+(?P<name>.+?)\s+(?P<year>(?:19\d{2}|20\d{2}))\s*$").unwrap()
     });
 
+    let mut result = Vec::new();
     for c in copyrights {
         let trimmed = c.copyright.trim();
         let Some(cap) = BARE_C_NAME_YEAR_RE.captures(trimmed) else {
@@ -193,19 +195,13 @@ pub fn add_missing_holders_for_bare_c_name_year_suffixes(
         if holder.is_empty() {
             continue;
         }
-        if holders.iter().any(|h| {
-            h.start_line.get() == c.start_line.get()
-                && h.end_line.get() == c.end_line.get()
-                && h.holder == holder
-        }) {
-            continue;
-        }
-        holders.push(HolderDetection {
+        result.push(HolderDetection {
             holder,
             start_line: c.start_line,
             end_line: c.end_line,
         });
     }
+    result
 }
 
 pub fn truncate_lonely_svox_baslerstr_address(
@@ -247,11 +243,12 @@ pub fn truncate_lonely_svox_baslerstr_address(
 }
 
 pub fn add_short_svox_baslerstr_variants(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    holders: &[HolderDetection],
+    seen: &SeenTextSets,
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if copyrights.is_empty() || holders.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     fn truncate_at_baslerstr(s: &str) -> Option<String> {
@@ -270,24 +267,21 @@ pub fn add_short_svox_baslerstr_variants(
         c.copyright.contains("SVOX") && c.copyright.to_ascii_lowercase().contains("baslerstr")
     });
     if !has_full {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     if copyrights.len() == 1 && holders.len() == 1 {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
-    let existing_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let existing_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     let mut new_c = Vec::new();
-    for c in copyrights.iter() {
+    for c in copyrights {
         if !c.copyright.contains("SVOX") || !c.copyright.to_ascii_lowercase().contains("baslerstr")
         {
             continue;
         }
         if let Some(short) = truncate_at_baslerstr(&c.copyright)
-            && !existing_c.contains(&short)
+            && !seen.copyrights.contains(&short)
         {
             new_c.push(CopyrightDetection {
                 copyright: short,
@@ -296,15 +290,14 @@ pub fn add_short_svox_baslerstr_variants(
             });
         }
     }
-    copyrights.extend(new_c);
 
     let mut new_h = Vec::new();
-    for h in holders.iter() {
+    for h in holders {
         if !h.holder.contains("SVOX") || !h.holder.to_ascii_lowercase().contains("baslerstr") {
             continue;
         }
         if let Some(short) = truncate_at_baslerstr(&h.holder)
-            && !existing_h.contains(&short)
+            && !seen.holders.contains(&short)
         {
             new_h.push(HolderDetection {
                 holder: short,
@@ -313,7 +306,7 @@ pub fn add_short_svox_baslerstr_variants(
             });
         }
     }
-    holders.extend(new_h);
+    (new_c, new_h)
 }
 
 pub fn drop_shadowed_year_only_copyright_prefixes_same_start_line(
@@ -489,21 +482,18 @@ pub fn merge_multiline_person_year_copyright_continuations(
     }
 }
 
-pub fn add_embedded_copyright_clause_variants(copyrights: &mut Vec<CopyrightDetection>) {
+pub fn add_embedded_copyright_clause_variants(
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
     if copyrights.len() < 50 {
-        return;
+        return Vec::new();
     }
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
     let mut to_add = Vec::new();
-    for c in copyrights.iter() {
+    for c in copyrights {
         let lower = c.copyright.to_ascii_lowercase();
         if !lower.starts_with("portions created by the initial developer are ") {
             continue;
@@ -524,41 +514,29 @@ pub fn add_embedded_copyright_clause_variants(copyrights: &mut Vec<CopyrightDete
         {
             continue;
         }
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if !existing.contains(&key) {
-            to_add.push(CopyrightDetection {
-                copyright: refined,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        to_add.push(CopyrightDetection {
+            copyright: refined,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
-    copyrights.extend(to_add);
+    to_add
 }
 
 pub fn add_found_at_short_variants(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    _holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if copyrights.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static FOUND_AT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\(c\)\s+by\s+(?P<name>.+?)\s+found\s+at\b").unwrap());
 
-    let existing_c: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-    let existing_h: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
-
     let mut new_c = Vec::new();
     let mut new_h = Vec::new();
-    for c in copyrights.iter() {
+    for c in copyrights {
         let Some(cap) = FOUND_AT_RE.captures(c.copyright.trim()) else {
             continue;
         };
@@ -567,33 +545,26 @@ pub fn add_found_at_short_variants(
             continue;
         }
         let short = format!("(c) by {name}");
-        let key = (c.start_line.get(), c.end_line.get(), short.clone());
-        if !existing_c.contains(&key) {
-            new_c.push(CopyrightDetection {
-                copyright: short,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_c.push(CopyrightDetection {
+            copyright: short,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
 
         let holder_short = name.to_string();
-        let hkey = (c.start_line.get(), c.end_line.get(), holder_short.clone());
-        if !existing_h.contains(&hkey) {
-            new_h.push(HolderDetection {
-                holder: holder_short,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_h.push(HolderDetection {
+            holder: holder_short,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
-    copyrights.extend(new_c);
-    holders.extend(new_h);
+    (new_c, new_h)
 }
 
 pub fn add_missing_holders_from_email_bearing_copyrights(
     copyrights: &[CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+    _holders: &[HolderDetection],
+) -> Vec<HolderDetection> {
     static COPYRIGHT_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^copyright(?:\s*\(c\))?\s+[0-9][0-9,\-–/ ]*\s+(?:by\s+)?(?P<name>[^<]+?)\s*<[^>\s]*@[^>\s]*>\s*$",
@@ -601,18 +572,7 @@ pub fn add_missing_holders_from_email_bearing_copyrights(
         .unwrap()
     });
 
-    let existing: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| {
-            (
-                h.start_line.get(),
-                h.end_line.get(),
-                super::token_utils::normalize_whitespace(&h.holder),
-            )
-        })
-        .collect();
-
-    let mut additions = Vec::new();
+    let mut result = Vec::new();
     for c in copyrights {
         let Some(cap) = COPYRIGHT_NAME_EMAIL_RE.captures(c.copyright.trim()) else {
             continue;
@@ -634,19 +594,14 @@ pub fn add_missing_holders_from_email_bearing_copyrights(
             continue;
         }
 
-        let key = (c.start_line.get(), c.end_line.get(), name.clone());
-        if existing.contains(&key) {
-            continue;
-        }
-
-        additions.push(HolderDetection {
+        result.push(HolderDetection {
             holder: name,
             start_line: c.start_line,
             end_line: c.end_line,
         });
     }
 
-    holders.extend(additions);
+    result
 }
 
 pub fn normalize_email_copyright_holder_candidate(raw_name: &str) -> String {
@@ -790,19 +745,14 @@ pub fn restore_linux_foundation_copyrights_from_raw_lines(
 
 pub fn add_bare_email_variants_for_escaped_angle_lines(
     raw_lines: &[&str],
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if raw_lines.is_empty() || copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static ANGLE_EMAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"<\s*([^\s<>]+@[^\s<>]+)\s*>").unwrap());
-
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
 
     let mut to_add = Vec::new();
     for c in copyrights.iter() {
@@ -825,16 +775,13 @@ pub fn add_bare_email_variants_for_escaped_angle_lines(
         let Some(refined) = refine_copyright(&bare) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if !existing.contains(&key) {
-            to_add.push(CopyrightDetection {
-                copyright: refined,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        to_add.push(CopyrightDetection {
+            copyright: refined,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
-    copyrights.extend(to_add);
+    to_add
 }
 
 pub fn drop_comma_holders_shadowed_by_space_version_same_span(holders: &mut Vec<HolderDetection>) {
@@ -969,27 +916,20 @@ pub fn normalize_company_suffix_period_holder_variants(holders: &mut Vec<HolderD
 }
 
 pub fn add_confidential_short_variants_late(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    _holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if copyrights.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static CONF_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^copyright\s+(?P<year>\d{4})\s+confidential\s+information\b").unwrap()
     });
 
-    let mut existing_c: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-    let mut existing_h: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
-
-    for c in copyrights.clone() {
+    let mut new_c = Vec::new();
+    let mut new_h = Vec::new();
+    for c in copyrights {
         let Some(cap) = CONF_RE.captures(c.copyright.as_str()) else {
             continue;
         };
@@ -1001,25 +941,20 @@ pub fn add_confidential_short_variants_late(
         let Some(short_c) = refine_copyright(&short_c_raw) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), short_c.clone());
-        if existing_c.insert(key) {
-            copyrights.push(CopyrightDetection {
-                copyright: short_c,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_c.push(CopyrightDetection {
+            copyright: short_c,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
 
         let short_h = "Confidential".to_string();
-        let hkey = (c.start_line.get(), c.end_line.get(), short_h.clone());
-        if existing_h.insert(hkey) {
-            holders.push(HolderDetection {
-                holder: short_h,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_h.push(HolderDetection {
+            holder: short_h,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
+    (new_c, new_h)
 }
 
 pub fn split_multiline_holder_lists_from_copyright_email_sequences(
@@ -1123,11 +1058,11 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
 }
 
 pub fn add_karlsruhe_university_short_variants(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if copyrights.is_empty() && holders.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static KARLSRUHE_RE: LazyLock<Regex> =
@@ -1136,16 +1071,8 @@ pub fn add_karlsruhe_university_short_variants(
         Regex::new(r"(?i)\bUniversity\s+of\s+Karlsruhe\b\s*[)\]\.\,;:]?\s*$").unwrap()
     });
 
-    let mut existing_c: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-    let mut existing_h: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
-
-    for c in copyrights.clone() {
+    let mut new_c = Vec::new();
+    for c in copyrights {
         if !KARLSRUHE_RE.is_match(c.copyright.as_str()) {
             continue;
         }
@@ -1159,17 +1086,15 @@ pub fn add_karlsruhe_university_short_variants(
         if short == c.copyright {
             continue;
         }
-        let key = (c.start_line.get(), c.end_line.get(), short.clone());
-        if existing_c.insert(key) {
-            copyrights.push(CopyrightDetection {
-                copyright: short,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_c.push(CopyrightDetection {
+            copyright: short,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
 
-    for h in holders.clone() {
+    let mut new_h = Vec::new();
+    for h in holders {
         if !KARLSRUHE_RE.is_match(h.holder.as_str()) {
             continue;
         }
@@ -1183,23 +1108,21 @@ pub fn add_karlsruhe_university_short_variants(
         if short == h.holder {
             continue;
         }
-        let key = (h.start_line.get(), h.end_line.get(), short.clone());
-        if existing_h.insert(key) {
-            holders.push(HolderDetection {
-                holder: short,
-                start_line: h.start_line,
-                end_line: h.end_line,
-            });
-        }
+        new_h.push(HolderDetection {
+            holder: short,
+            start_line: h.start_line,
+            end_line: h.end_line,
+        });
     }
+    (new_c, new_h)
 }
 
 pub fn add_intel_and_sun_non_portions_variants(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if prepared_cache.is_empty() || copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static PORTIONS_SUN_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -1216,12 +1139,8 @@ pub fn add_intel_and_sun_non_portions_variants(
             .unwrap()
     });
 
-    let mut existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
-    for c in copyrights.clone() {
+    let mut result = Vec::new();
+    for c in copyrights {
         let trimmed = c.copyright.trim();
         if let Some(cap) = PORTIONS_SUN_RE.captures(trimmed) {
             let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -1231,14 +1150,11 @@ pub fn add_intel_and_sun_non_portions_variants(
                     "Copyright {year} Sun Microsystems{tail}"
                 ));
                 if let Some(refined) = refine_copyright(&candidate) {
-                    let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-                    if existing.insert(key) {
-                        copyrights.push(CopyrightDetection {
-                            copyright: refined,
-                            start_line: c.start_line,
-                            end_line: c.end_line,
-                        });
-                    }
+                    result.push(CopyrightDetection {
+                        copyright: refined,
+                        start_line: c.start_line,
+                        end_line: c.end_line,
+                    });
                 }
             }
         }
@@ -1263,36 +1179,32 @@ pub fn add_intel_and_sun_non_portions_variants(
                         "Copyright 2002 Intel ({emails})"
                     ));
                     if let Some(refined) = refine_copyright(&candidate) {
-                        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-                        if existing.insert(key) {
-                            copyrights.push(CopyrightDetection {
-                                copyright: refined,
-                                start_line: c.start_line,
-                                end_line: c.end_line,
-                            });
-                        }
+                        result.push(CopyrightDetection {
+                            copyright: refined,
+                            start_line: c.start_line,
+                            end_line: c.end_line,
+                        });
                     }
                 }
             }
         }
     }
+    result
 }
 
-pub fn add_first_angle_email_only_variants(copyrights: &mut Vec<CopyrightDetection>) {
+pub fn add_first_angle_email_only_variants(
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static MULTI_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"^(?P<prefix>Copyright\b.*?<[^>\s]*@[^>\s]+>)(?:\s*,\s*.+)$").unwrap()
     });
 
-    let mut existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
-    for c in copyrights.clone() {
+    let mut result = Vec::new();
+    for c in copyrights {
         let trimmed = c.copyright.trim();
         let Some(cap) = MULTI_EMAIL_RE.captures(trimmed) else {
             continue;
@@ -1304,15 +1216,13 @@ pub fn add_first_angle_email_only_variants(copyrights: &mut Vec<CopyrightDetecti
         let Some(refined) = refine_copyright(prefix) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if existing.insert(key) {
-            copyrights.push(CopyrightDetection {
-                copyright: refined,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        result.push(CopyrightDetection {
+            copyright: refined,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
+    result
 }
 
 pub fn drop_shadowed_angle_email_prefix_copyrights_same_span(
@@ -1410,51 +1320,42 @@ pub fn drop_shadowed_quote_before_email_variants_same_span(
 }
 
 pub fn add_missing_holder_from_single_copyright(
-    copyrights: &mut [CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    holders: &[HolderDetection],
+) -> Option<HolderDetection> {
     if !holders.is_empty() || copyrights.len() != 1 {
-        return;
+        return None;
     }
     let c = &copyrights[0];
-    let Some(h) = derive_holder_from_simple_copyright_string(&c.copyright) else {
-        return;
-    };
-    let Some(h) = refine_holder_in_copyright_context(&h) else {
-        return;
-    };
+    let h = derive_holder_from_simple_copyright_string(&c.copyright)?;
+    let h = refine_holder_in_copyright_context(&h)?;
 
     let trimmed = h.trim();
     if trimmed.to_ascii_lowercase().starts_with("copyright ") {
-        return;
+        return None;
     }
     static YEAR_ONLY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^\d{4}(?:\s*[-–]\s*\d{4})?$").unwrap());
     if YEAR_ONLY_RE.is_match(trimmed) {
-        return;
+        return None;
     }
-    holders.push(HolderDetection {
+    Some(HolderDetection {
         holder: h,
         start_line: c.start_line,
         end_line: c.end_line,
-    });
+    })
 }
 
-pub fn add_but_suffix_short_variants(copyrights: &mut Vec<CopyrightDetection>) {
+pub fn add_but_suffix_short_variants(copyrights: &[CopyrightDetection]) -> Vec<CopyrightDetection> {
     if copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static BUT_SUFFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^(?P<prefix>.+?),\s*but\s*$").unwrap());
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
-    let mut to_add = Vec::new();
-    for c in copyrights.iter() {
+    let mut result = Vec::new();
+    for c in copyrights {
         let trimmed = c.copyright.trim();
         let Some(cap) = BUT_SUFFIX_RE.captures(trimmed) else {
             continue;
@@ -1466,38 +1367,26 @@ pub fn add_but_suffix_short_variants(copyrights: &mut Vec<CopyrightDetection>) {
         let Some(refined) = refine_copyright(prefix) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if !existing.contains(&key) {
-            to_add.push(CopyrightDetection {
-                copyright: refined,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        result.push(CopyrightDetection {
+            copyright: refined,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
 
-    copyrights.extend(to_add);
+    result
 }
 
 pub fn add_at_affiliation_short_variants(
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+    holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if copyrights.is_empty() && holders.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
-    let existing_c: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-    let existing_h: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
-
-    let mut to_add_c = Vec::new();
-    for c in copyrights.iter() {
+    let mut new_c = Vec::new();
+    for c in copyrights {
         let Some((head, _tail)) = c.copyright.split_once(" @ ") else {
             continue;
         };
@@ -1508,19 +1397,15 @@ pub fn add_at_affiliation_short_variants(
         let Some(refined) = refine_copyright(head) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if !existing_c.contains(&key) {
-            to_add_c.push(CopyrightDetection {
-                copyright: refined,
-                start_line: c.start_line,
-                end_line: c.end_line,
-            });
-        }
+        new_c.push(CopyrightDetection {
+            copyright: refined,
+            start_line: c.start_line,
+            end_line: c.end_line,
+        });
     }
-    copyrights.extend(to_add_c);
 
-    let mut to_add_h = Vec::new();
-    for h in holders.iter() {
+    let mut new_h = Vec::new();
+    for h in holders {
         let Some((head, tail)) = h.holder.split_once(" @ ") else {
             continue;
         };
@@ -1534,41 +1419,33 @@ pub fn add_at_affiliation_short_variants(
         let Some(refined) = refine_holder_in_copyright_context(head) else {
             continue;
         };
-        let key = (h.start_line.get(), h.end_line.get(), refined.clone());
-        if !existing_h.contains(&key) {
-            to_add_h.push(HolderDetection {
-                holder: refined,
-                start_line: h.start_line,
-                end_line: h.end_line,
-            });
-        }
+        new_h.push(HolderDetection {
+            holder: refined,
+            start_line: h.start_line,
+            end_line: h.end_line,
+        });
     }
-    holders.extend(to_add_h);
+    (new_c, new_h)
 }
 
 pub fn add_missing_copyrights_for_holder_lines_with_emails(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
+    copyrights: &[CopyrightDetection],
     holders: &[HolderDetection],
-) {
+) -> Vec<CopyrightDetection> {
     if prepared_cache.is_empty() || holders.is_empty() {
-        return;
+        return Vec::new();
     }
 
     let mut copyright_lines: HashSet<usize> = HashSet::new();
-    for c in copyrights.iter() {
+    for c in copyrights {
         if c.start_line.get() == c.end_line.get() {
             copyright_lines.insert(c.start_line.get());
         }
     }
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
-    let mut to_add = Vec::new();
-    for h in holders.iter() {
+    let mut result = Vec::new();
+    for h in holders {
         if h.start_line.get() != h.end_line.get() {
             continue;
         }
@@ -1599,17 +1476,13 @@ pub fn add_missing_copyrights_for_holder_lines_with_emails(
         let Some(refined) = refine_copyright(prepared) else {
             continue;
         };
-        let key = (ln, ln, refined.clone());
-        if existing.contains(&key) {
-            continue;
-        }
-        to_add.push(CopyrightDetection {
+        result.push(CopyrightDetection {
             copyright: refined,
             start_line: LineNumber::new(ln).expect("invalid line number"),
             end_line: LineNumber::new(ln).expect("invalid line number"),
         });
     }
-    copyrights.extend(to_add);
+    result
 }
 
 pub fn extend_inline_obfuscated_angle_email_suffixes(
@@ -1772,26 +1645,21 @@ pub fn strip_lone_obfuscated_angle_email_user_tokens(
 
 pub fn add_at_domain_variants_for_short_net_angle_emails(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     if !prepared_cache.contains_ci("pipe read code from") {
-        return;
+        return Vec::new();
     }
 
     static SHORT_NET_EMAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)<(?P<user>[a-z]{3})@(?P<domain>[^>\s]+\.net)>").unwrap());
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
-    let mut to_add = Vec::new();
-    for c in copyrights.iter() {
+    let mut result = Vec::new();
+    for c in copyrights {
         let Some(cap) = SHORT_NET_EMAIL_RE.captures(c.copyright.as_str()) else {
             continue;
         };
@@ -1806,17 +1674,13 @@ pub fn add_at_domain_variants_for_short_net_angle_emails(
         let Some(refined) = refine_copyright(&replaced) else {
             continue;
         };
-        let key = (c.start_line.get(), c.end_line.get(), refined.clone());
-        if existing.contains(&key) {
-            continue;
-        }
-        to_add.push(CopyrightDetection {
+        result.push(CopyrightDetection {
             copyright: refined,
             start_line: c.start_line,
             end_line: c.end_line,
         });
     }
-    copyrights.extend(to_add);
+    result
 }
 
 pub fn drop_shadowed_plain_email_prefix_copyrights_same_span(
@@ -2100,20 +1964,16 @@ pub fn drop_shadowed_email_org_location_suffixes_same_span(
 
 pub fn add_pipe_read_parenthetical_variants(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if prepared_cache.len() < 2 || copyrights.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static PIPE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\(\s*pipe\s+read\s+code\s+from\s+[^)]+\)\s*$").unwrap());
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
+    let mut result = Vec::new();
     for i in 0..prepared_cache.len().saturating_sub(1) {
         let ln1 = i + 1;
         let ln2 = i + 2;
@@ -2136,33 +1996,27 @@ pub fn add_pipe_read_parenthetical_variants(
         let Some(refined) = refine_copyright(&combined) else {
             continue;
         };
-        let key = (ln1, ln2, refined.clone());
-        if !existing.contains(&key) {
-            copyrights.push(CopyrightDetection {
-                copyright: refined,
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
-            });
-        }
+        result.push(CopyrightDetection {
+            copyright: refined,
+            start_line: LineNumber::new(ln1).expect("valid"),
+            end_line: LineNumber::new(ln2).expect("valid"),
+        });
     }
+    result
 }
 
 pub fn add_from_url_parenthetical_copyright_variants(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-) {
+    _copyrights: &[CopyrightDetection],
+) -> Vec<CopyrightDetection> {
     if prepared_cache.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static FROM_URL_COPY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bfrom\s+https?://\S+\s*\(\s*copyright\b").unwrap());
 
-    let existing: HashSet<(usize, usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
-        .collect();
-
+    let mut result = Vec::new();
     for i in 0..prepared_cache.len() {
         let ln = i + 1;
         let Some(line) = prepared_cache.get_by_index(i).map(|s| s.trim().to_string()) else {
@@ -2182,15 +2036,13 @@ pub fn add_from_url_parenthetical_copyright_variants(
         let Some(refined) = refine_copyright(&s) else {
             continue;
         };
-        let key = (ln, ln, refined.clone());
-        if !existing.contains(&key) {
-            copyrights.push(CopyrightDetection {
-                copyright: refined,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        result.push(CopyrightDetection {
+            copyright: refined,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
     }
+    result
 }
 
 pub fn drop_shadowed_acronym_location_suffix_copyrights_same_span(
@@ -3091,18 +2943,14 @@ pub fn extend_copyrights_with_following_all_rights_reserved_line(
 
 pub fn add_modify_suffix_holders(
     prepared_cache: &mut PreparedLineCache<'_>,
-    holders: &mut Vec<HolderDetection>,
-) {
+    holders: &[HolderDetection],
+) -> Vec<HolderDetection> {
     if prepared_cache.is_empty() || holders.is_empty() {
-        return;
+        return Vec::new();
     }
 
-    let mut existing: HashSet<(usize, usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
-        .collect();
-
-    for h in holders.clone() {
+    let mut result = Vec::new();
+    for h in holders {
         let idx = h.end_line.get() + 1;
         let Some(next) = prepared_cache.get(idx) else {
             continue;
@@ -3125,15 +2973,13 @@ pub fn add_modify_suffix_holders(
             continue;
         }
         let combined = super::token_utils::normalize_whitespace(&format!("{} {t}", h.holder));
-        let key = (h.start_line.get(), h.end_line.get() + 1, combined.clone());
-        if existing.insert(key) {
-            holders.push(HolderDetection {
-                holder: combined,
-                start_line: h.start_line,
-                end_line: h.end_line + 1,
-            });
-        }
+        result.push(HolderDetection {
+            holder: combined,
+            start_line: h.start_line,
+            end_line: h.end_line + 1,
+        });
     }
+    result
 }
 
 pub fn drop_shadowed_c_sign_variants(copyrights: &mut Vec<CopyrightDetection>) {
@@ -3229,12 +3075,11 @@ pub fn drop_shadowed_for_clause_holders_with_email_copyrights(
 
     use std::collections::{HashMap, HashSet};
 
-    let mut spans_with_email: HashSet<(usize, usize)> = HashSet::new();
-    for c in copyrights {
-        if c.copyright.contains('@') {
-            spans_with_email.insert((c.start_line.get(), c.end_line.get()));
-        }
-    }
+    let spans_with_email: HashSet<(usize, usize)> = copyrights
+        .iter()
+        .filter(|c| c.copyright.contains('@'))
+        .map(|c| (c.start_line.get(), c.end_line.get()))
+        .collect();
     if spans_with_email.is_empty() {
         return;
     }
@@ -6097,26 +5942,27 @@ pub fn fix_sundry_contributors_truncation(
 pub fn add_missing_holders_for_debian_modifications(
     content: &str,
     copyrights: &[CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> Vec<HolderDetection> {
     let has_debian_mods_line = content.lines().any(|l| {
         let lower = l.trim().to_ascii_lowercase();
         lower.starts_with("modifications for debian copyright")
     });
     if !has_debian_mods_line {
-        return;
+        return Vec::new();
     }
 
+    let mut result = Vec::new();
     for cr in copyrights {
         let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
             continue;
         };
-        holders.push(HolderDetection {
+        result.push(HolderDetection {
             holder,
             start_line: cr.start_line,
             end_line: cr.end_line,
         });
     }
+    result
 }
 
 pub fn split_embedded_copyright_detections(
@@ -6223,7 +6069,9 @@ pub fn split_embedded_copyright_detections(
 
     *copyrights = out;
 
-    add_missing_holders_derived_from_split_copyrights(&split_copyrights, holders);
+    holders.extend(add_missing_holders_derived_from_split_copyrights(
+        &split_copyrights,
+    ));
 }
 
 pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
@@ -6297,18 +6145,19 @@ pub fn extend_bare_c_year_detections_to_line_end_for_multi_c_lines(
 
 pub fn add_missing_holders_derived_from_split_copyrights(
     copyrights: &[CopyrightDetection],
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> Vec<HolderDetection> {
+    let mut result = Vec::new();
     for cr in copyrights {
         let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
             continue;
         };
-        holders.push(HolderDetection {
+        result.push(HolderDetection {
             holder,
             start_line: cr.start_line,
             end_line: cr.end_line,
         });
     }
+    result
 }
 
 pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -3644,25 +3644,17 @@ pub fn merge_year_only_copyrights_with_following_author_colon_lines(
 
 pub fn extract_question_mark_year_copyrights(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     if prepared_cache.is_empty() {
-        return;
+        return (Vec::new(), Vec::new());
     }
 
     static QMARK_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*copyright\s+(?P<year>\d{3}\?)\s+(?P<tail>.+)$").unwrap()
     });
 
-    let mut seen_c: HashSet<(usize, String)> = copyrights
-        .iter()
-        .map(|c| (c.start_line.get(), c.copyright.clone()))
-        .collect();
-    let mut seen_h: HashSet<(usize, String)> = holders
-        .iter()
-        .map(|h| (h.start_line.get(), h.holder.clone()))
-        .collect();
+    let mut new_copyrights = Vec::new();
+    let mut new_holders = Vec::new();
 
     for ln in 1..=prepared_cache.len() {
         let Some(prepared) = prepared_cache.get(ln) else {
@@ -3682,25 +3674,23 @@ pub fn extract_question_mark_year_copyrights(
         let Some(cr) = refine_copyright(&raw) else {
             continue;
         };
-        if seen_c.insert((ln, cr.clone())) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        new_copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
 
         let raw_holder = format!("{year} {tail}");
-        if let Some(h) = refine_holder_in_copyright_context(&raw_holder)
-            && seen_h.insert((ln, h.clone()))
-        {
-            holders.push(HolderDetection {
+        if let Some(h) = refine_holder_in_copyright_context(&raw_holder) {
+            new_holders.push(HolderDetection {
                 holder: h,
                 start_line: LineNumber::new(ln).unwrap(),
                 end_line: LineNumber::new(ln).unwrap(),
             });
         }
     }
+
+    (new_copyrights, new_holders)
 }
 
 pub fn strip_inc_suffix_from_holders_for_today_year_copyrights(
@@ -3960,9 +3950,7 @@ pub fn apply_openoffice_org_report_builder_bin_normalizations(
 
 pub fn extract_midline_c_year_holder_with_leading_acronym(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static MIDLINE_C_YEAR_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?ix)^
@@ -3976,6 +3964,9 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
         )
         .unwrap()
     });
+
+    let mut new_copyrights = Vec::new();
+    let mut new_holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -4008,7 +3999,7 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
             continue;
         };
 
-        copyrights.push(CopyrightDetection {
+        new_copyrights.push(CopyrightDetection {
             copyright: cr,
             start_line: LineNumber::new(ln).unwrap(),
             end_line: LineNumber::new(ln).unwrap(),
@@ -4016,13 +4007,15 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
 
         let holder_raw = format!("{holder} {prefix}");
         if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
-            holders.push(HolderDetection {
+            new_holders.push(HolderDetection {
                 holder: h,
                 start_line: LineNumber::new(ln).unwrap(),
                 end_line: LineNumber::new(ln).unwrap(),
             });
         }
     }
+
+    (new_copyrights, new_holders)
 }
 
 pub fn dedupe_exact_span_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
@@ -4872,9 +4865,6 @@ pub fn merge_freebird_c_inc_urls(
         return;
     }
 
-    let mut seen_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for i in 0..prepared_cache.len() {
         let ln = i + 1;
         let Some(prepared) = prepared_cache.get_by_index(i) else {
@@ -4917,9 +4907,7 @@ pub fn merge_freebird_c_inc_urls(
         };
 
         let cr_raw = format!("(c), Inc. {url}");
-        if let Some(cr) = refine_copyright(&cr_raw)
-            && seen_c.insert(cr.clone())
-        {
+        if let Some(cr) = refine_copyright(&cr_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -4927,9 +4915,7 @@ pub fn merge_freebird_c_inc_urls(
             });
         }
         let holder_raw = "Inc.";
-        if let Some(h) = refine_holder(holder_raw)
-            && seen_h.insert(h.clone())
-        {
+        if let Some(h) = refine_holder(holder_raw) {
             holders.push(HolderDetection {
                 holder: h,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -5125,9 +5111,6 @@ pub fn merge_kirkwood_converted_to(
         Regex::new(r"(?i)\(c\)\s+(?P<year>19\d{2}|20\d{2})\s+(?P<who>M\.?\s*Kirkwood)\b").unwrap()
     });
 
-    let mut seen_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for i in 0..prepared_cache.len().saturating_sub(1) {
         let ln = i + 1;
         let Some(p1) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
@@ -5152,9 +5135,7 @@ pub fn merge_kirkwood_converted_to(
         }
 
         let cr_raw = format!("(c) {year} {who} Converted to");
-        if let Some(cr) = refine_copyright(&cr_raw)
-            && seen_c.insert(cr.clone())
-        {
+        if let Some(cr) = refine_copyright(&cr_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -5162,9 +5143,7 @@ pub fn merge_kirkwood_converted_to(
             });
         }
         let holder_raw = format!("{who} Converted");
-        if let Some(h) = refine_holder_in_copyright_context(&holder_raw)
-            && seen_h.insert(h.clone())
-        {
+        if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
             holders.push(HolderDetection {
                 holder: h,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -5187,8 +5166,6 @@ pub fn split_reworked_by_suffixes(
         Regex::new(r"(?i)^(?P<prefix>.+?)\s+Re-worked\s+by\s+(?P<who>.+)$").unwrap()
     });
 
-    let mut seen_authors: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
-
     for det in copyrights.iter_mut() {
         let current = det.copyright.clone();
         let Some(cap) = REWORKED_RE.captures(current.as_str()) else {
@@ -5210,9 +5187,7 @@ pub fn split_reworked_by_suffixes(
         } else {
             det.copyright = prefix.to_string();
         }
-        if let Some(author) = refine_author(&who)
-            && seen_authors.insert(author.clone())
-        {
+        if let Some(author) = refine_author(&who) {
             authors.push(AuthorDetection {
                 author,
                 start_line: det.start_line,
@@ -5270,10 +5245,10 @@ pub fn drop_combined_period_holders(holders: &mut Vec<HolderDetection>) {
 
 pub fn extract_line_ending_copyright_then_by_holder(
     prepared_cache: &mut PreparedLineCache<'_>,
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
-    let mut existing: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    let mut new_copyrights = Vec::new();
+    let mut new_holders = Vec::new();
 
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
@@ -5313,10 +5288,8 @@ pub fn extract_line_ending_copyright_then_by_holder(
             if next_lower.starts_with("by ") {
                 let holder_raw = next_prepared[3..].trim();
                 let copyright_raw = format!("copyright {}", next_prepared.trim());
-                if let Some(copyright_text) = refine_copyright(&copyright_raw)
-                    && existing.insert(copyright_text.clone())
-                {
-                    copyrights.push(CopyrightDetection {
+                if let Some(copyright_text) = refine_copyright(&copyright_raw) {
+                    new_copyrights.push(CopyrightDetection {
                         copyright: copyright_text,
                         start_line: LineNumber::new(ln).unwrap(),
                         end_line: LineNumber::new(next_ln).expect("valid"),
@@ -5324,9 +5297,9 @@ pub fn extract_line_ending_copyright_then_by_holder(
                 }
 
                 if let Some(holder) = refine_holder_in_copyright_context(holder_raw)
-                    && !holders.iter().any(|h| h.holder == holder)
+                    && !existing_holders.iter().any(|h| h.holder == holder)
                 {
-                    holders.push(HolderDetection {
+                    new_holders.push(HolderDetection {
                         holder,
                         start_line: LineNumber::new(next_ln).expect("valid"),
                         end_line: LineNumber::new(next_ln).expect("valid"),
@@ -5336,6 +5309,8 @@ pub fn extract_line_ending_copyright_then_by_holder(
             break;
         }
     }
+
+    (new_copyrights, new_holders)
 }
 
 pub fn drop_trailing_software_line_from_holders(
@@ -5426,10 +5401,6 @@ pub fn recover_template_literal_year_range_copyrights(
         .expect("valid template literal copyright regex")
     });
 
-    let mut seen_copyrights: HashSet<String> =
-        copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_holders: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for (idx, raw_line) in content.lines().enumerate() {
         if !(raw_line.contains("Copyright") || raw_line.contains("copyright")) {
             continue;
@@ -5459,13 +5430,11 @@ pub fn recover_template_literal_year_range_copyrights(
         };
 
         let copyright_text = format!("Copyright {start}-{templ} {holder}");
-        if seen_copyrights.insert(copyright_text.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: copyright_text,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: copyright_text,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
 
         let truncated = format!("Copyright {start}-$");
         copyrights.retain(|c| {
@@ -5474,13 +5443,11 @@ pub fn recover_template_literal_year_range_copyrights(
                 && c.copyright.eq_ignore_ascii_case(&truncated))
         });
 
-        if seen_holders.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
     }
 }
 
@@ -5652,17 +5619,17 @@ pub fn drop_url_embedded_suffix_variants_same_span(
 pub fn extract_following_authors_holders(
     raw_lines: &[&str],
     prepared_cache: &mut PreparedLineCache<'_>,
-    authors: &mut Vec<AuthorDetection>,
-) {
+) -> Vec<AuthorDetection> {
     if raw_lines.is_empty() {
-        return;
+        return Vec::new();
     }
 
     static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^\s*copyright\b.*\bby\s+the\s+following\s+authors\b.*$")
             .expect("valid following authors header regex")
     });
-    let mut seen: HashSet<String> = authors.iter().map(|a| a.author.clone()).collect();
+
+    let mut new_authors = Vec::new();
 
     let mut i = 0;
     while i < raw_lines.len() {
@@ -5694,9 +5661,8 @@ pub fn extract_following_authors_holders(
             item = super::token_utils::normalize_whitespace(&item);
             if !item.is_empty()
                 && let Some(author) = refine_author(&item)
-                && seen.insert(author.clone())
             {
-                authors.push(AuthorDetection {
+                new_authors.push(AuthorDetection {
                     author,
                     start_line: LineNumber::new(next_ln).unwrap(),
                     end_line: LineNumber::new(next_ln).unwrap(),
@@ -5708,6 +5674,8 @@ pub fn extract_following_authors_holders(
 
         i = if extracted_any { j } else { i + 1 };
     }
+
+    new_authors
 }
 
 pub fn drop_created_by_camelcase_identifier_authors(
@@ -5967,9 +5935,6 @@ pub fn fix_shm_inline_copyrights(
             .unwrap()
     });
 
-    let mut seen_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     for idx in 0..prepared_cache.len() {
         let ln = idx + 1;
         let Some(prepared) = prepared_cache.get_by_index(idx) else {
@@ -5993,17 +5958,13 @@ pub fn fix_shm_inline_copyrights(
         let Some(cr) = refine_copyright(&cr_raw) else {
             continue;
         };
-        if seen_c.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln).unwrap(),
+        });
 
-        if let Some(holder) = refine_holder(name)
-            && seen_h.insert(holder.clone())
-        {
+        if let Some(holder) = refine_holder(name) {
             holders.push(HolderDetection {
                 holder,
                 start_line: LineNumber::new(ln).unwrap(),
@@ -6029,9 +5990,6 @@ pub fn fix_n_tty_linus_torvalds_written_by_clause(
         return;
     }
 
-    let mut seen_c: HashSet<String> = copyrights.iter().map(|c| c.copyright.clone()).collect();
-    let mut seen_h: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
-
     let lines: Vec<&str> = content.lines().collect();
     for i in 0..lines.len().saturating_sub(1) {
         if !lines[i].contains("Linus Torvalds") {
@@ -6042,21 +6000,17 @@ pub fn fix_n_tty_linus_torvalds_written_by_clause(
         }
         let ln = i + 1;
         let cr = "Linus Torvalds, Copyright 1991, 1992, 1993".to_string();
-        if seen_c.insert(cr.clone()) {
-            copyrights.push(CopyrightDetection {
-                copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
-            });
-        }
+        copyrights.push(CopyrightDetection {
+            copyright: cr,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+        });
         let holder = "Linus Torvalds".to_string();
-        if seen_h.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: LineNumber::new(ln).unwrap(),
+            end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+        });
         break;
     }
 }
@@ -6153,18 +6107,15 @@ pub fn add_missing_holders_for_debian_modifications(
         return;
     }
 
-    let mut seen: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
     for cr in copyrights {
         let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
             continue;
         };
-        if seen.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: cr.start_line,
-                end_line: cr.end_line,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: cr.start_line,
+            end_line: cr.end_line,
+        });
     }
 }
 
@@ -6348,18 +6299,15 @@ pub fn add_missing_holders_derived_from_split_copyrights(
     copyrights: &[CopyrightDetection],
     holders: &mut Vec<HolderDetection>,
 ) {
-    let mut seen: HashSet<String> = holders.iter().map(|h| h.holder.clone()).collect();
     for cr in copyrights {
         let Some(holder) = derive_holder_from_simple_copyright_string(&cr.copyright) else {
             continue;
         };
-        if seen.insert(holder.clone()) {
-            holders.push(HolderDetection {
-                holder,
-                start_line: cr.start_line,
-                end_line: cr.end_line,
-            });
-        }
+        holders.push(HolderDetection {
+            holder,
+            start_line: cr.start_line,
+            end_line: cr.end_line,
+        });
     }
 }
 

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -245,6 +245,9 @@ pub fn add_short_svox_baslerstr_variants(
     if copyrights.is_empty() || holders.is_empty() {
         return (Vec::new(), Vec::new());
     }
+    if copyrights.len() == 1 && holders.len() == 1 {
+        return (Vec::new(), Vec::new());
+    }
 
     fn truncate_at_baslerstr(s: &str) -> Option<String> {
         let lower = s.to_ascii_lowercase();
@@ -258,49 +261,42 @@ pub fn add_short_svox_baslerstr_variants(
         }
     }
 
-    let has_full = copyrights.iter().any(|c| {
-        c.copyright.contains("SVOX") && c.copyright.to_ascii_lowercase().contains("baslerstr")
-    });
-    if !has_full {
+    let full_copyrights: Vec<&CopyrightDetection> = copyrights
+        .iter()
+        .filter(|c| {
+            c.copyright.contains("SVOX") && c.copyright.to_ascii_lowercase().contains("baslerstr")
+        })
+        .collect();
+    if full_copyrights.is_empty() {
         return (Vec::new(), Vec::new());
     }
 
-    if copyrights.len() == 1 && holders.len() == 1 {
-        return (Vec::new(), Vec::new());
-    }
-
-    let mut new_c = Vec::new();
-    for c in copyrights {
-        if !c.copyright.contains("SVOX") || !c.copyright.to_ascii_lowercase().contains("baslerstr")
-        {
-            continue;
-        }
-        if let Some(short) = truncate_at_baslerstr(&c.copyright)
-            && !seen.copyrights.contains(&short)
-        {
-            new_c.push(CopyrightDetection {
+    let new_c = full_copyrights
+        .into_iter()
+        .filter_map(|c| {
+            let short = truncate_at_baslerstr(&c.copyright)?;
+            (!seen.copyrights.contains(&short)).then_some(CopyrightDetection {
                 copyright: short,
                 start_line: c.start_line,
                 end_line: c.end_line,
-            });
-        }
-    }
+            })
+        })
+        .collect();
 
-    let mut new_h = Vec::new();
-    for h in holders {
-        if !h.holder.contains("SVOX") || !h.holder.to_ascii_lowercase().contains("baslerstr") {
-            continue;
-        }
-        if let Some(short) = truncate_at_baslerstr(&h.holder)
-            && !seen.holders.contains(&short)
-        {
-            new_h.push(HolderDetection {
+    let new_h = holders
+        .iter()
+        .filter(|h| {
+            h.holder.contains("SVOX") && h.holder.to_ascii_lowercase().contains("baslerstr")
+        })
+        .filter_map(|h| {
+            let short = truncate_at_baslerstr(&h.holder)?;
+            (!seen.holders.contains(&short)).then_some(HolderDetection {
                 holder: short,
                 start_line: h.start_line,
                 end_line: h.end_line,
-            });
-        }
-    }
+            })
+        })
+        .collect();
     (new_c, new_h)
 }
 
@@ -518,31 +514,25 @@ pub fn add_found_at_short_variants(
     static FOUND_AT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\(c\)\s+by\s+(?P<name>.+?)\s+found\s+at\b").unwrap());
 
-    let mut new_c = Vec::new();
-    let mut new_h = Vec::new();
-    for c in copyrights {
-        let Some(cap) = FOUND_AT_RE.captures(c.copyright.trim()) else {
-            continue;
-        };
-        let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
-        if name.is_empty() {
-            continue;
-        }
-        let short = format!("(c) by {name}");
-        new_c.push(CopyrightDetection {
-            copyright: short,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-
-        let holder_short = name.to_string();
-        new_h.push(HolderDetection {
-            holder: holder_short,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    (new_c, new_h)
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let cap = FOUND_AT_RE.captures(c.copyright.trim())?;
+            let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
+            (!name.is_empty()).then_some((
+                CopyrightDetection {
+                    copyright: format!("(c) by {name}"),
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                },
+                HolderDetection {
+                    holder: name.to_string(),
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                },
+            ))
+        })
+        .unzip()
 }
 
 pub fn add_missing_holders_from_email_bearing_copyrights(
@@ -736,34 +726,37 @@ pub fn add_bare_email_variants_for_escaped_angle_lines(
     static ANGLE_EMAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"<\s*([^\s<>]+@[^\s<>]+)\s*>").unwrap());
 
-    let mut to_add = Vec::new();
-    for c in copyrights.iter() {
-        if c.start_line.get() != c.end_line.get() {
-            continue;
-        }
-        let Some(raw) = raw_lines.get(c.start_line.get() - 1) else {
-            continue;
-        };
-        let raw_lower = raw.to_ascii_lowercase();
-        if !(raw_lower.contains("&lt;") && raw_lower.contains("&gt;") && raw_lower.contains('@')) {
-            continue;
-        }
-        if !(c.copyright.contains('<') && c.copyright.contains('>') && c.copyright.contains('@')) {
-            continue;
-        }
-        let bare = ANGLE_EMAIL_RE
-            .replace_all(c.copyright.as_str(), "$1")
-            .to_string();
-        let Some(refined) = refine_copyright(&bare) else {
-            continue;
-        };
-        to_add.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    to_add
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            if c.start_line.get() != c.end_line.get() {
+                return None;
+            }
+            let raw = raw_lines.get(c.start_line.get() - 1)?;
+            let raw_lower = raw.to_ascii_lowercase();
+            if !(raw_lower.contains("&lt;")
+                && raw_lower.contains("&gt;")
+                && raw_lower.contains('@'))
+            {
+                return None;
+            }
+            if !(c.copyright.contains('<')
+                && c.copyright.contains('>')
+                && c.copyright.contains('@'))
+            {
+                return None;
+            }
+            let bare = ANGLE_EMAIL_RE
+                .replace_all(c.copyright.as_str(), "$1")
+                .to_string();
+            let refined = refine_copyright(&bare)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn drop_comma_holders_shadowed_by_space_version_same_span(holders: &mut Vec<HolderDetection>) {
@@ -906,34 +899,26 @@ pub fn add_confidential_short_variants_late(
         Regex::new(r"(?i)^copyright\s+(?P<year>\d{4})\s+confidential\s+information\b").unwrap()
     });
 
-    let mut new_c = Vec::new();
-    let mut new_h = Vec::new();
-    for c in copyrights {
-        let Some(cap) = CONF_RE.captures(c.copyright.as_str()) else {
-            continue;
-        };
-        let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
-        if year.is_empty() {
-            continue;
-        }
-        let short_c_raw = format!("Copyright {year} Confidential");
-        let Some(short_c) = refine_copyright(&short_c_raw) else {
-            continue;
-        };
-        new_c.push(CopyrightDetection {
-            copyright: short_c,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-
-        let short_h = "Confidential".to_string();
-        new_h.push(HolderDetection {
-            holder: short_h,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    (new_c, new_h)
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let cap = CONF_RE.captures(c.copyright.as_str())?;
+            let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
+            let short_c = refine_copyright(&format!("Copyright {year} Confidential"))?;
+            Some((
+                CopyrightDetection {
+                    copyright: short_c,
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                },
+                HolderDetection {
+                    holder: "Confidential".to_string(),
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                },
+            ))
+        })
+        .unzip()
 }
 
 pub fn split_multiline_holder_lists_from_copyright_email_sequences(
@@ -1050,49 +1035,44 @@ pub fn add_karlsruhe_university_short_variants(
         Regex::new(r"(?i)\bUniversity\s+of\s+Karlsruhe\b\s*[)\]\.\,;:]?\s*$").unwrap()
     });
 
-    let mut new_c = Vec::new();
-    for c in copyrights {
-        if !KARLSRUHE_RE.is_match(c.copyright.as_str()) {
-            continue;
+    fn shorten_karlsruhe(
+        text: &str,
+        karlsruhe_re: &Regex,
+        karlsruhe_terminal_re: &Regex,
+    ) -> Option<String> {
+        if !karlsruhe_re.is_match(text) || !karlsruhe_terminal_re.is_match(text) {
+            return None;
         }
-        if !KARLSRUHE_TERMINAL_RE.is_match(c.copyright.as_str()) {
-            continue;
-        }
-        let short = KARLSRUHE_RE
-            .replace_all(c.copyright.as_str(), "University")
-            .to_string();
+        let short = karlsruhe_re.replace_all(text, "University").to_string();
         let short = super::token_utils::normalize_whitespace(&short);
-        if short == c.copyright {
-            continue;
-        }
-        new_c.push(CopyrightDetection {
-            copyright: short,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
+        (short != text).then_some(short)
     }
 
-    let mut new_h = Vec::new();
-    for h in holders {
-        if !KARLSRUHE_RE.is_match(h.holder.as_str()) {
-            continue;
-        }
-        if !KARLSRUHE_TERMINAL_RE.is_match(h.holder.as_str()) {
-            continue;
-        }
-        let short = KARLSRUHE_RE
-            .replace_all(h.holder.as_str(), "University")
-            .to_string();
-        let short = super::token_utils::normalize_whitespace(&short);
-        if short == h.holder {
-            continue;
-        }
-        new_h.push(HolderDetection {
-            holder: short,
-            start_line: h.start_line,
-            end_line: h.end_line,
-        });
-    }
+    let new_c = copyrights
+        .iter()
+        .filter_map(|c| {
+            let short =
+                shorten_karlsruhe(c.copyright.as_str(), &KARLSRUHE_RE, &KARLSRUHE_TERMINAL_RE)?;
+            Some(CopyrightDetection {
+                copyright: short,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect();
+
+    let new_h = holders
+        .iter()
+        .filter_map(|h| {
+            let short =
+                shorten_karlsruhe(h.holder.as_str(), &KARLSRUHE_RE, &KARLSRUHE_TERMINAL_RE)?;
+            Some(HolderDetection {
+                holder: short,
+                start_line: h.start_line,
+                end_line: h.end_line,
+            })
+        })
+        .collect();
     (new_c, new_h)
 }
 
@@ -1118,57 +1098,58 @@ pub fn add_intel_and_sun_non_portions_variants(
             .unwrap()
     });
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let trimmed = c.copyright.trim();
-        if let Some(cap) = PORTIONS_SUN_RE.captures(trimmed) {
-            let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
-            let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("");
-            if !year.is_empty() {
+    copyrights
+        .iter()
+        .flat_map(|c| {
+            let trimmed = c.copyright.trim();
+
+            let sun_variant = PORTIONS_SUN_RE.captures(trimmed).and_then(|cap| {
+                let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
+                let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("");
+                if year.is_empty() {
+                    return None;
+                }
                 let candidate = super::token_utils::normalize_whitespace(&format!(
                     "Copyright {year} Sun Microsystems{tail}"
                 ));
-                if let Some(refined) = refine_copyright(&candidate) {
-                    result.push(CopyrightDetection {
-                        copyright: refined,
-                        start_line: c.start_line,
-                        end_line: c.end_line,
-                    });
-                }
-            }
-        }
+                let refined = refine_copyright(&candidate)?;
+                Some(CopyrightDetection {
+                    copyright: refined,
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                })
+            });
 
-        if PORTIONS_INTEL_RE.is_match(trimmed)
-            && (c.end_line.get() > c.start_line.get() || trimmed.contains('('))
-        {
-            let mut joined = String::new();
-            for ln in c.start_line.get()..=c.end_line.get() {
-                if let Some(p) = prepared_cache.get(ln) {
-                    if !joined.is_empty() {
-                        joined.push(' ');
+            let intel_variant = if PORTIONS_INTEL_RE.is_match(trimmed)
+                && (c.end_line.get() > c.start_line.get() || trimmed.contains('('))
+            {
+                let joined = (c.start_line.get()..=c.end_line.get())
+                    .filter_map(|ln| prepared_cache.get(ln))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let joined = super::token_utils::normalize_whitespace(&joined);
+                INTEL_EMAILS_RE.captures(joined.as_str()).and_then(|cap| {
+                    let emails = cap.name("emails").map(|m| m.as_str()).unwrap_or("").trim();
+                    if emails.is_empty() {
+                        return None;
                     }
-                    joined.push_str(p);
-                }
-            }
-            let joined = super::token_utils::normalize_whitespace(&joined);
-            if let Some(cap) = INTEL_EMAILS_RE.captures(joined.as_str()) {
-                let emails = cap.name("emails").map(|m| m.as_str()).unwrap_or("").trim();
-                if !emails.is_empty() {
                     let candidate = super::token_utils::normalize_whitespace(&format!(
                         "Copyright 2002 Intel ({emails})"
                     ));
-                    if let Some(refined) = refine_copyright(&candidate) {
-                        result.push(CopyrightDetection {
-                            copyright: refined,
-                            start_line: c.start_line,
-                            end_line: c.end_line,
-                        });
-                    }
-                }
-            }
-        }
-    }
-    result
+                    let refined = refine_copyright(&candidate)?;
+                    Some(CopyrightDetection {
+                        copyright: refined,
+                        start_line: c.start_line,
+                        end_line: c.end_line,
+                    })
+                })
+            } else {
+                None
+            };
+
+            [sun_variant, intel_variant].into_iter().flatten()
+        })
+        .collect()
 }
 
 pub fn add_first_angle_email_only_variants(
@@ -1351,46 +1332,34 @@ pub fn add_at_affiliation_short_variants(
         return (Vec::new(), Vec::new());
     }
 
-    let mut new_c = Vec::new();
-    for c in copyrights {
-        let Some((head, _tail)) = c.copyright.split_once(" @ ") else {
-            continue;
-        };
-        let head = head.trim_end();
-        if head.is_empty() {
-            continue;
-        }
-        let Some(refined) = refine_copyright(head) else {
-            continue;
-        };
-        new_c.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
+    let new_c = copyrights
+        .iter()
+        .filter_map(|c| {
+            let (head, _tail) = c.copyright.split_once(" @ ")?;
+            let refined = refine_copyright(head.trim_end())?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect();
 
-    let mut new_h = Vec::new();
-    for h in holders {
-        let Some((head, tail)) = h.holder.split_once(" @ ") else {
-            continue;
-        };
-        if tail.contains('@') {
-            continue;
-        }
-        let head = head.trim_end();
-        if head.is_empty() {
-            continue;
-        }
-        let Some(refined) = refine_holder_in_copyright_context(head) else {
-            continue;
-        };
-        new_h.push(HolderDetection {
-            holder: refined,
-            start_line: h.start_line,
-            end_line: h.end_line,
-        });
-    }
+    let new_h = holders
+        .iter()
+        .filter_map(|h| {
+            let (head, tail) = h.holder.split_once(" @ ")?;
+            if tail.contains('@') {
+                return None;
+            }
+            let refined = refine_holder_in_copyright_context(head.trim_end())?;
+            Some(HolderDetection {
+                holder: refined,
+                start_line: h.start_line,
+                end_line: h.end_line,
+            })
+        })
+        .collect();
     (new_c, new_h)
 }
 
@@ -1403,52 +1372,39 @@ pub fn add_missing_copyrights_for_holder_lines_with_emails(
         return Vec::new();
     }
 
-    let mut copyright_lines: HashSet<usize> = HashSet::new();
-    for c in copyrights {
-        if c.start_line.get() == c.end_line.get() {
-            copyright_lines.insert(c.start_line.get());
-        }
-    }
+    let copyright_lines: HashSet<usize> = copyrights
+        .iter()
+        .filter(|c| c.start_line == c.end_line)
+        .map(|c| c.start_line.get())
+        .collect();
 
-    let mut result = Vec::new();
-    for h in holders {
-        if h.start_line.get() != h.end_line.get() {
-            continue;
-        }
-        let ln = h.start_line.get();
-        if ln == 0 || ln > prepared_cache.len() {
-            continue;
-        }
-        if copyright_lines.contains(&ln) {
-            continue;
-        }
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let prepared = prepared.trim();
-        if prepared.is_empty() {
-            continue;
-        }
-        if !prepared.to_ascii_lowercase().contains("copyright") {
-            continue;
-        }
-        if !prepared.contains('@') {
-            continue;
-        }
-        if !prepared.chars().any(|c| c.is_ascii_digit()) {
-            continue;
-        }
+    holders
+        .iter()
+        .filter_map(|h| {
+            if h.start_line != h.end_line {
+                return None;
+            }
+            let line_number = h.start_line;
+            if copyright_lines.contains(&line_number.get()) {
+                return None;
+            }
+            let prepared = prepared_cache.get(line_number.get())?.trim();
+            if prepared.is_empty()
+                || !prepared.to_ascii_lowercase().contains("copyright")
+                || !prepared.contains('@')
+                || !prepared.chars().any(|c| c.is_ascii_digit())
+            {
+                return None;
+            }
 
-        let Some(refined) = refine_copyright(prepared) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: LineNumber::new(ln).expect("invalid line number"),
-            end_line: LineNumber::new(ln).expect("invalid line number"),
-        });
-    }
-    result
+            let refined = refine_copyright(prepared)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: line_number,
+                end_line: line_number,
+            })
+        })
+        .collect()
 }
 
 pub fn extend_inline_obfuscated_angle_email_suffixes(
@@ -1624,29 +1580,26 @@ pub fn add_at_domain_variants_for_short_net_angle_emails(
     static SHORT_NET_EMAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)<(?P<user>[a-z]{3})@(?P<domain>[^>\s]+\.net)>").unwrap());
 
-    let mut result = Vec::new();
-    for c in copyrights {
-        let Some(cap) = SHORT_NET_EMAIL_RE.captures(c.copyright.as_str()) else {
-            continue;
-        };
-        let user = cap.name("user").map(|m| m.as_str()).unwrap_or("").trim();
-        let domain = cap.name("domain").map(|m| m.as_str()).unwrap_or("").trim();
-        if user.is_empty() || domain.is_empty() {
-            continue;
-        }
-        let replaced = SHORT_NET_EMAIL_RE
-            .replace_all(c.copyright.as_str(), format!("@{domain}").as_str())
-            .into_owned();
-        let Some(refined) = refine_copyright(&replaced) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: c.start_line,
-            end_line: c.end_line,
-        });
-    }
-    result
+    copyrights
+        .iter()
+        .filter_map(|c| {
+            let cap = SHORT_NET_EMAIL_RE.captures(c.copyright.as_str())?;
+            let user = cap.name("user").map(|m| m.as_str()).unwrap_or("").trim();
+            let domain = cap.name("domain").map(|m| m.as_str()).unwrap_or("").trim();
+            if user.is_empty() || domain.is_empty() {
+                return None;
+            }
+            let replaced = SHORT_NET_EMAIL_RE
+                .replace_all(c.copyright.as_str(), format!("@{domain}").as_str())
+                .into_owned();
+            let refined = refine_copyright(&replaced)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect()
 }
 
 pub fn drop_shadowed_plain_email_prefix_copyrights_same_span(
@@ -1947,28 +1900,27 @@ pub fn add_pipe_read_parenthetical_variants(
     static PIPE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^\(\s*pipe\s+read\s+code\s+from\s+[^)]+\)\s*$").unwrap());
 
-    let mut result = Vec::new();
-    for (first, second) in prepared_cache.adjacent_pairs() {
-        if first.prepared.is_empty() || second.prepared.is_empty() {
-            continue;
-        }
-        if !first.prepared.to_ascii_lowercase().contains("copyright") {
-            continue;
-        }
-        if !PIPE_RE.is_match(second.prepared) {
-            continue;
-        }
-        let combined = format!("{} {}", first.prepared, second.prepared);
-        let Some(refined) = refine_copyright(&combined) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: first.line_number,
-            end_line: second.line_number,
-        });
-    }
-    result
+    prepared_cache
+        .adjacent_pairs()
+        .filter_map(|(first, second)| {
+            if first.prepared.is_empty() || second.prepared.is_empty() {
+                return None;
+            }
+            if !first.prepared.to_ascii_lowercase().contains("copyright") {
+                return None;
+            }
+            if !PIPE_RE.is_match(second.prepared) {
+                return None;
+            }
+            let combined = format!("{} {}", first.prepared, second.prepared);
+            let refined = refine_copyright(&combined)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: first.line_number,
+                end_line: second.line_number,
+            })
+        })
+        .collect()
 }
 
 pub fn add_from_url_parenthetical_copyright_variants(
@@ -2903,37 +2855,35 @@ pub fn add_modify_suffix_holders(
         return Vec::new();
     }
 
-    let mut result = Vec::new();
-    for h in holders {
-        let idx = h.end_line.get() + 1;
-        let Some(next) = prepared_cache.get(idx) else {
-            continue;
-        };
-        let t = next.trim();
-        if t.is_empty() {
-            continue;
-        }
-        let lower = t.to_ascii_lowercase();
-        if !lower.starts_with("modify ") {
-            continue;
-        }
-        if t.len() > 64 {
-            continue;
-        }
-        if !t
-            .split_whitespace()
-            .any(|w| w.chars().any(|c| c.is_ascii_uppercase()))
-        {
-            continue;
-        }
-        let combined = super::token_utils::normalize_whitespace(&format!("{} {t}", h.holder));
-        result.push(HolderDetection {
-            holder: combined,
-            start_line: h.start_line,
-            end_line: h.end_line + 1,
-        });
-    }
-    result
+    holders
+        .iter()
+        .filter_map(|h| {
+            let idx = h.end_line.get() + 1;
+            let t = prepared_cache.get(idx)?.trim();
+            if t.is_empty() {
+                return None;
+            }
+            let lower = t.to_ascii_lowercase();
+            if !lower.starts_with("modify ") {
+                return None;
+            }
+            if t.len() > 64 {
+                return None;
+            }
+            if !t
+                .split_whitespace()
+                .any(|w| w.chars().any(|c| c.is_ascii_uppercase()))
+            {
+                return None;
+            }
+            let combined = super::token_utils::normalize_whitespace(&format!("{} {t}", h.holder));
+            Some(HolderDetection {
+                holder: combined,
+                start_line: h.start_line,
+                end_line: h.end_line.next(),
+            })
+        })
+        .collect()
 }
 
 pub fn drop_shadowed_c_sign_variants(copyrights: &mut Vec<CopyrightDetection>) {
@@ -3473,40 +3423,34 @@ pub fn extract_question_mark_year_copyrights(
         Regex::new(r"(?i)^\s*copyright\s+(?P<year>\d{3}\?)\s+(?P<tail>.+)$").unwrap()
     });
 
-    let mut new_copyrights = Vec::new();
-    let mut new_holders = Vec::new();
+    prepared_cache
+        .iter_non_empty()
+        .filter_map(|line| {
+            let cap = QMARK_COPY_RE.captures(line.prepared)?;
+            let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
+            let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
+            if year.is_empty() || tail.is_empty() {
+                return None;
+            }
 
-    for line in prepared_cache.iter_non_empty() {
-        let Some(cap) = QMARK_COPY_RE.captures(line.prepared) else {
-            continue;
-        };
-        let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
-        let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
-        if year.is_empty() || tail.is_empty() {
-            continue;
-        }
+            let raw = format!("Copyright {year} {tail}");
+            let cr = refine_copyright(&raw)?;
+            let h = refine_holder_in_copyright_context(&format!("{year} {tail}"))?;
 
-        let raw = format!("Copyright {year} {tail}");
-        let Some(cr) = refine_copyright(&raw) else {
-            continue;
-        };
-        new_copyrights.push(CopyrightDetection {
-            copyright: cr,
-            start_line: line.line_number,
-            end_line: line.line_number,
-        });
-
-        let raw_holder = format!("{year} {tail}");
-        if let Some(h) = refine_holder_in_copyright_context(&raw_holder) {
-            new_holders.push(HolderDetection {
-                holder: h,
-                start_line: line.line_number,
-                end_line: line.line_number,
-            });
-        }
-    }
-
-    (new_copyrights, new_holders)
+            Some((
+                CopyrightDetection {
+                    copyright: cr,
+                    start_line: line.line_number,
+                    end_line: line.line_number,
+                },
+                HolderDetection {
+                    holder: h,
+                    start_line: line.line_number,
+                    end_line: line.line_number,
+                },
+            ))
+        })
+        .unzip()
 }
 
 pub fn strip_inc_suffix_from_holders_for_today_year_copyrights(
@@ -3763,53 +3707,41 @@ pub fn extract_midline_c_year_holder_with_leading_acronym(
         .unwrap()
     });
 
-    let mut new_copyrights = Vec::new();
-    let mut new_holders = Vec::new();
+    prepared_cache
+        .iter_non_empty()
+        .filter_map(|prepared_line| {
+            let trimmed = prepared_line.prepared;
+            let lower = trimmed.to_ascii_lowercase();
+            if !lower.contains("fix") || lower.starts_with("copyright") {
+                return None;
+            }
 
-    for prepared_line in prepared_cache.iter_non_empty() {
-        let trimmed = prepared_line.prepared;
+            let cap = MIDLINE_C_YEAR_HOLDER_RE.captures(trimmed)?;
 
-        let lower = trimmed.to_ascii_lowercase();
-        if !lower.contains("fix") {
-            continue;
-        }
+            let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+            let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
+            let holder = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+            if prefix.is_empty() || year.is_empty() || holder.is_empty() {
+                return None;
+            }
 
-        let Some(cap) = MIDLINE_C_YEAR_HOLDER_RE.captures(trimmed) else {
-            continue;
-        };
+            let cr = refine_copyright(&format!("(c) {year} {holder} {prefix}"))?;
+            let h = refine_holder_in_copyright_context(&format!("{holder} {prefix}"))?;
 
-        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
-        let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
-        let holder = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
-        if prefix.is_empty() || year.is_empty() || holder.is_empty() {
-            continue;
-        }
-        if trimmed.to_ascii_lowercase().starts_with("copyright") {
-            continue;
-        }
-
-        let cr_raw = format!("(c) {year} {holder} {prefix}");
-        let Some(cr) = refine_copyright(&cr_raw) else {
-            continue;
-        };
-
-        new_copyrights.push(CopyrightDetection {
-            copyright: cr,
-            start_line: prepared_line.line_number,
-            end_line: prepared_line.line_number,
-        });
-
-        let holder_raw = format!("{holder} {prefix}");
-        if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
-            new_holders.push(HolderDetection {
-                holder: h,
-                start_line: prepared_line.line_number,
-                end_line: prepared_line.line_number,
-            });
-        }
-    }
-
-    (new_copyrights, new_holders)
+            Some((
+                CopyrightDetection {
+                    copyright: cr,
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
+                },
+                HolderDetection {
+                    holder: h,
+                    start_line: prepared_line.line_number,
+                    end_line: prepared_line.line_number,
+                },
+            ))
+        })
+        .unzip()
 }
 
 pub fn dedupe_exact_span_copyrights(copyrights: &mut Vec<CopyrightDetection>) {

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -418,22 +418,11 @@ pub fn merge_multiline_person_year_copyright_continuations(
         trimmed.to_string()
     }
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln1 = i + 1;
-        let ln2 = i + 2;
-        let Some(l1) = prepared_cache.get(ln1).map(|s| s.to_string()) else {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        let Some(c1) = FIRST_RE.captures(first.prepared) else {
             continue;
         };
-        let Some(l2) = prepared_cache.get(ln2).map(|s| s.to_string()) else {
-            continue;
-        };
-        let l1t = l1.trim();
-        let l2t = l2.trim();
-
-        let Some(c1) = FIRST_RE.captures(l1t) else {
-            continue;
-        };
-        let Some(c2) = SECOND_RE.captures(l2t) else {
+        let Some(c2) = SECOND_RE.captures(second.prepared) else {
             continue;
         };
         let name1 =
@@ -451,27 +440,30 @@ pub fn merge_multiline_person_year_copyright_continuations(
             continue;
         };
 
-        if !copyrights
-            .iter()
-            .any(|c| c.start_line.get() == ln1 && c.end_line.get() == ln2 && c.copyright == refined)
-        {
+        if !copyrights.iter().any(|c| {
+            c.start_line == first.line_number
+                && c.end_line == second.line_number
+                && c.copyright == refined
+        }) {
             copyrights.push(CopyrightDetection {
                 copyright: refined.clone(),
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
         let raw_holder = format!("{name1}, {name2}");
         if let Some(h) = refine_holder_in_copyright_context(&raw_holder)
-            && !holders
-                .iter()
-                .any(|x| x.start_line.get() == ln1 && x.end_line.get() == ln2 && x.holder == h)
+            && !holders.iter().any(|x| {
+                x.start_line == first.line_number
+                    && x.end_line == second.line_number
+                    && x.holder == h
+            })
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln1).expect("valid"),
-                end_line: LineNumber::new(ln2).expect("valid"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -1956,32 +1948,24 @@ pub fn add_pipe_read_parenthetical_variants(
         LazyLock::new(|| Regex::new(r"(?i)^\(\s*pipe\s+read\s+code\s+from\s+[^)]+\)\s*$").unwrap());
 
     let mut result = Vec::new();
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln1 = i + 1;
-        let ln2 = i + 2;
-        let Some(l1) = prepared_cache.get(ln1).map(|s| s.trim().to_string()) else {
-            continue;
-        };
-        let Some(l2) = prepared_cache.get(ln2).map(|s| s.trim().to_string()) else {
-            continue;
-        };
-        if l1.is_empty() || l2.is_empty() {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        if first.prepared.is_empty() || second.prepared.is_empty() {
             continue;
         }
-        if !l1.to_ascii_lowercase().contains("copyright") {
+        if !first.prepared.to_ascii_lowercase().contains("copyright") {
             continue;
         }
-        if !PIPE_RE.is_match(l2.as_str()) {
+        if !PIPE_RE.is_match(second.prepared) {
             continue;
         }
-        let combined = format!("{} {}", l1.trim_end(), l2.trim_start());
+        let combined = format!("{} {}", first.prepared, second.prepared);
         let Some(refined) = refine_copyright(&combined) else {
             continue;
         };
         result.push(CopyrightDetection {
             copyright: refined,
-            start_line: LineNumber::new(ln1).expect("valid"),
-            end_line: LineNumber::new(ln2).expect("valid"),
+            start_line: first.line_number,
+            end_line: second.line_number,
         });
     }
     result
@@ -1998,33 +1982,29 @@ pub fn add_from_url_parenthetical_copyright_variants(
     static FROM_URL_COPY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\bfrom\s+https?://\S+\s*\(\s*copyright\b").unwrap());
 
-    let mut result = Vec::new();
-    for i in 0..prepared_cache.len() {
-        let ln = i + 1;
-        let Some(line) = prepared_cache.get_by_index(i).map(|s| s.trim().to_string()) else {
-            continue;
-        };
-        if line.is_empty() {
-            continue;
-        }
-        if !FROM_URL_COPY_RE.is_match(line.as_str()) {
-            continue;
-        }
-        let mut s = line;
-        let lower = s.to_ascii_lowercase();
-        if lower.starts_with("adapted from ") {
-            s = format!("from {}", s["adapted from ".len()..].trim_start());
-        }
-        let Some(refined) = refine_copyright(&s) else {
-            continue;
-        };
-        result.push(CopyrightDetection {
-            copyright: refined,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
-        });
-    }
-    result
+    prepared_cache
+        .iter_non_empty()
+        .filter_map(|line| {
+            if !FROM_URL_COPY_RE.is_match(line.prepared) {
+                return None;
+            }
+            let lower = line.prepared.to_ascii_lowercase();
+            let candidate = if lower.starts_with("adapted from ") {
+                format!(
+                    "from {}",
+                    line.prepared["adapted from ".len()..].trim_start()
+                )
+            } else {
+                line.prepared.to_string()
+            };
+            let refined = refine_copyright(&candidate)?;
+            Some(CopyrightDetection {
+                copyright: refined,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            })
+        })
+        .collect()
 }
 
 pub fn drop_shadowed_acronym_location_suffix_copyrights_same_span(
@@ -3504,12 +3484,8 @@ pub fn extract_question_mark_year_copyrights(
     let mut new_copyrights = Vec::new();
     let mut new_holders = Vec::new();
 
-    for ln in 1..=prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get(ln) else {
-            continue;
-        };
-        let line = prepared.trim();
-        let Some(cap) = QMARK_COPY_RE.captures(line) else {
+    for line in prepared_cache.iter_non_empty() {
+        let Some(cap) = QMARK_COPY_RE.captures(line.prepared) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -3524,16 +3500,16 @@ pub fn extract_question_mark_year_copyrights(
         };
         new_copyrights.push(CopyrightDetection {
             copyright: cr,
-            start_line: LineNumber::new(ln).unwrap(),
-            end_line: LineNumber::new(ln).unwrap(),
+            start_line: line.line_number,
+            end_line: line.line_number,
         });
 
         let raw_holder = format!("{year} {tail}");
         if let Some(h) = refine_holder_in_copyright_context(&raw_holder) {
             new_holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: line.line_number,
+                end_line: line.line_number,
             });
         }
     }
@@ -3607,11 +3583,8 @@ pub fn extend_copyrights_with_authors_blocks(
     static STRIP_ANGLE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\s*<[^>]*>\s*").unwrap());
 
-    for i in 0..prepared_cache.len().saturating_sub(2) {
-        let Some(base_prepared) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
+    for (base, header, author_line) in prepared_cache.adjacent_triples() {
+        let base_prepared = base.prepared;
         if base_prepared.is_empty() {
             continue;
         }
@@ -3619,27 +3592,15 @@ pub fn extend_copyrights_with_authors_blocks(
         if !base_lower.contains("copyright") && !base_lower.contains("(c)") {
             continue;
         }
-        if !YEAR_RE.is_match(&base_prepared) {
+        if !YEAR_RE.is_match(base_prepared) {
             continue;
         }
 
-        let Some(header_prepared) = prepared_cache
-            .get_by_index(i + 1)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if !AUTHORS_HEADER_RE.is_match(&header_prepared) {
+        if !AUTHORS_HEADER_RE.is_match(header.prepared) {
             continue;
         }
 
-        let Some(author_prepared) = prepared_cache
-            .get_by_index(i + 2)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        let mut author = author_prepared;
+        let mut author = author_line.prepared.to_string();
         if author.is_empty() {
             continue;
         }
@@ -3681,16 +3642,13 @@ pub fn extend_copyrights_with_authors_blocks(
             continue;
         };
 
-        let ln = i + 1;
-        let end_ln = i + 3;
-
         for c in copyrights
             .iter_mut()
-            .filter(|c| c.start_line.get() == ln && c.end_line.get() == ln)
+            .filter(|c| c.start_line == base.line_number && c.end_line == base.line_number)
         {
             if c.copyright.starts_with("Copyright") || c.copyright.starts_with("(c)") {
                 c.copyright = extended.clone();
-                c.end_line = LineNumber::new(end_ln).expect("valid");
+                c.end_line = author_line.line_number;
             }
         }
 
@@ -3699,12 +3657,12 @@ pub fn extend_copyrights_with_authors_blocks(
         {
             holders.push(HolderDetection {
                 holder: h.clone(),
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(end_ln).expect("valid"),
+                start_line: base.line_number,
+                end_line: author_line.line_number,
             });
 
             holders.retain(|hh| {
-                if hh.start_line.get() != ln || hh.end_line.get() != ln {
+                if hh.start_line != base.line_number || hh.end_line != base.line_number {
                     return true;
                 }
                 if hh.holder == h {

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -4668,42 +4668,26 @@ pub fn merge_freebird_c_inc_urls(
         return;
     }
 
-    for i in 0..prepared_cache.len() {
-        let ln = i + 1;
-        let Some(prepared) = prepared_cache.get_by_index(i) else {
-            continue;
-        };
-        let line = prepared.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let line_lower = line.to_ascii_lowercase();
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let line_lower = prepared_line.prepared.to_ascii_lowercase();
         if !line_lower.contains("(c)") || !line_lower.contains("inc") {
             continue;
         }
 
-        let mut url: Option<String> = None;
-        let mut j = i + 1;
-        while j < prepared_cache.len() {
-            let Some(next) = prepared_cache.get_by_index(j).map(|p| p.trim().to_string()) else {
-                break;
-            };
-            if next.is_empty() {
-                j += 1;
-                continue;
-            }
-            if next.to_ascii_lowercase().contains("http") {
-                if next.to_ascii_lowercase().contains("web.archive.org/web") {
-                    url = Some("http://web.archive.org/web".to_string());
-                } else {
-                    let next_lower = next.to_ascii_lowercase();
-                    if next_lower.contains("coventive.com") {
-                        url = Some(next.to_string());
-                    }
+        let url = prepared_cache
+            .next_non_empty_line(prepared_line.line_number)
+            .and_then(|next| {
+                let next_lower = next.prepared.to_ascii_lowercase();
+                if !next_lower.contains("http") {
+                    return None;
                 }
-            }
-            break;
-        }
+                if next_lower.contains("web.archive.org/web") {
+                    return Some("http://web.archive.org/web".to_string());
+                }
+                next_lower
+                    .contains("coventive.com")
+                    .then(|| next.prepared.to_string())
+            });
 
         let Some(url) = url else {
             continue;
@@ -4713,16 +4697,16 @@ pub fn merge_freebird_c_inc_urls(
         if let Some(cr) = refine_copyright(&cr_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
         let holder_raw = "Inc.";
         if let Some(h) = refine_holder(holder_raw) {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln).unwrap(),
+                start_line: prepared_line.line_number,
+                end_line: prepared_line.line_number,
             });
         }
     }
@@ -4741,22 +4725,12 @@ pub fn merge_debugging390_best_viewed_suffix(
         Regex::new(r"(?i)^copyright\s*\(c\)\s*2000-2001\s+(?P<who>IBM\b.+)$").unwrap()
     });
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln = i + 1;
-        let Some(p1) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            continue;
-        };
-        let Some(cap) = IBM_RE.captures(&p1) else {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        let Some(cap) = IBM_RE.captures(first.prepared) else {
             continue;
         };
         let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
-        if who.is_empty() {
-            continue;
-        }
-        let Some(p2) = prepared_cache.get_by_index(i + 1) else {
-            continue;
-        };
-        if !p2.trim_start().starts_with("Best") {
+        if who.is_empty() || !second.prepared.trim_start().starts_with("Best") {
             continue;
         }
 
@@ -4766,7 +4740,7 @@ pub fn merge_debugging390_best_viewed_suffix(
         };
 
         copyrights.retain(|c| {
-            !(c.start_line.get() == ln
+            !(c.start_line == first.line_number
                 && c.copyright.contains(who)
                 && c.copyright.contains("2000-2001")
                 && !c.copyright.ends_with("Best"))
@@ -4774,18 +4748,18 @@ pub fn merge_debugging390_best_viewed_suffix(
         if !copyrights.iter().any(|c| c.copyright == merged) {
             copyrights.push(CopyrightDetection {
                 copyright: merged,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
         let holder_raw = format!("{who} Best");
-        holders.retain(|h| !(h.start_line.get() == ln && h.holder == who));
+        holders.retain(|h| !(h.start_line == first.line_number && h.holder == who));
         if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -4800,31 +4774,24 @@ pub fn merge_fsf_gdb_notice_lines(
         return;
     }
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln = i + 1;
-        let Some(p1) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            continue;
-        };
-        if !p1.starts_with("Copyright 1998 Free Software Foundation") {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        if !first
+            .prepared
+            .starts_with("Copyright 1998 Free Software Foundation")
+        {
             continue;
         }
-        let Some(p2) = prepared_cache
-            .get_by_index(i + 1)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if !p2.starts_with("GDB is free software") {
+        if !second.prepared.starts_with("GDB is free software") {
             continue;
         }
 
-        let tail = if let Some(idx) = p2.find("GNU General Public License,") {
-            &p2[..(idx + "GNU General Public License,".len())]
+        let tail = if let Some(idx) = second.prepared.find("GNU General Public License,") {
+            &second.prepared[..(idx + "GNU General Public License,".len())]
         } else {
-            &p2
+            second.prepared
         };
 
-        let merged_raw = format!("{p1} {tail}");
+        let merged_raw = format!("{} {tail}", first.prepared);
         let merged = super::token_utils::normalize_whitespace(&merged_raw);
         if !merged.ends_with(',') {
             continue;
@@ -4832,8 +4799,8 @@ pub fn merge_fsf_gdb_notice_lines(
         if !copyrights.iter().any(|c| c.copyright == merged) {
             copyrights.push(CopyrightDetection {
                 copyright: merged,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
@@ -4841,8 +4808,8 @@ pub fn merge_fsf_gdb_notice_lines(
         if !holders.iter().any(|x| x.holder == holder) {
             holders.push(HolderDetection {
                 holder: holder.to_string(),
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -4857,21 +4824,11 @@ pub fn merge_axis_ethereal_suffix(
         return;
     }
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln = i + 1;
-        let Some(p1) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            continue;
-        };
-        if p1 != "Copyright 2000, Axis Communications AB" {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        if first.prepared != "Copyright 2000, Axis Communications AB" {
             continue;
         }
-        let Some(p2) = prepared_cache
-            .get_by_index(i + 1)
-            .map(|p| p.trim().to_string())
-        else {
-            continue;
-        };
-        if !p2.starts_with("Ethereal") {
+        if !second.prepared.starts_with("Ethereal") {
             continue;
         }
         let merged_raw = "Copyright 2000, Axis Communications AB Ethereal";
@@ -4879,23 +4836,26 @@ pub fn merge_axis_ethereal_suffix(
             continue;
         };
 
-        copyrights.retain(|c| !(c.start_line.get() == ln && c.copyright == p1));
+        copyrights
+            .retain(|c| !(c.start_line == first.line_number && c.copyright == first.prepared));
         if !copyrights.iter().any(|c| c.copyright == merged) {
             copyrights.push(CopyrightDetection {
                 copyright: merged,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
 
-        holders.retain(|h| !(h.start_line.get() == ln && h.holder == "Axis Communications AB"));
+        holders.retain(|h| {
+            !(h.start_line == first.line_number && h.holder == "Axis Communications AB")
+        });
         if let Some(h) = refine_holder_in_copyright_context("Axis Communications AB Ethereal")
             && !holders.iter().any(|x| x.holder == h)
         {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -4914,12 +4874,8 @@ pub fn merge_kirkwood_converted_to(
         Regex::new(r"(?i)\(c\)\s+(?P<year>19\d{2}|20\d{2})\s+(?P<who>M\.?\s*Kirkwood)\b").unwrap()
     });
 
-    for i in 0..prepared_cache.len().saturating_sub(1) {
-        let ln = i + 1;
-        let Some(p1) = prepared_cache.get_by_index(i).map(|p| p.trim().to_string()) else {
-            continue;
-        };
-        let Some(cap) = EMBEDDED_RE.captures(&p1) else {
+    for (first, second) in prepared_cache.adjacent_pairs() {
+        let Some(cap) = EMBEDDED_RE.captures(first.prepared) else {
             continue;
         };
         let year = cap.name("year").map(|m| m.as_str()).unwrap_or("").trim();
@@ -4927,12 +4883,7 @@ pub fn merge_kirkwood_converted_to(
         if year.is_empty() || who.is_empty() {
             continue;
         }
-        let Some(p2) = prepared_cache
-            .get_by_index(i + 1)
-            .map(|p| p.trim().trim_start_matches('*').trim_start().to_string())
-        else {
-            continue;
-        };
+        let p2 = second.prepared.trim_start_matches('*').trim_start();
         if !p2.to_ascii_lowercase().starts_with("converted to") {
             continue;
         }
@@ -4941,16 +4892,16 @@ pub fn merge_kirkwood_converted_to(
         if let Some(cr) = refine_copyright(&cr_raw) {
             copyrights.push(CopyrightDetection {
                 copyright: cr,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
         let holder_raw = format!("{who} Converted");
         if let Some(h) = refine_holder_in_copyright_context(&holder_raw) {
             holders.push(HolderDetection {
                 holder: h,
-                start_line: LineNumber::new(ln).unwrap(),
-                end_line: LineNumber::new(ln + 1).expect("invalid line number"),
+                start_line: first.line_number,
+                end_line: second.line_number,
             });
         }
     }
@@ -5495,17 +5446,14 @@ pub fn drop_created_by_camelcase_identifier_authors(
     });
 
     let mut by_line: HashMap<usize, HashSet<String>> = HashMap::new();
-    for idx in 0..prepared_cache.len() {
-        let Some(prepared) = prepared_cache.get_by_index(idx) else {
-            continue;
-        };
-        for cap in CREATED_BY_CAMELCASE_RE.captures_iter(prepared) {
+    for line in prepared_cache.iter_non_empty() {
+        for cap in CREATED_BY_CAMELCASE_RE.captures_iter(line.prepared) {
             let name = cap.name("name").map(|m| m.as_str()).unwrap_or("").trim();
             if name.is_empty() {
                 continue;
             }
             by_line
-                .entry(idx + 1)
+                .entry(line.line_number.get())
                 .or_default()
                 .insert(name.to_ascii_lowercase());
         }

--- a/src/copyright/detector/primary_phase.rs
+++ b/src/copyright/detector/primary_phase.rs
@@ -4,6 +4,9 @@
 use crate::copyright::line_tracking::{LineNumberIndex, PreparedLineCache};
 use crate::copyright::types::{CopyrightDetection, HolderDetection};
 
+use super::seen_text::SeenTextSets;
+
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_phase_primary_extractions(
     content: &str,
     groups: &[Vec<(usize, String)>],
@@ -11,33 +14,60 @@ pub(super) fn run_phase_primary_extractions(
     prepared_cache: &mut PreparedLineCache<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
+    seen: &mut SeenTextSets,
 ) {
-    super::postprocess_transforms::extract_midline_c_year_holder_with_leading_acronym(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
+    let (mut new_c, mut new_h) =
+        super::postprocess_transforms::extract_midline_c_year_holder_with_leading_acronym(
+            prepared_cache,
+        );
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::extend_copyrights_with_authors_blocks(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::extend_year_only_copyrights_with_trailing_text(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
 
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::merge_year_only_copyrights_with_following_author_colon_lines(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::extract_licensed_material_of_company_bare_c_year_lines(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
 
     super::pattern_extract::drop_shadowed_and_or_holders(holders);
     super::pattern_extract::drop_shadowed_prefix_holders(holders);
@@ -45,165 +75,429 @@ pub(super) fn run_phase_primary_extractions(
     super::pattern_extract::drop_shadowed_prefix_copyrights(copyrights);
     super::postprocess_transforms::drop_shadowed_c_sign_variants(copyrights);
     super::postprocess_transforms::drop_shadowed_year_prefixed_holders(holders);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
 
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::merge_multiline_person_year_copyright_continuations(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
 
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::extract_mso_document_properties_copyrights(
         content, copyrights, holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
     super::postprocess_transforms::expand_portions_copyright_variants(copyrights);
+    seen.rebuild_copyrights_from(copyrights);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::expand_year_only_copyrights_with_by_name_prefix(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::expand_year_only_copyrights_with_read_the_suffix(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::postprocess_transforms::merge_multiline_obfuscated_name_year_copyright_pairs(
         prepared_cache,
         copyrights,
         holders,
     );
-    super::postprocess_transforms::add_modify_suffix_holders(prepared_cache, holders);
-    super::postprocess_transforms::drop_shadowed_prefix_bare_c_copyrights_same_span(copyrights);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
 
+    let h_before = holders.len();
+    super::postprocess_transforms::add_modify_suffix_holders(prepared_cache, holders);
+    seen.dedup_new_holders(holders, h_before);
+
+    super::postprocess_transforms::drop_shadowed_prefix_bare_c_copyrights_same_span(copyrights);
+    seen.rebuild_copyrights_from(copyrights);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::apply_javadoc_company_metadata(
         content,
         line_number_index,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::apply_european_community_copyright(
         content,
         line_number_index,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
     super::pattern_extract::extract_html_entity_year_range_copyrights(
         content,
         line_number_index,
         copyrights,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_copr_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_standalone_c_holder_year_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_c_years_then_holder_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_copyright_c_years_holder_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_versioned_project_c_holder_banner_lines(
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_standalone_c_holder_year_lines(groups, copyrights);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) =
+        super::pattern_extract::extract_c_years_then_holder_lines(groups, copyrights, holders);
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) =
+        super::pattern_extract::extract_copyright_c_years_holder_lines(groups, copyrights, holders);
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) = super::pattern_extract::extract_versioned_project_c_holder_banner_lines(
         groups, copyrights, holders,
     );
-    super::pattern_extract::extract_c_holder_without_year_lines(
-        content, groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_three_digit_copyright_year_lines(
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_c_holder_without_year_lines(content, groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) = super::pattern_extract::extract_three_digit_copyright_year_lines(
         prepared_cache,
         copyrights,
         holders,
     );
-    super::pattern_extract::extract_copyrighted_by_lines(prepared_cache, copyrights, holders);
-    super::pattern_extract::extract_c_word_year_lines(prepared_cache, copyrights, holders);
-    super::pattern_extract::extract_are_c_year_holder_lines(prepared_cache, copyrights, holders);
-    super::pattern_extract::extract_bare_c_by_holder_lines(prepared_cache, copyrights, holders);
-    super::pattern_extract::extract_all_rights_reserved_by_holder_lines(
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) =
+        super::pattern_extract::extract_copyrighted_by_lines(prepared_cache, copyrights, holders);
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) =
+        super::pattern_extract::extract_c_word_year_lines(prepared_cache, copyrights, holders);
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) = super::pattern_extract::extract_are_c_year_holder_lines(
         prepared_cache,
         copyrights,
         holders,
     );
-    super::pattern_extract::extract_trailing_bare_c_year_range_suffixes(groups, copyrights);
-    super::pattern_extract::extract_common_year_only_lines(groups, copyrights);
-    super::pattern_extract::extract_embedded_bare_c_year_suffixes(groups, copyrights);
-    super::pattern_extract::extract_repeated_embedded_bare_c_year_suffixes(groups, copyrights);
-    super::pattern_extract::extract_lowercase_username_angle_email_copyrights(
-        groups, copyrights, holders,
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) =
+        super::pattern_extract::extract_bare_c_by_holder_lines(prepared_cache, copyrights, holders);
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) = super::pattern_extract::extract_all_rights_reserved_by_holder_lines(
+        prepared_cache,
+        copyrights,
+        holders,
     );
-    super::pattern_extract::extract_lowercase_username_paren_email_copyrights(
-        groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_copyright_c_year_comma_name_angle_email_lines(
-        groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_c_year_range_by_name_comma_email_lines(
-        groups, copyrights, holders,
-    );
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let mut new_c = super::pattern_extract::extract_trailing_bare_c_year_range_suffixes(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    copyrights.extend(new_c);
+
+    let mut new_c = super::pattern_extract::extract_common_year_only_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    copyrights.extend(new_c);
+
+    let mut new_c =
+        super::pattern_extract::extract_embedded_bare_c_year_suffixes(groups, copyrights);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    copyrights.extend(new_c);
+
+    let mut new_c = super::pattern_extract::extract_repeated_embedded_bare_c_year_suffixes(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    copyrights.extend(new_c);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_lowercase_username_angle_email_copyrights(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_lowercase_username_paren_email_copyrights(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_c_year_comma_name_angle_email_lines(
+            groups, copyrights,
+        );
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_c_year_range_by_name_comma_email_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_copyright_years_by_name_then_paren_email_next_line(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_copyright_years_by_name_paren_email_lines(
         groups, copyrights, holders,
     );
-    super::pattern_extract::extract_copyright_year_name_with_of_lines(groups, copyrights, holders);
-    super::postprocess_transforms::extract_line_ending_copyright_then_by_holder(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
-    super::pattern_extract::extract_changelog_timestamp_copyrights_from_content(
-        content, copyrights, holders,
-    );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+    seen.rebuild_copyrights_from(copyrights);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_year_name_with_of_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
+    let (extracted_c, extracted_h) =
+        super::postprocess_transforms::extract_line_ending_copyright_then_by_holder(
+            prepared_cache,
+            holders,
+        );
+    copyrights.extend(extracted_c);
+    holders.extend(extracted_h);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let (mut new_c, new_h) =
+        super::pattern_extract::extract_changelog_timestamp_copyrights_from_content(
+            content, holders,
+        );
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
     super::pattern_extract::drop_url_extended_prefix_duplicates(copyrights);
 
     super::postprocess_transforms::drop_obfuscated_email_year_only_copyrights(
         content, copyrights, holders,
     );
-    super::pattern_extract::extract_glide_3dfx_copyright_notice(content, copyrights);
-    super::pattern_extract::extract_spdx_filecopyrighttext_c_without_year(
-        content, copyrights, holders,
-    );
-    super::pattern_extract::extract_html_meta_name_copyright_content(content, copyrights, holders);
-    super::pattern_extract::extract_html_anchor_copyright_url(
-        content,
-        line_number_index,
-        copyrights,
-        holders,
-    );
+    seen.rebuild_copyrights_from(copyrights);
+    seen.rebuild_holders_from(holders);
+
+    let mut new_c = super::pattern_extract::extract_glide_3dfx_copyright_notice(content);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    copyrights.extend(new_c);
+
+    let (mut new_c, new_h) =
+        super::pattern_extract::extract_spdx_filecopyrighttext_c_without_year(content, holders);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, new_h) =
+        super::pattern_extract::extract_html_meta_name_copyright_content(content, holders);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_html_anchor_copyright_url(content, line_number_index);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::normalize_pudn_html_footer_copyrights(
         content,
         line_number_index,
         copyrights,
         holders,
     );
-    super::pattern_extract::extract_angle_bracket_year_name_copyrights(groups, copyrights, holders);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let (mut new_c, new_h) = super::pattern_extract::extract_angle_bracket_year_name_copyrights(
+        groups, copyrights, holders,
+    );
+    seen.rebuild_copyrights_from(copyrights);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_html_icon_class_copyrights(
         content,
         line_number_index,
         copyrights,
         holders,
     );
-    super::pattern_extract::extract_added_the_copyright_year_for_lines(
-        prepared_cache,
-        copyrights,
-        holders,
-    );
-    super::pattern_extract::extract_copyright_by_without_year_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_copyright_notice_paren_year_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_copyright_year_c_holder_mid_sentence_lines(
-        groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_javadoc_author_copyright_lines(groups, copyrights, holders);
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let (mut new_c, new_h) =
+        super::pattern_extract::extract_added_the_copyright_year_for_lines(prepared_cache, holders);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_by_without_year_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_notice_paren_year_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_year_c_holder_mid_sentence_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_javadoc_author_copyright_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::pattern_extract::extract_xml_copyright_tag_c_lines(
         content,
         line_number_index,
         copyrights,
         holders,
     );
-    super::pattern_extract::extract_copyright_its_authors_lines(groups, copyrights, holders);
-    super::pattern_extract::extract_copyright_year_c_name_angle_email_lines(
-        groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_us_government_year_placeholder_copyrights(
-        groups, copyrights, holders,
-    );
-    super::pattern_extract::extract_holder_is_name_paren_email_lines(
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_its_authors_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_copyright_year_c_name_angle_email_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (mut new_c, mut new_h) =
+        super::pattern_extract::extract_us_government_year_placeholder_copyrights(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
+    let (new_c, new_h) = super::pattern_extract::extract_holder_is_name_paren_email_lines(
         prepared_cache,
         copyrights,
         holders,
     );
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
 }

--- a/src/copyright/detector/primary_phase.rs
+++ b/src/copyright/detector/primary_phase.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::copyright::line_tracking::{LineNumberIndex, PreparedLineCache};
+use crate::copyright::line_tracking::{LineNumberIndex, PreparedLines};
 use crate::copyright::types::{CopyrightDetection, HolderDetection};
 
 use super::seen_text::SeenTextSets;
@@ -11,7 +11,7 @@ pub(super) fn run_phase_primary_extractions(
     content: &str,
     groups: &[Vec<(usize, String)>],
     line_number_index: &LineNumberIndex,
-    prepared_cache: &mut PreparedLineCache<'_>,
+    prepared_cache: &PreparedLines<'_>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
     seen: &mut SeenTextSets,

--- a/src/copyright/detector/primary_phase.rs
+++ b/src/copyright/detector/primary_phase.rs
@@ -133,9 +133,11 @@ pub(super) fn run_phase_primary_extractions(
     seen.rebuild_copyrights_from(copyrights);
     seen.rebuild_holders_from(holders);
 
-    let h_before = holders.len();
-    super::postprocess_transforms::add_modify_suffix_holders(prepared_cache, holders);
-    seen.dedup_new_holders(holders, h_before);
+    let new_h =
+        super::postprocess_transforms::add_modify_suffix_holders(prepared_cache, &holders[..]);
+    holders.extend(new_h);
+
+    super::postprocess_transforms::dedupe_exact_span_holders(holders);
 
     super::postprocess_transforms::drop_shadowed_prefix_bare_c_copyrights_same_span(copyrights);
     seen.rebuild_copyrights_from(copyrights);

--- a/src/copyright/detector/seen_text.rs
+++ b/src/copyright/detector/seen_text.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};

--- a/src/copyright/detector/seen_text.rs
+++ b/src/copyright/detector/seen_text.rs
@@ -94,21 +94,18 @@ impl SeenTextSets {
     }
 
     pub(crate) fn register_copyrights(&mut self, copyrights: &[CopyrightDetection]) {
-        for c in copyrights {
-            self.copyrights.insert(c.copyright.clone());
-        }
+        self.copyrights
+            .extend(copyrights.iter().map(|c| c.copyright.clone()));
     }
 
     pub(crate) fn register_holders(&mut self, holders: &[HolderDetection]) {
-        for h in holders {
-            self.holders.insert(h.holder.clone());
-        }
+        self.holders
+            .extend(holders.iter().map(|h| h.holder.clone()));
     }
 
     pub(crate) fn register_authors(&mut self, authors: &[AuthorDetection]) {
-        for a in authors {
-            self.authors.insert(a.author.clone());
-        }
+        self.authors
+            .extend(authors.iter().map(|a| a.author.clone()));
     }
 
     pub(crate) fn rebuild_copyrights_from(&mut self, copyrights: &[CopyrightDetection]) {

--- a/src/copyright/detector/seen_text.rs
+++ b/src/copyright/detector/seen_text.rs
@@ -1,0 +1,125 @@
+use std::collections::HashSet;
+
+use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
+
+pub(crate) struct SeenTextSets {
+    pub(crate) copyrights: HashSet<String>,
+    pub(crate) holders: HashSet<String>,
+    pub(crate) authors: HashSet<String>,
+}
+
+impl SeenTextSets {
+    pub(crate) fn from_existing(
+        copyrights: &[CopyrightDetection],
+        holders: &[HolderDetection],
+        authors: &[AuthorDetection],
+    ) -> Self {
+        Self {
+            copyrights: copyrights.iter().map(|c| c.copyright.clone()).collect(),
+            holders: holders.iter().map(|h| h.holder.clone()).collect(),
+            authors: authors.iter().map(|a| a.author.clone()).collect(),
+        }
+    }
+
+    pub(crate) fn dedup_new_copyrights(
+        &mut self,
+        copyrights: &mut Vec<CopyrightDetection>,
+        before: usize,
+    ) {
+        self.dedup_appended_copyrights(copyrights, before);
+    }
+
+    pub(crate) fn dedup_appended_copyrights(
+        &mut self,
+        copyrights: &mut Vec<CopyrightDetection>,
+        before: usize,
+    ) {
+        if copyrights.len() <= before {
+            return;
+        }
+        let mut i = before;
+        while i < copyrights.len() {
+            let text = &copyrights[i].copyright;
+            if self.copyrights.insert(text.clone()) {
+                i += 1;
+            } else {
+                copyrights.remove(i);
+            }
+        }
+    }
+
+    pub(crate) fn dedup_new_holders(&mut self, holders: &mut Vec<HolderDetection>, before: usize) {
+        self.dedup_appended_holders(holders, before);
+    }
+
+    pub(crate) fn dedup_appended_holders(
+        &mut self,
+        holders: &mut Vec<HolderDetection>,
+        before: usize,
+    ) {
+        if holders.len() <= before {
+            return;
+        }
+        let mut i = before;
+        while i < holders.len() {
+            let text = &holders[i].holder;
+            if self.holders.insert(text.clone()) {
+                i += 1;
+            } else {
+                holders.remove(i);
+            }
+        }
+    }
+
+    pub(crate) fn dedup_new_authors(&mut self, authors: &mut Vec<AuthorDetection>, before: usize) {
+        self.dedup_appended_authors(authors, before);
+    }
+
+    pub(crate) fn dedup_appended_authors(
+        &mut self,
+        authors: &mut Vec<AuthorDetection>,
+        before: usize,
+    ) {
+        if authors.len() <= before {
+            return;
+        }
+        let mut i = before;
+        while i < authors.len() {
+            if self.authors.insert(authors[i].author.clone()) {
+                i += 1;
+            } else {
+                authors.remove(i);
+            }
+        }
+    }
+
+    pub(crate) fn register_copyrights(&mut self, copyrights: &[CopyrightDetection]) {
+        for c in copyrights {
+            self.copyrights.insert(c.copyright.clone());
+        }
+    }
+
+    pub(crate) fn register_holders(&mut self, holders: &[HolderDetection]) {
+        for h in holders {
+            self.holders.insert(h.holder.clone());
+        }
+    }
+
+    pub(crate) fn register_authors(&mut self, authors: &[AuthorDetection]) {
+        for a in authors {
+            self.authors.insert(a.author.clone());
+        }
+    }
+
+    pub(crate) fn rebuild_copyrights_from(&mut self, copyrights: &[CopyrightDetection]) {
+        self.copyrights = copyrights.iter().map(|c| c.copyright.clone()).collect();
+    }
+
+    pub(crate) fn rebuild_holders_from(&mut self, holders: &[HolderDetection]) {
+        self.holders = holders.iter().map(|h| h.holder.clone()).collect();
+    }
+
+    pub(crate) fn rebuild_authors_from(&mut self, authors: &[AuthorDetection]) {
+        self.authors = authors.iter().map(|a| a.author.clone()).collect();
+    }
+}

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1918,10 +1918,7 @@ fn test_index_html_first_group_span_extraction_keeps_copyright_word() {
     let tokens = get_tokens(&groups[0]);
     let tree = parse(tokens);
 
-    let mut c = Vec::new();
-    let mut h = Vec::new();
-    let mut a = Vec::new();
-    extract_from_spans(&tree, &mut c, &mut h, &mut a, false);
+    let (c, _h, _a) = extract_from_spans(&tree, false);
 
     assert!(
         c.iter()
@@ -1946,10 +1943,7 @@ fn test_index_html_first_group_tree_node_extraction_matches_span_extraction() {
     let tokens = get_tokens(&groups[0]);
     let tree = parse(tokens);
 
-    let mut c = Vec::new();
-    let mut h = Vec::new();
-    let mut a = Vec::new();
-    extract_from_tree_nodes(&tree, &mut c, &mut h, &mut a, false);
+    let (c, _h, _a) = extract_from_tree_nodes(&tree, false);
 
     assert!(
         c.iter()

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -5,8 +5,8 @@ use super::postprocess_transforms::{
     drop_shadowed_c_sign_variants, drop_shadowed_year_only_copyright_prefixes_same_start_line,
 };
 use super::token_utils::{
-    collect_filtered_leaves, collect_holder_filtered_leaves, normalize_whitespace,
-    signal_lines_before_copy_line, strip_all_rights_reserved, tokens_to_string,
+    collect_filtered_leaves, collect_holder_filtered_leaves, normalized_tokens_to_string,
+    signal_lines_before_copy_line, strip_all_rights_reserved,
 };
 use super::*;
 use crate::models::LineNumber;
@@ -1006,7 +1006,7 @@ fn test_extract_from_tree_nodes_builds_hall_holder_tokens() {
     holder_tokens.extend(node_holder_leaves);
     holder_tokens.extend(&trailing_tokens);
 
-    let holder_string = normalize_whitespace(&tokens_to_string(&holder_tokens));
+    let holder_string = normalized_tokens_to_string(&holder_tokens);
     let refined = refine_holder_in_copyright_context(&holder_string);
 
     assert_eq!(

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -2159,9 +2159,10 @@ fn test_author_colon_multiline_keeps_emails() {
     let input = "/*\n * Authors: Jorge Cwik, <jorge@laser.satlink.net>\n *\t\tArnt Gulbrandsen, <agulbra@nvg.unit.no>\n */\n";
 
     let raw_lines: Vec<&str> = input.lines().collect();
-    let mut prepared_cache = crate::copyright::line_tracking::PreparedLineCache::new(&raw_lines);
+    let prepared_cache =
+        crate::copyright::line_tracking::PreparedLineCache::new(&raw_lines).materialize();
     let mut extracted: Vec<AuthorDetection> = Vec::new();
-    super::author_heuristics::extract_author_colon_blocks(&mut prepared_cache, &mut extracted);
+    super::author_heuristics::extract_author_colon_blocks(&prepared_cache, &mut extracted);
     assert!(
         extracted.iter().any(|ad| ad.author
             == "Jorge Cwik, <jorge@laser.satlink.net> Arnt Gulbrandsen, <agulbra@nvg.unit.no>"),
@@ -2185,9 +2186,10 @@ fn test_author_colon_empty_tail_collects_following_rst_roster_lines() {
         "Authors:\n\t Richard Walker,\n\t Jamie Honan,\n\t Michael Hunold\n\nGeneral information\n";
 
     let raw_lines: Vec<&str> = input.lines().collect();
-    let mut prepared_cache = crate::copyright::line_tracking::PreparedLineCache::new(&raw_lines);
+    let prepared_cache =
+        crate::copyright::line_tracking::PreparedLineCache::new(&raw_lines).materialize();
     let mut extracted: Vec<AuthorDetection> = Vec::new();
-    super::author_heuristics::extract_author_colon_blocks(&mut prepared_cache, &mut extracted);
+    super::author_heuristics::extract_author_colon_blocks(&prepared_cache, &mut extracted);
     assert!(
         extracted
             .iter()

--- a/src/copyright/detector/token_utils.rs
+++ b/src/copyright/detector/token_utils.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -974,4 +974,24 @@ pub fn tokens_to_string(tokens: &[&Token]) -> String {
 
 pub fn normalize_whitespace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub fn group_by<T, K>(items: Vec<T>, key_fn: impl Fn(&T) -> K) -> Vec<(K, Vec<T>)>
+where
+    K: std::hash::Hash + Eq + Clone,
+{
+    let mut order: Vec<K> = Vec::new();
+    let mut seen: HashSet<K> = HashSet::new();
+    let mut map: HashMap<K, Vec<T>> = HashMap::new();
+    for item in items {
+        let key = key_fn(&item);
+        if seen.insert(key.clone()) {
+            order.push(key.clone());
+        }
+        map.entry(key).or_default().push(item);
+    }
+    order
+        .into_iter()
+        .filter_map(|k| map.remove_entry(&k))
+        .collect()
 }

--- a/src/copyright/detector/token_utils.rs
+++ b/src/copyright/detector/token_utils.rs
@@ -408,7 +408,7 @@ pub fn build_copyright_from_tokens(tokens: &[&Token]) -> Option<CopyrightDetecti
     if tokens.is_empty() {
         return None;
     }
-    let node_string = normalize_whitespace(&tokens_to_string(tokens));
+    let node_string = normalized_tokens_to_string(tokens);
     let refined = refine_copyright(&node_string)?;
     if is_junk_copyright(&refined) {
         return None;
@@ -433,7 +433,7 @@ pub fn build_holder_from_tokens(
     if tokens.is_empty() {
         return None;
     }
-    let node_string = normalize_whitespace(&tokens_to_string(tokens));
+    let node_string = normalized_tokens_to_string(tokens);
     let refined = if allow_single_word_contributors {
         refine_holder_in_copyright_context(&node_string)?
     } else {
@@ -459,7 +459,7 @@ pub fn build_author_from_tokens(tokens: &[&Token]) -> Option<AuthorDetection> {
     if tokens.is_empty() {
         return None;
     }
-    let node_string = normalize_whitespace(&tokens_to_string(tokens));
+    let node_string = normalized_tokens_to_string(tokens);
     let refined = refine_author(&node_string)?;
     if is_junk_copyright(&refined) {
         return None;
@@ -964,12 +964,21 @@ pub fn is_copyright_of_header(span: &[&Token]) -> bool {
     !has_year && !has_c
 }
 
-pub fn tokens_to_string(tokens: &[&Token]) -> String {
-    tokens
-        .iter()
-        .map(|t| t.value.as_str())
-        .collect::<Vec<_>>()
-        .join(" ")
+pub fn normalized_tokens_to_string(tokens: &[&Token]) -> String {
+    let mut out = String::new();
+    let mut first = true;
+
+    for token in tokens {
+        for piece in token.value.split_whitespace() {
+            if !first {
+                out.push(' ');
+            }
+            out.push_str(piece);
+            first = false;
+        }
+    }
+
+    out
 }
 
 pub fn normalize_whitespace(s: &str) -> String {

--- a/src/copyright/detector/tree_walk.rs
+++ b/src/copyright/detector/tree_walk.rs
@@ -2586,9 +2586,8 @@ pub fn fix_truncated_contributors_authors(tree: &[ParseNode], authors: &mut Vec<
                         .filter(|t| !super::NON_AUTHOR_POS_TAGS.contains(&t.tag))
                         .collect();
                     if !name_tokens.is_empty() {
-                        let name_str = super::token_utils::normalize_whitespace(
-                            &super::token_utils::tokens_to_string(&name_tokens),
-                        );
+                        let name_str =
+                            super::token_utils::normalized_tokens_to_string(&name_tokens);
                         let refined = refine_author(&name_str);
                         if let Some(mut author_text) = refined {
                             if !author_text.ends_with("contributors") {

--- a/src/copyright/detector/tree_walk.rs
+++ b/src/copyright/detector/tree_walk.rs
@@ -115,11 +115,16 @@ fn single_portions_prefix_token<'a>(
 
 pub fn extract_from_tree_nodes(
     tree: &[ParseNode],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-    authors: &mut Vec<AuthorDetection>,
     allow_not_copyrighted_prefix: bool,
+) -> (
+    Vec<CopyrightDetection>,
+    Vec<HolderDetection>,
+    Vec<AuthorDetection>,
 ) {
+    let mut copyrights: Vec<CopyrightDetection> = Vec::new();
+    let mut holders: Vec<HolderDetection> = Vec::new();
+    let mut authors: Vec<AuthorDetection> = Vec::new();
+
     let group_has_copyright = tree.iter().any(|n| {
         matches!(
             n.label(),
@@ -891,6 +896,8 @@ pub fn extract_from_tree_nodes(
         }
         i += 1;
     }
+
+    (copyrights, holders, authors)
 }
 
 fn merge_copyright_with_following_author<'a>(
@@ -2485,7 +2492,9 @@ fn extract_author_from_copyright_node(node: &ParseNode) -> Option<AuthorDetectio
     super::token_utils::build_author_from_tokens(&author_tokens)
 }
 
-pub fn extract_orphaned_by_authors(tree: &[ParseNode], authors: &mut Vec<AuthorDetection>) {
+pub fn extract_orphaned_by_authors(tree: &[ParseNode]) -> Vec<AuthorDetection> {
+    let mut authors: Vec<AuthorDetection> = Vec::new();
+
     let mut i = 0;
     while i < tree.len() {
         if let Some((det, skip)) = try_extract_orphaned_by_author(tree, i) {
@@ -2497,6 +2506,8 @@ pub fn extract_orphaned_by_authors(tree: &[ParseNode], authors: &mut Vec<AuthorD
         }
         i += 1;
     }
+
+    authors
 }
 
 pub fn fix_truncated_contributors_authors(tree: &[ParseNode], authors: &mut Vec<AuthorDetection>) {
@@ -2627,9 +2638,10 @@ fn restore_trailing_contributors_suffix(author: &str, suffix: &str) -> String {
 
 pub fn extract_holder_is_name(
     tree: &[ParseNode],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    let mut copyrights: Vec<CopyrightDetection> = Vec::new();
+    let mut holders: Vec<HolderDetection> = Vec::new();
+
     let mut i = 0;
     while i < tree.len() {
         if let ParseNode::Leaf(token) = &tree[i]
@@ -2672,6 +2684,8 @@ pub fn extract_holder_is_name(
         }
         i += 1;
     }
+
+    (copyrights, holders)
 }
 
 /// Handle "bare copyright" pattern: a Copy leaf followed by a NameYear/Name/Company
@@ -2679,9 +2693,7 @@ pub fn extract_holder_is_name(
 /// Also handles "Portions/Parts (c) ..." by including a preceding Portions token.
 pub fn extract_bare_copyrights(
     tree: &[ParseNode],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     fn has_line_start_copyright_prefix(tree: &[ParseNode], idx: usize, line: LineNumber) -> bool {
         let mut found_copyright = false;
         for j in (0..idx).rev() {
@@ -2704,6 +2716,9 @@ pub fn extract_bare_copyrights(
         }
         found_copyright
     }
+
+    let mut copyrights: Vec<CopyrightDetection> = Vec::new();
+    let mut holders: Vec<HolderDetection> = Vec::new();
 
     let mut i = 0;
     while i < tree.len() {
@@ -2805,19 +2820,26 @@ pub fn extract_bare_copyrights(
         }
         i += 1;
     }
+
+    (copyrights, holders)
 }
 
 pub fn extract_from_spans(
     tree: &[ParseNode],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
-    authors: &mut Vec<AuthorDetection>,
     allow_not_copyrighted_prefix: bool,
+) -> (
+    Vec<CopyrightDetection>,
+    Vec<HolderDetection>,
+    Vec<AuthorDetection>,
 ) {
+    let mut copyrights: Vec<CopyrightDetection> = Vec::new();
+    let mut holders: Vec<HolderDetection> = Vec::new();
+    let mut authors: Vec<AuthorDetection> = Vec::new();
+
     let all_leaves: Vec<&Token> = tree.iter().flat_map(super::collect_all_leaves).collect();
 
     if all_leaves.is_empty() {
-        return;
+        return (copyrights, holders, authors);
     }
 
     let mut i = 0;
@@ -3072,17 +3094,20 @@ pub fn extract_from_spans(
             i += 1;
         }
     }
+
+    (copyrights, holders, authors)
 }
 
 pub fn extract_copyrights_from_spans(
     tree: &[ParseNode],
-    copyrights: &mut Vec<CopyrightDetection>,
-    holders: &mut Vec<HolderDetection>,
     allow_not_copyrighted_prefix: bool,
-) {
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    let mut copyrights: Vec<CopyrightDetection> = Vec::new();
+    let mut holders: Vec<HolderDetection> = Vec::new();
+
     let all_leaves: Vec<&Token> = tree.iter().flat_map(super::collect_all_leaves).collect();
     if all_leaves.is_empty() {
-        return;
+        return (copyrights, holders);
     }
 
     let mut i = 0;
@@ -3261,4 +3286,6 @@ pub fn extract_copyrights_from_spans(
             i += 1;
         }
     }
+
+    (copyrights, holders)
 }

--- a/src/copyright/lexer.rs
+++ b/src/copyright/lexer.rs
@@ -9,17 +9,17 @@
 //!
 //! Pipeline: numbered lines → tokenize → POS tag → tagged tokens
 
-use std::sync::LazyLock;
-
 use regex::Regex;
 
-use super::patterns::COMPILED_PATTERNS;
+use super::patterns::match_token_thread_local;
 use super::types::{PosTag, Token};
 use crate::models::LineNumber;
 
-/// Splitter regex: splits on tabs, spaces, equals signs, and semicolons.
-/// Matches Python's `re.compile(r'[\t =;]+').split`.
-static SPLITTER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[\t =;]+").unwrap());
+// Splitter regex: splits on tabs, spaces, equals signs, and semicolons.
+// Matches Python's `re.compile(r'[\t =;]+').split`.
+thread_local! {
+    static SPLITTER: Regex = Regex::new(r"[\t =;]+").unwrap();
+}
 
 /// Tokenize and POS-tag a group of numbered lines.
 ///
@@ -60,53 +60,55 @@ pub fn get_tokens(numbered_lines: &[(usize, String)]) -> Vec<Token> {
 
         last_line.clone_from(line);
 
-        for tok_str in SPLITTER.split(line) {
-            let quoted_structured_key = is_quoted_structured_key(tok_str);
-            let mut tok = tok_str.to_string();
+        SPLITTER.with(|splitter| {
+            for tok_str in splitter.split(line) {
+                let quoted_structured_key = is_quoted_structured_key(tok_str);
+                let mut tok = tok_str.to_string();
 
-            if tok.ends_with("',") {
-                tok = tok.trim_end_matches(&[',', '\''][..]).to_string();
-            }
+                if tok.ends_with("',") {
+                    tok = tok.trim_end_matches(&[',', '\''][..]).to_string();
+                }
 
-            tok = tok.trim_matches(&['\'', ' '][..]).to_string();
-            tok = tok.trim_end_matches(':').to_string();
-            tok = tok.trim_end_matches('"').trim_end_matches('\'').to_string();
-            tok = tok.trim().to_string();
+                tok = tok.trim_matches(&['\'', ' '][..]).to_string();
+                tok = tok.trim_end_matches(':').to_string();
+                tok = tok.trim_end_matches('"').trim_end_matches('\'').to_string();
+                tok = tok.trim().to_string();
 
-            if tok.is_empty() || tok == ":" || tok == "." {
-                continue;
-            }
-
-            if tok.ends_with(',') {
-                let base = tok.trim_end_matches(',').trim();
-                if !base.is_empty() {
-                    let tag = COMPILED_PATTERNS.match_token(base);
-                    tokens.push(Token {
-                        value: base.to_string(),
-                        tag,
-                        start_line: LineNumber::new(*start_line).expect("invalid line number"),
-                    });
-                    tokens.push(Token {
-                        value: ",".to_string(),
-                        tag: PosTag::Cc,
-                        start_line: LineNumber::new(*start_line).expect("invalid line number"),
-                    });
+                if tok.is_empty() || tok == ":" || tok == "." {
                     continue;
                 }
+
+                if tok.ends_with(',') {
+                    let base = tok.trim_end_matches(',').trim();
+                    if !base.is_empty() {
+                        let tag = match_token_thread_local(base);
+                        tokens.push(Token {
+                            value: base.to_string(),
+                            tag,
+                            start_line: LineNumber::new(*start_line).expect("invalid line number"),
+                        });
+                        tokens.push(Token {
+                            value: ",".to_string(),
+                            tag: PosTag::Cc,
+                            start_line: LineNumber::new(*start_line).expect("invalid line number"),
+                        });
+                        continue;
+                    }
+                }
+
+                let tag = if quoted_structured_key {
+                    PosTag::Junk
+                } else {
+                    match_token_thread_local(&tok)
+                };
+
+                tokens.push(Token {
+                    value: tok,
+                    tag,
+                    start_line: LineNumber::new(*start_line).expect("invalid line number"),
+                });
             }
-
-            let tag = if quoted_structured_key {
-                PosTag::Junk
-            } else {
-                COMPILED_PATTERNS.match_token(&tok)
-            };
-
-            tokens.push(Token {
-                value: tok,
-                tag,
-                start_line: LineNumber::new(*start_line).expect("invalid line number"),
-            });
-        }
+        });
     }
 
     retag_camel_case_junk_before_company_suffix_in_copyright_context(&mut tokens);

--- a/src/copyright/line_tracking.rs
+++ b/src/copyright/line_tracking.rs
@@ -21,6 +21,26 @@ pub(super) struct PreparedLine<'a> {
     pub(super) prepared: &'a str,
 }
 
+pub(super) struct PreparedLinesIter<'a> {
+    lines: &'a PreparedLines<'a>,
+    idx: usize,
+}
+
+pub(super) struct PreparedLinesNonEmptyIter<'a> {
+    lines: &'a PreparedLines<'a>,
+    idx: usize,
+}
+
+pub(super) struct PreparedLinesAdjacentPairsIter<'a> {
+    lines: &'a PreparedLines<'a>,
+    idx: usize,
+}
+
+pub(super) struct PreparedLinesAdjacentTriplesIter<'a> {
+    lines: &'a PreparedLines<'a>,
+    idx: usize,
+}
+
 impl<'a> PreparedLineCache<'a> {
     pub(super) fn new(raw_lines: &'a [&'a str]) -> Self {
         Self {
@@ -45,6 +65,14 @@ impl<'a> PreparedLineCache<'a> {
 }
 
 impl<'a> PreparedLines<'a> {
+    fn prepared_line_at_index(&self, idx: usize) -> PreparedLine<'_> {
+        PreparedLine {
+            line_number: LineNumber::from_0_indexed(idx),
+            raw: self.raw_lines[idx],
+            prepared: self.prepared[idx].as_str(),
+        }
+    }
+
     pub(super) fn raw_line_count(&self) -> usize {
         self.raw_lines.len()
     }
@@ -59,104 +87,46 @@ impl<'a> PreparedLines<'a> {
 
     pub(super) fn line(&self, line_number: LineNumber) -> Option<PreparedLine<'_>> {
         let idx = line_number - 1;
-        Some(PreparedLine {
-            line_number,
-            raw: self.raw_lines.get(idx).copied()?,
-            prepared: self.prepared.get(idx).map(String::as_str)?,
-        })
+        (idx < self.len()).then(|| self.prepared_line_at_index(idx))
     }
 
-    pub(super) fn iter(&self) -> impl Iterator<Item = PreparedLine<'_>> + '_ {
-        self.raw_lines
-            .iter()
-            .copied()
-            .zip(self.prepared.iter().map(String::as_str))
-            .enumerate()
-            .map(|(idx, (raw, prepared))| PreparedLine {
-                line_number: LineNumber::from_0_indexed(idx),
-                raw,
-                prepared,
-            })
+    pub(super) fn iter(&self) -> PreparedLinesIter<'_> {
+        PreparedLinesIter {
+            lines: self,
+            idx: 0,
+        }
     }
 
-    pub(super) fn iter_non_empty(&self) -> impl Iterator<Item = PreparedLine<'_>> + '_ {
-        self.iter().filter(|line| !line.prepared.is_empty())
+    pub(super) fn iter_non_empty(&self) -> PreparedLinesNonEmptyIter<'_> {
+        PreparedLinesNonEmptyIter {
+            lines: self,
+            idx: 0,
+        }
     }
 
-    pub(super) fn adjacent_pairs(
-        &self,
-    ) -> impl Iterator<Item = (PreparedLine<'_>, PreparedLine<'_>)> + '_ {
-        self.raw_lines
-            .iter()
-            .copied()
-            .zip(self.prepared.iter().map(String::as_str))
-            .zip(
-                self.raw_lines
-                    .iter()
-                    .copied()
-                    .skip(1)
-                    .zip(self.prepared.iter().skip(1).map(String::as_str)),
-            )
-            .enumerate()
-            .map(|(idx, ((raw1, prepared1), (raw2, prepared2)))| {
-                (
-                    PreparedLine {
-                        line_number: LineNumber::from_0_indexed(idx),
-                        raw: raw1,
-                        prepared: prepared1,
-                    },
-                    PreparedLine {
-                        line_number: LineNumber::from_0_indexed(idx + 1),
-                        raw: raw2,
-                        prepared: prepared2,
-                    },
-                )
-            })
+    pub(super) fn next_non_empty_line(&self, line_number: LineNumber) -> Option<PreparedLine<'_>> {
+        let mut idx = line_number.get();
+        while idx < self.len() {
+            if !self.prepared[idx].is_empty() {
+                return Some(self.prepared_line_at_index(idx));
+            }
+            idx += 1;
+        }
+        None
     }
 
-    pub(super) fn adjacent_triples(
-        &self,
-    ) -> impl Iterator<Item = (PreparedLine<'_>, PreparedLine<'_>, PreparedLine<'_>)> + '_ {
-        self.raw_lines
-            .iter()
-            .copied()
-            .zip(self.prepared.iter().map(String::as_str))
-            .zip(
-                self.raw_lines
-                    .iter()
-                    .copied()
-                    .skip(1)
-                    .zip(self.prepared.iter().skip(1).map(String::as_str)),
-            )
-            .zip(
-                self.raw_lines
-                    .iter()
-                    .copied()
-                    .skip(2)
-                    .zip(self.prepared.iter().skip(2).map(String::as_str)),
-            )
-            .enumerate()
-            .map(
-                |(idx, (((raw1, prepared1), (raw2, prepared2)), (raw3, prepared3)))| {
-                    (
-                        PreparedLine {
-                            line_number: LineNumber::from_0_indexed(idx),
-                            raw: raw1,
-                            prepared: prepared1,
-                        },
-                        PreparedLine {
-                            line_number: LineNumber::from_0_indexed(idx + 1),
-                            raw: raw2,
-                            prepared: prepared2,
-                        },
-                        PreparedLine {
-                            line_number: LineNumber::from_0_indexed(idx + 2),
-                            raw: raw3,
-                            prepared: prepared3,
-                        },
-                    )
-                },
-            )
+    pub(super) fn adjacent_pairs(&self) -> PreparedLinesAdjacentPairsIter<'_> {
+        PreparedLinesAdjacentPairsIter {
+            lines: self,
+            idx: 0,
+        }
+    }
+
+    pub(super) fn adjacent_triples(&self) -> PreparedLinesAdjacentTriplesIter<'_> {
+        PreparedLinesAdjacentTriplesIter {
+            lines: self,
+            idx: 0,
+        }
     }
 
     pub(super) fn get(&self, line_number: usize) -> Option<&str> {
@@ -182,6 +152,72 @@ impl<'a> PreparedLines<'a> {
                 .windows(pattern_bytes.len())
                 .any(|w| w.eq_ignore_ascii_case(pattern_bytes))
         })
+    }
+}
+
+impl<'a> Iterator for PreparedLinesIter<'a> {
+    type Item = PreparedLine<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.lines.len() {
+            return None;
+        }
+
+        let line = self.lines.prepared_line_at_index(self.idx);
+        self.idx += 1;
+        Some(line)
+    }
+}
+
+impl<'a> Iterator for PreparedLinesNonEmptyIter<'a> {
+    type Item = PreparedLine<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.idx < self.lines.len() {
+            let idx = self.idx;
+            self.idx += 1;
+            if self.lines.prepared[idx].is_empty() {
+                continue;
+            }
+            return Some(self.lines.prepared_line_at_index(idx));
+        }
+
+        None
+    }
+}
+
+impl<'a> Iterator for PreparedLinesAdjacentPairsIter<'a> {
+    type Item = (PreparedLine<'a>, PreparedLine<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx + 1 >= self.lines.len() {
+            return None;
+        }
+
+        let pair = (
+            self.lines.prepared_line_at_index(self.idx),
+            self.lines.prepared_line_at_index(self.idx + 1),
+        );
+        self.idx += 1;
+        Some(pair)
+    }
+}
+
+impl<'a> Iterator for PreparedLinesAdjacentTriplesIter<'a> {
+    type Item = (PreparedLine<'a>, PreparedLine<'a>, PreparedLine<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx + 2 >= self.lines.len() {
+            return None;
+        }
+
+        let triple = (
+            self.lines.prepared_line_at_index(self.idx),
+            self.lines.prepared_line_at_index(self.idx + 1),
+            self.lines.prepared_line_at_index(self.idx + 2),
+        );
+        self.idx += 1;
+        Some(triple)
     }
 }
 

--- a/src/copyright/line_tracking.rs
+++ b/src/copyright/line_tracking.rs
@@ -138,10 +138,6 @@ impl<'a> PreparedLines<'a> {
         self.prepared.get(idx).map(String::as_str)
     }
 
-    pub(super) fn raw_by_index(&self, idx: usize) -> Option<&str> {
-        self.raw_lines.get(idx).copied()
-    }
-
     pub(super) fn contains_ci(&self, pattern: &str) -> bool {
         let pattern_bytes = pattern.as_bytes();
         if pattern_bytes.is_empty() {

--- a/src/copyright/line_tracking.rs
+++ b/src/copyright/line_tracking.rs
@@ -14,6 +14,13 @@ pub(super) struct PreparedLines<'a> {
     prepared: Vec<String>,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct PreparedLine<'a> {
+    pub(super) line_number: LineNumber,
+    pub(super) raw: &'a str,
+    pub(super) prepared: &'a str,
+}
+
 impl<'a> PreparedLineCache<'a> {
     pub(super) fn new(raw_lines: &'a [&'a str]) -> Self {
         Self {
@@ -48,6 +55,108 @@ impl<'a> PreparedLines<'a> {
 
     pub(super) fn len(&self) -> usize {
         self.raw_lines.len()
+    }
+
+    pub(super) fn line(&self, line_number: LineNumber) -> Option<PreparedLine<'_>> {
+        let idx = line_number - 1;
+        Some(PreparedLine {
+            line_number,
+            raw: self.raw_lines.get(idx).copied()?,
+            prepared: self.prepared.get(idx).map(String::as_str)?,
+        })
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = PreparedLine<'_>> + '_ {
+        self.raw_lines
+            .iter()
+            .copied()
+            .zip(self.prepared.iter().map(String::as_str))
+            .enumerate()
+            .map(|(idx, (raw, prepared))| PreparedLine {
+                line_number: LineNumber::from_0_indexed(idx),
+                raw,
+                prepared,
+            })
+    }
+
+    pub(super) fn iter_non_empty(&self) -> impl Iterator<Item = PreparedLine<'_>> + '_ {
+        self.iter().filter(|line| !line.prepared.is_empty())
+    }
+
+    pub(super) fn adjacent_pairs(
+        &self,
+    ) -> impl Iterator<Item = (PreparedLine<'_>, PreparedLine<'_>)> + '_ {
+        self.raw_lines
+            .iter()
+            .copied()
+            .zip(self.prepared.iter().map(String::as_str))
+            .zip(
+                self.raw_lines
+                    .iter()
+                    .copied()
+                    .skip(1)
+                    .zip(self.prepared.iter().skip(1).map(String::as_str)),
+            )
+            .enumerate()
+            .map(|(idx, ((raw1, prepared1), (raw2, prepared2)))| {
+                (
+                    PreparedLine {
+                        line_number: LineNumber::from_0_indexed(idx),
+                        raw: raw1,
+                        prepared: prepared1,
+                    },
+                    PreparedLine {
+                        line_number: LineNumber::from_0_indexed(idx + 1),
+                        raw: raw2,
+                        prepared: prepared2,
+                    },
+                )
+            })
+    }
+
+    pub(super) fn adjacent_triples(
+        &self,
+    ) -> impl Iterator<Item = (PreparedLine<'_>, PreparedLine<'_>, PreparedLine<'_>)> + '_ {
+        self.raw_lines
+            .iter()
+            .copied()
+            .zip(self.prepared.iter().map(String::as_str))
+            .zip(
+                self.raw_lines
+                    .iter()
+                    .copied()
+                    .skip(1)
+                    .zip(self.prepared.iter().skip(1).map(String::as_str)),
+            )
+            .zip(
+                self.raw_lines
+                    .iter()
+                    .copied()
+                    .skip(2)
+                    .zip(self.prepared.iter().skip(2).map(String::as_str)),
+            )
+            .enumerate()
+            .map(
+                |(idx, (((raw1, prepared1), (raw2, prepared2)), (raw3, prepared3)))| {
+                    (
+                        PreparedLine {
+                            line_number: LineNumber::from_0_indexed(idx),
+                            raw: raw1,
+                            prepared: prepared1,
+                        },
+                        PreparedLine {
+                            line_number: LineNumber::from_0_indexed(idx + 1),
+                            raw: raw2,
+                            prepared: prepared2,
+                        },
+                        PreparedLine {
+                            line_number: LineNumber::from_0_indexed(idx + 2),
+                            raw: raw3,
+                            prepared: prepared3,
+                        },
+                    )
+                },
+            )
     }
 
     pub(super) fn get(&self, line_number: usize) -> Option<&str> {

--- a/src/copyright/line_tracking.rs
+++ b/src/copyright/line_tracking.rs
@@ -9,6 +9,11 @@ pub(super) struct PreparedLineCache<'a> {
     prepared: Vec<Option<String>>,
 }
 
+pub(super) struct PreparedLines<'a> {
+    raw_lines: &'a [&'a str],
+    prepared: Vec<String>,
+}
+
 impl<'a> PreparedLineCache<'a> {
     pub(super) fn new(raw_lines: &'a [&'a str]) -> Self {
         Self {
@@ -17,6 +22,22 @@ impl<'a> PreparedLineCache<'a> {
         }
     }
 
+    pub(super) fn materialize(self) -> PreparedLines<'a> {
+        let prepared = self
+            .prepared
+            .into_iter()
+            .zip(self.raw_lines.iter().copied())
+            .map(|(prepared, raw)| prepared.unwrap_or_else(|| prepare_text_line(raw)))
+            .collect();
+
+        PreparedLines {
+            raw_lines: self.raw_lines,
+            prepared,
+        }
+    }
+}
+
+impl<'a> PreparedLines<'a> {
     pub(super) fn raw_line_count(&self) -> usize {
         self.raw_lines.len()
     }
@@ -29,20 +50,13 @@ impl<'a> PreparedLineCache<'a> {
         self.raw_lines.len()
     }
 
-    pub(super) fn get(&mut self, line_number: usize) -> Option<&str> {
+    pub(super) fn get(&self, line_number: usize) -> Option<&str> {
         let idx = line_number.checked_sub(1)?;
         self.get_by_index(idx)
     }
 
-    pub(super) fn get_by_index(&mut self, idx: usize) -> Option<&str> {
-        if idx >= self.raw_lines.len() {
-            return None;
-        }
-        if self.prepared[idx].is_none() {
-            let raw = self.raw_lines[idx];
-            self.prepared[idx] = Some(prepare_text_line(raw));
-        }
-        self.prepared[idx].as_deref()
+    pub(super) fn get_by_index(&self, idx: usize) -> Option<&str> {
+        self.prepared.get(idx).map(String::as_str)
     }
 
     pub(super) fn raw_by_index(&self, idx: usize) -> Option<&str> {

--- a/src/copyright/patterns.rs
+++ b/src/copyright/patterns.rs
@@ -25,6 +25,18 @@ pub(super) struct CompiledPatterns {
 }
 
 impl CompiledPatterns {
+    fn from_raw_patterns(raw_patterns: &[(String, PosTag)]) -> Self {
+        let patterns = raw_patterns
+            .iter()
+            .map(|(regex_str, tag)| PatternEntry {
+                regex: Regex::new(regex_str)
+                    .unwrap_or_else(|e| panic!("Failed to compile regex '{}': {}", regex_str, e)),
+                tag: *tag,
+            })
+            .collect();
+        Self { patterns }
+    }
+
     /// Match a token value against all patterns, returning the first matching tag.
     /// Returns `PosTag::Nn` if no pattern matches (catch-all).
     pub(super) fn match_token(&self, value: &str) -> PosTag {
@@ -37,19 +49,21 @@ impl CompiledPatterns {
     }
 }
 
-/// Global compiled patterns, initialized once.
-pub(super) static COMPILED_PATTERNS: LazyLock<CompiledPatterns> = LazyLock::new(|| {
-    let raw_patterns = build_pattern_list();
-    let patterns = raw_patterns
-        .into_iter()
-        .map(|(regex_str, tag)| PatternEntry {
-            regex: Regex::new(&regex_str)
-                .unwrap_or_else(|e| panic!("Failed to compile regex '{}': {}", regex_str, e)),
-            tag,
-        })
-        .collect();
-    CompiledPatterns { patterns }
-});
+static RAW_PATTERNS: LazyLock<Vec<(String, PosTag)>> = LazyLock::new(build_pattern_list);
+
+/// Global compiled patterns, initialized once for tests.
+#[cfg(test)]
+pub(super) static COMPILED_PATTERNS: LazyLock<CompiledPatterns> =
+    LazyLock::new(|| CompiledPatterns::from_raw_patterns(RAW_PATTERNS.as_slice()));
+
+thread_local! {
+    static THREAD_LOCAL_COMPILED_PATTERNS: CompiledPatterns =
+        CompiledPatterns::from_raw_patterns(RAW_PATTERNS.as_slice());
+}
+
+pub(super) fn match_token_thread_local(value: &str) -> PosTag {
+    THREAD_LOCAL_COMPILED_PATTERNS.with(|patterns| patterns.match_token(value))
+}
 
 /// Build the ordered list of (regex_string, PosTag) pairs.
 /// This is split from compilation to make it easier to test pattern strings.

--- a/src/models/line_number.rs
+++ b/src/models/line_number.rs
@@ -28,6 +28,22 @@ impl LineNumber {
         self.0.get()
     }
 
+    pub fn checked_add(self, n: usize) -> Option<Self> {
+        self.0.get().checked_add(n).and_then(Self::new)
+    }
+
+    pub fn checked_sub(self, n: usize) -> Option<Self> {
+        self.0.get().checked_sub(n).and_then(Self::new)
+    }
+
+    pub fn next(self) -> Self {
+        self.checked_add(1).expect("valid line number")
+    }
+
+    pub fn prev(self) -> Option<Self> {
+        self.checked_sub(1)
+    }
+
     pub fn saturating_add(self, n: usize) -> Self {
         Self(NonZeroUsize::new(self.0.get().saturating_add(n)).expect("LineNumber overflow"))
     }


### PR DESCRIPTION
## Summary

- Refactor the copyright detector toward a more uniform, functional style: centralize dedup, make many extract/add helpers return `Vec`s, convert many grouped rebuilds into retain-style filters, and simplify nearby dual-output builder helpers.
- Roll out dense immutable `PreparedLines` and `LineNumber` helper APIs across later detector phases, replacing most index-heavy scans with `PreparedLines` iteration helpers and `LineNumber::next()/prev()`.
- Improve detector throughput with three kept performance changes: thread-local lexer regexes, one-pass token normalization, and collapsed repeated tree-analysis scans. Final Chromium benchmark (`-q -n 8 --timeout 3600 -c`) improved from `549.357s` on `main` to `497.258s` on this branch, a `52.099s` / `9.48%` speedup.

## Scope and exclusions

- Included:
  - copyright detector refactors in `src/copyright/detector/**`
  - `PreparedLines` / `LineNumber` API cleanup and adoption in detector code
  - benchmark-positive performance phases only
- Explicit exclusions:
  - no intentional detector-output semantic changes
  - no expected-output fixture or golden-file rewrites

## Intentional differences from Python

- None intended; this branch keeps detector behavior aligned while restructuring helpers and retaining green focused detector and golden validation.

## Follow-up work

- Created or intentionally deferred:
  - deeper parser-rule bucketing and tree-walk metadata caching were investigated but deferred in favor of the smaller benchmark-positive phases above