### PR TITLE
docs(benchmarks): record boostorg graph snapshot

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 178 of 178 recorded runs, with a **11.7× median speedup** and **11.0× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
+> Provenant is faster on 179 of 179 recorded runs, with a **11.7× median speedup** and **11.0× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -517,6 +517,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `12.34s`; ScanCode `151.70s`
 - Direct `.gitmodules` package-adjacent visibility (`1` vs `0` file-level package records, plus one raw dependency edge) across the umbrella superproject, cleaner XML author extraction that drops prose-tainted suffixes such as `A.Meredith Compiler`, and Unicode-preserving name normalization for identities such as `René Ferdinand Rivera Morell`, `Ion Gaztañaga`, and `J. López`
+
+##### [boostorg/graph @ ae8e08d](https://github.com/boostorg/graph/tree/ae8e08d88f68669dc3fe5c7043dbc01b3c7c52ae) — **13.04× faster**
+
+- Files: 2,117
+- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `15.37s`; ScanCode `200.37s`
+- Cleaner URL and copyright normalization across Boost metadata files, preserving the real `http://www.boost.org/` target while dropping ScanCode's broken pseudo-URL variant in `example/boost_web.dat`, plus Unicode-preserving `René Ferdinand Rivera Morell` handling on `build.jam` and top-level `.gitattributes` visibility in the final output
 
 ##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **6.02× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -377,6 +377,9 @@ ScanCode: 463.11s</title></rect>
     <rect x="618.50" y="382.03" width="8" height="8" fill="#d97706" rx="1.5"><title>rubocop/rubocop @ 4e0d642
 Files: 2081
 ScanCode: 182.30s</title></rect>
+    <rect x="619.68" y="377.56" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/graph @ ae8e08d
+Files: 2117
+ScanCode: 200.37s</title></rect>
     <rect x="619.78" y="321.51" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 ScanCode: 656.13s</title></rect>
@@ -913,6 +916,9 @@ Provenant: 34.69s</title></circle>
     <circle cx="622.50" cy="481.54" r="4.5" fill="#2563eb"><title>rubocop/rubocop @ 4e0d642
 Files: 2081
 Provenant: 24.15s</title></circle>
+    <circle cx="623.68" cy="502.89" r="4.5" fill="#2563eb"><title>boostorg/graph @ ae8e08d
+Files: 2117
+Provenant: 15.37s</title></circle>
     <circle cx="623.78" cy="468.34" r="4.5" fill="#2563eb"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 Provenant: 31.93s</title></circle>


### PR DESCRIPTION
## Summary

- Record a new `boostorg/graph @ ae8e08d` benchmark row from compare run `20260429T173144Z-graph-50926` and regenerate the benchmark chart/output summary.
- Triage the shared-profile compare-outputs artifacts for Boost Graph and confirm the remaining deltas are documentation-worthy normalization differences rather than unresolved ScanCode-better regressions.
- Verify `include/boost/detail/algorithm.hpp` specifically: both scanners currently agree on `BSL-1.0 AND Advanced-Cryptics-Dictionary`; Boost guidance still makes `BSL-1.0` the canonical project-level license while the preserved HP/SGI notice blocks remain historical notice text.

## Scope and exclusions

- Included: `docs/BENCHMARKS.md`, `docs/benchmarks/scan-duration-vs-files.svg`, compare artifacts under `.provenant/compare-runs/20260429T173144Z-graph-50926/`
- Explicit exclusions: no scanner/parity code changes, no scorecard edits, no golden fixture rewrites

## Follow-up work

- Created or intentionally deferred: no follow-up code changes from this verification pass; HTML holder/author noise remains a separate generic cleanup area, but it was not a ScanCode-better blocker on this target

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this branch does not change scanner behavior; it records a triaged benchmark snapshot and regenerated benchmark chart only
