### PR TITLE
docs(parsers): keep compile-only API examples

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -104,9 +104,6 @@ jobs:
       - name: Check compilation
         run: cargo check --all --verbose
 
-      - name: Run doctests
-        run: cargo test --doc --profile ci-release --verbose
-
       - name: Check dependency policy
         uses: EmbarkStudios/cargo-deny-action@44db170f6a7d12a6e90340e9e0fca1f650d34b14
         with:

--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -816,11 +816,8 @@ fn is_year_only_copy_marker_line(prepared: &str) -> bool {
 ///
 /// Only strips if the parentheses are truly wrapping (no inner parens).
 ///
-/// # Examples
-/// ```ignore
-/// assert_eq!(strip_balanced_edge_parens("(Hello World)"), "Hello World");
-/// assert_eq!(strip_balanced_edge_parens("(Hello (World)"), "(Hello (World)");
-/// ```
+/// For example, `(Hello World)` unwraps to `Hello World`, while unbalanced
+/// input such as `(Hello (World)` is left unchanged.
 pub fn strip_balanced_edge_parens(s: &str) -> &str {
     if s.starts_with('(') && s.ends_with(')') {
         let inner = &s[1..s.len() - 1];

--- a/src/license_detection/expression/parse.rs
+++ b/src/license_detection/expression/parse.rs
@@ -35,12 +35,8 @@ pub(super) enum Token {
 /// # Returns
 /// Ok with parsed LicenseExpression, or Err with ParseError
 ///
-/// # Examples
-/// ```
-/// use provenant::license_detection::expression::parse_expression;
-///
-/// let expr = parse_expression("MIT AND Apache-2.0").unwrap();
-/// ```
+/// For example, `parse_expression("MIT AND Apache-2.0")` parses a simple
+/// conjunction expression.
 pub fn parse_expression(expr: &str) -> Result<LicenseExpression, ParseError> {
     let trimmed = expr.trim();
     if trimmed.is_empty() {

--- a/src/license_detection/spdx_mapping/mod.rs
+++ b/src/license_detection/spdx_mapping/mod.rs
@@ -82,28 +82,9 @@ impl SpdxMapping {
     /// # Returns
     /// String containing the expression with SPDX keys, or parse error
     ///
-    /// # Example
-    /// ```
-    /// use provenant::license_detection::spdx_mapping::build_spdx_mapping;
-    /// use provenant::license_detection::models::License;
-    ///
-    /// let licenses = vec![
-    ///     License {
-    ///         key: "mit".to_string(),
-    ///         name: "MIT License".to_string(),
-    ///         spdx_license_key: Some("MIT".to_string()),
-    ///         ..Default::default()
-    ///     },
-    ///     License {
-    ///         key: "gpl-2.0-plus".to_string(),
-    ///         name: "GPL 2.0+".to_string(),
-    ///         ..Default::default()
-    ///     },
-    /// ];
-    /// let mapping = build_spdx_mapping(&licenses);
-    /// let spdx_expr = mapping.expression_scancode_to_spdx("mit OR gpl-2.0-plus").unwrap();
-    /// assert_eq!(spdx_expr, "LicenseRef-scancode-gpl-2.0-plus OR MIT");
-    /// ```
+    /// Example: if `mit` maps to SPDX `MIT` and `gpl-2.0-plus` has no SPDX key,
+    /// then `mit OR gpl-2.0-plus` becomes
+    /// `LicenseRef-scancode-gpl-2.0-plus OR MIT`.
     pub fn expression_scancode_to_spdx(&self, scancode_expr: &str) -> Result<String, String> {
         let parsed = parse_expression(scancode_expr).map_err(|e| format!("Parse error: {}", e))?;
         let converted = simplify_expression(&self.convert_expression_to_spdx(&parsed));

--- a/src/license_detection/tokenize.rs
+++ b/src/license_detection/tokenize.rs
@@ -236,14 +236,7 @@ pub fn count_tokens(text: &str) -> usize {
 /// A vector of Range<usize> representing token positions for each required phrase.
 /// Empty vector if no valid required phrases found.
 ///
-/// # Examples
-/// ```
-/// use provenant::license_detection::tokenize::parse_required_phrase_spans;
-///
-/// let text = "This is {{enclosed}} in braces";
-/// let spans = parse_required_phrase_spans(text);
-/// assert_eq!(spans, vec![2..3]);
-/// ```
+/// Example: `This is {{enclosed}} in braces` yields `vec![2..3]`.
 ///
 /// Based on Python: `get_existing_required_phrase_spans()` in tokenize.py:122-174
 pub fn parse_required_phrase_spans(text: &str) -> Vec<Range<usize>> {

--- a/src/models/datasource_id.rs
+++ b/src/models/datasource_id.rs
@@ -22,15 +22,8 @@ use strum::{EnumCount, EnumIter};
 /// Variants serialize to snake_case strings matching the Python reference values.
 /// The JSON output is identical to the Python ScanCode Toolkit.
 ///
-/// # Examples
-///
-/// ```ignore
-/// use provenant::models::DatasourceId;
-///
-/// let id = DatasourceId::NpmPackageJson;
-/// assert_eq!(id.as_ref(), "npm_package_json");
-/// assert_eq!(id.to_string(), "npm_package_json");
-/// ```
+/// For example, `DatasourceId::NpmPackageJson` formats as
+/// `npm_package_json` for both `AsRef<str>` and `Display`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, EnumCount, EnumIter)]
 #[serde(rename_all = "snake_case")]
 pub enum DatasourceId {

--- a/src/models/package_type.rs
+++ b/src/models/package_type.rs
@@ -28,15 +28,8 @@ use std::str::FromStr;
 /// Python reference values. The JSON output is identical to the
 /// Python ScanCode Toolkit.
 ///
-/// # Examples
-///
-/// ```ignore
-/// use provenant::models::PackageType;
-///
-/// let pt = PackageType::Npm;
-/// assert_eq!(pt.as_ref(), "npm");
-/// assert_eq!(pt.to_string(), "npm");
-/// ```
+/// For example, `PackageType::Npm` formats as `npm` for both `AsRef<str>` and
+/// `Display`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PackageType {

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -664,11 +664,8 @@ fn looks_like_conda_environment_yaml(yaml: &Value) -> bool {
 
 /// Extract Jinja2-style variables from a Conda meta.yaml
 ///
-/// Example:
-/// ```ignore
-/// {% set version = "0.45.0" %}
-/// {% set sha256 = "abc123..." %}
-/// ```
+/// For example, lines like `{% set version = "0.45.0" %}` and
+/// `{% set sha256 = "abc123..." %}` are captured as variables.
 pub fn extract_jinja2_variables(content: &str) -> HashMap<String, String> {
     let mut variables = HashMap::new();
 

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -61,15 +61,9 @@ use super::license_normalization::{
 /// - Easier maintenance for DSL-specific quirks
 /// - Better error messages for malformed input
 ///
-/// # Example
-/// ```no_run
-/// use provenant::parsers::{GradleParser, PackageParser};
-/// use std::path::Path;
-///
-/// let path = Path::new("testdata/gradle-golden/groovy1/build.gradle");
-/// let package_data = GradleParser::extract_first_package(path);
-/// assert!(!package_data.dependencies.is_empty());
-/// ```
+/// Typical usage is calling `GradleParser::extract_first_package()` on a
+/// `build.gradle` or `build.gradle.kts` file and then inspecting the returned
+/// dependency list.
 pub struct GradleParser;
 
 impl PackageParser for GradleParser {

--- a/src/parsers/metadata.rs
+++ b/src/parsers/metadata.rs
@@ -29,7 +29,9 @@ inventory::collect!(ParserMetadata);
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use provenant::register_parser;
+///
 /// register_parser!(
 ///     "npm package.json manifest",
 ///     &["**/package.json"],

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -466,7 +466,7 @@ macro_rules! parser_warn {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use provenant::models::{PackageData, PackageType};
 /// use provenant::parsers::PackageParser;
 /// use std::path::Path;

--- a/src/parsers/rfc822.rs
+++ b/src/parsers/rfc822.rs
@@ -63,14 +63,8 @@ pub struct Rfc822Metadata {
 ///
 /// An `Rfc822Metadata` struct with parsed headers and body.
 ///
-/// # Examples
-///
-/// ```ignore
-/// let content = "Name: example\nVersion: 1.0\n\nBody text here";
-/// let metadata = parse_rfc822_content(content);
-/// assert_eq!(get_header_first(&metadata.headers, "name"), Some("example".to_string()));
-/// assert_eq!(metadata.body, "Body text here");
-/// ```
+/// For example, parsing `Name: example\nVersion: 1.0\n\nBody text here`
+/// yields `name=example` in the headers and `Body text here` as the body.
 pub fn parse_rfc822_content(content: &str) -> Rfc822Metadata {
     let mut headers: HashMap<String, Vec<String>> = HashMap::new();
     let mut current_name: Option<String> = None;

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -55,11 +55,8 @@ const PACKAGE_TYPE: PackageType = PackageType::Gem;
 /// In Ruby, `.freeze` makes a string immutable. We need to remove this suffix
 /// when parsing gem names and versions from Gemfile.
 ///
-/// # Examples
-/// ```ignore
-/// assert_eq!(strip_freeze_suffix("\"name\".freeze"), "\"name\"");
-/// assert_eq!(strip_freeze_suffix("'1.0.0'.freeze"), "'1.0.0'");
-/// ```
+/// For example, `"name".freeze` becomes `"name"` and `'1.0.0'.freeze`
+/// becomes `'1.0.0'`.
 pub fn strip_freeze_suffix(s: &str) -> &str {
     s.trim_end_matches(".freeze")
 }

--- a/src/parsers/swift_resolved.rs
+++ b/src/parsers/swift_resolved.rs
@@ -33,14 +33,8 @@ use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_f
 /// - Generates namespace from repository URL (e.g., github.com/apple)
 /// - Handles exact versions, branch references, and commit SHAs
 ///
-/// # Example
-/// ```no_run
-/// use provenant::parsers::{PackageParser, SwiftPackageResolvedParser};
-/// use std::path::Path;
-///
-/// let path = Path::new("Package.resolved");
-/// let package_data = SwiftPackageResolvedParser::extract_first_package(path);
-/// ```
+/// Typical usage is calling `SwiftPackageResolvedParser::extract_first_package()`
+/// on a `Package.resolved` or `.package.resolved` file.
 pub struct SwiftPackageResolvedParser;
 
 impl PackageParser for SwiftPackageResolvedParser {

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -43,15 +43,18 @@ pub const MAX_RECURSION_DEPTH: usize = 50;
 ///   indices, `String` for dependency names, `PathBuf` for file paths,
 ///   or `()` for depth-only tracking).
 ///
-/// # Examples
+/// # Example
 ///
 /// ```no_run
 /// use provenant::parsers::utils::RecursionGuard;
 ///
 /// fn walk_tree(idx: usize, guard: &mut RecursionGuard<usize>) {
-///     if guard.exceeded() { return; }
-///     if guard.enter(idx) { return; } // cycle detected
-///     // ... recurse into children ...
+///     if guard.exceeded() {
+///         return;
+///     }
+///     if guard.enter(idx) {
+///         return;
+///     }
 ///     walk_tree(idx + 1, guard);
 ///     guard.leave(idx);
 /// }
@@ -146,15 +149,9 @@ pub fn truncate_field(value: String) -> String {
 /// * `Ok(String)` - File contents as UTF-8 string (lossy if non-UTF-8 bytes found)
 /// * `Err` - File doesn't exist, is too large, or cannot be read
 ///
-/// # Examples
-///
-/// ```no_run
-/// use std::path::Path;
-/// use provenant::parsers::utils::read_file_to_string;
-///
-/// let content = read_file_to_string(Path::new("path/to/file.txt"), None)?;
-/// # Ok::<(), anyhow::Error>(())
-/// ```
+/// Typical usage is `read_file_to_string(path, None)` for the default size
+/// limit, or `read_file_to_string(path, Some(limit))` when a tighter bound is
+/// needed.
 pub fn read_file_to_string(path: &Path, max_size: Option<u64>) -> Result<String> {
     let limit = max_size.unwrap_or(MAX_MANIFEST_SIZE);
 
@@ -255,26 +252,10 @@ pub fn parse_sri(integrity: &str) -> Option<(String, String)> {
 /// - If `\<email\>` pattern found: name (trimmed, or None if empty) and email
 /// - If no pattern: trimmed input as name, None for email
 ///
-/// # Examples
-///
-/// ```
-/// use provenant::parsers::utils::split_name_email;
-///
-/// // Full format
-/// let (name, email) = split_name_email("John Doe <john@example.com>");
-/// assert_eq!(name, Some("John Doe".to_string()));
-/// assert_eq!(email, Some("john@example.com".to_string()));
-///
-/// // Email only in angle brackets
-/// let (name, email) = split_name_email("<john@example.com>");
-/// assert_eq!(name, None);
-/// assert_eq!(email, Some("john@example.com".to_string()));
-///
-/// // Name only (no angle brackets)
-/// let (name, email) = split_name_email("John Doe");
-/// assert_eq!(name, Some("John Doe".to_string()));
-/// assert_eq!(email, None);
-/// ```
+/// Examples: `John Doe <john@example.com>` becomes `(Some("John Doe"),
+/// Some("john@example.com"))`, `<john@example.com>` becomes `(None,
+/// Some("john@example.com"))`, and `John Doe` becomes
+/// `(Some("John Doe"), None)`.
 pub fn split_name_email(s: &str) -> (Option<String>, Option<String>) {
     if let Some(email_start) = s.find('<')
         && let Some(email_end) = s.find('>')
@@ -300,6 +281,48 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_recursion_guard_tracks_depth_and_cycles() {
+        let mut guard = RecursionGuard::new();
+
+        assert_eq!(guard.depth(), 0);
+        assert!(!guard.exceeded());
+
+        assert!(!guard.enter("root"));
+        assert_eq!(guard.depth(), 1);
+        assert!(!guard.enter("child"));
+        assert_eq!(guard.depth(), 2);
+
+        assert!(guard.enter("root"));
+        assert_eq!(guard.depth(), 2);
+
+        guard.leave("child");
+        assert_eq!(guard.depth(), 1);
+        guard.leave("root");
+        assert_eq!(guard.depth(), 0);
+        assert!(!guard.exceeded());
+    }
+
+    #[test]
+    fn test_recursion_guard_depth_limit_and_depth_only_mode() {
+        let mut guard = RecursionGuard::<()>::depth_only();
+
+        for _ in 0..MAX_RECURSION_DEPTH {
+            assert!(!guard.descend());
+        }
+
+        assert_eq!(guard.depth(), MAX_RECURSION_DEPTH);
+        assert!(!guard.exceeded());
+
+        assert!(guard.descend());
+        assert_eq!(guard.depth(), MAX_RECURSION_DEPTH + 1);
+        assert!(guard.exceeded());
+
+        guard.ascend();
+        assert_eq!(guard.depth(), MAX_RECURSION_DEPTH);
+        assert!(!guard.exceeded());
+    }
 
     #[test]
     fn test_read_file_to_string_success() {


### PR DESCRIPTION
## Summary

- replace redundant doctests across parser and model docs with prose examples, while keeping the `PackageParser`, `RecursionGuard`, and `register_parser!` snippets as `no_run` examples
- add direct `RecursionGuard` unit tests so its behavior stays covered by normal tests instead of documentation snippets
- remove the dedicated doctest CI step from `.github/workflows/check.yml` now that doctests are no longer being used as meaningful test coverage

## Issues

- Covers:
- Closes:

## Scope and exclusions

- Included: documentation cleanup for former doctests, `RecursionGuard` test coverage, and CI removal of the doctest step
- Explicit exclusions: the unrelated dirty `reference/scancode-toolkit` submodule change in the worktree

## Intentional differences from Python

- None

## Follow-up work

- Created or intentionally deferred: repo docs that still mention doctests were left unchanged because this PR only removes the dedicated CI step and standardizes the remaining examples as compile-only docs

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no golden or expected-output fixtures changed in this branch