### PR TITLE
fix(cli): collect paths-file entries directly

### DIFF
--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -28,7 +28,8 @@ use crate::scan_result_shaping::{
     trim_preloaded_assembly_to_files,
 };
 use crate::scanner::{
-    LicenseScanOptions, TextDetectionOptions, collect_paths, process_collected_with_memory_limit,
+    CollectionFrontier, LicenseScanOptions, TextDetectionOptions, collect_paths,
+    collect_selected_paths, process_collected_with_memory_limit,
     process_collected_with_memory_limit_sequential, scan_options_fingerprint,
 };
 use crate::time::format_scancode_timestamp;
@@ -135,8 +136,12 @@ pub fn run() -> Result<()> {
             None,
         )
     } else {
-        let (scan_path, selected_paths, missing_paths_file_entries) =
-            resolve_native_scan_selection(&cli)?;
+        let NativeScanSelection {
+            scan_path,
+            selected_paths,
+            collection_frontier,
+            missing_entries: missing_paths_file_entries,
+        } = resolve_native_scan_selection(&cli)?;
         let paths_file_warnings = build_paths_file_warning_messages(&missing_paths_file_entries);
         for warning in &paths_file_warnings {
             progress.output_written(warning);
@@ -148,7 +153,16 @@ pub fn run() -> Result<()> {
         let collection_exclude_patterns =
             build_collection_exclude_patterns(Path::new(&scan_path), cache_config.root_dir());
 
-        let mut collected = collect_paths(&scan_path, cli.max_depth, &collection_exclude_patterns);
+        let mut collected = if cli.paths_file.is_empty() {
+            collect_paths(&scan_path, cli.max_depth, &collection_exclude_patterns)
+        } else {
+            collect_selected_paths(
+                Path::new(&scan_path),
+                &collection_frontier,
+                cli.max_depth,
+                &collection_exclude_patterns,
+            )
+        };
         let user_excluded_count = apply_user_path_filters_to_collected(
             &mut collected,
             Path::new(&scan_path),
@@ -651,10 +665,23 @@ fn touch_license_golden_symbols() {
     let _ = crate::license_detection::LicenseDetectionEngine::detect_matches_with_kind;
 }
 
-fn resolve_native_scan_selection(cli: &Cli) -> Result<(String, Vec<SelectedPath>, Vec<String>)> {
+#[derive(Debug)]
+struct NativeScanSelection {
+    scan_path: String,
+    selected_paths: Vec<SelectedPath>,
+    collection_frontier: Vec<CollectionFrontier>,
+    missing_entries: Vec<String>,
+}
+
+fn resolve_native_scan_selection(cli: &Cli) -> Result<NativeScanSelection> {
     if cli.paths_file.is_empty() {
         let (scan_path, selected_paths) = resolve_native_scan_inputs(&cli.dir_path)?;
-        return Ok((scan_path, selected_paths, Vec::new()));
+        return Ok(NativeScanSelection {
+            scan_path,
+            selected_paths,
+            collection_frontier: Vec::new(),
+            missing_entries: Vec::new(),
+        });
     }
 
     let scan_path = cli
@@ -671,7 +698,12 @@ fn resolve_native_scan_selection(cli: &Cli) -> Result<(String, Vec<SelectedPath>
         ));
     }
 
-    Ok((scan_path, resolved.selections, resolved.missing_entries))
+    Ok(NativeScanSelection {
+        scan_path,
+        selected_paths: resolved.selections,
+        collection_frontier: resolved.frontier,
+        missing_entries: resolved.missing_entries,
+    })
 }
 
 fn load_paths_file_entries(paths_files: &[String]) -> Result<Vec<String>> {

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -1305,14 +1305,31 @@ fn resolve_native_scan_selection_uses_paths_file_under_explicit_root() {
 
     std::env::set_current_dir(old_cwd).expect("restore cwd");
 
-    let (resolved_root, includes, missing_entries) =
-        result.expect("paths file selection should resolve");
+    let NativeScanSelection {
+        scan_path: resolved_root,
+        selected_paths: includes,
+        collection_frontier: frontier,
+        missing_entries,
+    } = result.expect("paths file selection should resolve");
     assert_eq!(resolved_root, scan_root.to_str().expect("utf-8 path"));
     assert_eq!(
         includes,
         vec![
             crate::scan_result_shaping::SelectedPath::Exact("src/lib.rs".to_string()),
             crate::scan_result_shaping::SelectedPath::Subtree("docs".to_string())
+        ]
+    );
+    assert_eq!(
+        frontier,
+        vec![
+            crate::scanner::CollectionFrontier {
+                path: std::path::PathBuf::from("src/lib.rs"),
+                recurse: false,
+            },
+            crate::scanner::CollectionFrontier {
+                path: std::path::PathBuf::from("docs"),
+                recurse: true,
+            }
         ]
     );
     assert_eq!(missing_entries, vec!["missing.rs"]);

--- a/src/scan_result_shaping/selection.rs
+++ b/src/scan_result_shaping/selection.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::models::FileInfo;
-use crate::scanner::CollectedPaths;
+use crate::scanner::{CollectedPaths, CollectionFrontier};
 
 use super::apply_path_selection_filter;
 
@@ -59,6 +59,7 @@ pub(crate) fn resolve_native_scan_inputs(inputs: &[String]) -> Result<(String, V
 #[derive(Debug)]
 pub(crate) struct ResolvedPathsFileEntries {
     pub selections: Vec<SelectedPath>,
+    pub frontier: Vec<CollectionFrontier>,
     pub missing_entries: Vec<String>,
 }
 
@@ -80,6 +81,7 @@ pub(crate) fn resolve_paths_file_entries(
     }
 
     let mut selections = Vec::new();
+    let mut frontier = Vec::new();
     let mut missing_entries = Vec::new();
     let mut seen = HashSet::new();
 
@@ -92,6 +94,10 @@ pub(crate) fn resolve_paths_file_entries(
         if absolute.exists() {
             let selection = build_selected_path(&normalized, absolute.is_dir());
             if seen.insert(selection_cache_key(&selection)) {
+                frontier.push(CollectionFrontier {
+                    path: PathBuf::from(&normalized),
+                    recurse: absolute.is_dir(),
+                });
                 selections.push(selection);
             }
         } else if seen.insert(format!("missing:{normalized}")) {
@@ -101,6 +107,7 @@ pub(crate) fn resolve_paths_file_entries(
 
     Ok(ResolvedPathsFileEntries {
         selections,
+        frontier,
         missing_entries,
     })
 }

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -234,6 +234,19 @@ fn resolve_paths_file_entries_normalizes_existing_entries_and_tracks_missing() {
             SelectedPath::Subtree("docs".to_string())
         ]
     );
+    assert_eq!(
+        resolved.frontier,
+        vec![
+            CollectionFrontier {
+                path: PathBuf::from("src/nested/main.rs"),
+                recurse: false,
+            },
+            CollectionFrontier {
+                path: PathBuf::from("docs"),
+                recurse: true,
+            }
+        ]
+    );
     assert_eq!(resolved.missing_entries, vec!["missing/file.rs"]);
 }
 

--- a/src/scanner/collect.rs
+++ b/src/scanner/collect.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use glob::Pattern;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -13,6 +14,22 @@ pub struct CollectedPaths {
     pub excluded_count: usize,
     pub total_file_bytes: u64,
     pub collection_errors: Vec<(PathBuf, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionFrontier {
+    pub path: PathBuf,
+    pub recurse: bool,
+}
+
+struct CollectionAccumulator {
+    files: Vec<(PathBuf, fs::Metadata)>,
+    directories: Vec<(PathBuf, fs::Metadata)>,
+    file_seen: HashSet<PathBuf>,
+    dir_seen: HashSet<PathBuf>,
+    excluded_count: usize,
+    total_file_bytes: u64,
+    collection_errors: Vec<(PathBuf, String)>,
 }
 
 impl CollectedPaths {
@@ -67,6 +84,104 @@ pub fn collect_paths<P: AsRef<Path>>(
     }
 
     collect_all_paths(root, &metadata, depth_limit, exclude_patterns)
+}
+
+pub fn collect_selected_paths(
+    root: &Path,
+    selected: &[CollectionFrontier],
+    max_depth: usize,
+    exclude_patterns: &[Pattern],
+) -> CollectedPaths {
+    let depth_limit = depth_limit_from_cli(max_depth);
+
+    if is_path_excluded(root, exclude_patterns) {
+        return CollectedPaths {
+            files: Vec::new(),
+            directories: Vec::new(),
+            excluded_count: 1,
+            total_file_bytes: 0,
+            collection_errors: Vec::new(),
+        };
+    }
+
+    let root_metadata = match fs::metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return CollectedPaths {
+                files: Vec::new(),
+                directories: Vec::new(),
+                excluded_count: 0,
+                total_file_bytes: 0,
+                collection_errors: vec![(root.to_path_buf(), error.to_string())],
+            };
+        }
+    };
+
+    let mut accumulator = CollectionAccumulator {
+        files: Vec::new(),
+        directories: vec![(root.to_path_buf(), root_metadata)],
+        file_seen: HashSet::new(),
+        dir_seen: HashSet::from([root.to_path_buf()]),
+        excluded_count: 0,
+        total_file_bytes: 0,
+        collection_errors: Vec::new(),
+    };
+
+    for frontier in minimize_frontier(selected) {
+        let relative_depth = frontier.path.components().count();
+        if depth_limit.is_some_and(|limit| relative_depth > limit) {
+            continue;
+        }
+
+        let absolute = root.join(&frontier.path);
+        if is_path_or_any_ancestor_excluded(root, &absolute, exclude_patterns) {
+            accumulator.excluded_count += 1;
+            continue;
+        }
+
+        let metadata = match fs::metadata(&absolute) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                accumulator
+                    .collection_errors
+                    .push((absolute, error.to_string()));
+                continue;
+            }
+        };
+
+        add_ancestor_directories(root, &absolute, &mut accumulator);
+
+        if metadata.is_file() {
+            insert_file(&mut accumulator, absolute, metadata);
+            continue;
+        }
+
+        if !metadata.is_dir() {
+            continue;
+        }
+
+        let subtree_depth_limit = depth_limit.map(|limit| limit.saturating_sub(relative_depth));
+        let collected = if frontier.recurse {
+            collect_all_paths(&absolute, &metadata, subtree_depth_limit, exclude_patterns)
+        } else {
+            CollectedPaths {
+                files: Vec::new(),
+                directories: vec![(absolute, metadata)],
+                excluded_count: 0,
+                total_file_bytes: 0,
+                collection_errors: Vec::new(),
+            }
+        };
+        merge_collected(&mut accumulator, collected);
+    }
+
+    CollectedPaths {
+        files: accumulator.files,
+        directories: accumulator.directories,
+        excluded_count: accumulator.excluded_count,
+        total_file_bytes: accumulator.total_file_bytes,
+        collection_errors: accumulator.collection_errors,
+    }
 }
 
 fn collect_all_paths(
@@ -132,5 +247,81 @@ fn depth_limit_from_cli(max_depth: usize) -> Option<usize> {
         None
     } else {
         Some(max_depth)
+    }
+}
+
+fn is_path_or_any_ancestor_excluded(
+    path_root: &Path,
+    path: &Path,
+    exclude_patterns: &[Pattern],
+) -> bool {
+    let mut current = Some(path);
+    while let Some(candidate) = current {
+        if is_path_excluded(candidate, exclude_patterns) {
+            return true;
+        }
+        if candidate == path_root {
+            break;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn minimize_frontier(selected: &[CollectionFrontier]) -> Vec<CollectionFrontier> {
+    let mut ordered = selected.to_vec();
+    ordered.sort_by_key(|entry| (entry.path.components().count(), !entry.recurse));
+
+    let mut minimized = Vec::new();
+    for entry in ordered {
+        let covered = minimized.iter().any(|existing: &CollectionFrontier| {
+            existing.recurse
+                && (entry.path == existing.path || entry.path.starts_with(&existing.path))
+        });
+        if !covered {
+            minimized.push(entry);
+        }
+    }
+    minimized
+}
+
+fn add_ancestor_directories(root: &Path, path: &Path, accumulator: &mut CollectionAccumulator) {
+    let mut current = path.parent();
+    while let Some(dir) = current {
+        if dir == root {
+            break;
+        }
+        if accumulator.dir_seen.insert(dir.to_path_buf()) {
+            match fs::metadata(dir) {
+                Ok(metadata) => accumulator.directories.push((dir.to_path_buf(), metadata)),
+                Err(error) => accumulator
+                    .collection_errors
+                    .push((dir.to_path_buf(), error.to_string())),
+            }
+        }
+        current = dir.parent();
+    }
+}
+
+fn insert_file(accumulator: &mut CollectionAccumulator, path: PathBuf, metadata: fs::Metadata) {
+    if accumulator.file_seen.insert(path.clone()) {
+        accumulator.total_file_bytes += metadata.len();
+        accumulator.files.push((path, metadata));
+    }
+}
+
+fn merge_collected(accumulator: &mut CollectionAccumulator, collected: CollectedPaths) {
+    accumulator.excluded_count += collected.excluded_count;
+    accumulator
+        .collection_errors
+        .extend(collected.collection_errors);
+
+    for (path, metadata) in collected.files {
+        insert_file(accumulator, path, metadata);
+    }
+    for (path, metadata) in collected.directories {
+        if accumulator.dir_seen.insert(path.clone()) {
+            accumulator.directories.push((path, metadata));
+        }
     }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -107,7 +107,9 @@ pub fn scan_options_fingerprint(
     )
 }
 
-pub use self::collect::{CollectedPaths, collect_paths};
+pub use self::collect::{
+    CollectedPaths, CollectionFrontier, collect_paths, collect_selected_paths,
+};
 #[allow(unused_imports)]
 pub use self::process::{
     MemoryMode, process_collected, process_collected_sequential,
@@ -122,13 +124,15 @@ mod tests {
 
     use tempfile::TempDir;
 
+    use crate::cache::build_collection_exclude_patterns;
     use crate::license_detection::LicenseDetectionEngine;
     use crate::models::{DatasourceId, FileType, PackageType as FilePackageType};
     use crate::progress::{ProgressMode, ScanProgress};
 
     use super::{
-        LicenseScanOptions, MemoryMode, TextDetectionOptions, collect_paths, process_collected,
-        process_collected_with_memory_limit, scan_options_fingerprint,
+        CollectionFrontier, LicenseScanOptions, MemoryMode, TextDetectionOptions, collect_paths,
+        collect_selected_paths, process_collected, process_collected_with_memory_limit,
+        scan_options_fingerprint,
     };
 
     fn build_sparse_oversized_rpm_with_filename(
@@ -1837,6 +1841,87 @@ mod tests {
         assert_eq!(collected.files.len(), 1);
         assert!(collected.directories.is_empty());
         assert_eq!(collected.files[0].0, file_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_selected_paths_does_not_walk_unselected_siblings() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join("selected/docs")).expect("create selected dir");
+        fs::create_dir_all(root.join("blocked/secret")).expect("create blocked dir");
+        fs::write(root.join("selected/docs/guide.md"), "# guide\n").expect("write guide");
+
+        let blocked = root.join("blocked");
+        let mut perms = fs::metadata(&blocked)
+            .expect("blocked metadata")
+            .permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&blocked, perms).expect("remove blocked permissions");
+
+        let collected = collect_selected_paths(
+            root,
+            &[CollectionFrontier {
+                path: PathBuf::from("selected"),
+                recurse: true,
+            }],
+            0,
+            &[],
+        );
+
+        let mut restore = fs::metadata(&blocked)
+            .expect("blocked metadata")
+            .permissions();
+        restore.set_mode(0o755);
+        fs::set_permissions(&blocked, restore).expect("restore blocked permissions");
+
+        assert!(
+            collected.collection_errors.is_empty(),
+            "{:#?}",
+            collected.collection_errors
+        );
+        assert!(
+            collected
+                .files
+                .iter()
+                .any(|(path, _)| path == &root.join("selected/docs/guide.md"))
+        );
+        assert!(
+            collected
+                .files
+                .iter()
+                .all(|(path, _): &(PathBuf, fs::Metadata)| !path.starts_with(&blocked))
+        );
+    }
+
+    #[test]
+    fn collect_selected_paths_respects_excluded_ancestor_directories() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join(".git")).expect("create git dir");
+        fs::write(
+            root.join(".git/config"),
+            "[core]\nrepositoryformatversion = 0\n",
+        )
+        .expect("write git config");
+
+        let exclude_patterns =
+            build_collection_exclude_patterns(root, &root.join(".provenant-cache"));
+        let collected = collect_selected_paths(
+            root,
+            &[CollectionFrontier {
+                path: PathBuf::from(".git/config"),
+                recurse: false,
+            }],
+            0,
+            &exclude_patterns,
+        );
+
+        assert!(collected.files.is_empty());
+        assert!(collected.directories.iter().all(|(path, _)| path == root));
+        assert_eq!(collected.excluded_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stop whole-root enumeration for `--paths-file` scans by collecting only the resolved file/subtree frontier under the explicit scan root
- preserve shaping and assembly expectations by synthesizing ancestor directories, minimizing overlapping frontier entries, and keeping collection excludes in force
- add regression coverage for the resolved frontier tuple, unreadable unselected siblings, and exact entries under excluded ancestor directories

## Issues

- Covers: follow-up to #759
- Closes:

## Scope and exclusions

- Included:
  - direct frontier-based collection for `--paths-file`
  - exclusion checks for selected entries and their ancestors
  - targeted tests for non-enumerating and excluded-ancestor cases
- Explicit exclusions:
  - any change to `--paths-file` CLI syntax or user-facing semantics
  - absolute or multi-root `--paths-file` support
  - changes to non-`--paths-file` native scan collection

## Intentional differences from Python

- Provenant already has a rooted `--paths-file` workflow that Python ScanCode does not. This change keeps that workflow efficient by using the scan root only for resolving listed entries, not for full-root traversal.

## Follow-up work

- Created or intentionally deferred:
  - no new follow-up created; this closes the performance regression in the current `--paths-file` implementation

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this patch changes the collection frontier for `--paths-file` scans without changing the intended selected resource set, and the focused regression tests cover the preserved semantics
