### PR TITLE
fix(copyright): recover eigen benchmark author parity

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -770,12 +770,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `290.44s`; ScanCode `5927.08s`
 - Broader Bazel and mixed-tree dependency extraction (`8202` vs `8056` packages, `1465` vs `700` dependencies) from root and vendored `MODULE.bazel`, many committed `BUILD` files, Python lockfiles, Dockerfiles, and Debian control metadata, plus direct `CITATION.cff` package visibility
 
-##### [ValveSoftware/eigen @ e9c4315](https://github.com/ValveSoftware/eigen/tree/e9c43151265207fd3366bba21cddd61141ff402c) — **18.92× faster**
+##### [ValveSoftware/eigen @ e9c4315](https://github.com/ValveSoftware/eigen/tree/e9c43151265207fd3366bba21cddd61141ff402c) — **21.86× faster**
 
 - Files: 1,784
-- Run context: 2026-04-29 · eigen-48035 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `20.35s`; ScanCode `384.96s`
-- Unicode-preserving holder normalization such as `Désiré Nuentsa-Wakam`, split multi-person holder recovery where ScanCode merges names, and matched BLAS/LAPACK Doxygen author coverage across committed `blas/testing/*.f` and `lapack/*.f` Fortran headers; the remaining ScanCode edge is limited to a few legacy acknowledgments, typoed-year spline headers, and SuperLU/Xerox holder extraction cases
+- Run context: 2026-04-29 · eigen-90726 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `17.61s`; ScanCode `384.96s`
+- Zero package or dependency deltas on this manifest-free source tree, plus Unicode-preserving holder normalization such as `Désiré Nuentsa-Wakam`, split multi-person holder recovery where ScanCode merges names, and full BLAS/LAPACK Doxygen author coverage across committed `blas/testing/*.f` and `lapack/*.f` Fortran headers; the remaining ScanCode edge is limited to a few legacy acknowledgments and SuperLU/Xerox holder extraction cases
 
 ##### [tokio-rs/tokio @ 5db10f5](https://github.com/tokio-rs/tokio/tree/5db10f538b683fe88d699dfd11be31d193db011c) — **3.31× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 177 of 177 recorded runs, with a **11.7× median speedup** and **10.9× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
+> Provenant is faster on 178 of 178 recorded runs, with a **11.7× median speedup** and **11.0× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -769,6 +769,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `290.44s`; ScanCode `5927.08s`
 - Broader Bazel and mixed-tree dependency extraction (`8202` vs `8056` packages, `1465` vs `700` dependencies) from root and vendored `MODULE.bazel`, many committed `BUILD` files, Python lockfiles, Dockerfiles, and Debian control metadata, plus direct `CITATION.cff` package visibility
+
+##### [ValveSoftware/eigen @ e9c4315](https://github.com/ValveSoftware/eigen/tree/e9c43151265207fd3366bba21cddd61141ff402c) — **18.92× faster**
+
+- Files: 1,784
+- Run context: 2026-04-29 · eigen-48035 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `20.35s`; ScanCode `384.96s`
+- Unicode-preserving holder normalization such as `Désiré Nuentsa-Wakam`, split multi-person holder recovery where ScanCode merges names, and matched BLAS/LAPACK Doxygen author coverage across committed `blas/testing/*.f` and `lapack/*.f` Fortran headers; the remaining ScanCode edge is limited to a few legacy acknowledgments, typoed-year spline headers, and SuperLU/Xerox holder extraction cases
 
 ##### [tokio-rs/tokio @ 5db10f5](https://github.com/tokio-rs/tokio/tree/5db10f538b683fe88d699dfd11be31d193db011c) — **3.31× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -770,12 +770,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `290.44s`; ScanCode `5927.08s`
 - Broader Bazel and mixed-tree dependency extraction (`8202` vs `8056` packages, `1465` vs `700` dependencies) from root and vendored `MODULE.bazel`, many committed `BUILD` files, Python lockfiles, Dockerfiles, and Debian control metadata, plus direct `CITATION.cff` package visibility
 
-##### [ValveSoftware/eigen @ e9c4315](https://github.com/ValveSoftware/eigen/tree/e9c43151265207fd3366bba21cddd61141ff402c) — **21.86× faster**
+##### [ValveSoftware/eigen @ e9c4315](https://github.com/ValveSoftware/eigen/tree/e9c43151265207fd3366bba21cddd61141ff402c) — **19.84× faster**
 
 - Files: 1,784
-- Run context: 2026-04-29 · eigen-90726 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `17.61s`; ScanCode `384.96s`
-- Zero package or dependency deltas on this manifest-free source tree, plus Unicode-preserving holder normalization such as `Désiré Nuentsa-Wakam`, split multi-person holder recovery where ScanCode merges names, and full BLAS/LAPACK Doxygen author coverage across committed `blas/testing/*.f` and `lapack/*.f` Fortran headers; the remaining ScanCode edge is limited to a few legacy acknowledgments and SuperLU/Xerox holder extraction cases
+- Run context: 2026-04-29 · eigen-43257 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `19.40s`; ScanCode `384.96s`
+- Zero package, dependency, and top-level license-detection deltas on this manifest-free source tree, plus Unicode-preserving holder normalization such as `Désiré Nuentsa-Wakam` and split multi-person holder recovery where ScanCode merges names; the remaining ScanCode edge is limited to a weak `Distributed` holder overcapture in `bench/eig33.cpp`, a few legacy acknowledgment-shaped author/copyright cases, minor holder formatting differences, and URL normalization deltas
 
 ##### [tokio-rs/tokio @ 5db10f5](https://github.com/tokio-rs/tokio/tree/5db10f538b683fe88d699dfd11be31d193db011c) — **3.31× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -356,6 +356,9 @@ ScanCode: 240.24s</title></rect>
     <rect x="607.19" y="328.71" width="8" height="8" fill="#d97706" rx="1.5"><title>guillemj/dpkg @ 0061122
 Files: 1766
 ScanCode: 563.43s</title></rect>
+    <rect x="607.89" y="346.71" width="8" height="8" fill="#d97706" rx="1.5"><title>ValveSoftware/eigen @ e9c4315
+Files: 1784
+ScanCode: 384.96s</title></rect>
     <rect x="613.31" y="384.18" width="8" height="8" fill="#d97706" rx="1.5"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 ScanCode: 174.19s</title></rect>
@@ -889,6 +892,9 @@ Provenant: 25.23s</title></circle>
     <circle cx="611.19" cy="474.77" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
 Files: 1766
 Provenant: 27.87s</title></circle>
+    <circle cx="611.89" cy="489.63" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
+Files: 1784
+Provenant: 20.35s</title></circle>
     <circle cx="617.31" cy="514.08" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 Provenant: 12.13s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -892,9 +892,9 @@ Provenant: 25.23s</title></circle>
     <circle cx="611.19" cy="474.77" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
 Files: 1766
 Provenant: 27.87s</title></circle>
-    <circle cx="611.89" cy="489.63" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
+    <circle cx="611.89" cy="496.46" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
-Provenant: 20.35s</title></circle>
+Provenant: 17.61s</title></circle>
     <circle cx="617.31" cy="514.08" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 Provenant: 12.13s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -892,9 +892,9 @@ Provenant: 25.23s</title></circle>
     <circle cx="611.19" cy="474.77" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
 Files: 1766
 Provenant: 27.87s</title></circle>
-    <circle cx="611.89" cy="496.46" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
+    <circle cx="611.89" cy="491.89" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
-Provenant: 17.61s</title></circle>
+Provenant: 19.40s</title></circle>
     <circle cx="617.31" cy="514.08" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 Provenant: 12.13s</title></circle>

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1822,7 +1822,9 @@ pub(in super::super) fn extract_comment_author_label_authors(
     }
 
     static DOXYGEN_AUTHOR_TAG_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)^(?:[@\\]author)\s+(?P<who>.+?)\s*$").unwrap());
+        LazyLock::new(|| Regex::new(r"(?i)^\\author\s+(?P<who>.+?)\s*$").unwrap());
+    static YEAR_ONLY_COPY_LINE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?ix)^copyright\s*\(c\)\s*[0-9\s,\-–/]+$").unwrap());
     let normalize_comment_line = |line: &str| {
         line.trim()
             .trim_start_matches(|ch: char| {
@@ -1842,7 +1844,9 @@ pub(in super::super) fn extract_comment_author_label_authors(
                 .map(|m| m.as_str())
                 .unwrap_or("")
                 .trim();
-            if let Some(author) = refine_author_with_optional_handle_suffix(who) {
+            if !(who.contains('<') || who.contains('>') || who.contains('@'))
+                && let Some(author) = refine_author_with_optional_handle_suffix(who)
+            {
                 authors.push(AuthorDetection {
                     author,
                     start_line: LineNumber::new(idx + 1).expect("invalid line number"),
@@ -1865,13 +1869,25 @@ pub(in super::super) fn extract_comment_author_label_authors(
         }
 
         let start_line = LineNumber::new(idx + 1).expect("invalid line number");
+        let previous_is_year_only_copyright =
+            idx > 0 && YEAR_ONLY_COPY_LINE_RE.is_match(&normalize_comment_line(raw_lines[idx - 1]));
 
-        if who.contains('<') && who.contains('>') && who_lower.contains(" at ") {
-            authors.push(AuthorDetection {
-                author: who.to_string(),
-                start_line,
-                end_line: start_line,
-            });
+        if label.eq_ignore_ascii_case("author") {
+            if previous_is_year_only_copyright {
+                continue;
+            }
+
+            if who.contains('<') && who.contains('>') && who_lower.contains(" at ") {
+                authors.push(AuthorDetection {
+                    author: who.to_string(),
+                    start_line,
+                    end_line: start_line,
+                });
+            }
+            continue;
+        }
+
+        if !previous_is_year_only_copyright {
             continue;
         }
 

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1821,29 +1821,93 @@ pub(in super::super) fn extract_comment_author_label_authors(
         return authors;
     }
 
-    for (idx, raw_line) in raw_lines.iter().enumerate() {
-        let trimmed = raw_line.trim();
-        let normalized = trimmed
+    static DOXYGEN_AUTHOR_TAG_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^(?:[@\\]author)\s+(?P<who>.+?)\s*$").unwrap());
+    let normalize_comment_line = |line: &str| {
+        line.trim()
             .trim_start_matches(|ch: char| {
-                ch.is_whitespace() || matches!(ch, '#' | ';' | '/' | '*' | '!' | '-')
+                ch.is_whitespace() || matches!(ch, '#' | ';' | '/' | '*' | '!' | '-' | '>')
             })
-            .trim();
+            .trim()
+            .to_string()
+    };
+
+    for (idx, raw_line) in raw_lines.iter().enumerate() {
+        let normalized = normalize_comment_line(raw_line);
+        let normalized = normalized.as_str();
+
+        if let Some(captures) = DOXYGEN_AUTHOR_TAG_RE.captures(normalized) {
+            let who = captures
+                .name("who")
+                .map(|m| m.as_str())
+                .unwrap_or("")
+                .trim();
+            if let Some(author) = refine_author_with_optional_handle_suffix(who) {
+                authors.push(AuthorDetection {
+                    author,
+                    start_line: LineNumber::new(idx + 1).expect("invalid line number"),
+                    end_line: LineNumber::new(idx + 1).expect("invalid line number"),
+                });
+            }
+            continue;
+        }
+
         let Some((label, who_raw)) = normalized.split_once(':') else {
             continue;
         };
-        if !label.eq_ignore_ascii_case("author") {
+        if !label.eq_ignore_ascii_case("author") && !label.eq_ignore_ascii_case("authors") {
             continue;
         }
         let who = who_raw.trim().trim_end_matches('.').trim();
         let who_lower = who.to_ascii_lowercase();
-        if who.is_empty() || !who.contains('<') || !who.contains('>') || !who_lower.contains(" at ")
-        {
+        if who.is_empty() {
             continue;
         }
+
+        let start_line = LineNumber::new(idx + 1).expect("invalid line number");
+
+        if who.contains('<') && who.contains('>') && who_lower.contains(" at ") {
+            authors.push(AuthorDetection {
+                author: who.to_string(),
+                start_line,
+                end_line: start_line,
+            });
+            continue;
+        }
+
+        let mut segments = vec![who.to_string()];
+        let mut end_line = start_line;
+        let should_collect_following =
+            label.eq_ignore_ascii_case("authors") || who.contains('<') || who.contains('@');
+
+        if should_collect_following {
+            for (offset, next_raw_line) in raw_lines.iter().skip(idx + 1).take(4).enumerate() {
+                let next_normalized = normalize_comment_line(next_raw_line);
+                if next_normalized.is_empty() || next_normalized.contains(':') {
+                    break;
+                }
+                let include = next_normalized.contains('<')
+                    || next_normalized.contains('@')
+                    || next_normalized
+                        .chars()
+                        .find(|ch| !ch.is_whitespace())
+                        .is_some_and(|ch| ch.is_ascii_uppercase());
+                if !include {
+                    break;
+                }
+                segments.push(next_normalized);
+                end_line = LineNumber::new(idx + offset + 2).expect("invalid line number");
+            }
+        }
+
+        let candidate = segments.join(" ");
+        let Some(author) = refine_author_with_optional_handle_suffix(&candidate) else {
+            continue;
+        };
         authors.push(AuthorDetection {
-            author: who.to_string(),
-            start_line: LineNumber::new(idx + 1).expect("invalid line number"),
-            end_line: LineNumber::new(idx + 1).expect("invalid line number"),
+            author,
+            start_line,
+            end_line,
         });
     }
 

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -90,6 +90,75 @@ fn test_extract_comment_author_label_authors_keeps_obfuscated_angle_contact() {
 }
 
 #[test]
+fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
+    let raw_lines = vec![
+        "*> \\author Univ. of California Berkeley",
+        "*> \\author Univ. of Colorado Denver",
+    ];
+    let authors = extract_comment_author_label_authors(&raw_lines);
+
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    assert!(
+        values.contains(&"Univ. of California Berkeley"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Univ. of Colorado Denver"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_detect_doxygen_author_tag_roster_in_comment_block() {
+    let input = concat!(
+        "*  Authors:\n",
+        "*> \\author Univ. of Tennessee\n",
+        "*> \\author Univ. of California Berkeley\n",
+        "*> \\author Univ. of Colorado Denver\n",
+        "*> \\author NAG Ltd.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    assert!(
+        values.contains(&"Univ. of Tennessee"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Univ. of California Berkeley"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Univ. of Colorado Denver"),
+        "authors: {values:?}"
+    );
+    assert!(values.contains(&"NAG Ltd."), "authors: {values:?}");
+}
+
+#[test]
+fn test_detect_multiline_comment_authors_block_after_year_only_copyright() {
+    let input = concat!(
+        "// Copyright (C) 1997-2001\n",
+        "// Authors: Andrew Lumsdaine <lums@osl.iu.edu>\n",
+        "//          Lie-Quan Lee     <llee@osl.iu.edu>\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors.iter().any(|author| {
+            author.author == "Andrew Lumsdaine <lums@osl.iu.edu> Lie-Quan Lee <llee@osl.iu.edu>"
+        }),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_extract_collective_author_with_contributors_before_email() {
     let input = "authors = [\"Tokio Contributors <team@tokio.rs>\"]\n";
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -935,6 +935,9 @@ pub fn extract_copyright_c_years_holder_lines(
             if years.is_empty() || holder_raw.is_empty() {
                 continue;
             }
+            if holder_raw.contains("...") || holder_raw.contains('…') {
+                continue;
+            }
             let raw = format!("Copyright (c) {years} {holder_raw}");
             let Some(cr) = refine_copyright(&raw) else {
                 continue;

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -924,15 +924,15 @@ pub fn extract_copyright_c_years_holder_lines(
             if trimmed.is_empty() {
                 continue;
             }
-            let Some(cap) = COPY_C_YEARS_HOLDER_RE.captures(trimmed) else {
+            let normalized = trimmed
+                .trim_start_matches(['*', '/', '#', ';', '%', '!'])
+                .trim_start();
+            let Some(cap) = COPY_C_YEARS_HOLDER_RE.captures(normalized) else {
                 continue;
             };
             let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
             let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
             if years.is_empty() || holder_raw.is_empty() {
-                continue;
-            }
-            if holder_raw.to_ascii_lowercase().contains("all rights") {
                 continue;
             }
             let raw = format!("Copyright (c) {years} {holder_raw}");
@@ -947,7 +947,8 @@ pub fn extract_copyright_c_years_holder_lines(
                 });
             }
 
-            if let Some(h) = refine_holder_in_copyright_context(holder_raw)
+            if let Some(h) = postprocess_transforms::derive_holder_from_simple_copyright_string(&cr)
+                .or_else(|| refine_holder_in_copyright_context(holder_raw))
                 && seen_h.insert((*ln, h.clone()))
             {
                 holders.push(HolderDetection {

--- a/src/copyright/detector/postprocess_transforms/year_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/year_repairs.rs
@@ -815,6 +815,16 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         Regex::new(r"(?i)^copyright\s*\(c\)\s*(?:19|20)\d{2}-\d{2}-\d{2}\s+(?P<holder>.+)$")
             .expect("valid iso-date copyright holder regex")
     });
+    static LEADING_YEARISH_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)^
+            (?:19\d{2}|20\d{2}|\?\?\?\?|\$)
+            (?:\s*[-–/,:]\s*(?:19\d{2}|20\d{2}|\d{2}|\?\?\?\?|\?\?|present|\$))*
+            [\.,;:]?$
+            ",
+        )
+        .expect("valid leading yearish token regex")
+    });
     static BARE_HOLDER_C_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?P<holder>[^\n]+?)\s*,?\s*\(c\)\s*(?:19|20)\d{2}\b")
             .expect("valid bare holder (c) year regex")
@@ -822,6 +832,19 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
 
     static EMBEDDED_C_MARKER_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^(?P<head>.+?)\s*,\s*\(c\)\s*(?:19|20)\d{2}\b").unwrap());
+
+    fn strip_leading_yearish_tokens<'a>(tail: &'a str, yearish_re: &Regex) -> &'a str {
+        let mut rest = tail.trim_start();
+        while !rest.is_empty() {
+            let token_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+            let token = &rest[..token_end];
+            if !yearish_re.is_match(token) {
+                break;
+            }
+            rest = rest[token_end..].trim_start();
+        }
+        rest
+    }
 
     let trimmed = s.trim();
     if trimmed.to_ascii_lowercase().starts_with("copyright")
@@ -844,17 +867,7 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         let t = trimmed.trim_start();
         if t.to_ascii_lowercase().starts_with("(c)") {
             let mut tail = t.get(3..).unwrap_or("").trim_start();
-            let mut start = 0usize;
-            for (i, ch) in tail.char_indices() {
-                if ch.is_ascii_digit() || matches!(ch, ' ' | ',' | '-' | '–' | '/' | '+') {
-                    start = i + ch.len_utf8();
-                    continue;
-                }
-                break;
-            }
-            if start > 0 && start < tail.len() {
-                tail = tail[start..].trim();
-            }
+            tail = strip_leading_yearish_tokens(tail, &LEADING_YEARISH_TOKEN_RE);
             if tail.is_empty() {
                 return None;
             }
@@ -883,15 +896,7 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
 
     tail = tail.trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ':' | '.'));
 
-    let mut start = 0usize;
-    for (i, ch) in tail.char_indices() {
-        if ch.is_ascii_digit() || matches!(ch, ' ' | ',' | '-' | '–' | '/') {
-            start = i + ch.len_utf8();
-            continue;
-        }
-        break;
-    }
-    let mut holder_raw = tail[start..].trim();
+    let mut holder_raw = strip_leading_yearish_tokens(tail, &LEADING_YEARISH_TOKEN_RE).trim();
     if let Some(rest) = holder_raw.strip_prefix("by ") {
         holder_raw = rest.trim();
     }

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -119,6 +119,14 @@ fn test_derive_holder_from_simple_copyright_string_strips_by_prefix() {
 }
 
 #[test]
+fn test_derive_holder_from_simple_copyright_string_keeps_leading_digits() {
+    assert_eq!(
+        derive_holder_from_simple_copyright_string("Copyright (c) 2010 42North Inc."),
+        Some("42North Inc.".to_string())
+    );
+}
+
+#[test]
 fn test_refine_final_authors_keeps_structured_metadata_collectives() {
     let mut authors = vec![
         AuthorDetection {

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -111,6 +111,14 @@ fn test_derive_holder_from_simple_copyright_string_keeps_iso_date_holder() {
 }
 
 #[test]
+fn test_derive_holder_from_simple_copyright_string_strips_by_prefix() {
+    assert_eq!(
+        derive_holder_from_simple_copyright_string("Copyright (c) 1994 by Xerox Corporation"),
+        Some("Xerox Corporation".to_string())
+    );
+}
+
+#[test]
 fn test_refine_final_authors_keeps_structured_metadata_collectives() {
     let mut authors = vec![
         AuthorDetection {

--- a/src/copyright/detector/tests_copyright_holder_pipeline.rs
+++ b/src/copyright/detector/tests_copyright_holder_pipeline.rs
@@ -129,6 +129,24 @@ fn test_by_keyword_holder_captured() {
 }
 
 #[test]
+fn test_comment_led_by_keyword_holder_backfilled() {
+    let input = "* Copyright (c) 1994 by Xerox Corporation.  All rights reserved.";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "Copyright (c) 1994 by Xerox Corporation"),
+        "Should preserve the simple copyright string, got: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter().any(|hh| hh.holder == "Xerox Corporation"),
+        "Should backfill holder from the preserved copyright string, got: {:?}",
+        h.iter().map(|hh| &hh.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_holder_company_with_digits_absorbed() {
     let input = "Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.";
     let (c, h, _a) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -110,6 +110,15 @@ fn test_glide_3dfx_copyright_notice_does_not_trigger_for_notice_s_plural() {
 }
 
 #[test]
+fn test_copyright_notice_of_prose_does_not_emit_xerox_holder() {
+    let content = "the above copyright notice of Xerox Corporation,";
+    let (copyrights, holders, authors) = detect_copyrights_from_text(content);
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:#?}");
+    assert!(holders.is_empty(), "holders: {holders:#?}");
+    assert!(authors.is_empty(), "authors: {authors:#?}");
+}
+
+#[test]
 fn test_play_header_does_not_emit_bare_c_from_year_shadow() {
     let content = "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>\n";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(content);

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -677,7 +677,18 @@ pub fn is_copyright_of_header(span: &[&Token]) -> bool {
     if first.tag != PosTag::Copy || !first.value.eq_ignore_ascii_case("copyright") {
         return false;
     }
-    if second.tag != PosTag::Of || !second.value.eq_ignore_ascii_case("of") {
+
+    let starts_with_notice_of = if span.len() >= 4 {
+        second.value.eq_ignore_ascii_case("notice")
+            && span[2].tag == PosTag::Of
+            && span[2].value.eq_ignore_ascii_case("of")
+    } else {
+        false
+    };
+
+    if !(second.tag == PosTag::Of && second.value.eq_ignore_ascii_case("of")
+        || starts_with_notice_of)
+    {
         return false;
     }
 

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -171,7 +171,6 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^the\s+standard$",
         r"(?i)^the\s+product$",
         r"(?i)^rsa$",
-        r"(?i)^xerox corporation$",
         r"(?i)^david j\. bradshaw$",
         r"(?i)^gias kay lee$",
         r"(?i)^tim ruffles$",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1411,6 +1411,12 @@ fn test_refine_holder_strips_trailing_period() {
 }
 
 #[test]
+fn test_refine_holder_keeps_xerox_corporation() {
+    let result = refine_holder("Xerox Corporation");
+    assert_eq!(result, Some("Xerox Corporation".to_string()));
+}
+
+#[test]
 fn test_refine_holder_strips_trailing_division_of_company_suffix() {
     let input = "Industrial Light & Magic, a division of Lucas Digital Ltd. LLC";
     assert_eq!(

--- a/testdata/copyright-golden/copyrights/libopenthreads12-libopenthreads.copyright.yml
+++ b/testdata/copyright-golden/copyrights/libopenthreads12-libopenthreads.copyright.yml
@@ -3,10 +3,10 @@ what:
   - holders
   - holders_summary
 copyrights:
-  - Copyright (c) 1998 Julian Smart, Robert Roebling, ...
+  - Copyright (c) 1998 Julian Smart, Robert Roebling
   - Copyright (c) 2002 Robert Osfield
 holders:
-  - Julian Smart, Robert Roebling, ...
+  - Julian Smart, Robert Roebling
   - Robert Osfield
 holders_summary:
   - value: Julian Smart, Robert Roebling

--- a/testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-115.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-115.txt.yml
@@ -5,5 +5,5 @@ what:
 copyrights:
   - Copyright (c) 2012 Vitaly Puzrin (https://github.com/puzrin)
 holders:
-  - Vitaly Puzrin (
+  - Vitaly Puzrin
 authors: []

--- a/testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-204.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-204.txt.yml
@@ -5,5 +5,5 @@ what:
 copyrights:
   - Copyright (c) 2011-2014 Paul Vorbach (http://paul.vorba.ch/)
 holders:
-  - Paul Vorbach (
+  - Paul Vorbach
 authors: []

--- a/testdata/copyright-golden/copyrights/wxWindows_Library_.0_variant.yml
+++ b/testdata/copyright-golden/copyrights/wxWindows_Library_.0_variant.yml
@@ -3,9 +3,9 @@ what:
   - holders
   - holders_summary
 copyrights:
-  - Copyright (c) 1998 Julian Smart, Robert Roebling, ...
+  - Copyright (c) 1998 Julian Smart, Robert Roebling
 holders:
-  - Julian Smart, Robert Roebling, ...
+  - Julian Smart, Robert Roebling
 holders_summary:
   - value: Julian Smart, Robert Roebling
     count: 1


### PR DESCRIPTION
## Summary

- keep comment-led `Copyright (c) ... by ...` lines on the shared holder-extraction path, stop treating `Xerox Corporation` as junk holder text, and tighten follow-up holder recovery so prose-only `copyright notice of ...` spans do not leak holders while real names like `42North Inc.` are preserved
- rerun `compare-outputs` for `ValveSoftware/eigen @ e9c43151265207fd3366bba21cddd61141ff402c` with the maintained `common` profile and the same shared ScanCode cache identity
- refresh the eigen benchmark checkpoint and chart to the latest end-state snapshot (`eigen-43257`), which keeps `0` package deltas, `0` dependency deltas, and `42` vs `42` top-level license detections, then sync the small set of copyright-golden expectations whose cleaner holder/copyright output is now intentionally preserved

## Issues

- Covers: benchmark verification for `ValveSoftware/eigen`
- Closes:

## Scope and exclusions

- Included:
  - `src/copyright/detector/pattern_extract/extraction/groups.rs`
  - `src/copyright/detector/postprocess_transforms/year_repairs.rs`
  - `src/copyright/detector/postprocess_transforms_test.rs`
  - `src/copyright/detector/tests_copyright_holder_pipeline.rs`
  - `src/copyright/detector/tests_false_positives.rs`
  - `src/copyright/detector/token_utils/filters.rs`
  - `src/copyright/refiner/holders_junk_patterns.rs`
  - `src/copyright/refiner/tests.rs`
  - `docs/BENCHMARKS.md`
  - `docs/benchmarks/scan-duration-vs-files.svg`
  - targeted copyright golden expectations under `testdata/copyright-golden/copyrights/`
- Explicit exclusions:
  - no attempt to match ScanCode's weak `Distributed` holder overcapture in `bench/eig33.cpp`

## Intentional differences from Python

- No intentional Python-compatibility divergence was introduced. The remaining `bench/eig33.cpp` holder delta is a weak license-prose overcapture (`Distributed`) that Provenant intentionally does not model as a holder.

## Follow-up work

- Created or intentionally deferred:
  - none for this PR beyond any future review of unrelated legacy acknowledgment-shaped author/copyright differences surfaced by the eigen compare run

## Expected-output fixture changes

- Files changed:
  - `testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-115.txt.yml`
  - `testdata/copyright-golden/copyrights/misco2/regexhq/regexhq-204.txt.yml`
  - `testdata/copyright-golden/copyrights/libopenthreads12-libopenthreads.copyright.yml`
  - `testdata/copyright-golden/copyrights/wxWindows_Library_.0_variant.yml`
- Why the new expected output is correct:
  - markdown-link and ellipsis-tailed holder/copyright cleanup now preserves the cleaner short form instead of stale dangling `(` or `...` suffixes
  - follow-up false-positive fixes keep prose-only `copyright notice of ...` text from leaking holders and preserve real derived names like `42North Inc.`
  - validated with:
    - `cargo test test_refine_holder_keeps_xerox_corporation`
    - `cargo test test_derive_holder_from_simple_copyright_string_strips_by_prefix`
    - `cargo test test_derive_holder_from_simple_copyright_string_keeps_leading_digits`
    - `cargo test test_comment_led_by_keyword_holder_backfilled`
    - `cargo test test_copyright_notice_of_prose_does_not_emit_xerox_holder`
    - `cargo test --features golden-tests --test copyright_golden test_fixture_misco3_not_real_copyrights -- --nocapture`
    - `cargo test --features golden-tests --test copyright_golden test_golden_copyrights -- --nocapture`
    - `cargo test --features golden-tests --test copyright_golden test_golden_holders -- --nocapture`
    - `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/ValveSoftware/eigen.git --repo-ref e9c43151265207fd3366bba21cddd61141ff402c --profile common`
