### PR TITLE
fix(nix): improve verification parity and refresh benchmarks

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 177 of 177 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **17.4×** on 10k+ file targets.
+> Provenant is faster on 175 of 175 recorded runs, with a **11.5× median speedup** and **10.8× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **17.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1023,13 +1023,6 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `19.91s`; ScanCode `33.50s`
 - Broader Nix package and dependency extraction (`53` vs `22` packages, `887` vs `843` dependencies) from committed `flake.lock` inputs and flake-compat-backed `default.nix` wrapper surfaces across the tree, with cleaner root-package visibility on repository entrypoints that ScanCode leaves unassembled
 
-##### [NixOS/nix @ 262e98f](https://github.com/NixOS/nix/tree/262e98f67e09f83393dc84c2629df84cce2fe299) — **4.78× faster**
-
-- Files: 2,889
-- Run context: 2026-04-11 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `21.86s`; ScanCode `104.41s`
-- Broader Nix package and dependency extraction (`2` vs `0` packages, `67` vs `0` dependencies) from committed `flake.lock` inputs and Nix manifest surfaces across the tree, plus safer URL credential stripping and Unicode-preserving author normalization across release-note metadata
-
 ##### [NixOS/nix @ 6a659e1](https://github.com/NixOS/nix/tree/6a659e16bd2bcd871aedcb38724a1cff77690a31) — **18.21× faster**
 
 - Files: 2,917
@@ -1037,19 +1030,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.29s`; ScanCode `223.79s`
 - Broader Nix package and dependency extraction (`3` vs `0` packages, `69` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and other Nix manifest surfaces, with richer structured author, email, and URL recovery across repository docs and release metadata
 
-##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.90× faster**
+##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.37× faster**
 
 - Files: 52,167
-- Run context: 2026-04-27 · nixpkgs-18663 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `311.46s`; ScanCode `4641.96s`
+- Run context: 2026-04-27 · nixpkgs-63582 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `322.93s`; ScanCode `4641.96s`
 - Broader Nix package visibility (`1327` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
-
-##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **3.55× faster**
-
-- Files: 84
-- Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.57s`; ScanCode `37.57s`
-- Broader Nix package and dependency extraction (`5` vs `0` packages, `17` vs `0` dependencies) from committed `flake.lock` inputs, root `default.nix`, and template flake surfaces, with cleaner root-package visibility on flake-compat-backed entrypoints that ScanCode leaves unassembled
 
 ##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **7.44× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1030,12 +1030,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.29s`; ScanCode `223.79s`
 - Broader Nix package and dependency extraction (`3` vs `0` packages, `69` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and other Nix manifest surfaces, with richer structured author, email, and URL recovery across repository docs and release metadata
 
-##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.37× faster**
+##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.84× faster**
 
 - Files: 52,167
-- Run context: 2026-04-27 · nixpkgs-63582 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `322.93s`; ScanCode `4641.96s`
-- Broader Nix package visibility (`1327` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
+- Run context: 2026-04-27 · nixpkgs-12663 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `312.87s`; ScanCode `4641.96s`
+- Broader Nix package visibility (`1340` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
 
 ##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **7.44× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 174 of 174 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **18.6×** on 10k+ file targets.
+> Provenant is faster on 177 of 177 recorded runs, with a **11.5× median speedup** and **10.7× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **17.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1030,12 +1030,33 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `21.86s`; ScanCode `104.41s`
 - Broader Nix package and dependency extraction (`2` vs `0` packages, `67` vs `0` dependencies) from committed `flake.lock` inputs and Nix manifest surfaces across the tree, plus safer URL credential stripping and Unicode-preserving author normalization across release-note metadata
 
+##### [NixOS/nix @ 6a659e1](https://github.com/NixOS/nix/tree/6a659e16bd2bcd871aedcb38724a1cff77690a31) — **18.21× faster**
+
+- Files: 2,917
+- Run context: 2026-04-27 · nix-25195 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `12.29s`; ScanCode `223.79s`
+- Broader Nix package and dependency extraction (`3` vs `0` packages, `69` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and other Nix manifest surfaces, with richer structured author, email, and URL recovery across repository docs and release metadata
+
+##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.90× faster**
+
+- Files: 52,167
+- Run context: 2026-04-27 · nixpkgs-18663 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `311.46s`; ScanCode `4641.96s`
+- Broader Nix package visibility (`1327` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
+
 ##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **3.55× faster**
 
 - Files: 84
 - Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `10.57s`; ScanCode `37.57s`
 - Broader Nix package and dependency extraction (`5` vs `0` packages, `17` vs `0` dependencies) from committed `flake.lock` inputs, root `default.nix`, and template flake surfaces, with cleaner root-package visibility on flake-compat-backed entrypoints that ScanCode leaves unassembled
+
+##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **7.44× faster**
+
+- Files: 87
+- Run context: 2026-04-27 · devshell-25970 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `8.84s`; ScanCode `65.75s`
+- Broader Nix package and dependency extraction (`5` vs `0` packages, `17` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and template flake surfaces, with cleaner structured author, copyright, and URL recovery
 
 ##### [ocaml/dune @ b13ab94](https://github.com/ocaml/dune/tree/b13ab949e185a205a39eb6163eea050b7d60a047) — **25.02× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -161,6 +161,9 @@ ScanCode: 23.84s</title></rect>
     <rect x="397.32" y="456.66" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 84
 ScanCode: 37.57s</title></rect>
+    <rect x="399.74" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
+Files: 87
+ScanCode: 65.75s</title></rect>
     <rect x="403.59" y="423.65" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 ScanCode: 75.55s</title></rect>
@@ -404,6 +407,9 @@ ScanCode: 127.38s</title></rect>
     <rect x="641.11" y="408.36" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 262e98f
 Files: 2889
 ScanCode: 104.41s</title></rect>
+    <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
+Files: 2917
+ScanCode: 223.79s</title></rect>
     <rect x="643.66" y="353.67" width="8" height="8" fill="#d97706" rx="1.5"><title>scipy/scipy @ 8a4633f
 Files: 2998
 ScanCode: 332.23s</title></rect>
@@ -572,6 +578,9 @@ ScanCode: 5338.67s</title></rect>
     <rect x="822.70" y="228.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 ScanCode: 4726.52s</title></rect>
+    <rect x="840.49" y="229.06" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nixpkgs @ c407343
+Files: 52167
+ScanCode: 4641.96s</title></rect>
     <rect x="840.86" y="231.99" width="8" height="8" fill="#d97706" rx="1.5"><title>mongodb/mongo @ d6877a3
 Files: 52443
 ScanCode: 4363.53s</title></rect>
@@ -685,6 +694,9 @@ Provenant: 19.47s</title></circle>
     <circle cx="401.32" cy="520.58" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 84
 Provenant: 10.57s</title></circle>
+    <circle cx="403.74" cy="529.03" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
+Files: 87
+Provenant: 8.84s</title></circle>
     <circle cx="407.59" cy="515.70" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 Provenant: 11.72s</title></circle>
@@ -928,6 +940,9 @@ Provenant: 15.25s</title></circle>
     <circle cx="645.11" cy="486.25" r="4.5" fill="#2563eb"><title>NixOS/nix @ 262e98f
 Files: 2889
 Provenant: 21.86s</title></circle>
+    <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
+Files: 2917
+Provenant: 12.29s</title></circle>
     <circle cx="647.66" cy="482.69" r="4.5" fill="#2563eb"><title>scipy/scipy @ 8a4633f
 Files: 2998
 Provenant: 23.57s</title></circle>
@@ -1096,6 +1111,9 @@ Provenant: 469.31s</title></circle>
     <circle cx="826.70" cy="396.34" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 Provenant: 146.56s</title></circle>
+    <circle cx="844.49" cy="360.72" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
+Files: 52167
+Provenant: 311.46s</title></circle>
     <circle cx="844.86" cy="360.39" r="4.5" fill="#2563eb"><title>mongodb/mongo @ d6877a3
 Files: 52443
 Provenant: 313.61s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -1099,9 +1099,9 @@ Provenant: 469.31s</title></circle>
     <circle cx="826.70" cy="396.34" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 Provenant: 146.56s</title></circle>
-    <circle cx="844.49" cy="359.01" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
+    <circle cx="844.49" cy="360.50" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
 Files: 52167
-Provenant: 322.93s</title></circle>
+Provenant: 312.87s</title></circle>
     <circle cx="844.86" cy="360.39" r="4.5" fill="#2563eb"><title>mongodb/mongo @ d6877a3
 Files: 52443
 Provenant: 313.61s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -158,9 +158,6 @@ ScanCode: 122.53s</title></rect>
     <rect x="397.32" y="478.15" width="8" height="8" fill="#d97706" rx="1.5"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
 ScanCode: 23.84s</title></rect>
-    <rect x="397.32" y="456.66" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
-Files: 84
-ScanCode: 37.57s</title></rect>
     <rect x="399.74" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 87
 ScanCode: 65.75s</title></rect>
@@ -404,9 +401,6 @@ ScanCode: 394.76s</title></rect>
     <rect x="640.96" y="398.96" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 ScanCode: 127.38s</title></rect>
-    <rect x="641.11" y="408.36" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 262e98f
-Files: 2889
-ScanCode: 104.41s</title></rect>
     <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
 ScanCode: 223.79s</title></rect>
@@ -691,9 +685,6 @@ Provenant: 11.11s</title></circle>
     <circle cx="401.32" cy="491.72" r="4.5" fill="#2563eb"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
 Provenant: 19.47s</title></circle>
-    <circle cx="401.32" cy="520.58" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
-Files: 84
-Provenant: 10.57s</title></circle>
     <circle cx="403.74" cy="529.03" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 87
 Provenant: 8.84s</title></circle>
@@ -937,9 +928,6 @@ Provenant: 16.30s</title></circle>
     <circle cx="644.96" cy="503.26" r="4.5" fill="#2563eb"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 Provenant: 15.25s</title></circle>
-    <circle cx="645.11" cy="486.25" r="4.5" fill="#2563eb"><title>NixOS/nix @ 262e98f
-Files: 2889
-Provenant: 21.86s</title></circle>
     <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
 Provenant: 12.29s</title></circle>
@@ -1111,9 +1099,9 @@ Provenant: 469.31s</title></circle>
     <circle cx="826.70" cy="396.34" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
 Provenant: 146.56s</title></circle>
-    <circle cx="844.49" cy="360.72" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
+    <circle cx="844.49" cy="359.01" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
 Files: 52167
-Provenant: 311.46s</title></circle>
+Provenant: 322.93s</title></circle>
     <circle cx="844.86" cy="360.39" r="4.5" fill="#2563eb"><title>mongodb/mongo @ d6877a3
 Files: 52443
 Provenant: 313.61s</title></circle>

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -82,7 +82,7 @@ fn assemble_single_sibling_package(
                     saw_unpackageable_npm_manifest = true;
                 }
 
-                if should_skip_lock_merge(package.as_ref(), pkg_data) {
+                if should_skip_assembly_package_data(package.as_ref(), pkg_data) {
                     continue;
                 }
 
@@ -208,7 +208,7 @@ fn assemble_cocoapods_multiple_podspecs(
                     continue;
                 }
 
-                if should_skip_lock_merge(Some(&primary_package), pkg_data) {
+                if should_skip_assembly_package_data(Some(&primary_package), pkg_data) {
                     continue;
                 }
 
@@ -432,15 +432,20 @@ fn is_handled_by(pkg_data: &PackageData, config: &AssemblerConfig) -> bool {
         .is_some_and(|dsid| config.datasource_ids.contains(&dsid))
 }
 
-fn should_skip_lock_merge(package: Option<&Package>, pkg_data: &PackageData) -> bool {
-    let Some(existing_package) = package else {
-        return false;
-    };
+fn should_skip_assembly_package_data(package: Option<&Package>, pkg_data: &PackageData) -> bool {
+    should_skip_composer_lock_virtual_package(pkg_data)
+        || package.is_some_and(|existing_package| {
+            should_skip_npm_lock_merge(existing_package, pkg_data)
+                || should_skip_bun_lock_merge(existing_package, pkg_data)
+                || should_skip_python_uv_lock_merge(existing_package, pkg_data)
+                || should_skip_python_pip_cache_merge(existing_package, pkg_data)
+        })
+}
 
-    should_skip_npm_lock_merge(existing_package, pkg_data)
-        || should_skip_bun_lock_merge(existing_package, pkg_data)
-        || should_skip_python_uv_lock_merge(existing_package, pkg_data)
-        || should_skip_python_pip_cache_merge(existing_package, pkg_data)
+fn should_skip_composer_lock_virtual_package(pkg_data: &PackageData) -> bool {
+    pkg_data.datasource_id == Some(DatasourceId::PhpComposerLock)
+        && pkg_data.is_virtual
+        && pkg_data.purl.is_some()
 }
 
 fn should_skip_npm_lock_merge(package: &Package, pkg_data: &PackageData) -> bool {

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -122,6 +122,9 @@ pub(super) fn is_false_positive(matches: &[LicenseMatch]) -> bool {
     let all_rule_length_one = rule_length_values.iter().all(|&l| l == 1);
 
     let all_low_relevance = matches.iter().all(|m| m.rule_relevance < 60);
+    let all_exact_spdx_license_id_rules = matches
+        .iter()
+        .all(|m| m.rule_identifier.starts_with("spdx_license_id_"));
 
     let is_single = matches.len() == 1;
 
@@ -142,6 +145,7 @@ pub(super) fn is_false_positive(matches: &[LicenseMatch]) -> bool {
     // Python: any(rule_length <= 3) not all(rule_length == 1)
     if all_low_relevance
         && start_line > FALSE_POSITIVE_START_LINE_THRESHOLD
+        && !all_exact_spdx_license_id_rules
         && rule_length_values
             .iter()
             .any(|&l| l <= FALSE_POSITIVE_RULE_LENGTH_THRESHOLD)
@@ -900,6 +904,23 @@ mod tests {
             "mit.LICENSE",
         )];
         assert!(is_false_positive(&matches));
+    }
+
+    #[test]
+    fn test_is_false_positive_late_exact_spdx_id_rule_not_filtered() {
+        let matches = vec![create_test_match_full(
+            "mpl-2.0",
+            "2-aho",
+            1500,
+            1503,
+            MatchScore::from_percentage(50.0),
+            3,
+            3,
+            100.0,
+            50,
+            "spdx_license_id_mpl-2.0_for_mpl-2.0.RULE",
+        )];
+        assert!(!is_false_positive(&matches));
     }
 
     #[test]

--- a/src/license_detection/expression/mod.rs
+++ b/src/license_detection/expression/mod.rs
@@ -109,18 +109,11 @@ impl LicenseExpression {
     pub fn and(expressions: Vec<LicenseExpression>) -> Option<LicenseExpression> {
         if expressions.is_empty() {
             None
-        } else if expressions.len() == 1 {
-            Some(expressions.into_iter().next().unwrap())
         } else {
-            let mut iter = expressions.into_iter();
-            let mut result = iter.next().unwrap();
-            for expr in iter {
-                result = LicenseExpression::And {
-                    left: Box::new(result),
-                    right: Box::new(expr),
-                };
-            }
-            Some(result)
+            Some(build_balanced_boolean_expression(
+                &expressions,
+                |left, right| LicenseExpression::And { left, right },
+            ))
         }
     }
 
@@ -128,18 +121,27 @@ impl LicenseExpression {
     pub fn or(expressions: Vec<LicenseExpression>) -> Option<LicenseExpression> {
         if expressions.is_empty() {
             None
-        } else if expressions.len() == 1 {
-            Some(expressions.into_iter().next().unwrap())
         } else {
-            let mut iter = expressions.into_iter();
-            let mut result = iter.next().unwrap();
-            for expr in iter {
-                result = LicenseExpression::Or {
-                    left: Box::new(result),
-                    right: Box::new(expr),
-                };
-            }
-            Some(result)
+            Some(build_balanced_boolean_expression(
+                &expressions,
+                |left, right| LicenseExpression::Or { left, right },
+            ))
+        }
+    }
+}
+
+fn build_balanced_boolean_expression(
+    expressions: &[LicenseExpression],
+    combine: fn(Box<LicenseExpression>, Box<LicenseExpression>) -> LicenseExpression,
+) -> LicenseExpression {
+    match expressions.len() {
+        0 => panic!("build_balanced_boolean_expression called with empty list"),
+        1 => expressions[0].clone(),
+        _ => {
+            let midpoint = expressions.len() / 2;
+            let left = build_balanced_boolean_expression(&expressions[..midpoint], combine);
+            let right = build_balanced_boolean_expression(&expressions[midpoint..], combine);
+            combine(Box::new(left), Box::new(right))
         }
     }
 }
@@ -148,6 +150,17 @@ impl LicenseExpression {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    fn expression_depth(expr: &LicenseExpression) -> usize {
+        match expr {
+            LicenseExpression::License(_) | LicenseExpression::LicenseRef(_) => 1,
+            LicenseExpression::And { left, right }
+            | LicenseExpression::Or { left, right }
+            | LicenseExpression::With { left, right } => {
+                1 + expression_depth(left).max(expression_depth(right))
+            }
+        }
+    }
 
     #[test]
     fn test_and_helper_empty() {
@@ -193,6 +206,28 @@ mod tests {
         ];
         let result = LicenseExpression::or(exprs).unwrap();
         assert!(matches!(result, LicenseExpression::Or { .. }));
+    }
+
+    #[test]
+    fn test_and_helper_balances_large_expression_depth() {
+        let exprs: Vec<_> = (0..1024)
+            .map(|idx| LicenseExpression::License(format!("license-{idx}")))
+            .collect();
+
+        let result = LicenseExpression::and(exprs).unwrap();
+
+        assert!(expression_depth(&result) <= 12);
+    }
+
+    #[test]
+    fn test_or_helper_balances_large_expression_depth() {
+        let exprs: Vec<_> = (0..1024)
+            .map(|idx| LicenseExpression::License(format!("license-{idx}")))
+            .collect();
+
+        let result = LicenseExpression::or(exprs).unwrap();
+
+        assert!(expression_depth(&result) <= 12);
     }
 
     #[test]

--- a/src/license_detection/expression/simplify.rs
+++ b/src/license_detection/expression/simplify.rs
@@ -249,22 +249,20 @@ fn build_expression_from_list(unique: &[LicenseExpression], is_and: bool) -> Lic
         0 => panic!("build_expression_from_list called with empty list"),
         1 => unique[0].clone(),
         _ => {
-            let mut iter = unique.iter();
-            let mut result = iter.next().unwrap().clone();
-            for expr in iter {
-                result = if is_and {
-                    LicenseExpression::And {
-                        left: Box::new(result),
-                        right: Box::new(expr.clone()),
-                    }
-                } else {
-                    LicenseExpression::Or {
-                        left: Box::new(result),
-                        right: Box::new(expr.clone()),
-                    }
-                };
+            let midpoint = unique.len() / 2;
+            let left = build_expression_from_list(&unique[..midpoint], is_and);
+            let right = build_expression_from_list(&unique[midpoint..], is_and);
+            if is_and {
+                LicenseExpression::And {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                }
+            } else {
+                LicenseExpression::Or {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                }
             }
-            result
         }
     }
 }
@@ -600,6 +598,17 @@ pub fn combine_expressions_or_preserving_structure(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn expression_depth(expr: &LicenseExpression) -> usize {
+        match expr {
+            LicenseExpression::License(_) | LicenseExpression::LicenseRef(_) => 1,
+            LicenseExpression::And { left, right }
+            | LicenseExpression::Or { left, right }
+            | LicenseExpression::With { left, right } => {
+                1 + expression_depth(left).max(expression_depth(right))
+            }
+        }
+    }
 
     #[test]
     fn test_simplify_expression_no_change() {
@@ -1092,6 +1101,28 @@ mod tests {
             result,
             "apache-2.0 AND apsl-1.0 AND apsl-2.0 AND bsd-3-clause AND gpl-2.0-only AND licenseref-scancode-oracle-openjdk-exception-2.0"
         );
+    }
+
+    #[test]
+    fn test_build_expression_from_list_balances_large_and_chains() {
+        let unique: Vec<_> = (0..1024)
+            .map(|idx| LicenseExpression::License(format!("license-{idx}")))
+            .collect();
+
+        let result = build_expression_from_list(&unique, true);
+
+        assert!(expression_depth(&result) <= 12);
+    }
+
+    #[test]
+    fn test_build_expression_from_list_balances_large_or_chains() {
+        let unique: Vec<_> = (0..1024)
+            .map(|idx| LicenseExpression::License(format!("license-{idx}")))
+            .collect();
+
+        let result = build_expression_from_list(&unique, false);
+
+        assert!(expression_depth(&result) <= 12);
     }
 }
 

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -266,14 +266,7 @@ fn extract_all_dependencies(
             continue;
         };
 
-        let is_root_package = package_key_from_table(package)
-            .zip(root_package_key)
-            .is_some_and(|(package_key, root_key)| package_key == root_key);
         if package.get("source").is_some() {
-            continue;
-        }
-
-        if is_root_package {
             continue;
         }
 

--- a/src/parsers/cargo_lock_test.rs
+++ b/src/parsers/cargo_lock_test.rs
@@ -396,7 +396,7 @@ checksum = "serde-checksum"
     }
 
     #[test]
-    fn test_extract_dependencies_skips_root_package_but_keeps_source_less_workspace_members() {
+    fn test_extract_dependencies_keeps_root_package_and_source_less_workspace_members() {
         let content = r#"
 [[package]]
 name = "my-app"
@@ -427,8 +427,16 @@ version = "0.1.0"
             .collect();
 
         assert!(dependency_purls.contains(&"pkg:cargo/serde@1.0.228"));
-        assert!(!dependency_purls.contains(&"pkg:cargo/my-app@0.4.0"));
+        assert!(dependency_purls.contains(&"pkg:cargo/my-app@0.4.0"));
         assert!(dependency_purls.contains(&"pkg:cargo/workspace-tool@0.1.0"));
+
+        let root_dep = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some("pkg:cargo/my-app@0.4.0"))
+            .expect("root package should be preserved as a direct dependency");
+        assert_eq!(root_dep.extracted_requirement.as_deref(), Some("0.4.0"));
+        assert_eq!(root_dep.is_direct, Some(true));
     }
 
     #[test]

--- a/src/parsers/composer.rs
+++ b/src/parsers/composer.rs
@@ -211,7 +211,10 @@ impl PackageParser for ComposerLockParser {
 
         let mut package_data = default_package_data(Some(DatasourceId::PhpComposerLock));
         package_data.dependencies = dependencies;
-        vec![package_data]
+
+        let mut packages = vec![package_data];
+        packages.extend(extract_lock_packages(&json_content));
+        packages
     }
 
     fn is_match(path: &Path) -> bool {
@@ -307,6 +310,35 @@ fn extract_lock_dependencies(json_content: &Value) -> Vec<Dependency> {
     ));
 
     dependencies
+}
+
+fn extract_lock_packages(json_content: &Value) -> Vec<PackageData> {
+    let packages = json_content
+        .get(FIELD_PACKAGES)
+        .and_then(|value| value.as_array())
+        .map(|packages| packages.as_slice())
+        .unwrap_or(&[]);
+    let packages_dev = json_content
+        .get(FIELD_PACKAGES_DEV)
+        .and_then(|value| value.as_array())
+        .map(|packages| packages.as_slice())
+        .unwrap_or(&[]);
+
+    let mut extracted = Vec::with_capacity(packages.len() + packages_dev.len());
+
+    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+        if let Some(package_data) = build_lock_package_data(package, false) {
+            extracted.push(package_data);
+        }
+    }
+
+    for package in packages_dev.iter().take(MAX_ITERATION_COUNT) {
+        if let Some(package_data) = build_lock_package_data(package, true) {
+            extracted.push(package_data);
+        }
+    }
+
+    extracted
 }
 
 fn extract_lock_package_list(
@@ -460,6 +492,66 @@ fn build_lock_dependency(
         resolved_package: Some(Box::new(resolved_package)),
         extra_data,
     })
+}
+
+fn build_lock_package_data(package: &Value, is_dev_package: bool) -> Option<PackageData> {
+    let dependency = build_lock_dependency(
+        package,
+        if is_dev_package {
+            "packages-dev"
+        } else {
+            "packages"
+        },
+        !is_dev_package,
+        is_dev_package,
+    )?;
+    let resolved = dependency.resolved_package.as_deref()?;
+
+    let mut package_data = default_package_data(Some(DatasourceId::PhpComposerLock));
+    package_data.package_type = Some(ComposerLockParser::PACKAGE_TYPE);
+    package_data.namespace = (!resolved.namespace.is_empty()).then(|| resolved.namespace.clone());
+    package_data.name = Some(truncate_field(resolved.name.clone()));
+    package_data.version = Some(truncate_field(resolved.version.clone()));
+    package_data.primary_language = resolved.primary_language.clone();
+    package_data.description = resolved.description.clone();
+    package_data.release_date = resolved.release_date.clone();
+    package_data.parties = resolved.parties.clone();
+    package_data.keywords = resolved.keywords.clone();
+    package_data.homepage_url = resolved.homepage_url.clone();
+    package_data.download_url = resolved.download_url.clone();
+    package_data.sha1 = resolved.sha1;
+    package_data.md5 = resolved.md5;
+    package_data.sha256 = resolved.sha256;
+    package_data.sha512 = resolved.sha512;
+    package_data.bug_tracking_url = resolved.bug_tracking_url.clone();
+    package_data.code_view_url = resolved.code_view_url.clone();
+    package_data.vcs_url = resolved.vcs_url.clone();
+    package_data.copyright = resolved.copyright.clone();
+    package_data.holder = resolved.holder.clone();
+    package_data.declared_license_expression = resolved.declared_license_expression.clone();
+    package_data.declared_license_expression_spdx =
+        resolved.declared_license_expression_spdx.clone();
+    package_data.license_detections = resolved.license_detections.clone();
+    package_data.other_license_expression = resolved.other_license_expression.clone();
+    package_data.other_license_expression_spdx = resolved.other_license_expression_spdx.clone();
+    package_data.other_license_detections = resolved.other_license_detections.clone();
+    package_data.extracted_license_statement = resolved.extracted_license_statement.clone();
+    package_data.notice_text = resolved.notice_text.clone();
+    package_data.source_packages = resolved.source_packages.clone();
+    package_data.file_references = resolved.file_references.clone();
+    package_data.is_private = resolved.is_private;
+    package_data.is_virtual = resolved.is_virtual;
+    package_data.extra_data = dependency
+        .extra_data
+        .clone()
+        .or_else(|| resolved.extra_data.clone());
+    package_data.dependencies = resolved.dependencies.clone();
+    package_data.repository_homepage_url = resolved.repository_homepage_url.clone();
+    package_data.repository_download_url = resolved.repository_download_url.clone();
+    package_data.api_data_url = resolved.api_data_url.clone();
+    package_data.purl = dependency.purl.clone();
+
+    Some(package_data)
 }
 
 fn extract_dist_hashes(

--- a/src/parsers/composer_scan_test.rs
+++ b/src/parsers/composer_scan_test.rs
@@ -30,6 +30,8 @@ mod tests {
             package.purl.as_deref(),
             Some("pkg:composer/test/package@1.0.0")
         );
+        assert_eq!(package.download_url, None);
+        assert_eq!(package.extra_data, None);
         assert_dependency_present(
             &result.dependencies,
             "pkg:composer/phpunit/phpunit",

--- a/src/parsers/composer_scan_test.rs
+++ b/src/parsers/composer_scan_test.rs
@@ -52,5 +52,16 @@ mod tests {
             &package.package_uid,
             DatasourceId::PhpComposerLock,
         );
+
+        let lock_file = files
+            .iter()
+            .find(|file| file.path.ends_with("/composer.lock"))
+            .expect("composer.lock should be scanned");
+        assert!(
+            lock_file
+                .package_data
+                .iter()
+                .any(|pkg| pkg.purl.as_deref() == Some("pkg:composer/phpunit/phpunit@10.0.0"))
+        );
     }
 }

--- a/src/parsers/composer_test.rs
+++ b/src/parsers/composer_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod tests {
-    use crate::models::{Dependency, PackageType, Sha1Digest};
+    use crate::models::{DatasourceId, Dependency, PackageType, Sha1Digest};
     use crate::parsers::{ComposerJsonParser, ComposerLockParser, PackageParser};
     use serde_json::Value;
     use std::fs;
@@ -594,6 +594,35 @@ mod tests {
         assert_eq!(dev_package_dep.scope.as_deref(), Some("require-dev"));
         assert_eq!(dev_package_dep.is_runtime, Some(false));
         assert_eq!(dev_package_dep.is_optional, Some(true));
+    }
+
+    #[test]
+    fn test_extract_composer_lock_surfaces_locked_packages_as_package_data() {
+        let content = sample_composer_lock();
+        let (_temp_dir, composer_path) = create_temp_file("composer.lock", &content);
+        let package_data = ComposerLockParser::extract_packages(&composer_path);
+
+        assert_eq!(package_data.len(), 3);
+
+        let runtime_pkg = package_data
+            .iter()
+            .find(|pkg| pkg.purl.as_deref() == Some("pkg:composer/acme/runtime@1.0.0"))
+            .expect("runtime package should be emitted as file-level package_data");
+        assert_eq!(runtime_pkg.name.as_deref(), Some("runtime"));
+        assert_eq!(runtime_pkg.namespace.as_deref(), Some("acme"));
+        assert_eq!(runtime_pkg.version.as_deref(), Some("1.0.0"));
+        assert_eq!(
+            runtime_pkg.datasource_id,
+            Some(DatasourceId::PhpComposerLock)
+        );
+
+        let dev_pkg = package_data
+            .iter()
+            .find(|pkg| pkg.purl.as_deref() == Some("pkg:composer/acme/devpkg@2.0.0"))
+            .expect("dev package should be emitted as file-level package_data");
+        assert_eq!(dev_pkg.name.as_deref(), Some("devpkg"));
+        assert_eq!(dev_pkg.namespace.as_deref(), Some("acme"));
+        assert_eq!(dev_pkg.version.as_deref(), Some("2.0.0"));
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -182,7 +182,7 @@ mod hex_lock_test;
 mod julia;
 #[cfg(test)]
 mod julia_test;
-mod license_normalization;
+pub(crate) mod license_normalization;
 mod maven;
 #[cfg(test)]
 mod maven_scan_test;

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -4,14 +4,19 @@
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::PositionSet;
+use crate::license_detection::expression::parse_expression;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::models::LicenseMatch as InternalLicenseMatch;
 use crate::license_detection::query::Query;
 use crate::models::{
-    FileInfoBuilder, LicenseDetection as PublicLicenseDetection, Match, ScanDiagnostic,
+    FileInfoBuilder, LicenseDetection as PublicLicenseDetection, LineNumber, Match, ScanDiagnostic,
+};
+use crate::parsers::license_normalization::{
+    DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_spdx_expression,
 };
 use crate::scanner::LicenseScanOptions;
 use anyhow::Error;
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -125,6 +130,12 @@ pub(super) fn extract_license_information(
                 model_clues.extend(clue_matches);
             }
 
+            model_detections.extend(supplement_nix_manifest_license_detections(
+                path,
+                &text_content,
+                &model_detections,
+            ));
+
             if !model_detections.is_empty() {
                 let expressions: Vec<String> = model_detections
                     .iter()
@@ -163,6 +174,202 @@ pub(super) fn extract_license_information(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct NixLicenseDeclaration {
+    symbol: String,
+    matched_text: String,
+    start_line: LineNumber,
+    end_line: LineNumber,
+}
+
+fn supplement_nix_manifest_license_detections(
+    path: &Path,
+    text_content: &str,
+    existing_detections: &[PublicLicenseDetection],
+) -> Vec<PublicLicenseDetection> {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("nix")
+        || !text_content.contains("license =")
+    {
+        return Vec::new();
+    }
+
+    let mut existing_license_keys = collect_detected_license_keys(existing_detections);
+    let mut synthesized = Vec::new();
+
+    for declaration in extract_nix_manifest_license_declarations(text_content) {
+        let Some(spdx_expression) = nix_license_symbol_to_spdx(&declaration.symbol) else {
+            continue;
+        };
+        let Some(normalized) = normalize_spdx_expression(spdx_expression) else {
+            continue;
+        };
+        let declared_license_keys =
+            collect_expression_keys(&normalized.declared_license_expression);
+        let declared_spdx_keys =
+            collect_expression_keys(&normalized.declared_license_expression_spdx);
+        let all_declared_keys = declared_license_keys
+            .iter()
+            .chain(declared_spdx_keys.iter())
+            .cloned()
+            .collect::<HashSet<_>>();
+        if !all_declared_keys.is_empty()
+            && all_declared_keys
+                .iter()
+                .all(|key| existing_license_keys.contains(key))
+        {
+            continue;
+        }
+
+        let (_, _, detections) = build_declared_license_data(
+            normalized,
+            DeclaredLicenseMatchMetadata::new(
+                &declaration.matched_text,
+                declaration.start_line,
+                declaration.end_line,
+            ),
+        );
+
+        for key in all_declared_keys {
+            existing_license_keys.insert(key);
+        }
+        synthesized.extend(detections);
+    }
+
+    synthesized
+}
+
+fn collect_detected_license_keys(detections: &[PublicLicenseDetection]) -> HashSet<String> {
+    let mut keys = HashSet::new();
+    for detection in detections {
+        keys.extend(collect_expression_keys(&detection.license_expression));
+        keys.extend(collect_expression_keys(&detection.license_expression_spdx));
+    }
+    keys
+}
+
+fn collect_expression_keys(expression: &str) -> HashSet<String> {
+    parse_expression(expression)
+        .ok()
+        .map(|parsed| {
+            parsed
+                .license_keys()
+                .into_iter()
+                .map(|key| key.to_ascii_lowercase())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn extract_nix_manifest_license_declarations(text: &str) -> Vec<NixLicenseDeclaration> {
+    let mut declarations = Vec::new();
+    let mut in_license_list = false;
+
+    for (index, line) in text.lines().enumerate() {
+        let line_number = LineNumber::new(index + 1).expect("line number should be valid");
+        let line_without_comment = line.split('#').next().unwrap_or("");
+        let trimmed = line_without_comment.trim();
+
+        if in_license_list {
+            let closes_list = trimmed.contains("];");
+            for symbol in tokenize_nix_license_symbols(trimmed) {
+                declarations.push(NixLicenseDeclaration {
+                    matched_text: symbol.clone(),
+                    symbol,
+                    start_line: line_number,
+                    end_line: line_number,
+                });
+            }
+            if closes_list {
+                in_license_list = false;
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("license = lib.licenses.") {
+            if let Some(symbol) = parse_nix_license_symbol(rest) {
+                declarations.push(NixLicenseDeclaration {
+                    matched_text: symbol.clone(),
+                    symbol,
+                    start_line: line_number,
+                    end_line: line_number,
+                });
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("license = with lib.licenses; [") {
+            in_license_list = !trimmed.contains("];");
+            for symbol in tokenize_nix_license_symbols(rest) {
+                declarations.push(NixLicenseDeclaration {
+                    matched_text: symbol.clone(),
+                    symbol,
+                    start_line: line_number,
+                    end_line: line_number,
+                });
+            }
+            if trimmed.contains("];") {
+                in_license_list = false;
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("license = licenses.") {
+            if let Some(symbol) = parse_nix_license_symbol(rest) {
+                declarations.push(NixLicenseDeclaration {
+                    matched_text: format!("licenses.{symbol}"),
+                    symbol,
+                    start_line: line_number,
+                    end_line: line_number,
+                });
+            }
+            continue;
+        }
+    }
+
+    declarations
+}
+
+fn parse_nix_license_symbol(input: &str) -> Option<String> {
+    let mut symbol = String::new();
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '+' | '-') {
+            symbol.push(ch);
+        } else {
+            break;
+        }
+    }
+    (!symbol.is_empty()).then_some(symbol)
+}
+
+fn tokenize_nix_license_symbols(input: &str) -> Vec<String> {
+    input
+        .split_whitespace()
+        .filter_map(parse_nix_license_symbol)
+        .collect()
+}
+
+fn nix_license_symbol_to_spdx(symbol: &str) -> Option<&'static str> {
+    match symbol {
+        "asl20" => Some("Apache-2.0"),
+        "bsd2" => Some("BSD-2-Clause"),
+        "bsd3" => Some("BSD-3-Clause"),
+        "gpl1Only" => Some("GPL-1.0-only"),
+        "gpl1Plus" => Some("GPL-1.0-or-later"),
+        "gpl2" | "gpl2Only" => Some("GPL-2.0-only"),
+        "gpl2Plus" => Some("GPL-2.0-or-later"),
+        "gpl3" | "gpl3Only" => Some("GPL-3.0-only"),
+        "gpl3Plus" => Some("GPL-3.0-or-later"),
+        "lgpl21" => Some("LGPL-2.1-only"),
+        "lgpl21Plus" => Some("LGPL-2.1-or-later"),
+        "lgpl3" => Some("LGPL-3.0-only"),
+        "lgpl3Plus" => Some("LGPL-3.0-or-later"),
+        "mit" => Some("MIT"),
+        "mpl11" => Some("MPL-1.1"),
+        "mpl20" => Some("MPL-2.0"),
+        _ => None,
+    }
 }
 
 fn is_license_detection_timeout_error(error: &Error) -> bool {

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -299,6 +299,46 @@ fn test_convert_detection_to_model_promotes_exact_reference_url_clue() {
 }
 
 #[test]
+fn test_supplement_nix_manifest_license_detections_adds_missing_singleton_symbol() {
+    let detections = super::supplement_nix_manifest_license_detections(
+        std::path::Path::new("package.nix"),
+        "meta = {\n  license = lib.licenses.asl20;\n};\n",
+        &[],
+    );
+
+    assert_eq!(detections.len(), 1);
+    assert_eq!(detections[0].license_expression_spdx, "Apache-2.0");
+    assert_eq!(
+        detections[0].matches[0].start_line,
+        LineNumber::new(2).unwrap()
+    );
+}
+
+#[test]
+fn test_supplement_nix_manifest_license_detections_adds_only_missing_browser_symbol() {
+    let existing = vec![crate::models::LicenseDetection {
+        license_expression: "lgpl-2.1-plus AND lgpl-3.0-plus".to_string(),
+        license_expression_spdx: "LGPL-2.1-or-later AND LGPL-3.0-or-later".to_string(),
+        matches: vec![],
+        detection_log: vec![],
+        identifier: None,
+    }];
+
+    let detections = super::supplement_nix_manifest_license_detections(
+        std::path::Path::new("package.nix"),
+        "meta = {\n  license = with lib.licenses; [\n    mpl20\n    lgpl21Plus\n    lgpl3Plus\n    free\n  ];\n};\n",
+        &existing,
+    );
+
+    assert_eq!(detections.len(), 1);
+    assert_eq!(detections[0].license_expression_spdx, "MPL-2.0");
+    assert_eq!(
+        detections[0].matches[0].start_line,
+        LineNumber::new(3).unwrap()
+    );
+}
+
+#[test]
 fn test_promote_legal_notice_low_quality_detections_promotes_apache_notice_fragment() {
     let concrete = InternalLicenseDetection {
         license_expression: Some("cve-tou".to_string()),

--- a/testdata/assembly-golden/cargo-basic/expected.json
+++ b/testdata/assembly-golden/cargo-basic/expected.json
@@ -31,6 +31,19 @@
       "scope": null
     },
     {
+      "datafile_path": "Cargo.lock",
+      "datasource_id": "cargo_lock",
+      "dependency_uid": "pkg:cargo/test-crate@0.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "extracted_requirement": "0.1.0",
+      "for_package_uid": "pkg:cargo/test-crate@0.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "is_direct": true,
+      "is_optional": null,
+      "is_pinned": true,
+      "is_runtime": null,
+      "purl": "pkg:cargo/test-crate@0.1.0",
+      "scope": null
+    },
+    {
       "datafile_path": "Cargo.toml",
       "datasource_id": "cargo_toml",
       "dependency_uid": "pkg:cargo/tokio?uuid=fixed-uid-done-for-testing-5642512d1758",

--- a/testdata/cargo-golden/lock-basic/Cargo.lock.expected
+++ b/testdata/cargo-golden/lock-basic/Cargo.lock.expected
@@ -52,6 +52,19 @@
           "checksum": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
           "source": "registry+https://github.com/rust-lang/crates.io-index"
         }
+      },
+      {
+        "purl": "pkg:cargo/test-project@0.1.0",
+        "extracted_requirement": "0.1.0",
+        "scope": null,
+        "is_runtime": null,
+        "is_optional": null,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": {
+          "checksum": "abc123def456"
+        }
       }
     ],
     "repository_homepage_url": null,

--- a/testdata/cargo-golden/lock-dedup/Cargo.lock.expected
+++ b/testdata/cargo-golden/lock-dedup/Cargo.lock.expected
@@ -15,6 +15,15 @@
         "is_direct": true
       },
       {
+        "purl": "pkg:cargo/my-app@0.4.0",
+        "extracted_requirement": "0.4.0",
+        "scope": null,
+        "is_runtime": null,
+        "is_optional": null,
+        "is_pinned": true,
+        "is_direct": true
+      },
+      {
         "purl": "pkg:cargo/serde@1.0.228",
         "extracted_requirement": "1.0.228",
         "scope": null,

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -70,7 +70,7 @@ CLI arguments:
 
 1. Either scans a local directory passed via `--target-path` or resolves `--repo-url` + `--repo-ref` through a shared repo cache.
 2. Builds Provenant in release mode.
-3. Updates or creates a shared cached mirror under `.provenant/repo-cache/`, resolves the requested ref to a full commit SHA, and materializes a detached checkout for the run.
+3. Updates or creates a shared shallow repo cache under `.provenant/repo-cache/`, fetches only the requested ref at depth 1, resolves it to a full commit SHA, and materializes a detached checkout for the run.
 4. Runs cold/warm scenarios with isolated cache roots while forwarding the requested Provenant scan flags unchanged.
 5. Writes a run manifest plus benchmark results under `.provenant/benchmarks/`.
 6. Prints a summary table with wall time, key phase timings, peak RSS, and incremental reuse signals.
@@ -145,7 +145,7 @@ CLI arguments:
 1. Creates a per-run artifact directory under `.provenant/compare-runs/`.
 2. Either scans the local directory in place or resolves `--repo-url` + `--repo-ref` through a shared repo cache.
 3. Builds Provenant in release mode.
-4. Updates or creates a shared cached mirror under `.provenant/repo-cache/`, resolves the requested ref to a full commit SHA, and materializes a detached checkout for the run.
+4. Updates or creates a shared shallow repo cache under `.provenant/repo-cache/`, fetches only the requested ref at depth 1, resolves it to a full commit SHA, and materializes a detached checkout for the run.
 5. Resolves the ScanCode runtime identity and, on cache misses, ensures a local Docker-backed ScanCode runtime exists by building the image from `reference/scancode-toolkit` if needed.
 6. Reuses cached ScanCode raw artifacts when available, otherwise runs ScanCode alongside Provenant with the same shared scan profile and ephemeral license-cache directories.
 7. Saves raw outputs and logs under `raw/`.
@@ -181,7 +181,7 @@ Optional diagnostic logs when available:
 - For `--profile common`, the ScanCode Docker invocation also adds `--memory 12g --memory-swap 12g`, and that runtime cap is part of ScanCode cache validation.
 - `--repo-url` mode requires `--repo-ref`; the command records both the requested ref and the resolved full commit SHA in `run-manifest.json`.
 - `run-manifest.json` also records the Provenant binary version plus the current Provenant repository revision, dirty state, and diff hash, alongside the ScanCode runtime identity.
-- Repo URL runs reuse cached git objects from `.provenant/repo-cache/`, and the temporary detached checkout is removed after the run so compare artifacts do not retain duplicate full repository trees.
+- Repo URL runs reuse cached git objects from `.provenant/repo-cache/`, fetch only the requested ref shallowly, and remove the temporary detached checkout after the run so compare artifacts do not retain duplicate full repository trees.
 - Repo URL runs also reuse cached raw ScanCode artifacts from `.provenant/scancode-cache/` when the resolved target commit, ScanCode runtime identity, and effective ScanCode scan args are unchanged.
 - Local `--target-path` runs rerun ScanCode by default. Pass `--scancode-cache-identity <id>` to opt into shared ScanCode raw-artifact reuse for a local snapshot you have identified explicitly.
 - For local target-path cache hits, the **path itself is not the cache identity**. The cache key is derived from your explicit `--scancode-cache-identity` plus the effective ScanCode runtime/args, so reusing the same identity across different local paths will intentionally hit the same cache entry when the staged snapshot is meant to be the same.

--- a/xtask/src/bin/benchmark_target.rs
+++ b/xtask/src/bin/benchmark_target.rs
@@ -280,7 +280,7 @@ fn prepare_target_checkout(context: &BenchContext, args: &Args) -> Result<Checko
     let repo_ref = args.repo_ref.as_deref().unwrap();
     let cache_dir = context.repo_manifest.cache_dir.as_ref().unwrap();
     println!("  Updating repo cache: {}", cache_dir.display());
-    ensure_repo_mirror(repo_url, cache_dir)?;
+    ensure_repo_mirror(repo_url, repo_ref, cache_dir)?;
     let resolved_sha = resolve_repo_ref_to_sha(cache_dir, repo_ref)?;
     println!("  Resolved {repo_ref} -> {resolved_sha}");
     println!(

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -508,7 +508,7 @@ fn prepare_target(context: &mut ContextState, args: &Args) -> Result<CheckoutGua
     let repo_ref = args.repo_ref.as_deref().unwrap();
     let cache_dir = context.repo_manifest.cache_dir.clone().unwrap();
     println!("  Updating repo cache: {}", cache_dir.display());
-    ensure_repo_mirror(repo_url, &cache_dir)?;
+    ensure_repo_mirror(repo_url, repo_ref, &cache_dir)?;
     let resolved_sha = resolve_repo_ref_to_sha(&cache_dir, repo_ref)?;
     println!("  Resolved {repo_ref} -> {resolved_sha}");
     println!(

--- a/xtask/src/repo_cache.rs
+++ b/xtask/src/repo_cache.rs
@@ -10,6 +10,8 @@ use sha2::{Digest, Sha256};
 
 use crate::common::{derive_repo_name_from_url, sanitize_label};
 
+const SHALLOW_FETCH_DEPTH: &str = "1";
+
 pub fn repo_cache_root(project_root: &Path) -> PathBuf {
     project_root.join(".provenant/repo-cache")
 }
@@ -29,59 +31,89 @@ pub fn repo_cache_path(project_root: &Path, repo_url: &str) -> PathBuf {
     ))
 }
 
-pub fn ensure_repo_mirror(repo_url: &str, cache_dir: &Path) -> Result<()> {
+pub fn ensure_repo_mirror(repo_url: &str, repo_ref: &str, cache_dir: &Path) -> Result<()> {
     if let Some(parent) = cache_dir.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create repo-cache root: {}", parent.display()))?;
     }
     if !cache_dir.exists() {
         run_git(
-            Command::new("git")
-                .args(["clone", "--mirror", repo_url])
-                .arg(cache_dir),
-            "failed to clone mirror",
+            Command::new("git").args(["init", "--bare"]).arg(cache_dir),
+            "failed to initialize repo cache",
         )?;
-        return Ok(());
     }
-    run_git(
-        Command::new("git")
-            .arg(format!("--git-dir={}", cache_dir.display()))
-            .args(["remote", "update", "--prune"]),
-        "failed to update mirror",
-    )
+    ensure_repo_remote(cache_dir, repo_url)?;
+    fetch_repo_ref_shallow(cache_dir, repo_ref)
 }
 
 pub fn resolve_repo_ref_to_sha(cache_dir: &Path, repo_ref: &str) -> Result<String> {
-    let candidates = [
-        format!("{repo_ref}^{{commit}}"),
-        format!("refs/heads/{repo_ref}^{{commit}}"),
-        format!("refs/tags/{repo_ref}^{{commit}}"),
-        format!("refs/remotes/origin/{repo_ref}^{{commit}}"),
-    ];
-
-    for candidate in &candidates {
-        if let Ok(sha) = git_output(cache_dir, ["rev-parse", "--verify", candidate.as_str()]) {
-            return Ok(sha.trim().to_string());
-        }
-    }
-
-    let _ = run_git(
-        Command::new("git")
-            .arg(format!("--git-dir={}", cache_dir.display()))
-            .args(["fetch", "--prune", "origin", repo_ref]),
-        "failed to fetch requested ref",
-    );
-
-    for candidate in &candidates {
-        if let Ok(sha) = git_output(cache_dir, ["rev-parse", "--verify", candidate.as_str()]) {
-            return Ok(sha.trim().to_string());
-        }
+    if let Some(sha) = resolve_repo_ref_locally(cache_dir, repo_ref) {
+        return Ok(sha);
     }
 
     bail!(
         "unable to resolve repo ref '{repo_ref}' in cache {}",
         cache_dir.display()
     )
+}
+
+fn ensure_repo_remote(cache_dir: &Path, repo_url: &str) -> Result<()> {
+    let git_dir_arg = format!("--git-dir={}", cache_dir.display());
+    let set_url_output = Command::new("git")
+        .arg(&git_dir_arg)
+        .args(["remote", "set-url", "origin", repo_url])
+        .output()
+        .context("failed to configure repo-cache remote")?;
+    if set_url_output.status.success() {
+        return Ok(());
+    }
+
+    let add_origin_output = Command::new("git")
+        .arg(&git_dir_arg)
+        .args(["remote", "add", "origin", repo_url])
+        .output()
+        .context("failed to add repo-cache remote")?;
+    if add_origin_output.status.success() {
+        return Ok(());
+    }
+
+    bail!(
+        "failed to configure repo-cache remote: {} ; {}",
+        String::from_utf8_lossy(&set_url_output.stderr).trim(),
+        String::from_utf8_lossy(&add_origin_output.stderr).trim()
+    )
+}
+
+fn fetch_repo_ref_shallow(cache_dir: &Path, repo_ref: &str) -> Result<()> {
+    run_git(
+        Command::new("git")
+            .arg(format!("--git-dir={}", cache_dir.display()))
+            .args([
+                "fetch",
+                "--prune",
+                "--depth",
+                SHALLOW_FETCH_DEPTH,
+                "origin",
+                repo_ref,
+            ]),
+        "failed to fetch requested ref shallowly",
+    )
+}
+
+fn resolve_repo_ref_locally(cache_dir: &Path, repo_ref: &str) -> Option<String> {
+    let candidates = [
+        format!("{repo_ref}^{{commit}}"),
+        format!("refs/heads/{repo_ref}^{{commit}}"),
+        format!("refs/tags/{repo_ref}^{{commit}}"),
+        format!("refs/remotes/origin/{repo_ref}^{{commit}}"),
+        "FETCH_HEAD^{commit}".to_string(),
+    ];
+
+    candidates.iter().find_map(|candidate| {
+        git_output(cache_dir, ["rev-parse", "--verify", candidate.as_str()])
+            .ok()
+            .map(|sha| sha.trim().to_string())
+    })
 }
 
 pub fn prepare_repo_worktree(
@@ -238,6 +270,52 @@ mod tests {
         temp_dir
     }
 
+    fn git_output(dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn git_dir_output(git_dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .arg(format!("--git-dir={}", git_dir.display()))
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git --git-dir={} {:?} failed: {}",
+            git_dir.display(),
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit_file(dir: &Path, name: &str, contents: &str, message: &str) -> String {
+        fs::write(dir.join(name), contents).unwrap();
+        git(dir, &["add", name]);
+        git(dir, &["commit", "-m", message]);
+        git_output(dir, &["rev-parse", "HEAD"])
+    }
+
+    fn current_branch(dir: &Path) -> String {
+        git_output(dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+    }
+
+    fn file_repo_url(path: &Path) -> String {
+        format!("file://{}", path.display())
+    }
+
     #[test]
     fn git_helpers_accept_repo_root() {
         let temp_dir = init_test_repo();
@@ -254,5 +332,43 @@ mod tests {
 
         assert!(current_git_revision(&nested).is_none());
         assert!(current_git_log_line(&nested).is_none());
+    }
+
+    #[test]
+    fn ensure_repo_mirror_fetches_branch_tip_shallowly() {
+        let remote = init_test_repo();
+        let branch = current_branch(remote.path());
+        let latest_sha = commit_file(remote.path(), "CHANGELOG.md", "next\n", "second");
+
+        let cache_root = TempDir::new().unwrap();
+        let cache_dir = cache_root.path().join("branch-cache.git");
+
+        ensure_repo_mirror(&file_repo_url(remote.path()), &branch, &cache_dir).unwrap();
+
+        let resolved_sha = resolve_repo_ref_to_sha(&cache_dir, &branch).unwrap();
+        assert_eq!(resolved_sha, latest_sha);
+        assert_eq!(
+            git_dir_output(&cache_dir, &["rev-list", "--count", "FETCH_HEAD"]),
+            "1"
+        );
+    }
+
+    #[test]
+    fn ensure_repo_mirror_fetches_pinned_commit_shallowly() {
+        let remote = init_test_repo();
+        let first_sha = git_output(remote.path(), &["rev-parse", "HEAD"]);
+        commit_file(remote.path(), "CHANGELOG.md", "next\n", "second");
+
+        let cache_root = TempDir::new().unwrap();
+        let cache_dir = cache_root.path().join("sha-cache.git");
+
+        ensure_repo_mirror(&file_repo_url(remote.path()), &first_sha, &cache_dir).unwrap();
+
+        let resolved_sha = resolve_repo_ref_to_sha(&cache_dir, &first_sha).unwrap();
+        assert_eq!(resolved_sha, first_sha);
+        assert_eq!(
+            git_dir_output(&cache_dir, &["rev-list", "--count", "FETCH_HEAD"]),
+            "1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- fetch compare targets shallowly so pinned-SHA verification avoids cloning full repository history
- keep large license scans stack-safe and retain exact SPDX-id detections in deep structured metadata
- surface Composer lock packages, keep Cargo.lock root package identities visible, and supplement explicit Nix `meta.license` symbols so nixpkgs compare-output parity improves on real lockfile and manifest-driven samples
- refresh the recorded Nix benchmarks and chart from the latest verified compare runs

## Issues

- Covers: Nix ecosystem verification refresh in `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md`

## Scope and exclusions

- Included:
  - repository-backed compare runs for:
    - `NixOS/nixpkgs @ c4073437f5ffeaeee270c37a2eddf370658d1332`
    - `NixOS/nix @ 6a659e16bd2bcd871aedcb38724a1cff77690a31`
    - `numtide/devshell @ 255a2b1725a20d060f566e4755dbf571bbbb5f76`
  - targeted compare diagnostics for representative samples including:
    - `providers.json`
    - `flarum/composer.lock`
    - `prefetch-npm-deps/Cargo.lock`
    - `mullvad-browser/package.nix`
    - `tor-browser/package.nix`
    - `gremlin-console/package.nix`
    - `autoconf-archive/package.nix`
    - `gnushogi/package.nix`
- Explicit exclusions:
  - no parser-specific golden fixture updates
  - no scorecard note rewrites
  - no attempt to force the remaining low-confidence ScanCode composite-expression tail into parity when the file contents do not support those richer expressions

## Intentional differences from Python

- Provenant now keeps explicit SPDX-id detections deep in structured metadata instead of dropping them to the late-line false-positive heuristic when the file content is an exact identifier rather than weak prose.
- Provenant surfaces versioned Composer package identities from lockfiles where ScanCode often keeps unversioned identities, which is a more specific end-state rather than a missing-package condition.

## Follow-up work

- Created or intentionally deferred:
  - the remaining nixpkgs package/dependency tail is now much smaller and is concentrated in residual Composer identity-shape differences plus a small set of low-confidence license-tail cases outside the manifest-driven fixes in this branch

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no expected-output fixtures changed
