### PR TITLE
fix(license): treat bare GPL1 as a clue

### DIFF
--- a/resources/license_detection/overlay/rules/gpl1_bare_word_only.RULE
+++ b/resources/license_detection/overlay/rules/gpl1_bare_word_only.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: gpl-1.0
+is_license_clue: yes
+relevance: 50
+notes: Bare GPL1 shorthand is too weak for a hard detection; preserve it as clue-only evidence.
+---
+
+GPL1

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -457,6 +457,41 @@ fn test_engine_surfaces_bare_gpl_as_clue_not_detection() {
 }
 
 #[test]
+fn test_engine_surfaces_bare_gpl1_as_clue_not_detection() {
+    let engine = get_engine();
+
+    let detections = engine
+        .detect_with_kind("GPL1", false, false)
+        .expect("Detection should succeed");
+
+    assert!(
+        detections.iter().any(|detection| {
+            detection
+                .detection_log
+                .iter()
+                .any(|log| log == "license-clues")
+                && detection.license_expression.is_none()
+                && detection
+                    .matches
+                    .iter()
+                    .any(|m| m.rule_identifier == "gpl1_bare_word_only.RULE")
+        }),
+        "bare GPL1 should remain visible as clue-only evidence: {:?}",
+        detections
+            .iter()
+            .map(|d| (
+                d.license_expression.as_deref().unwrap_or("none"),
+                d.detection_log.clone(),
+                d.matches
+                    .iter()
+                    .map(|m| m.rule_identifier.as_str())
+                    .collect::<Vec<_>>()
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_engine_does_not_detect_graphics_pipeline_library_as_gpl() {
     let engine = get_engine();
 


### PR DESCRIPTION
## Summary

- demote `gpl1_bare_word_only.RULE` to clue-only evidence so bare `GPL1` tokens remain visible without surfacing as hard `GPL-1.0` detections
- keep the change isolated to the `GPL1` bare-word rule family only; no adjacent GPL phrase rules are adjusted here
- add one behavior-only regression test showing `GPL1` is surfaced as a clue rather than a detected license expression

## Issues

- Covers: false-positive handling aligned with upstream ScanCode history around bare `GPL1` tokens in aboutcode-org/scancode-toolkit#2585, kernel-symbol false positives in #1914 fixed by #1963, and later `GPL1/GPL2/GPL3` label noise in #3932 fixed by #4106
- Closes:

## Scope and exclusions

- Included:
  - new overlay for `gpl1_bare_word_only.RULE`
  - regenerated embedded license index artifact
  - one behavior-only engine test for `GPL1` clue output
- Explicit exclusions:
  - no changes to `gpl_194.RULE` or `gpl-1.0-plus_200.RULE`
  - no new configuration-coupled tests asserting overlay presence or rule-kind internals
  - no changes to existing golden fixtures or broader GPL false-positive policy

## Intentional differences from Python

- This PR intentionally treats bare `GPL1` the same way Provenant already treats bare `GPL`: as weak shorthand that should remain inspectable as a clue, but not be asserted as a hard license detection. That is narrower than a general GPL phrase policy and is specifically motivated by the upstream false-positive history in #2585, #1914/#1963, and #3932/#4106.

## Follow-up work

- Created or intentionally deferred:
  - deferred any changes for `released under the GPL` (`gpl_194.RULE`) and `under the GPL` (`gpl-1.0-plus_200.RULE`) until there is similarly direct upstream false-positive evidence for those exact rules

## Expected-output fixture changes

- Files changed: `resources/license_detection/overlay/rules/gpl1_bare_word_only.RULE`, `resources/license_detection/license_index.zst`
- Why the new expected output is correct:
  - bare `GPL1` is weak shorthand analogous to the already-demoted bare `GPL` family, and current upstream issue history shows repeated false positives from code tokens and labels rather than reliable substantive license notices