### PR TITLE
fix(parsers): require Soong content for Android METADATA matching

### DIFF
--- a/src/parsers/android.rs
+++ b/src/parsers/android.rs
@@ -39,16 +39,71 @@ pub struct AndroidManifestParser;
 pub struct AndroidApkParser;
 pub struct AndroidAabParser;
 
+fn looks_like_android_soong_metadata_content(content: &str) -> bool {
+    let mut saw_named_field = false;
+
+    for line in content.lines().take(40) {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if trimmed.starts_with("//") {
+            return false;
+        }
+
+        if trimmed.starts_with("third_party {")
+            || trimmed.starts_with("third_party{")
+            || trimmed.starts_with("url {")
+            || trimmed.starts_with("url{")
+            || trimmed.starts_with("identifier {")
+            || trimmed.starts_with("identifier{")
+            || trimmed.starts_with("security {")
+            || trimmed.starts_with("security{")
+            || trimmed.starts_with("last_upgrade_date {")
+            || trimmed.starts_with("last_upgrade_date{")
+        {
+            return true;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("license_type:") {
+            let value = value.trim();
+            if !value.is_empty()
+                && value
+                    .chars()
+                    .all(|character| character.is_ascii_uppercase() || character == '_')
+            {
+                return true;
+            }
+        }
+
+        if trimmed.starts_with("name:")
+            || trimmed.starts_with("description:")
+            || trimmed.starts_with("homepage:")
+        {
+            saw_named_field = true;
+        }
+    }
+
+    saw_named_field && content.contains("third_party")
+}
+
 impl PackageParser for AndroidSoongMetadataParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
     fn is_match(path: &Path) -> bool {
-        path.file_name().and_then(|name| name.to_str()) == Some("METADATA")
-            && !path
-                .parent()
-                .and_then(|parent| parent.file_name())
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".dist-info"))
+        if path.file_name().and_then(|name| name.to_str()) != Some("METADATA") {
+            return false;
+        }
+
+        if !path.is_file() {
+            return false;
+        }
+
+        crate::parsers::utils::read_file_to_string(path, Some(MAX_MANIFEST_SIZE))
+            .map(|content| looks_like_android_soong_metadata_content(&content))
+            .unwrap_or(false)
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {

--- a/src/parsers/android_test.rs
+++ b/src/parsers/android_test.rs
@@ -161,6 +161,27 @@ mod tests {
 
     #[test]
     fn test_android_parser_is_match() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let soong_metadata_path = temp_dir.path().join("METADATA");
+        fs::write(
+            &soong_metadata_path,
+            r#"
+third_party {
+  license_type: NOTICE
+}
+"#,
+        )
+        .expect("write soong metadata");
+
+        let python_dist_info = temp_dir.path().join("demo-1.0.0.dist-info");
+        fs::create_dir_all(&python_dist_info).expect("create dist-info dir");
+        let python_metadata_path = python_dist_info.join("METADATA");
+        fs::write(
+            &python_metadata_path,
+            "Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\nSummary: demo\n",
+        )
+        .expect("write python metadata");
+
         let (_apk_dir, apk_path) = create_zip(
             &[
                 ("AndroidManifest.xml", &decode_binary_manifest_fixture()),
@@ -176,12 +197,8 @@ mod tests {
             "sample.aab",
         );
 
-        assert!(AndroidSoongMetadataParser::is_match(&PathBuf::from(
-            "vendor/fmt/METADATA"
-        )));
-        assert!(!AndroidSoongMetadataParser::is_match(&PathBuf::from(
-            "site-packages/demo-1.0.0.dist-info/METADATA"
-        )));
+        assert!(AndroidSoongMetadataParser::is_match(&soong_metadata_path));
+        assert!(!AndroidSoongMetadataParser::is_match(&python_metadata_path));
         assert!(AndroidManifestParser::is_match(&PathBuf::from(
             "app/src/main/AndroidManifest.xml"
         )));
@@ -191,6 +208,38 @@ mod tests {
         let broken_apk = apk_path.with_file_name("broken.apk");
         fs::write(&broken_apk, b"not a zip archive").expect("write broken apk");
         assert!(!AndroidApkParser::is_match(&broken_apk));
+    }
+
+    #[test]
+    fn test_soong_metadata_match_requires_soong_like_content() {
+        let temp_dir = TempDir::new().expect("temp dir");
+
+        let soong_path = temp_dir.path().join("METADATA");
+        fs::write(
+            &soong_path,
+            r#"
+third_party {
+  license_type: NOTICE
+}
+"#,
+        )
+        .expect("write soong metadata");
+        assert!(AndroidSoongMetadataParser::is_match(&soong_path));
+
+        let generic_path = temp_dir.path().join("generic-METADATA");
+        fs::create_dir_all(&generic_path).expect("create generic metadata dir");
+        let generic_path = generic_path.join("METADATA");
+        fs::write(
+            &generic_path,
+            r#"
+name: "demo"
+description: "not actually soong"
+"#,
+        )
+        .expect("write generic metadata");
+
+        assert!(!AndroidSoongMetadataParser::is_match(&generic_path));
+        assert!(try_parse_file(&generic_path).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require Soong-specific content signals before claiming bare `METADATA` files
- stop generic or Python-style metadata files from emitting Android Soong parse warnings
- add regression coverage for real Soong, `.dist-info/METADATA`, and generic non-Soong metadata

## Scope and exclusions

- Included: Android Soong `METADATA` matching in `src/parsers/android.rs` and its regression coverage in `src/parsers/android_test.rs`
- Explicit exclusions: no broader cross-ecosystem `METADATA` routing changes and no expected-output fixture updates

## Intentional differences from Python

- None. This only narrows when Provenant routes `METADATA` files into the Android Soong parser.

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: valid Soong files still parse the same way; only false-positive parser claiming and warning noise are reduced.
