### PR TITLE
fix(copyright): generalize compare-target cleanup

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 176 of 176 recorded runs, with a **11.6× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **17.4×** on 10k+ file targets.
+> Provenant is faster on 177 of 177 recorded runs, with a **11.6× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -827,6 +827,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `25.02s`; ScanCode `219.35s`
 - Broader Flutter/Firebase package and dependency extraction (`102` vs `100` packages, `964` vs `803` dependencies) from many committed `pubspec.yaml`, CocoaPods `podspec` / `Podfile`, and Android Gradle inputs, plus contributor-roster visibility from `AUTHORS` where ScanCode stays silent
+
+##### [flutter/flutter @ 238d79a](https://github.com/flutter/flutter/tree/238d79aba784bc75c87f226ca7e7e7015b12bfd6) — **20.54× faster**
+
+- Files: 15,670
+- Run context: 2026-04-27 · flutter-8526 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `124.69s`; ScanCode `2561.81s`
+- Broader Dart/Flutter package and dependency extraction (`141` vs `126` packages, `1477` vs `1185` dependencies) across repo-root, engine, benchmark, and integration-test `pubspec.yaml` manifests plus committed AndroidManifest and podspec surfaces, with contributor-roster visibility from `AUTHORS` files that ScanCode leaves empty
 
 ##### [flutter/packages @ 06fee7a](https://github.com/flutter/packages/tree/06fee7af139504f708b5eb10bfb5593c08a24985) — **22.90× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -551,6 +551,9 @@ ScanCode: 1410.57s</title></rect>
     <rect x="752.40" y="311.70" width="8" height="8" fill="#d97706" rx="1.5"><title>conan-io/conan-center-index @ bc78dfb
 Files: 14527
 ScanCode: 807.63s</title></rect>
+    <rect x="757.62" y="257.15" width="8" height="8" fill="#d97706" rx="1.5"><title>flutter/flutter @ 238d79a
+Files: 15670
+ScanCode: 2561.81s</title></rect>
     <rect x="767.28" y="288.09" width="8" height="8" fill="#d97706" rx="1.5"><title>metabase/metabase @ 10997b1
 Files: 18030
 ScanCode: 1330.92s</title></rect>
@@ -1081,6 +1084,9 @@ Provenant: 58.96s</title></circle>
     <circle cx="756.40" cy="466.20" r="4.5" fill="#2563eb"><title>conan-io/conan-center-index @ bc78dfb
 Files: 14527
 Provenant: 33.41s</title></circle>
+    <circle cx="761.62" cy="403.97" r="4.5" fill="#2563eb"><title>flutter/flutter @ 238d79a
+Files: 15670
+Provenant: 124.69s</title></circle>
     <circle cx="771.28" cy="445.44" r="4.5" fill="#2563eb"><title>metabase/metabase @ 10997b1
 Files: 18030
 Provenant: 51.84s</title></circle>

--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -483,6 +483,15 @@ fn json_window_is_simple_author_only_fragment(window: &str) -> bool {
     JSON_AUTHOR_ONLY_STRING_RE.is_match(window) || JSON_AUTHOR_ONLY_OBJECT_RE.is_match(window)
 }
 
+fn looks_like_simple_machine_author_token(name: &str) -> bool {
+    let trimmed = name.trim();
+    trimmed.split_whitespace().count() == 1
+        && trimmed.len() >= 6
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-'))
+}
+
 pub(in super::super) fn looks_like_structured_json_author_fallback(value: &str) -> bool {
     let trimmed = value.trim();
     if looks_like_name_with_parenthesized_url(trimmed) {
@@ -548,10 +557,19 @@ pub(in super::super) fn refine_json_author_candidate(name: &str, window: &str) -
         .trim()
         .trim_end_matches(&[',', ';', '.'][..])
         .trim();
+    let has_metadata_context = json_window_has_metadata_context(window);
+    let is_simple_author_only_fragment = json_window_is_simple_author_only_fragment(window);
 
-    if !json_window_has_metadata_context(window)
-        && !json_window_is_simple_author_only_fragment(window)
+    if !has_metadata_context
+        && !is_simple_author_only_fragment
         && !looks_like_name_with_parenthesized_url(trimmed)
+    {
+        return None;
+    }
+
+    if !has_metadata_context
+        && is_simple_author_only_fragment
+        && looks_like_simple_machine_author_token(trimmed)
     {
         return None;
     }
@@ -560,8 +578,8 @@ pub(in super::super) fn refine_json_author_candidate(name: &str, window: &str) -
         return Some(author);
     }
 
-    if !json_window_has_metadata_context(window)
-        && !json_window_is_simple_author_only_fragment(window)
+    if !has_metadata_context
+        && !is_simple_author_only_fragment
         && !looks_like_name_with_parenthesized_url(trimmed)
     {
         return None;

--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -560,20 +560,16 @@ pub(in super::super) fn refine_json_author_candidate(name: &str, window: &str) -
     let has_metadata_context = json_window_has_metadata_context(window);
     let is_simple_author_only_fragment = json_window_is_simple_author_only_fragment(window);
 
+    if looks_like_simple_machine_author_token(trimmed) {
+        return None;
+    }
+
     if !has_metadata_context
         && !is_simple_author_only_fragment
         && !looks_like_name_with_parenthesized_url(trimmed)
     {
         return None;
     }
-
-    if !has_metadata_context
-        && is_simple_author_only_fragment
-        && looks_like_simple_machine_author_token(trimmed)
-    {
-        return None;
-    }
-
     if let Some(author) = refine_author(name) {
         return Some(author);
     }

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -236,6 +236,30 @@ fn trim_notice_support_sentence(who: &str) -> String {
     trimmed.to_string()
 }
 
+fn refine_author_or_institution(who: &str) -> Option<String> {
+    if let Some(author) = refine_author(who) {
+        return Some(author);
+    }
+
+    let trimmed = who.trim().trim_end_matches('.').trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.starts_with("the ") {
+        return None;
+    }
+
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    if words.len() < 4 {
+        return None;
+    }
+
+    let capitalized_word_count = words
+        .iter()
+        .filter_map(|word| word.chars().find(|ch| ch.is_alphabetic()))
+        .filter(|ch| ch.is_uppercase())
+        .count();
+    (capitalized_word_count >= 2).then(|| trimmed.to_string())
+}
+
 fn refine_notice_collective_author(who: &str) -> Option<String> {
     let trimmed = trim_notice_support_sentence(&trim_following_sentence_clause(who))
         .trim_end_matches(&['.', ';', ','][..])
@@ -934,7 +958,7 @@ pub(in super::super) fn extract_was_developed_by_author_blocks(
             continue;
         }
 
-        let Some(author) = refine_author(&joined) else {
+        let Some(author) = refine_author_or_institution(&joined) else {
             line_number = line_number.next();
             continue;
         };
@@ -1221,6 +1245,13 @@ fn sanitize_author_colon_tail(tail: &str) -> Option<String> {
 fn is_author_metadata_line(line: &str) -> bool {
     let lower = line.trim().to_ascii_lowercase();
     lower.starts_with("url:")
+        || lower.starts_with("homepage:")
+        || lower.starts_with("repository:")
+        || lower.starts_with("documentation:")
+        || lower.starts_with("bugs:")
+        || lower.starts_with("issuetracker:")
+        || lower.starts_with("issue-tracker:")
+        || lower.starts_with("issue_tracker:")
         || lower.starts_with("version:")
         || lower.starts_with("wiki:")
         || lower.starts_with("gav:")
@@ -1237,6 +1268,12 @@ fn is_author_metadata_line(line: &str) -> bool {
         || lower.starts_with("releasetimestamp:")
         || lower.starts_with("requiredcore:")
         || lower.starts_with("scm:")
+        || lower.starts_with("title:")
+        || lower.starts_with("description:")
+        || lower.starts_with("subject:")
+        || lower.starts_with("comment:")
+        || lower.starts_with("usageterms:")
+        || lower.starts_with("webstatement:")
         || lower.starts_with("disambiguatingdescription")
 }
 
@@ -1776,6 +1813,43 @@ pub(in super::super) fn extract_toml_author_assignment_authors(
     authors
 }
 
+pub(in super::super) fn extract_comment_author_label_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
+    if raw_lines.is_empty() {
+        return authors;
+    }
+
+    for (idx, raw_line) in raw_lines.iter().enumerate() {
+        let trimmed = raw_line.trim();
+        let normalized = trimmed
+            .trim_start_matches(|ch: char| {
+                ch.is_whitespace() || matches!(ch, '#' | ';' | '/' | '*' | '!' | '-')
+            })
+            .trim();
+        let Some((label, who_raw)) = normalized.split_once(':') else {
+            continue;
+        };
+        if !label.eq_ignore_ascii_case("author") {
+            continue;
+        }
+        let who = who_raw.trim().trim_end_matches('.').trim();
+        let who_lower = who.to_ascii_lowercase();
+        if who.is_empty() || !who.contains('<') || !who.contains('>') || !who_lower.contains(" at ")
+        {
+            continue;
+        }
+        authors.push(AuthorDetection {
+            author: who.to_string(),
+            start_line: LineNumber::new(idx + 1).expect("invalid line number"),
+            end_line: LineNumber::new(idx + 1).expect("invalid line number"),
+        });
+    }
+
+    authors
+}
+
 pub(in super::super) fn extract_written_by_comma_and_copyright_authors(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
@@ -1891,7 +1965,7 @@ pub(in super::super) fn extract_developed_by_sentence_authors(
         }
 
         let candidate = format!("{p1} {p2}");
-        let Some(author) = refine_author(&candidate) else {
+        let Some(author) = refine_author_or_institution(&candidate) else {
             continue;
         };
 
@@ -1928,7 +2002,7 @@ pub(in super::super) fn extract_developed_by_phrase_authors(
                 continue;
             }
 
-            let Some(author) = refine_author(who) else {
+            let Some(author) = refine_author_or_institution(who) else {
                 continue;
             };
 

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -207,7 +207,7 @@ fn trim_attribution_tail(who: &str) -> String {
 
 fn trim_following_sentence_clause(who: &str) -> String {
     static FOLLOWING_SENTENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an)\b.*$").unwrap()
+        Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an|no)\b.*$").unwrap()
     });
 
     let trimmed = who.trim();
@@ -934,11 +934,10 @@ pub(in super::super) fn extract_was_developed_by_author_blocks(
             continue;
         }
 
-        let author = refine_author(&joined).unwrap_or(joined);
-        if author.is_empty() {
+        let Some(author) = refine_author(&joined) else {
             line_number = line_number.next();
             continue;
-        }
+        };
 
         authors.push(AuthorDetection {
             author,
@@ -1892,10 +1891,9 @@ pub(in super::super) fn extract_developed_by_sentence_authors(
         }
 
         let candidate = format!("{p1} {p2}");
-        let author = refine_author(&candidate).unwrap_or(candidate);
-        if author.is_empty() {
+        let Some(author) = refine_author(&candidate) else {
             continue;
-        }
+        };
 
         authors.push(AuthorDetection {
             author,
@@ -1930,10 +1928,9 @@ pub(in super::super) fn extract_developed_by_phrase_authors(
                 continue;
             }
 
-            let author = refine_author(who).unwrap_or_else(|| who.to_string());
-            if author.is_empty() {
+            let Some(author) = refine_author(who) else {
                 continue;
-            }
+            };
 
             authors.push(AuthorDetection {
                 author,

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -77,6 +77,19 @@ fn test_extract_authors_from_dense_name_email_list() {
 }
 
 #[test]
+fn test_extract_comment_author_label_authors_keeps_obfuscated_angle_contact() {
+    let raw_lines = vec!["* Author: Deepak M <m.deepak at intel.com>"];
+    let authors = extract_comment_author_label_authors(&raw_lines);
+
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.author == "Deepak M <m.deepak at intel.com>"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_extract_collective_author_with_contributors_before_email() {
     let input = "authors = [\"Tokio Contributors <team@tokio.rs>\"]\n";
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -311,6 +311,7 @@ pub fn detect_copyrights_from_text_with_deadline(
 
     if deadline_exceeded(deadline) {
         refine_final_copyrights(&mut copyrights);
+        postprocess_transforms::refine_final_authors(&mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
         dedupe_exact_span_authors(&mut authors);

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -357,10 +357,17 @@ pub fn detect_copyrights_from_text_with_deadline(
         extend_dash_obfuscated_email_suffixes(&raw_lines, group, &mut copyrights[..], &holders[..]);
     }
     restore_linux_foundation_copyrights_from_raw_lines(&raw_lines, &mut copyrights);
+    copyrights.retain(|c| {
+        let trimmed = c.copyright.trim();
+        !trimmed.eq_ignore_ascii_case("copyright holders")
+            && !trimmed.eq_ignore_ascii_case("the above copyright holders")
+    });
 
     holders.extend(add_missing_holders_for_bare_c_name_year_suffixes(
         &copyrights,
     ));
+    holders
+        .extend(postprocess_transforms::add_missing_holders_for_iso_date_copyrights(&copyrights));
 
     dedupe_exact_span_holders(&mut holders);
 

--- a/src/copyright/detector/pattern_extract/extraction/content.rs
+++ b/src/copyright/detector/pattern_extract/extraction/content.rs
@@ -259,6 +259,69 @@ pub fn extract_markup_copyright_attributes(
     (copyrights, holders)
 }
 
+pub fn extract_markup_text_attributes_with_copyright(
+    content: &str,
+    line_number_index: &LineNumberIndex,
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    static TEXT_ATTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?is)\btext\s*=\s*(?:\"(?P<dq>[^\"]*(?:©|\(c\)|opyright)[^\"]*)\"|'(?P<sq>[^']*(?:©|\(c\)|opyright)[^']*)')"#,
+        )
+        .unwrap()
+    });
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+    let mut seen_h: HashSet<(String, usize)> = existing_holders
+        .iter()
+        .map(|h| (h.holder.clone(), h.start_line.get()))
+        .collect();
+
+    for caps in TEXT_ATTR_RE.captures_iter(content) {
+        let Some(m) = caps.get(0) else {
+            continue;
+        };
+        let value = caps
+            .name("dq")
+            .or_else(|| caps.name("sq"))
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        if value.is_empty() {
+            continue;
+        }
+
+        let normalized = normalize_markup_attribute_value(value);
+        if normalized.is_empty() {
+            continue;
+        }
+
+        let Some(refined) = refine_copyright(&normalized) else {
+            continue;
+        };
+        let ln = line_number_index.line_number_at_offset(m.start());
+        copyrights.push(CopyrightDetection {
+            copyright: refined.clone(),
+            start_line: ln,
+            end_line: ln,
+        });
+
+        if let Some(holder) =
+            postprocess_transforms::derive_holder_from_simple_copyright_string(&refined)
+            && seen_h.insert((holder.clone(), ln.get()))
+        {
+            holders.push(HolderDetection {
+                holder,
+                start_line: ln,
+                end_line: ln,
+            });
+        }
+    }
+
+    (copyrights, holders)
+}
+
 pub fn extract_changelog_timestamp_copyrights_from_content(
     content: &str,
     existing_holders: &[HolderDetection],

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -638,9 +638,9 @@ pub fn extract_standalone_c_holder_year_lines(
                 }
             } else if has_separator_comma {
                 if use_copyright_prefix {
-                    format!("Copyright (c) {holder_raw}, {yearish}")
+                    format!("Copyright (c) {holder_raw} {yearish}")
                 } else {
-                    format!("(c) {holder_raw}, {yearish}")
+                    format!("(c) {holder_raw} {yearish}")
                 }
             } else if use_copyright_prefix {
                 format!("Copyright (c) {holder_raw} {yearish}")
@@ -901,7 +901,7 @@ pub fn extract_copyright_c_years_holder_lines(
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_C_YEARS_HOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^copyright\s*\(c\)\s*(?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*?)\s+(?P<holder>.+?)\s*$",
+            r"(?i)^copyright\s*\(c\)\s*(?P<years>(?:19\d{2}|20\d{2}|\?\?\?\?)(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*?)\s+(?P<holder>.+?)\s*$",
         )
         .unwrap()
     });
@@ -1181,7 +1181,7 @@ pub fn extract_copyright_c_year_comma_name_angle_email_lines(
 
     static COPY_C_YEAR_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^copyright\s*\(c\)\s+(?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:\d{4}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*)\s*,\s*(?P<name>[^<>]+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s*[\.,;:]*\s*$",
+            r"(?i)^copyright\s*\(c\)\s+(?P<years>(?:19\d{2}|20\d{2}|\?\?\?\?)(?:\s*[-–]\s*(?:\d{4}|\d{2}))?(?:\s*,\s*(?:19\d{2}|20\d{2}))*)\s*,?\s*(?P<name>[^<>]+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s*[\.,;:]*\s*$",
         )
         .unwrap()
     });
@@ -1206,8 +1206,8 @@ pub fn extract_copyright_c_year_comma_name_angle_email_lines(
                 continue;
             }
 
-            let raw = format!("Copyright (c) {years}, {name} <{email}>");
-            let Some(cr) = refine_copyright(&raw) else {
+            let matched = cap.get(0).map(|m| m.as_str()).unwrap_or(trimmed);
+            let Some(cr) = refine_copyright(matched) else {
                 continue;
             };
 
@@ -1665,7 +1665,7 @@ pub fn extract_copyright_year_c_name_angle_email_lines(
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static COPY_YEAR_C_NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^copyright\s+(?P<year>19\d{2}|20\d{2})\s+\(c\)\s+(?P<name>.+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s*$",
+            r"(?i)^copyright\s+(?P<year>19\d{2}|20\d{2}|\?\?\?\?)\s+\(c\)\s+(?P<name>.+?)\s*<\s*(?P<email>[^>\s]+@[^>\s]+)\s*>\s*$",
         )
         .unwrap()
     });

--- a/src/copyright/detector/pattern_extract/extraction/prepared.rs
+++ b/src/copyright/detector/pattern_extract/extraction/prepared.rs
@@ -239,6 +239,7 @@ pub fn extract_copyrighted_by_lines(
             .prepared
             .to_ascii_lowercase()
             .contains("not copyrighted")
+            && !crate::copyright::hints::has_year(prepared_line.prepared)
         {
             continue;
         }

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -282,6 +282,10 @@ fn run_author_extraction_and_repairs(
     let mut new_a = super::author_heuristics::extract_name_contributed_authors(prepared_cache);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_comment_author_label_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/copyright/detector/phases/primary.rs
+++ b/src/copyright/detector/phases/primary.rs
@@ -435,6 +435,17 @@ fn run_content_and_markup_extractions(
     copyrights.extend(new_c);
     holders.extend(new_h);
 
+    let (mut new_c, new_h) =
+        super::super::pattern_extract::extract_markup_text_attributes_with_copyright(
+            content,
+            line_number_index,
+            holders,
+        );
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
     let (mut new_c, mut new_h) = super::super::pattern_extract::extract_html_anchor_copyright_url(
         content,
         line_number_index,

--- a/src/copyright/detector/postprocess_transforms/mod.rs
+++ b/src/copyright/detector/postprocess_transforms/mod.rs
@@ -63,6 +63,8 @@ pub fn refine_final_authors(authors: &mut Vec<AuthorDetection>) {
         return;
     }
 
+    authors.retain(|author| !contains_markdown_link_author_fragment(&author.author));
+
     *authors = authors
         .iter()
         .filter_map(|a| {
@@ -83,6 +85,14 @@ pub fn refine_final_authors(authors: &mut Vec<AuthorDetection>) {
             })
         })
         .collect();
+}
+
+fn contains_markdown_link_author_fragment(author: &str) -> bool {
+    let trimmed = author.trim();
+    trimmed.contains("](http")
+        || trimmed.contains("](https://")
+        || trimmed.contains("] (http")
+        || trimmed.contains("] (https://")
 }
 
 fn looks_like_collective_institution_author(author: &str) -> bool {

--- a/src/copyright/detector/postprocess_transforms/year_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/year_repairs.rs
@@ -40,6 +40,36 @@ pub fn add_missing_holders_for_bare_c_name_year_suffixes(
         .collect()
 }
 
+pub fn add_missing_holders_for_iso_date_copyrights(
+    copyrights: &[CopyrightDetection],
+) -> Vec<HolderDetection> {
+    static ISO_DATE_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^copyright\s*\(c\)\s*(?:19|20)\d{2}-\d{2}-\d{2}\s+(?P<holder>.+)$")
+            .expect("valid iso-date copyright holder regex")
+    });
+
+    copyrights
+        .iter()
+        .filter_map(|cr| {
+            let cap = ISO_DATE_COPY_RE.captures(cr.copyright.trim())?;
+            let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+            if holder_raw.is_empty() {
+                return None;
+            }
+            let holder = refine_holder_in_copyright_context(holder_raw)
+                .or_else(|| refine_holder(holder_raw))
+                .or_else(|| {
+                    Some(crate::copyright::detector::token_utils::normalize_whitespace(holder_raw))
+                })?;
+            Some(HolderDetection {
+                holder,
+                start_line: cr.start_line,
+                end_line: cr.end_line,
+            })
+        })
+        .collect()
+}
+
 pub fn drop_shadowed_year_only_copyright_prefixes_same_start_line(
     copyrights: &mut Vec<CopyrightDetection>,
 ) {
@@ -781,6 +811,10 @@ pub fn add_missing_holders_derived_from_split_copyrights(
 }
 
 pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
+    static ISO_DATE_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^copyright\s*\(c\)\s*(?:19|20)\d{2}-\d{2}-\d{2}\s+(?P<holder>.+)$")
+            .expect("valid iso-date copyright holder regex")
+    });
     static BARE_HOLDER_C_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?P<holder>[^\n]+?)\s*,?\s*\(c\)\s*(?:19|20)\d{2}\b")
             .expect("valid bare holder (c) year regex")
@@ -790,6 +824,21 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         LazyLock::new(|| Regex::new(r"(?i)^(?P<head>.+?)\s*,\s*\(c\)\s*(?:19|20)\d{2}\b").unwrap());
 
     let trimmed = s.trim();
+    if trimmed.to_ascii_lowercase().starts_with("copyright")
+        && crate::copyright::refiner::is_junk_copyright(trimmed)
+    {
+        return None;
+    }
+    if let Some(cap) = ISO_DATE_COPY_RE.captures(trimmed)
+        && let Some(holder_raw) = cap.name("holder").map(|m| m.as_str().trim())
+        && !holder_raw.is_empty()
+    {
+        return refine_holder_in_copyright_context(holder_raw)
+            .or_else(|| refine_holder(holder_raw))
+            .or_else(|| {
+                Some(crate::copyright::detector::token_utils::normalize_whitespace(holder_raw))
+            });
+    }
     let lower = trimmed.to_ascii_lowercase();
     if !lower.starts_with("copyright") {
         let t = trimmed.trim_start();
@@ -809,7 +858,7 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
             if tail.is_empty() {
                 return None;
             }
-            return refine_holder_in_copyright_context(tail);
+            return refine_holder_in_copyright_context(tail).or_else(|| refine_holder(tail));
         }
 
         let cap = BARE_HOLDER_C_YEAR_RE.captures(trimmed)?;
@@ -817,7 +866,8 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         if holder_raw.is_empty() {
             return None;
         }
-        return refine_holder_in_copyright_context(holder_raw);
+        return refine_holder_in_copyright_context(holder_raw)
+            .or_else(|| refine_holder(holder_raw));
     }
     let next = trimmed.chars().nth("copyright".len());
     if !matches!(next, Some(' ') | Some('\t') | Some('(') | None) {
@@ -856,5 +906,5 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         return None;
     }
 
-    refine_holder_in_copyright_context(holder_raw)
+    refine_holder_in_copyright_context(holder_raw).or_else(|| refine_holder(holder_raw))
 }

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -122,3 +122,23 @@ fn test_refine_final_authors_keeps_structured_metadata_collectives() {
         ]
     );
 }
+
+#[test]
+fn test_refine_final_authors_drops_markdown_link_fragments() {
+    let mut authors = vec![
+        AuthorDetection {
+            author: "[becoming a sponsor] (https://opencollective.com/pnpm#sponsor)".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        AuthorDetection {
+            author: "the command [#7403] (https://github.com/pnpm/pnpm/issues/7403)".to_string(),
+            start_line: LineNumber::new(2).unwrap(),
+            end_line: LineNumber::new(2).unwrap(),
+        },
+    ];
+
+    refine_final_authors(&mut authors);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -83,6 +83,34 @@ fn test_refine_final_authors_keeps_handle_suffixed_maintainer() {
 }
 
 #[test]
+fn test_refine_final_authors_keeps_obfuscated_angle_contact_author() {
+    let mut authors = vec![AuthorDetection {
+        author: "Deepak M <m.deepak at intel.com>".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    refine_final_authors(&mut authors);
+
+    assert_eq!(
+        authors,
+        vec![AuthorDetection {
+            author: "Deepak M m.deepak at intel.com".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        }]
+    );
+}
+
+#[test]
+fn test_derive_holder_from_simple_copyright_string_keeps_iso_date_holder() {
+    assert_eq!(
+        derive_holder_from_simple_copyright_string("Copyright (c) 2006-07-24 John Boolage"),
+        Some("John Boolage".to_string())
+    );
+}
+
+#[test]
 fn test_refine_final_authors_keeps_structured_metadata_collectives() {
     let mut authors = vec![
         AuthorDetection {

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1109,6 +1109,44 @@ fn test_detect_copyright_holders_boilerplate_regression() {
 }
 
 #[test]
+fn test_detect_sample_comment_prose_does_not_survive_as_holder_or_copyright() {
+    let input = "// Copyright\n// Flutter code sample for [MyElement].\n";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        !c.iter()
+            .any(|cr| cr.copyright.contains("Flutter code sample for MyElement")),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        !h.iter()
+            .any(|ho| ho.holder.contains("Flutter code sample for MyElement")),
+        "holders: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_detect_notice_prose_fragment_does_not_survive_as_holder_or_copyright() {
+    let input = "copyright comments are original works produced specifically for use as part of";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter().all(|cr| !cr
+            .copyright
+            .contains("original works produced specifically for use as")),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter().all(|ho| !ho
+            .holder
+            .contains("original works produced specifically for use as")),
+        "holders: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_detect_copyright_c_symbol() {
     let (c, h, _a) = detect_copyrights_from_text("Copyright (c) 2020-2024 Foo Bar");
     assert!(!c.is_empty(), "Should detect copyright with (c)");

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1053,6 +1053,62 @@ fn test_detect_not_copyrighted_statement() {
 }
 
 #[test]
+fn test_detect_unknown_year_placeholder_copyright_with_email() {
+    let input = "Copyright (C) ???? Simon Mourier <simonm@microsoft.com>";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "Copyright (c) ???? Simon Mourier <simonm@microsoft.com>"),
+        "Missing copyright, got: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter().any(|ho| ho.holder == "Simon Mourier"),
+        "Missing holder, got: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_detect_storyboard_text_attribute_copyright_holder() {
+    let input = r#"<label text="© 2018 The Flutter Authors. All rights reserved." />"#;
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "(c) 2018 The Flutter Authors"),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter().any(|ho| ho.holder == "The Flutter Authors"),
+        "holders: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_detect_iso_date_holder_regression() {
+    let input = "Copyright (c) 2006-07-24 John Boolage";
+    let (_c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        h.iter().any(|ho| ho.holder == "John Boolage"),
+        "holders: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_detect_copyright_holders_boilerplate_regression() {
+    let input = "The above copyright holders, or their entities, not be used in advertising.";
+    let (c, _h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter().all(|cr| cr.copyright != "copyright holders"),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_detect_copyright_c_symbol() {
     let (c, h, _a) = detect_copyrights_from_text("Copyright (c) 2020-2024 Foo Bar");
     assert!(!c.is_empty(), "Should detect copyright with (c)");

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -123,6 +123,30 @@ fn test_plain_json_author_string_with_parenthesized_url_and_following_key_preser
 }
 
 #[test]
+fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
+    let input = r#""author": "makeappicon", "images": []"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_span_prose_continuation_not_detected() {
+    let input = "contributors, for example.\nIf you want to help, start with docs.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_span_legal_clause_not_detected() {
+    let input = "authors, grants you the right to use and distribute this work.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_json_author_object_name_preferred_over_url_tail() {
     let input =
         "\"author\": { \"name\": \"Chen Fengyuan\", \"url\": \"https://chenfengyuan.com/\" }";

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -147,6 +147,65 @@ fn test_author_span_legal_clause_not_detected() {
 }
 
 #[test]
+fn test_author_markdown_link_prose_not_detected() {
+    let input = "the command [#7403] (https://github.com/pnpm/pnpm/issues/7403) changed behavior.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_markdown_link_label_not_detected() {
+    let input = "[becoming a sponsor] (https://opencollective.com/pnpm#sponsor)";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_pnpm_readme_sponsor_line_not_detected() {
+    let input =
+        "Support this project by [becoming a sponsor](https://opencollective.com/pnpm#sponsor).";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_pnpm_changelog_issue_link_not_detected() {
+    let input = "- Fixed `minimumReleaseAgeExclude` not being respected by `pnpm dlx` [#10338](https://github.com/pnpm/pnpm/issues/10338).";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_pnpm_readme_snippet_not_detected() {
+    let input = concat!(
+        "</table>\n\n",
+        "<!-- sponsors end -->\n\n",
+        "Support this project by [becoming a sponsor](https://opencollective.com/pnpm#sponsor).\n\n",
+        "## Background\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_pnpm_changelog_snippet_not_detected() {
+    let input = concat!(
+        "- Fixed `allowBuilds` not working when set via `.pnpmfile.cjs` [#10516](https://github.com/pnpm/pnpm/issues/10516).\n",
+        "- When the [`enableGlobalVirtualStore`](https://pnpm.io/settings#enableglobalvirtualstore) option is set, the `pnpm deploy` command would incorrectly create symlinks to the global virtual store. To keep the deploy directory self-contained, `pnpm deploy` now ignores this setting and always creates a localized virtual store within the deploy directory.\n",
+        "- Fixed `minimumReleaseAgeExclude` not being respected by `pnpm dlx` [#10338](https://github.com/pnpm/pnpm/issues/10338).\n\n",
+        "## 10.29.2\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_json_author_object_name_preferred_over_url_tail() {
     let input =
         "\"author\": { \"name\": \"Chen Fengyuan\", \"url\": \"https://chenfengyuan.com/\" }";

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -131,6 +131,21 @@ fn test_plain_json_author_string_machine_token_dropped_without_metadata_context(
 }
 
 #[test]
+fn test_nested_json_author_string_machine_token_dropped_with_metadata_context() {
+    let input = concat!(
+        "{\n",
+        "  \"info\": {\n",
+        "    \"version\": 1,\n",
+        "    \"author\": \"makeappicon\"\n",
+        "  }\n",
+        "}\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_author_span_prose_continuation_not_detected() {
     let input = "contributors, for example.\nIf you want to help, start with docs.";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
@@ -160,6 +175,63 @@ fn test_author_markdown_link_label_not_detected() {
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
 
     assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_flutter_issue_hygiene_link_not_detected() {
+    let input = "[All open issues sorted by thumbs-up] (https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_flutter_api_sentence_not_detected() {
+    let input =
+        "If fixing it requires an API that is not yet available on stable, add the waiting label.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_windows_filedescription_resource_not_detected() {
+    let input = concat!(
+        "VALUE \"LegalCopyright\", \"Copyright 2014 The Flutter Authors. All rights reserved.\" \"\\0\"\n",
+        "VALUE \"FileDescription\", \"A sample application demonstrating Flutter APIs.\" \"\\0\"\n",
+        "VALUE \"FileVersion\", VERSION_AS_STRING \"\\0\"\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .all(|a| !a.author.contains("FileDescription") && !a.author.contains("FileVersion")),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_author_camel_case_class_phrase_not_detected() {
+    let input = "A delegate used by RenderListWheelViewport to manage its children. the ListWheelChildManager";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_written_by_notice_tail_not_detected() {
+    let input = "This software was written by Alexander Peslyak in d+. No copyright is claimed.";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|a| a.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Alexander Peslyak"],
+        "authors: {authors:?}"
+    );
 }
 
 #[test]

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -146,6 +146,29 @@ fn test_nested_json_author_string_machine_token_dropped_with_metadata_context() 
 }
 
 #[test]
+fn test_author_metadata_label_placeholder_not_detected() {
+    let input = "author: Package Author\nhomepage: Homepage\nrepository: Repository";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_author_media_title_metadata_does_not_merge_into_author() {
+    let input = "Author: Chinmay Garde\nTitle: Bay Bridge At Night\nDescription: Embarcadero in the evening on Delta 3200";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|a| a.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Chinmay Garde"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_author_span_prose_continuation_not_detected() {
     let input = "contributors, for example.\nIf you want to help, start with docs.";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
@@ -232,6 +255,14 @@ fn test_author_written_by_notice_tail_not_detected() {
         vec!["Alexander Peslyak"],
         "authors: {authors:?}"
     );
+}
+
+#[test]
+fn test_author_homepage_label_not_detected() {
+    let input = "homepage Homepage repository Repository";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
 }
 
 #[test]
@@ -691,6 +722,22 @@ fn test_maintainer_comment_extracts_author_without_label() {
     );
     assert!(
         !values.iter().any(|value| value.contains("Maintainer")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_author_comment_extracts_obfuscated_angle_contact_author() {
+    let input = "* Author: Deepak M <m.deepak at intel.com>\n";
+
+    let (_c, _h, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Deepak M m.deepak at intel.com"),
         "authors: {values:?}"
     );
 }

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -277,3 +277,35 @@ fn test_drop_trademarked_materials_prose_false_positive_copyrights_and_holders()
         "holders: {holders:?}"
     );
 }
+
+#[test]
+fn test_drop_code_and_cc0_prose_false_positive_copyrights() {
+    let input = concat!(
+        "String generateCode(CodeSample sample, { File? output, String? copyright, String? description, bool includeAssumptions = false, }) {\n",
+        "  return '${addCopyright ? '{{copyright}}\\n\\n' : ''}$template'.replaceAllMapped(RegExp(r'{{([^}]+)}}'), (Match match) {\n",
+        "    final String name = match[1]!;\n",
+        "  });\n",
+        "}\n\n",
+        "the copyright and related or neighboring legal rights previously held by the Affirmer in the Work, to the greatest extent permitted by law.\n",
+    );
+    let (copyrights, _holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights
+            .iter()
+            .all(|c| !c.copyright.contains("String? description, bool")),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        copyrights
+            .iter()
+            .all(|c| !c.copyright.contains("replaceAllMapped") && !c.copyright.contains("RegExp")),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        copyrights
+            .iter()
+            .all(|c| !c.copyright.contains("related or neighboring legal rights")),
+        "copyrights: {copyrights:?}"
+    );
+}

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -235,6 +235,7 @@ pub fn looks_like_bad_generic_author_candidate(s: &str) -> bool {
                 | "developers"
                 | "developer"
                 | "based"
+                | "grants"
                 | "working"
                 | "features"
                 | "components"

--- a/src/copyright/hints.rs
+++ b/src/copyright/hints.rs
@@ -54,9 +54,12 @@ static YEAR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"[\(\.,\-\)\s]+(19[6-9][0-9]|20[0-9]{2})([\(\.,\-\)\s]+|$)").unwrap()
 });
 
+static UNKNOWN_YEAR_PLACEHOLDER_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)copyright\s*\(c\)\s*\?\?\?\?").unwrap());
+
 /// Check if a line contains a copyright-relevant year (1960–2099).
 pub fn has_year(line: &str) -> bool {
-    YEAR_REGEX.is_match(line)
+    YEAR_REGEX.is_match(line) || UNKNOWN_YEAR_PLACEHOLDER_REGEX.is_match(line)
 }
 
 /// Check if a line contains any copyright hint marker (case-insensitive).
@@ -272,6 +275,13 @@ mod tests {
     #[test]
     fn test_year_at_end_of_line() {
         assert!(has_year("Copyright 2024"));
+    }
+
+    #[test]
+    fn test_unknown_year_placeholder_in_copyright_matches() {
+        assert!(has_year(
+            "Copyright (C) ???? Simon Mourier <simonm@microsoft.com>"
+        ));
     }
 
     // ── is_candidate ────────────────────────────────────────────────

--- a/src/copyright/mod.rs
+++ b/src/copyright/mod.rs
@@ -28,6 +28,7 @@ mod refiner;
 mod types;
 
 pub use credits::{detect_credits_authors, is_credits_file};
+pub(crate) use refiner::refine_author;
 pub use types::{AuthorDetection, CopyrightDetection, HolderDetection};
 
 pub fn detect_copyrights(

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -86,6 +86,10 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
         return true;
     }
 
+    if contains_markdown_link_fragment(trimmed) {
+        return true;
+    }
+
     if looks_like_structured_key_with_hex_value(trimmed) {
         return true;
     }
@@ -163,6 +167,14 @@ fn contains_html_like_fragment(s: &str) -> bool {
     trimmed.contains("</")
         || trimmed.contains("/>")
         || (trimmed.contains('<') || trimmed.contains('>'))
+}
+
+fn contains_markdown_link_fragment(s: &str) -> bool {
+    let trimmed = s.trim();
+    trimmed.contains("](http")
+        || trimmed.contains("](https://")
+        || trimmed.contains("] (http")
+        || trimmed.contains("] (https://")
 }
 
 fn looks_like_machine_style_colon_token(s: &str) -> bool {

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -126,8 +126,21 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
             .all(|ch| !ch.is_alphabetic() || ch.is_lowercase());
         return !all_lower || word.len() < 6;
     }
-    if words.len() == 2 && words.iter().all(|word| starts_with_lowercase_alpha(word)) {
-        return true;
+    if words.len() == 2 {
+        if words.iter().all(|word| starts_with_lowercase_alpha(word)) {
+            return true;
+        }
+
+        if words[0].ends_with('.')
+            && starts_with_lowercase_alpha(words[0])
+            && starts_with_uppercase_alpha(words[1])
+        {
+            return true;
+        }
+
+        if starts_with_lowercase_alpha(words[0]) && words[1].contains('?') {
+            return true;
+        }
     }
     if words.len() < 3 {
         return false;
@@ -301,6 +314,12 @@ fn starts_with_lowercase_alpha(word: &str) -> bool {
     word.chars()
         .find(|ch| ch.is_alphabetic())
         .is_some_and(|ch| ch.is_lowercase())
+}
+
+fn starts_with_uppercase_alpha(word: &str) -> bool {
+    word.chars()
+        .find(|ch| ch.is_alphabetic())
+        .is_some_and(|ch| ch.is_uppercase())
 }
 
 fn restore_leading_the_for_institution_and_contributors(original: &str, refined: &str) -> String {

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -90,6 +90,14 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
         return true;
     }
 
+    if contains_windows_versioninfo_fragment(trimmed) {
+        return true;
+    }
+
+    if contains_no_copyright_clause(trimmed) {
+        return true;
+    }
+
     if looks_like_structured_key_with_hex_value(trimmed) {
         return true;
     }
@@ -135,6 +143,10 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
             return true;
         }
 
+        if words[0].eq_ignore_ascii_case("the") && looks_like_camel_case_identifier(words[1]) {
+            return true;
+        }
+
         if words[0].ends_with('.')
             && starts_with_lowercase_alpha(words[0])
             && starts_with_uppercase_alpha(words[1])
@@ -153,13 +165,47 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
     let starts_lowercase = words
         .first()
         .is_some_and(|word| starts_with_lowercase_alpha(word));
+    let lowercase_word_count = words
+        .iter()
+        .filter(|word| starts_with_lowercase_alpha(word))
+        .count();
     let capitalized_word_count = words
         .iter()
         .filter_map(|word| word.chars().find(|ch| ch.is_alphabetic()))
         .filter(|ch| ch.is_uppercase())
         .count();
 
+    if words.len() >= 4 && lowercase_word_count >= 2 && capitalized_word_count <= 2 {
+        return true;
+    }
+
     starts_lowercase || capitalized_word_count < 2
+}
+
+fn contains_windows_versioninfo_fragment(s: &str) -> bool {
+    let trimmed = s.trim();
+    trimmed.starts_with("VALUE ")
+        && (trimmed.contains("FileDescription") || trimmed.contains("FileVersion"))
+}
+
+fn contains_no_copyright_clause(s: &str) -> bool {
+    s.to_ascii_lowercase().contains("no copyright")
+}
+
+fn looks_like_camel_case_identifier(s: &str) -> bool {
+    let token = s.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '_');
+    if token.len() < 6 || token.contains('_') || token.contains('-') || token.contains('.') {
+        return false;
+    }
+
+    let starts_upper = token
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_uppercase());
+    let uppercase_count = token.chars().filter(|ch| ch.is_ascii_uppercase()).count();
+    let lowercase_count = token.chars().filter(|ch| ch.is_ascii_lowercase()).count();
+
+    starts_upper && uppercase_count >= 2 && lowercase_count >= 1
 }
 
 fn contains_html_like_fragment(s: &str) -> bool {

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -30,6 +30,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_bug_reports_clause(&a);
     a = truncate_caller_specificaly_clause(&a);
     a = truncate_json_metadata_tail(&a);
+    a = truncate_distribution_metadata_tail(&a);
     a = normalize_slash_spacing(&a);
     a = normalize_slash_author_pairs(&a);
     a = strip_trailing_status_works(&a);
@@ -52,6 +53,14 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = restore_leading_the_for_collective_author(s, &a);
 
     if is_path_like_code_fragment(&a) {
+        return None;
+    }
+
+    if !a.chars().any(|ch| ch.is_alphabetic()) {
+        return None;
+    }
+
+    if looks_like_generated_resource_identifier(&a) {
         return None;
     }
 
@@ -81,6 +90,10 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
     let trimmed = s.trim();
     if trimmed.is_empty() {
         return false;
+    }
+
+    if looks_like_generated_resource_identifier(trimmed) {
+        return true;
     }
 
     if contains_standalone_at_prefixed_token(trimmed) {
@@ -116,6 +129,14 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
     }
 
     if contains_dollar_prefixed_code_token(trimmed) {
+        return true;
+    }
+
+    if looks_like_template_token_run(trimmed) {
+        return true;
+    }
+
+    if looks_like_uppercase_numeric_token_run(trimmed) {
         return true;
     }
 
@@ -485,6 +506,68 @@ fn truncate_json_metadata_tail(s: &str) -> String {
         }
     }
     s.to_string()
+}
+
+fn truncate_distribution_metadata_tail(s: &str) -> String {
+    static DISTRIBUTION_METADATA_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<prefix>.+?)\s+(?:author|maintainer)-email\b.*$").unwrap()
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = DISTRIBUTION_METADATA_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+    if prefix.is_empty() {
+        return s.to_string();
+    }
+
+    prefix.to_string()
+}
+
+fn looks_like_generated_resource_identifier(s: &str) -> bool {
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed.contains(' ') {
+        return false;
+    }
+
+    contains_generated_resource_token(trimmed)
+}
+
+fn looks_like_template_token_run(s: &str) -> bool {
+    let trimmed = s.trim();
+    if !(trimmed.contains('+') || trimmed.contains('?')) {
+        return false;
+    }
+
+    let uppercase_count = trimmed.chars().filter(|ch| ch.is_ascii_uppercase()).count();
+    let digit_count = trimmed.chars().filter(|ch| ch.is_ascii_digit()).count();
+    uppercase_count >= 4 && digit_count >= 1
+}
+
+fn looks_like_uppercase_numeric_token_run(s: &str) -> bool {
+    let trimmed = s.trim();
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    if words.len() < 2 || words.len() > 6 {
+        return false;
+    }
+
+    let has_digits = words
+        .iter()
+        .any(|word| word.chars().any(|ch| ch.is_ascii_digit()));
+    let uppercaseish = words
+        .iter()
+        .filter(|word| {
+            !word.is_empty()
+                && word.chars().all(|ch| {
+                    ch.is_ascii_uppercase()
+                        || ch.is_ascii_digit()
+                        || matches!(ch, '_' | '+' | '?' | '-')
+                })
+        })
+        .count();
+
+    has_digits && uppercaseish >= 2
 }
 
 fn truncate_bug_reports_clause(s: &str) -> String {

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -8,6 +8,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     if s.is_empty() {
         return None;
     }
+    let had_obfuscated_angle_contact = contains_obfuscated_angle_contact(s);
     let mut a = remove_some_extra_words_and_punct(s);
     a = strip_leading_maintainers_label(&a);
     a = strip_trailing_javadoc_tags(&a);
@@ -21,6 +22,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_common_clock_framework_clause(&a);
     a = truncate_omap_dual_mode_clause(&a);
     a = strip_initials_before_angle_email(&a);
+    a = normalize_obfuscated_angle_contact(&a);
     a = strip_trailing_comma_year_after_angle_email(&a);
     a = strip_trailing_comma_month_year(&a);
     a = strip_trailing_comma_email_matching_name(&a);
@@ -53,7 +55,7 @@ pub fn refine_author(s: &str) -> Option<String> {
         return None;
     }
 
-    if looks_like_prose_fragment_author(&a) {
+    if looks_like_prose_fragment_author(&a) && !had_obfuscated_angle_contact {
         return None;
     }
 
@@ -66,6 +68,13 @@ pub fn refine_author(s: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn contains_obfuscated_angle_contact(s: &str) -> bool {
+    static OBFUSCATED_ANGLE_CONTACT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
+
+    OBFUSCATED_ANGLE_CONTACT_RE.is_match(s)
 }
 
 fn looks_like_prose_fragment_author(s: &str) -> bool {
@@ -121,6 +130,9 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
     }
 
     if looks_like_institution_and_contributors_author(trimmed) {
+        return false;
+    }
+    if looks_like_leading_the_institution_author(trimmed) {
         return false;
     }
     if looks_like_collective_author_with_leading_the(trimmed) {
@@ -366,6 +378,39 @@ fn looks_like_collective_author_with_leading_the(s: &str) -> bool {
     ]
     .iter()
     .any(|suffix| lower.ends_with(suffix))
+}
+
+fn looks_like_leading_the_institution_author(s: &str) -> bool {
+    let trimmed = s.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.starts_with("the ") {
+        return false;
+    }
+
+    let uppercase_word_count = trimmed
+        .split_whitespace()
+        .filter(|word| {
+            word.chars()
+                .find(|ch| ch.is_alphabetic())
+                .is_some_and(|ch| ch.is_uppercase())
+        })
+        .count();
+
+    uppercase_word_count >= 3 && (lower.contains(" at the ") || lower.contains(" of the "))
+}
+
+fn normalize_obfuscated_angle_contact(s: &str) -> String {
+    static OBFUSCATED_ANGLE_CONTACT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
+
+    let replaced = OBFUSCATED_ANGLE_CONTACT_RE
+        .replace_all(s, |caps: &regex::Captures| {
+            caps.name("inner")
+                .map(|m| format!(" {} ", m.as_str().trim()))
+                .unwrap_or_default()
+        })
+        .into_owned();
+    normalize_whitespace(&replaced)
 }
 
 fn starts_with_lowercase_alpha(word: &str) -> bool {

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -227,6 +227,7 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright law\b",
         r"(?i)^copyright page\b",
         r"(?i)^copyright holders? or\b",
+        r"(?i)^the above copyright holders\b",
         r"(?i)^copyrighted material outside\b",
         r"(?i)^copyright holder as a result\b",
         r"(?i)^copyright holder explicitly\b",
@@ -812,7 +813,6 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^\(c\)\s+final\s+[a-z_][a-zA-Z0-9_]*$",
         r"(?i)^copyright\s+referencing\b.*$",
         r"(?i)^copyright\s+and\s+comment\s+directing\b.*$",
-        r"(?i)^not\s+copyrighted\b.*$",
     ];
     patterns.iter().filter_map(|p| Regex::new(p).ok()).collect()
 });

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -806,9 +806,13 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^not\s+copyrighted\s*[-–]\s*provided\s+to\s+the\s+public\s+domain\b",
         r"(?i)^copyright\s+and\s+related\s+rights\b",
         r"(?i)^copyright\s+and\s+related\s+or\s+neighboring\s+rights$",
+        r"(?i)^copyright\s+and\s+related\s+or\s+neighboring\s+legal\s+rights\b.*$",
         r"(?i)^copyright\s+was\s+owned\s+solely\s+by\s+fsf$",
         r"(?i)^copyright\s+years\s+may\s+be\s+listed$",
         r"(?i)^\(c\)\s+final\s+[a-z_][a-zA-Z0-9_]*$",
+        r"(?i)^copyright\s+referencing\b.*$",
+        r"(?i)^copyright\s+and\s+comment\s+directing\b.*$",
+        r"(?i)^not\s+copyrighted\b.*$",
     ];
     patterns.iter().filter_map(|p| Regex::new(p).ok()).collect()
 });

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -155,6 +155,7 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "incorporated",
         "ds",
         "guide",
+        "grants",
         "recommend",
         "recheck",
         "reputations",

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -484,13 +484,14 @@ fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || lower.contains("formatoutput")
         || lower.contains("$template")
         || trimmed.contains("??");
+    let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
     if !lower.starts_with("copyright") {
         return (lower.starts_with("not copyrighted") && !has_copyright_year(trimmed))
-            || (lower.contains("copyright") && has_code_markers);
+            || (lower.contains("copyright") && (has_code_markers || has_prose_markers));
     }
 
-    has_code_markers && !has_copyright_year(trimmed)
+    (has_code_markers || has_prose_markers) && !has_copyright_year(trimmed)
 }
 
 /// Return true if `s` matches any known junk holder pattern.
@@ -514,8 +515,9 @@ fn is_junk_holder_code_fragment(s: &str) -> bool {
         || lower.contains(".startswith")
         || lower.contains("startswith(")
         || lower.contains("$template");
+    let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
-    has_code_markers && !has_copyright_year(trimmed)
+    (has_code_markers || has_prose_markers) && !has_copyright_year(trimmed)
 }
 
 fn is_junk_holder_symbol_garbage(s: &str) -> bool {
@@ -525,12 +527,72 @@ fn is_junk_holder_symbol_garbage(s: &str) -> bool {
     }
 
     let alpha_count = trimmed.chars().filter(|ch| ch.is_alphabetic()).count();
+    let ascii_alpha_count = trimmed
+        .chars()
+        .filter(|ch| ch.is_ascii_alphabetic())
+        .count();
+    let non_ascii_count = trimmed.chars().filter(|ch| !ch.is_ascii()).count();
     let symbol_count = trimmed
         .chars()
         .filter(|ch| !ch.is_alphanumeric() && !ch.is_whitespace())
         .count();
+    let token_count = trimmed
+        .split_whitespace()
+        .filter(|token| token.chars().any(|ch| ch.is_alphanumeric()))
+        .count();
 
-    alpha_count <= 2 && symbol_count >= 6
+    (alpha_count <= 2 && symbol_count >= 6)
+        || (trimmed.len() >= 16
+            && non_ascii_count >= 12
+            && ascii_alpha_count <= 2
+            && symbol_count >= 4
+            && token_count <= 4)
+}
+
+fn is_obvious_prose_fragment(s: &str) -> bool {
+    let trimmed = s.trim();
+    if trimmed.is_empty()
+        || has_copyright_year(trimmed)
+        || trimmed.contains('@')
+        || trimmed.contains("http://")
+        || trimmed.contains("https://")
+    {
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("not by ") {
+        return false;
+    }
+    if lower.contains("code sample for") {
+        return true;
+    }
+
+    let phrase_markers = [
+        "directing the reader",
+        "for use as part of",
+        "original works produced specifically for use as",
+        "confusion over",
+        "original source",
+    ];
+    if phrase_markers.iter().any(|marker| lower.contains(marker)) {
+        return true;
+    }
+
+    let words: Vec<&str> = lower.split_whitespace().collect();
+    if words.len() < 3 {
+        return false;
+    }
+
+    matches!(
+        words.first().copied(),
+        Some("comment" | "comments" | "referencing" | "resulting" | "not")
+    )
+}
+
+fn is_trailing_component_descriptor(desc: &str) -> bool {
+    let desc_lower = desc.to_ascii_lowercase();
+    desc_lower.contains("noise") || desc_lower.ends_with("and others")
 }
 
 pub(crate) fn is_path_like_code_fragment(s: &str) -> bool {
@@ -1186,12 +1248,40 @@ fn strip_trailing_parenthesized_descriptor_after_by_holder(s: &str) -> String {
         return s.to_string();
     }
 
-    let desc_lower = desc.to_ascii_lowercase();
-    if !(desc_lower.contains("noise") || desc_lower.ends_with("and others")) {
+    if !is_trailing_component_descriptor(desc) {
         return s.to_string();
     }
 
     prefix.to_string()
+}
+
+fn strip_trailing_component_descriptor_from_holder(s: &str) -> String {
+    static PAREN_DESCRIPTOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^(?P<prefix>.+?)\s*\(\s*(?P<desc>[A-Za-z][A-Za-z\s-]{2,64})\s*\)\s*$").unwrap()
+    });
+    static TRAILING_COMPONENT_DESCRIPTOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\s+(?P<desc>(?:[A-Za-z]+\s+)?noise(?:\s+and\s+others)?)$").unwrap()
+    });
+
+    let trimmed = s.trim();
+
+    if let Some(cap) = PAREN_DESCRIPTOR_RE.captures(trimmed) {
+        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+        let desc = cap.name("desc").map(|m| m.as_str()).unwrap_or("").trim();
+        if !prefix.is_empty() && is_trailing_component_descriptor(desc) {
+            return prefix.to_string();
+        }
+    }
+
+    if let Some(m) = TRAILING_COMPONENT_DESCRIPTOR_RE.find(trimmed) {
+        let prefix = trimmed[..m.start()].trim();
+        let desc = m.as_str().trim();
+        if !prefix.is_empty() && is_trailing_component_descriptor(desc) {
+            return prefix.to_string();
+        }
+    }
+
+    s.to_string()
 }
 
 fn strip_trailing_or_suffix(s: &str) -> String {
@@ -1697,6 +1787,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     if had_paren_email {
         h = remove_comma_between_person_and_company_suffix(&h);
     }
+    h = strip_trailing_component_descriptor_from_holder(&h);
     h = strip_trailing_by_person_clause_after_company(&h);
     h = strip_trailing_division_of_company_suffix(&h);
     h = strip_leading_product_operating_system_title(&h);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -135,6 +135,11 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "attributions",
         "the",
         "app id",
+        "homepage",
+        "repository",
+        "documentation",
+        "package author",
+        "package authors",
         "project",
         "previous lucene",
         "group",
@@ -467,10 +472,6 @@ fn is_junk_c_sign_path_fragment(s: &str) -> bool {
 fn is_junk_copyright_code_fragment(s: &str) -> bool {
     let trimmed = s.trim();
     let lower = trimmed.to_ascii_lowercase();
-    if !lower.starts_with("copyright") {
-        return false;
-    }
-
     let has_code_markers = lower.contains("string?")
         || lower.contains("bool")
         || lower.contains("final ")
@@ -478,16 +479,58 @@ fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || lower.contains("regexp")
         || lower.contains("match ")
         || lower.contains("replaceallmapped")
+        || lower.contains(".startswith")
+        || lower.contains("startswith(")
         || lower.contains("formatoutput")
         || lower.contains("$template")
         || trimmed.contains("??");
+
+    if !lower.starts_with("copyright") {
+        return (lower.starts_with("not copyrighted") && !has_copyright_year(trimmed))
+            || (lower.contains("copyright") && has_code_markers);
+    }
 
     has_code_markers && !has_copyright_year(trimmed)
 }
 
 /// Return true if `s` matches any known junk holder pattern.
 pub(crate) fn is_junk_holder(s: &str) -> bool {
-    HOLDERS_JUNK_PATTERNS.iter().any(|re| re.is_match(s)) || s.eq_ignore_ascii_case("MIT")
+    HOLDERS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
+        || is_junk_holder_code_fragment(s)
+        || is_junk_holder_symbol_garbage(s)
+        || s.eq_ignore_ascii_case("MIT")
+}
+
+fn is_junk_holder_code_fragment(s: &str) -> bool {
+    let trimmed = s.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let has_code_markers = lower.contains("string?")
+        || lower.contains("bool")
+        || lower.contains("final ")
+        || lower.contains("this.")
+        || lower.contains("regexp")
+        || lower.contains("match ")
+        || lower.contains("replaceallmapped")
+        || lower.contains(".startswith")
+        || lower.contains("startswith(")
+        || lower.contains("$template");
+
+    has_code_markers && !has_copyright_year(trimmed)
+}
+
+fn is_junk_holder_symbol_garbage(s: &str) -> bool {
+    let trimmed = s.trim();
+    if trimmed.len() < 12 {
+        return false;
+    }
+
+    let alpha_count = trimmed.chars().filter(|ch| ch.is_alphabetic()).count();
+    let symbol_count = trimmed
+        .chars()
+        .filter(|ch| !ch.is_alphanumeric() && !ch.is_whitespace())
+        .count();
+
+    alpha_count <= 2 && symbol_count >= 6
 }
 
 pub(crate) fn is_path_like_code_fragment(s: &str) -> bool {
@@ -525,6 +568,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_leading_author_label_in_copyright(&c);
     c = strip_leading_licensed_material_of(&c);
     c = strip_leading_version_number_before_c(&c);
+    c = strip_trailing_parenthesized_descriptor_after_by_holder(&c);
     c = strip_contributor_parens_after_org(&c);
     c = strip_trailing_paren_email_after_c_by(&c);
     c = strip_trailing_for_clause_after_email(&c);
@@ -541,6 +585,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_et_al(&c);
     c = strip_trailing_authors_clause(&c);
     c = strip_trailing_document_authors_clause(&c);
+    c = strip_trailing_parenthesized_descriptor_after_by_holder(&c);
     c = strip_trailing_amp_authors(&c);
     c = strip_trailing_x509_dn_fields(&c);
     c = strip_some_punct(&c);
@@ -561,7 +606,6 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_linux_ag_location_in_copyright(&c);
     c = strip_trailing_by_person_clause_after_company(&c);
     c = strip_trailing_division_of_company_suffix(&c);
-    c = strip_trailing_linux_foundation_suffix(&c);
     c = strip_trailing_paren_at_without_domain(&c);
     c = strip_trailing_inc_after_today_year_placeholder(&c);
     c = truncate_trailing_boilerplate(&c);
@@ -587,6 +631,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = c.trim_matches('\'').to_string();
     c = wrap_trailing_and_urls_in_parens(&c);
     c = strip_trailing_url_slash(&c);
+    c = strip_trailing_or_suffix(&c);
     c = truncate_long_words(&c);
     c = strip_trailing_single_digit_token(&c);
     c = strip_trailing_period(&c);
@@ -648,10 +693,30 @@ fn strip_trailing_obfuscated_email_after_dash(s: &str) -> String {
         return s.to_string();
     };
 
-    cap.name("prefix")
+    let prefix = cap
+        .name("prefix")
         .map(|m| m.as_str().trim_end_matches(&[' ', '-', '–', '—'][..]))
         .unwrap_or(trimmed)
-        .to_string()
+        .trim();
+    let user = cap.name("user").map(|m| m.as_str()).unwrap_or("").trim();
+    let host = cap.name("host").map(|m| m.as_str()).unwrap_or("").trim();
+    let tld = cap.name("tld").map(|m| m.as_str()).unwrap_or("").trim();
+
+    let prefix_lower = prefix.to_ascii_lowercase();
+    let holderish_word_count = prefix
+        .split_whitespace()
+        .filter(|word| word.chars().any(|ch| ch.is_alphabetic()))
+        .count();
+    if prefix_lower.starts_with("copyright")
+        && !user.is_empty()
+        && !host.is_empty()
+        && !tld.is_empty()
+        && holderish_word_count >= 3
+    {
+        return format!("{prefix} - {user} at {host} dot {tld}");
+    }
+
+    prefix.to_string()
 }
 
 fn strip_trailing_secondary_angle_email_after_comma(s: &str) -> String {
@@ -741,23 +806,6 @@ fn strip_obfuscated_angle_emails(s: &str) -> String {
     }
     let out = OBF_ANGLE_RE.replace_all(trimmed, " ").into_owned();
     normalize_whitespace(&out)
-}
-
-fn strip_trailing_linux_foundation_suffix(s: &str) -> String {
-    static LINUX_FOUNDATION_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(
-            r"(?i)^(?P<prefix>Copyright\s*\(c\)\s*\d{4}(?:\s*,\s*\d{4})*)\s+Linux\s+Foundation\s*$",
-        )
-        .unwrap()
-    });
-    let trimmed = s.trim();
-    if let Some(cap) = LINUX_FOUNDATION_RE.captures(trimmed) {
-        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
-        if !prefix.is_empty() {
-            return prefix.to_string();
-        }
-    }
-    s.to_string()
 }
 
 fn strip_trailing_linux_ag_location_in_copyright(s: &str) -> String {
@@ -1118,6 +1166,45 @@ fn strip_trailing_et_al(s: &str) -> String {
     };
     let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("");
     prefix.trim().trim_end_matches(',').trim().to_string()
+}
+
+fn strip_trailing_parenthesized_descriptor_after_by_holder(s: &str) -> String {
+    static DESCRIPTOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?P<prefix>Copyright\s*\(c\)\s*(?:19\d{2}|20\d{2})(?:\s*[-–]\s*(?:19\d{2}|20\d{2}|\d{2}))?\s+by\s+.+?)\s*\(\s*(?P<paren>[A-Za-z][A-Za-z\s-]{2,64})\s*\)\s*$",
+        )
+        .unwrap()
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = DESCRIPTOR_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+    let desc = cap.name("paren").map(|m| m.as_str()).unwrap_or("").trim();
+    if prefix.is_empty() || desc.is_empty() {
+        return s.to_string();
+    }
+
+    let desc_lower = desc.to_ascii_lowercase();
+    if !(desc_lower.contains("noise") || desc_lower.ends_with("and others")) {
+        return s.to_string();
+    }
+
+    prefix.to_string()
+}
+
+fn strip_trailing_or_suffix(s: &str) -> String {
+    static TRAILING_OR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^(?P<prefix>copyright\b.+?)\s+or\s*$").unwrap());
+
+    let trimmed = s.trim();
+    let Some(cap) = TRAILING_OR_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    cap.name("prefix")
+        .map(|m| m.as_str().trim_end().to_string())
+        .unwrap_or_else(|| s.to_string())
 }
 
 fn strip_trailing_x509_dn_fields(s: &str) -> String {
@@ -1492,7 +1579,10 @@ fn is_junk_copyrighted_works_header(s: &str) -> bool {
 }
 
 fn is_junk_copyrighted_software_phrase(s: &str) -> bool {
-    s.trim().eq_ignore_ascii_case("copyrighted software")
+    let trimmed = s.trim();
+    trimmed.eq_ignore_ascii_case("copyrighted software")
+        || trimmed.eq_ignore_ascii_case("copyright holders")
+        || trimmed.eq_ignore_ascii_case("the above copyright holders")
 }
 
 fn strip_trailing_company_name_placeholder(s: &str) -> String {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -160,6 +160,9 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "recheck",
         "reputations",
         "review",
+        "reviewer",
+        "document",
+        "otherwise",
         "disclaims",
         "liability",
         "required",
@@ -434,6 +437,7 @@ static HOLDERS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 pub fn is_junk_copyright(s: &str) -> bool {
     COPYRIGHTS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
         || is_junk_copyright_scan_phrase(s)
+        || is_junk_copyright_code_fragment(s)
         || is_junk_c_sign_path_fragment(s)
 }
 
@@ -458,6 +462,27 @@ fn is_junk_c_sign_path_fragment(s: &str) -> bool {
     };
 
     !has_copyright_year(s) && is_path_like_code_fragment(tail)
+}
+
+fn is_junk_copyright_code_fragment(s: &str) -> bool {
+    let trimmed = s.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.starts_with("copyright") {
+        return false;
+    }
+
+    let has_code_markers = lower.contains("string?")
+        || lower.contains("bool")
+        || lower.contains("final ")
+        || lower.contains("this.")
+        || lower.contains("regexp")
+        || lower.contains("match ")
+        || lower.contains("replaceallmapped")
+        || lower.contains("formatoutput")
+        || lower.contains("$template")
+        || trimmed.contains("??");
+
+    has_code_markers && !has_copyright_year(trimmed)
 }
 
 /// Return true if `s` matches any known junk holder pattern.

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -443,6 +443,7 @@ pub fn is_junk_copyright(s: &str) -> bool {
     COPYRIGHTS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
         || is_junk_copyright_scan_phrase(s)
         || is_junk_copyright_code_fragment(s)
+        || is_junk_copyright_symbol_garbage(s)
         || is_junk_c_sign_path_fragment(s)
 }
 
@@ -476,6 +477,9 @@ fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || lower.contains("bool")
         || lower.contains("final ")
         || lower.contains("this.")
+        || lower.contains("absl::")
+        || lower.contains("strcat(")
+        || lower.contains(" main.cc")
         || lower.contains("regexp")
         || lower.contains("match ")
         || lower.contains("replaceallmapped")
@@ -483,7 +487,15 @@ fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || lower.contains("startswith(")
         || lower.contains("formatoutput")
         || lower.contains("$template")
-        || trimmed.contains("??");
+        || lower.contains("icondata")
+        || lower.contains("static const")
+        || lower.contains("classifiers")
+        || lower.contains("authors.append")
+        || lower == "copyright void"
+        || trimmed.contains("??")
+        || contains_regex_or_template_marker(trimmed)
+        || contains_generated_resource_token(trimmed)
+        || contains_malformed_spaced_year(trimmed);
     let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
     if !lower.starts_with("copyright") {
@@ -514,7 +526,13 @@ fn is_junk_holder_code_fragment(s: &str) -> bool {
         || lower.contains("replaceallmapped")
         || lower.contains(".startswith")
         || lower.contains("startswith(")
-        || lower.contains("$template");
+        || lower.contains("$template")
+        || lower.contains("::")
+        || lower.contains("static const")
+        || lower.contains("icondata")
+        || lower.contains("authors.append")
+        || contains_regex_or_template_marker(trimmed)
+        || contains_generated_resource_token(trimmed);
     let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
     (has_code_markers || has_prose_markers) && !has_copyright_year(trimmed)
@@ -547,6 +565,67 @@ fn is_junk_holder_symbol_garbage(s: &str) -> bool {
             && ascii_alpha_count <= 2
             && symbol_count >= 4
             && token_count <= 4)
+}
+
+fn is_junk_copyright_symbol_garbage(s: &str) -> bool {
+    let trimmed = s.trim();
+    if trimmed.len() < 8 || has_copyright_year(trimmed) {
+        return false;
+    }
+
+    let tail = trimmed
+        .strip_prefix("Copyright")
+        .unwrap_or(trimmed)
+        .trim()
+        .strip_prefix("(c)")
+        .unwrap_or(trimmed)
+        .trim();
+
+    let ascii_alpha_count = tail.chars().filter(|ch| ch.is_ascii_alphabetic()).count();
+    let non_ascii_count = tail.chars().filter(|ch| !ch.is_ascii()).count();
+    let symbol_count = tail
+        .chars()
+        .filter(|ch| !ch.is_alphanumeric() && !ch.is_whitespace())
+        .count();
+
+    (contains_malformed_spaced_year(trimmed) && !tail.contains('@'))
+        || (tail.len() >= 10 && non_ascii_count >= 4 && ascii_alpha_count <= 2 && symbol_count >= 2)
+}
+
+fn contains_regex_or_template_marker(s: &str) -> bool {
+    let trimmed = s.trim();
+    trimmed.contains("(?")
+        || trimmed.contains("?:")
+        || trimmed.contains(r"\d")
+        || trimmed.contains(r"\s")
+        || trimmed.contains(r"\w")
+        || trimmed.contains("{{")
+        || trimmed.contains("}}")
+        || trimmed.contains("${")
+        || trimmed.contains("^ ")
+        || trimmed.contains(" d+")
+        || trimmed.contains(" ?")
+}
+
+fn contains_generated_resource_token(s: &str) -> bool {
+    static ASSET_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)(?:@(?:1x|2x|3x|4x))?\.(?:png|jpg|jpeg|gif|webp|bmp|ico|icns|svg|ttf|otf|woff2?|img|tmpl|json|xml|yaml|yml|g\.dart)\b")
+            .unwrap()
+    });
+
+    let trimmed = s.trim();
+    if trimmed.contains(' ') && !trimmed.contains("FileDescription") {
+        return false;
+    }
+
+    ASSET_RE.is_match(trimmed)
+}
+
+fn contains_malformed_spaced_year(s: &str) -> bool {
+    static SPACED_YEAR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b(?:19|20)\s+\d{2}\b|\b\d{3}\s+\d{1,2}\b").unwrap());
+
+    SPACED_YEAR_RE.is_match(s)
 }
 
 fn is_obvious_prose_fragment(s: &str) -> bool {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1171,8 +1171,12 @@ fn test_refine_author_drops_glibc_prose_fragments() {
     );
     assert_eq!(refine_author("versions, and"), None);
     assert_eq!(refine_author("makes"), None);
+    assert_eq!(refine_author("grants"), None);
     assert_eq!(refine_author("grants irrevocable"), None);
     assert_eq!(refine_author("version information"), None);
+    assert_eq!(refine_author("example. If"), None);
+    assert_eq!(refine_author("doxygen. Using"), None);
+    assert_eq!(refine_author("final String?"), None);
     assert_eq!(
         refine_author("not responsible for the consequences of use of"),
         None

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1178,6 +1178,14 @@ fn test_refine_author_drops_glibc_prose_fragments() {
     assert_eq!(refine_author("doxygen. Using"), None);
     assert_eq!(refine_author("final String?"), None);
     assert_eq!(
+        refine_author("[becoming a sponsor] (https://opencollective.com/pnpm#sponsor)"),
+        None
+    );
+    assert_eq!(
+        refine_author("the command [#7403] (https://github.com/pnpm/pnpm/issues/7403)"),
+        None
+    );
+    assert_eq!(
         refine_author("not responsible for the consequences of use of"),
         None
     );

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1260,6 +1260,13 @@ fn test_is_junk_copyright_drops_code_signature_and_commentary_fragments() {
         "line.startswith Copyright (c) Microsoft Corporation"
     ));
     assert!(is_junk_copyright("not copyrighted The Flutter Authors"));
+    assert!(is_junk_copyright(
+        "copyright comments are original works produced specifically for use as"
+    ));
+    assert!(is_junk_copyright("copyright, resulting in confusion over"));
+    assert!(is_junk_copyright(
+        "Copyright Flutter code sample for MyElement"
+    ));
     assert!(!is_junk_copyright("Not copyrighted 1992 by Mark Adler"));
 }
 
@@ -1291,6 +1298,38 @@ fn test_refine_holder_drops_flutter_compare_noise_fragments() {
     assert_eq!(refine_holder("String? description late bool"), None);
     assert_eq!(
         refine_holder("$template .replaceAllMapped RegExp r ^ +), (Match match) final"),
+        None
+    );
+    assert_eq!(
+        refine_holder("comment directing the reader to the original source"),
+        None
+    );
+    assert_eq!(refine_holder("Flutter code sample for MyElement"), None);
+    assert_eq!(refine_holder("not The Flutter Authors"), None);
+    assert_eq!(refine_holder("referencing The Flutter Authors"), None);
+    assert_eq!(
+        refine_holder("comments original works produced specifically for use as part of"),
+        None
+    );
+    assert_eq!(refine_holder("resulting in confusion over"), None);
+}
+
+#[test]
+fn test_refine_holder_strips_trailing_noise_descriptors() {
+    assert_eq!(
+        refine_holder("Ashima Arts (Simplex noise)"),
+        Some("Ashima Arts".to_string())
+    );
+    assert_eq!(
+        refine_holder("Stefan Gustavson Classic noise and others"),
+        Some("Stefan Gustavson".to_string())
+    );
+}
+
+#[test]
+fn test_refine_holder_drops_dense_unicode_symbol_runs() {
+    assert_eq!(
+        refine_holder("˙∆˚¬…æ≈ç√∫˜µ≤≥≥≥≥÷¡™£¢∞ ¶•ªº-≠⁄€‹›ﬁﬂ‡°·‚—±Œ„´‰Á¨Ø∏”’"),
         None
     );
 }

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -65,14 +65,14 @@ fn test_refine_copyright_keeps_year_only_line() {
 }
 
 #[test]
-fn test_refine_copyright_strips_obfuscated_email_after_dash() {
+fn test_refine_copyright_preserves_holder_obfuscated_email_after_dash() {
     assert_eq!(
         refine_copyright("Copyright (c) 2005, 2006 Nick Galbreath -- nickg at modp dot com"),
-        Some("Copyright (c) 2005, 2006 Nick Galbreath".to_string()),
+        Some("Copyright (c) 2005, 2006 Nick Galbreath - nickg at modp dot com".to_string()),
     );
     assert_eq!(
         refine_copyright("Copyright (c) 2005, 2006 Nick Galbreath - nickg at modp dot com"),
-        Some("Copyright (c) 2005, 2006 Nick Galbreath".to_string()),
+        Some("Copyright (c) 2005, 2006 Nick Galbreath - nickg at modp dot com".to_string()),
     );
 }
 
@@ -95,6 +95,8 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
     assert_eq!(refine_author("compatible"), None);
     assert_eq!(refine_author("desired"), None);
     assert_eq!(refine_author("document"), None);
+    assert_eq!(refine_author("homepage"), None);
+    assert_eq!(refine_author("Package Author"), None);
     assert_eq!(refine_author("otherwise"), None);
     assert_eq!(refine_author("performing"), None);
     assert_eq!(refine_author("review"), None);
@@ -111,6 +113,10 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
     assert_eq!(
         refine_author("the University of California, Berkeley and its contributors"),
         Some("the University of California, Berkeley and its contributors".to_string())
+    );
+    assert_eq!(
+        refine_author("the National Center for Supercomputing Applications at the University of Illinois at Urbana-Champaign"),
+        Some("the National Center for Supercomputing Applications at the University of Illinois at Urbana-Champaign".to_string())
     );
     assert_eq!(
         refine_author(
@@ -1250,7 +1256,27 @@ fn test_is_junk_copyright_drops_code_signature_and_commentary_fragments() {
     assert!(is_junk_copyright(
         "copyright referencing The Flutter Authors"
     ));
+    assert!(is_junk_copyright(
+        "line.startswith Copyright (c) Microsoft Corporation"
+    ));
     assert!(is_junk_copyright("not copyrighted The Flutter Authors"));
+    assert!(!is_junk_copyright("Not copyrighted 1992 by Mark Adler"));
+}
+
+#[test]
+fn test_refine_copyright_strips_trailing_or_and_noise_descriptors() {
+    assert_eq!(
+        refine_copyright("Copyright (c) 1993,2004 Sun Microsystems or"),
+        Some("Copyright (c) 1993,2004 Sun Microsystems".to_string())
+    );
+    assert_eq!(
+        refine_copyright("Copyright (c) 2011 by Ashima Arts (Simplex noise)"),
+        Some("Copyright (c) 2011 by Ashima Arts".to_string())
+    );
+    assert_eq!(
+        refine_copyright("Copyright (c) 2011-2016 by Stefan Gustavson (Classic noise and others)"),
+        Some("Copyright (c) 2011-2016 by Stefan Gustavson".to_string())
+    );
 }
 
 #[test]
@@ -1260,9 +1286,25 @@ fn test_refine_holder_strips_trailing_et_al() {
 }
 
 #[test]
+fn test_refine_holder_drops_flutter_compare_noise_fragments() {
+    assert_eq!(refine_holder("String? description, bool"), None);
+    assert_eq!(refine_holder("String? description late bool"), None);
+    assert_eq!(
+        refine_holder("$template .replaceAllMapped RegExp r ^ +), (Match match) final"),
+        None
+    );
+}
+
+#[test]
 fn test_refine_author_normalizes_angle_bracket_email_comma_spacing() {
     let result = refine_author("dev <dev@acme.test>, Foo");
     assert_eq!(result, Some("dev <dev@acme.test>, Foo".to_string()));
+}
+
+#[test]
+fn test_refine_author_keeps_obfuscated_angle_contact_author() {
+    let result = refine_author("Deepak M <m.deepak at intel.com>");
+    assert_eq!(result, Some("Deepak M m.deepak at intel.com".to_string()));
 }
 
 #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -94,8 +94,11 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
     assert_eq!(refine_author("chef-client"), None);
     assert_eq!(refine_author("compatible"), None);
     assert_eq!(refine_author("desired"), None);
+    assert_eq!(refine_author("document"), None);
+    assert_eq!(refine_author("otherwise"), None);
     assert_eq!(refine_author("performing"), None);
     assert_eq!(refine_author("review"), None);
+    assert_eq!(refine_author("reviewer"), None);
     assert_eq!(refine_author("volunteers"), None);
     assert_eq!(refine_author("Guide"), None);
     assert_eq!(refine_author("maintainers with write access"), None);
@@ -125,6 +128,11 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
     );
     assert_eq!(refine_author("the DTD (see Section 13.3).</p>"), None);
     assert_eq!(refine_author("distribute Contributors"), None);
+    assert_eq!(refine_author("If fixing it requires an API"), None);
+    assert_eq!(
+        refine_author("Flutter and Dart have told us they plan to work contributors"),
+        None
+    );
 }
 
 #[test]
@@ -1178,6 +1186,17 @@ fn test_refine_author_drops_glibc_prose_fragments() {
     assert_eq!(refine_author("doxygen. Using"), None);
     assert_eq!(refine_author("final String?"), None);
     assert_eq!(
+        refine_author(
+            "VALUE FileDescription A sample application demonstrating Flutter APIs VALUE FileVersion"
+        ),
+        None
+    );
+    assert_eq!(refine_author("the ListWheelChildManager"), None);
+    assert_eq!(
+        refine_author("Alexander Peslyak in d+. No copyright is"),
+        None
+    );
+    assert_eq!(
         refine_author("[becoming a sponsor] (https://opencollective.com/pnpm#sponsor)"),
         None
     );
@@ -1212,8 +1231,26 @@ fn test_is_junk_copyright_drops_cc0_and_libgcrypt_junk_fragments() {
     assert!(is_junk_copyright(
         "copyright and related or neighboring rights"
     ));
+    assert!(is_junk_copyright(
+        "copyright and related or neighboring legal rights in the Work"
+    ));
     assert!(is_junk_copyright("copyright was owned solely by FSF"));
     assert!(is_junk_copyright("copyright years may be listed"));
+}
+
+#[test]
+fn test_is_junk_copyright_drops_code_signature_and_commentary_fragments() {
+    assert!(is_junk_copyright("copyright, String? description, bool"));
+    assert!(is_junk_copyright(
+        "copyright $template .replaceAllMapped RegExp r ( ^ +), (Match match) final"
+    ));
+    assert!(is_junk_copyright(
+        "copyright and comment directing the reader to the original source"
+    ));
+    assert!(is_junk_copyright(
+        "copyright referencing The Flutter Authors"
+    ));
+    assert!(is_junk_copyright("not copyrighted The Flutter Authors"));
 }
 
 #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1267,6 +1267,13 @@ fn test_is_junk_copyright_drops_code_signature_and_commentary_fragments() {
     assert!(is_junk_copyright(
         "Copyright Flutter code sample for MyElement"
     ));
+    assert!(is_junk_copyright(
+        "Copyright d+(?:- d+)?, the V8 project authors"
+    ));
+    assert!(is_junk_copyright("Copyright (c ) d+ Google Inc."));
+    assert!(is_junk_copyright("Copyright 201 34"));
+    assert!(is_junk_copyright("Copyright 0 absl::StrCat(errors 0 )"));
+    assert!(is_junk_copyright("Copyright void"));
     assert!(!is_junk_copyright("Not copyrighted 1992 by Mark Adler"));
 }
 
@@ -1312,6 +1319,7 @@ fn test_refine_holder_drops_flutter_compare_noise_fragments() {
         None
     );
     assert_eq!(refine_holder("resulting in confusion over"), None);
+    assert_eq!(refine_holder("absl::StrCat(errors 0"), None);
 }
 
 #[test]
@@ -1344,6 +1352,32 @@ fn test_refine_author_normalizes_angle_bracket_email_comma_spacing() {
 fn test_refine_author_keeps_obfuscated_angle_contact_author() {
     let result = refine_author("Deepak M <m.deepak at intel.com>");
     assert_eq!(result, Some("Deepak M m.deepak at intel.com".to_string()));
+}
+
+#[test]
+fn test_refine_author_strips_distribution_metadata_tails() {
+    assert_eq!(
+        refine_author("Armin Ronacher Author-email armin.ronacher@active-4.com"),
+        Some("Armin Ronacher".to_string())
+    );
+    assert_eq!(
+        refine_author("OWASP Foundation Maintainer-email security@owasp.org"),
+        Some("OWASP Foundation".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_drops_generated_resource_identifiers() {
+    assert_eq!(refine_author("icon-app-20x20@2x.png.img.tmpl"), None);
+}
+
+#[test]
+fn test_refine_author_drops_template_token_runs_and_numeric_fragments() {
+    assert_eq!(refine_author("AUTH CONTRIBUTORS AUTHS+ + 2660"), None);
+    assert_eq!(refine_author("AUTH AUTHS 2730"), None);
+    assert_eq!(refine_author("COMPANY 1411"), None);
+    assert_eq!(refine_author("MAINT 26382"), None);
+    assert_eq!(refine_author("2645-1"), None);
 }
 
 #[test]

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -44,9 +44,31 @@ const JUNK_DOMAIN_SUFFIXES: &[&str] =
     &[".png", ".jpg", ".gif", ".jpeg", ".local", ".blank", ".fill"];
 
 const JUNK_EMAIL_AND_HOST_SUFFIXES: &[&str] = &[
-    ".png", ".jpg", ".gif", ".jpeg", ".local", ".blank", ".fill", ".html", ".htm", ".txt", ".conf",
-    ".cfg", ".default", ".patch", ".diff", ".tar.gz", ".tar.bz2", ".tar.xz", ".gz", ".bz2", ".xz",
-    ".hint", ".sftp",
+    ".png",
+    ".jpg",
+    ".gif",
+    ".jpeg",
+    ".local",
+    ".blank",
+    ".fill",
+    ".html",
+    ".htm",
+    ".txt",
+    ".conf",
+    ".cfg",
+    ".default",
+    ".patch",
+    ".diff",
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.xz",
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".hint",
+    ".sftp",
+    ".tmpl",
+    ".projectdir",
 ];
 
 const JUNK_URLS: &[&str] = &[

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -212,6 +212,31 @@ mod tests {
     }
 
     #[test]
+    fn test_find_urls_keeps_closed_template_placeholders() {
+        let text =
+            "https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=${branchName}";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(
+            urls[0].url,
+            "https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=${branchName}"
+        );
+    }
+
+    #[test]
+    fn test_find_urls_trims_open_template_suffixes() {
+        let text =
+            "https://github.com/flutter/flutter/pull/${{ github.event.pull_request.number }}";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(urls[0].url, "https://github.com/flutter/flutter/pull");
+    }
+
+    #[test]
     fn test_find_urls_ignores_markdown_emphasis_inside_hostname() {
         let text = "Use https://**yourcompany**.atlassian.net for Jira Cloud.";
         let config = DetectionConfig::default();

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -265,6 +265,16 @@ mod tests {
     }
 
     #[test]
+    fn test_find_emails_ignores_generated_template_asset_tokens() {
+        let text = "icon-app-20x20@2x.png.img.tmpl git@github.com this@mockk.projectdir";
+        let config = DetectionConfig::default();
+        let emails = find_emails(text, &config);
+
+        let values: Vec<_> = emails.into_iter().map(|email| email.email).collect();
+        assert_eq!(values, vec!["git@github.com".to_string()]);
+    }
+
+    #[test]
     fn test_find_urls_ignores_file_like_fake_hosts() {
         let text = "http://ftp.sftp/ http://www.classes.hint/ http://www.conf.default/ https://rust-lang.org/real";
         let config = DetectionConfig::default();

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -65,6 +65,7 @@ fn end_of_url_cleaner(url: &str) -> String {
     }
 
     if let Some((before, after)) = cleaned.split_once('}')
+        && !has_unclosed_dollar_template(before)
         && ({
             let trimmed_after =
                 after.trim_matches(|c: char| [',', '.', ':', ';', '!', '?'].contains(&c));
@@ -76,9 +77,30 @@ fn end_of_url_cleaner(url: &str) -> String {
         cleaned = before.to_string();
     }
 
+    cleaned = trim_trailing_template_openers(&cleaned);
+
     cleaned
         .trim_end_matches(|c: char| [',', '.', ':', ';', '!', '?'].contains(&c))
         .to_string()
+}
+
+fn has_unclosed_dollar_template(url: &str) -> bool {
+    url.rfind("${")
+        .is_some_and(|idx| !url[idx + 2..].contains('}'))
+}
+
+fn trim_trailing_template_openers(url: &str) -> String {
+    let mut cleaned = url.to_string();
+
+    for opener in ["${{", "${"] {
+        if cleaned.ends_with(opener) {
+            cleaned.truncate(cleaned.len() - opener.len());
+            cleaned = cleaned.trim_end_matches('/').to_string();
+            break;
+        }
+    }
+
+    cleaned
 }
 
 fn add_fake_scheme(url: &str) -> String {

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -87,6 +87,7 @@ pub fn clean_spdx_text(text: &str) -> String {
     text = text.replace("</p>", "");
     text = text.replace("</div>", "");
     text = text.replace("</licenseUrl>", "");
+    text = text.replace('\\', "");
 
     normalize_spaces(&mut text);
 

--- a/src/license_detection/spdx_lid/test.rs
+++ b/src/license_detection/spdx_lid/test.rs
@@ -161,6 +161,18 @@ mod tests {
     }
 
     #[test]
+    fn test_clean_spdx_text_strips_escaped_punctuation() {
+        let clean = clean_spdx_text("Apache-2\\.0");
+        assert_eq!(clean, "Apache-2.0");
+    }
+
+    #[test]
+    fn test_clean_spdx_text_strips_escaped_punctuation_in_expression() {
+        let clean = clean_spdx_text("Apache-2\\.0 OR MIT");
+        assert_eq!(clean, "Apache-2.0 OR MIT");
+    }
+
+    #[test]
     fn test_extract_spdx_expressions_single() {
         let text = "# SPDX-License-Identifier: MIT";
         let exprs = extract_cleaned_spdx_expressions(text);

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -249,8 +249,10 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
         let trimmed = line.trim();
         let normalized = normalize_comment_author_line(trimmed);
         let line_number = LineNumber::from_0_indexed(line_index);
+        let is_comment_like = looks_like_comment_author_source_line(trimmed);
 
-        if let Some(captures) = COMMENT_AUTHOR_RE.captures(&normalized)
+        if is_comment_like
+            && let Some(captures) = COMMENT_AUTHOR_RE.captures(&normalized)
             && let Some(author) = captures
                 .name("author")
                 .or_else(|| captures.name("author2"))
@@ -263,7 +265,9 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
             });
         }
 
-        if let Some(captures) = COMMENT_PAREN_CONTACT_AUTHOR_RE.captures(&normalized) {
+        if is_comment_like
+            && let Some(captures) = COMMENT_PAREN_CONTACT_AUTHOR_RE.captures(&normalized)
+        {
             let name = captures
                 .name("name")
                 .or_else(|| captures.name("name2"))
@@ -292,6 +296,10 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
             });
         }
 
+        if !is_comment_like {
+            continue;
+        }
+
         for captures in EMAIL_PAREN_NAME_RE.captures_iter(trimmed) {
             let Some(email) = captures.name("email").map(|m| m.as_str().trim()) else {
                 continue;
@@ -311,6 +319,17 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
     }
 
     authors
+}
+
+fn looks_like_comment_author_source_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('#')
+        || trimmed.starts_with("//")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with(';')
+        || trimmed.starts_with("--")
+        || trimmed.starts_with("<!--")
 }
 
 fn normalize_comment_author_line(line: &str) -> String {

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -225,7 +225,7 @@ fn extract_patch_header_author_supplements(text_content: &str) -> Vec<AuthorDete
 fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection> {
     static COMMENT_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:written|edited|modified|updated|originally)\s+by\s+(?P<author>[^<\n]+<\s*(?:[^>\s]+@[^>\s]+|https?://[^>\s]+)\s*>)\s*\.?$|^(?:[#;/*!\-\s]+)?(?:[^<\n]*?\bby\s+(?P<author2>[^<\n]+<\s*(?:[^>\s]+@[^>\s]+|https?://[^>\s]+)\s*>))\s*\.?$",
+            r"(?i)\b(?:written|edited|modified|updated|originally)\s+by\s+(?P<author>[^<\n]+<\s*(?:[^>\s]+@[^>\s]+|https?://[^>\s]+|[^>\n]*\bat\b[^>\n]*)\s*>)\s*\.?$|^(?:[#;/*!\-\s]+)?(?:[^<\n]*?\bby\s+(?P<author2>[^<\n]+<\s*(?:[^>\s]+@[^>\s]+|https?://[^>\s]+|[^>\n]*\bat\b[^>\n]*)\s*>))\s*\.?$|^(?:[#;/*!\-\s]+)?author:\s*(?P<author3>[^<\n]+<\s*(?:[^>\s]+@[^>\s]+|https?://[^>\s]+|[^>\n]*\bat\b[^>\n]*)\s*>)\s*\.?$",
         )
         .expect("valid comment author regex")
     });
@@ -257,6 +257,7 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
             && let Some(author) = captures
                 .name("author")
                 .or_else(|| captures.name("author2"))
+                .or_else(|| captures.name("author3"))
                 .map(|m| m.as_str().trim())
             && let Some(author) = refine_author(&normalize_comment_author_candidate(author))
         {

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -5,7 +5,7 @@ use super::binary_text::{
     extract_named_author_from_binary_line, has_binary_name_like_shape, has_excessive_at_noise,
     has_sufficient_alphabetic_content, is_binary_string_author_candidate, is_company_like_suffix,
 };
-use crate::copyright::{self, AuthorDetection, CopyrightDetection, HolderDetection};
+use crate::copyright::{self, AuthorDetection, CopyrightDetection, HolderDetection, refine_author};
 use crate::models::{Author, Copyright, FileInfoBuilder, Holder, LineNumber};
 use regex::Regex;
 use std::collections::HashSet;
@@ -212,8 +212,9 @@ fn extract_patch_header_author_supplements(text_content: &str) -> Vec<AuthorDete
         .filter_map(|(line_index, line)| {
             let captures = PATCH_AUTHOR_RE.captures(line.trim())?;
             let author = captures.name("author")?.as_str().trim();
+            let author = refine_author(author)?;
             Some(AuthorDetection {
-                author: author.to_string(),
+                author,
                 start_line: LineNumber::from_0_indexed(line_index),
                 end_line: LineNumber::from_0_indexed(line_index),
             })
@@ -257,9 +258,10 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
                 .name("author")
                 .or_else(|| captures.name("author2"))
                 .map(|m| m.as_str().trim())
+            && let Some(author) = refine_author(&normalize_comment_author_candidate(author))
         {
             authors.push(AuthorDetection {
-                author: normalize_comment_author_candidate(author),
+                author,
                 start_line: line_number,
                 end_line: line_number,
             });
@@ -278,8 +280,12 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
                 .map(|m| m.as_str().trim());
 
             if let (Some(name), Some(contact)) = (name, contact) {
+                let author = normalize_parenthesized_contact_author(name, contact);
+                let Some(author) = refine_author(&author) else {
+                    continue;
+                };
                 authors.push(AuthorDetection {
-                    author: normalize_parenthesized_contact_author(name, contact),
+                    author,
                     start_line: line_number,
                     end_line: line_number,
                 });
@@ -288,9 +294,10 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
 
         if let Some(captures) = DOCKER_MAINTAINER_LABEL_RE.captures(trimmed)
             && let Some(author) = captures.name("author").map(|m| m.as_str().trim())
+            && let Some(author) = refine_author(author)
         {
             authors.push(AuthorDetection {
-                author: author.to_string(),
+                author,
                 start_line: line_number,
                 end_line: line_number,
             });
@@ -310,8 +317,12 @@ fn extract_comment_author_supplements(text_content: &str) -> Vec<AuthorDetection
             if name.is_empty() {
                 continue;
             }
+            let author = format!("{name} <{email}>");
+            let Some(author) = refine_author(&author) else {
+                continue;
+            };
             authors.push(AuthorDetection {
-                author: format!("{name} <{email}>"),
+                author,
                 start_line: line_number,
                 end_line: line_number,
             });
@@ -356,7 +367,7 @@ fn normalize_comment_author_candidate(author: &str) -> String {
             .name("url")
             .map(|m| m.as_str().trim_end_matches('/'))
             .unwrap_or(trimmed);
-        return format!("{name} {url}");
+        return format!("{name} ({url})");
     }
 
     trimmed.to_string()

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    extract_comment_author_supplements, extract_patch_header_author_supplements,
-    is_binary_string_copyright_candidate,
+    extract_comment_author_supplements, extract_copyright_information,
+    extract_patch_header_author_supplements, is_binary_string_copyright_candidate,
 };
+use crate::copyright;
+use crate::models::{FileInfoBuilder, FileType};
+use std::path::Path;
+use std::time::Duration;
 
 #[test]
 fn test_binary_string_copyright_candidate_rejects_gibberish_holder_text() {
@@ -108,4 +112,86 @@ fn test_extract_comment_author_supplements_ignores_html_tags() {
     let authors = extract_comment_author_supplements(text);
 
     assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_extract_comment_author_supplements_ignores_plain_markdown_prose() {
+    let text =
+        "Support this project by [becoming a sponsor](https://opencollective.com/pnpm#sponsor).";
+
+    let authors = extract_comment_author_supplements(text);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_extract_copyright_information_ignores_pnpm_markdown_link_prose() {
+    let text = concat!(
+        "</table>\n\n",
+        "<!-- sponsors end -->\n\n",
+        "Support this project by [becoming a sponsor](https://opencollective.com/pnpm#sponsor).\n\n",
+        "## Background\n",
+    );
+
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("README.md"), text, 120.0, false);
+
+    let file = builder
+        .name("README.md".to_string())
+        .base_name("README".to_string())
+        .extension(".md".to_string())
+        .path("README.md".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
+}
+
+#[test]
+fn test_detector_timeout_and_non_timeout_paths_match_for_pnpm_markdown_link_prose() {
+    let text = concat!(
+        "</table>\n\n",
+        "<!-- sponsors end -->\n\n",
+        "Support this project by [becoming a sponsor](https://opencollective.com/pnpm#sponsor).\n\n",
+        "## Background\n",
+    );
+
+    let (_c1, _h1, authors_no_deadline) = copyright::detect_copyrights(text, None);
+    let (_c2, _h2, authors_with_deadline) =
+        copyright::detect_copyrights(text, Some(Duration::from_secs(120)));
+
+    assert_eq!(authors_no_deadline, authors_with_deadline);
+    assert!(
+        authors_with_deadline.is_empty(),
+        "authors_with_deadline: {authors_with_deadline:?}"
+    );
+}
+
+#[test]
+fn test_extract_copyright_information_ignores_pnpm_changelog_markdown_link_on_large_input() {
+    let repeated = "- Do not hang indefinitely, when there is a glob that starts with `!/` in `pnpm-workspace.yaml`. This fixes a regression introduced by [#9169](https://github.com/pnpm/pnpm/pull/9169).\n";
+    let text = repeated.repeat(4000);
+
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(
+        &mut builder,
+        Path::new("pnpm/CHANGELOG.md"),
+        &text,
+        0.000001,
+        false,
+    );
+
+    let file = builder
+        .name("CHANGELOG.md".to_string())
+        .base_name("CHANGELOG".to_string())
+        .extension(".md".to_string())
+        .path("pnpm/CHANGELOG.md".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
 }

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -98,7 +98,7 @@ fn test_extract_comment_author_supplements_handles_c_style_translator_headers() 
         values,
         vec![
             "Jorge Barreiro <yortx.barry@gmail.com>",
-            "Mathias Bynens https://mathiasbynens.be",
+            "Mathias Bynens (https://mathiasbynens.be)",
             "Cloudream (cloudream@gmail.com)",
             "S A Sureshkumar (saskumar@live.com)",
         ]
@@ -141,6 +141,65 @@ fn test_extract_copyright_information_ignores_pnpm_markdown_link_prose() {
         .base_name("README".to_string())
         .extension(".md".to_string())
         .path("README.md".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
+}
+
+#[test]
+fn test_extract_copyright_information_ignores_flutter_issue_hygiene_markdown_link_prose() {
+    let text = concat!(
+        "See also:\n\n",
+        " * [All open issues sorted by thumbs-up](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)\n",
+        " * [Feature requests by thumbs-up](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3A%22c%3A+new+feature%22)\n",
+    );
+
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(
+        &mut builder,
+        Path::new("docs/contributing/issue_hygiene/README.md"),
+        text,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("README.md".to_string())
+        .base_name("README".to_string())
+        .extension(".md".to_string())
+        .path("docs/contributing/issue_hygiene/README.md".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
+}
+
+#[test]
+fn test_extract_copyright_information_ignores_flutter_api_sentence_fragment() {
+    let text = concat!(
+        "* If fixing it requires an API that is not yet available on stable, add the `p: waiting for stable update` label.\n",
+        "  * If it's easy to determine, include the version that the replacement API will be available in the issue description.\n",
+    );
+
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(
+        &mut builder,
+        Path::new("docs/infra/Packages-Gardener-Rotation.md"),
+        text,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("Packages-Gardener-Rotation.md".to_string())
+        .base_name("Packages-Gardener-Rotation".to_string())
+        .extension(".md".to_string())
+        .path("docs/infra/Packages-Gardener-Rotation.md".to_string())
         .file_type(FileType::File)
         .size(text.len() as u64)
         .build()

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -68,6 +68,16 @@ fn test_extract_comment_author_supplements_collects_written_by_and_email_name_fo
 }
 
 #[test]
+fn test_extract_comment_author_supplements_collects_obfuscated_angle_contact_author() {
+    let text = "* Author: Deepak M <m.deepak at intel.com>\n";
+
+    let authors = extract_comment_author_supplements(text);
+    let values: Vec<_> = authors.into_iter().map(|author| author.author).collect();
+
+    assert_eq!(values, vec!["Deepak M m.deepak at intel.com"]);
+}
+
+#[test]
 fn test_extract_comment_author_supplements_collects_comment_by_and_docker_maintainer_lines() {
     let text = "# a2enmod by Stefan Fritsch <sf@debian.org>\n\
 LABEL maintainer=\"Progress Chef <docker@chef.io>\"\n";

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1634,12 +1634,21 @@ fn extract_exif_metadata_values(bytes: &[u8]) -> Vec<String> {
     let mut values = Vec::new();
     for field in exif.fields() {
         let rendered = match field.tag {
-            exif::Tag::ImageDescription | exif::Tag::Copyright | exif::Tag::UserComment => {
-                Some(field.display_value().with_unit(&exif).to_string())
-            }
-            exif::Tag::Artist => Some(format!(
-                "Author: {}",
-                field.display_value().with_unit(&exif)
+            exif::Tag::ImageDescription => Some(format_metadata_field(
+                "Description",
+                &field.display_value().with_unit(&exif).to_string(),
+            )),
+            exif::Tag::Copyright => Some(format_metadata_field(
+                "Copyright",
+                &field.display_value().with_unit(&exif).to_string(),
+            )),
+            exif::Tag::UserComment => Some(format_metadata_field(
+                "Comment",
+                &field.display_value().with_unit(&exif).to_string(),
+            )),
+            exif::Tag::Artist => Some(format_metadata_field(
+                "Author",
+                &field.display_value().with_unit(&exif).to_string(),
             )),
             _ => None,
         };
@@ -1816,23 +1825,50 @@ fn allowed_xmp_field(name: &str) -> Option<&'static str> {
 
 fn format_xmp_value(field: &str, value: &str) -> String {
     match field {
-        "creator" => format!("Author: {value}"),
+        "creator" => format_metadata_field("Author", value),
+        "rights" => format_metadata_field("Copyright", value),
+        "description" => format_metadata_field("Description", value),
+        "title" => format_metadata_field("Title", value),
+        "subject" => format_metadata_field("Subject", value),
+        "usage_terms" => format_metadata_field("UsageTerms", value),
+        "web_statement" => format_metadata_field("WebStatement", value),
         _ => value.to_string(),
     }
 }
 
+fn format_metadata_field(label: &str, value: &str) -> String {
+    format!("{label}: {value}")
+}
+
 fn values_to_text(values: Vec<String>) -> String {
     let mut seen = BTreeSet::new();
+    let mut normalized_lines = Vec::new();
+
+    for value in values {
+        let normalized = normalize_metadata_value(&value);
+        if normalized.is_empty() || !seen.insert(normalized.clone()) {
+            continue;
+        }
+
+        normalized_lines.push(normalized);
+    }
+
+    let author_values: BTreeSet<String> = normalized_lines
+        .iter()
+        .filter_map(|line| split_metadata_field(line))
+        .filter(|(label, _)| label.eq_ignore_ascii_case("Author"))
+        .map(|(_, value)| value.to_string())
+        .collect();
+
     let mut lines = Vec::new();
     let mut total_bytes = 0usize;
 
-    for value in values {
+    for normalized in normalized_lines {
         if lines.len() >= MAX_IMAGE_METADATA_VALUES {
             break;
         }
 
-        let normalized = normalize_metadata_value(&value);
-        if normalized.is_empty() || !seen.insert(normalized.clone()) {
+        if should_suppress_bare_copyright_metadata_line(&normalized, &author_values) {
             continue;
         }
 
@@ -1846,6 +1882,33 @@ fn values_to_text(values: Vec<String>) -> String {
     }
 
     lines.join("\n")
+}
+
+fn split_metadata_field(line: &str) -> Option<(&str, &str)> {
+    let (label, value) = line.split_once(':')?;
+    Some((label.trim(), value.trim()))
+}
+
+fn should_suppress_bare_copyright_metadata_line(
+    line: &str,
+    author_values: &BTreeSet<String>,
+) -> bool {
+    let Some((label, value)) = split_metadata_field(line) else {
+        return false;
+    };
+    if !label.eq_ignore_ascii_case("Copyright")
+        || value.is_empty()
+        || !author_values.contains(value)
+    {
+        return false;
+    }
+
+    let lower = value.to_ascii_lowercase();
+    !lower.contains("copyright")
+        && !lower.contains("(c)")
+        && !lower.contains('©')
+        && !lower.contains("all rights")
+        && !value.chars().any(|ch| ch.is_ascii_digit())
 }
 
 fn normalize_metadata_value(value: &str) -> String {
@@ -2148,13 +2211,53 @@ pub fn extract_printable_strings(bytes: &[u8]) -> String {
 mod tests {
     use std::path::Path;
 
+    use crate::copyright::detect_copyrights;
+
     use super::{
         ExtractedTextKind, LARGE_OPAQUE_BINARY_SKIP_BYTES, classify_file_info,
         extract_printable_strings, extract_text_for_detection,
-        extract_text_for_detection_with_diagnostics, is_non_actionable_pdf_failure,
-        normalize_mime_type, normalize_pdf_heading_comparison_text,
-        windows_metadata_or_empty_result,
+        extract_text_for_detection_with_diagnostics, format_metadata_field, format_xmp_value,
+        is_non_actionable_pdf_failure, normalize_mime_type, normalize_pdf_heading_comparison_text,
+        values_to_text, windows_metadata_or_empty_result,
     };
+
+    fn png_chunk(chunk_type: &[u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        out.extend_from_slice(chunk_type);
+        out.extend_from_slice(data);
+        out.extend_from_slice(&0u32.to_be_bytes());
+        out
+    }
+
+    fn build_png_with_xmp(xmp: &str) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"\x89PNG\r\n\x1a\n");
+
+        let ihdr = [
+            0, 0, 0, 1, // width
+            0, 0, 0, 1, // height
+            8, // bit depth
+            2, // color type
+            0, // compression
+            0, // filter
+            0, // interlace
+        ];
+        bytes.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+
+        let mut itxt = Vec::new();
+        itxt.extend_from_slice(b"XML:com.adobe.xmp");
+        itxt.push(0); // keyword terminator
+        itxt.push(0); // compression flag
+        itxt.push(0); // compression method
+        itxt.push(0); // language tag terminator
+        itxt.push(0); // translated keyword terminator
+        itxt.extend_from_slice(xmp.as_bytes());
+        bytes.extend_from_slice(&png_chunk(b"iTXt", &itxt));
+
+        bytes.extend_from_slice(&png_chunk(b"IEND", &[]));
+        bytes
+    }
 
     #[test]
     fn test_extract_text_for_detection_skips_jar_archives() {
@@ -2304,6 +2407,79 @@ mod tests {
         assert_eq!(kind, ExtractedTextKind::WindowsExecutableMetadata);
         assert_eq!(text, "LegalCopyright: Example Corp");
         assert!(scan_error.is_none());
+    }
+
+    #[test]
+    fn test_format_xmp_value_labels_creator_and_title_fields() {
+        assert_eq!(
+            format_xmp_value("creator", "Chinmay Garde"),
+            "Author: Chinmay Garde"
+        );
+        assert_eq!(
+            format_xmp_value("title", "Bay Bridge At Night"),
+            "Title: Bay Bridge At Night"
+        );
+        assert_eq!(
+            format_xmp_value("description", "Embarcadero in the evening on Delta 3200"),
+            "Description: Embarcadero in the evening on Delta 3200"
+        );
+    }
+
+    #[test]
+    fn test_format_metadata_field_prefixes_exif_text() {
+        assert_eq!(
+            format_metadata_field("Author", "Chinmay Garde"),
+            "Author: Chinmay Garde"
+        );
+        assert_eq!(
+            format_metadata_field("Description", "Bay Bridge At Night"),
+            "Description: Bay Bridge At Night"
+        );
+    }
+
+    #[test]
+    fn test_extract_text_for_detection_keeps_image_author_separate_from_title_and_description() {
+        let xmp = r#"<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:creator>Chinmay Garde</dc:creator><dc:title>Bay Bridge At Night</dc:title><dc:description>Embarcadero in the evening on Delta 3200</dc:description></rdf:Description></rdf:RDF></x:xmpmeta>"#;
+        let bytes = build_png_with_xmp(xmp);
+
+        let (text, kind) = extract_text_for_detection(Path::new("fixture.png"), &bytes);
+
+        assert_eq!(kind, ExtractedTextKind::ImageMetadata);
+        assert!(text.contains("Author: Chinmay Garde"), "text: {text:?}");
+        assert!(
+            text.contains("Title: Bay Bridge At Night"),
+            "text: {text:?}"
+        );
+        assert!(
+            text.contains("Description: Embarcadero in the evening on Delta 3200"),
+            "text: {text:?}"
+        );
+
+        let (_copyrights, _holders, authors) = detect_copyrights(&text, None);
+        assert_eq!(
+            authors
+                .iter()
+                .map(|a| a.author.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Chinmay Garde"],
+            "authors: {authors:?}; text: {text:?}"
+        );
+    }
+
+    #[test]
+    fn test_values_to_text_suppresses_bare_copyright_duplicate_of_author() {
+        let text = values_to_text(vec![
+            "Author: Chinmay Garde".to_string(),
+            "Copyright: Chinmay Garde".to_string(),
+            "Title: Bay Bridge At Night".to_string(),
+        ]);
+
+        assert!(text.contains("Author: Chinmay Garde"), "text: {text:?}");
+        assert!(
+            text.contains("Title: Bay Bridge At Night"),
+            "text: {text:?}"
+        );
+        assert!(!text.contains("Copyright: Chinmay Garde"), "text: {text:?}");
     }
 
     #[test]

--- a/testdata/copyright-golden/copyrights/licco.txt.yml
+++ b/testdata/copyright-golden/copyrights/licco.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hartmut Goebel
 authors:
+  - Hartmut Goebel
   - Hartmut Goebel <h.goebel@crazy-compilers.com>
-  - Hartmut Goebel Author-email h.goebel@crazy-compilers.com

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/bpf/bpf_devel_QA.rst.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/bpf/bpf_devel_QA.rst.yml
@@ -3,7 +3,6 @@ what:
   - holders
   - authors
 authors:
-  - did. Thus
   - in Cc
 copyrights: []
 holders: []


### PR DESCRIPTION
## Summary

- generalize shared copyright, holder, and author cleanup across detector/refiner/scanner paths so compare-target noise is reduced without introducing Flutter-specific string blacklists
- add supporting extraction and normalization work for storyboard/XML `text=` copyright evidence, image metadata dedupe, ISO-date/unknown-year holder recovery, templated URL cleanup, escaped SPDX tag normalization, and a final cleanup pass for regex/template junk, generated-resource email noise, and distribution-metadata author tails
- validate the branch with focused regressions, copyright golden + library-profile checks, a documented Flutter benchmark checkpoint, a clean pnpm compare check, and fresh exact compare reruns with ScanCode cache hits

## Issues

- Covers: flutter/flutter residual compare cleanup, pnpm/pnpm regression safety, and broader cross-target copyright/holder/author false positives
- Closes:

## Scope and exclusions

- Included: shared detector/refiner/scanner cleanup, metadata extraction refinements, finder/SPDX normalization fixes, benchmark documentation refresh, two copyright golden expectation updates, and compare-run verification evidence
- Explicit exclusions: no claim that `flutter/flutter` is fully clean yet; remaining sampled deltas still include `planet.frag` normalization duplicates, `the Dart project authors` vs `the Dart project`, Flutter code-fragment leftovers like `Copyright 0 absl::StrCat(errors 0 )` / `Copyright void`, and scancode-toolkit fixture-token leftovers like `AUTH AUTHS 2730`, `COMPANY 1411`, and `MAINT 26382`

## Intentional differences from Python

- Provenant continues to preserve structured contributor/author evidence from committed `AUTHORS` files and labeled image metadata when that evidence is present, even where ScanCode often leaves those surfaces empty

## Follow-up work

- Created or intentionally deferred: if we continue, the next high-value buckets are the remaining code-fragment junk in Flutter license-checker fixture text and the remaining uppercase fixture-token author noise in scancode-toolkit `src/cluecode/copyrights.py`

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/bpf/bpf_devel_QA.rst.yml`, `testdata/copyright-golden/copyrights/licco.txt.yml`
- Why the new expected output is correct: the old expectations kept stale false-positive author forms; after the generalized cleanup the focused regressions, copyright golden, and library-profile validation all pass with the corrected expectations

## Compare artifacts

- Flutter benchmark/checkpoint recorded in docs: `.provenant/compare-runs/20260427T223247Z-flutter-8526/`
- pnpm clean validation checkpoint: `.provenant/compare-runs/20260428T124247Z-pnpm-1113/`
- exact rerun at pushed HEAD before the final mini-pass: `.provenant/compare-runs/20260428T135306Z-scancode-toolkit-92561/` (ScanCode cache hit)
- exact rerun at pushed HEAD before the final mini-pass: `.provenant/compare-runs/20260428T140858Z-camel-12496/` (ScanCode cache hit)
- latest dirty-tree rerun including the final mini-pass: `.provenant/compare-runs/20260428T151953Z-flutter-6927/` (ScanCode cache hit)
- latest dirty-tree rerun including the final mini-pass: `.provenant/compare-runs/20260428T152754Z-scancode-toolkit-16046/` (ScanCode cache hit)