### PR TITLE
fix(assembly): preserve pnpm workspace lockfile dependencies

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 175 of 175 recorded runs, with a **11.5× median speedup** and **10.8× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **17.4×** on 10k+ file targets.
+> Provenant is faster on 176 of 176 recorded runs, with a **11.6× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **17.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -366,6 +366,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `43.05s`; ScanCode `849.10s`
 - Far broader Bun/npm-family package extraction (`382` vs `29` packages, `5773` vs `323` dependencies) from the repo's 52 committed `bun.lock` / `bun.lockb` inputs that ScanCode leaves at zero, plus legacy `bun.lockb` coverage on `bench/bundle` and plainer `BSD-2-Clause` rebucketing where ScanCode uses the over-specific `BSD-2-Clause-Views` label
+
+##### [pnpm/pnpm @ 2a1ffe1](https://github.com/pnpm/pnpm/tree/2a1ffe1956a75746844b1c6cd863ecfbb5a55729) — **21.11× faster**
+
+- Files: 2,887
+- Run context: 2026-04-27 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `16.54s`; ScanCode `349.11s`
+- Broader pnpm/npm monorepo package and dependency extraction (`396` vs `282` packages, `11606` vs `3080` dependencies) from the root `pnpm-lock.yaml`, nested workspace member manifests, and shared workspace `npm-shrinkwrap.json` / `pnpm-lock.yaml` roots, plus zero scan-file errors where ScanCode crashes on the root workspace manifests and catalog-protocol fixture inputs
 
 ##### [renovatebot/renovate @ 91a7213](https://github.com/renovatebot/renovate/tree/91a72131e8aefcda8f0dab7499f378f7eb41300f) — **18.82× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -401,6 +401,9 @@ ScanCode: 394.76s</title></rect>
     <rect x="640.96" y="398.96" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 ScanCode: 127.38s</title></rect>
+    <rect x="641.06" y="351.33" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
+Files: 2887
+ScanCode: 349.11s</title></rect>
     <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
 ScanCode: 223.79s</title></rect>
@@ -928,6 +931,9 @@ Provenant: 16.30s</title></circle>
     <circle cx="644.96" cy="503.26" r="4.5" fill="#2563eb"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 Provenant: 15.25s</title></circle>
+    <circle cx="645.06" cy="499.42" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
+Files: 2887
+Provenant: 16.54s</title></circle>
     <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
 Provenant: 12.29s</title></circle>

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -307,13 +307,11 @@ pub(super) fn apply_npm_workspace_domain(
         .collect();
 
     // Step 5: Handle root dependencies (hoist to workspace level)
-    if let Some(idx) = workspace_domain.root_package_json_idx
-        && !workspace_domain.is_pnpm_with_root_package
-    {
+    if !workspace_domain.is_pnpm_with_root_package {
         remove_root_level_dependencies(dependencies, &workspace_domain.root_dir);
         hoist_root_dependencies(
             files,
-            idx,
+            workspace_domain.root_package_json_idx,
             &workspace_domain.root_dir,
             dependencies,
             &member_versions,
@@ -483,20 +481,13 @@ fn remove_root_package(
     packages: &mut Vec<Package>,
     dependencies: &mut Vec<TopLevelDependency>,
 ) {
-    let root_purl = root_file
-        .package_data
-        .iter()
-        .find(|pkg| pkg.datasource_id == Some(DatasourceId::NpmPackageJson))
-        .and_then(|pkg| pkg.purl.as_ref())
-        .cloned();
-
-    let Some(purl) = root_purl else {
-        return;
-    };
-
     let mut removed_uid = None;
     packages.retain(|pkg| {
-        if pkg.purl.as_ref() == Some(&purl) {
+        if pkg
+            .datafile_paths
+            .iter()
+            .any(|path| path == &root_file.path)
+        {
             removed_uid = Some(pkg.package_uid.clone());
             false
         } else {
@@ -547,11 +538,28 @@ fn create_member_packages(
     members: &[NpmWorkspaceMemberDomain],
 ) -> Vec<(Package, Vec<TopLevelDependency>)> {
     let mut results = Vec::new();
+    let npm_config = npm_family_assembler_config();
 
     for member in members {
-        let file = &files[member.manifest_idx];
+        let member_file_indices: Vec<usize> = files
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, file)| {
+                (Path::new(&file.path).parent() == Some(member.dir_path.as_path())).then_some(idx)
+            })
+            .collect();
 
-        // Find the first valid PackageData
+        if let Some((package, deps, _)) =
+            sibling_merge::assemble_siblings(npm_config, files, &member_file_indices)
+                .into_iter()
+                .next()
+            && let Some(package) = package
+        {
+            results.push((package, deps));
+            continue;
+        }
+
+        let file = &files[member.manifest_idx];
         let pkg_data = if let Some(pkg) = file.package_data.iter().find(|pkg| {
             pkg.datasource_id == Some(DatasourceId::NpmPackageJson) && pkg.purl.is_some()
         }) {
@@ -565,7 +573,6 @@ fn create_member_packages(
         let package = Package::from_package_data(pkg_data, datafile_path.clone());
         let for_package_uid = Some(package.package_uid.clone());
 
-        // Collect dependencies
         let deps: Vec<TopLevelDependency> = pkg_data
             .dependencies
             .iter()
@@ -592,44 +599,40 @@ fn create_member_packages(
 /// If None, deps are workspace-level with no owning package.
 fn hoist_root_dependencies(
     files: &[FileInfo],
-    root_idx: usize,
+    root_idx: Option<usize>,
     root_dir: &Path,
     dependencies: &mut Vec<TopLevelDependency>,
     member_versions: &HashMap<String, String>,
     for_package_uid: Option<PackageUid>,
 ) {
-    let root_file = &files[root_idx];
+    if let Some(root_idx) = root_idx {
+        let root_file = &files[root_idx];
 
-    // Find root PackageData
-    let root_pkg_data = if let Some(pkg) = root_file
-        .package_data
-        .iter()
-        .find(|pkg| pkg.datasource_id == Some(DatasourceId::NpmPackageJson))
-    {
-        pkg
-    } else {
-        return;
-    };
+        if let Some(root_pkg_data) = root_file
+            .package_data
+            .iter()
+            .find(|pkg| pkg.datasource_id == Some(DatasourceId::NpmPackageJson))
+        {
+            for dep in &root_pkg_data.dependencies {
+                if dep.purl.is_some() {
+                    let mut top_dep = TopLevelDependency::from_dependency(
+                        dep,
+                        root_file.path.clone(),
+                        DatasourceId::NpmPackageJson,
+                        for_package_uid.clone(),
+                    );
 
-    for dep in &root_pkg_data.dependencies {
-        if dep.purl.is_some() {
-            let mut top_dep = TopLevelDependency::from_dependency(
-                dep,
-                root_file.path.clone(),
-                DatasourceId::NpmPackageJson,
-                for_package_uid.clone(),
-            );
+                    if let Some(req) = &top_dep.extracted_requirement
+                        && req.starts_with("workspace:")
+                        && let Some(resolved) =
+                            resolve_workspace_requirement(req, &top_dep.purl, member_versions)
+                    {
+                        top_dep.extracted_requirement = Some(resolved);
+                    }
 
-            // Resolve workspace: version immediately
-            if let Some(req) = &top_dep.extracted_requirement
-                && req.starts_with("workspace:")
-                && let Some(resolved) =
-                    resolve_workspace_requirement(req, &top_dep.purl, member_versions)
-            {
-                top_dep.extracted_requirement = Some(resolved);
+                    dependencies.push(top_dep);
+                }
             }
-
-            dependencies.push(top_dep);
         }
     }
 
@@ -651,9 +654,10 @@ fn hoist_root_dependencies(
         let matches_datasource = |datasource_id: DatasourceId| match file_name {
             "bun.lock" => datasource_id == DatasourceId::BunLock,
             "bun.lockb" => datasource_id == DatasourceId::BunLockb,
-            ".package-lock.json" | "package-lock.json" | ".npm-shrinkwrap.json" => {
-                datasource_id == DatasourceId::NpmPackageLockJson
-            }
+            ".package-lock.json"
+            | "package-lock.json"
+            | ".npm-shrinkwrap.json"
+            | "npm-shrinkwrap.json" => datasource_id == DatasourceId::NpmPackageLockJson,
             "yarn.lock" => matches!(
                 datasource_id,
                 DatasourceId::YarnLock | DatasourceId::YarnLockV1 | DatasourceId::YarnLockV2

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -141,6 +141,7 @@ fn parse_lockfile_v2_plus(
     let (root_name, root_version) = extract_root_package_identity(json, root_name, root_version);
     let (namespace, name, version, purl) =
         normalize_root_package_metadata(&root_name, &root_version);
+    let linked_workspace_names = collect_linked_workspace_names(packages);
 
     // Collect root-level dependencies from top-level sections
     let mut root_deps = std::collections::HashSet::new();
@@ -182,6 +183,7 @@ fn parse_lockfile_v2_plus(
             .map(str::trim)
             .filter(|name| !name.is_empty())
             .map(str::to_string)
+            .or_else(|| linked_workspace_names.get(key).cloned())
             .unwrap_or_else(|| install_name.clone());
 
         let version = value
@@ -295,6 +297,35 @@ fn parse_lockfile_v2_plus(
         datasource_id: Some(DatasourceId::NpmPackageLockJson),
         purl,
     }
+}
+
+fn collect_linked_workspace_names(
+    packages: &serde_json::Map<String, Value>,
+) -> HashMap<String, String> {
+    let mut linked_names = HashMap::new();
+
+    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
+        let is_link = value
+            .get(FIELD_LINK)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !is_link {
+            continue;
+        }
+
+        let Some(resolved) = value.get(FIELD_RESOLVED).and_then(|v| v.as_str()) else {
+            continue;
+        };
+
+        let install_name = extract_package_name_from_path(key);
+        if install_name.is_empty() || install_name == key.as_str() {
+            continue;
+        }
+
+        linked_names.insert(resolved.to_string(), install_name);
+    }
+
+    linked_names
 }
 
 /// Parse lockfile version 1 (nested structure with "dependencies" key)

--- a/src/parsers/npm_lock_test.rs
+++ b/src/parsers/npm_lock_test.rs
@@ -550,6 +550,61 @@ mod tests {
     }
 
     #[test]
+    fn test_workspace_path_entry_uses_linked_package_name() {
+        let content = r#"{
+            "name": "workspace-root",
+            "version": "1.0.0",
+            "lockfileVersion": 2,
+            "packages": {
+                "": {
+                    "name": "workspace-root",
+                    "version": "1.0.0"
+                },
+                "node_modules/foo": {
+                    "resolved": "packages/foo",
+                    "link": true
+                },
+                "packages/foo": {
+                    "version": "0.0.0",
+                    "dependencies": {
+                        "is-positive": "^1.0.0"
+                    }
+                },
+                "node_modules/is-positive": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz"
+                }
+            },
+            "dependencies": {
+                "foo": {
+                    "version": "file:packages/foo",
+                    "requires": {
+                        "is-positive": "^1.0.0"
+                    }
+                },
+                "is-positive": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz"
+                }
+            }
+        }"#;
+
+        let (_temp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        assert!(package_data.dependencies.iter().any(|dep| {
+            dep.purl.as_deref() == Some("pkg:npm/foo@0.0.0")
+                && dep.extracted_requirement.as_deref() == Some("0.0.0")
+        }));
+        assert!(
+            !package_data
+                .dependencies
+                .iter()
+                .any(|dep| { dep.purl.as_deref() == Some("pkg:npm/packages%2Ffoo@0.0.0") })
+        );
+    }
+
+    #[test]
     fn test_root_package_falls_back_to_packages_entry_and_keeps_lockfile_version() {
         let content = r#"{
             "lockfileVersion": 3,

--- a/src/parsers/npm_scan_test.rs
+++ b/src/parsers/npm_scan_test.rs
@@ -294,6 +294,305 @@ mod tests {
     }
 
     #[test]
+    fn test_pnpm_workspace_member_scan_keeps_member_lockfile_dependencies() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let member_dir = temp_dir.path().join("packages").join("fixture");
+
+        fs::create_dir_all(&member_dir).expect("create workspace member dir");
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{
+  "name": "root",
+  "private": true
+}
+"#,
+        )
+        .expect("write root package.json");
+        fs::write(
+            temp_dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - \"packages/*\"\n",
+        )
+        .expect("write pnpm-workspace.yaml");
+        fs::write(
+            member_dir.join("package.json"),
+            r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "write-json-file": "^2.2.0"
+  },
+  "optionalDependencies": {
+    "is-negative": "^2.1.0"
+  },
+  "devDependencies": {
+    "is-positive": "^3.1.0"
+  }
+}
+"#,
+        )
+        .expect("write member package.json");
+        fs::write(
+            member_dir.join("pnpm-lock.yaml"),
+            include_str!("../../testdata/pnpm/pnpm-v9.yaml"),
+        )
+        .expect("write member pnpm-lock.yaml");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        let package = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("fixture"))
+            .expect("workspace member should be assembled");
+
+        assert!(package.datasource_ids.contains(&DatasourceId::PnpmLockYaml));
+        assert!(
+            package
+                .datafile_paths
+                .iter()
+                .any(|path| path.ends_with("/packages/fixture/pnpm-lock.yaml"))
+        );
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/write-json-file",
+            "package.json",
+        );
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/%40babel/helper-string-parser@7.24.8",
+            "pnpm-lock.yaml",
+        );
+
+        let lockfile = files
+            .iter()
+            .find(|file| file.path.ends_with("/packages/fixture/pnpm-lock.yaml"))
+            .expect("pnpm-lock.yaml should be scanned");
+        assert!(lockfile.for_packages.contains(&package.package_uid));
+        assert!(
+            lockfile
+                .package_data
+                .iter()
+                .any(|pkg_data| pkg_data.datasource_id == Some(DatasourceId::PnpmLockYaml))
+        );
+    }
+
+    #[test]
+    fn test_pnpm_workspace_roots_with_same_purl_do_not_clobber_each_other() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+
+        for workspace_name in ["one", "two"] {
+            let workspace_root = temp_dir.path().join(workspace_name);
+            let member_dir = workspace_root.join("packages").join("a");
+
+            fs::create_dir_all(&member_dir).expect("create workspace member dir");
+            fs::write(
+                workspace_root.join("package.json"),
+                r#"{
+  "name": "root",
+  "version": "1.0.0",
+  "dependencies": {
+    "@scope/a": "workspace:*"
+  }
+}
+"#,
+            )
+            .expect("write workspace root package.json");
+            fs::write(
+                workspace_root.join("pnpm-workspace.yaml"),
+                "packages:\n  - \"packages/*\"\n",
+            )
+            .expect("write workspace config");
+            fs::write(
+                member_dir.join("package.json"),
+                r#"{
+  "name": "@scope/a",
+  "version": "1.0.0"
+}
+"#,
+            )
+            .expect("write member package.json");
+        }
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_eq!(
+            result
+                .packages
+                .iter()
+                .filter(|package| package.purl.as_deref() == Some("pkg:npm/root@1.0.0"))
+                .count(),
+            2,
+            "workspace roots with identical purls should both survive assembly"
+        );
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/%40scope/a",
+            "one/package.json",
+        );
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/%40scope/a",
+            "two/package.json",
+        );
+    }
+
+    #[test]
+    fn test_pnpm_workspace_without_root_manifest_keeps_shared_lockfile_dependencies() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let member_dir = temp_dir.path().join("pkg");
+
+        fs::create_dir_all(&member_dir).expect("create workspace member dir");
+        fs::write(
+            temp_dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - \"pkg\"\n",
+        )
+        .expect("write workspace config");
+        fs::write(
+            temp_dir.path().join("pnpm-lock.yaml"),
+            r#"lockfileVersion: '9.0'
+
+importers:
+
+  pkg:
+    dependencies:
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  is-positive@1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+
+snapshots:
+
+  is-positive@1.0.0: {}
+"#,
+        )
+        .expect("write shared pnpm-lock.yaml");
+        fs::write(
+            member_dir.join("package.json"),
+            r#"{
+  "name": "pkg",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "1.0.0"
+  }
+}
+"#,
+        )
+        .expect("write member package.json");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/is-positive@1.0.0",
+            "pnpm-lock.yaml",
+        );
+
+        let lockfile = files
+            .iter()
+            .find(|file| file.path.ends_with("/pnpm-lock.yaml"))
+            .expect("pnpm-lock.yaml should be scanned");
+        assert!(
+            lockfile
+                .package_data
+                .iter()
+                .any(|pkg_data| pkg_data.datasource_id == Some(DatasourceId::PnpmLockYaml))
+        );
+    }
+
+    #[test]
+    fn test_npm_workspace_without_root_manifest_keeps_shared_shrinkwrap_dependencies() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let member_dir = temp_dir.path().join("packages").join("foo");
+
+        fs::create_dir_all(&member_dir).expect("create workspace member dir");
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{
+  "private": true,
+  "name": "workspace-root",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/**"
+  ]
+}
+"#,
+        )
+        .expect("write workspace root package.json");
+        fs::write(
+            temp_dir.path().join("npm-shrinkwrap.json"),
+            r#"{
+  "name": "workspace-root",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "packages": {
+    "": {
+      "name": "workspace-root",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/**"
+      ]
+    },
+    "node_modules/foo": {
+      "resolved": "packages/foo",
+      "link": true
+    },
+    "node_modules/is-positive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz",
+      "integrity": "sha1-iACYVrZKLx632LsBeUGEJK4EUss="
+    },
+    "packages/foo": {
+      "version": "0.0.0",
+      "dependencies": {
+        "is-positive": "^1.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "foo": {
+      "version": "file:packages/foo",
+      "requires": {
+        "is-positive": "^1.0.0"
+      }
+    },
+    "is-positive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz",
+      "integrity": "sha1-iACYVrZKLx632LsBeUGEJK4EUss="
+    }
+  }
+}
+"#,
+        )
+        .expect("write shared npm-shrinkwrap.json");
+        fs::write(
+            member_dir.join("package.json"),
+            r#"{
+  "name": "foo",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-positive": "^1.0.0"
+  }
+}
+"#,
+        )
+        .expect("write member package.json");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:npm/is-positive@1.0.0",
+            "npm-shrinkwrap.json",
+        );
+        assert_dependency_present(&result.dependencies, "pkg:npm/foo", "npm-shrinkwrap.json");
+    }
+
+    #[test]
     fn test_yarn_pnp_scan_assembles_dependency_source_into_root_package() {
         let temp_dir = tempfile::TempDir::new().expect("create temp dir");
 


### PR DESCRIPTION
## Summary

- Preserve sibling lockfile dependency hoisting when npm/pnpm workspace members are reassembled.
- Preserve shared workspace-root lockfile dependencies even without a root package manifest, and stop removing workspace roots by shared PURL alone.
- Normalize npm workspace lockfile path keys such as `packages/foo` back to linked package names instead of emitting path-derived npm PURLs.
- Add a pnpm/pnpm benchmark checkpoint from `.provenant/compare-runs/20260427T175225Z-pnpm-87511` and refresh the benchmark chart.

## Issues

- Covers:
- Closes:

## Scope and exclusions

- Included:
  - `src/assembly/npm_workspace_merge.rs`
  - `src/parsers/npm_lock.rs`
  - `src/parsers/npm_lock_test.rs`
  - `src/parsers/npm_scan_test.rs`
  - `docs/BENCHMARKS.md`
  - `docs/benchmarks/scan-duration-vs-files.svg`
- Explicit exclusions:
  - No scorecard row changes.
  - No golden expected file updates.

## Intentional differences from Python

- Keep URL-safe encoding for path-shaped lockfile metadata while preferring real linked package names over raw workspace path keys in npm lockfile-derived dependency identities.

## Follow-up work

- Created or intentionally deferred:
  - None.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused npm and pnpm workspace regression tests plus the targeted `test_assembly_npm_workspace`, `test_assembly_pnpm_workspace`, and `pnpm_lock` goldens all passed without requiring fixture refreshes.