### PR TITLE
fix(scanner): normalize redundant SPDX match parentheses

### DIFF
--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -186,10 +186,9 @@ fn convert_detection_to_model(
         (
             Some(PublicLicenseDetection {
                 license_expression,
-                license_expression_spdx: detection
-                    .license_expression_spdx
-                    .clone()
-                    .unwrap_or_default(),
+                license_expression_spdx: normalize_optional_spdx_expression(
+                    detection.license_expression_spdx.as_deref(),
+                ),
                 matches,
                 detection_log: if license_options.include_diagnostics {
                     detection.detection_log.clone()
@@ -320,7 +319,9 @@ fn convert_match_to_model(
     };
     Match {
         license_expression: m.license_expression.clone(),
-        license_expression_spdx: m.license_expression_spdx.clone().unwrap_or_default(),
+        license_expression_spdx: normalize_optional_spdx_expression(
+            m.license_expression_spdx.as_deref(),
+        ),
         from_file: m.from_file.clone(),
         start_line: m.start_line,
         end_line: m.end_line,
@@ -335,6 +336,20 @@ fn convert_match_to_model(
         referenced_filenames: m.referenced_filenames.clone(),
         matched_text_diagnostics,
     }
+}
+
+fn normalize_optional_spdx_expression(expression: Option<&str>) -> String {
+    let Some(expression) = expression
+        .map(str::trim)
+        .filter(|expression| !expression.is_empty())
+    else {
+        return String::new();
+    };
+
+    crate::utils::spdx::combine_license_expressions_preserving_structure(std::iter::once(
+        expression.to_string(),
+    ))
+    .unwrap_or_else(|| expression.to_string())
 }
 
 fn compute_percentage_of_license_text(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -127,6 +127,26 @@ fn test_convert_detection_to_model_rounds_match_coverage() {
 }
 
 #[test]
+fn test_convert_detection_to_model_normalizes_redundant_outer_spdx_parentheses() {
+    let mut detection = make_detection("");
+    detection.license_expression = Some("mit OR cc0-1.0".to_string());
+    detection.license_expression_spdx = Some("(MIT OR CC0-1.0)".to_string());
+    detection.matches[0].license_expression = "mit OR cc0-1.0".to_string();
+    detection.matches[0].license_expression_spdx = Some("(MIT OR CC0-1.0)".to_string());
+
+    let (converted, clues) =
+        convert_detection_to_model(&detection, LicenseScanOptions::default(), "", None, None);
+    let converted = converted.expect("detection should convert");
+
+    assert_eq!(converted.license_expression_spdx, "MIT OR CC0-1.0");
+    assert_eq!(
+        converted.matches[0].license_expression_spdx,
+        "MIT OR CC0-1.0"
+    );
+    assert!(clues.is_empty());
+}
+
+#[test]
 fn test_convert_detection_to_model_routes_expressionless_detection_to_license_clues() {
     let mut detection = make_detection(
         "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-clue_1.RULE",


### PR DESCRIPTION
## Summary

- normalize public `license_expression_spdx` rendering for detections and nested matches so redundant top-level parentheses are removed consistently
- add a regression test covering `(MIT OR CC0-1.0)` at both detection and match level
- keep the fix scoped to the scanner conversion boundary, reusing the existing SPDX combiner instead of changing internal detection behavior

## Scope and exclusions

- Included: `src/scanner/process/license.rs` and `src/scanner/process/license_test.rs`
- Explicit exclusions: no changes to internal license detection generation, no golden fixture updates, and no broader output-schema refactors
