### PR TITLE
fix(gradle): resolve buildSrc dependency constants and verify fresco

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 179 of 179 recorded runs, with a **11.7× median speedup** and **11.0× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
+> Provenant is faster on 180 of 180 recorded runs, with a **11.7× median speedup** and **11.0× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **18.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -55,6 +55,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `25.23s`; ScanCode `240.24s`
 - Broader Android package visibility (`14` vs `0` file-level package records) across committed Soong `METADATA`, `AndroidManifest.xml`, and `TestApp.apk` surfaces, plus extra `go.work` and Docker metadata detection, with cleaner clue-only handling of bare-word GPL/LGPL, placeholder-author, and URL-shape noise
+
+##### [facebook/fresco @ c991a69](https://github.com/facebook/fresco/tree/c991a692a254358d1cf56c5b4b06e6c5dd96cfab) — **23.42× faster**
+
+- Files: 2,900
+- Run context: 2026-04-29 · fresco-98279 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `21.38s`; ScanCode `500.76s`
+- Richer Android and Gradle dependency extraction (`768` vs `688`) across committed `build.gradle`, nearby Kotlin `buildSrc` constant catalogs, and `AndroidManifest.xml` surfaces, with exact Maven coordinates for symbolic Gradle references such as `Deps.AndroidX.*`, `Deps.Bolts.*`, and `TestDeps.*` where ScanCode emits placeholder-only names like `AndroidX`, `Bolts`, or `junit`, plus direct Android package visibility and cleaner URL normalization
 
 ##### [KhronosGroup/Vulkan-ValidationLayers @ d72c5f5](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/d72c5f52886913598d4064fe8d03bf8ac471e215) — **17.97× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -410,6 +410,9 @@ ScanCode: 127.38s</title></rect>
     <rect x="641.06" y="351.33" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 ScanCode: 349.11s</title></rect>
+    <rect x="641.37" y="334.28" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
+Files: 2900
+ScanCode: 500.76s</title></rect>
     <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
 ScanCode: 223.79s</title></rect>
@@ -949,6 +952,9 @@ Provenant: 15.25s</title></circle>
     <circle cx="645.06" cy="499.42" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 Provenant: 16.54s</title></circle>
+    <circle cx="645.37" cy="487.30" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
+Files: 2900
+Provenant: 21.38s</title></circle>
     <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
 Provenant: 12.29s</title></circle>

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -24,7 +24,9 @@
 //! - Graceful error handling with `warn!()` logs
 //! - Direct dependency tracking (all in build file are direct)
 
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use crate::parser_warn as warn;
 use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
@@ -86,8 +88,7 @@ impl PackageParser for GradleParser {
         };
 
         let tokens = lex(&content);
-        let mut dependencies = extract_dependencies(&tokens);
-        resolve_gradle_version_catalog_aliases(path, &mut dependencies);
+        let dependencies = extract_dependencies_with_context(path, &tokens);
         let (
             extracted_license_statement,
             declared_license_expression,
@@ -366,21 +367,53 @@ struct RawDep {
     version: String,
     scope: String,
     catalog_alias: Option<String>,
+    symbolic_ref: Option<String>,
     project_path: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BuildSrcExpr {
+    Literal(String),
+    Ref(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuildSrcConst {
+    scope: String,
+    expr: BuildSrcExpr,
+}
+
+type BuildSrcConstMap = HashMap<String, BuildSrcConst>;
+type BuildSrcCache = HashMap<PathBuf, Option<BuildSrcConstMap>>;
+
+static BUILD_SRC_CONSTANT_CACHE: OnceLock<Mutex<BuildSrcCache>> = OnceLock::new();
+
+fn extract_dependencies_with_context(path: &Path, tokens: &[Tok]) -> Vec<Dependency> {
+    let mut raw_dependencies = extract_raw_dependencies(tokens);
+    resolve_gradle_buildsrc_symbolic_refs(path, &mut raw_dependencies);
+    let mut dependencies = raw_dependencies
+        .iter()
+        .filter_map(create_dependency)
+        .collect::<Vec<_>>();
+    resolve_gradle_version_catalog_aliases(path, &mut dependencies);
+    dependencies
+}
+
+#[cfg(test)]
 fn extract_dependencies(tokens: &[Tok]) -> Vec<Dependency> {
+    extract_raw_dependencies(tokens)
+        .iter()
+        .filter_map(create_dependency)
+        .collect()
+}
+
+fn extract_raw_dependencies(tokens: &[Tok]) -> Vec<RawDep> {
     let blocks = find_dependency_blocks(tokens);
     let mut dependencies = Vec::new();
 
     for block in blocks {
         for rd in parse_block(&block).into_iter().take(MAX_ITERATION_COUNT) {
-            if rd.name.is_empty() {
-                continue;
-            }
-            if let Some(dep) = create_dependency(&rd) {
-                dependencies.push(dep);
-            }
+            dependencies.push(rd);
         }
     }
 
@@ -559,8 +592,18 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
                 catalog_alias: val
                     .strip_prefix("libs.")
                     .map(|alias| truncate_field(alias.to_string())),
+                symbolic_ref: None,
                 project_path: None,
             });
+            i = next + 1;
+            continue;
+        }
+
+        if next < tokens.len()
+            && let Tok::Ident(ref val) = tokens[next]
+            && val.contains('.')
+        {
+            deps.push(parse_symbolic_ref(&scope_name, val));
             i = next + 1;
             continue;
         }
@@ -652,7 +695,21 @@ fn parse_paren_content(scope: &str, tokens: &[Tok], deps: &mut Vec<RawDep>) {
                 deps.push(parse_colon_string(val, inner_fn));
                 return;
             }
+
+            if let Some(Tok::Ident(val)) = inner.first()
+                && val.contains('.')
+            {
+                deps.push(parse_symbolic_ref(inner_fn, val));
+                return;
+            }
         }
+    }
+
+    if let Some(Tok::Ident(val)) = tokens.first()
+        && val.contains('.')
+    {
+        deps.push(parse_symbolic_ref(scope, val));
+        return;
     }
 
     // Simple string: ("g:n:v")
@@ -728,6 +785,7 @@ fn parse_map_entries(tokens: &[Tok]) -> Option<RawDep> {
         version,
         scope: String::new(),
         catalog_alias: None,
+        symbolic_ref: None,
         project_path: None,
     })
 }
@@ -770,6 +828,7 @@ fn parse_named_params(scope: &str, tokens: &[Tok]) -> Option<(RawDep, usize)> {
             version,
             scope: scope.to_string(),
             catalog_alias: None,
+            symbolic_ref: None,
             project_path: None,
         },
         i,
@@ -797,10 +856,23 @@ fn parse_project_ref(tokens: &[Tok], scope: &str) -> Option<RawDep> {
             version: String::new(),
             scope: truncate_field(scope.to_string()),
             catalog_alias: None,
+            symbolic_ref: None,
             project_path: Some(truncate_field(module_name.to_string())),
         });
     }
     None
+}
+
+fn parse_symbolic_ref(scope: &str, value: &str) -> RawDep {
+    RawDep {
+        namespace: String::new(),
+        name: String::new(),
+        version: String::new(),
+        scope: truncate_field(scope.to_string()),
+        catalog_alias: None,
+        symbolic_ref: Some(truncate_field(value.to_string())),
+        project_path: None,
+    }
 }
 
 fn parse_colon_string(val: &str, scope: &str) -> RawDep {
@@ -834,6 +906,7 @@ fn parse_colon_string(val: &str, scope: &str) -> RawDep {
         version,
         scope: truncate_field(scope.to_string()),
         catalog_alias: None,
+        symbolic_ref: None,
         project_path: None,
     }
 }
@@ -936,6 +1009,12 @@ fn create_dependency(raw: &RawDep) -> Option<Dependency> {
             json!(truncate_field(project_path.clone())),
         );
     }
+    if let Some(symbolic_ref) = &raw.symbolic_ref {
+        extra_data.insert(
+            "symbolic_ref".to_string(),
+            json!(truncate_field(symbolic_ref.clone())),
+        );
+    }
 
     Some(Dependency {
         purl: Some(purl_string),
@@ -965,6 +1044,333 @@ fn classify_scope(scope: &str) -> (bool, bool) {
     }
 
     (true, false)
+}
+
+fn resolve_gradle_buildsrc_symbolic_refs(path: &Path, raw_dependencies: &mut [RawDep]) {
+    let Some(build_src_dir) = find_build_src_dir(path) else {
+        return;
+    };
+    let Some(constants) = load_build_src_constants(&build_src_dir) else {
+        return;
+    };
+
+    for raw in raw_dependencies.iter_mut() {
+        let Some(symbolic_ref) = raw.symbolic_ref.as_deref() else {
+            continue;
+        };
+
+        let mut visiting = HashSet::new();
+        let Some(resolved) = resolve_build_src_value(symbolic_ref, &constants, &mut visiting)
+        else {
+            continue;
+        };
+        if !resolved.contains(':') {
+            continue;
+        }
+
+        let resolved_dependency = parse_colon_string(&resolved, &raw.scope);
+        raw.namespace = resolved_dependency.namespace;
+        raw.name = resolved_dependency.name;
+        raw.version = resolved_dependency.version;
+    }
+}
+
+fn find_build_src_dir(path: &Path) -> Option<PathBuf> {
+    for ancestor in path.ancestors() {
+        let build_src_dir = ancestor.join("buildSrc");
+        if build_src_dir.is_dir() {
+            return Some(build_src_dir);
+        }
+    }
+    None
+}
+
+fn load_build_src_constants(build_src_dir: &Path) -> Option<BuildSrcConstMap> {
+    let cache = BUILD_SRC_CONSTANT_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock()
+        && let Some(cached) = guard.get(build_src_dir)
+    {
+        return cached.clone();
+    }
+
+    let parsed = parse_build_src_constants_dir(build_src_dir);
+
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(build_src_dir.to_path_buf(), parsed.clone());
+    }
+
+    parsed
+}
+
+fn parse_build_src_constants_dir(build_src_dir: &Path) -> Option<BuildSrcConstMap> {
+    let mut kotlin_files = Vec::new();
+    for source_dir in [
+        build_src_dir.join("src").join("main").join("java"),
+        build_src_dir.join("src").join("main").join("kotlin"),
+    ] {
+        collect_build_src_kotlin_files(&source_dir, &mut kotlin_files);
+    }
+
+    if kotlin_files.is_empty() {
+        return None;
+    }
+
+    let mut constants = HashMap::new();
+    for file in kotlin_files.into_iter().take(MAX_ITERATION_COUNT) {
+        let Ok(content) = read_file_to_string(&file, None) else {
+            continue;
+        };
+        constants.extend(parse_build_src_constants(&content));
+    }
+
+    (!constants.is_empty()).then_some(constants)
+}
+
+fn collect_build_src_kotlin_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    if files.len() >= MAX_ITERATION_COUNT || !dir.is_dir() {
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten().take(MAX_ITERATION_COUNT) {
+        if files.len() >= MAX_ITERATION_COUNT {
+            break;
+        }
+
+        let path = entry.path();
+        if path.is_dir() {
+            collect_build_src_kotlin_files(&path, files);
+            continue;
+        }
+
+        if path.extension().is_some_and(|ext| ext == "kt") {
+            files.push(path);
+        }
+    }
+}
+
+fn parse_build_src_constants(content: &str) -> BuildSrcConstMap {
+    let tokens = lex(content);
+    let mut constants = HashMap::new();
+    let mut object_stack = Vec::new();
+    let mut brace_stack: Vec<Option<String>> = Vec::new();
+    let mut i = 0;
+
+    while i < tokens.len() && i < MAX_ITERATION_COUNT {
+        if let Some((name, consumed)) = parse_object_declaration(&tokens[i..]) {
+            object_stack.push(name.clone());
+            brace_stack.push(Some(name));
+            i += consumed;
+            continue;
+        }
+
+        if let Some((name, expr, consumed)) = parse_build_src_const_definition(&tokens[i..]) {
+            let scope = object_stack.join(".");
+            let full_name = if scope.is_empty() {
+                name.clone()
+            } else {
+                format!("{scope}.{name}")
+            };
+            constants.insert(
+                truncate_field(full_name),
+                BuildSrcConst {
+                    scope: truncate_field(scope),
+                    expr,
+                },
+            );
+            i += consumed;
+            continue;
+        }
+
+        match &tokens[i] {
+            Tok::OpenBrace => brace_stack.push(None),
+            Tok::CloseBrace => {
+                if let Some(marker) = brace_stack.pop()
+                    && marker.is_some()
+                {
+                    object_stack.pop();
+                }
+            }
+            _ => {}
+        }
+
+        i += 1;
+    }
+
+    constants
+}
+
+fn parse_object_declaration(tokens: &[Tok]) -> Option<(String, usize)> {
+    if let [Tok::Ident(keyword), Tok::Ident(name), Tok::OpenBrace, ..] = tokens
+        && keyword == "object"
+    {
+        return Some((truncate_field(name.clone()), 3));
+    }
+    None
+}
+
+fn parse_build_src_const_definition(tokens: &[Tok]) -> Option<(String, BuildSrcExpr, usize)> {
+    let mut cursor = 0;
+
+    while let Some(Tok::Ident(modifier)) = tokens.get(cursor) {
+        if matches!(
+            modifier.as_str(),
+            "private" | "internal" | "public" | "protected"
+        ) {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+
+    if !matches!(tokens.get(cursor), Some(Tok::Ident(keyword)) if keyword == "const")
+        || !matches!(tokens.get(cursor + 1), Some(Tok::Ident(keyword)) if keyword == "val")
+    {
+        return None;
+    }
+
+    let Tok::Ident(name) = tokens.get(cursor + 2)? else {
+        return None;
+    };
+    if tokens.get(cursor + 3) != Some(&Tok::Equals) {
+        return None;
+    }
+
+    let expr = match tokens.get(cursor + 4)? {
+        Tok::Str(value) => BuildSrcExpr::Literal(truncate_field(value.clone())),
+        Tok::Ident(value) => BuildSrcExpr::Ref(truncate_field(value.clone())),
+        _ => return None,
+    };
+
+    Some((truncate_field(name.clone()), expr, cursor + 5))
+}
+
+fn resolve_build_src_value(
+    key: &str,
+    constants: &BuildSrcConstMap,
+    visiting: &mut HashSet<String>,
+) -> Option<String> {
+    if !visiting.insert(key.to_string()) {
+        return None;
+    }
+
+    let resolved = constants
+        .get(key)
+        .and_then(|constant| resolve_build_src_expr(constant, constants, visiting));
+    visiting.remove(key);
+    resolved
+}
+
+fn resolve_build_src_expr(
+    constant: &BuildSrcConst,
+    constants: &BuildSrcConstMap,
+    visiting: &mut HashSet<String>,
+) -> Option<String> {
+    match &constant.expr {
+        BuildSrcExpr::Literal(value) => Some(interpolate_build_src_string(
+            value,
+            &constant.scope,
+            constants,
+            visiting,
+        )),
+        BuildSrcExpr::Ref(reference) => {
+            resolve_build_src_symbol(&constant.scope, reference, constants, visiting)
+        }
+    }
+}
+
+fn resolve_build_src_symbol(
+    scope: &str,
+    reference: &str,
+    constants: &BuildSrcConstMap,
+    visiting: &mut HashSet<String>,
+) -> Option<String> {
+    if reference.contains('.') {
+        return resolve_build_src_value(reference, constants, visiting);
+    }
+
+    let mut current_scope = Some(scope);
+    while let Some(scope_name) = current_scope {
+        if !scope_name.is_empty() {
+            let candidate = format!("{scope_name}.{reference}");
+            if let Some(value) = resolve_build_src_value(&candidate, constants, visiting) {
+                return Some(value);
+            }
+        }
+
+        current_scope = scope_name.rsplit_once('.').map(|(parent, _)| parent);
+    }
+
+    resolve_build_src_value(reference, constants, visiting)
+}
+
+fn interpolate_build_src_string(
+    value: &str,
+    scope: &str,
+    constants: &BuildSrcConstMap,
+    visiting: &mut HashSet<String>,
+) -> String {
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut rendered = String::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] != '$' {
+            rendered.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if i + 1 >= chars.len() {
+            rendered.push(chars[i]);
+            break;
+        }
+
+        if chars[i + 1] == '{' {
+            let start = i;
+            i += 2;
+            let mut reference = String::new();
+            while i < chars.len() && chars[i] != '}' {
+                reference.push(chars[i]);
+                i += 1;
+            }
+            if i < chars.len() && chars[i] == '}' {
+                i += 1;
+            }
+
+            if let Some(resolved) = resolve_build_src_symbol(scope, &reference, constants, visiting)
+            {
+                rendered.push_str(&resolved);
+            } else {
+                rendered.push_str(&value[start..i]);
+            }
+            continue;
+        }
+
+        let start = i;
+        i += 1;
+        let mut reference = String::new();
+        while i < chars.len() && matches!(chars[i], 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '.') {
+            reference.push(chars[i]);
+            i += 1;
+        }
+
+        if reference.is_empty() {
+            rendered.push('$');
+            continue;
+        }
+
+        if let Some(resolved) = resolve_build_src_symbol(scope, &reference, constants, visiting) {
+            rendered.push_str(&resolved);
+        } else {
+            rendered.push_str(&value[start..i]);
+        }
+    }
+
+    truncate_field(rendered)
 }
 
 #[derive(Debug, Clone)]
@@ -1668,6 +2074,101 @@ dependencies {
                 .and_then(|value| value.as_str()),
             Some("mockito-config")
         );
+    }
+
+    #[test]
+    fn test_buildsrc_kotlin_constants_resolve_from_committed_files() {
+        let temp_dir = tempdir().unwrap();
+        let build_src_dir = temp_dir
+            .path()
+            .join("buildSrc/src/main/java/com/example/buildsrc");
+        std::fs::create_dir_all(&build_src_dir).unwrap();
+        std::fs::write(
+            build_src_dir.join("GradleDeps.kt"),
+            r#"
+object GradleDeps {
+    object Kotlin {
+        const val version = "2.0.0"
+        const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
+    }
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            build_src_dir.join("Deps.kt"),
+            r#"
+object Deps {
+    object AndroidX {
+        const val core = "androidx.core:core:1.15.0"
+    }
+
+    object SoLoader {
+        private const val version = "0.11.0"
+        const val soloader = "com.facebook.soloader:soloader:$version"
+    }
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            build_src_dir.join("TestDeps.kt"),
+            r#"
+object TestDeps {
+    const val junit = "junit:junit:4.13.2"
+}
+"#,
+        )
+        .unwrap();
+
+        let build_gradle = temp_dir.path().join("build.gradle");
+        std::fs::write(
+            &build_gradle,
+            r#"
+buildscript {
+    dependencies {
+        classpath GradleDeps.Kotlin.gradlePlugin
+    }
+}
+
+dependencies {
+    implementation Deps.AndroidX.core
+    implementation Deps.SoLoader.soloader
+    implementation project(':fbcore')
+    testImplementation(TestDeps.junit) {
+        because 'exercise parenthesized symbolic refs'
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let package_data = GradleParser::extract_first_package(&build_gradle);
+
+        assert_eq!(package_data.dependencies.len(), 5);
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref()
+                == Some("pkg:maven/org.jetbrains.kotlin/kotlin-gradle-plugin@2.0.0")
+                && dependency.scope.as_deref() == Some("classpath")
+        }));
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/androidx.core/core@1.15.0")
+                && dependency.scope.as_deref() == Some("implementation")
+        }));
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/com.facebook.soloader/soloader@0.11.0")
+                && dependency.scope.as_deref() == Some("implementation")
+        }));
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/fbcore")
+                && dependency.scope.as_deref() == Some("implementation")
+        }));
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/junit/junit@4.13.2")
+                && dependency.scope.as_deref() == Some("testImplementation")
+                && dependency.is_runtime == Some(false)
+                && dependency.is_optional == Some(true)
+        }));
     }
 
     #[test]

--- a/src/parsers/gradle_golden_test.rs
+++ b/src/parsers/gradle_golden_test.rs
@@ -126,6 +126,14 @@ mod golden_tests {
     }
 
     #[test]
+    fn test_golden_groovy_buildsrc_constants() {
+        run_golden(
+            "testdata/gradle-golden/groovy/buildsrc-constants/build.gradle",
+            "testdata/gradle-golden/groovy/buildsrc-constants/build.gradle-expected.json",
+        );
+    }
+
+    #[test]
     fn test_golden_groovy_no_parens() {
         run_golden(
             "testdata/gradle-golden/groovy/groovy-no-parens/build.gradle",

--- a/src/parsers/gradle_scan_test.rs
+++ b/src/parsers/gradle_scan_test.rs
@@ -67,4 +67,65 @@ mod tests {
                 .any(|pkg_data| pkg_data.datasource_id == Some(DatasourceId::GradleLockfile))
         );
     }
+
+    #[test]
+    fn test_gradle_scan_resolves_buildsrc_kotlin_constants() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let build_src_dir = temp_dir
+            .path()
+            .join("buildSrc/src/main/java/com/example/buildsrc");
+        fs::create_dir_all(&build_src_dir).expect("create buildSrc source dir");
+        fs::write(
+            build_src_dir.join("GradleDeps.kt"),
+            r#"
+object GradleDeps {
+    object Android {
+        private const val version = "8.5.2"
+        const val gradlePlugin = "com.android.tools.build:gradle:$version"
+    }
+}
+"#,
+        )
+        .expect("write GradleDeps.kt");
+        fs::write(
+            build_src_dir.join("Deps.kt"),
+            r#"
+object Deps {
+    object AndroidX {
+        const val core = "androidx.core:core:1.15.0"
+    }
+}
+"#,
+        )
+        .expect("write Deps.kt");
+        fs::write(
+            temp_dir.path().join("build.gradle"),
+            r#"
+buildscript {
+    dependencies {
+        classpath GradleDeps.Android.gradlePlugin
+    }
+}
+
+dependencies {
+    implementation Deps.AndroidX.core
+}
+"#,
+        )
+        .expect("write build.gradle");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        assert!(result.packages.is_empty());
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:maven/com.android.tools.build/gradle@8.5.2",
+            "build.gradle",
+        );
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:maven/androidx.core/core@1.15.0",
+            "build.gradle",
+        );
+    }
 }

--- a/testdata/gradle-golden/README.md
+++ b/testdata/gradle-golden/README.md
@@ -93,7 +93,7 @@ The Python ScanCode Toolkit implementation uses **pygmars** (a token-based parse
    implementation libs.androidx.appcompat
    ```
 
-   - **Why partial**: TOML-backed `libs.versions.toml` aliases can now be resolved from nearby catalogs, but arbitrary dotted identifiers (for example `dependencies.lombok` or `Deps.AndroidX.core`) are intentionally ignored unless they are real `libs.*` catalog aliases
+   - **Why partial**: TOML-backed `libs.versions.toml` aliases can now be resolved from nearby catalogs, and committed Kotlin `buildSrc` object constants such as `Deps.AndroidX.core` can be resolved statically when the supporting files are present nearby. Unresolved arbitrary dotted identifiers (for example `dependencies.lombok`) still remain intentionally unsupported.
 
 ## Test Files Status
 
@@ -101,7 +101,7 @@ The Python ScanCode Toolkit implementation uses **pygmars** (a token-based parse
 
 - No parser-only Gradle goldens remain ignored.
 - The cleanup now exercises `groovy4`, `groovy-no-parens`, `kotlin2`, and `end2end` directly instead of masking them behind `#[ignore]`.
-- Additional parser goldens now cover TOML-backed version catalog alias resolution and Gradle POM license metadata extraction.
+- Additional parser goldens now cover TOML-backed version catalog alias resolution, committed `buildSrc` Kotlin constant resolution, and Gradle POM license metadata extraction.
 - Remaining failures, if any, should now represent real parser regressions rather than deferred fixtures.
 
 ## Path Forward: Full Feature Parity

--- a/testdata/gradle-golden/groovy/buildsrc-constants/build.gradle
+++ b/testdata/gradle-golden/groovy/buildsrc-constants/build.gradle
@@ -1,0 +1,14 @@
+buildscript {
+    dependencies {
+        classpath GradleDeps.Kotlin.gradlePlugin
+    }
+}
+
+dependencies {
+    implementation Deps.AndroidX.core
+    implementation Deps.SoLoader.soloader
+    implementation project(':fbcore')
+    testImplementation(TestDeps.junit) {
+        because 'exercise parenthesized symbolic refs'
+    }
+}

--- a/testdata/gradle-golden/groovy/buildsrc-constants/build.gradle-expected.json
+++ b/testdata/gradle-golden/groovy/buildsrc-constants/build.gradle-expected.json
@@ -1,0 +1,112 @@
+[
+  {
+    "type": "maven",
+    "namespace": null,
+    "name": null,
+    "version": null,
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": null,
+    "description": null,
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {},
+    "dependencies": [
+      {
+        "purl": "pkg:maven/org.jetbrains.kotlin/kotlin-gradle-plugin@2.0.0",
+        "extracted_requirement": "2.0.0",
+        "scope": "classpath",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {
+          "symbolic_ref": "GradleDeps.Kotlin.gradlePlugin"
+        }
+      },
+      {
+        "purl": "pkg:maven/androidx.core/core@1.15.0",
+        "extracted_requirement": "1.15.0",
+        "scope": "implementation",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {
+          "symbolic_ref": "Deps.AndroidX.core"
+        }
+      },
+      {
+        "purl": "pkg:maven/com.facebook.soloader/soloader@0.11.0",
+        "extracted_requirement": "0.11.0",
+        "scope": "implementation",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {
+          "symbolic_ref": "Deps.SoLoader.soloader"
+        }
+      },
+      {
+        "purl": "pkg:maven/fbcore",
+        "extracted_requirement": "",
+        "scope": "implementation",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {
+          "project_path": "fbcore"
+        }
+      },
+      {
+        "purl": "pkg:maven/junit/junit@4.13.2",
+        "extracted_requirement": "4.13.2",
+        "scope": "testImplementation",
+        "is_runtime": false,
+        "is_optional": true,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {
+          "symbolic_ref": "TestDeps.junit"
+        }
+      }
+    ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "build_gradle",
+    "purl": null
+  }
+]

--- a/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/Deps.kt
+++ b/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/Deps.kt
@@ -1,0 +1,10 @@
+object Deps {
+    object AndroidX {
+        const val core = "androidx.core:core:1.15.0"
+    }
+
+    object SoLoader {
+        private const val version = "0.11.0"
+        const val soloader = "com.facebook.soloader:soloader:$version"
+    }
+}

--- a/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/GradleDeps.kt
+++ b/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/GradleDeps.kt
@@ -1,0 +1,6 @@
+object GradleDeps {
+    object Kotlin {
+        const val version = "2.0.0"
+        const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
+    }
+}

--- a/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/TestDeps.kt
+++ b/testdata/gradle-golden/groovy/buildsrc-constants/buildSrc/src/main/java/com/example/buildsrc/TestDeps.kt
@@ -1,0 +1,3 @@
+object TestDeps {
+    const val junit = "junit:junit:4.13.2"
+}


### PR DESCRIPTION
## Summary

- resolve committed Kotlin `buildSrc` constants when Gradle manifests use symbolic refs such as `Deps.AndroidX.*`, `Deps.Bolts.*`, `GradleDeps.*`, and `TestDeps.*`, then keep the resulting dependency attached to the referencing `build.gradle` instead of duplicating it onto the supporting `.kt` files
- verify `facebook/fresco @ c991a692a254358d1cf56c5b4b06e6c5dd96cfab` with `compare-outputs --profile common`, record the final checkpoint in `docs/BENCHMARKS.md`, and regenerate `docs/benchmarks/scan-duration-vs-files.svg`
- add parser, scan, and golden coverage for the new Gradle behavior, including a focused `buildsrc-constants` fixture tree that exercises nested Kotlin `object` constants plus simple `$version` interpolation

## Scope and exclusions

- Included:
  - static lookup of nearby committed `buildSrc` Kotlin constants under `buildSrc/src/main/java` and `buildSrc/src/main/kotlin`
  - bounded resolution of nested `object` / `const val` references and simple `$name` / `${name}` interpolation when they collapse to literal `group:name:version` coordinates
  - Fresco benchmark verification and benchmark-doc refresh
  - focused parser, scan, and golden regression coverage
- Explicit exclusions:
  - no Gradle execution, no Kotlin compilation, and no `buildSrc` code evaluation
  - no attempt to resolve helper methods, arbitrary expressions, remote catalogs, or other non-constant Gradle indirection
  - unresolved symbolic refs without a nearby static match still stay omitted rather than guessed

## Intentional differences from Python

- Provenant now upgrades static `buildSrc` constant references to exact Maven coordinates when the supporting Kotlin files are committed nearby. In the Fresco case, `imagepipeline-base/build.gradle` can therefore surface concrete dependencies like `androidx.exifinterface:exifinterface:1.3.7` and `com.parse.bolts:bolts-tasks:1.4.0` instead of leaving the reference unresolved.
- When no matching `buildSrc` constant exists, Provenant intentionally prefers an honest unknown over placeholder package identities. We do **not** emit a dependency entry for unresolved refs such as `Deps.AndroidX.androidxAnnotation`; we also do **not** fall back to ScanCode-style placeholders like `pkg:maven/AndroidX`.
- The dependency remains attributed to the manifest that declared it. In the verified Fresco run, the resolved dependency entries have `datafile_path: "imagepipeline-base/build.gradle"` plus `extra_data.symbolic_ref`, while the supporting `buildSrc/*.kt` files remain ordinary scanned source files with `package_data: []`.

## Follow-up work

- Created or intentionally deferred:
  - deferred: broader support for non-constant Gradle indirection (helper functions, arbitrary expressions, external runtime state)
  - deferred: unrelated common-profile text-detection noise in Fresco docs/static assets, since the benchmark triage here was focused on resolving the real Gradle package/dependency gap before recording the checkpoint
  - recorded compare artifacts:
    - initial triage run: `.provenant/compare-runs/20260429T191522Z-fresco-70123/`
    - final verified run: `.provenant/compare-runs/20260429T193659Z-fresco-98279/`
  - local validation used while iterating:
    - `cargo test buildsrc_kotlin_constants`
    - `cargo test parsers::gradle::tests::`
    - `cargo test gradle_scan_test::tests::`
    - `cargo test --features golden-tests test_golden_groovy_buildsrc_constants`

## Expected-output fixture changes

- Files changed:
  - `testdata/gradle-golden/groovy/buildsrc-constants/build.gradle-expected.json`
  - plus the matching `buildsrc-constants` fixture inputs and the golden registration in `src/parsers/gradle_golden_test.rs`
- Why the new expected output is correct:
  - the expected dependency coordinates come from committed `buildSrc` Kotlin constants that live at the repo root in the fixture tree, so the parser can resolve them statically without executing Gradle
  - the expected output intentionally shows the dependency on the referencing `build.gradle` with `symbolic_ref` metadata, while the supporting `.kt` files themselves continue to produce no package data
  - this matches the verified Fresco behavior and keeps the scanner honest when no static `buildSrc` match exists