### PR TITLE
fix(license-detection): improve legal text and font coverage

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -102,12 +102,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `42.96s`; ScanCode `393.40s`
 - Broader ABOUT and Python package visibility (`25` vs `1` packages, `284` vs `56` dependencies) across committed `.ABOUT` files, root and suffixed `pyproject.toml` manifests, and `uv.lock`, plus zero scan-file errors where ScanCode times out on large generated scan-result JSON fixtures
 
-##### [aboutcode-org/scancode-toolkit @ 6570c13](https://github.com/aboutcode-org/scancode-toolkit/tree/6570c131e2821388286f661368a70e0120aaf2c6) — **12.38× faster**
+##### [aboutcode-org/scancode-toolkit @ 6570c13](https://github.com/aboutcode-org/scancode-toolkit/tree/6570c131e2821388286f661368a70e0120aaf2c6) — **13.48× faster**
 
 - Files: 64,369
-- Run context: 2026-04-24 · scancode-toolkit-35446 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `582.86s`; ScanCode `7214.43s`
-- Far broader ABOUT-adjacent package and dependency visibility (`1281` vs `6` packages, `10943` vs `377` dependencies) across committed `.ABOUT` sidecars, Python/Swift/Dart/CocoaPods fixture manifests, and bounded RPM header metadata recovery, with real ecosystem PURLs derived from ABOUT `download_url` metadata instead of `pkg:about/...` fallbacks and zero scan-file errors where ScanCode times out on heavy fixture snapshots
+- Run context: 2026-04-25 · scancode-toolkit-41061 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `535.40s`; ScanCode `7214.43s`
+- Far broader ABOUT-adjacent package and dependency visibility (`1281` vs `6` packages, `10943` vs `377` dependencies) across committed `.ABOUT` sidecars, Python/Swift/Dart/CocoaPods fixture manifests, and bounded RPM header metadata recovery, with real ecosystem PURLs derived from ABOUT `download_url` metadata instead of `pkg:about/...` fallbacks and zero scan-file errors where ScanCode times out on heavy fixture snapshots; the remaining ScanCode edge is concentrated in a small set of license-detection corpus and legal-text cases where it still preserves extra detections beyond Provenant’s current policy or refinement choices
 
 ##### [apache/airflow @ 47ce5f3](https://github.com/apache/airflow/tree/47ce5f32b4fae95f5865ba256d409c778d53a3d5) — **14.33× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -1084,9 +1084,9 @@ Provenant: 313.61s</title></circle>
     <circle cx="852.76" cy="437.38" r="4.5" fill="#2563eb"><title>rust-lang/rust @ dab8d9d
 Files: 58818
 Provenant: 61.49s</title></circle>
-    <circle cx="858.98" cy="331.11" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode-toolkit @ 6570c13
+    <circle cx="858.98" cy="335.12" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode-toolkit @ 6570c13
 Files: 64369
-Provenant: 582.86s</title></circle>
+Provenant: 535.40s</title></circle>
     <circle cx="883.98" cy="348.76" r="4.5" fill="#2563eb"><title>torvalds/linux @ b42ed3b
 Files: 92523
 Provenant: 401.15s</title></circle>

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -18,6 +18,7 @@ use crate::license_detection::models::LicenseMatch;
 use crate::license_detection::spdx_mapping::SpdxMapping;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use crate::license_detection::expression::licensing_contains;
 use crate::license_detection::expression::parse_expression;
 use analysis::{
     analyze_detection, classify_detection, compute_detection_score,
@@ -198,6 +199,113 @@ pub(crate) fn empty_detection() -> LicenseDetection {
         identifier: None,
         file_regions: Vec::new(),
     }
+}
+
+pub(crate) fn split_groups_across_frontmatter_boundary(
+    groups: Vec<DetectionGroup>,
+    source_text: Option<&str>,
+) -> Vec<DetectionGroup> {
+    let Some(source_text) = source_text else {
+        return groups;
+    };
+    let Some(frontmatter_end_line) = frontmatter_end_line(source_text) else {
+        return groups;
+    };
+
+    groups
+        .into_iter()
+        .flat_map(|group| split_group_across_frontmatter_boundary(group, frontmatter_end_line))
+        .collect()
+}
+
+fn frontmatter_end_line(source_text: &str) -> Option<usize> {
+    let mut lines = source_text.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    for (index, line) in source_text.lines().enumerate().skip(1) {
+        if index > 40 {
+            return None;
+        }
+        if line.trim() == "---" {
+            return Some(index + 1);
+        }
+    }
+
+    None
+}
+
+fn split_group_across_frontmatter_boundary(
+    group: DetectionGroup,
+    frontmatter_end_line: usize,
+) -> Vec<DetectionGroup> {
+    if group.matches.len() < 2 {
+        return vec![group];
+    }
+
+    let Some(anchor_start_line) =
+        find_frontmatter_spanning_anchor_start_line(&group, frontmatter_end_line)
+    else {
+        return vec![group];
+    };
+
+    let split_index = group
+        .matches
+        .iter()
+        .position(|match_item| match_item.end_line.get() >= anchor_start_line)
+        .unwrap_or(group.matches.len());
+
+    if split_index == 0 || split_index >= group.matches.len() {
+        return vec![group];
+    }
+
+    let leading_matches = &group.matches[..split_index];
+    let trailing_matches = &group.matches[split_index..];
+
+    if !trailing_matches.iter().any(is_unknown_reference_like_match) {
+        return vec![group];
+    }
+
+    if !leading_matches.iter().all(|match_item| {
+        match_item.matched_length <= 12
+            && !match_item.is_license_clue()
+            && !is_unknown_reference_like_match(match_item)
+            && trailing_matches.iter().any(|body_match| {
+                !body_match.is_license_clue()
+                    && !is_unknown_reference_like_match(body_match)
+                    && licensing_contains(
+                        body_match.license_expression.as_str(),
+                        match_item.license_expression.as_str(),
+                    )
+            })
+    }) {
+        return vec![group];
+    }
+
+    vec![
+        DetectionGroup::new(leading_matches.to_vec()),
+        DetectionGroup::new(trailing_matches.to_vec()),
+    ]
+}
+
+fn find_frontmatter_spanning_anchor_start_line(
+    group: &DetectionGroup,
+    frontmatter_end_line: usize,
+) -> Option<usize> {
+    group
+        .matches
+        .iter()
+        .filter(|match_item| {
+            !match_item.is_license_clue()
+                && !is_unknown_reference_like_match(match_item)
+                && match_item.start_line.get() > 1
+                && match_item.start_line.get() <= frontmatter_end_line
+                && match_item.end_line.get() > frontmatter_end_line + 10
+                && match_item.matched_length >= 100
+        })
+        .map(|match_item| match_item.start_line.get())
+        .min()
 }
 
 pub(crate) fn attach_source_path_to_detections(
@@ -790,6 +898,104 @@ mod tests {
         );
 
         assert_eq!(selected, vec![referenced_license]);
+    }
+
+    #[test]
+    fn split_groups_across_frontmatter_boundary_separates_mysql_style_header_hits() {
+        let source = r#"---
+short_name: MySQL FLOSS exception to GPL 2.0
+name: MySQL FLOSS exception to GPL 2.0
+category: Copyleft Limited
+owner: Oracle Corporation
+homepage_url: https://mariadb.com/kb/en/mariadb/mariadb-license/#the-floss-exception
+spdx_license_key: LicenseRef-scancode-mysql-floss-exception-2.0
+other_urls:
+  - http://www.gnu.org/licenses/gpl-2.0.txt
+ignorable_urls:
+  - http://www.gnu.org/philosophy/free-sw.html
+  - http://www.opensource.org/docs/definition.php
+---
+
+MySQL FLOSS License Exception body starts here.
+"#;
+
+        let mut header_gpl_one = create_test_match(3, 3, "2-aho", "gpl-2.0_52.RULE");
+        header_gpl_one.license_expression = "gpl-2.0".to_string();
+        header_gpl_one.license_expression_spdx = Some("GPL-2.0-only".to_string());
+        header_gpl_one.matched_length = 3;
+
+        let mut header_gpl_two = create_test_match(4, 4, "2-aho", "gpl-2.0_52.RULE");
+        header_gpl_two.license_expression = "gpl-2.0".to_string();
+        header_gpl_two.license_expression_spdx = Some("GPL-2.0-only".to_string());
+        header_gpl_two.matched_length = 3;
+
+        let mut body_with_exception = create_test_match(
+            7,
+            40,
+            "3-seq",
+            "gpl-2.0-plus_with_mysql-floss-exception-2.0_1.RULE",
+        );
+        body_with_exception.license_expression =
+            "gpl-2.0-plus WITH mysql-floss-exception-2.0".to_string();
+        body_with_exception.license_expression_spdx =
+            Some("GPL-2.0-or-later WITH LicenseRef-scancode-mysql-floss-exception-2.0".to_string());
+        body_with_exception.matched_length = 300;
+
+        let mut body_gpl = create_test_match(11, 11, "2-aho", "gpl-2.0_29.RULE");
+        body_gpl.license_expression = "gpl-2.0".to_string();
+        body_gpl.license_expression_spdx = Some("GPL-2.0-only".to_string());
+        body_gpl.matched_length = 9;
+
+        let mut body_unknown =
+            create_test_match(14, 14, "2-aho", "unknown-license-reference_299.RULE");
+        body_unknown.license_expression = "unknown-license-reference".to_string();
+        body_unknown.license_expression_spdx =
+            Some("LicenseRef-scancode-unknown-license-reference".to_string());
+        body_unknown.matched_length = 7;
+
+        let groups = split_groups_across_frontmatter_boundary(
+            vec![DetectionGroup::new(vec![
+                header_gpl_one.clone(),
+                header_gpl_two.clone(),
+                body_with_exception.clone(),
+                body_gpl.clone(),
+                body_unknown.clone(),
+            ])],
+            Some(source),
+        );
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].matches, vec![header_gpl_one, header_gpl_two]);
+        assert_eq!(
+            groups[1].matches,
+            vec![body_with_exception, body_gpl, body_unknown]
+        );
+    }
+
+    #[test]
+    fn split_groups_across_frontmatter_boundary_does_not_split_without_spanning_body_match() {
+        let source = "---\nname: GPL 2.0\n---\nGPL 2.0\n";
+
+        let mut header_gpl = create_test_match(2, 2, "2-aho", "gpl-2.0_52.RULE");
+        header_gpl.license_expression = "gpl-2.0".to_string();
+        header_gpl.license_expression_spdx = Some("GPL-2.0-only".to_string());
+        header_gpl.matched_length = 3;
+
+        let mut body_gpl = create_test_match(4, 4, "2-aho", "gpl-2.0_29.RULE");
+        body_gpl.license_expression = "gpl-2.0".to_string();
+        body_gpl.license_expression_spdx = Some("GPL-2.0-only".to_string());
+        body_gpl.matched_length = 3;
+
+        let groups = split_groups_across_frontmatter_boundary(
+            vec![DetectionGroup::new(vec![
+                header_gpl.clone(),
+                body_gpl.clone(),
+            ])],
+            Some(source),
+        );
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].matches, vec![header_gpl, body_gpl]);
     }
 
     fn create_test_license() -> License {

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -62,6 +62,7 @@ use crate::utils::text::strip_utf8_bom_str;
 
 use crate::license_detection::detection::{
     attach_source_path_to_detections, empty_detection, populate_detection_from_group_with_spdx,
+    split_groups_across_frontmatter_boundary,
 };
 use crate::license_detection::models::MatcherKind;
 
@@ -798,7 +799,10 @@ impl LicenseDetectionEngine {
                 let mut matches = hash_matches;
                 sort_matches_by_line(&mut matches);
 
-                let groups = group_matches_by_region(&matches);
+                let groups = split_groups_across_frontmatter_boundary(
+                    group_matches_by_region(&matches),
+                    Some(content),
+                );
                 let detections: Vec<LicenseDetection> = groups
                     .iter()
                     .map(|group| {
@@ -922,7 +926,10 @@ impl LicenseDetectionEngine {
         let mut sorted = refined;
         sort_matches_by_line(&mut sorted);
 
-        let groups = group_matches_by_region(&sorted);
+        let groups = split_groups_across_frontmatter_boundary(
+            group_matches_by_region(&sorted),
+            Some(content),
+        );
 
         let detections: Vec<LicenseDetection> = groups
             .iter()

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -99,6 +99,9 @@ pub(super) fn extract_license_information(
                 }
                 Err(_) => None,
             };
+            let mut detections = detections;
+            promote_legal_notice_low_quality_detections(&mut detections, path);
+
             let mut model_detections = Vec::new();
             let mut model_clues = Vec::new();
 
@@ -257,6 +260,88 @@ fn promote_reference_url_clue_detection(
         },
         identifier: detection.identifier.clone(),
     })
+}
+
+fn promote_legal_notice_low_quality_detections(
+    detections: &mut [InternalLicenseDetection],
+    path: &Path,
+) {
+    if !is_legal_notice_like_path(path) {
+        return;
+    }
+
+    let has_concrete_detection = detections
+        .iter()
+        .any(|detection| detection.license_expression.is_some());
+    if !has_concrete_detection {
+        return;
+    }
+
+    for detection in detections {
+        if detection.license_expression.is_some()
+            || !detection
+                .detection_log
+                .iter()
+                .any(|log| log == "low-quality-match-fragments")
+            || detection.matches.is_empty()
+        {
+            continue;
+        }
+
+        if !detection.matches.iter().all(|license_match| {
+            !license_match.is_license_clue()
+                && !license_match.license_expression.is_empty()
+                && !license_match.license_expression.contains("unknown")
+        }) {
+            continue;
+        }
+
+        let Some(license_expression) =
+            crate::utils::spdx::combine_license_expressions_preserving_structure(
+                detection
+                    .matches
+                    .iter()
+                    .map(|license_match| license_match.license_expression.clone())
+                    .collect::<Vec<_>>(),
+            )
+        else {
+            continue;
+        };
+        let license_expression_spdx =
+            crate::utils::spdx::combine_license_expressions_preserving_structure(
+                detection
+                    .matches
+                    .iter()
+                    .filter_map(|license_match| license_match.license_expression_spdx.clone())
+                    .collect::<Vec<_>>(),
+            );
+
+        detection.license_expression = Some(license_expression);
+        detection.license_expression_spdx = license_expression_spdx;
+        detection
+            .detection_log
+            .push("promoted-low-quality-legal-notice".to_string());
+    }
+}
+
+fn is_legal_notice_like_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(base_name) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+
+    let name = name.to_ascii_lowercase();
+    let base_name = base_name.to_ascii_lowercase();
+    ["notice", "copyright", "copying", "license", "licence"]
+        .iter()
+        .any(|pattern| {
+            name.starts_with(pattern)
+                || name.ends_with(pattern)
+                || base_name.starts_with(pattern)
+                || base_name.ends_with(pattern)
+        })
 }
 
 fn match_has_exact_reference_url(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -3,7 +3,7 @@
 
 use super::{
     LicenseExtractionInput, compute_percentage_of_license_text, convert_detection_to_model,
-    extract_license_information,
+    extract_license_information, promote_legal_notice_low_quality_detections,
 };
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
@@ -75,6 +75,40 @@ fn create_test_index(entries: &[(&str, u16)], len_legalese: usize) -> LicenseInd
     let mut index = LicenseIndex::new(dictionary);
     index.len_legalese = len_legalese;
     index
+}
+
+fn make_internal_notice_match(
+    expr: &str,
+    expr_spdx: &str,
+    start_line: usize,
+    end_line: usize,
+) -> LicenseMatch {
+    LicenseMatch {
+        rid: 0,
+        license_expression: expr.to_string(),
+        license_expression_spdx: Some(expr_spdx.to_string()),
+        from_file: Some("NOTICE".to_string()),
+        start_line: LineNumber::new(start_line).expect("valid start line"),
+        end_line: LineNumber::new(end_line).expect("valid end line"),
+        start_token: start_line,
+        end_token: end_line + 1,
+        matcher: MatcherKind::Seq,
+        score: MatchScore::from_percentage(50.0),
+        matched_length: 11,
+        rule_length: 22,
+        match_coverage: 50.0,
+        rule_relevance: 100,
+        rule_identifier: "apache-2.0_559.RULE".to_string(),
+        rule_url: String::new(),
+        matched_text: None,
+        referenced_filenames: None,
+        rule_kind: RuleKind::Text,
+        is_from_license: false,
+        rule_start_token: 0,
+        coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
+        candidate_resemblance: 0.0,
+        candidate_containment: 0.0,
+    }
 }
 
 #[test]
@@ -261,6 +295,95 @@ fn test_convert_detection_to_model_promotes_exact_reference_url_clue() {
     assert_eq!(converted.matches.len(), 1);
     assert_eq!(converted.matches[0].license_expression, "cc-by-sa-3.0");
     assert!(clues.is_empty());
+}
+
+#[test]
+fn test_promote_legal_notice_low_quality_detections_promotes_apache_notice_fragment() {
+    let concrete = InternalLicenseDetection {
+        license_expression: Some("cve-tou".to_string()),
+        license_expression_spdx: Some("cve-tou".to_string()),
+        matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
+        detection_log: Vec::new(),
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let low_quality = InternalLicenseDetection {
+        license_expression: None,
+        license_expression_spdx: None,
+        matches: vec![make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8)],
+        detection_log: vec!["low-quality-match-fragments".to_string()],
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let mut detections = vec![concrete, low_quality];
+
+    promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("NOTICE"));
+
+    assert_eq!(
+        detections[1].license_expression.as_deref(),
+        Some("apache-2.0")
+    );
+    assert_eq!(
+        detections[1].license_expression_spdx.as_deref(),
+        Some("Apache-2.0")
+    );
+    assert!(
+        detections[1]
+            .detection_log
+            .contains(&"promoted-low-quality-legal-notice".to_string())
+    );
+}
+
+#[test]
+fn test_promote_legal_notice_low_quality_detections_ignores_non_legal_path() {
+    let concrete = InternalLicenseDetection {
+        license_expression: Some("cve-tou".to_string()),
+        license_expression_spdx: Some("cve-tou".to_string()),
+        matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
+        detection_log: Vec::new(),
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let low_quality = InternalLicenseDetection {
+        license_expression: None,
+        license_expression_spdx: None,
+        matches: vec![make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8)],
+        detection_log: vec!["low-quality-match-fragments".to_string()],
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let mut detections = vec![concrete, low_quality];
+
+    promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("README.md"));
+
+    assert!(detections[1].license_expression.is_none());
+}
+
+#[test]
+fn test_promote_legal_notice_low_quality_detections_ignores_true_clue_rules() {
+    let concrete = InternalLicenseDetection {
+        license_expression: Some("cve-tou".to_string()),
+        license_expression_spdx: Some("cve-tou".to_string()),
+        matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
+        detection_log: Vec::new(),
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let mut clue_match = make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8);
+    clue_match.rule_kind = RuleKind::Clue;
+    let low_quality = InternalLicenseDetection {
+        license_expression: None,
+        license_expression_spdx: None,
+        matches: vec![clue_match],
+        detection_log: vec!["low-quality-match-fragments".to_string()],
+        identifier: None,
+        file_regions: Vec::new(),
+    };
+    let mut detections = vec![concrete, low_quality];
+
+    promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("NOTICE"));
+
+    assert!(detections[1].license_expression.is_none());
 }
 
 #[test]

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -259,7 +259,13 @@ pub(crate) fn extract_text_for_detection_with_diagnostics(
     }
 
     if let Some(text) = extract_font_metadata_text(path, bytes) {
-        return (text, ExtractedTextKind::FontMetadata, None);
+        let strings = extract_printable_strings(bytes);
+        let combined = if strings.is_empty() {
+            text
+        } else {
+            combine_extracted_text_fragments(Some(text), strings)
+        };
+        return (combined, ExtractedTextKind::FontMetadata, None);
     }
 
     let windows_executable_metadata_text = extract_windows_executable_metadata_text(bytes);
@@ -2250,6 +2256,7 @@ mod tests {
             text.contains("Open Font License") || text.contains("OFL"),
             "{text}"
         );
+        assert!(text.contains("Lato"), "{text}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split MySQL FLOSS full-license detections across YAML frontmatter and body text so the full `mysql-floss-exception-2.0.LICENSE` case no longer collapses into one combined detection
- promote low-quality Apache notice fragments in legal notice-like files when another concrete detection already exists in the same file, fixing the standalone `apache-harmony/NOTICE` miss
- augment font extraction with printable strings so DarkGarden-style binaries retain the extra `other-copyleft` companion detection, and refresh the `scancode-toolkit` benchmark row/chart to match the latest kept compare checkpoint

## Issues
- Covers: remaining real standalone `scancode-toolkit` self-scan gaps for the full MySQL FLOSS exception license, `apache-harmony/NOTICE`, and DarkGarden font binaries
- Closes:

## Scope and exclusions
- Included:
  - detector grouping split for MySQL frontmatter/body
  - scanner notice promotion for corroborated low-quality Apache notice fragments
  - font extraction enrichment for binary strings
  - `scancode-toolkit` benchmark-row and chart refresh
- Explicit exclusions:
  - no change to bare-GPL clue overlay policy
  - no Trolltech or `opendefinition` GPL-clue promotion
  - no classpath heuristic retained after corpus-wide compare regression
  - no OpenSSL `COPYRIGHT` refinement change retained after broader compare regressions

## Intentional differences from Python
- Provenant still keeps bare GPL shorthand as clue-only evidence via the overlay rules, so some ScanCode extra GPL detections in exception-heavy legal texts remain intentionally out of scope.

## Follow-up work
- Created or intentionally deferred:
  - revisit `tests/cluecode/data/ics/openssl-crypto-bf/COPYRIGHT` with a more surgical refinement-stage fix; the obvious seq-overlap heuristic fixed the standalone file but regressed the full corpus compare and was reverted