### PR TITLE
fix(detection): improve apache camel compare parity

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 173 of 173 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 174 of 174 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -410,6 +410,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `52.75s`; ScanCode `479.56s`
 - Matched Maven/OSGi package coverage (`196` vs `196`) with richer dependency extraction (`995` vs `962`) from classifier/type-aware Maven coordinates, OSGi integration-test POMs, and committed JAR or `MANIFEST.MF` metadata
+
+##### [apache/camel @ c9c34a1](https://github.com/apache/camel/tree/c9c34a1c2fbc5d093241565c0272ca466407a8e1) — **11.38× faster**
+
+- Files: 36,792
+- Run context: 2026-04-26 · camel-80585 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `469.31s`; ScanCode `5338.67s`
+- Broader Maven dependency extraction (`14818` vs `7645`) from the large multi-module reactor, archetype template POMs, and mixed package-adjacent Helm, Docker, and Cargo surfaces, plus restored UTF-16 template license detection and broader notice-author recovery across Apache/Spring/OpenShift acknowledgements, with zero scan-file errors where ScanCode times out on the committed `camel-sbom.json` and `camel-sbom.xml`
 
 ##### [apache/kafka @ 0d9fe51](https://github.com/apache/kafka/tree/0d9fe518b616725fecd96162297fee89a7b7a6a5) — **14.02× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -566,6 +566,9 @@ ScanCode: 2291.67s</title></rect>
     <rect x="815.39" y="217.51" width="8" height="8" fill="#d97706" rx="1.5"><title>tensorflow/tensorflow @ 2cd48d2
 Files: 36237
 ScanCode: 5927.08s</title></rect>
+    <rect x="816.43" y="222.46" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/camel @ c9c34a1
+Files: 36792
+ScanCode: 5338.67s</title></rect>
     <rect x="822.70" y="228.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 ScanCode: 4726.52s</title></rect>
@@ -1087,6 +1090,9 @@ Provenant: 141.58s</title></circle>
     <circle cx="819.39" cy="364.02" r="4.5" fill="#2563eb"><title>tensorflow/tensorflow @ 2cd48d2
 Files: 36237
 Provenant: 290.44s</title></circle>
+    <circle cx="820.43" cy="341.35" r="4.5" fill="#2563eb"><title>apache/camel @ c9c34a1
+Files: 36792
+Provenant: 469.31s</title></circle>
     <circle cx="826.70" cy="396.34" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 Provenant: 146.56s</title></circle>

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -205,6 +205,87 @@ fn trim_attribution_tail(who: &str) -> String {
     }
 }
 
+fn trim_following_sentence_clause(who: &str) -> String {
+    static FOLLOWING_SENTENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an)\b.*$").unwrap()
+    });
+
+    let trimmed = who.trim();
+    if let Some(cap) = FOLLOWING_SENTENCE_RE.captures(trimmed) {
+        let head = cap.name("head").map(|m| m.as_str()).unwrap_or("").trim();
+        if !head.is_empty() {
+            return head.to_string();
+        }
+    }
+
+    trimmed.to_string()
+}
+
+fn refine_notice_collective_author(who: &str) -> Option<String> {
+    let trimmed = trim_following_sentence_clause(who)
+        .trim_end_matches(&['.', ';', ','][..])
+        .trim_matches(&['"', '\''][..])
+        .trim()
+        .to_string();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(author) = refine_author(&trimmed) {
+        return Some(author);
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.starts_with("the ") {
+        return None;
+    }
+
+    let collective_suffix = [" project", " foundation", " group", " team", " committee"]
+        .iter()
+        .any(|suffix| lower.contains(suffix));
+    if !collective_suffix {
+        return None;
+    }
+
+    let mut capitalized = trimmed.clone();
+    capitalized.replace_range(..1, "T");
+    if refine_author(&capitalized).is_some() {
+        return Some(trimmed);
+    }
+
+    let capitalized_words = trimmed
+        .split_whitespace()
+        .filter_map(|word| word.chars().find(|ch| ch.is_alphabetic()))
+        .filter(|ch| ch.is_uppercase())
+        .count();
+    let has_url = trimmed.contains("http://") || trimmed.contains("https://");
+    if has_url && capitalized_words >= 2 {
+        Some(trimmed)
+    } else {
+        None
+    }
+}
+
+fn extract_written_by_subject(line: &str) -> Option<String> {
+    static WRITTEN_BY_PREFIX_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:written|authored|created|developed)\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+    static WRITTEN_BY_ANYWHERE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:written|authored|created|developed)\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+
+    WRITTEN_BY_PREFIX_LINE_RE
+        .captures(line)
+        .or_else(|| WRITTEN_BY_ANYWHERE_RE.captures(line))
+        .and_then(|cap| cap.name("who").map(|m| m.as_str().trim().to_string()))
+}
+
 fn extract_dash_bullet_attribution_author(line: &str) -> Option<String> {
     static DASH_BULLET_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -430,12 +511,6 @@ pub(in super::super) fn extract_multiline_written_by_author_blocks(
         LazyLock::new(|| Regex::new(r"(?i)^\s*written\s+by\s+(?P<who>.+?)(?:\s+for\b|$)").unwrap());
     static AUTHOR_EMAIL_HEAD_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^(?P<head>.+?<[^>]+>)(?:\s+(?:for|to)\b.*)?$").unwrap());
-    static WRITTEN_BY_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(
-            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:written|authored|created|developed)\s+by\s+(?P<who>.+)$",
-        )
-        .unwrap()
-    });
     static MAINTAINED_BY_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^(?:(?:it|this\s+package)\s+is\s+)?maintained(?:\s+for\s+debian)?\s+by\s+(?P<who>.+)$",
@@ -570,13 +645,15 @@ pub(in super::super) fn extract_multiline_written_by_author_blocks(
                 .map(|(_, raw_line)| raw_line.trim())
                 .collect::<Vec<_>>()
                 .join(" ");
-            let combined_candidate = WRITTEN_BY_PREFIX_RE
-                .captures(&combined_raw)
-                .or_else(|| MAINTAINED_BY_PREFIX_RE.captures(&combined_raw))
-                .and_then(|cap| cap.name("who").map(|m| m.as_str().trim()))
-                .unwrap_or(combined_raw.as_str())
-                .trim_end_matches('.')
-                .trim();
+            let combined_candidate = extract_written_by_subject(&combined_raw)
+                .or_else(|| {
+                    MAINTAINED_BY_PREFIX_RE
+                        .captures(&combined_raw)
+                        .and_then(|cap| cap.name("who").map(|m| m.as_str().trim().to_string()))
+                })
+                .unwrap_or(combined_raw);
+            let combined_candidate = trim_following_sentence_clause(&combined_candidate);
+            let combined_candidate = combined_candidate.trim_end_matches('.').trim();
             if let Some(combined) = refine_author(combined_candidate) {
                 authors.retain(|a| a.start_line < start_line || a.end_line > end_line);
                 authors.push(AuthorDetection {
@@ -592,25 +669,24 @@ pub(in super::super) fn extract_multiline_written_by_author_blocks(
         let mut extracted_any = false;
         for (_l, raw_line) in &block_lines {
             let candidate = raw_line.trim();
-            if let Some(cap) = WRITTEN_BY_PREFIX_RE
-                .captures(candidate)
-                .or_else(|| MAINTAINED_BY_PREFIX_RE.captures(candidate))
-            {
-                let who = cap.name("who").map(|m| m.as_str()).unwrap_or("").trim();
-                if !who.is_empty() {
-                    let who = who.trim_end_matches('.').trim();
-                    if !who.to_ascii_lowercase().starts_with("the ") {
-                        if let Some(author) = refine_author(who) {
-                            authors.push(AuthorDetection {
-                                author,
-                                start_line,
-                                end_line,
-                            });
-                        }
-                        extracted_any = true;
+            if let Some(who) = extract_written_by_subject(candidate).or_else(|| {
+                MAINTAINED_BY_PREFIX_RE
+                    .captures(candidate)
+                    .and_then(|cap| cap.name("who").map(|m| m.as_str().trim().to_string()))
+            }) {
+                let who = trim_following_sentence_clause(&who);
+                let who = who.trim_end_matches('.').trim();
+                if !who.to_ascii_lowercase().starts_with("the ") {
+                    if let Some(author) = refine_author(who) {
+                        authors.push(AuthorDetection {
+                            author,
+                            start_line,
+                            end_line,
+                        });
                     }
-                    continue;
+                    extracted_any = true;
                 }
+                continue;
             }
         }
 
@@ -620,13 +696,15 @@ pub(in super::super) fn extract_multiline_written_by_author_blocks(
                 .map(|(_, raw_line)| raw_line.trim())
                 .collect::<Vec<_>>()
                 .join(" ");
-            let combined_candidate = WRITTEN_BY_PREFIX_RE
-                .captures(&combined_raw)
-                .or_else(|| MAINTAINED_BY_PREFIX_RE.captures(&combined_raw))
-                .and_then(|cap| cap.name("who").map(|m| m.as_str().trim()))
-                .unwrap_or(combined_raw.as_str())
-                .trim_end_matches('.')
-                .trim();
+            let combined_candidate = extract_written_by_subject(&combined_raw)
+                .or_else(|| {
+                    MAINTAINED_BY_PREFIX_RE
+                        .captures(&combined_raw)
+                        .and_then(|cap| cap.name("who").map(|m| m.as_str().trim().to_string()))
+                })
+                .unwrap_or(combined_raw);
+            let combined_candidate = trim_following_sentence_clause(&combined_candidate);
+            let combined_candidate = combined_candidate.trim_end_matches('.').trim();
             if let Some(combined) = refine_author(combined_candidate) {
                 authors.retain(|a| a.start_line < start_line || a.end_line > end_line);
                 authors.push(AuthorDetection {
@@ -1897,6 +1975,74 @@ pub(in super::super) fn extract_developed_by_contributors_authors(
         }
 
         let Some(author) = refine_author(who) else {
+            continue;
+        };
+
+        authors.push(AuthorDetection {
+            author,
+            start_line: prepared_line.line_number,
+            end_line,
+        });
+    }
+
+    authors
+}
+
+pub(in super::super) fn extract_notice_developed_by_authors(
+    prepared_cache: &PreparedLines<'_>,
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
+    if prepared_cache.is_empty() {
+        return authors;
+    }
+
+    const NOTICE_PREFIX: &str = "this product includes software developed by";
+    const NOTICE_ALSO_PREFIX: &str = "this product also includes software developed by";
+
+    for prepared_line in prepared_cache.iter_non_empty() {
+        let lower = prepared_line.prepared.to_ascii_lowercase();
+        if !lower.contains("this product") || !lower.contains("includes software developed by") {
+            continue;
+        }
+
+        let mut window = prepared_line.prepared.to_string();
+        let mut end_line = prepared_line.line_number;
+        let should_extend = lower.trim_end().ends_with("developed by")
+            || (!window.contains(')') && !window.trim_end().ends_with('.'));
+        if should_extend {
+            for offset in 1..=2 {
+                let next_value = prepared_line.line_number.get() + offset;
+                let Some(next_line) =
+                    prepared_cache.line(LineNumber::new(next_value).expect("valid line"))
+                else {
+                    break;
+                };
+                if next_line.prepared.is_empty() {
+                    break;
+                }
+                window.push(' ');
+                window.push_str(next_line.prepared);
+                end_line = next_line.line_number;
+                if next_line.prepared.contains('.') {
+                    break;
+                }
+            }
+        }
+
+        let window_lower = window.to_ascii_lowercase();
+        let who = if let Some(index) = window_lower.find(NOTICE_ALSO_PREFIX) {
+            &window[index + NOTICE_ALSO_PREFIX.len()..]
+        } else if let Some(index) = window_lower.find(NOTICE_PREFIX) {
+            &window[index + NOTICE_PREFIX.len()..]
+        } else {
+            continue;
+        };
+        let who = who
+            .trim()
+            .trim_matches(&['"', '\''][..])
+            .trim_end_matches(&['.', ';', '"', '\''][..])
+            .trim();
+        let Some(author) = refine_notice_collective_author(who) else {
             continue;
         };
 

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -221,8 +221,23 @@ fn trim_following_sentence_clause(who: &str) -> String {
     trimmed.to_string()
 }
 
+fn trim_notice_support_sentence(who: &str) -> String {
+    static NOTICE_SUPPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?is)^(?P<head>.+?)\.\s+Visit\b.*$").unwrap());
+
+    let trimmed = who.trim();
+    if let Some(cap) = NOTICE_SUPPORT_RE.captures(trimmed) {
+        let head = cap.name("head").map(|m| m.as_str()).unwrap_or("").trim();
+        if !head.is_empty() {
+            return head.to_string();
+        }
+    }
+
+    trimmed.to_string()
+}
+
 fn refine_notice_collective_author(who: &str) -> Option<String> {
-    let trimmed = trim_following_sentence_clause(who)
+    let trimmed = trim_notice_support_sentence(&trim_following_sentence_clause(who))
         .trim_end_matches(&['.', ';', ','][..])
         .trim_matches(&['"', '\''][..])
         .trim()
@@ -2042,6 +2057,11 @@ pub(in super::super) fn extract_notice_developed_by_authors(
             .trim_matches(&['"', '\''][..])
             .trim_end_matches(&['.', ';', '"', '\''][..])
             .trim();
+        let who_lower = who.to_ascii_lowercase();
+        let has_url = who.contains("http://") || who.contains("https://");
+        if !has_url && !who_lower.starts_with("the ") {
+            continue;
+        }
         let Some(author) = refine_notice_collective_author(who) else {
             continue;
         };

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -304,6 +304,39 @@ fn test_developed_by_phrase_author_is_extracted() {
 }
 
 #[test]
+fn test_notice_developed_by_multiline_collective_author_is_extracted() {
+    let input = concat!(
+        "This product includes software developed by\n",
+        "The Apache Software Foundation (http://www.apache.org/).\n",
+    );
+
+    let (_c, _h, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|a| a.author == "The Apache Software Foundation (http://www.apache.org/)"),
+        "authors: {:?}",
+        authors.iter().map(|a| &a.author).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_notice_developed_by_quoted_project_author_is_extracted() {
+    let input = "\"This product includes software developed by the Spring Framework Project (http://www.springframework.org).\"";
+
+    let (_c, _h, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|a| a.author == "the Spring Framework Project (http://www.springframework.org)"),
+        "authors: {:?}",
+        authors.iter().map(|a| &a.author).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_modified_portion_developed_by_author_with_url_is_extracted() {
     let input = concat!(
         "# This product contains a modified portion of 'Flask App Builder' developed by Daniel Vaz Gaspar.\n",

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -173,6 +173,10 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    let mut new_a = super::author_heuristics::extract_notice_developed_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let mut new_a =
         super::author_heuristics::extract_with_additional_hacking_by_authors(prepared_cache);
     seen.dedup_new_authors(&mut new_a, 0);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -303,6 +303,19 @@ fn test_required_scope_word_is_not_author() {
 }
 
 #[test]
+fn test_notice_developed_by_org_list_without_url_is_not_author() {
+    let input = concat!(
+        "This product includes software developed by NASA Ames Research Center,\n",
+        "Lawrence Livermore National Laboratory, and Veridian Information Solutions,\n",
+        "Inc. Visit www.OpenPBS.org for OpenPBS software support,\n",
+        "products, and information.\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_fast_path_proposal_phrase_not_author() {
     let input = "Clinger's fast path, inspired by Jakub Jelínek's proposal";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -250,6 +250,59 @@ fn test_json_sponsor_description_does_not_create_authors() {
 }
 
 #[test]
+fn test_written_by_sentence_trims_following_description_clause() {
+    let input = "JUnit is a regression testing framework written by Erich Gamma and Kent Beck. It is used by the developer who implements unit tests in Java.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+    assert!(
+        values.contains(&"Erich Gamma and Kent Beck"),
+        "authors: {authors:?}"
+    );
+    assert!(
+        !values
+            .iter()
+            .any(|value| value.contains("It is used by the developer")),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_multiline_xml_description_written_by_sentence_keeps_only_author_names() {
+    let input = concat!(
+        "<description>JUnit is a regression testing framework written by Erich Gamma and Kent Beck.\n",
+        "It is used by the developer who implements unit tests in Java.</description>\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+    assert!(
+        values.contains(&"Erich Gamma and Kent Beck"),
+        "authors: {authors:?}"
+    );
+    assert!(
+        !values
+            .iter()
+            .any(|value| value.contains("JUnit is a regression testing framework")),
+        "authors: {authors:?}"
+    );
+    assert!(
+        !values
+            .iter()
+            .any(|value| value.contains("It is used by the developer")),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_required_scope_word_is_not_author() {
+    let input = "required";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_fast_path_proposal_phrase_not_author() {
     let input = "Clinger's fast path, inspired by Jakub Jelínek's proposal";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -251,7 +251,7 @@ fn contains_dollar_prefixed_code_token(s: &str) -> bool {
 pub(crate) fn looks_like_name_with_parenthesized_url(s: &str) -> bool {
     static NAME_WITH_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"^[A-Z][\p{L}'\-.]+(?:\s+(?:[a-z]{1,3}|[A-Z][\p{L}'\-.]+)){0,5}\s*\(\s*https?://[^)\s]+\s*\)$",
+            r"^(?:(?:[Tt]he)|[A-Z][\p{L}'\-.]+)(?:\s+(?:[a-z]{1,3}|[A-Z][\p{L}'\-.]+)){0,5}\s*\(\s*https?://[^)\s]+\s*\)$",
         )
         .unwrap()
     });

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -154,6 +154,7 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "review",
         "disclaims",
         "liability",
+        "required",
         "desired",
         "intended",
         "someone",

--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -57,6 +57,8 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
     };
 
     if config.max_emails > 0 && detections.len() > config.max_emails {
+        let mut seen = std::collections::HashSet::<String>::new();
+        detections.retain(|d| seen.insert(d.email.clone()));
         detections.truncate(config.max_emails);
     }
 

--- a/src/finder/host.rs
+++ b/src/finder/host.rs
@@ -43,6 +43,15 @@ pub(crate) fn is_good_host(host: &str) -> bool {
         return false;
     }
 
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() >= 3
+        && labels[..labels.len() - 1]
+            .iter()
+            .all(|label| !label.is_empty() && label.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        return false;
+    }
+
     classify_host(&host)
 }
 

--- a/src/scanner/process/contacts_test.rs
+++ b/src/scanner/process/contacts_test.rs
@@ -200,3 +200,56 @@ fn test_extract_email_url_information_keeps_gettext_mo_contacts() {
     assert_eq!(file.emails[0].email, "ll@li.org");
     assert_eq!(file.emails[1].email, "cs@sweetgood.de");
 }
+
+#[test]
+fn test_extract_email_url_information_prefers_unique_text_emails_before_cap() {
+    let mut builder = FileInfoBuilder::default();
+    let options = TextDetectionOptions {
+        collect_info: false,
+        detect_packages: false,
+        detect_application_packages: false,
+        detect_system_packages: false,
+        detect_packages_in_compiled: false,
+        detect_copyrights: false,
+        detect_generated: false,
+        detect_emails: true,
+        detect_urls: false,
+        max_emails: 4,
+        max_urls: 50,
+        timeout_seconds: 120.0,
+    };
+
+    let text = concat!(
+        "dev-subscribe@camel.apache.org\n",
+        "dev-subscribe@camel.apache.org\n",
+        "users@maven.apache.org\n",
+        "users@maven.apache.org\n",
+        "mvel2@2.5.2.final\n",
+        "dev-subscribe@parquet.apache.org\n",
+        "jaxrs-dev@eclipse.org\n",
+    );
+
+    extract_email_url_information(&mut builder, Path::new("sbom.txt"), text, &options, false);
+
+    let file = builder
+        .name("sbom.txt".to_string())
+        .base_name("sbom".to_string())
+        .extension(".txt".to_string())
+        .path("sbom.txt".to_string())
+        .file_type(FileType::File)
+        .size(1)
+        .build()
+        .expect("builder should produce file info");
+
+    let emails: Vec<&str> = file
+        .emails
+        .iter()
+        .map(|email| email.email.as_str())
+        .collect();
+    assert_eq!(emails.len(), 4, "emails: {:?}", file.emails);
+    assert_eq!(emails[0], "dev-subscribe@camel.apache.org");
+    assert_eq!(emails[1], "users@maven.apache.org");
+    assert!(emails.contains(&"dev-subscribe@parquet.apache.org"));
+    assert!(emails.contains(&"jaxrs-dev@eclipse.org"));
+    assert!(!emails.contains(&"mvel2@2.5.2.final"));
+}

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -703,7 +703,7 @@ fn is_wrapped_invalid_json_string_text(bytes: &[u8]) -> bool {
 }
 
 fn json_binary_override(bytes: &[u8]) -> Option<bool> {
-    if has_valid_json_text(bytes) || decode_utf16_json_text(bytes).is_some() {
+    if has_valid_json_text(bytes) {
         return Some(false);
     }
 

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -100,12 +100,17 @@ pub fn is_path_excluded(path: &Path, exclude_patterns: &[Pattern]) -> bool {
     false
 }
 
-/// Decode a byte buffer to a String, trying UTF-8 first, then Latin-1.
+/// Decode a byte buffer to a String, trying UTF-16 first when the byte shape
+/// strongly suggests it, then UTF-8, then Latin-1.
 ///
 /// Latin-1 (ISO-8859-1) maps bytes 0x00-0xFF directly to Unicode U+0000-U+00FF,
 /// so it can decode any byte sequence. This matches Python ScanCode's use of
 /// `UnicodeDammit` which auto-detects encoding with Latin-1 as fallback.
 pub fn decode_bytes_to_string(bytes: &[u8]) -> String {
+    if let Some(decoded) = decode_utf16_text(bytes) {
+        return decoded;
+    }
+
     match String::from_utf8(bytes.to_vec()) {
         Ok(s) => s,
         Err(e) => {
@@ -368,8 +373,149 @@ fn detect_file_format(bytes: &[u8]) -> FileFormat {
     FileFormat::from_reader(Cursor::new(bytes)).unwrap_or(FileFormat::ArbitraryBinaryData)
 }
 
+const CORRUPTED_UTF16_BOM_PREFIX: &[u8] = &[0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD];
+
 fn is_utf8_text(bytes: &[u8]) -> bool {
     std::str::from_utf8(bytes).is_ok()
+}
+
+fn strip_corrupted_utf16_bom_prefix(bytes: &[u8]) -> &[u8] {
+    bytes
+        .strip_prefix(CORRUPTED_UTF16_BOM_PREFIX)
+        .unwrap_or(bytes)
+}
+
+fn decode_utf16_units(bytes: &[u8], is_le: bool, require_text_shape: bool) -> Option<String> {
+    if bytes.is_empty() || !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+
+    let code_units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|chunk| {
+            if is_le {
+                u16::from_le_bytes([chunk[0], chunk[1]])
+            } else {
+                u16::from_be_bytes([chunk[0], chunk[1]])
+            }
+        })
+        .collect();
+
+    let decoded = std::char::decode_utf16(code_units)
+        .collect::<Result<String, _>>()
+        .ok()?;
+
+    if !require_text_shape {
+        return (!decoded.contains('\0')).then_some(decoded);
+    }
+
+    let visible = decoded
+        .chars()
+        .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'))
+        .count();
+    if visible < 3 || decoded.contains('\0') {
+        return None;
+    }
+
+    let alpha = decoded.chars().filter(|ch| ch.is_alphabetic()).count();
+    let punctuation = decoded
+        .chars()
+        .filter(|ch| {
+            matches!(
+                ch,
+                '{' | '}'
+                    | '['
+                    | ']'
+                    | '<'
+                    | '>'
+                    | '('
+                    | ')'
+                    | ':'
+                    | ';'
+                    | ','
+                    | '"'
+                    | '\''
+                    | '/'
+                    | '='
+                    | '-'
+                    | '_'
+                    | '#'
+                    | '!'
+            )
+        })
+        .count();
+    let whitespace = decoded.chars().filter(|ch| ch.is_whitespace()).count();
+
+    let textish = alpha + punctuation + whitespace;
+    if textish + (visible / 5) < visible || (alpha == 0 && punctuation < 2) {
+        return None;
+    }
+
+    Some(decoded)
+}
+
+fn detect_utf16_endianness(bytes: &[u8]) -> Option<bool> {
+    let stripped = strip_corrupted_utf16_bom_prefix(bytes);
+    if stripped.len() < 4 || !stripped.len().is_multiple_of(2) {
+        return None;
+    }
+
+    let pair_count = stripped.len() / 2;
+    let even_zero = stripped.iter().step_by(2).filter(|&&b| b == 0).count();
+    let odd_zero = stripped
+        .iter()
+        .skip(1)
+        .step_by(2)
+        .filter(|&&b| b == 0)
+        .count();
+
+    let looks_like_be = even_zero * 3 >= pair_count && odd_zero * 6 <= pair_count;
+    let looks_like_le = odd_zero * 3 >= pair_count && even_zero * 6 <= pair_count;
+
+    match (looks_like_le, looks_like_be) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        (true, true) => Some(true),
+        (false, false) => None,
+    }
+}
+
+fn decode_utf16_text(bytes: &[u8]) -> Option<String> {
+    if let Some(decoded) = decode_utf16_bom_text(bytes) {
+        return Some(decoded);
+    }
+
+    let stripped = strip_corrupted_utf16_bom_prefix(bytes);
+    match detect_utf16_endianness(bytes) {
+        Some(true) => decode_utf16_units(stripped, true, true),
+        Some(false) => decode_utf16_units(stripped, false, true),
+        None => None,
+    }
+}
+
+fn decode_utf16_json_text(bytes: &[u8]) -> Option<String> {
+    if bytes.len() >= 2 {
+        let (is_le, body) = match bytes {
+            [0xFF, 0xFE, rest @ ..] => (true, rest),
+            [0xFE, 0xFF, rest @ ..] => (false, rest),
+            _ => {
+                let stripped = strip_corrupted_utf16_bom_prefix(bytes);
+                return match detect_utf16_endianness(bytes) {
+                    Some(true) => decode_utf16_units(stripped, true, false),
+                    Some(false) => decode_utf16_units(stripped, false, false),
+                    None => None,
+                };
+            }
+        };
+
+        if body.is_empty() || !body.len().is_multiple_of(2) {
+            return None;
+        }
+
+        return decode_utf16_units(body, is_le, false);
+    }
+
+    None
 }
 
 fn decode_utf16_bom_text(bytes: &[u8]) -> Option<String> {
@@ -387,20 +533,7 @@ fn decode_utf16_bom_text(bytes: &[u8]) -> Option<String> {
         return None;
     }
 
-    let code_units: Vec<u16> = body
-        .chunks_exact(2)
-        .map(|chunk| {
-            if is_le {
-                u16::from_le_bytes([chunk[0], chunk[1]])
-            } else {
-                u16::from_be_bytes([chunk[0], chunk[1]])
-            }
-        })
-        .collect();
-
-    std::char::decode_utf16(code_units)
-        .collect::<Result<String, _>>()
-        .ok()
+    decode_utf16_units(body, is_le, true)
 }
 
 fn has_binary_control_chars(bytes: &[u8]) -> bool {
@@ -414,7 +547,7 @@ fn has_binary_control_chars(bytes: &[u8]) -> bool {
 fn has_decodable_text(bytes: &[u8]) -> bool {
     bytes.is_empty()
         || is_utf8_text(bytes)
-        || decode_utf16_bom_text(bytes).is_some()
+        || decode_utf16_text(bytes).is_some()
         || !has_binary_control_chars(bytes)
 }
 
@@ -422,7 +555,7 @@ fn looks_like_textual_bytes(bytes: &[u8]) -> bool {
     if bytes.is_empty() || is_utf8_text(bytes) {
         return true;
     }
-    if let Some(decoded) = decode_utf16_bom_text(bytes) {
+    if let Some(decoded) = decode_utf16_text(bytes) {
         return decoded
             .chars()
             .any(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'));
@@ -556,7 +689,7 @@ fn has_valid_json_text(bytes: &[u8]) -> bool {
     }
 
     serde_json::from_slice::<serde_json::Value>(bytes).is_ok()
-        || decode_utf16_bom_text(bytes)
+        || decode_utf16_json_text(bytes)
             .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
             .is_some()
 }
@@ -570,7 +703,7 @@ fn is_wrapped_invalid_json_string_text(bytes: &[u8]) -> bool {
 }
 
 fn json_binary_override(bytes: &[u8]) -> Option<bool> {
-    if has_valid_json_text(bytes) || decode_utf16_bom_text(bytes).is_some() {
+    if has_valid_json_text(bytes) || decode_utf16_json_text(bytes).is_some() {
         return Some(false);
     }
 
@@ -2411,6 +2544,46 @@ mod tests {
         assert!(classification.is_text);
         assert_eq!(classification.mime_type, "application/json");
         assert_eq!(classification.file_type, "JSON text data");
+    }
+
+    #[test]
+    fn test_classify_file_info_treats_valid_utf16be_json_without_bom_as_text() {
+        let classification = classify_file_info(
+            Path::new("utf16be.json"),
+            &[0x00, 0x5B, 0x00, 0x22, 0x00, 0xE9, 0x00, 0x22, 0x00, 0x5D],
+        );
+
+        assert!(!classification.is_binary);
+        assert!(classification.is_text);
+        assert_eq!(classification.mime_type, "application/json");
+        assert_eq!(classification.file_type, "JSON text data");
+    }
+
+    #[test]
+    fn test_classify_file_info_treats_small_valid_utf16be_json_literal_as_text() {
+        let classification =
+            classify_file_info(Path::new("utf16be-literal.json"), &[0x00, 0x5B, 0x00, 0x5D]);
+
+        assert!(!classification.is_binary);
+        assert!(classification.is_text);
+        assert_eq!(classification.mime_type, "application/json");
+        assert_eq!(classification.file_type, "JSON text data");
+    }
+
+    #[test]
+    fn test_extract_text_for_detection_decodes_utf16be_text_with_corrupted_bom_prefix() {
+        let mut bytes = super::CORRUPTED_UTF16_BOM_PREFIX.to_vec();
+        for code_unit in
+            "Licensed to the Apache Software Foundation\nApache License, Version 2.0".encode_utf16()
+        {
+            bytes.extend_from_slice(&code_unit.to_be_bytes());
+        }
+
+        let (text, kind) = extract_text_for_detection(Path::new("notice.ftl"), &bytes);
+
+        assert_eq!(kind, ExtractedTextKind::Decoded);
+        assert!(text.contains("Apache Software Foundation"), "{text}");
+        assert!(text.contains("Apache License, Version 2.0"), "{text}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- improve shared UTF-16 decoding so BOM-less or corrupted-BOM inputs stay on the decoded-text path, including the Camel template files that previously missed Apache-2.0
- recover Apache, Spring, and OpenShift notice attributions and trim written-by prose spillover in shared author heuristics, including the Camel SBOM XML false-positive sentence
- filter version-shaped SBOM pseudo-emails before truncation and record the explicit Apache Camel benchmark checkpoint in docs/BENCHMARKS.md

## Issues

- Covers: Apache Camel compare target from docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md
- Closes: none

## Scope and exclusions

- Included: shared text decoding in src/utils/file.rs, shared copyright/author heuristics, shared email host filtering, Camel benchmark/chart refresh
- Explicit exclusions: unrelated remaining Camel compare deltas outside the three targeted gaps, such as the longstanding top-level package-count mismatch

## Intentional differences from Python

- keep the UTF-16 improvement generic by recognizing BOM-less and corrupted-BOM UTF-16 shapes before falling back to Latin-1 or binary-string extraction
- prefer unique SBOM emails before the cap only after filtering version-shaped pseudo-hosts, instead of keeping obviously fake package-version addresses in the truncated result set

## Follow-up work

- Created or intentionally deferred:
  - recorded compare artifacts:
    - baseline before these fixes: .provenant/compare-runs/20260426T074449Z-camel-39047
    - first fully-fixed benchmark checkpoint: .provenant/compare-runs/20260426T202057Z-camel-80585
    - immediate repeat for timing variance: .provenant/compare-runs/20260426T203456Z-camel-82481
  - the benchmark row uses camel-80585; the repeat camel-82481 was retained only to check fluctuation and came out 7.84s slower (1.67%), which suggests the earlier 473s vs 514s spread was mostly different code state rather than pure runtime noise
  - remaining non-targeted Camel compare deltas are left for later triage

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this branch changes shared scanner behavior and validates it with targeted Rust tests plus repeated compare-output artifacts; no checked-in golden or expected-output fixtures required updates
