### PR TITLE
fix(cli): align only-findings filtering with ScanCode parity

### DIFF
--- a/docs/implementation-plans/post-processing/SCAN_RESULT_SHAPING_PLAN.md
+++ b/docs/implementation-plans/post-processing/SCAN_RESULT_SHAPING_PLAN.md
@@ -56,7 +56,7 @@ Current shaping steps:
 
 - `apply_ignore_resource_filter()` — drops whole file resources whose detected authors or holders match user-supplied regex filters
 - `apply_include_filter()` — keeps matching files and the directory chain needed to retain a valid tree
-- `apply_only_findings_filter()` — drops files without findings while retaining necessary ancestor directories
+- `apply_only_findings_filter()` — drops resources without findings and keeps only resources that themselves carry findings
 - `filter_redundant_clues()` — deduplicates identical copyrights/holders/authors/emails/URLs by value and line span
 - `normalize_paths()` — applies `--strip-root` / `--full-root` to file paths, package file references, and embedded `Match.from_file` paths
 - `apply_mark_source()` — marks source-heavy files/directories and computes `source_count`
@@ -83,7 +83,7 @@ This already differs favorably from Python's plugin-oriented summarycode approac
 - ✅ Root-resource collection and single-file scan support now give path shaping an explicit scan-root model
 - ✅ Native multi-input relative scans now follow the upstream common-prefix + synthetic-include model
 - ✅ Whole-resource `--ignore-author` / `--ignore-copyright-holder` filtering with ancestor-directory preservation
-- ✅ Only-findings filtering with ancestor-directory preservation, including generated-only files
+- ✅ Only-findings filtering by per-resource findings, including generated-only files
 - ✅ Redundant-clue deduplication by exact value/line-span identity
 - ✅ Rule-based ignorable clue suppression for `--filter-clues` using matched rule identifiers and coverage thresholds
 - ✅ Relative and absolute path normalization for resource paths, package file references, and embedded `Match.from_file` references
@@ -132,7 +132,7 @@ This layer should remain a **presentation shaper**, not a data enricher.
 
 - [x] All shaping-specific CLI flags are implemented and wired through the intended pipeline stage
 - [x] Output-shaping flags remain clearly separated from summary/tally computation
-- [x] Filtering preserves required ancestor directories deterministically
+- [x] Filters that reshape tree structure preserve required ancestor directories deterministically where that ancestry is part of the contract
 - [x] Path normalization behavior is explicit and tested
 - [x] `mark_source` remains count-based and does not introduce rescans
 - [x] Large scans do not incur Python-style repeated persistence/copy overhead in this layer

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -376,9 +376,9 @@ pub fn run() -> Result<()> {
     }
 
     if cli.only_findings {
-        progress.post_scan_step("Filtering to files with findings...");
+        progress.post_scan_step("Filtering to resources with findings...");
         record_detail_timing(&progress, "output-filter:only-findings", || {
-            apply_only_findings_for_mode(&mut scan_result.files, cli.from_json);
+            apply_only_findings_filter(&mut scan_result.files);
         });
     }
 
@@ -632,14 +632,6 @@ pub fn run() -> Result<()> {
     );
 
     Ok(())
-}
-
-fn apply_only_findings_for_mode(files: &mut Vec<FileInfo>, from_json: bool) {
-    if from_json {
-        files.clear();
-    } else {
-        apply_only_findings_filter(files);
-    }
 }
 
 fn collect_top_level_license_detections_for_mode(

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -552,14 +552,14 @@ fn from_json_recomputes_top_level_uniques_even_without_shaping_flags() {
 }
 
 #[test]
-fn from_json_only_findings_clears_files_for_replay_output() {
+fn from_json_only_findings_keeps_files_with_findings() {
     let mut file = json_file("project/package.json", crate::models::FileType::File);
     file.license_expression = Some("mit".to_string());
     let mut files = vec![file];
 
-    apply_only_findings_for_mode(&mut files, true);
+    apply_only_findings_filter(&mut files);
 
-    assert!(files.is_empty());
+    assert_eq!(files.len(), 1);
 }
 
 #[test]
@@ -568,7 +568,7 @@ fn native_only_findings_still_keeps_files_with_findings() {
     file.license_expression = Some("mit".to_string());
     let mut files = vec![file];
 
-    apply_only_findings_for_mode(&mut files, false);
+    apply_only_findings_filter(&mut files);
 
     assert_eq!(files.len(), 1);
 }

--- a/src/scan_result_shaping/core_test.rs
+++ b/src/scan_result_shaping/core_test.rs
@@ -72,7 +72,7 @@ fn path_selection_filter_keeps_matching_directories_without_file_descendants() {
 }
 
 #[test]
-fn only_findings_keeps_file_with_findings_and_parent_dirs() {
+fn only_findings_drops_directories_without_findings() {
     let mut files = vec![dir("project"), file("project/a.txt"), file("project/b.txt")];
     files[2].copyrights = vec![Copyright {
         copyright: "Copyright Example".to_string(),
@@ -83,8 +83,20 @@ fn only_findings_keeps_file_with_findings_and_parent_dirs() {
     apply_only_findings_filter(&mut files);
 
     let paths: HashSet<_> = files.into_iter().map(|f| f.path).collect();
-    assert!(paths.contains("project"));
     assert!(paths.contains("project/b.txt"));
+    assert!(!paths.contains("project/a.txt"));
+    assert!(!paths.contains("project"));
+}
+
+#[test]
+fn only_findings_keeps_directories_with_findings() {
+    let mut files = vec![dir("project"), file("project/a.txt")];
+    files[0].scan_errors = vec!["permission denied".to_string()];
+
+    apply_only_findings_filter(&mut files);
+
+    let paths: HashSet<_> = files.into_iter().map(|f| f.path).collect();
+    assert!(paths.contains("project"));
     assert!(!paths.contains("project/a.txt"));
 }
 
@@ -724,9 +736,9 @@ fn only_findings_keeps_generated_only_files() {
     apply_only_findings_filter(&mut files);
 
     let paths: HashSet<_> = files.into_iter().map(|f| f.path).collect();
-    assert!(paths.contains("project"));
     assert!(paths.contains("project/generated.js"));
     assert!(!paths.contains("project/empty.txt"));
+    assert!(!paths.contains("project"));
 }
 
 #[test]

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -149,7 +149,7 @@ fn has_findings(file: &FileInfo) -> bool {
 }
 
 pub(crate) fn apply_only_findings_filter(files: &mut Vec<FileInfo>) {
-    retain_matching_files_with_ancestor_dirs(files, has_findings);
+    files.retain(has_findings);
 }
 
 fn matches_any_regex<'a, I>(patterns: &[Regex], values: I) -> bool


### PR DESCRIPTION
## Summary

- align `--only-findings` with per-resource findings so native scans and `--from-json` replay both drop structural directories that carry no findings
- add focused shaping and CLI tests for direct findings, generated-only files, directory findings, and replay behavior
- update the shaping plan notes and validate parity with ScanCode using compare run `.provenant/compare-runs/20260423T132846Z-json-39522/`, where both scanners finish with 176 files and 0 directories under `--only-findings`

## Scope and exclusions

- Included: scan-result shaping behavior, CLI replay wiring, tests, and shaping-plan documentation for `--only-findings`
- Explicit exclusions: unrelated license-expression grouping deltas in `boostorg/json` Ryu headers; no golden expected files changed