### PR TITLE
fix(copyright): reject file-reference note authors

### DIFF
--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -534,6 +534,14 @@ fn test_tomcat_contributing_prose_not_author() {
 }
 
 #[test]
+fn test_license_file_reference_note_not_author() {
+    let input = "Licence: BSD 3-Clause + Condition for any enhancements shared publicly or with the author (see LICENSE.txt).";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_update_center_metadata_blob_not_multiple_authors() {
     let input = "author: Box UK, url: http://updates.jenkins-ci.org/download/plugins/jslint/0.7.6/jslint.hpi, version: 0.7.6, wiki: https://wiki.jenkins-ci.org/display/JENKINS/JSLint+plugin, title: JSLint plugin, buildDate: Jan 03, 2013, developerId: gavd";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -56,6 +56,10 @@ pub fn refine_author(s: &str) -> Option<String> {
         return None;
     }
 
+    if looks_like_file_reference_note_author(&a) {
+        return None;
+    }
+
     if !a.chars().any(|ch| ch.is_alphabetic()) {
         return None;
     }
@@ -219,6 +223,30 @@ fn contains_windows_versioninfo_fragment(s: &str) -> bool {
     let trimmed = s.trim();
     trimmed.starts_with("VALUE ")
         && (trimmed.contains("FileDescription") || trimmed.contains("FileVersion"))
+}
+
+fn looks_like_file_reference_note_author(s: &str) -> bool {
+    static FILE_REFERENCE_NOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^
+            (?:see|see\ also|refer\ to|consult)
+            \s+
+            (?P<target>
+                [A-Za-z0-9_./-]+
+                \.[A-Za-z0-9]{1,16}
+            )
+            $
+            ",
+        )
+        .unwrap()
+    });
+
+    let trimmed = s.trim();
+    FILE_REFERENCE_NOTE_RE
+        .captures(trimmed)
+        .and_then(|caps| caps.name("target").map(|m| m.as_str()))
+        .is_some_and(|target| target.chars().any(|ch| ch.is_ascii_alphabetic()))
 }
 
 fn contains_no_copyright_clause(s: &str) -> bool {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1684,6 +1684,12 @@ fn test_refine_author_drops_path_like_fragment() {
 }
 
 #[test]
+fn test_refine_author_drops_file_reference_note() {
+    assert_eq!(refine_author("see LICENSE.txt"), None);
+    assert_eq!(refine_author("refer to docs/NOTICE.md"), None);
+}
+
+#[test]
 fn test_refine_author_drops_dollar_prefixed_code_tokens() {
     assert_eq!(refine_author("Agatha Christie, $sort"), None);
     assert_eq!(refine_author("$limit 10"), None);


### PR DESCRIPTION
## Summary

- reject directive-style file-reference notes such as `see LICENSE.txt` when they reach author refinement
- add refiner and detector regressions for the reported false positive from `README.md`
- keep existing `Name (http://...)` author behavior covered and unchanged

## Scope and exclusions

- Included: narrow author-refiner filtering for file-reference note candidates and focused regression coverage in refiner and detector tests
- Explicit exclusions: no parser changes, no broad author cleanup refactor, no golden fixture churn

## Follow-up work

- Created or intentionally deferred: none

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: the sample no longer emits `see LICENSE.txt` as an author, and the change is covered by focused regressions plus a real CLI rescan of the reported file
