### PR TITLE
fix(copyright): trim late code fragment noise

### DIFF
--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -311,6 +311,7 @@ pub fn detect_copyrights_from_text_with_deadline(
 
     if deadline_exceeded(deadline) {
         refine_final_copyrights(&mut copyrights);
+        postprocess_transforms::refine_final_holders(&mut holders);
         postprocess_transforms::refine_final_authors(&mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
@@ -342,6 +343,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     );
 
     refine_final_copyrights(&mut copyrights);
+    postprocess_transforms::refine_final_holders(&mut holders);
     postprocess_transforms::refine_final_authors(&mut authors);
     postprocess_transforms::drop_trademark_boilerplate_multiline_extensions(
         &raw_lines,

--- a/src/copyright/detector/postprocess_transforms/mod.rs
+++ b/src/copyright/detector/postprocess_transforms/mod.rs
@@ -49,6 +49,9 @@ pub fn refine_final_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
         .iter()
         .filter_map(|c| {
             let text = refine_copyright(&c.copyright)?;
+            if is_late_code_fragment_copyright(&text) {
+                return None;
+            }
             Some(CopyrightDetection {
                 copyright: text,
                 start_line: c.start_line,
@@ -56,6 +59,30 @@ pub fn refine_final_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
             })
         })
         .collect();
+}
+
+pub fn refine_final_holders(holders: &mut Vec<HolderDetection>) {
+    if holders.is_empty() {
+        return;
+    }
+
+    holders.retain(|holder| !is_late_code_fragment_holder(&holder.holder));
+}
+
+fn is_late_code_fragment_copyright(s: &str) -> bool {
+    let lower = s.trim().to_ascii_lowercase();
+    lower == "copyright void"
+        || lower.contains("absl::")
+        || lower.contains("strcat(")
+        || lower.contains(" main.cc")
+}
+
+fn is_late_code_fragment_holder(s: &str) -> bool {
+    let lower = s.trim().to_ascii_lowercase();
+    lower == "void"
+        || lower.contains("absl::")
+        || lower.contains("strcat(")
+        || lower.contains(" main.cc")
 }
 
 pub fn refine_final_authors(authors: &mut Vec<AuthorDetection>) {

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -170,3 +170,36 @@ fn test_refine_final_authors_drops_markdown_link_fragments() {
 
     assert!(authors.is_empty(), "authors: {authors:?}");
 }
+
+#[test]
+fn test_refine_final_copyrights_drops_late_code_fragment_junk() {
+    let mut copyrights = vec![CopyrightDetection {
+        copyright: "Copyright 0 absl::StrCat(errors 0 )".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    refine_final_copyrights(&mut copyrights);
+
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+}
+
+#[test]
+fn test_refine_final_holders_drops_late_code_fragment_junk() {
+    let mut holders = vec![
+        HolderDetection {
+            holder: "absl::StrCat(errors 0".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        HolderDetection {
+            holder: "void".to_string(),
+            start_line: LineNumber::new(2).unwrap(),
+            end_line: LineNumber::new(2).unwrap(),
+        },
+    ];
+
+    refine_final_holders(&mut holders);
+
+    assert!(holders.is_empty(), "holders: {holders:?}");
+}

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -519,6 +519,7 @@ fn is_junk_holder_code_fragment(s: &str) -> bool {
     let lower = trimmed.to_ascii_lowercase();
     let has_code_markers = lower.contains("string?")
         || lower.contains("bool")
+        || lower == "void"
         || lower.contains("final ")
         || lower.contains("this.")
         || lower.contains("regexp")


### PR DESCRIPTION
## Summary

- add a narrow late-stage copyright/holder cleanup pass that drops surviving code-fragment residuals after normal refinement
- wire the late holder cleanup into both normal and deadline detector paths, and keep the scope tight with focused regressions
- validate the pass with targeted detector/refiner tests, copyright golden + library-profile checks, and fresh clean-main compare reruns for `flutter/flutter` and `scancode-toolkit`

## Issues

- Covers: final narrow parity cleanup for late code-fragment copyright/holder junk
- Closes:

## Scope and exclusions

- Included: late postprocess cleanup in `src/copyright/detector/postprocess_transforms/mod.rs`, detector wiring in `src/copyright/detector/mod.rs`, focused postprocess tests, and one narrow shared-refiner holder heuristic for `void`
- Explicit exclusions: no claim that compare parity is closed overall; remaining residuals still include Flutter `planet.frag` normalization duplicates / `the Dart project authors` wording, and scancode-toolkit uppercase fixture-token author noise such as `AUTH AUTHS 2730`, `COMPANY 1411`, and `MAINT 26382`

## Intentional differences from Python

- This pass keeps the existing Provenant behavior of preserving broader structured author and metadata signals; it only trims a traced late-stage code-fragment junk family after normal refinement has already run

## Follow-up work

- Created or intentionally deferred: if we continue after this, the next worthwhile target is the remaining scancode-toolkit uppercase grammar-token author family, likely via an author-only final-pass cleanup rather than broader refiner changes

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no expected-output fixtures changed in this pass; the changes are supported by focused regressions, green copyright golden/library validation, and fresh compare artifacts

## Compare artifacts

- clean-main Flutter rerun: `.provenant/compare-runs/20260428T165451Z-flutter-21037/` (ScanCode cache hit)
- clean-main scancode-toolkit rerun: `.provenant/compare-runs/20260428T170436Z-scancode-toolkit-33563/` (ScanCode cache hit)