### PR TITLE
fix(package-detection): harden benchmark verification targets

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 163 of 165 recorded runs, with a **11.5× median speedup** and **10.1× geometric-mean speedup** overall; the median gap grows from **6.9×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 165 of 165 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -95,12 +95,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `65.32s`; ScanCode `936.34s`
 - Far broader Python/provider package coverage (`142` vs `1`) and dependency extraction (`7579` vs `450`) from `uv.lock`, provider `pyproject.toml`, and committed `pnpm-lock.yaml` inputs, plus extra Docker and Helm package visibility, safer URL credential stripping, and cleaner copyright/author normalization across large documentation and kernel-style metadata blocks
 
-##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **2.45× faster**
+##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **17.90× faster**
 
-- Files: 1,225
-- Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `106.58s`; ScanCode `261.33s`
-- Far broader Python-family package and dependency extraction (`112` vs `1` packages, `4488` vs `759` dependencies) from the large `test/requirements/**` tree, many fixture/workspace `pyproject.toml` files, and multiple `uv.lock` inputs that ScanCode leaves at zero, with safer URL credential stripping, Unicode-preserving party normalization, and METADATA-backed wheel identity instead of double-counting a misleading filename
+- Files: 1,259
+- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `20.79s`; ScanCode `372.18s`
+- Far broader Python-family package and dependency extraction (`112` vs `1` packages, `5277` vs `759` dependencies) from the large `test/requirements/**` tree, many fixture/workspace `pyproject.toml` files, and multiple `uv.lock` inputs that ScanCode leaves at zero, with safer URL credential stripping, Unicode-preserving party normalization, and METADATA-backed wheel identity instead of double-counting a misleading filename
 
 ##### [astropy/astropy @ 40280e3](https://github.com/astropy/astropy/tree/40280e3bd715a4968eda816c73bf88f05aa6cdc0) — **22.04× faster**
 
@@ -439,11 +439,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `67.58s`; ScanCode `776.24s`
 - Broader JVM monorepo package and dependency extraction (`173` vs `165` packages, `4434` vs `4233` dependencies) from nested Maven example POMs, the committed Antora `package-lock.json`, and Docker/WAR metadata, plus more specific SBOM license expressions where ScanCode flattens `EPL-2.0 AND Classpath-exception-2.0` or `BSD-2-Clause-Views AND BSD-3-Clause`
 
-##### [technomancy/leiningen @ 4022732](https://github.com/technomancy/leiningen/tree/40227328d4a9c8945362d6d626d19c2449175df6) — **1.10× slower**
+##### [technomancy/leiningen @ 4022732](https://github.com/technomancy/leiningen/tree/40227328d4a9c8945362d6d626d19c2449175df6) — **8.90× faster**
 
-- Files: 300
-- Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `18.81s`; ScanCode `17.13s`
+- Files: 302
+- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.34s`; ScanCode `91.99s`
 - Broader Clojure manifest and dependency extraction (`82` vs `10` dependencies) from the root, nested checkout, and test-project `project.clj` surfaces that ScanCode leaves at manifest-only visibility, plus OFL font-license recovery and cleaner URL normalization where ScanCode preserves regex suffixes, trailing-slash drift, or percent-encoded placeholder text
 
 #### Rust / Go / native / infrastructure
@@ -483,11 +483,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.29s`; ScanCode `71.17s`
 - Cleaner XML author extraction without ScanCode's prose-tainted suffixes such as `A.Meredith Compiler`, while still recovering real names like `Jeremy Siek` and `David Goodger` that ScanCode misses
 
-##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **4.65× faster**
+##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **8.46× faster**
 
-- Files: 701
-- Run context: 2026-04-10 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `32.30s`; ScanCode `150.19s`
+- Files: 705
+- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `28.27s`; ScanCode `239.21s`
 - Cleaner GSoC participant-name extraction in `bench/data/gsoc-2018.json`, preserving real names like `Adrián Bazaga` instead of ScanCode's `type' Person name' ...` noise, plus more complete placeholder URL closure on templated GitHub API routes
 
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
@@ -1092,12 +1092,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `10.31s`; ScanCode `69.61s`
 - Matched distroless Debian package coverage (`9` vs `9`) with broader dependency extraction (`84` vs `0`) from `status.d` relation fields, maintainer parties preserved in package metadata, and zero scan errors where ScanCode crashes on all nine `*.md5sums` companions
 
-##### [Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069](https://quay.io/repository/fedora/fedora-minimal) — **16.19× faster**
+##### [Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069](https://quay.io/repository/fedora/fedora-minimal) — **17.88× faster**
 
 - Files: 3
 - Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.46s`; ScanCode `169.36s`
-- Direct installed-RPM package and dependency extraction (`127` vs `0` packages, `1831` vs `0` dependencies) from the real Fedora SQLite primary DB plus WAL/SHM companions, with zero scan errors
+- Timing: Provenant `9.09s`; ScanCode `162.53s`
+- No installed-RPM package extraction on the narrow SQLite primary-DB snapshot (`0` vs `0` packages, `0` vs `0` dependencies); this lane is mostly a raw database byte scan, and the remaining ScanCode-only detections on `rpmdb.sqlite` are low-value noise/false positives rather than useful package or license coverage
 
 ##### [openSUSE Tumbleweed rpmdb NDB snapshot @ sha256:25afd25](https://registry.opensuse.org/) — **16.99× faster**
 
@@ -1136,11 +1136,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `9.81s`; ScanCode `70.01s`
 - Matched FreeBSD package-manifest package coverage (`1` vs `1`) on the `+COMPACT_MANIFEST` extracted from the shipped `.pkg`, with normalized `MIT` declared-license reporting instead of a raw manifest-license structure
 
-##### [Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521](https://api.nuget.org/v3-flatcontainer/humanizer.core/3.0.10/humanizer.core.3.0.10.nupkg) — **4.55× slower**
+##### [Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521](https://api.nuget.org/v3-flatcontainer/humanizer.core/3.0.10/humanizer.core.3.0.10.nupkg) — **7.24× faster**
 
 - Files: 1
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `19.19s`; ScanCode `4.22s`
+- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `9.66s`; ScanCode `69.97s`
 - Real NuGet package-archive extraction on the shipped `.nupkg` (`1` vs `0` packages, `6` vs `0` dependencies), with a named `pkg:nuget/Humanizer.Core@3.0.10` identity instead of ScanCode's generic unnamed archive row, plus an `MIT` license detection from modern package metadata
 
 ##### [pkg 2.7.4 .pkg +COMPACT_MANIFEST sample @ sha256:4128dba](https://pkg.freebsd.org/FreeBSD:14:amd64/latest/Latest/pkg.pkg) — **7.72× faster**

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -77,9 +77,9 @@ ScanCode: 73.02s</title></rect>
     <rect x="92.00" y="424.52" width="8" height="8" fill="#d97706" rx="1.5"><title>Firefox langpack en-GB 141.0.2 .xpi
 Files: 1
 ScanCode: 74.17s</title></rect>
-    <rect x="92.00" y="559.97" width="8" height="8" fill="#d97706" rx="1.5"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
+    <rect x="92.00" y="427.27" width="8" height="8" fill="#d97706" rx="1.5"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
 Files: 1
-ScanCode: 4.22s</title></rect>
+ScanCode: 69.97s</title></rect>
     <rect x="92.00" y="422.38" width="8" height="8" fill="#d97706" rx="1.5"><title>NSIS 3.12 setup.exe
 Files: 1
 ScanCode: 77.60s</title></rect>
@@ -113,9 +113,9 @@ ScanCode: 172.04s</title></rect>
     <rect x="167.70" y="427.04" width="8" height="8" fill="#d97706" rx="1.5"><title>Bitwarden Android v2024.12.0 APK+AAB+manifest
 Files: 3
 ScanCode: 70.31s</title></rect>
-    <rect x="167.70" y="385.51" width="8" height="8" fill="#d97706" rx="1.5"><title>Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069
+    <rect x="167.70" y="387.45" width="8" height="8" fill="#d97706" rx="1.5"><title>Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069
 Files: 3
-ScanCode: 169.36s</title></rect>
+ScanCode: 162.53s</title></rect>
     <rect x="167.70" y="427.99" width="8" height="8" fill="#d97706" rx="1.5"><title>glzr-io/glazewm v3.10.1 Windows snapshot
 Files: 3
 ScanCode: 68.91s</title></rect>
@@ -209,9 +209,9 @@ ScanCode: 87.06s</title></rect>
     <rect x="481.50" y="402.72" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda @ 37549c4
 Files: 285
 ScanCode: 117.64s</title></rect>
-    <rect x="485.04" y="493.77" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
-Files: 300
-ScanCode: 17.13s</title></rect>
+    <rect x="485.49" y="414.35" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
+Files: 302
+ScanCode: 91.99s</title></rect>
     <rect x="490.34" y="410.86" width="8" height="8" fill="#d97706" rx="1.5"><title>yesodweb/yesod @ 1b033c7
 Files: 324
 ScanCode: 99.03s</title></rect>
@@ -278,12 +278,12 @@ ScanCode: 203.47s</title></rect>
     <rect x="539.99" y="385.56" width="8" height="8" fill="#d97706" rx="1.5"><title>HeapsIO/heaps @ d2992b0
 Files: 666
 ScanCode: 169.15s</title></rect>
-    <rect x="543.52" y="391.18" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
-Files: 701
-ScanCode: 150.19s</title></rect>
     <rect x="543.81" y="392.44" width="8" height="8" fill="#d97706" rx="1.5"><title>select2/select2 @ 595494a
 Files: 704
 ScanCode: 146.24s</title></rect>
+    <rect x="543.91" y="369.19" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
+Files: 705
+ScanCode: 239.21s</title></rect>
     <rect x="555.41" y="432.81" width="8" height="8" fill="#d97706" rx="1.5"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 ScanCode: 62.23s</title></rect>
@@ -326,9 +326,9 @@ ScanCode: 216.36s</title></rect>
     <rect x="580.51" y="358.66" width="8" height="8" fill="#d97706" rx="1.5"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 ScanCode: 298.91s</title></rect>
-    <rect x="581.98" y="365.01" width="8" height="8" fill="#d97706" rx="1.5"><title>astral-sh/uv @ 9581f2b
-Files: 1225
-ScanCode: 261.33s</title></rect>
+    <rect x="583.87" y="348.30" width="8" height="8" fill="#d97706" rx="1.5"><title>astral-sh/uv @ 9581f2b
+Files: 1259
+ScanCode: 372.18s</title></rect>
     <rect x="584.14" y="405.69" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian12 @ sha256:9dce90e
 Files: 1264
 ScanCode: 110.49s</title></rect>
@@ -574,9 +574,9 @@ Provenant: 10.11s</title></circle>
     <circle cx="96.00" cy="521.94" r="4.5" fill="#2563eb"><title>Firefox langpack en-GB 141.0.2 .xpi
 Files: 1
 Provenant: 10.27s</title></circle>
-    <circle cx="96.00" cy="492.40" r="4.5" fill="#2563eb"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
+    <circle cx="96.00" cy="524.83" r="4.5" fill="#2563eb"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
 Files: 1
-Provenant: 19.19s</title></circle>
+Provenant: 9.66s</title></circle>
     <circle cx="96.00" cy="490.35" r="4.5" fill="#2563eb"><title>NSIS 3.12 setup.exe
 Files: 1
 Provenant: 20.04s</title></circle>
@@ -610,9 +610,9 @@ Provenant: 10.13s</title></circle>
     <circle cx="171.70" cy="522.87" r="4.5" fill="#2563eb"><title>Bitwarden Android v2024.12.0 APK+AAB+manifest
 Files: 3
 Provenant: 10.07s</title></circle>
-    <circle cx="171.70" cy="521.07" r="4.5" fill="#2563eb"><title>Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069
+    <circle cx="171.70" cy="527.71" r="4.5" fill="#2563eb"><title>Fedora Minimal 42 rpmdb SQLite snapshot @ sha256:c30f069
 Files: 3
-Provenant: 10.46s</title></circle>
+Provenant: 9.09s</title></circle>
     <circle cx="171.70" cy="480.11" r="4.5" fill="#2563eb"><title>glzr-io/glazewm v3.10.1 Windows snapshot
 Files: 3
 Provenant: 24.89s</title></circle>
@@ -706,9 +706,9 @@ Provenant: 10.04s</title></circle>
     <circle cx="485.50" cy="522.96" r="4.5" fill="#2563eb"><title>conda/conda @ 37549c4
 Files: 285
 Provenant: 10.05s</title></circle>
-    <circle cx="489.04" cy="493.35" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
-Files: 300
-Provenant: 18.81s</title></circle>
+    <circle cx="489.49" cy="521.62" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
+Files: 302
+Provenant: 10.34s</title></circle>
     <circle cx="494.34" cy="520.36" r="4.5" fill="#2563eb"><title>yesodweb/yesod @ 1b033c7
 Files: 324
 Provenant: 10.62s</title></circle>
@@ -775,12 +775,12 @@ Provenant: 14.37s</title></circle>
     <circle cx="543.99" cy="520.31" r="4.5" fill="#2563eb"><title>HeapsIO/heaps @ d2992b0
 Files: 666
 Provenant: 10.63s</title></circle>
-    <circle cx="547.52" cy="467.80" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
-Files: 701
-Provenant: 32.30s</title></circle>
     <circle cx="547.81" cy="512.39" r="4.5" fill="#2563eb"><title>select2/select2 @ 595494a
 Files: 704
 Provenant: 12.57s</title></circle>
+    <circle cx="547.91" cy="474.10" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
+Files: 705
+Provenant: 28.27s</title></circle>
     <circle cx="559.41" cy="493.35" r="4.5" fill="#2563eb"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 Provenant: 18.81s</title></circle>
@@ -823,9 +823,9 @@ Provenant: 12.77s</title></circle>
     <circle cx="584.51" cy="495.58" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 Provenant: 17.94s</title></circle>
-    <circle cx="585.98" cy="411.39" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
-Files: 1225
-Provenant: 106.58s</title></circle>
+    <circle cx="587.87" cy="488.62" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
+Files: 1259
+Provenant: 20.79s</title></circle>
     <circle cx="588.14" cy="514.39" r="4.5" fill="#2563eb"><title>distroless base-debian12 @ sha256:9dce90e
 Files: 1264
 Provenant: 12.05s</title></circle>

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -212,6 +212,11 @@ impl Reader {
                 self.parse_form()
             }
             Some('=') => Err("unsupported reader eval dispatch".to_string()),
+            Some('\'') => {
+                self.index += 1;
+                let form = self.parse_form()?;
+                Ok(Form::Prefixed(Box::new(form)))
+            }
             Some('"') => {
                 // Tolerate regex literals in ignored fields without implementing reader semantics.
                 self.parse_string().map(Form::String)

--- a/src/parsers/clojure_test.rs
+++ b/src/parsers/clojure_test.rs
@@ -359,6 +359,33 @@ mod tests {
     }
 
     #[test]
+    fn test_project_clj_accepts_var_quote_in_ignored_fields() {
+        let content = r#"
+(defproject org.example/var-quote "1.0.0"
+  :dependencies [[org.clojure/clojure "1.12.0"]]
+  :middleware [#'project/warn]
+  :hooks [#'leiningen.test.helper/with-system-out-str])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let result = capture_parser_diagnostics(
+            || ClojureProjectCljParser::extract_packages(&path),
+            "ClojureProjectCljParser",
+            &path,
+            None,
+        );
+
+        assert!(result.scan_errors.is_empty());
+        assert_eq!(result.packages.len(), 1);
+
+        let package_data = &result.packages[0];
+        assert_eq!(package_data.namespace.as_deref(), Some("org.example"));
+        assert_eq!(package_data.name.as_deref(), Some("var-quote"));
+        assert_eq!(package_data.version.as_deref(), Some("1.0.0"));
+        assert_eq!(package_data.dependencies.len(), 1);
+    }
+
+    #[test]
     fn test_deps_edn_allows_commas_as_whitespace() {
         let content = r#"
 {:paths ["src", "resources"],

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 const LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES: usize = 128 * 1024;
+const LARGE_NON_SOURCE_JSON_MIN_PREFIX_LINES_TO_KEEP: usize = 256;
 
 pub(super) fn process_file(
     path: &Path,
@@ -558,6 +559,7 @@ fn cap_non_source_json_license_text<'a>(
         || crate::utils::sourcemap::is_sourcemap(path)
         || is_npm_lockfile(path)
         || !is_json_like_text(classification, path)
+        || has_line_rich_json_prefix(text)
         || text.len() <= LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES
     {
         return Cow::Borrowed(text);
@@ -566,6 +568,15 @@ fn cap_non_source_json_license_text<'a>(
     Cow::Owned(
         truncate_at_char_boundary(text, LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES).to_string(),
     )
+}
+
+fn has_line_rich_json_prefix(text: &str) -> bool {
+    truncate_at_char_boundary(text, LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES)
+        .bytes()
+        .filter(|byte| *byte == b'\n')
+        .take(LARGE_NON_SOURCE_JSON_MIN_PREFIX_LINES_TO_KEEP)
+        .count()
+        >= LARGE_NON_SOURCE_JSON_MIN_PREFIX_LINES_TO_KEEP
 }
 
 fn is_json_like_text(classification: &FileInfoClassification, path: &Path) -> bool {

--- a/src/scanner/process/pipeline_test.rs
+++ b/src/scanner/process/pipeline_test.rs
@@ -3,7 +3,7 @@
 
 use super::{
     LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES, cap_non_source_json_license_text,
-    maybe_record_processing_timeout, merge_parse_results, process_file,
+    has_line_rich_json_prefix, maybe_record_processing_timeout, merge_parse_results, process_file,
 };
 use crate::models::DatasourceId;
 use crate::models::{DiagnosticSeverity, PackageData, PackageType, ScanDiagnostic};
@@ -160,6 +160,57 @@ fn test_cap_non_source_json_license_text_keeps_npm_shrinkwrap_intact() {
     );
 
     assert_eq!(capped.as_ref(), large_json);
+}
+
+#[test]
+fn test_cap_non_source_json_license_text_keeps_line_rich_large_json_intact() {
+    let classification = FileInfoClassification {
+        mime_type: "application/json".to_string(),
+        file_type: "JSON text data".to_string(),
+        programming_language: None,
+        is_binary: false,
+        is_text: true,
+        is_archive: false,
+        is_media: false,
+        is_source: false,
+        is_script: false,
+    };
+    let entries = (0..2_000)
+        .map(|index| {
+            format!(
+                "  {{\"id\":{index},\"description\":\"This project is free software under GPL2 and Apache-2.0 terms\"}}"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let large_json = format!("[\n{entries}\n]");
+
+    let capped = cap_non_source_json_license_text(
+        Path::new("benchmark-data.json"),
+        &classification,
+        &large_json,
+    );
+
+    assert!(large_json.len() > LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES);
+    assert_eq!(capped.as_ref(), large_json);
+}
+
+#[test]
+fn test_has_line_rich_json_prefix_detects_multiline_json() {
+    let entries = (0..512)
+        .map(|index| format!("  {{\"id\":{index}}}"))
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let large_json = format!("[\n{entries}\n]");
+
+    assert!(has_line_rich_json_prefix(&large_json));
+}
+
+#[test]
+fn test_has_line_rich_json_prefix_rejects_compact_json() {
+    let compact_json = format!("{{\"items\":[\"{}\"]}}", "x".repeat(200_000));
+
+    assert!(!has_line_rich_json_prefix(&compact_json));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep line-rich large JSON scans intact so benchmark verification on `boostorg/json` does not regress to the truncated-license tail
- support Clojure `#'` var-quote reader dispatch so Leiningen `project.clj` inputs stay parseable without warnings
- rerun a 20-target benchmark sanity sample across recorded ecosystems and refresh benchmark artifacts, including correcting the Fedora SQLite snapshot row to match the saved compare artifacts

## Scope and exclusions

- Included: targeted scanner/parser fixes, focused regression tests, benchmark row/chart refresh after the sanity sweep
- Explicit exclusions: no broad benchmark-doc rewrite, no new parser families, no changes to the scorecard status table

## Follow-up work

- Created or intentionally deferred: the 20-target rerun sample produced many saved compare artifacts for audit, but only the Fedora SQLite benchmark row needed a checked-in correction