### PR TITLE
fix(nuget): prefer AssemblyName over filename fallback

### DIFF
--- a/src/parsers/nuget/nuget_test.rs
+++ b/src/parsers/nuget/nuget_test.rs
@@ -1503,6 +1503,42 @@ mod tests {
     }
 
     #[test]
+    fn test_csproj_prefers_package_id_then_assembly_name_then_filename() {
+        let xml = r#"<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><AssemblyName>Assembly.Identity</AssemblyName><Version>1.2.3</Version></PropertyGroup></Project>"#;
+
+        let temp_file = Builder::new()
+            .prefix("filename-wins-wrongly")
+            .suffix(".csproj")
+            .tempfile()
+            .unwrap();
+        std::fs::write(temp_file.path(), xml).unwrap();
+
+        let package_data = PackageReferenceProjectParser::extract_first_package(temp_file.path());
+        assert_eq!(package_data.name.as_deref(), Some("Assembly.Identity"));
+        assert_eq!(package_data.version.as_deref(), Some("1.2.3"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:nuget/Assembly.Identity@1.2.3")
+        );
+
+        let xml_with_package_id = r#"<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><PackageId>Package.Identity</PackageId><AssemblyName>Assembly.Identity</AssemblyName><Version>1.2.3</Version></PropertyGroup></Project>"#;
+
+        let temp_file = Builder::new()
+            .prefix("packageid-beats-assembly")
+            .suffix(".csproj")
+            .tempfile()
+            .unwrap();
+        std::fs::write(temp_file.path(), xml_with_package_id).unwrap();
+
+        let package_data = PackageReferenceProjectParser::extract_first_package(temp_file.path());
+        assert_eq!(package_data.name.as_deref(), Some("Package.Identity"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:nuget/Package.Identity@1.2.3")
+        );
+    }
+
+    #[test]
     fn test_nupkg_extracts_embedded_license_file_contents() {
         let nuspec = r#"<?xml version="1.0" encoding="utf-8"?>
 <package>

--- a/src/parsers/nuget/project_file.rs
+++ b/src/parsers/nuget/project_file.rs
@@ -64,10 +64,11 @@ impl PackageParser for PackageReferenceProjectParser {
         xml_reader.config_mut().trim_text(true);
 
         let mut name = None;
-        let mut fallback_name = path
+        let filename_stem = path
             .file_stem()
             .and_then(|stem| stem.to_str())
             .map(|stem| stem.to_string());
+        let mut assembly_name = None;
         let mut version = None;
         let mut description = None;
         let mut homepage_url = None;
@@ -210,7 +211,7 @@ impl PackageParser for PackageReferenceProjectParser {
                         project_properties.insert(current_element.clone(), text.clone());
                         match current_element.as_str() {
                             "PackageId" => name = Some(text),
-                            "AssemblyName" if fallback_name.is_none() => fallback_name = Some(text),
+                            "AssemblyName" => assembly_name = Some(text),
                             "Version" if version.is_none() => version = Some(text),
                             "PackageVersion" => version = Some(text),
                             "Description" => description = Some(text),
@@ -265,7 +266,7 @@ impl PackageParser for PackageReferenceProjectParser {
             buf.clear();
         }
 
-        let name = name.or(fallback_name);
+        let name = name.or(assembly_name).or(filename_stem);
         let vcs_url = repository_url.map(|url| match repository_type {
             Some(repo_type) if !repo_type.trim().is_empty() => format!("{}+{}", repo_type, url),
             _ => url,


### PR DESCRIPTION
## Summary

- fix PackageReference project identity precedence so `AssemblyName` actually works as the intended fallback before the filename stem
- add a focused regression proving `PackageId > AssemblyName > filename stem` for `.csproj` package identity and purl generation
- keep existing datasource and PackageReference golden behavior intact

## Scope and exclusions

- Included:
  - `src/parsers/nuget/project_file.rs` name fallback precedence
  - `src/parsers/nuget/nuget_test.rs` regression coverage for conflicting identity sources
- Explicit exclusions:
  - no broader NuGet metadata resolution redesign
  - no changes to CPM `PackageVersion` semantics or other NuGet parsers

## Intentional differences from Python

- None beyond making the existing `AssemblyName` fallback path actually reachable and test-covered in Provenant's NuGet project parser.
