### PR TITLE
fix: preserve downstream Rust compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
       "automerge": false,
       "groupName": "Rust toolchain",
       "labels": ["dependencies", "rust-toolchain"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "30 days"
     },
     {
       "description": "Automerge minor Rust toolchain updates after release age",
@@ -72,7 +72,7 @@
       "automerge": true,
       "groupName": "Rust toolchain",
       "labels": ["dependencies", "rust-toolchain"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "30 days"
     },
     {
       "description": "Only update engines field for major Node.js versions",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.94.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/copyright/detector/tree_walk/author.rs
+++ b/src/copyright/detector/tree_walk/author.rs
@@ -9,7 +9,7 @@ use crate::copyright::refiner::{is_junk_copyright, refine_author};
 use crate::copyright::types::{AuthorDetection, ParseNode, PosTag, Token, TreeLabel};
 use crate::models::LineNumber;
 
-use super::super as detector;
+use crate::copyright::detector;
 
 pub(super) fn extract_sectioned_authors_from_author_node(
     node: &ParseNode,

--- a/src/copyright/detector/tree_walk/copyright.rs
+++ b/src/copyright/detector/tree_walk/copyright.rs
@@ -6,7 +6,7 @@ use crate::copyright::types::{
 };
 use crate::models::LineNumber;
 
-use super::super as detector;
+use crate::copyright::detector;
 
 fn mpl_portions_created_prefix_tokens<'a>(
     tree: &'a [ParseNode],


### PR DESCRIPTION
## Summary

- replace `use super::super as detector` in the copyright tree-walk modules with explicit crate paths so Rust 1.94.x and Buck2 consumers do not hit keyword path alias parsing failures
- adopt a 30-day Renovate lag for Rust toolchain bumps and pin `rust-toolchain.toml` to `1.94.1` so downstream users are not forced onto the newest stable compiler immediately
- keep the repository policy coherent by making the pinned Rust toolchain match the new lag window today

## Issues

- Covers: downstream integration of Provenant into Buck2 environments pinned to Rust 1.94.1
- Closes:

## Scope and exclusions

- Included: copyright detector import compatibility fix, Rust toolchain Renovate delay, Rust toolchain pin adjustment
- Explicit exclusions: no broader MSRV promise, no previous-stable CI lane, no unrelated parser or CI refactors

## Follow-up work

- Created or intentionally deferred:
  - Renovate can advance to Rust 1.95.0 on or after 2026-05-16 under the 30-day lag policy.