### PR TITLE
fix(copyright): filter trade-secret notice false positives

### DIFF
--- a/src/copyright/detector/tests_copyright_holder_pipeline.rs
+++ b/src/copyright/detector/tests_copyright_holder_pipeline.rs
@@ -368,6 +368,36 @@ fn test_mit_intro_not_copyright_or_holder() {
 }
 
 #[test]
+fn test_confidential_notice_trade_secret_phrase_not_detected_as_copyright() {
+    let input = concat!(
+        "/*\n",
+        " * Copyright Acme Inc. and its affiliates.\n",
+        " * The information contained herein is protected by applicable copyright and trade secret law.\n",
+        " */\n",
+    );
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright Acme Inc. and its affiliates"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        !copyrights
+            .iter()
+            .any(|c| c.copyright == "copyright and trade secret"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders
+            .iter()
+            .any(|h| h.holder == "Acme Inc. and its affiliates"),
+        "holders: {holders:?}"
+    );
+}
+
+#[test]
 fn test_rest_api_description_not_holder_or_copyright() {
     let input = "We provide developers, researchers, and students the ability to access any model using a simple REST API call. The REST API description.";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -183,6 +183,7 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright holder, author\b",
         r"(?i)^copyright holders? disclaim\b",
         r"(?i)^copyright and has\b",
+        r"(?i)^copyright and trade secrets?\b",
         r"(?i)^copyright and trademark\b",
         r"(?i)^copyright and other proprietary\b",
         r"(?i)^copyright in the\b",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -379,6 +379,8 @@ fn test_is_junk_copyright_patents_trade_secrets() {
 fn test_is_junk_copyright_trade_secrets_fragments() {
     assert!(is_junk_copyright("copyrights, trade secrets or"));
     assert!(is_junk_copyright("COPYRIGHT, TRADE SECRET OR"));
+    assert!(is_junk_copyright("copyright and trade secret"));
+    assert!(is_junk_copyright("COPYRIGHT AND TRADE SECRETS"));
     assert!(is_junk_copyright(
         "copyright, trade secret, trademark or other intellectual property rights of"
     ));


### PR DESCRIPTION
## Summary

- add a refiner junk-pattern rule for extracted `copyright and trade secret[s]` boilerplate fragments
- add targeted copyright regressions for the refiner and detector pipeline, using an anonymized `Acme Inc.` notice sample
- preserve the real copyright/holder extraction while preventing the confidentiality-notice false positive

## Scope and exclusions

- Included:
  - refiner-layer junk filtering for trade-secret boilerplate fragments
  - unit and detector-level regression coverage for the reported false positive
- Explicit exclusions:
  - broader detector/tree-walk refactors toward ScanCode's parser/token architecture
  - golden fixture changes or output-schema changes

## Intentional differences from Python

- none intended; this change narrows Provenant's behavior toward ScanCode by dropping a false-positive boilerplate fragment that ScanCode does not emit

## Follow-up work

- Created or intentionally deferred:
  - evaluate whether a small amount of earlier candidate/token filtering would reduce future late-stage junk-pattern additions without adopting ScanCode's architecture wholesale
