### PR TITLE
fix(copyright): restore detector authors and cover tests in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,7 +122,7 @@ jobs:
         run: ./scripts/check_unused_deps.sh
 
   rust-library-tests:
-    name: Rust Library Tests
+    name: Rust Unit Tests
     runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
@@ -143,8 +143,11 @@ jobs:
         with:
           shared-key: rust-library-tests-release
 
-      - name: Run unit tests except scanner/assembly contract layer
+      - name: Run CLI/bin unit tests except scanner/assembly contract layer
         run: "cargo test --bin provenant --release --verbose -- --skip _scan_test::"
+
+      - name: Run copyright detector library unit tests
+        run: "cargo test -p provenant-cli --lib --release --verbose copyright::detector::"
 
   windows-build-smoke:
     name: Windows Build Smoke Test

--- a/src/copyright/detector/author_heuristics.rs
+++ b/src/copyright/detector/author_heuristics.rs
@@ -1092,7 +1092,7 @@ fn extract_author_colon_inline_roster(tail: &str, line_number: usize) -> Vec<Aut
     authors
 }
 
-fn refine_author_with_optional_handle_suffix(candidate: &str) -> Option<String> {
+pub(super) fn refine_author_with_optional_handle_suffix(candidate: &str) -> Option<String> {
     static TRAILING_HANDLE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\s*\(@[A-Za-z0-9_.-]+\)\s*$").unwrap());
 
@@ -2538,7 +2538,7 @@ fn json_window_is_simple_author_only_fragment(window: &str) -> bool {
     JSON_AUTHOR_ONLY_STRING_RE.is_match(window) || JSON_AUTHOR_ONLY_OBJECT_RE.is_match(window)
 }
 
-fn looks_like_structured_json_author_fallback(value: &str) -> bool {
+pub(super) fn looks_like_structured_json_author_fallback(value: &str) -> bool {
     let trimmed = value.trim();
     if looks_like_name_with_parenthesized_url(trimmed) {
         return true;

--- a/src/copyright/detector/postprocess_transforms.rs
+++ b/src/copyright/detector/postprocess_transforms.rs
@@ -15,6 +15,9 @@ use crate::copyright::refiner::{
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 use crate::models::LineNumber;
 
+use super::author_heuristics::{
+    looks_like_structured_json_author_fallback, refine_author_with_optional_handle_suffix,
+};
 use super::seen_text::SeenTextSets;
 use super::token_utils::group_by;
 
@@ -50,7 +53,10 @@ pub fn refine_final_authors(authors: &mut Vec<AuthorDetection>) {
         .filter_map(|a| {
             let author = if let Some(author) = refine_author(&a.author) {
                 author
-            } else if looks_like_collective_institution_author(&a.author) {
+            } else if refine_author_with_optional_handle_suffix(&a.author).is_some()
+                || looks_like_structured_json_author_fallback(&a.author)
+                || looks_like_collective_institution_author(&a.author)
+            {
                 a.author.trim().to_string()
             } else {
                 return None;

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::copyright::types::AuthorDetection;
 use crate::models::LineNumber;
 
 #[test]
@@ -59,4 +60,65 @@ fn test_drop_shadowed_c_sign_variants_unit() {
     ];
     expected.sort();
     assert_eq!(got, expected, "After dropping variants, got: {c:?}");
+}
+
+#[test]
+fn test_refine_final_authors_keeps_handle_suffixed_maintainer() {
+    let mut authors = vec![AuthorDetection {
+        author: "Tianon Gravi <admwiggin@gmail.com> (@tianon)".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    refine_final_authors(&mut authors);
+
+    assert_eq!(
+        authors,
+        vec![AuthorDetection {
+            author: "Tianon Gravi <admwiggin@gmail.com> (@tianon)".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        }]
+    );
+}
+
+#[test]
+fn test_refine_final_authors_keeps_structured_metadata_collectives() {
+    let mut authors = vec![
+        AuthorDetection {
+            author: "gRPC authors".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        AuthorDetection {
+            author: "Meta".to_string(),
+            start_line: LineNumber::new(2).unwrap(),
+            end_line: LineNumber::new(2).unwrap(),
+        },
+        AuthorDetection {
+            author: "The libunwind project".to_string(),
+            start_line: LineNumber::new(3).unwrap(),
+            end_line: LineNumber::new(3).unwrap(),
+        },
+        AuthorDetection {
+            author: "S2Geometry".to_string(),
+            start_line: LineNumber::new(4).unwrap(),
+            end_line: LineNumber::new(4).unwrap(),
+        },
+    ];
+
+    refine_final_authors(&mut authors);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "gRPC authors",
+            "Meta",
+            "The libunwind project",
+            "S2Geometry"
+        ]
+    );
 }


### PR DESCRIPTION
## Summary

- fix `refine_final_authors` so it no longer drops valid authors that earlier detector heuristics already accepted, including maintainer lines with trailing handles and structured metadata names like `gRPC authors`, `Meta`, `The libunwind project`, and `S2Geometry`
- add focused regression tests at the postprocess layer and restore the hidden `copyright::detector` unit-test target to green
- fix the CI coverage gap: the job named `Rust Library Tests` was only running `cargo test --bin provenant`, so detector library tests were never exercised; this PR renames that job/step accurately and adds a dedicated `cargo test -p provenant-cli --lib --release copyright::detector::` step

## Issues

- Covers: hidden copyright detector regressions in maintainer/metadata author extraction and the CI gap that let those library tests break without detection

## Scope and exclusions

- Included: the minimal author postprocess fix, focused regression tests, targeted CI coverage for `copyright::detector`, and clearer unit-test job naming
- Explicit exclusions: broadening CI to the full `cargo test -p provenant-cli --lib --release` target. Local validation surfaced unrelated pre-existing non-detector lib-target failures, so this PR fixes the missed copyright coverage without expanding into those separate failures.

## Intentional differences from Python

- None. This restores intended detector behavior by preserving valid author detections that the Rust heuristics had already accepted upstream.

## Follow-up work

- Created or intentionally deferred: investigate the unrelated failing non-detector `--lib` tests separately, then consider broadening CI to full library-target coverage once that suite is green

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this change only fixes author retention in detector unit-tested code paths and CI coverage; it does not intentionally change golden or expected output fixtures
