### PR TITLE
fix(parsers): tighten remaining precedence fallbacks

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -1386,6 +1386,70 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_npm_package_json_with_yarn_lock() {
+        let mut files = vec![
+            create_test_file_info(
+                "project/package.json",
+                DatasourceId::NpmPackageJson,
+                Some("pkg:npm/my-app@1.0.0"),
+                Some("my-app"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:npm/rimraf",
+                    Some("~2.5.4"),
+                    None,
+                )],
+            ),
+            create_test_file_info(
+                "project/yarn.lock",
+                DatasourceId::YarnLockV1,
+                None,
+                None,
+                None,
+                vec![create_test_dependency(
+                    "pkg:npm/rimraf@2.5.4",
+                    Some("2.5.4"),
+                    None,
+                )],
+            ),
+        ];
+
+        let result = assemble(&mut files);
+
+        assert_eq!(result.packages.len(), 1);
+        let package = &result.packages[0];
+        assert_eq!(package.name.as_deref(), Some("my-app"));
+        assert!(
+            package
+                .datasource_ids
+                .contains(&DatasourceId::NpmPackageJson)
+        );
+        assert!(package.datasource_ids.contains(&DatasourceId::YarnLockV1));
+        assert!(
+            package
+                .datafile_paths
+                .contains(&"project/package.json".to_string())
+        );
+        assert!(
+            package
+                .datafile_paths
+                .contains(&"project/yarn.lock".to_string())
+        );
+
+        assert_eq!(result.dependencies.len(), 2);
+        assert!(result.dependencies.iter().any(|dep| {
+            dep.purl.as_deref() == Some("pkg:npm/rimraf")
+                && dep.datasource_id == DatasourceId::NpmPackageJson
+                && dep.datafile_path == "project/package.json"
+        }));
+        assert!(result.dependencies.iter().any(|dep| {
+            dep.purl.as_deref() == Some("pkg:npm/rimraf@2.5.4")
+                && dep.datasource_id == DatasourceId::YarnLockV1
+                && dep.datafile_path == "project/yarn.lock"
+        }));
+    }
+
+    #[test]
     fn test_assemble_npm_package_json_skips_mismatched_lockfile() {
         let mut files = vec![
             create_test_file_info(

--- a/src/parsers/gradle_module.rs
+++ b/src/parsers/gradle_module.rs
@@ -134,7 +134,11 @@ fn parse_gradle_module(json: &Value) -> PackageData {
         .map(|value| truncate_field(value.to_string()));
 
     let (dependencies, file_references, top_level_artifact, variant_metadata) =
-        extract_variant_data(json.get(FIELD_VARIANTS).and_then(Value::as_array));
+        extract_variant_data(
+            json.get(FIELD_VARIANTS).and_then(Value::as_array),
+            name.as_deref(),
+            version.as_deref(),
+        );
 
     let purl = match (namespace.as_deref(), name.as_deref(), version.as_deref()) {
         (Some(namespace), Some(name), version) => build_maven_purl(namespace, name, version),
@@ -233,14 +237,18 @@ fn parse_gradle_module(json: &Value) -> PackageData {
     }
 }
 
-fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
+fn extract_variant_data(
+    variants: Option<&Vec<Value>>,
+    module_name: Option<&str>,
+    version: Option<&str>,
+) -> ExtractedVariantData {
     let mut dependencies = Vec::new();
     let mut file_references = Vec::new();
     let mut variant_metadata = Vec::new();
     let mut seen_dependencies: HashMap<(String, String, Option<String>), ExtractedDependency> =
         HashMap::new();
     let mut seen_files: HashSet<String> = HashSet::new();
-    let mut top_level_artifact: Option<JsonMap<String, Value>> = None;
+    let mut top_level_artifact: Option<(i32, JsonMap<String, Value>)> = None;
 
     for variant in variants
         .into_iter()
@@ -285,50 +293,49 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
         }
         variant_metadata.push(Value::Object(variant_entry));
 
-        if !is_documentation {
-            if top_level_artifact.is_none() {
-                top_level_artifact = variant
-                    .get(FIELD_FILES)
-                    .and_then(Value::as_array)
-                    .and_then(|files| files.first())
-                    .and_then(Value::as_object)
-                    .cloned();
-            }
-
-            if let Some(files) = variant.get(FIELD_FILES).and_then(Value::as_array) {
-                for file in files
-                    .iter()
-                    .filter_map(Value::as_object)
-                    .take(MAX_ITERATION_COUNT)
+        if !is_documentation && let Some(files) = variant.get(FIELD_FILES).and_then(Value::as_array)
+        {
+            for file in files
+                .iter()
+                .filter_map(Value::as_object)
+                .take(MAX_ITERATION_COUNT)
+            {
+                let artifact_score =
+                    score_top_level_artifact(file, module_name, version, scope.as_deref());
+                if top_level_artifact
+                    .as_ref()
+                    .is_none_or(|(best_score, _)| artifact_score > *best_score)
                 {
-                    let file_path = truncate_field(
-                        file.get("url")
-                            .and_then(Value::as_str)
-                            .or_else(|| file.get("name").and_then(Value::as_str))
-                            .unwrap_or_default()
-                            .to_string(),
-                    );
-                    if file_path.is_empty() || !seen_files.insert(file_path.clone()) {
-                        continue;
-                    }
-                    let (size, sha1, md5, sha256, sha512) = extract_file_hashes(file);
-                    let mut extra_data = HashMap::new();
-                    if let Some(name) = file.get("name").and_then(Value::as_str) {
-                        extra_data.insert(
-                            "name".to_string(),
-                            Value::String(truncate_field(name.to_string())),
-                        );
-                    }
-                    file_references.push(FileReference {
-                        path: file_path,
-                        size,
-                        sha1,
-                        md5,
-                        sha256,
-                        sha512,
-                        extra_data: (!extra_data.is_empty()).then_some(extra_data),
-                    });
+                    top_level_artifact = Some((artifact_score, file.clone()));
                 }
+
+                let file_path = truncate_field(
+                    file.get("url")
+                        .and_then(Value::as_str)
+                        .or_else(|| file.get("name").and_then(Value::as_str))
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+                if file_path.is_empty() || !seen_files.insert(file_path.clone()) {
+                    continue;
+                }
+                let (size, sha1, md5, sha256, sha512) = extract_file_hashes(file);
+                let mut extra_data = HashMap::new();
+                if let Some(name) = file.get("name").and_then(Value::as_str) {
+                    extra_data.insert(
+                        "name".to_string(),
+                        Value::String(truncate_field(name.to_string())),
+                    );
+                }
+                file_references.push(FileReference {
+                    path: file_path,
+                    size,
+                    sha1,
+                    md5,
+                    sha256,
+                    sha512,
+                    extra_data: (!extra_data.is_empty()).then_some(extra_data),
+                });
             }
         }
 
@@ -391,9 +398,64 @@ fn extract_variant_data(variants: Option<&Vec<Value>>) -> ExtractedVariantData {
     (
         dependencies,
         file_references,
-        top_level_artifact,
+        top_level_artifact.map(|(_, artifact)| artifact),
         variant_metadata,
     )
+}
+
+fn score_top_level_artifact(
+    file: &JsonMap<String, Value>,
+    module_name: Option<&str>,
+    version: Option<&str>,
+    scope: Option<&str>,
+) -> i32 {
+    let file_name = file
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| file.get("url").and_then(Value::as_str))
+        .unwrap_or_default()
+        .rsplit('/')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    let mut score = 0;
+
+    if matches!(scope, Some("runtime")) {
+        score += 10;
+    }
+
+    if file_name.ends_with(".jar")
+        || file_name.ends_with(".aar")
+        || file_name.ends_with(".war")
+        || file_name.ends_with(".zip")
+    {
+        score += 30;
+    }
+
+    if file_name.ends_with(".pom") || file_name.ends_with(".module") {
+        score -= 20;
+    }
+
+    if file_name.contains("-sources")
+        || file_name.contains("-source")
+        || file_name.contains("-javadoc")
+        || file_name.contains("-docs")
+        || file_name.contains("-doc")
+        || file_name.contains("-kdoc")
+    {
+        score -= 100;
+    }
+
+    if let (Some(module_name), Some(version)) = (module_name, version) {
+        let module_name = module_name.to_ascii_lowercase();
+        let version = version.to_ascii_lowercase();
+        if file_name.starts_with(&format!("{}-{}.", module_name, version)) {
+            score += 50;
+        }
+    }
+
+    score
 }
 
 fn build_dependency_extra_data(

--- a/src/parsers/gradle_module_test.rs
+++ b/src/parsers/gradle_module_test.rs
@@ -338,4 +338,51 @@ mod tests {
         assert!(package_data.name.is_none());
         assert!(package_data.dependencies.is_empty());
     }
+
+    #[test]
+    fn test_extract_prefers_primary_artifact_over_first_file_order() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("artifact-order.module");
+        let content = r#"{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.example",
+    "module": "artifact-order",
+    "version": "1.0.0"
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-api"
+      },
+      "files": [
+        {
+          "name": "artifact-order-1.0.0.pom",
+          "url": "artifact-order-1.0.0.pom",
+          "size": 10,
+          "sha1": "1111111111111111111111111111111111111111"
+        },
+        {
+          "name": "artifact-order-1.0.0.jar",
+          "url": "artifact-order-1.0.0.jar",
+          "size": 20,
+          "sha1": "2222222222222222222222222222222222222222"
+        }
+      ]
+    }
+  ]
+}"#;
+        fs::write(&file_path, content).unwrap();
+
+        let package_data = GradleModuleParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.size, Some(20));
+        assert_eq!(
+            package_data.sha1,
+            Some(Sha1Digest::from_hex("2222222222222222222222222222222222222222").unwrap())
+        );
+        assert_eq!(package_data.file_references.len(), 2);
+    }
 }

--- a/src/parsers/nuget/deps_json.rs
+++ b/src/parsers/nuget/deps_json.rs
@@ -294,7 +294,11 @@ fn select_root_library_key(
         return Some(matched.clone());
     }
 
-    project_keys.into_iter().next()
+    if project_keys.len() == 1 {
+        project_keys.into_iter().next()
+    } else {
+        None
+    }
 }
 
 fn split_library_key(key: &str) -> Option<(&str, &str)> {

--- a/src/parsers/nuget/nuget_test.rs
+++ b/src/parsers/nuget/nuget_test.rs
@@ -886,6 +886,51 @@ mod tests {
     }
 
     #[test]
+    fn test_dotnet_deps_json_with_multiple_project_roots_and_no_filename_match_stays_dependency_only()
+     {
+        let json = r#"{
+  "targets": {
+    ".NETCoreApp,Version=v8.0": {
+      "App.One/1.0.0": {
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "App.Two/2.0.0": {
+        "dependencies": {
+          "Serilog": "2.12.0"
+        }
+      },
+      "Newtonsoft.Json/13.0.1": {},
+      "Serilog/2.12.0": {}
+    }
+  },
+  "libraries": {
+    "App.One/1.0.0": { "type": "project" },
+    "App.Two/2.0.0": { "type": "project" },
+    "Newtonsoft.Json/13.0.1": { "type": "package" },
+    "Serilog/2.12.0": { "type": "package" }
+  }
+}"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("UnknownRoot.deps.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let package_data = DotNetDepsJsonParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.name.as_deref(), Some("UnknownRoot"));
+        assert_eq!(package_data.purl.as_deref(), Some("pkg:nuget/UnknownRoot"));
+        assert_eq!(package_data.dependencies.len(), 4);
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .all(|dep| dep.is_direct.is_none())
+        );
+    }
+
+    #[test]
     fn test_dotnet_deps_json_malformed_returns_default() {
         let json = r#"{"runtimeTarget": "broken""#;
 


### PR DESCRIPTION
## Summary

- avoid arbitrary root selection in `.deps.json` when multiple project roots exist and no filename match is available
- prefer the primary Gradle module artifact over incidental variant/file ordering when deriving package-level hashes and size
- add the missing assembly regression for `package.json` + `yarn.lock` sibling merge behavior

## Scope and exclusions

- Included:
  - `src/parsers/nuget/deps_json.rs` and `src/parsers/nuget/nuget_test.rs`
  - `src/parsers/gradle_module.rs` and `src/parsers/gradle_module_test.rs`
  - `src/assembly/assembly_test.rs`
- Explicit exclusions:
  - no additional changes to Ruby or Swift parsers because the remaining audits did not produce a confirmed precedence bug there
  - no broad Cargo or Dart parser changes; the remaining notable gaps there were lower priority than the fixes in this branch

## Intentional differences from Python

- When a `.deps.json` target graph contains multiple project roots and none matches the filename, Provenant now stays dependency-only instead of choosing an arbitrary project root.
- Gradle module package-level artifact metadata is now selected by a simple primary-artifact heuristic instead of first-file order.

## Follow-up work

- Created or intentionally deferred:
  - Cargo and Dart still have some lower-priority precedence coverage opportunities, but I did not find another confirmed parser bug worth folding into this branch.

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct:
  - the branch changes parser and assembly selection logic plus direct unit regressions only; existing parser goldens continue to pass unchanged
