### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.md
+++ b/.github/ISSUE_TEMPLATE/01-bug.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report incorrect behavior, crashes, or compatibility problems
+labels: bug
+---
+
+## Summary
+
+<!-- Describe the problem in 1-3 sentences. -->
+
+## Steps to reproduce
+
+<!-- Share the command, inputs, and exact steps if you can. -->
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? Include key errors or incorrect output. -->
+
+## Environment
+
+- Provenant version or commit:
+- OS / environment (if relevant):
+- Command run:
+- Scan target (repo, directory, file, archive, imported JSON, etc.):
+
+## Additional context
+
+<!-- Logs, output snippets, sample files, and screenshots all help.
+For security issues, please follow SECURITY.md instead of opening a public issue. -->

--- a/.github/ISSUE_TEMPLATE/02-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest a new capability or workflow improvement
+labels: enhancement
+---
+
+## Summary
+
+<!-- Describe the idea in 1-3 sentences. -->
+
+## Problem or use case
+
+<!-- What are you trying to do, and what is missing today? -->
+
+## Proposed solution
+
+<!-- Describe the behavior, CLI shape, or workflow you would like to see. -->
+
+## Alternatives considered
+
+<!-- Optional: what workarounds did you try, and why are they not enough? -->
+
+## Additional context
+
+<!-- Links, examples, prior art, or compatibility concerns are helpful. -->

--- a/.github/ISSUE_TEMPLATE/03-documentation.md
+++ b/.github/ISSUE_TEMPLATE/03-documentation.md
@@ -1,0 +1,25 @@
+---
+name: Documentation improvement
+about: Report confusing, missing, or outdated docs
+labels: documentation
+---
+
+## Summary
+
+<!-- Describe the documentation problem in 1-3 sentences. -->
+
+## Where is the issue?
+
+<!-- Link the page, file, section, or command output if you can. -->
+
+## What is confusing, missing, or incorrect?
+
+<!-- Explain what a reader would likely misunderstand. -->
+
+## Suggested improvement
+
+<!-- Optional: share wording, examples, or structure that would help. -->
+
+## Additional context
+
+<!-- Screenshots, logs, and reproduction steps can help for docs tied to CLI behavior. -->

--- a/.github/ISSUE_TEMPLATE/04-question.md
+++ b/.github/ISSUE_TEMPLATE/04-question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Ask for clarification about Provenant behavior or workflows
+labels: question
+---
+
+## Question
+
+<!-- What are you trying to understand or achieve? -->
+
+## Context
+
+<!-- Share the command, input, docs, or behavior you already checked. -->
+
+## Additional details
+
+<!-- Include output snippets, links, or examples if they help explain the question. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary

- add simple label-driven GitHub issue templates for bugs, feature requests, documentation issues, and questions
- disable blank issues so reports use the intended templates instead of free-form issue bodies
- order the templates so the chooser shows bug, feature, documentation, then question

## Scope and exclusions

- Included: `.github/ISSUE_TEMPLATE/` metadata only
- Explicit exclusions: issue forms, contact links, GitHub Discussions routing, and workflow changes

## Follow-up work

- Created or intentionally deferred: optional `contact_links` if maintainers later want to route support or security traffic outside issues