### PR TITLE
fix(python): prefer field-level pyproject identity fallback

### DIFF
--- a/src/parsers/python/pyproject.rs
+++ b/src/parsers/python/pyproject.rs
@@ -39,6 +39,18 @@ const FIELD_EXTRAS: &str = "extras";
 const FIELD_DEPENDENCY_GROUPS: &str = "dependency-groups";
 const FIELD_DEV_DEPENDENCIES: &str = "dev-dependencies";
 
+fn preferred_string_field<'a>(
+    project: Option<&'a TomlMap<String, TomlValue>>,
+    poetry: Option<&'a TomlMap<String, TomlValue>>,
+    legacy: Option<&'a TomlMap<String, TomlValue>>,
+    field: &str,
+) -> Option<&'a str> {
+    project
+        .and_then(|table| table.get(field).and_then(|value| value.as_str()))
+        .or_else(|| poetry.and_then(|table| table.get(field).and_then(|value| value.as_str())))
+        .or_else(|| legacy.and_then(|table| table.get(field).and_then(|value| value.as_str())))
+}
+
 pub(super) fn extract(path: &Path) -> Vec<PackageData> {
     let toml_content = match read_toml_file(path) {
         Ok(content) => content,
@@ -57,37 +69,49 @@ pub(super) fn extract(path: &Path) -> Vec<PackageData> {
         .and_then(|value| value.as_table())
         .is_some();
 
-    let project_table =
-        if let Some(project) = toml_content.get(FIELD_PROJECT).and_then(|v| v.as_table()) {
-            project.clone()
-        } else if let Some(tool) = tool_table {
-            if let Some(poetry) = tool.get("poetry").and_then(|v| v.as_table()) {
-                poetry.clone()
-            } else {
+    let project_metadata = toml_content.get(FIELD_PROJECT).and_then(|v| v.as_table());
+    let poetry_metadata = tool_table.and_then(|tool| tool.get("poetry").and_then(|v| v.as_table()));
+    let legacy_metadata = if toml_content.get(FIELD_NAME).is_some() {
+        match toml_content.as_table() {
+            Some(table) => Some(table),
+            None => {
+                warn!("Failed to convert TOML content to table in {:?}", path);
                 return default_package_data(path);
             }
-        } else if toml_content.get(FIELD_NAME).is_some() {
-            match toml_content.as_table() {
-                Some(table) => table.clone(),
-                None => {
-                    warn!("Failed to convert TOML content to table in {:?}", path);
-                    return default_package_data(path);
-                }
-            }
-        } else {
-            return default_package_data(path);
-        };
+        }
+    } else {
+        None
+    };
 
-    let name = project_table
-        .get(FIELD_NAME)
-        .and_then(|v| v.as_str())
+    if project_metadata.is_none() && poetry_metadata.is_none() && legacy_metadata.is_none() {
+        return default_package_data(path);
+    }
+
+    let selected_metadata = project_metadata
+        .or(poetry_metadata)
+        .or(legacy_metadata)
+        .expect("metadata source checked above");
+
+    let name = project_metadata
+        .and_then(|project| project.get(FIELD_NAME).and_then(|v| v.as_str()))
+        .or_else(|| {
+            poetry_metadata.and_then(|poetry| poetry.get(FIELD_NAME).and_then(|v| v.as_str()))
+        })
+        .or_else(|| {
+            legacy_metadata.and_then(|legacy| legacy.get(FIELD_NAME).and_then(|v| v.as_str()))
+        })
         .map(|v| truncate_field(v.to_string()));
 
-    let version = project_table
-        .get(FIELD_VERSION)
-        .and_then(|v| v.as_str())
+    let version = project_metadata
+        .and_then(|project| project.get(FIELD_VERSION).and_then(|v| v.as_str()))
+        .or_else(|| {
+            poetry_metadata.and_then(|poetry| poetry.get(FIELD_VERSION).and_then(|v| v.as_str()))
+        })
+        .or_else(|| {
+            legacy_metadata.and_then(|legacy| legacy.get(FIELD_VERSION).and_then(|v| v.as_str()))
+        })
         .map(String::from);
-    let classifiers = project_table
+    let classifiers = selected_metadata
         .get("classifiers")
         .and_then(|value| value.as_array())
         .map(|values| {
@@ -99,15 +123,18 @@ pub(super) fn extract(path: &Path) -> Vec<PackageData> {
         .unwrap_or_default();
     let (classifier_keywords, license_classifiers) = split_classifiers(&classifiers);
 
-    let extracted_license_statement = extract_raw_license_string(&project_table);
+    let extracted_license_statement = extract_raw_license_string(selected_metadata);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-        normalize_spdx_declared_license(extract_license_expression_candidate(&project_table));
+        normalize_spdx_declared_license(extract_license_expression_candidate(selected_metadata));
 
-    let description = project_table
-        .get(FIELD_DESCRIPTION)
-        .and_then(|value| value.as_str())
-        .map(|value| truncate_field(value.to_string()));
-    let mut keywords = project_table
+    let description = preferred_string_field(
+        project_metadata,
+        poetry_metadata,
+        legacy_metadata,
+        FIELD_DESCRIPTION,
+    )
+    .map(|value| truncate_field(value.to_string()));
+    let mut keywords = selected_metadata
         .get(FIELD_KEYWORDS)
         .and_then(|value| value.as_array())
         .map(|values| {
@@ -124,9 +151,15 @@ pub(super) fn extract(path: &Path) -> Vec<PackageData> {
     }
 
     let mut extra_data = extract_pyproject_extra_data(&toml_content).unwrap_or_default();
-    let urls = extract_urls(&project_table, &mut extra_data);
+    let urls = extract_urls(
+        project_metadata,
+        poetry_metadata,
+        legacy_metadata,
+        &mut extra_data,
+    );
 
-    let (dependencies, optional_dependencies) = extract_dependencies(&project_table, &toml_content);
+    let (dependencies, optional_dependencies) =
+        extract_dependencies(selected_metadata, &toml_content);
 
     let purl = name.as_ref().and_then(|n| {
         let mut package_url = match PackageUrl::new(PythonParser::PACKAGE_TYPE.as_str(), n) {
@@ -182,13 +215,10 @@ pub(super) fn extract(path: &Path) -> Vec<PackageData> {
         name,
         version,
         description,
-        parties: extract_parties(&project_table),
+        parties: extract_parties(selected_metadata),
         keywords,
         homepage_url: urls.homepage_url.or(pypi_homepage_url),
-        download_url: urls
-            .download_url
-            .or_else(|| urls.vcs_url.clone())
-            .or(pypi_download_url),
+        download_url: urls.download_url.or(pypi_download_url),
         bug_tracking_url: urls.bug_tracking_url,
         code_view_url: urls.code_view_url,
         vcs_url: urls.vcs_url,
@@ -245,7 +275,9 @@ fn extract_license_expression_candidate(project: &TomlMap<String, TomlValue>) ->
 }
 
 fn extract_urls(
-    project: &TomlMap<String, TomlValue>,
+    project: Option<&TomlMap<String, TomlValue>>,
+    poetry: Option<&TomlMap<String, TomlValue>>,
+    legacy: Option<&TomlMap<String, TomlValue>>,
     extra_data: &mut HashMap<String, serde_json::Value>,
 ) -> ProjectUrls {
     let mut urls = ProjectUrls {
@@ -257,7 +289,12 @@ fn extract_urls(
         changelog_url: None,
     };
 
-    if let Some(url_table) = project.get(FIELD_URLS).and_then(|v| v.as_table()) {
+    let url_table = project
+        .and_then(|table| table.get(FIELD_URLS).and_then(|v| v.as_table()))
+        .or_else(|| poetry.and_then(|table| table.get(FIELD_URLS).and_then(|v| v.as_table())))
+        .or_else(|| legacy.and_then(|table| table.get(FIELD_URLS).and_then(|v| v.as_table())));
+
+    if let Some(url_table) = url_table {
         let parsed_urls: Vec<(String, String)> = url_table
             .iter()
             .filter_map(|(label, value)| {
@@ -289,17 +326,13 @@ fn extract_urls(
     }
 
     if urls.homepage_url.is_none() {
-        urls.homepage_url = project
-            .get(FIELD_HOMEPAGE)
-            .and_then(|v| v.as_str())
-            .map(String::from);
+        urls.homepage_url =
+            preferred_string_field(project, poetry, legacy, FIELD_HOMEPAGE).map(String::from);
     }
 
     if urls.vcs_url.is_none() {
-        urls.vcs_url = project
-            .get(FIELD_REPOSITORY)
-            .and_then(|v| v.as_str())
-            .map(String::from);
+        urls.vcs_url =
+            preferred_string_field(project, poetry, legacy, FIELD_REPOSITORY).map(String::from);
     }
 
     urls

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -889,6 +889,64 @@ homepage = "https://example.com"
     }
 
     #[test]
+    fn test_extract_from_mixed_project_and_poetry_falls_back_per_identity_field() {
+        let content = r#"
+[project]
+description = "pep-621 metadata exists but is incomplete"
+
+[tool.poetry]
+name = "poetry-fallback"
+version = "1.2.3"
+homepage = "https://example.com/poetry-fallback"
+repository = "https://github.com/example/poetry-fallback"
+"#;
+
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.name.as_deref(), Some("poetry-fallback"));
+        assert_eq!(package_data.version.as_deref(), Some("1.2.3"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:pypi/poetry-fallback@1.2.3")
+        );
+        assert_eq!(
+            package_data.homepage_url.as_deref(),
+            Some("https://example.com/poetry-fallback")
+        );
+        assert_eq!(
+            package_data.vcs_url.as_deref(),
+            Some("https://github.com/example/poetry-fallback")
+        );
+        assert_eq!(
+            package_data.download_url.as_deref(),
+            Some("https://pypi.org/packages/source/p/poetry-fallback/poetry-fallback-1.2.3.tar.gz")
+        );
+    }
+
+    #[test]
+    fn test_extract_download_url_does_not_fall_back_to_repository() {
+        let content = r#"
+[project]
+name = "test-package"
+version = "1.0.0"
+repository = "https://github.com/user/test-package"
+"#;
+
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(
+            package_data.vcs_url.as_deref(),
+            Some("https://github.com/user/test-package")
+        );
+        assert_eq!(
+            package_data.download_url.as_deref(),
+            Some("https://pypi.org/packages/source/t/test-package/test-package-1.0.0.tar.gz")
+        );
+    }
+
+    #[test]
     fn test_extract_vcs_url_without_repository() {
         // Given: A minimal pyproject.toml without a repository
         let content = r#"

--- a/testdata/python/golden/pyproject.toml-expected.json
+++ b/testdata/python/golden/pyproject.toml-expected.json
@@ -20,7 +20,7 @@
     ],
     "keywords": [],
     "homepage_url": "https://example.com",
-    "download_url": "https://github.com/example/test-package",
+    "download_url": "https://pypi.org/packages/source/t/test-package/test-package-0.1.0.tar.gz",
     "size": null,
     "sha1": null,
     "md5": null,


### PR DESCRIPTION
## Summary

- fix `pyproject.toml` identity precedence so incomplete `[project]` metadata can fall back per field to `[tool.poetry]` or legacy top-level metadata instead of suppressing a stronger available identity
- stop treating `repository`/`vcs_url` as a fallback `download_url`, and keep `download_url` aligned with explicit download links or the synthetic PyPI source tarball
- add targeted regressions for mixed `[project]` + `[tool.poetry]` identity fallback and update the existing pyproject golden expectation to reflect the corrected download URL semantics

## Scope and exclusions

- Included:
  - `src/parsers/python/pyproject.rs` field-level precedence for identity-bearing fields and URL fallback tightening
  - `src/parsers/python/test.rs` regression coverage for mixed-surface identity fallback and repository-vs-download behavior
  - `testdata/python/golden/pyproject.toml-expected.json` expected output update for corrected `download_url`
- Explicit exclusions:
  - no broader Python parser architecture changes
  - no changes to setup.py/setup.cfg/metadata precedence outside `pyproject.toml`

## Intentional differences from Python

- Provenant now keeps pyproject identity fields source-coherent across `[project]`, `[tool.poetry]`, and legacy top-level metadata, instead of letting a present-but-incomplete higher-priority table suppress a stronger lower-priority identity.

## Expected-output fixture changes

- Files changed: `testdata/python/golden/pyproject.toml-expected.json`
- Why the new expected output is correct:
  - the fixture has a repository URL but no explicit download URL
  - `download_url` should describe an artifact download, not the source repository homepage
  - the parser now correctly emits the synthetic PyPI source tarball URL while preserving the repository URL in `vcs_url`
