### PR TITLE
fix(gradle): preserve project scopes and ignore unresolved dotted refs

### DIFF
--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -425,7 +425,7 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             continue;
         }
 
-        if let Tok::Str(_) = &tokens[i]
+        if let Tok::Str(scope_name) = &tokens[i]
             && i + 1 < tokens.len()
             && tokens[i + 1] == Tok::OpenParen
             && let Some(end) = find_matching_paren(tokens, i + 1)
@@ -438,7 +438,7 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
                 && let Some(project_end) = find_matching_paren(inner, 1)
             {
                 let project_tokens = &inner[2..project_end];
-                if let Some(rd) = parse_project_ref(project_tokens) {
+                if let Some(rd) = parse_project_ref(project_tokens, scope_name) {
                     deps.push(rd);
                 }
                 i = end + 1;
@@ -541,13 +541,13 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             continue;
         }
 
-        // PATTERN: scope ident.attr (variable reference / dotted identifier)
-        // Note: Skip references starting with "dependencies." as Python's pygmars
-        // relabels the "dependencies" token, breaking the DEPENDENCY-5 grammar rule.
+        // PATTERN: scope libs.foo.bar (version catalog alias)
+        // Keep TOML-backed `libs.*` aliases for later version-catalog resolution,
+        // but ignore other unresolved dotted identifiers such as `dependencies.*`
+        // or arbitrary constants like `Deps.AndroidX.core`.
         if next < tokens.len()
             && let Tok::Ident(ref val) = tokens[next]
-            && val.contains('.')
-            && !val.starts_with("dependencies.")
+            && val.starts_with("libs.")
             && let Some(last_seg) = val.rsplit('.').next()
             && !last_seg.is_empty()
         {
@@ -574,7 +574,7 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             && let Some(end) = find_matching_paren(tokens, next + 1)
         {
             let inner = &tokens[next + 2..end];
-            if let Some(rd) = parse_project_ref(inner) {
+            if let Some(rd) = parse_project_ref(inner, &scope_name) {
                 deps.push(rd);
             }
             i = end + 1;
@@ -637,7 +637,7 @@ fn parse_paren_content(scope: &str, tokens: &[Tok], deps: &mut Vec<RawDep>) {
         if inner_fn == "project" {
             if let Some(end) = find_matching_paren(tokens, 1) {
                 let inner = &tokens[2..end];
-                if let Some(rd) = parse_project_ref(inner) {
+                if let Some(rd) = parse_project_ref(inner, scope) {
                     deps.push(rd);
                 }
             }
@@ -776,7 +776,7 @@ fn parse_named_params(scope: &str, tokens: &[Tok]) -> Option<(RawDep, usize)> {
     ))
 }
 
-fn parse_project_ref(tokens: &[Tok]) -> Option<RawDep> {
+fn parse_project_ref(tokens: &[Tok], scope: &str) -> Option<RawDep> {
     if let Some(Tok::Str(val)) = tokens.first() {
         let module_name = val.trim_start_matches(':');
         let mut segments = module_name
@@ -795,7 +795,7 @@ fn parse_project_ref(tokens: &[Tok]) -> Option<RawDep> {
             },
             name: truncate_field(name.to_string()),
             version: String::new(),
-            scope: "project".to_string(),
+            scope: truncate_field(scope.to_string()),
             catalog_alias: None,
             project_path: Some(truncate_field(module_name.to_string())),
         });
@@ -1561,8 +1561,25 @@ dependencies {
         let tokens = lex(content);
         let deps = extract_dependencies(&tokens);
         assert_eq!(deps.len(), 2);
-        assert_eq!(deps[0].scope, Some("project".to_string()));
+        assert_eq!(deps[0].scope, Some("implementation".to_string()));
+        assert_eq!(
+            deps[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("documentation")
+        );
         assert_eq!(deps[0].purl, Some("pkg:maven/documentation".to_string()));
+        assert_eq!(deps[1].scope, Some("implementation".to_string()));
+        assert_eq!(
+            deps[1]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("basics")
+        );
         assert_eq!(deps[1].purl, Some("pkg:maven/basics".to_string()));
     }
 
@@ -1579,8 +1596,78 @@ dependencies {
 
         assert_eq!(deps.len(), 2);
         assert_eq!(deps[0].purl, Some("pkg:maven/libs/download".to_string()));
-        assert_eq!(deps[0].scope, Some("project".to_string()));
+        assert_eq!(deps[0].scope, Some("implementation".to_string()));
+        assert_eq!(
+            deps[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("libs:download")
+        );
+        assert_eq!(deps[1].scope, Some("implementation".to_string()));
+        assert_eq!(
+            deps[1]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("libs:index")
+        );
         assert_eq!(deps[1].purl, Some("pkg:maven/libs/index".to_string()));
+    }
+
+    #[test]
+    fn test_testimplementation_project_reference_is_not_runtime() {
+        let content = r#"
+dependencies {
+    testImplementation project(':mockito-config')
+}
+"#;
+        let tokens = lex(content);
+        let deps = extract_dependencies(&tokens);
+
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].scope, Some("testImplementation".to_string()));
+        assert_eq!(deps[0].purl, Some("pkg:maven/mockito-config".to_string()));
+        assert_eq!(deps[0].is_runtime, Some(false));
+        assert_eq!(deps[0].is_optional, Some(true));
+        assert_eq!(
+            deps[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("mockito-config")
+        );
+    }
+
+    #[test]
+    fn test_unresolved_dotted_identifiers_are_ignored_but_project_refs_survive() {
+        let content = r#"
+dependencies {
+    implementation Deps.AndroidX.core
+    implementation Deps.AndroidX.androidxAnnotation
+    testImplementation TestDeps.mockitoCore3
+    testImplementation project(':mockito-config')
+}
+"#;
+        let tokens = lex(content);
+        let deps = extract_dependencies(&tokens);
+
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].scope, Some("testImplementation".to_string()));
+        assert_eq!(deps[0].purl, Some("pkg:maven/mockito-config".to_string()));
+        assert_eq!(deps[0].is_runtime, Some(false));
+        assert_eq!(deps[0].is_optional, Some(true));
+        assert_eq!(
+            deps[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("mockito-config")
+        );
     }
 
     #[test]
@@ -1784,8 +1871,18 @@ subprojects {
         let tokens = lex(content);
         let deps = extract_dependencies(&tokens);
         assert_eq!(deps.len(), 1);
-        assert_eq!(deps[0].scope, Some("project".to_string()));
+        assert_eq!(deps[0].scope, Some("testImplementation".to_string()));
         assert_eq!(deps[0].purl, Some("pkg:maven/utils/test-utils".to_string()));
+        assert_eq!(deps[0].is_runtime, Some(false));
+        assert_eq!(deps[0].is_optional, Some(true));
+        assert_eq!(
+            deps[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("project_path"))
+                .and_then(|value| value.as_str()),
+            Some("utils:test-utils")
+        );
     }
 
     #[test]

--- a/testdata/gradle-golden/README.md
+++ b/testdata/gradle-golden/README.md
@@ -87,13 +87,13 @@ The Python ScanCode Toolkit implementation uses **pygmars** (a token-based parse
 
    - **Why partial**: We preserve the literal tokenized value, but do not resolve variables or version catalogs semantically
 
-3. **Gradle dotted identifier resolution outside catalogs**:
+3. **Gradle dotted identifier handling**:
 
    ```groovy
    implementation libs.androidx.appcompat
    ```
 
-   - **Why partial**: TOML-backed `libs.versions.toml` aliases can now be resolved from nearby catalogs, but arbitrary dotted identifiers (for example `dependencies.lombok`) still need semantic evaluation beyond static parsing
+   - **Why partial**: TOML-backed `libs.versions.toml` aliases can now be resolved from nearby catalogs, but arbitrary dotted identifiers (for example `dependencies.lombok` or `Deps.AndroidX.core`) are intentionally ignored unless they are real `libs.*` catalog aliases
 
 ## Test Files Status
 

--- a/testdata/gradle-golden/groovy/groovy6-with-props/build.gradle-expected.json
+++ b/testdata/gradle-golden/groovy/groovy6-with-props/build.gradle-expected.json
@@ -40,7 +40,7 @@
       {
         "purl": "pkg:maven/cassandra-commons",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "compile",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,

--- a/testdata/gradle-golden/groovy/version-catalog/build.gradle-expected.json
+++ b/testdata/gradle-golden/groovy/version-catalog/build.gradle-expected.json
@@ -66,7 +66,7 @@
       {
         "purl": "pkg:maven/libs/download",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "implementation",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,

--- a/testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json
+++ b/testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json
@@ -63,7 +63,7 @@
       {
         "purl": "pkg:maven/detekt-rules",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "detektPlugins",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
@@ -74,9 +74,9 @@
       {
         "purl": "pkg:maven/utils/test-utils",
         "extracted_requirement": "",
-        "scope": "project",
-        "is_runtime": true,
-        "is_optional": false,
+        "scope": "testImplementation",
+        "is_runtime": false,
+        "is_optional": true,
         "is_pinned": false,
         "is_direct": true,
         "resolved_package": {},

--- a/testdata/gradle-golden/kotlin/kotlin3/build.gradle.kts-expected.json
+++ b/testdata/gradle-golden/kotlin/kotlin3/build.gradle.kts-expected.json
@@ -40,7 +40,7 @@
       {
         "purl": "pkg:maven/documentation",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "implementation",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
@@ -51,7 +51,7 @@
       {
         "purl": "pkg:maven/basics",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "implementation",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
@@ -62,7 +62,7 @@
       {
         "purl": "pkg:maven/module-identity",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "implementation",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,
@@ -73,7 +73,7 @@
       {
         "purl": "pkg:maven/jvm",
         "extracted_requirement": "",
-        "scope": "project",
+        "scope": "implementation",
         "is_runtime": true,
         "is_optional": false,
         "is_pinned": false,


### PR DESCRIPTION
## Summary

- preserve the enclosing Gradle configuration scope for `project(':...')` dependencies so test-scoped project refs stay non-runtime and optional
- ignore unresolved arbitrary dotted identifiers such as `Deps.AndroidX.*` and `TestDeps.*` instead of emitting fake Maven package placeholders, while keeping `libs.*` version-catalog resolution intact
- refresh the affected Gradle parser expected-output fixtures and tighten the Gradle README wording to match the implemented libs-only dotted-identifier behavior

## Scope and exclusions

- Included:
  - `src/parsers/gradle.rs` parser logic and focused regression coverage
  - Gradle parser `.expected.json` fixtures that encoded the previous project-scope behavior
  - `testdata/gradle-golden/README.md` wording for dotted identifier handling
- Explicit exclusions:
  - no `buildSrc` / `Deps.*` static resolver
  - no broader Gradle semantic evaluation beyond existing `libs.versions.toml` support

## Intentional differences from Python

- Provenant now preserves the outer Gradle scope for local `project(':...')` dependencies instead of flattening them to `scope: "project"`, so `testImplementation project(':mockito-config')` stays test-scoped.
- Provenant intentionally ignores unresolved arbitrary dotted identifiers unless they are real `libs.*` version-catalog aliases, which avoids emitting misleading placeholder Maven packages like `pkg:maven/core`.

## Follow-up work

- Created or intentionally deferred:
  - deferred any bounded `buildSrc` constant resolution until compare-output data shows it is worth the extra parser complexity

## Expected-output fixture changes

- Files changed: `testdata/gradle-golden/groovy/groovy6-with-props/build.gradle-expected.json`, `testdata/gradle-golden/groovy/version-catalog/build.gradle-expected.json`, `testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json`, `testdata/gradle-golden/kotlin/kotlin3/build.gradle.kts-expected.json`
- Why the new expected output is correct:
  - local `project(':...')` dependencies should retain their enclosing Gradle scope (`compile`, `implementation`, `testImplementation`, `detektPlugins`) so runtime/optionality classification follows the real manifest semantics
