### PR TITLE
fix(compare): separate raw and assembled package comparisons

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 177 of 177 recorded runs, with a **11.6× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
+> Provenant is faster on 177 of 177 recorded runs, with a **11.7× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -511,19 +511,19 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `200.80s`; ScanCode `1974.56s`
 - Broader Bazel package and dependency extraction (`1729` vs `1711` packages, `79` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, with richer Debian and RPM sidecar package metadata
 
-##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **4.98× faster**
+##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **12.29× faster**
 
-- Files: 236
-- Run context: 2026-04-10 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `14.29s`; ScanCode `71.17s`
-- Cleaner XML author extraction without ScanCode's prose-tainted suffixes such as `A.Meredith Compiler`, while still recovering real names like `Jeremy Siek` and `David Goodger` that ScanCode misses
+- Files: 241
+- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `12.34s`; ScanCode `151.70s`
+- Direct `.gitmodules` package-adjacent visibility (`1` vs `0` file-level package records, plus one raw dependency edge) across the umbrella superproject, cleaner XML author extraction that drops prose-tainted suffixes such as `A.Meredith Compiler`, and Unicode-preserving name normalization for identities such as `René Ferdinand Rivera Morell`, `Ion Gaztañaga`, and `J. López`
 
-##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **8.46× faster**
+##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **6.02× faster**
 
 - Files: 705
-- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `28.27s`; ScanCode `239.21s`
-- Cleaner GSoC participant-name extraction in `bench/data/gsoc-2018.json`, preserving real names like `Adrián Bazaga` instead of ScanCode's `type' Person name' ...` noise, plus more complete placeholder URL closure on templated GitHub API routes
+- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `35.76s`; ScanCode `215.32s`
+- Cleaner benchmark-corpus author extraction in `bench/data/gsoc-2018.json` and `bench/data/github_events.json`, replacing ScanCode junk such as `type' Person name' AadityaNair` and prose fragments with actual participant names while preserving Unicode identities like `Nils Jørgen Mittet`, plus Unicode-preserving holder normalization for `René Ferdinand Rivera Morell` on build metadata
 
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1336,6 +1336,19 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Record same-host wall-clock timings for Provenant and ScanCode, plus relative speedup.
 - Record machine information per row. If `run-manifest.json` reports `scancode.cache_hit: true`, use the cached ScanCode raw timing for that target/ref/runtime. Otherwise treat both scanner timings as license-cache-cold because the maintained workflow disables persistent license-cache reuse during actual execution.
 
+### Comparison review discipline
+
+- Treat benchmark verification as a **full shared-scanner compare review**, not a package-count-only check. Under `--profile common`, package extraction, license detection, copyright/holder/author extraction, email extraction, URL extraction, and other shared-scan behavior are all in scope.
+- Treat any “more output” from either scanner as a claim to verify, not as proof by itself. Additional licenses, license-expression reshaping, copyrights, holders, authors, emails, or URLs only count as improvements when the scanned file text actually supports them.
+- Fix issues where **ScanCode is better than Provenant**. Treat `comparison_status: potential_regressions_detected` as a triage-required signal, not an automatic failure or an automatic pass.
+- When scanners disagree, inspect the underlying file text enough to decide whether the extra or missing finding is justified. Apply the same rigor to package, dependency, author, email, URL, copyright, holder, and license-expression deltas.
+- Treat holders and authors as **first-class verification signals**, not cosmetic tail cleanup. Review repeated holder/author mismatches before calling a target complete, and treat obvious Provenant junk such as prose fragments, role labels, malformed metadata blobs, or contact-trailer pollution in holder/author fields as bugs to fix or filter generically.
+- Do **not** count junky holder/author over-extraction as a win just because Provenant reports more names. More holder/author output is only better when the recovered identities are actually supported by the file text and are cleaner than ScanCode’s result.
+- Treat top-level license-expression deltas and repeated file-level license-detection mismatches as blocking regression signals. Do not defer that review until after package or dependency counts look healthy.
+- Do **not** treat normalization improvements as regressions when Provenant is more correct, for example preserving `René` instead of degrading to `Rene`. Parity is the bottom line, not the upper limit.
+- Fixes found during compare work must be **generic scanner improvements**, not target-specific tuning for one benchmark repository or artifact.
+- Any fixed regression or accepted behavior-shaping change should gain adequate automated coverage. Add focused parser tests, integration tests, and golden tests where those are the right durable fit.
+
 ### Row ordering
 
 - Order rows by **target kind first**, because that matches the maintained `compare-outputs` workflow split:

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -197,9 +197,9 @@ ScanCode: 88.26s</title></rect>
     <rect x="462.40" y="401.49" width="8" height="8" fill="#d97706" rx="1.5"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 ScanCode: 120.75s</title></rect>
-    <rect x="468.50" y="426.47" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
-Files: 236
-ScanCode: 71.17s</title></rect>
+    <rect x="469.95" y="390.71" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
+Files: 241
+ScanCode: 151.70s</title></rect>
     <rect x="471.36" y="416.81" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/apache2 @ 420d824
 Files: 246
 ScanCode: 87.31s</title></rect>
@@ -293,9 +293,9 @@ ScanCode: 169.15s</title></rect>
     <rect x="543.81" y="392.44" width="8" height="8" fill="#d97706" rx="1.5"><title>select2/select2 @ 595494a
 Files: 704
 ScanCode: 146.24s</title></rect>
-    <rect x="543.91" y="369.19" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
+    <rect x="543.91" y="374.16" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
 Files: 705
-ScanCode: 239.21s</title></rect>
+ScanCode: 215.32s</title></rect>
     <rect x="549.45" y="345.68" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode.io @ 904373a
 Files: 764
 ScanCode: 393.40s</title></rect>
@@ -730,9 +730,9 @@ Provenant: 10.94s</title></circle>
     <circle cx="466.40" cy="520.98" r="4.5" fill="#2563eb"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 Provenant: 10.48s</title></circle>
-    <circle cx="472.50" cy="506.33" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
-Files: 236
-Provenant: 14.29s</title></circle>
+    <circle cx="473.95" cy="513.26" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
+Files: 241
+Provenant: 12.34s</title></circle>
     <circle cx="475.36" cy="514.55" r="4.5" fill="#2563eb"><title>sous-chefs/apache2 @ 420d824
 Files: 246
 Provenant: 12.01s</title></circle>
@@ -826,9 +826,9 @@ Provenant: 10.63s</title></circle>
     <circle cx="547.81" cy="512.39" r="4.5" fill="#2563eb"><title>select2/select2 @ 595494a
 Files: 704
 Provenant: 12.57s</title></circle>
-    <circle cx="547.91" cy="474.10" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
+    <circle cx="547.91" cy="462.99" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
 Files: 705
-Provenant: 28.27s</title></circle>
+Provenant: 35.76s</title></circle>
     <circle cx="553.45" cy="454.32" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode.io @ 904373a
 Files: 764
 Provenant: 42.96s</title></circle>

--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -27,7 +27,7 @@ These topics are implemented. Some remain useful as completed historical records
   - Status: 🟢 Complete — planned production parser/recognizer coverage is implemented; deferred and future-scope items are documented in [PARSER_PLAN.md](package-detection/PARSER_PLAN.md)
 
 - **[PARSER_VERIFICATION_SCORECARD.md](package-detection/PARSER_VERIFICATION_SCORECARD.md)** - Maintained parser-family compare target checklist and verification tracker
-  - Status: 🟢 Canonical reference — use this for current end-to-end parser verification targets and to record which implemented parser families have already been compared against ScanCode
+  - Status: 🟢 Maintained checklist/reference — use this for current parser-family compare targets and verification status; the evergreen compare/benchmark methodology and recorded end-state outcomes live in [`../BENCHMARKS.md`](../BENCHMARKS.md)
 
 - **[ASSEMBLY_PLAN.md](package-detection/ASSEMBLY_PLAN.md)** - Package assembly roadmap
   - Status: 🟢 Complete — All phases done (sibling merge, nested merge, workspace assembly, file reference resolution)

--- a/docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md
+++ b/docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md
@@ -6,47 +6,11 @@ The ranked table below mostly follows the implemented ecosystem rows in [`PARSER
 
 ## Required comparison methodology
 
-Use the `xtask` compare workflow for parser verification. Do **not** substitute ad hoc manual scanner invocations for the main parity check.
+Use the repository-supported `xtask compare-outputs` workflow for parser verification. Do **not** substitute ad hoc manual scanner invocations for the main parity check.
 
-Repository-backed target:
+Read the canonical compare/benchmark methodology in [`../../BENCHMARKS.md`](../../BENCHMARKS.md#benchmark-conventions).
 
-```bash
-cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/org/repo.git --repo-ref <ref> --profile common
-```
-
-Artifact/rootfs-backed target:
-
-```bash
-cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --target-path /path/to/local/target --profile common
-```
-
-Compiled-binary artifact target:
-
-```bash
-cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --target-path /path/to/local/target --profile common-with-compiled
-```
-
-Method rules:
-
-- Run parser-family comparisons with `--profile common`, not `--profile packages`, so package extraction is always evaluated alongside installed-package DB coverage, license, copyright, author, email, URL, and other common-profile detection behavior.
-- Parser-family verification under `--profile common` is full shared-scanner verification, not parser-only verification: fixes may land in package parsing, license detection, copyright/holder/author extraction, email/URL extraction, or other common-profile subsystems when those are the real source of a delta.
-- When a row explicitly calls for compiled-binary verification such as Go build-info samples or cargo-auditable binaries, use `--target-path --profile common-with-compiled` for that local binary lane. In the current table, that applies to the Go row, the Cargo/Rust row, and the compiled Go/cargo-auditable lanes inside row `5a`; the Windows PE `VERSIONINFO` lane in row `5a` and ordinary rootfs, archive, and installed-package DB artifact lanes still use `--target-path --profile common`.
-- Treat any “more output” from either scanner as a claim to verify, not as proof by itself. Additional licenses, license-expression reshaping, copyrights, holders, authors, emails, or URLs only count as improvements when the scanned file text actually supports them.
-- Fix issues where **ScanCode is better than Provenant**.
-- When scanners disagree, inspect the underlying file text enough to decide whether the extra or missing finding is justified. Apply the same rigor to risky license-expression and file-level license-detection deltas that you would apply to package, dependency, author, email, or URL deltas; do not wave them through just because package counts look healthy.
-- Do **not** mark a row `🟢 Verified` while any ScanCode-better deltas remain unresolved for that target. Treat `comparison_status: potential_regressions_detected` as a triage-required signal, not an automatic failure: each such delta must be reviewed and either fixed or documented as not actually worse before the row becomes `🟢 Verified`.
-- Treat top-level license-expression deltas and repeated file-level license mismatches as first-class regression signals. Review every top-level license-expression delta before calling the row verified. If a compare target shows a suspicious cluster where ScanCode consistently reports stronger or more-complete license outcomes on the same files, investigate that pattern just as aggressively as you would a package or dependency regression before calling the row verified.
-- License-delta review is a **blocking verification gate**, not cleanup for later in the pass. Do not defer top-level license-expression or repeated file-level license-detection triage until after package-count or dependency-count review; the compare target is not ready to call verified until that review is done.
-- Fixes found during compare work must be **generic scanner improvements**, not target-specific tuning for one benchmark repository or artifact. If a proposed change only makes a single compare target look better without improving general scan quality, reject it and find the broader root cause instead.
-- Record end-state Provenant-over-ScanCode outcomes in [`../../BENCHMARKS.md`](../../BENCHMARKS.md), not in this table.
-- Do **not** treat normalization improvements as regressions when Provenant is more correct, for example preserving `René` instead of degrading to `Rene`. Parity is the bottom line, not the upper limit.
-- This scorecard's notes column is for **stable priority, scope, target-shape, and watch-out guidance**. It is not a verification-results column.
-- When a row is verified, update the **Status** cell only. Do **not** rewrite the notes column just to capture what verification found.
-- Do **not** narrate the implementation path or the verification outcome in this table. Avoid phrases such as `fixed`, `restored`, `aligned`, `verified reference`, `after`, `triaged`, `reviewed tail`, or `remaining deltas` in row notes.
-- If the planned scope of a row genuinely changes, update the notes column for that planning reason; otherwise keep it stable and put result details in benchmarks, PRs, or saved compare artifacts.
-- When a fix or accepted behavior-shaping change touches shared detection logic, run the relevant regression suites for that subsystem. For example, copyright-detection changes should rerun the copyright goldens; license-detection changes should rerun the license goldens; parser behavior fixes should rerun the narrow parser tests, relevant integration coverage, and any affected compare targets.
-- Any fixed regression or accepted behavior change should gain adequate automated coverage. Add focused parser tests, integration tests, and golden tests where those are the right durable fit.
-- Keep detailed diff analysis in PR descriptions, CI logs, and saved `.provenant/compare-runs/` artifacts rather than bloating this checklist.
+This scorecard remains the maintained checklist for **which targets** to run and **which rows are verified**.
 
 ## Status model
 

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
+use crate::utils::spdx::combine_license_expressions;
 use crate::version::BUILD_VERSION;
 
 const COMPARISON_MODE: &str = "direct_json";
@@ -1216,24 +1217,47 @@ fn normalize_compare_path(path: &str) -> String {
 
 fn normalize_license_expression(value: &str) -> String {
     let normalized = normalize_text(value);
-    if normalized.contains(" OR ")
-        || normalized.contains(" or ")
-        || normalized.contains(" WITH ")
-        || normalized.contains(" with ")
-    {
-        normalized
-    } else if normalized.contains(" AND ") {
-        let stripped = normalized.replace(['(', ')'], "");
-        let mut parts: Vec<_> = stripped
-            .split(" AND ")
-            .map(str::trim)
-            .filter(|part| !part.is_empty())
-            .collect();
-        parts.sort_unstable();
-        parts.join(" AND ")
-    } else {
-        normalized.replace(['(', ')'], "")
+    if normalized.is_empty() {
+        return normalized;
     }
+
+    let stripped = strip_trivial_outer_parens(&normalized);
+    let canonical =
+        combine_license_expressions(std::iter::once(stripped.clone())).unwrap_or(stripped);
+    strip_trivial_outer_parens(&canonical)
+}
+
+fn strip_trivial_outer_parens(value: &str) -> String {
+    let mut current = value.trim();
+    while has_trivial_outer_parens(current) {
+        current = current[1..current.len() - 1].trim();
+    }
+    current.to_string()
+}
+
+fn has_trivial_outer_parens(value: &str) -> bool {
+    if !(value.starts_with('(') && value.ends_with(')')) {
+        return false;
+    }
+
+    let mut depth = 0usize;
+    for (index, ch) in value.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                if depth == 0 {
+                    return false;
+                }
+                depth -= 1;
+                if depth == 0 && index != value.len() - 1 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    depth == 0
 }
 
 fn scalar_field_value(entry: &Value, key: &str) -> Option<String> {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -12,6 +12,15 @@ use serde_json::{Map, Value, json};
 use crate::version::BUILD_VERSION;
 
 const COMPARISON_MODE: &str = "direct_json";
+const FILES_COUNT_SOURCE: &str = "files[]";
+const PACKAGES_COUNT_SOURCE: &str = "packages[]";
+const PACKAGE_DATA_COUNT_SOURCE: &str = "packages[] empty; files[].package_data present";
+const DEPENDENCIES_COUNT_SOURCE: &str = "dependencies[]";
+const PACKAGE_DATA_DEPENDENCIES_COUNT_SOURCE: &str =
+    "dependencies[] empty; files[].package_data[].dependencies present";
+const LICENSE_DETECTIONS_COUNT_SOURCE: &str = "license_detections[]";
+const LICENSE_REFERENCES_COUNT_SOURCE: &str = "license_references[]";
+const LICENSE_RULE_REFERENCES_COUNT_SOURCE: &str = "license_rule_references[]";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompareArtifactLayout {
@@ -102,6 +111,39 @@ struct TopLevelSectionDifferenceEntry {
     section: String,
     scancode: Option<Value>,
     provenant: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct TopLevelCounts {
+    counts: HashMap<&'static str, i64>,
+    sources: HashMap<&'static str, &'static str>,
+}
+
+impl TopLevelCounts {
+    fn count(&self, key: &str) -> i64 {
+        *self.counts.get(key).expect("top-level count exists")
+    }
+
+    fn source(&self, key: &str) -> &'static str {
+        self.sources
+            .get(key)
+            .copied()
+            .expect("top-level count source exists")
+    }
+
+    fn counts_json(&self) -> BTreeMap<String, i64> {
+        self.counts
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value))
+            .collect()
+    }
+
+    fn sources_json(&self) -> BTreeMap<String, String> {
+        self.sources
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
 }
 
 pub(crate) fn compare_json_files(
@@ -422,6 +464,7 @@ pub(crate) fn write_comparison_artifacts(
     let license_deltas = top_level_license_deltas(&scancode, &provenant);
     let top_level_regressions_map = top_level_regressions(&sc_top, &pr_top, true);
     let top_level_higher_counts = top_level_regressions(&pr_top, &sc_top, false);
+    let skipped_comparisons = skipped_comparisons(&sc_top, &pr_top);
 
     let mut file_metric_summary = Map::new();
     let mut rows = vec![];
@@ -435,10 +478,10 @@ pub(crate) fn write_comparison_artifacts(
     ] {
         rows.push(tsv_row(
             key,
-            sc_top[key],
-            pr_top[key],
-            pr_top[key] - sc_top[key],
-            "top-level count",
+            sc_top.count(key),
+            pr_top.count(key),
+            pr_top.count(key) - sc_top.count(key),
+            &top_level_count_note(key, &sc_top, &pr_top),
         ));
     }
     rows.push(tsv_row(
@@ -623,37 +666,124 @@ pub(crate) fn write_comparison_artifacts(
         "top-level row-2 workflow sections with normalized JSON differences",
     ));
 
-    let dependency_value_differences = dependency_differences(&scancode, &provenant);
-    let dependency_missing = dependency_value_differences
+    let top_level_package_skip_reason = skipped_comparisons.get("packages").cloned();
+    let top_level_package_value_differences = top_level_package_differences(&scancode, &provenant);
+    let top_level_package_missing = top_level_package_value_differences
         .iter()
         .filter(|entry| !entry.missing_in_provenant.is_empty())
-        .count();
-    let dependency_extra = dependency_value_differences
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let top_level_package_extra = top_level_package_value_differences
         .iter()
         .filter(|entry| !entry.extra_in_provenant.is_empty())
-        .count();
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let top_level_dependency_skip_reason = skipped_comparisons.get("dependencies").cloned();
+    let top_level_dependency_value_differences =
+        top_level_dependency_differences(&scancode, &provenant);
+    let top_level_dependency_missing = top_level_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.missing_in_provenant.is_empty())
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let top_level_dependency_extra = top_level_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.extra_in_provenant.is_empty())
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let raw_dependency_value_differences = raw_dependency_differences(&scancode, &provenant);
+    let raw_dependency_missing = raw_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.missing_in_provenant.is_empty())
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let raw_dependency_extra = raw_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.extra_in_provenant.is_empty())
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let top_level_package_summary = json!({
+        "missing_in_provenant": top_level_package_missing,
+        "extra_in_provenant": top_level_package_extra,
+        "comparison_skipped": top_level_package_skip_reason.is_some(),
+        "skip_reason": top_level_package_skip_reason,
+    });
+    let top_level_dependency_summary = json!({
+        "missing_in_provenant": top_level_dependency_missing,
+        "extra_in_provenant": top_level_dependency_extra,
+        "comparison_skipped": top_level_dependency_skip_reason.is_some(),
+        "skip_reason": top_level_dependency_skip_reason,
+    });
+    let raw_dependency_summary = json!({
+        "missing_in_provenant": raw_dependency_missing,
+        "extra_in_provenant": raw_dependency_extra,
+    });
     file_metric_summary.insert(
-        "dependencies".to_string(),
+        "raw_package_dependencies".to_string(),
         json!({
-            "missing_in_provenant": dependency_missing,
-            "extra_in_provenant": dependency_extra,
+            "missing_in_provenant": raw_dependency_missing,
+            "extra_in_provenant": raw_dependency_extra,
         }),
     );
-    potential_regressions += dependency_missing;
-    potential_higher += dependency_extra;
+    if top_level_package_skip_reason.is_none() {
+        potential_regressions += top_level_package_missing;
+        potential_higher += top_level_package_extra;
+    }
+    if top_level_dependency_skip_reason.is_none() {
+        potential_regressions += top_level_dependency_missing;
+        potential_higher += top_level_dependency_extra;
+    }
+    potential_regressions += raw_dependency_missing;
+    potential_higher += raw_dependency_extra;
     rows.push(tsv_row(
-        "dependencies_missing_in_provenant",
-        dependency_missing as i64,
+        "top_level_packages_missing_in_provenant",
+        top_level_package_missing as i64,
         0,
-        -(dependency_missing as i64),
-        "dependency identities present only in ScanCode output",
+        -(top_level_package_missing as i64),
+        top_level_package_skip_reason
+            .as_deref()
+            .unwrap_or("top-level package identities present only in ScanCode output"),
     ));
     rows.push(tsv_row(
-        "dependencies_extra_in_provenant",
+        "top_level_packages_extra_in_provenant",
         0,
-        dependency_extra as i64,
-        dependency_extra as i64,
-        "dependency identities present only in Provenant output",
+        top_level_package_extra as i64,
+        top_level_package_extra as i64,
+        top_level_package_skip_reason
+            .as_deref()
+            .unwrap_or("top-level package identities present only in Provenant output"),
+    ));
+    rows.push(tsv_row(
+        "top_level_dependencies_missing_in_provenant",
+        top_level_dependency_missing as i64,
+        0,
+        -(top_level_dependency_missing as i64),
+        top_level_dependency_skip_reason
+            .as_deref()
+            .unwrap_or("top-level dependency identities present only in ScanCode output"),
+    ));
+    rows.push(tsv_row(
+        "top_level_dependencies_extra_in_provenant",
+        0,
+        top_level_dependency_extra as i64,
+        top_level_dependency_extra as i64,
+        top_level_dependency_skip_reason
+            .as_deref()
+            .unwrap_or("top-level dependency identities present only in Provenant output"),
+    ));
+    rows.push(tsv_row(
+        "raw_package_dependencies_missing_in_provenant",
+        raw_dependency_missing as i64,
+        0,
+        -(raw_dependency_missing as i64),
+        "raw dependency identities present only in ScanCode file-level package_data output",
+    ));
+    rows.push(tsv_row(
+        "raw_package_dependencies_extra_in_provenant",
+        0,
+        raw_dependency_extra as i64,
+        raw_dependency_extra as i64,
+        "raw dependency identities present only in Provenant file-level package_data output",
     ));
     rows.push(tsv_row(
         "top_level_license_expression_deltas",
@@ -701,8 +831,22 @@ pub(crate) fn write_comparison_artifacts(
                 .join("top_level_license_expression_deltas.json"),
         ),
         (
-            "dependency_value_differences",
-            layout.samples_dir.join("dependency_value_differences.json"),
+            "top_level_package_value_differences",
+            layout
+                .samples_dir
+                .join("top_level_package_value_differences.json"),
+        ),
+        (
+            "top_level_dependency_value_differences",
+            layout
+                .samples_dir
+                .join("top_level_dependency_value_differences.json"),
+        ),
+        (
+            "raw_dependency_value_differences",
+            layout
+                .samples_dir
+                .join("raw_dependency_value_differences.json"),
         ),
         (
             "info_value_differences",
@@ -728,26 +872,36 @@ pub(crate) fn write_comparison_artifacts(
     write_pretty_json(&sample_paths[3].1, &higher_counts)?;
     write_pretty_json(&sample_paths[4].1, &value_differences)?;
     write_pretty_json(&sample_paths[5].1, &license_deltas)?;
-    write_pretty_json(&sample_paths[6].1, &dependency_value_differences)?;
-    write_pretty_json(&sample_paths[7].1, &info_value_differences)?;
-    write_pretty_json(&sample_paths[8].1, &classify_value_differences)?;
-    write_pretty_json(&sample_paths[9].1, &row2_value_differences)?;
-    write_pretty_json(&sample_paths[10].1, &row2_top_level_differences)?;
+    write_pretty_json(&sample_paths[6].1, &top_level_package_value_differences)?;
+    write_pretty_json(&sample_paths[7].1, &top_level_dependency_value_differences)?;
+    write_pretty_json(&sample_paths[8].1, &raw_dependency_value_differences)?;
+    write_pretty_json(&sample_paths[9].1, &info_value_differences)?;
+    write_pretty_json(&sample_paths[10].1, &classify_value_differences)?;
+    write_pretty_json(&sample_paths[11].1, &row2_value_differences)?;
+    write_pretty_json(&sample_paths[12].1, &row2_top_level_differences)?;
 
     let summary = json!({
         "comparison_status": comparison_status,
         "top_level_counts": {
-            "scancode": sc_top,
-            "provenant": pr_top,
+            "scancode": sc_top.counts_json(),
+            "provenant": pr_top.counts_json(),
             "delta": {
-                "files": pr_top["files"] - sc_top["files"],
-                "packages": pr_top["packages"] - sc_top["packages"],
-                "dependencies": pr_top["dependencies"] - sc_top["dependencies"],
-                "license_detections": pr_top["license_detections"] - sc_top["license_detections"],
-                "license_references": pr_top["license_references"] - sc_top["license_references"],
-                "license_rule_references": pr_top["license_rule_references"] - sc_top["license_rule_references"],
-            }
+                "files": pr_top.count("files") - sc_top.count("files"),
+                "packages": pr_top.count("packages") - sc_top.count("packages"),
+                "dependencies": pr_top.count("dependencies") - sc_top.count("dependencies"),
+                "license_detections": pr_top.count("license_detections") - sc_top.count("license_detections"),
+                "license_references": pr_top.count("license_references") - sc_top.count("license_references"),
+                "license_rule_references": pr_top.count("license_rule_references") - sc_top.count("license_rule_references"),
+            },
+            "sources": {
+                "scancode": sc_top.sources_json(),
+                "provenant": pr_top.sources_json(),
+            },
         },
+        "skipped_comparisons": skipped_comparisons,
+        "top_level_package_summary": top_level_package_summary,
+        "top_level_dependency_summary": top_level_dependency_summary,
+        "raw_dependency_summary": raw_dependency_summary,
         "file_path_comparison": {
             "common_paths": common_paths.len(),
             "only_scancode_paths": only_scancode_paths.len(),
@@ -1367,24 +1521,53 @@ fn counter_entries(counter: &BTreeMap<String, usize>) -> Vec<ValueCountEntry> {
         .collect()
 }
 
-fn top_level_counts(value: &Value) -> HashMap<&'static str, i64> {
-    HashMap::from([
-        ("files", file_entry_count(value) as i64),
-        ("packages", array_len(value, "packages") as i64),
-        ("dependencies", array_len(value, "dependencies") as i64),
-        (
-            "license_detections",
-            array_len(value, "license_detections") as i64,
-        ),
-        (
-            "license_references",
-            array_len(value, "license_references") as i64,
-        ),
-        (
-            "license_rule_references",
-            array_len(value, "license_rule_references") as i64,
-        ),
-    ])
+fn top_level_counts(value: &Value) -> TopLevelCounts {
+    let package_count = array_len(value, "packages");
+    let fallback_package_count = file_package_data_count(value);
+    let dependency_count = array_len(value, "dependencies");
+    let fallback_dependency_count = file_package_data_dependency_count(value);
+
+    let packages_source = if package_count == 0 && fallback_package_count > 0 {
+        PACKAGE_DATA_COUNT_SOURCE
+    } else {
+        PACKAGES_COUNT_SOURCE
+    };
+    let dependencies_source = if dependency_count == 0 && fallback_dependency_count > 0 {
+        PACKAGE_DATA_DEPENDENCIES_COUNT_SOURCE
+    } else {
+        DEPENDENCIES_COUNT_SOURCE
+    };
+
+    TopLevelCounts {
+        counts: HashMap::from([
+            ("files", file_entry_count(value) as i64),
+            ("packages", package_count as i64),
+            ("dependencies", dependency_count as i64),
+            (
+                "license_detections",
+                array_len(value, "license_detections") as i64,
+            ),
+            (
+                "license_references",
+                array_len(value, "license_references") as i64,
+            ),
+            (
+                "license_rule_references",
+                array_len(value, "license_rule_references") as i64,
+            ),
+        ]),
+        sources: HashMap::from([
+            ("files", FILES_COUNT_SOURCE),
+            ("packages", packages_source),
+            ("dependencies", dependencies_source),
+            ("license_detections", LICENSE_DETECTIONS_COUNT_SOURCE),
+            ("license_references", LICENSE_REFERENCES_COUNT_SOURCE),
+            (
+                "license_rule_references",
+                LICENSE_RULE_REFERENCES_COUNT_SOURCE,
+            ),
+        ]),
+    }
 }
 
 fn file_entry_count(value: &Value) -> usize {
@@ -1403,6 +1586,46 @@ fn array_len(value: &Value, key: &str) -> usize {
         .and_then(Value::as_array)
         .map(|values| values.len())
         .unwrap_or(0)
+}
+
+fn file_package_data_count(value: &Value) -> usize {
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|entry| {
+            entry
+                .get("package_data")
+                .and_then(Value::as_array)
+                .map(|package_data| package_data.len())
+                .unwrap_or(0)
+        })
+        .sum()
+}
+
+fn file_package_data_dependency_count(value: &Value) -> usize {
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|entry| {
+            entry
+                .get("package_data")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .map(|package_data| {
+                    package_data
+                        .get("dependencies")
+                        .and_then(Value::as_array)
+                        .map(|dependencies| dependencies.len())
+                        .unwrap_or(0)
+                })
+                .sum::<usize>()
+        })
+        .sum()
 }
 
 fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
@@ -1446,9 +1669,57 @@ fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
         .collect()
 }
 
-fn dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
-    let sc_by_path = dependency_identities_by_path(scancode);
-    let pr_by_path = dependency_identities_by_path(provenant);
+fn top_level_package_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
+    let sc_top = top_level_counts(scancode);
+    let pr_top = top_level_counts(provenant);
+    if !count_delta_is_hard_regression_comparable("packages", &sc_top, &pr_top) {
+        return Vec::new();
+    }
+
+    let sc_identities = top_level_package_identities(scancode);
+    let pr_identities = top_level_package_identities(provenant);
+    let missing = difference_entries(&sc_identities, &pr_identities);
+    let extra = difference_entries(&pr_identities, &sc_identities);
+    if missing.is_empty() && extra.is_empty() {
+        return Vec::new();
+    }
+
+    vec![ValueDifferenceEntry {
+        path: "<top-level>".to_string(),
+        scancode: sc_identities.len(),
+        provenant: pr_identities.len(),
+        missing_in_provenant: missing,
+        extra_in_provenant: extra,
+    }]
+}
+
+fn top_level_package_identities(value: &Value) -> BTreeSet<String> {
+    value
+        .get("packages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|item| {
+            package_identity(item)
+                .map(str::to_string)
+                .or_else(|| package_fallback_identity(item))
+                .unwrap_or_else(|| "<unknown>".to_string())
+        })
+        .collect()
+}
+
+fn top_level_dependency_differences(
+    scancode: &Value,
+    provenant: &Value,
+) -> Vec<ValueDifferenceEntry> {
+    let sc_top = top_level_counts(scancode);
+    let pr_top = top_level_counts(provenant);
+    if !count_delta_is_hard_regression_comparable("dependencies", &sc_top, &pr_top) {
+        return Vec::new();
+    }
+
+    let sc_by_path = top_level_dependency_identities_by_path(scancode);
+    let pr_by_path = top_level_dependency_identities_by_path(provenant);
     let mut paths = BTreeSet::new();
     paths.extend(sc_by_path.keys().cloned());
     paths.extend(pr_by_path.keys().cloned());
@@ -1471,7 +1742,7 @@ fn dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDiffe
     differences
 }
 
-fn dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
+fn top_level_dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
     let mut output: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for item in value
         .get("dependencies")
@@ -1487,6 +1758,71 @@ fn dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<Str
             .unwrap_or_else(|| "<unknown>".to_string());
         let identity = dependency_identity(item).unwrap_or_else(|| "<unknown>".to_string());
         output.entry(path).or_default().insert(identity);
+    }
+    output
+}
+
+fn raw_dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
+    let sc_by_path = raw_dependency_identities_by_path(scancode);
+    let pr_by_path = raw_dependency_identities_by_path(provenant);
+    let mut paths = BTreeSet::new();
+    paths.extend(sc_by_path.keys().cloned());
+    paths.extend(pr_by_path.keys().cloned());
+    let mut differences = Vec::new();
+    for path in paths {
+        let sc_identities = sc_by_path.get(&path).cloned().unwrap_or_default();
+        let pr_identities = pr_by_path.get(&path).cloned().unwrap_or_default();
+        let missing = difference_entries(&sc_identities, &pr_identities);
+        let extra = difference_entries(&pr_identities, &sc_identities);
+        if !missing.is_empty() || !extra.is_empty() {
+            differences.push(ValueDifferenceEntry {
+                path,
+                scancode: sc_identities.len(),
+                provenant: pr_identities.len(),
+                missing_in_provenant: missing,
+                extra_in_provenant: extra,
+            });
+        }
+    }
+    differences
+}
+
+fn raw_dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
+    let mut output: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for file in value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let file_path = file
+            .get("path")
+            .and_then(Value::as_str)
+            .map(normalize_compare_path)
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        for package_data in file
+            .get("package_data")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            for item in package_data
+                .get("dependencies")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let path = item
+                    .get("datafile_path")
+                    .or_else(|| item.get("path"))
+                    .and_then(Value::as_str)
+                    .map(normalize_compare_path)
+                    .unwrap_or_else(|| file_path.clone());
+                let identity = dependency_identity(item).unwrap_or_else(|| "<unknown>".to_string());
+                output.entry(path).or_default().insert(identity);
+            }
+        }
     }
     output
 }
@@ -1539,8 +1875,8 @@ fn dependency_identity(item: &Value) -> Option<String> {
 }
 
 fn top_level_regressions(
-    left: &HashMap<&'static str, i64>,
-    right: &HashMap<&'static str, i64>,
+    left: &TopLevelCounts,
+    right: &TopLevelCounts,
     left_is_scancode: bool,
 ) -> BTreeMap<String, i64> {
     let mut output = BTreeMap::new();
@@ -1551,8 +1887,11 @@ fn top_level_regressions(
         "license_references",
         "license_rule_references",
     ] {
-        let left_value = left[key];
-        let right_value = right[key];
+        if !count_delta_is_hard_regression_comparable(key, left, right) {
+            continue;
+        }
+        let left_value = left.count(key);
+        let right_value = right.count(key);
         if left_is_scancode {
             if right_value < left_value {
                 output.insert(key.to_string(), left_value - right_value);
@@ -1562,6 +1901,64 @@ fn top_level_regressions(
         }
     }
     output
+}
+
+fn skipped_comparisons(left: &TopLevelCounts, right: &TopLevelCounts) -> BTreeMap<String, String> {
+    ["packages", "dependencies"]
+        .into_iter()
+        .filter(|metric| !count_delta_is_hard_regression_comparable(metric, left, right))
+        .map(|metric| {
+            (
+                metric.to_string(),
+                mixed_source_skip_reason(metric, left, right),
+            )
+        })
+        .collect()
+}
+
+fn count_delta_is_hard_regression_comparable(
+    key: &str,
+    left: &TopLevelCounts,
+    right: &TopLevelCounts,
+) -> bool {
+    match key {
+        "packages" => {
+            left.source(key) == PACKAGES_COUNT_SOURCE && right.source(key) == PACKAGES_COUNT_SOURCE
+        }
+        "dependencies" => {
+            left.source(key) == DEPENDENCIES_COUNT_SOURCE
+                && right.source(key) == DEPENDENCIES_COUNT_SOURCE
+        }
+        _ => true,
+    }
+}
+
+fn mixed_source_skip_reason(
+    metric: &str,
+    scancode: &TopLevelCounts,
+    provenant: &TopLevelCounts,
+) -> String {
+    format!(
+        "top-level {metric} comparison skipped: ScanCode {}; Provenant {}",
+        scancode.source(metric),
+        provenant.source(metric)
+    )
+}
+
+fn top_level_count_note(
+    metric: &str,
+    scancode: &TopLevelCounts,
+    provenant: &TopLevelCounts,
+) -> String {
+    if !matches!(metric, "packages" | "dependencies") {
+        return "top-level count".to_string();
+    }
+
+    if count_delta_is_hard_regression_comparable(metric, scancode, provenant) {
+        return "top-level count".to_string();
+    }
+
+    mixed_source_skip_reason(metric, scancode, provenant)
 }
 
 fn tsv_row(metric: &str, scancode: i64, provenant: i64, delta: i64, notes: &str) -> Vec<String> {

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -304,6 +304,70 @@ fn create_compare_json_fixtures_with_file_level_package_fallback() -> (TempDir, 
     )
 }
 
+fn create_compare_json_fixtures_with_equivalent_license_expressions() -> (TempDir, String, String) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let scancode_file = temp.path().join("scancode-license-parens.json");
+    let provenant_file = temp.path().join("provenant-license-parens.json");
+
+    fs::write(
+        &scancode_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "license_detections": [{
+                    "license_expression": "(MIT OR Apache-2.0)",
+                    "license_expression_spdx": "(MIT OR Apache-2.0)",
+                    "detection_count": 1
+                }]
+            }],
+            "license_detections": [{
+                "license_expression": "(MIT OR Apache-2.0)",
+                "license_expression_spdx": "(MIT OR Apache-2.0)",
+                "detection_count": 1
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write scancode equivalent-license fixture");
+
+    fs::write(
+        &provenant_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "license_detections": [{
+                    "license_expression": "Apache-2.0 OR MIT",
+                    "license_expression_spdx": "Apache-2.0 OR MIT",
+                    "detection_count": 1
+                }]
+            }],
+            "license_detections": [{
+                "license_expression": "Apache-2.0 OR MIT",
+                "license_expression_spdx": "Apache-2.0 OR MIT",
+                "detection_count": 1
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write provenant equivalent-license fixture");
+
+    (
+        temp,
+        scancode_file.to_string_lossy().to_string(),
+        provenant_file.to_string_lossy().to_string(),
+    )
+}
+
 fn normalize_multi_parser_header(output: &mut Value) {
     let header = output["headers"]
         .as_array_mut()
@@ -991,6 +1055,65 @@ fn compare_subcommand_uses_file_level_package_fallback_without_false_regressions
     assert!(summary_tsv.contains(
         "top-level dependencies comparison skipped: ScanCode dependencies[] empty; files[].package_data[].dependencies present; Provenant dependencies[]"
     ));
+}
+
+#[test]
+fn compare_subcommand_treats_trivial_license_expression_parentheses_as_equal() {
+    let (_temp, scancode_json, provenant_json) =
+        create_compare_json_fixtures_with_equivalent_license_expressions();
+    let artifact_temp = TempDir::new().expect("artifact temp dir");
+    let artifact_dir = artifact_temp.path().join("compare-artifacts");
+
+    let output = provenant_command()
+        .args([
+            "compare",
+            "--scancode-json",
+            &scancode_json,
+            "--provenant-json",
+            &provenant_json,
+            "--artifact-dir",
+            artifact_dir.to_str().expect("utf8 artifact path"),
+        ])
+        .output()
+        .expect("failed to run compare subcommand");
+
+    assert!(output.status.success(), "compare should succeed");
+
+    let summary_path = artifact_dir.join("comparison").join("summary.json");
+    let samples_path = artifact_dir
+        .join("comparison")
+        .join("samples")
+        .join("file_metric_value_differences.json");
+    let deltas_path = artifact_dir
+        .join("comparison")
+        .join("samples")
+        .join("top_level_license_expression_deltas.json");
+
+    let summary: Value =
+        serde_json::from_str(&fs::read_to_string(&summary_path).expect("summary json")).unwrap();
+    let samples: Value =
+        serde_json::from_str(&fs::read_to_string(&samples_path).expect("samples json")).unwrap();
+    let deltas: Value =
+        serde_json::from_str(&fs::read_to_string(&deltas_path).expect("deltas json")).unwrap();
+
+    assert_eq!(
+        summary["comparison_status"].as_str(),
+        Some("no_detected_differences")
+    );
+    assert_eq!(
+        summary["file_metric_summary"]["license_detections"]["missing_in_provenant"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["file_metric_summary"]["license_detections"]["extra_in_provenant"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["top_level_license_expression_delta_count"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(samples["license_detections"], serde_json::json!([]));
+    assert_eq!(deltas, serde_json::json!([]));
 }
 
 #[test]

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -234,6 +234,76 @@ fn create_compare_json_fixtures() -> (TempDir, String, String) {
     )
 }
 
+fn create_compare_json_fixtures_with_file_level_package_fallback() -> (TempDir, String, String) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let scancode_file = temp.path().join("scancode-fallback.json");
+    let provenant_file = temp.path().join("provenant-fallback.json");
+
+    let shared_package_data = serde_json::json!([{
+        "type": "npm",
+        "name": "left-pad",
+        "version": "1.3.0",
+        "purl": "pkg:npm/left-pad@1.3.0",
+        "dependencies": [{
+            "purl": "pkg:npm/ansi-regex@5.0.1",
+            "scope": "dependencies",
+            "is_runtime": true
+        }]
+    }]);
+
+    fs::write(
+        &scancode_file,
+        serde_json::json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": shared_package_data.clone()
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write scancode fallback fixture");
+
+    fs::write(
+        &provenant_file,
+        serde_json::json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": shared_package_data
+            }],
+            "packages": [{
+                "type": "npm",
+                "name": "left-pad",
+                "version": "1.3.0",
+                "purl": "pkg:npm/left-pad@1.3.0"
+            }],
+            "dependencies": [{
+                "purl": "pkg:npm/ansi-regex@5.0.1",
+                "datafile_path": "package-lock.json",
+                "scope": "dependencies",
+                "is_runtime": true
+            }],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write provenant fallback fixture");
+
+    (
+        temp,
+        scancode_file.to_string_lossy().to_string(),
+        provenant_file.to_string_lossy().to_string(),
+    )
+}
+
 fn normalize_multi_parser_header(output: &mut Value) {
     let header = output["headers"]
         .as_array_mut()
@@ -844,6 +914,83 @@ fn compare_subcommand_defaults_to_timestamped_artifact_dir_in_cwd() {
             .join("summary.json")
             .is_file()
     );
+}
+
+#[test]
+fn compare_subcommand_uses_file_level_package_fallback_without_false_regressions() {
+    let (_temp, scancode_json, provenant_json) =
+        create_compare_json_fixtures_with_file_level_package_fallback();
+    let artifact_temp = TempDir::new().expect("artifact temp dir");
+    let artifact_dir = artifact_temp.path().join("compare-artifacts");
+
+    let output = provenant_command()
+        .args([
+            "compare",
+            "--scancode-json",
+            &scancode_json,
+            "--provenant-json",
+            &provenant_json,
+            "--artifact-dir",
+            artifact_dir.to_str().expect("utf8 artifact path"),
+        ])
+        .output()
+        .expect("failed to run compare subcommand");
+
+    assert!(output.status.success(), "compare should succeed");
+
+    let summary_path = artifact_dir.join("comparison").join("summary.json");
+    let summary: Value =
+        serde_json::from_str(&fs::read_to_string(&summary_path).expect("summary json")).unwrap();
+
+    assert_eq!(
+        summary["comparison_status"].as_str(),
+        Some("no_detected_differences")
+    );
+    assert_eq!(
+        summary["top_level_counts"]["scancode"]["packages"].as_i64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["top_level_counts"]["scancode"]["dependencies"].as_i64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["top_level_counts"]["sources"]["scancode"]["packages"].as_str(),
+        Some("packages[] empty; files[].package_data present")
+    );
+    assert_eq!(
+        summary["top_level_counts"]["sources"]["scancode"]["dependencies"].as_str(),
+        Some("dependencies[] empty; files[].package_data[].dependencies present")
+    );
+    assert_eq!(
+        summary["skipped_comparisons"]["packages"].as_str(),
+        Some(
+            "top-level packages comparison skipped: ScanCode packages[] empty; files[].package_data present; Provenant packages[]"
+        )
+    );
+    assert_eq!(
+        summary["skipped_comparisons"]["dependencies"].as_str(),
+        Some(
+            "top-level dependencies comparison skipped: ScanCode dependencies[] empty; files[].package_data[].dependencies present; Provenant dependencies[]"
+        )
+    );
+    assert_eq!(
+        summary["raw_dependency_summary"]["missing_in_provenant"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["raw_dependency_summary"]["extra_in_provenant"].as_u64(),
+        Some(0)
+    );
+
+    let summary_tsv = fs::read_to_string(artifact_dir.join("comparison").join("summary.tsv"))
+        .expect("summary tsv");
+    assert!(summary_tsv.contains(
+        "top-level packages comparison skipped: ScanCode packages[] empty; files[].package_data present; Provenant packages[]"
+    ));
+    assert!(summary_tsv.contains(
+        "top-level dependencies comparison skipped: ScanCode dependencies[] empty; files[].package_data[].dependencies present; Provenant dependencies[]"
+    ));
 }
 
 #[test]

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
+use provenant::utils::spdx::combine_license_expressions;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use sha2::Digest;
@@ -2119,24 +2120,47 @@ fn normalize_compare_path(path: &str) -> String {
 
 fn normalize_license_expression(value: &str) -> String {
     let normalized = normalize_text(value);
-    if normalized.contains(" OR ")
-        || normalized.contains(" or ")
-        || normalized.contains(" WITH ")
-        || normalized.contains(" with ")
-    {
-        normalized
-    } else if normalized.contains(" AND ") {
-        let stripped = normalized.replace(['(', ')'], "");
-        let mut parts: Vec<_> = stripped
-            .split(" AND ")
-            .map(str::trim)
-            .filter(|part| !part.is_empty())
-            .collect();
-        parts.sort_unstable();
-        parts.join(" AND ")
-    } else {
-        normalized.replace(['(', ')'], "")
+    if normalized.is_empty() {
+        return normalized;
     }
+
+    let stripped = strip_trivial_outer_parens(&normalized);
+    let canonical =
+        combine_license_expressions(std::iter::once(stripped.clone())).unwrap_or(stripped);
+    strip_trivial_outer_parens(&canonical)
+}
+
+fn strip_trivial_outer_parens(value: &str) -> String {
+    let mut current = value.trim();
+    while has_trivial_outer_parens(current) {
+        current = current[1..current.len() - 1].trim();
+    }
+    current.to_string()
+}
+
+fn has_trivial_outer_parens(value: &str) -> bool {
+    if !(value.starts_with('(') && value.ends_with(')')) {
+        return false;
+    }
+
+    let mut depth = 0usize;
+    for (index, ch) in value.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                if depth == 0 {
+                    return false;
+                }
+                depth -= 1;
+                if depth == 0 && index != value.len() - 1 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    depth == 0
 }
 
 fn scalar_field_value(entry: &Value, key: &str) -> Option<String> {
@@ -4625,6 +4649,26 @@ mod tests {
         assert!(policy_values[0].contains("boost-1.0"));
         assert_eq!(clue_values.len(), 1);
         assert!(clue_values[0].contains("license_expression"));
+    }
+
+    #[test]
+    fn normalize_license_expression_ignores_trivial_outer_parentheses() {
+        assert_eq!(
+            normalize_license_expression("(MIT OR Apache-2.0)"),
+            normalize_license_expression("MIT OR Apache-2.0")
+        );
+        assert_eq!(
+            normalize_license_expression("MIT OR Apache-2.0"),
+            normalize_license_expression("Apache-2.0 OR MIT")
+        );
+        assert_eq!(
+            normalize_license_expression("MIT AND Apache-2.0"),
+            normalize_license_expression("Apache-2.0 AND MIT")
+        );
+        assert_eq!(
+            normalize_license_expression("((MIT))"),
+            normalize_license_expression("MIT")
+        );
     }
 
     #[test]

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -196,6 +196,48 @@ const SCANCODE_PLACEHOLDER_LOG_MESSAGE: &str = "ScanCode stdout was not captured
 const COMMON_PROFILE_SCANCODE_MEMORY_LIMIT: &str = "12g";
 const COMMON_PROFILE_SCANCODE_MEMORY_LIMIT_BYTES: u64 = 12 * 1024 * 1024 * 1024;
 const DIRECT_JSON_MODE_PLACEHOLDER: &str = "not executed (direct JSON compare mode)";
+const FILES_COUNT_SOURCE: &str = "files[]";
+const PACKAGES_COUNT_SOURCE: &str = "packages[]";
+const PACKAGE_DATA_COUNT_SOURCE: &str = "packages[] empty; files[].package_data present";
+const DEPENDENCIES_COUNT_SOURCE: &str = "dependencies[]";
+const PACKAGE_DATA_DEPENDENCIES_COUNT_SOURCE: &str =
+    "dependencies[] empty; files[].package_data[].dependencies present";
+const LICENSE_DETECTIONS_COUNT_SOURCE: &str = "license_detections[]";
+const LICENSE_REFERENCES_COUNT_SOURCE: &str = "license_references[]";
+const LICENSE_RULE_REFERENCES_COUNT_SOURCE: &str = "license_rule_references[]";
+
+#[derive(Debug, Clone)]
+struct TopLevelCounts {
+    counts: HashMap<&'static str, i64>,
+    sources: HashMap<&'static str, &'static str>,
+}
+
+impl TopLevelCounts {
+    fn count(&self, key: &str) -> i64 {
+        *self.counts.get(key).expect("top-level count exists")
+    }
+
+    fn source(&self, key: &str) -> &'static str {
+        self.sources
+            .get(key)
+            .copied()
+            .expect("top-level count source exists")
+    }
+
+    fn counts_json(&self) -> BTreeMap<String, i64> {
+        self.counts
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value))
+            .collect()
+    }
+
+    fn sources_json(&self) -> BTreeMap<String, String> {
+        self.sources
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+}
 
 fn main() -> Result<()> {
     let args = Args::parse();
@@ -1455,6 +1497,7 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
     let license_deltas = top_level_license_deltas(&scancode, &provenant);
     let top_level_regressions_map = top_level_regressions(&sc_top, &pr_top, true);
     let top_level_higher_counts = top_level_regressions(&pr_top, &sc_top, false);
+    let skipped_comparisons = skipped_comparisons(&sc_top, &pr_top);
 
     let mut file_metric_summary = Map::new();
     let mut rows = vec![];
@@ -1468,10 +1511,10 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
     ] {
         rows.push(tsv_row(
             key,
-            sc_top[key],
-            pr_top[key],
-            pr_top[key] - sc_top[key],
-            "top-level count",
+            sc_top.count(key),
+            pr_top.count(key),
+            pr_top.count(key) - sc_top.count(key),
+            &top_level_count_note(key, &sc_top, &pr_top),
         ));
     }
     rows.push(tsv_row(
@@ -1650,37 +1693,124 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         0,
         "top-level row-2 workflow sections with normalized JSON differences",
     ));
-    let dependency_value_differences = dependency_differences(&scancode, &provenant);
-    let dependency_missing = dependency_value_differences
+    let top_level_package_skip_reason = skipped_comparisons.get("packages").cloned();
+    let top_level_package_value_differences = top_level_package_differences(&scancode, &provenant);
+    let top_level_package_missing = top_level_package_value_differences
         .iter()
         .filter(|entry| !entry.missing_in_provenant.is_empty())
-        .count();
-    let dependency_extra = dependency_value_differences
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let top_level_package_extra = top_level_package_value_differences
         .iter()
         .filter(|entry| !entry.extra_in_provenant.is_empty())
-        .count();
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let top_level_dependency_skip_reason = skipped_comparisons.get("dependencies").cloned();
+    let top_level_dependency_value_differences =
+        top_level_dependency_differences(&scancode, &provenant);
+    let top_level_dependency_missing = top_level_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.missing_in_provenant.is_empty())
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let top_level_dependency_extra = top_level_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.extra_in_provenant.is_empty())
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let raw_dependency_value_differences = raw_dependency_differences(&scancode, &provenant);
+    let raw_dependency_missing = raw_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.missing_in_provenant.is_empty())
+        .map(|entry| entry.missing_in_provenant.len())
+        .sum::<usize>();
+    let raw_dependency_extra = raw_dependency_value_differences
+        .iter()
+        .filter(|entry| !entry.extra_in_provenant.is_empty())
+        .map(|entry| entry.extra_in_provenant.len())
+        .sum::<usize>();
+    let top_level_package_summary = json!({
+        "missing_in_provenant": top_level_package_missing,
+        "extra_in_provenant": top_level_package_extra,
+        "comparison_skipped": top_level_package_skip_reason.is_some(),
+        "skip_reason": top_level_package_skip_reason,
+    });
+    let top_level_dependency_summary = json!({
+        "missing_in_provenant": top_level_dependency_missing,
+        "extra_in_provenant": top_level_dependency_extra,
+        "comparison_skipped": top_level_dependency_skip_reason.is_some(),
+        "skip_reason": top_level_dependency_skip_reason,
+    });
+    let raw_dependency_summary = json!({
+        "missing_in_provenant": raw_dependency_missing,
+        "extra_in_provenant": raw_dependency_extra,
+    });
     file_metric_summary.insert(
-        "dependencies".to_string(),
+        "raw_package_dependencies".to_string(),
         json!({
-            "missing_in_provenant": dependency_missing,
-            "extra_in_provenant": dependency_extra,
+            "missing_in_provenant": raw_dependency_missing,
+            "extra_in_provenant": raw_dependency_extra,
         }),
     );
-    potential_regressions += dependency_missing;
-    potential_higher += dependency_extra;
+    if top_level_package_skip_reason.is_none() {
+        potential_regressions += top_level_package_missing;
+        potential_higher += top_level_package_extra;
+    }
+    if top_level_dependency_skip_reason.is_none() {
+        potential_regressions += top_level_dependency_missing;
+        potential_higher += top_level_dependency_extra;
+    }
+    potential_regressions += raw_dependency_missing;
+    potential_higher += raw_dependency_extra;
     rows.push(tsv_row(
-        "dependencies_missing_in_provenant",
-        dependency_missing as i64,
+        "top_level_packages_missing_in_provenant",
+        top_level_package_missing as i64,
         0,
-        -(dependency_missing as i64),
-        "dependency identities present only in ScanCode output",
+        -(top_level_package_missing as i64),
+        top_level_package_skip_reason
+            .as_deref()
+            .unwrap_or("top-level package identities present only in ScanCode output"),
     ));
     rows.push(tsv_row(
-        "dependencies_extra_in_provenant",
+        "top_level_packages_extra_in_provenant",
         0,
-        dependency_extra as i64,
-        dependency_extra as i64,
-        "dependency identities present only in Provenant output",
+        top_level_package_extra as i64,
+        top_level_package_extra as i64,
+        top_level_package_skip_reason
+            .as_deref()
+            .unwrap_or("top-level package identities present only in Provenant output"),
+    ));
+    rows.push(tsv_row(
+        "top_level_dependencies_missing_in_provenant",
+        top_level_dependency_missing as i64,
+        0,
+        -(top_level_dependency_missing as i64),
+        top_level_dependency_skip_reason
+            .as_deref()
+            .unwrap_or("top-level dependency identities present only in ScanCode output"),
+    ));
+    rows.push(tsv_row(
+        "top_level_dependencies_extra_in_provenant",
+        0,
+        top_level_dependency_extra as i64,
+        top_level_dependency_extra as i64,
+        top_level_dependency_skip_reason
+            .as_deref()
+            .unwrap_or("top-level dependency identities present only in Provenant output"),
+    ));
+    rows.push(tsv_row(
+        "raw_package_dependencies_missing_in_provenant",
+        raw_dependency_missing as i64,
+        0,
+        -(raw_dependency_missing as i64),
+        "raw dependency identities present only in ScanCode file-level package_data output",
+    ));
+    rows.push(tsv_row(
+        "raw_package_dependencies_extra_in_provenant",
+        0,
+        raw_dependency_extra as i64,
+        raw_dependency_extra as i64,
+        "raw dependency identities present only in Provenant file-level package_data output",
     ));
     rows.push(tsv_row(
         "top_level_license_expression_deltas",
@@ -1728,10 +1858,22 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
                 .join("top_level_license_expression_deltas.json"),
         ),
         (
-            "dependency_value_differences",
+            "top_level_package_value_differences",
             context
                 .samples_dir
-                .join("dependency_value_differences.json"),
+                .join("top_level_package_value_differences.json"),
+        ),
+        (
+            "top_level_dependency_value_differences",
+            context
+                .samples_dir
+                .join("top_level_dependency_value_differences.json"),
+        ),
+        (
+            "raw_dependency_value_differences",
+            context
+                .samples_dir
+                .join("raw_dependency_value_differences.json"),
         ),
         (
             "info_value_differences",
@@ -1756,26 +1898,36 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
     write_pretty_json(&sample_paths[3].1, &higher_counts)?;
     write_pretty_json(&sample_paths[4].1, &value_differences)?;
     write_pretty_json(&sample_paths[5].1, &license_deltas)?;
-    write_pretty_json(&sample_paths[6].1, &dependency_value_differences)?;
-    write_pretty_json(&sample_paths[7].1, &info_value_differences)?;
-    write_pretty_json(&sample_paths[8].1, &classify_value_differences)?;
-    write_pretty_json(&sample_paths[9].1, &row2_value_differences)?;
-    write_pretty_json(&sample_paths[10].1, &row2_top_level_differences)?;
+    write_pretty_json(&sample_paths[6].1, &top_level_package_value_differences)?;
+    write_pretty_json(&sample_paths[7].1, &top_level_dependency_value_differences)?;
+    write_pretty_json(&sample_paths[8].1, &raw_dependency_value_differences)?;
+    write_pretty_json(&sample_paths[9].1, &info_value_differences)?;
+    write_pretty_json(&sample_paths[10].1, &classify_value_differences)?;
+    write_pretty_json(&sample_paths[11].1, &row2_value_differences)?;
+    write_pretty_json(&sample_paths[12].1, &row2_top_level_differences)?;
 
     let summary = json!({
         "comparison_status": comparison_status,
         "top_level_counts": {
-            "scancode": sc_top,
-            "provenant": pr_top,
+            "scancode": sc_top.counts_json(),
+            "provenant": pr_top.counts_json(),
             "delta": {
-                "files": pr_top["files"] - sc_top["files"],
-                "packages": pr_top["packages"] - sc_top["packages"],
-                "dependencies": pr_top["dependencies"] - sc_top["dependencies"],
-                "license_detections": pr_top["license_detections"] - sc_top["license_detections"],
-                "license_references": pr_top["license_references"] - sc_top["license_references"],
-                "license_rule_references": pr_top["license_rule_references"] - sc_top["license_rule_references"],
-            }
+                "files": pr_top.count("files") - sc_top.count("files"),
+                "packages": pr_top.count("packages") - sc_top.count("packages"),
+                "dependencies": pr_top.count("dependencies") - sc_top.count("dependencies"),
+                "license_detections": pr_top.count("license_detections") - sc_top.count("license_detections"),
+                "license_references": pr_top.count("license_references") - sc_top.count("license_references"),
+                "license_rule_references": pr_top.count("license_rule_references") - sc_top.count("license_rule_references"),
+            },
+            "sources": {
+                "scancode": sc_top.sources_json(),
+                "provenant": pr_top.sources_json(),
+            },
         },
+        "skipped_comparisons": skipped_comparisons,
+        "top_level_package_summary": top_level_package_summary,
+        "top_level_dependency_summary": top_level_dependency_summary,
+        "raw_dependency_summary": raw_dependency_summary,
         "file_path_comparison": {
             "common_paths": common_paths.len(),
             "only_scancode_paths": only_scancode_paths.len(),
@@ -2274,24 +2426,53 @@ fn counter_entries(counter: &BTreeMap<String, usize>) -> Vec<ValueCountEntry> {
         .collect()
 }
 
-fn top_level_counts(value: &Value) -> HashMap<&'static str, i64> {
-    HashMap::from([
-        ("files", file_entry_count(value) as i64),
-        ("packages", array_len(value, "packages") as i64),
-        ("dependencies", array_len(value, "dependencies") as i64),
-        (
-            "license_detections",
-            array_len(value, "license_detections") as i64,
-        ),
-        (
-            "license_references",
-            array_len(value, "license_references") as i64,
-        ),
-        (
-            "license_rule_references",
-            array_len(value, "license_rule_references") as i64,
-        ),
-    ])
+fn top_level_counts(value: &Value) -> TopLevelCounts {
+    let package_count = array_len(value, "packages");
+    let fallback_package_count = file_package_data_count(value);
+    let dependency_count = array_len(value, "dependencies");
+    let fallback_dependency_count = file_package_data_dependency_count(value);
+
+    let packages_source = if package_count == 0 && fallback_package_count > 0 {
+        PACKAGE_DATA_COUNT_SOURCE
+    } else {
+        PACKAGES_COUNT_SOURCE
+    };
+    let dependencies_source = if dependency_count == 0 && fallback_dependency_count > 0 {
+        PACKAGE_DATA_DEPENDENCIES_COUNT_SOURCE
+    } else {
+        DEPENDENCIES_COUNT_SOURCE
+    };
+
+    TopLevelCounts {
+        counts: HashMap::from([
+            ("files", file_entry_count(value) as i64),
+            ("packages", package_count as i64),
+            ("dependencies", dependency_count as i64),
+            (
+                "license_detections",
+                array_len(value, "license_detections") as i64,
+            ),
+            (
+                "license_references",
+                array_len(value, "license_references") as i64,
+            ),
+            (
+                "license_rule_references",
+                array_len(value, "license_rule_references") as i64,
+            ),
+        ]),
+        sources: HashMap::from([
+            ("files", FILES_COUNT_SOURCE),
+            ("packages", packages_source),
+            ("dependencies", dependencies_source),
+            ("license_detections", LICENSE_DETECTIONS_COUNT_SOURCE),
+            ("license_references", LICENSE_REFERENCES_COUNT_SOURCE),
+            (
+                "license_rule_references",
+                LICENSE_RULE_REFERENCES_COUNT_SOURCE,
+            ),
+        ]),
+    }
 }
 
 fn file_entry_count(value: &Value) -> usize {
@@ -2310,6 +2491,46 @@ fn array_len(value: &Value, key: &str) -> usize {
         .and_then(Value::as_array)
         .map(|values| values.len())
         .unwrap_or(0)
+}
+
+fn file_package_data_count(value: &Value) -> usize {
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|entry| {
+            entry
+                .get("package_data")
+                .and_then(Value::as_array)
+                .map(|package_data| package_data.len())
+                .unwrap_or(0)
+        })
+        .sum()
+}
+
+fn file_package_data_dependency_count(value: &Value) -> usize {
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|entry| {
+            entry
+                .get("package_data")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .map(|package_data| {
+                    package_data
+                        .get("dependencies")
+                        .and_then(Value::as_array)
+                        .map(|dependencies| dependencies.len())
+                        .unwrap_or(0)
+                })
+                .sum::<usize>()
+        })
+        .sum()
 }
 
 fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
@@ -2343,9 +2564,57 @@ fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
     counter.into_iter().filter_map(|(key, (sc, pr))| (sc != pr).then_some(json!({"license_expression": key, "scancode": sc, "provenant": pr, "delta": pr - sc}))).collect()
 }
 
-fn dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
-    let sc_by_path = dependency_identities_by_path(scancode);
-    let pr_by_path = dependency_identities_by_path(provenant);
+fn top_level_package_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
+    let sc_top = top_level_counts(scancode);
+    let pr_top = top_level_counts(provenant);
+    if !count_delta_is_hard_regression_comparable("packages", &sc_top, &pr_top) {
+        return Vec::new();
+    }
+
+    let sc_identities = top_level_package_identities(scancode);
+    let pr_identities = top_level_package_identities(provenant);
+    let missing = difference_entries(&sc_identities, &pr_identities);
+    let extra = difference_entries(&pr_identities, &sc_identities);
+    if missing.is_empty() && extra.is_empty() {
+        return Vec::new();
+    }
+
+    vec![ValueDifferenceEntry {
+        path: "<top-level>".to_string(),
+        scancode: sc_identities.len(),
+        provenant: pr_identities.len(),
+        missing_in_provenant: missing,
+        extra_in_provenant: extra,
+    }]
+}
+
+fn top_level_package_identities(value: &Value) -> BTreeSet<String> {
+    value
+        .get("packages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|item| {
+            package_identity(item)
+                .map(str::to_string)
+                .or_else(|| package_fallback_identity(item))
+                .unwrap_or_else(|| "<unknown>".to_string())
+        })
+        .collect()
+}
+
+fn top_level_dependency_differences(
+    scancode: &Value,
+    provenant: &Value,
+) -> Vec<ValueDifferenceEntry> {
+    let sc_top = top_level_counts(scancode);
+    let pr_top = top_level_counts(provenant);
+    if !count_delta_is_hard_regression_comparable("dependencies", &sc_top, &pr_top) {
+        return Vec::new();
+    }
+
+    let sc_by_path = top_level_dependency_identities_by_path(scancode);
+    let pr_by_path = top_level_dependency_identities_by_path(provenant);
     let mut paths = BTreeSet::new();
     paths.extend(sc_by_path.keys().cloned());
     paths.extend(pr_by_path.keys().cloned());
@@ -2368,7 +2637,7 @@ fn dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDiffe
     differences
 }
 
-fn dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
+fn top_level_dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
     let mut output: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for item in value
         .get("dependencies")
@@ -2384,6 +2653,71 @@ fn dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<Str
             .unwrap_or_else(|| "<unknown>".to_string());
         let identity = dependency_identity(item).unwrap_or_else(|| "<unknown>".to_string());
         output.entry(path).or_default().insert(identity);
+    }
+    output
+}
+
+fn raw_dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
+    let sc_by_path = raw_dependency_identities_by_path(scancode);
+    let pr_by_path = raw_dependency_identities_by_path(provenant);
+    let mut paths = BTreeSet::new();
+    paths.extend(sc_by_path.keys().cloned());
+    paths.extend(pr_by_path.keys().cloned());
+    let mut differences = Vec::new();
+    for path in paths {
+        let sc_identities = sc_by_path.get(&path).cloned().unwrap_or_default();
+        let pr_identities = pr_by_path.get(&path).cloned().unwrap_or_default();
+        let missing = difference_entries(&sc_identities, &pr_identities);
+        let extra = difference_entries(&pr_identities, &sc_identities);
+        if !missing.is_empty() || !extra.is_empty() {
+            differences.push(ValueDifferenceEntry {
+                path,
+                scancode: sc_identities.len(),
+                provenant: pr_identities.len(),
+                missing_in_provenant: missing,
+                extra_in_provenant: extra,
+            });
+        }
+    }
+    differences
+}
+
+fn raw_dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTreeSet<String>> {
+    let mut output: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for file in value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let file_path = file
+            .get("path")
+            .and_then(Value::as_str)
+            .map(normalize_compare_path)
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        for package_data in file
+            .get("package_data")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            for item in package_data
+                .get("dependencies")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let path = item
+                    .get("datafile_path")
+                    .or_else(|| item.get("path"))
+                    .and_then(Value::as_str)
+                    .map(normalize_compare_path)
+                    .unwrap_or_else(|| file_path.clone());
+                let identity = dependency_identity(item).unwrap_or_else(|| "<unknown>".to_string());
+                output.entry(path).or_default().insert(identity);
+            }
+        }
     }
     output
 }
@@ -2436,8 +2770,8 @@ fn dependency_identity(item: &Value) -> Option<String> {
 }
 
 fn top_level_regressions(
-    left: &HashMap<&'static str, i64>,
-    right: &HashMap<&'static str, i64>,
+    left: &TopLevelCounts,
+    right: &TopLevelCounts,
     left_is_scancode: bool,
 ) -> BTreeMap<String, i64> {
     let mut output = BTreeMap::new();
@@ -2448,8 +2782,11 @@ fn top_level_regressions(
         "license_references",
         "license_rule_references",
     ] {
-        let left_value = left[key];
-        let right_value = right[key];
+        if !count_delta_is_hard_regression_comparable(key, left, right) {
+            continue;
+        }
+        let left_value = left.count(key);
+        let right_value = right.count(key);
         if left_is_scancode {
             if right_value < left_value {
                 output.insert(key.to_string(), left_value - right_value);
@@ -2459,6 +2796,64 @@ fn top_level_regressions(
         }
     }
     output
+}
+
+fn skipped_comparisons(left: &TopLevelCounts, right: &TopLevelCounts) -> BTreeMap<String, String> {
+    ["packages", "dependencies"]
+        .into_iter()
+        .filter(|metric| !count_delta_is_hard_regression_comparable(metric, left, right))
+        .map(|metric| {
+            (
+                metric.to_string(),
+                mixed_source_skip_reason(metric, left, right),
+            )
+        })
+        .collect()
+}
+
+fn count_delta_is_hard_regression_comparable(
+    key: &str,
+    left: &TopLevelCounts,
+    right: &TopLevelCounts,
+) -> bool {
+    match key {
+        "packages" => {
+            left.source(key) == PACKAGES_COUNT_SOURCE && right.source(key) == PACKAGES_COUNT_SOURCE
+        }
+        "dependencies" => {
+            left.source(key) == DEPENDENCIES_COUNT_SOURCE
+                && right.source(key) == DEPENDENCIES_COUNT_SOURCE
+        }
+        _ => true,
+    }
+}
+
+fn mixed_source_skip_reason(
+    metric: &str,
+    scancode: &TopLevelCounts,
+    provenant: &TopLevelCounts,
+) -> String {
+    format!(
+        "top-level {metric} comparison skipped: ScanCode {}; Provenant {}",
+        scancode.source(metric),
+        provenant.source(metric)
+    )
+}
+
+fn top_level_count_note(
+    metric: &str,
+    scancode: &TopLevelCounts,
+    provenant: &TopLevelCounts,
+) -> String {
+    if !matches!(metric, "packages" | "dependencies") {
+        return "top-level count".to_string();
+    }
+
+    if count_delta_is_hard_regression_comparable(metric, scancode, provenant) {
+        return "top-level count".to_string();
+    }
+
+    mixed_source_skip_reason(metric, scancode, provenant)
 }
 
 fn tsv_row(metric: &str, scancode: i64, provenant: i64, delta: i64, notes: &str) -> Vec<String> {
@@ -3496,7 +3891,120 @@ mod tests {
             ]
         });
 
-        assert!(dependency_differences(&scancode, &provenant).is_empty());
+        assert!(top_level_dependency_differences(&scancode, &provenant).is_empty());
+    }
+
+    #[test]
+    fn top_level_counts_record_missing_assembled_data_without_fallback() {
+        let value = json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": [{
+                    "type": "npm",
+                    "name": "left-pad",
+                    "version": "1.3.0",
+                    "purl": "pkg:npm/left-pad@1.3.0",
+                    "dependencies": [{
+                        "purl": "pkg:npm/ansi-regex@5.0.1",
+                        "scope": "dependencies",
+                        "is_runtime": true
+                    }]
+                }]
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        });
+
+        let counts = top_level_counts(&value);
+
+        assert_eq!(counts.count("packages"), 0);
+        assert_eq!(counts.count("dependencies"), 0);
+        assert_eq!(
+            counts.source("packages"),
+            "packages[] empty; files[].package_data present"
+        );
+        assert_eq!(
+            counts.source("dependencies"),
+            "dependencies[] empty; files[].package_data[].dependencies present"
+        );
+    }
+
+    #[test]
+    fn raw_dependency_differences_compare_file_level_package_data_when_top_level_is_empty() {
+        let scancode = json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": [{
+                    "type": "npm",
+                    "name": "left-pad",
+                    "version": "1.3.0",
+                    "purl": "pkg:npm/left-pad@1.3.0",
+                    "dependencies": [{
+                        "purl": "pkg:npm/ansi-regex@5.0.1",
+                        "scope": "dependencies",
+                        "is_runtime": true
+                    }]
+                }]
+            }],
+            "dependencies": []
+        });
+        let provenant = json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": [{
+                    "type": "npm",
+                    "name": "left-pad",
+                    "version": "1.3.0",
+                    "purl": "pkg:npm/left-pad@1.3.0",
+                    "dependencies": [{
+                        "purl": "pkg:npm/ansi-regex@5.0.1",
+                        "scope": "dependencies",
+                        "is_runtime": true
+                    }]
+                }]
+            }],
+            "dependencies": []
+        });
+
+        assert!(raw_dependency_differences(&scancode, &provenant).is_empty());
+    }
+
+    #[test]
+    fn top_level_dependency_differences_skip_mixed_source_inputs() {
+        let scancode = json!({
+            "files": [{
+                "path": "package-lock.json",
+                "type": "file",
+                "package_data": [{
+                    "type": "npm",
+                    "name": "left-pad",
+                    "version": "1.3.0",
+                    "purl": "pkg:npm/left-pad@1.3.0",
+                    "dependencies": [{
+                        "purl": "pkg:npm/ansi-regex@5.0.1",
+                        "scope": "dependencies",
+                        "is_runtime": true
+                    }]
+                }]
+            }],
+            "dependencies": []
+        });
+        let provenant = json!({
+            "dependencies": [{
+                "purl": "pkg:npm/chalk@5.3.0",
+                "datafile_path": "package-lock.json",
+                "scope": "dependencies",
+                "is_runtime": true
+            }]
+        });
+
+        assert!(top_level_dependency_differences(&scancode, &provenant).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split compare output into separate raw file-level and assembled top-level package/dependency comparisons
- canonicalize equivalent license expressions before generating compare summaries and sample artifacts so reordered or trivially parenthesized SPDX expressions do not appear as false differences
- mirror the same semantics in `src/compare.rs` and `xtask compare-outputs`, with focused unit and integration coverage for fallback and normalization behavior

## Scope and exclusions

- Included: `src/compare.rs`, `xtask/src/bin/compare_outputs.rs`, and focused compare integration/unit coverage
- Explicit exclusions: unrelated parser, assembly, or output-format behavior outside the compare workflows

## Intentional differences from Python

- compare artifacts now treat raw file-level package data and assembled top-level package data as separate layers, instead of allowing mixed-source direct comparison
- compare artifacts also canonicalize equivalent SPDX expressions before diffing so output review is driven by semantic differences rather than formatting-only noise

## Follow-up work

- Created or intentionally deferred: no additional follow-up required for this change set

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this branch changes compare summary/sample artifacts and targeted tests only; it does not update parser or golden expected-output fixtures