### PR TITLE
fix: restore hidden library regressions and CI coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,7 +122,7 @@ jobs:
         run: ./scripts/check_unused_deps.sh
 
   rust-library-tests:
-    name: Rust Unit Tests
+    name: Rust Library Tests
     runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
@@ -143,11 +143,8 @@ jobs:
         with:
           shared-key: rust-library-tests-release
 
-      - name: Run CLI/bin unit tests except scanner/assembly contract layer
-        run: "cargo test --bin provenant --release --verbose -- --skip _scan_test::"
-
-      - name: Run copyright detector library unit tests
-        run: "cargo test -p provenant-cli --lib --release --verbose copyright::detector::"
+      - name: Run library tests except scanner/assembly contract layer
+        run: "cargo test -p provenant-cli --lib --release --verbose -- --skip _scan_test::"
 
   windows-build-smoke:
     name: Windows Build Smoke Test

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -123,11 +123,8 @@ const FILE_REFERENCE_RESOLVER_CONFIGS: &[FileReferenceResolverConfig] = &[
         kind: FileReferenceResolverKind::PythonMetadata,
     },
     FileReferenceResolverConfig {
-        datasource_ids: &[DatasourceId::GradleModule],
-        kind: FileReferenceResolverKind::RelativeToDatafileParent,
-    },
-    FileReferenceResolverConfig {
         datasource_ids: &[
+            DatasourceId::GradleModule,
             DatasourceId::BitbakeRecipe,
             DatasourceId::BitbakeRecipeAppend,
         ],

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -18,6 +18,7 @@ use crate::scan_result_shaping::json_input::{
     JsonScanInput, load_scan_from_json, normalize_loaded_json_scan,
 };
 use crate::scanner::collect_paths;
+use crate::test_support::CurrentDirGuard;
 
 #[test]
 fn process_mode_to_i32_supports_reference_compat_values() {
@@ -1286,8 +1287,7 @@ fn resolve_native_scan_selection_uses_paths_file_under_explicit_root() {
     fs::write(&paths_file_b, "docs\nsrc/lib.rs\n").expect("write second paths file");
 
     let other_cwd = tempfile::TempDir::new().expect("create alternate cwd");
-    let old_cwd = std::env::current_dir().expect("current dir");
-    std::env::set_current_dir(other_cwd.path()).expect("set cwd");
+    let _cwd_guard = CurrentDirGuard::change_to(other_cwd.path());
 
     let cli = crate::cli::Cli::try_parse_from([
         "provenant",
@@ -1302,8 +1302,6 @@ fn resolve_native_scan_selection_uses_paths_file_under_explicit_root() {
     .expect("cli parse should succeed");
 
     let result = resolve_native_scan_selection(&cli);
-
-    std::env::set_current_dir(old_cwd).expect("restore cwd");
 
     let NativeScanSelection {
         scan_path: resolved_root,

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -44,8 +44,9 @@ const JUNK_DOMAIN_SUFFIXES: &[&str] =
     &[".png", ".jpg", ".gif", ".jpeg", ".local", ".blank", ".fill"];
 
 const JUNK_EMAIL_AND_HOST_SUFFIXES: &[&str] = &[
-    ".html", ".htm", ".txt", ".conf", ".cfg", ".default", ".patch", ".diff", ".tar.gz", ".tar.bz2",
-    ".tar.xz", ".gz", ".bz2", ".xz", ".hint", ".sftp",
+    ".png", ".jpg", ".gif", ".jpeg", ".local", ".blank", ".fill", ".html", ".htm", ".txt", ".conf",
+    ".cfg", ".default", ".patch", ".diff", ".tar.gz", ".tar.bz2", ".tar.xz", ".gz", ".bz2", ".xz",
+    ".hint", ".sftp",
 ];
 
 const JUNK_URLS: &[&str] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ pub(crate) mod post_processing;
 pub mod progress;
 pub(crate) mod scan_result_shaping;
 pub mod scanner;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod time;
 pub mod utils;
 pub mod version;

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -1414,7 +1414,7 @@ mod tests {
         assert_eq!(
             result.as_deref(),
             Ok(
-                "apache-2.0 AND apsl-1.0 AND apsl-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0"
+                "apache-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0 AND apsl-1.0 AND apsl-2.0"
             )
         );
     }

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -135,7 +135,7 @@ source:
 
         let result = apply_jinja2_substitutions(content, &variables);
 
-        assert!(result.contains("version: 0.45.0"));
+        assert!(result.contains("version: \"0.45.0\""));
         assert!(result.contains("sha256: abc123"));
         // Jinja2 set lines should be skipped
         assert!(!result.contains("{% set version"));

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -805,7 +805,7 @@ fn apply_local_file_reference_following_accepts_absolute_match_sources_for_curre
 }
 
 #[test]
-fn apply_local_file_reference_following_uses_resolved_license_over_reference_notice_expression() {
+fn apply_local_file_reference_following_preserves_notice_expression_alongside_resolved_license() {
     let mut license = file("LICENSE");
     license.license_expression = Some("mit".to_string());
     license.license_detections = vec![crate::models::LicenseDetection {
@@ -866,11 +866,23 @@ fn apply_local_file_reference_following_uses_resolved_license_over_reference_not
         .iter()
         .find(|file| file.path == "patches/example.patch")
         .expect("patch file should exist");
-    assert_eq!(patch.license_expression.as_deref(), Some("mit"));
-    assert_eq!(patch.license_detections[0].license_expression_spdx, "MIT");
+    assert_eq!(patch.license_expression.as_deref(), Some("bsd-new AND mit"));
+    assert_eq!(
+        patch.license_detections[0].license_expression_spdx,
+        "BSD-3-Clause AND MIT"
+    );
     assert_eq!(
         patch.license_detections[0].detection_log,
         vec!["unknown-reference-to-local-file"]
+    );
+    assert!(
+        patch.license_detections[0]
+            .matches
+            .iter()
+            .any(|detection_match| {
+                detection_match.from_file.as_deref() == Some("patches/example.patch")
+                    && detection_match.license_expression_spdx == "BSD-3-Clause"
+            })
     );
     assert!(
         patch.license_detections[0]

--- a/src/post_processing/output_test.rs
+++ b/src/post_processing/output_test.rs
@@ -1610,7 +1610,7 @@ fn apply_package_reference_following_resolves_absolute_rootfs_license_reference(
     );
     assert_eq!(
         service.license_detections[0].license_expression_spdx,
-        "GPL-2.0-only AND GPL-2.0-or-later"
+        "GPL-2.0-or-later AND GPL-2.0-only"
     );
     assert_eq!(service.license_detections[0].matches.len(), 2);
     assert_eq!(

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -610,6 +610,8 @@ fn sync_packages_from_followed_package_data(
     let mut modified = false;
 
     for package in packages {
+        let preserve_existing_package_license_fields = package.datafile_paths.len() > 1;
+
         for datafile_path in &package.datafile_paths {
             let matched_package_data =
                 package_data_by_path
@@ -631,14 +633,18 @@ fn sync_packages_from_followed_package_data(
                 .file_ix_by_path(datafile_path)
                 .and_then(|index| files.get(index.0));
 
-            let mut next_license_detections = if package.license_detections.is_empty() {
+            let mut next_license_detections = if !preserve_existing_package_license_fields
+                || package.license_detections.is_empty()
+            {
                 matched_package_data
                     .map(|package_data| package_data.license_detections.clone())
                     .unwrap_or_default()
             } else {
                 package.license_detections.clone()
             };
-            let next_other_license_detections = if package.other_license_detections.is_empty() {
+            let next_other_license_detections = if !preserve_existing_package_license_fields
+                || package.other_license_detections.is_empty()
+            {
                 matched_package_data
                     .map(|package_data| package_data.other_license_detections.clone())
                     .unwrap_or_default()
@@ -646,28 +652,44 @@ fn sync_packages_from_followed_package_data(
                 package.other_license_detections.clone()
             };
             let mut next_declared_license_expression =
-                package.declared_license_expression.clone().or_else(|| {
+                if preserve_existing_package_license_fields {
+                    package.declared_license_expression.clone()
+                } else {
+                    None
+                }
+                .or_else(|| {
                     matched_package_data
                         .and_then(|package_data| package_data.declared_license_expression.clone())
                 });
-            let mut next_declared_license_expression_spdx = package
-                .declared_license_expression_spdx
-                .clone()
+            let mut next_declared_license_expression_spdx =
+                if preserve_existing_package_license_fields {
+                    package.declared_license_expression_spdx.clone()
+                } else {
+                    None
+                }
                 .or_else(|| {
                     matched_package_data.and_then(|package_data| {
                         package_data.declared_license_expression_spdx.clone()
                     })
                 });
-            let next_other_license_expression =
-                package.other_license_expression.clone().or_else(|| {
-                    matched_package_data
-                        .and_then(|package_data| package_data.other_license_expression.clone())
-                });
-            let next_other_license_expression_spdx =
-                package.other_license_expression_spdx.clone().or_else(|| {
-                    matched_package_data
-                        .and_then(|package_data| package_data.other_license_expression_spdx.clone())
-                });
+            let next_other_license_expression = if preserve_existing_package_license_fields {
+                package.other_license_expression.clone()
+            } else {
+                None
+            }
+            .or_else(|| {
+                matched_package_data
+                    .and_then(|package_data| package_data.other_license_expression.clone())
+            });
+            let next_other_license_expression_spdx = if preserve_existing_package_license_fields {
+                package.other_license_expression_spdx.clone()
+            } else {
+                None
+            }
+            .or_else(|| {
+                matched_package_data
+                    .and_then(|package_data| package_data.other_license_expression_spdx.clone())
+            });
 
             if package.datafile_paths.len() == 1
                 && next_license_detections.is_empty()

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -815,12 +815,10 @@ fn apply_resolved_reference_targets(
         return false;
     }
 
-    let strip_source_matches_for_expression = detection_log
-        == DETECTION_LOG_UNKNOWN_REFERENCE_TO_LOCAL_FILE
-        || matches!(
-            detection.license_expression.as_str(),
-            "unknown-license-reference" | "free-unknown"
-        );
+    let strip_source_matches_for_expression = matches!(
+        detection.license_expression.as_str(),
+        "unknown-license-reference" | "free-unknown"
+    );
     let mut internal_detection = public_detection_to_internal(detection, current_path);
     let mut source_matches = Vec::new();
     if strip_source_matches_for_expression {

--- a/src/scan_result_shaping/json_input_test.rs
+++ b/src/scan_result_shaping/json_input_test.rs
@@ -65,8 +65,8 @@ fn load_scan_from_json_reads_files_and_metadata_sections() {
     let parsed = load_scan_from_json(temp_path.to_str().expect("utf-8 path"))
         .expect("from-json loading should succeed");
 
-    assert_eq!(parsed.files.len(), 1);
-    assert_eq!(parsed.files[0].path, "src/main.rs");
+    let paths: Vec<_> = parsed.files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(paths, vec!["src/main.rs", "src"]);
     assert_eq!(parsed.headers.len(), 1);
     assert_eq!(parsed.headers[0].errors, vec!["Path: src/main.rs"]);
     assert_eq!(parsed.headers[0].warnings, vec!["Imported warning"]);
@@ -168,7 +168,7 @@ fn normalize_loaded_json_scan_applies_strip_root_per_loaded_input() {
     normalize_loaded_json_scan(&mut loaded, true, false);
 
     let paths: Vec<_> = loaded.files.iter().map(|file| file.path.as_str()).collect();
-    assert_eq!(paths, vec!["root", "src/main.rs"]);
+    assert_eq!(paths, vec!["root", "src/main.rs", "src"]);
     assert_eq!(
         loaded.headers[0].errors,
         vec!["Failed to read or parse package.json: src/main.rs"]

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -27,7 +27,7 @@ fn is_included_path_applies_exclude_after_include() {
         &["/src/*.so".to_string()]
     ));
     assert!(is_included_path(
-        "some/src/this/that",
+        "some/src",
         &["src".to_string()],
         &["src/*.so".to_string()]
     ));

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::test_support::CurrentDirGuard;
 use std::fs;
 use std::path::PathBuf;
 
@@ -163,12 +164,9 @@ fn resolve_native_scan_inputs_builds_common_prefix_and_synthetic_includes() {
     fs::create_dir_all(parent.join("bar")).expect("create bar dir");
     fs::write(parent.join("bar/baz"), "data\n").expect("write baz file");
 
-    let old_cwd = std::env::current_dir().expect("current dir");
-    std::env::set_current_dir(temp_dir.path()).expect("set cwd");
+    let _cwd_guard = CurrentDirGuard::change_to(temp_dir.path());
 
     let result = resolve_native_scan_inputs(&["src/foo".to_string(), "src/bar/baz".to_string()]);
-
-    std::env::set_current_dir(old_cwd).expect("restore cwd");
 
     let (scan_root, includes) = result.expect("multiple relative inputs should resolve");
 
@@ -189,12 +187,9 @@ fn resolve_native_scan_inputs_uses_component_aware_prefix_for_siblings() {
     fs::create_dir_all(parent.join("bar")).expect("create bar dir");
     fs::create_dir_all(parent.join("baz")).expect("create baz dir");
 
-    let old_cwd = std::env::current_dir().expect("current dir");
-    std::env::set_current_dir(temp_dir.path()).expect("set cwd");
+    let _cwd_guard = CurrentDirGuard::change_to(temp_dir.path());
 
     let result = resolve_native_scan_inputs(&["src/bar".to_string(), "src/baz".to_string()]);
-
-    std::env::set_current_dir(old_cwd).expect("restore cwd");
 
     let (scan_root, includes) = result.expect("sibling inputs should resolve");
     assert_eq!(scan_root, "src");
@@ -270,12 +265,9 @@ fn resolve_paths_file_entries_uses_explicit_root_not_current_working_directory()
     fs::create_dir_all(scan_root.join("src")).expect("create src dir");
     fs::write(scan_root.join("src/lib.rs"), "pub fn demo() {}\n").expect("write lib");
 
-    let old_cwd = std::env::current_dir().expect("current dir");
-    std::env::set_current_dir(other_cwd.path()).expect("set cwd");
+    let _cwd_guard = CurrentDirGuard::change_to(other_cwd.path());
 
     let result = resolve_paths_file_entries(&scan_root, &["src/lib.rs".to_string()]);
-
-    std::env::set_current_dir(old_cwd).expect("restore cwd");
 
     let resolved = result.expect("absolute scan root should make cwd irrelevant");
     assert_eq!(

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -735,7 +735,7 @@ mod tests {
         assert_eq!(scanned.mime_type.as_deref(), Some("text/plain"));
         assert_eq!(
             scanned.file_type_label.as_deref(),
-            Some("UTF-8 Unicode text")
+            Some("TypeScript source, UTF-8 Unicode text")
         );
         assert_eq!(scanned.is_text, Some(true));
         assert_eq!(scanned.is_media, Some(false));
@@ -764,7 +764,7 @@ mod tests {
         assert_eq!(scanned.mime_type.as_deref(), Some("text/plain"));
         assert_eq!(
             scanned.file_type_label.as_deref(),
-            Some("UTF-8 Unicode text")
+            Some("TypeScript source, UTF-8 Unicode text")
         );
         assert_eq!(scanned.is_text, Some(true));
         assert_eq!(scanned.is_media, Some(false));
@@ -942,7 +942,7 @@ mod tests {
         assert_eq!(scanned.programming_language.as_deref(), Some("Dockerfile"));
         assert_eq!(
             scanned.file_type_label.as_deref(),
-            Some("UTF-8 Unicode text")
+            Some("Dockerfile source, UTF-8 Unicode text")
         );
         assert_eq!(scanned.is_source, Some(true));
         assert_eq!(scanned.is_script, Some(false));

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+static CURRENT_DIR_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub(crate) struct CurrentDirGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous_dir: PathBuf,
+}
+
+impl CurrentDirGuard {
+    pub(crate) fn change_to(path: &Path) -> Self {
+        let lock = CURRENT_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous_dir = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(path).expect("set cwd");
+
+        Self {
+            _lock: lock,
+            previous_dir,
+        }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.previous_dir).expect("restore cwd");
+    }
+}


### PR DESCRIPTION
## Summary

- Restore `rust-library-tests` to real library coverage by running `cargo test -p provenant-cli --lib --release --verbose -- --skip _scan_test::` again. The earlier CI change swapped that job to `cargo test --bin provenant --release --verbose -- --skip _scan_test::`, which runs `0 tests` in this repository and silently stopped covering the library suite.
- Fix the hidden copyright detector regression that CI missed: `refine_final_authors()` was over-pruning valid author detections after `fix(copyright): drop prose and trademark boilerplate noise`, so handle-suffixed maintainer authors and structured metadata authors like `gRPC authors`, `Meta`, `The libunwind project`, and `S2Geometry` were being dropped. The fix reuses the existing detector heuristics that had already accepted those forms.
- Fix the additional regressions surfaced once real library coverage was restored, and update the stale or racy tests whose expectations no longer matched intentional behavior. The restored library suite now passes cleanly in release mode: `4376 passed; 0 failed; 66 filtered out`.

## Issues

- Covers: hidden `copyright::detector` failures that were not exercised by CI, and the follow-on library regressions exposed when the `rust-library-tests` job was restored.

## Scope and exclusions

- Included:
- Restore the CI job label and command so `rust-library-tests` once again runs the actual library suite, while leaving `_scan_test::` parser scanner/assembly contract tests in the separate `contracts` shard.
- Fix `assembly::file_ref_resolve` duplicate resolver registration introduced by BitBake append support by merging the `RelativeToDatafileParent` datasource IDs into a single config entry.
- Fix finder email/host false positives reintroduced by the junk-suffix refactor by restoring the older `.local`, `.blank`, `.fill`, and related suffix filtering alongside the newer file-like host suffixes.
- Fix single-manifest package license syncing in post-processing so followed manifest/package-data results replace stale placeholder package-level detections for single-datafile packages, while preserving the newer multi-datafile behavior.
- Fix local-reference post-processing so concrete source-file license matches are no longer stripped from expression recomputation for non-placeholder local-file references; only placeholder detections keep the stripping behavior.
- Keep the copyright detector author fix and its focused regressions tests in the branch because that was the original hidden failure uncovered by the CI gap.
- Update replay/json-input tests to explicitly expect synthesized directory entries after `fix(replay): retain imported directories during filtering`.
- Update the shaping include-path test to match the intentional non-recursive bare-path semantics introduced by `fix(cli): keep bare include paths non-recursive`.
- Add a shared test-only current-directory guard and use it in the CLI/shaping tests that mutate process-global cwd, eliminating the parallel race that made `resolve_native_scan_inputs_*` flaky.
- Update the license-expression flattening test to assert the now-intentional preserved match order from `fix(license): keep match-derived SPDX detection output`.
- Update the Conda Jinja substitution test to expect quoted numeric-looking versions, matching the intentional string-preservation behavior added for feedstock `recipe.yaml` support.
- Update scanner tests to explicitly expect the richer source-aware file type labels now returned by the hardened pure-Rust file classifier.
- Update the follow-on post-processing expectation so a concrete notice expression from the source file is preserved alongside the resolved target license when local-file reference following retains both pieces of evidence.
- Explicit exclusions:
- No golden expected-output fixtures were changed.
- No `_scan_test::` contract tests were moved back into the main library job; they remain intentionally split into the `contracts` shard for CI sharding.

## Follow-up work

- Created or intentionally deferred:
- None in this branch. The restored split is: library tests in `rust-library-tests`, `_scan_test::` contract coverage in the `contracts` shard, and integration/golden coverage in their existing jobs.