### PR TITLE
fix(nuget): tighten bounded CPM props resolution

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 181 of 181 recorded runs, with a **11.7× median speedup** and **11.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 182 of 182 recorded runs, with a **11.8× median speedup** and **11.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -913,6 +913,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `38.15s`; ScanCode `379.55s`
 - Broader .NET/NuGet package and dependency extraction (`105` vs `3` packages, `145` vs `33` dependencies) from many `*.csproj` files plus `Directory.Packages.props` and `Directory.Build.props` across samples, tooling, and test projects, with zero scan errors where ScanCode trips on `TwitterColorEmoji-SVGinOT.ttf`
+
+##### [dotnet/extensions @ 7171956](https://github.com/dotnet/extensions/tree/7171956b4fbafdd5e44ca8ca1ceed72c0d6bbb66) — **15.95× faster**
+
+- Files: 3,643
+- Run context: 2026-04-30 · extensions-60029 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `32.94s`; ScanCode `525.35s`
+- Broader .NET/NuGet package and dependency extraction (`162` vs `2` packages, `1161` vs `690` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and imported `eng/packages/*.props` central-version surfaces, with Unicode-preserving holder normalization and safer URL normalization across notices and docs
 
 ##### [dotnet/runtime @ d1163e5](https://github.com/dotnet/runtime/tree/d1163e5a8f3f3aaa374993e8b5805911689aba28) — **31.49× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 182 of 182 recorded runs, with a **11.8× median speedup** and **11.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 183 of 183 recorded runs, with a **11.9× median speedup** and **11.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -914,12 +914,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `38.15s`; ScanCode `379.55s`
 - Broader .NET/NuGet package and dependency extraction (`105` vs `3` packages, `145` vs `33` dependencies) from many `*.csproj` files plus `Directory.Packages.props` and `Directory.Build.props` across samples, tooling, and test projects, with zero scan errors where ScanCode trips on `TwitterColorEmoji-SVGinOT.ttf`
 
-##### [dotnet/extensions @ 7171956](https://github.com/dotnet/extensions/tree/7171956b4fbafdd5e44ca8ca1ceed72c0d6bbb66) — **15.95× faster**
+##### [dotnet/extensions @ 7171956](https://github.com/dotnet/extensions/tree/7171956b4fbafdd5e44ca8ca1ceed72c0d6bbb66) — **19.08× faster**
 
 - Files: 3,643
-- Run context: 2026-04-30 · extensions-60029 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `32.94s`; ScanCode `525.35s`
-- Broader .NET/NuGet package and dependency extraction (`162` vs `2` packages, `1161` vs `690` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and imported `eng/packages/*.props` central-version surfaces, with Unicode-preserving holder normalization and safer URL normalization across notices and docs
+- Run context: 2026-04-30 · extensions-9749 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `27.54s`; ScanCode `525.35s`
+- Broader .NET/NuGet package and dependency extraction (`162` vs `2` packages, `1161` vs `690` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and imported `eng/packages/*.props` / `Tests.props` / `Tools.props` central-version surfaces, with root and nested central package manifests carrying resolved package-version dependency metadata instead of empty imported-props placeholders
 
 ##### [dotnet/runtime @ d1163e5](https://github.com/dotnet/runtime/tree/d1163e5a8f3f3aaa374993e8b5805911689aba28) — **31.49× faster**
 
@@ -934,6 +934,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `54.99s`; ScanCode `1313.69s`
 - Broader mixed-repository package and dependency extraction (`45` vs `1` packages, `3607` vs `80` dependencies) from `cmake/vcpkg.json` plus committed `cmake/vcpkg-ports/*/vcpkg.json` manifests, with the large `package-lock.json` license-count gap reduced with any residual license delta concentrated in ONNX model fixtures that still stay scan-error-free and explicit vcpkg package identities where ScanCode stays manifest-blind
+
+##### [microsoft/regorus @ 7f42115](https://github.com/microsoft/regorus/tree/7f42115b6338999efd13916e89b81ac278bc6273) — **13.37× faster**
+
+- Files: 1,121
+- Run context: 2026-04-30 · regorus-348 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `16.29s`; ScanCode `217.76s`
+- Broader mixed Rust/.NET/Ruby package and dependency extraction (`19` vs `14` packages, `1253` vs `1238` dependencies) across committed `bindings/csharp/Directory.Packages.props`, consumer `*.csproj`, and Ruby sidecar manifests, with resolved `Microsoft.Regorus` central package version `0.9.1` propagated from same-file property composition instead of leaving the CPM expression unresolved
 
 ##### [microsoft/terminal @ 84ae7ad](https://github.com/microsoft/terminal/tree/84ae7adec6b3975314d8ca73d8f0bf2128ae59e2) — **14.55× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -437,6 +437,9 @@ ScanCode: 194.82s</title></rect>
     <rect x="656.74" y="353.11" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/terminal @ 84ae7ad
 Files: 3625
 ScanCode: 336.14s</title></rect>
+    <rect x="657.08" y="332.02" width="8" height="8" fill="#d97706" rx="1.5"><title>dotnet/extensions @ 7171956
+Files: 3643
+ScanCode: 525.35s</title></rect>
     <rect x="657.46" y="339.67" width="8" height="8" fill="#d97706" rx="1.5"><title>renovatebot/renovate @ 91a7213
 Files: 3663
 ScanCode: 446.79s</title></rect>
@@ -982,6 +985,9 @@ Provenant: 23.75s</title></circle>
     <circle cx="660.74" cy="483.64" r="4.5" fill="#2563eb"><title>microsoft/terminal @ 84ae7ad
 Files: 3625
 Provenant: 23.10s</title></circle>
+    <circle cx="661.08" cy="466.87" r="4.5" fill="#2563eb"><title>dotnet/extensions @ 7171956
+Files: 3643
+Provenant: 32.94s</title></circle>
     <circle cx="661.46" cy="482.35" r="4.5" fill="#2563eb"><title>renovatebot/renovate @ 91a7213
 Files: 3663
 Provenant: 23.74s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -329,6 +329,9 @@ ScanCode: 127.50s</title></rect>
     <rect x="575.19" y="386.04" width="8" height="8" fill="#d97706" rx="1.5"><title>commercialhaskell/stack @ cb6070f
 Files: 1110
 ScanCode: 167.47s</title></rect>
+    <rect x="575.87" y="373.63" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/regorus @ 7f42115
+Files: 1121
+ScanCode: 217.76s</title></rect>
     <rect x="577.87" y="383.06" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 ScanCode: 178.35s</title></rect>
@@ -877,6 +880,9 @@ Provenant: 10.40s</title></circle>
     <circle cx="579.19" cy="502.52" r="4.5" fill="#2563eb"><title>commercialhaskell/stack @ cb6070f
 Files: 1110
 Provenant: 15.49s</title></circle>
+    <circle cx="579.87" cy="500.14" r="4.5" fill="#2563eb"><title>microsoft/regorus @ 7f42115
+Files: 1121
+Provenant: 16.29s</title></circle>
     <circle cx="581.87" cy="505.77" r="4.5" fill="#2563eb"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 Provenant: 14.46s</title></circle>
@@ -985,9 +991,9 @@ Provenant: 23.75s</title></circle>
     <circle cx="660.74" cy="483.64" r="4.5" fill="#2563eb"><title>microsoft/terminal @ 84ae7ad
 Files: 3625
 Provenant: 23.10s</title></circle>
-    <circle cx="661.08" cy="466.87" r="4.5" fill="#2563eb"><title>dotnet/extensions @ 7171956
+    <circle cx="661.08" cy="475.33" r="4.5" fill="#2563eb"><title>dotnet/extensions @ 7171956
 Files: 3643
-Provenant: 32.94s</title></circle>
+Provenant: 27.54s</title></circle>
     <circle cx="661.46" cy="482.35" r="4.5" fill="#2563eb"><title>renovatebot/renovate @ 91a7213
 Files: 3663
 Provenant: 23.74s</title></circle>

--- a/docs/improvements/nuget-parser.md
+++ b/docs/improvements/nuget-parser.md
@@ -8,7 +8,7 @@ Rust now goes beyond the released Python ScanCode NuGet support in six concrete 
 2. parses `.deps.json` runtime dependency graphs from built .NET outputs
 3. preserves modern nuspec license hints (`license_type`, `license_file`) instead of collapsing everything to deprecated `licenseUrl` fallbacks
 4. reads archive-backed license file contents from `.nupkg` files when the nuspec points at a packaged license file
-5. parses NuGet Central Package Management files (`Directory.Packages.props`) and statically backfills nearest-ancestor central versions into versionless project dependencies, including bounded literal `VersionOverride` support when explicitly enabled
+5. parses NuGet Central Package Management files (`Directory.Packages.props`) and statically backfills nearest-ancestor central versions into versionless project dependencies, including composed property-backed `PackageVersion` expressions, bounded repository-local `.props` imports, and bounded literal `VersionOverride` support when explicitly enabled
 6. adds bounded `Directory.Build.props` participation so CPM-relevant properties can flow into central versions and project overrides without full MSBuild evaluation
 
 ## Python Status
@@ -24,9 +24,9 @@ Rust now goes beyond the released Python ScanCode NuGet support in six concrete 
 - `project.json` now extracts package metadata plus direct and framework-specific dependencies.
 - `project.lock.json` now extracts dependency groups from `projectFileDependencyGroups`.
 - PackageReference `.csproj`, `.vbproj`, and `.fsproj` files now extract package metadata and `<PackageReference>` dependencies.
-- `Directory.Packages.props` now extracts central `PackageVersion` declarations as dependency metadata, including `Condition` and central-package-management feature flags.
+- `Directory.Packages.props` now extracts central `PackageVersion` declarations as dependency metadata, including `Condition`, central-package-management feature flags, and composed property-backed version expressions such as `$(VersionPrefix)-$(VersionSuffix)` when the bounded property chain is statically known.
 - `Directory.Build.props` now extracts bounded literal property maps and bounded parent-import metadata relevant to CPM.
-- Assembly now backfills versionless PackageReference dependencies from the nearest ancestor `Directory.Packages.props`, can merge bounded explicit parent `Directory.Packages.props` imports, can consume bounded `Directory.Build.props` property maps, and can prefer literal project-file `VersionOverride` values when CPM overrides are statically enabled.
+- Assembly now backfills versionless PackageReference dependencies from the nearest ancestor `Directory.Packages.props`, can merge bounded explicit parent `Directory.Packages.props` imports, can consume bounded `Directory.Build.props` property maps, can ingest bounded repository-local `.props` imports addressed directly or through `$(MSBuildThisFileDirectory)`-anchored paths, and can prefer literal project-file `VersionOverride` values when CPM overrides are statically enabled.
 - `.deps.json` now extracts runtime-target-aware resolved dependency graphs from built .NET outputs.
 
 ### Static CPM backfill with bounded parent imports and build-props participation
@@ -41,8 +41,9 @@ This CPM slice intentionally:
 - backfills versionless `PackageReference` entries from the nearest ancestor `Directory.Packages.props` when central package management is enabled and there is exactly one matching central entry
 - preserves literal `VersionOverride` metadata on `PackageReference` entries in project files
 - supports the documented explicit parent-import pattern for `Directory.Packages.props`, including bounded static handling of `GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..)`
+- supports bounded repository-local `.props` imports reachable from `Directory.Packages.props` / `Directory.Build.props`, including `$(MSBuildThisFileDirectory)`-anchored paths, when the resolved file stays under the same scan root
 - supports bounded nearest-ancestor and bounded parent-import participation for `Directory.Build.props`
-- resolves literal property-backed `PackageVersion Version="$(SomeVersion)"` values when the property is statically known in the bounded import chain
+- resolves literal and composed property-backed `PackageVersion` expressions such as `$(SomeVersion)` and `$(VersionPrefix)-$(VersionSuffix)` when the bounded import chain statically proves the needed properties
 - resolves literal project-file `VersionOverride="$(SomeProperty)"` values when that property is statically known in the project file
 - prefers a literal `PackageReference VersionOverride` over the nearest central package version only when CPM overrides are statically enabled and exactly one matching central package entry exists
 - prefers explicit project-file versions over central backfill

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -608,6 +608,287 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_nuget_cpm_uses_composed_central_versions() {
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({
+                    "ManagePackageVersionsCentrally": "true",
+                    "VersionPrefix": "1.4.0",
+                    "VersionSuffix": "preview.3"
+                }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "Newtonsoft.Json",
+                        "version": "$(VersionPrefix)-$(VersionSuffix)",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/src/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:nuget/Newtonsoft.Json",
+                    None,
+                    None,
+                )],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+        assert_eq!(
+            result.dependencies[0].extracted_requirement.as_deref(),
+            Some("1.4.0-preview.3")
+        );
+    }
+
+    #[test]
+    fn test_assemble_nuget_cpm_uses_optional_suffix_composed_central_versions() {
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({
+                    "ManagePackageVersionsCentrally": "true",
+                    "RegorusPackageVersion": "0.9.1",
+                    "RegorusPackageVersionSuffix": "-$(VersionSuffix)"
+                }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "Microsoft.Regorus",
+                        "version": "$(RegorusPackageVersion)$(RegorusPackageVersionSuffix)",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/src/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:nuget/Microsoft.Regorus",
+                    None,
+                    None,
+                )],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+        assert_eq!(
+            result.dependencies[0].extracted_requirement.as_deref(),
+            Some("0.9.1")
+        );
+    }
+
+    #[test]
+    fn test_assemble_nuget_cpm_leaves_composed_version_unresolved_when_all_properties_missing() {
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({
+                    "ManagePackageVersionsCentrally": "true"
+                }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "Newtonsoft.Json",
+                        "version": "$(VersionPrefix)-$(VersionSuffix)",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/src/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:nuget/Newtonsoft.Json",
+                    None,
+                    None,
+                )],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+        assert!(result.dependencies[0].extracted_requirement.is_none());
+    }
+
+    #[test]
+    fn test_assemble_nuget_cpm_leaves_partially_unresolved_composed_versions_empty() {
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({
+                    "ManagePackageVersionsCentrally": "true",
+                    "VersionPrefix": "1.4.0"
+                }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "Newtonsoft.Json",
+                        "version": "$(VersionPrefix)-$(VersionSuffix)",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/src/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:nuget/Newtonsoft.Json",
+                    None,
+                    None,
+                )],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+        assert!(result.dependencies[0].extracted_requirement.is_none());
+    }
+
+    #[test]
+    fn test_assemble_nuget_cpm_preserves_imported_versions_when_local_raw_versions_exist() {
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![create_test_central_dependency(
+                "pkg:nuget/Microsoft.Regorus",
+                Some("0.9.1"),
+                Some(HashMap::from([(
+                    "version_expression".to_string(),
+                    json!("$(RegorusPackageVersion)$(RegorusPackageVersionSuffix)"),
+                )])),
+            )],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({
+                    "ManagePackageVersionsCentrally": "true",
+                    "VersionPrefix": "1.4.0",
+                    "VersionSuffix": "preview.3"
+                }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "Newtonsoft.Json",
+                        "version": "$(VersionPrefix)-$(VersionSuffix)",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/src/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                vec![
+                    create_test_dependency("pkg:nuget/Newtonsoft.Json", None, None),
+                    create_test_dependency("pkg:nuget/Microsoft.Regorus", None, None),
+                ],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+        assert_eq!(result.dependencies.len(), 2);
+
+        let newtonsoft = result
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.purl.as_deref() == Some("pkg:nuget/Newtonsoft.Json"))
+            .expect("missing Newtonsoft.Json dependency");
+        assert_eq!(
+            newtonsoft.extracted_requirement.as_deref(),
+            Some("1.4.0-preview.3")
+        );
+
+        let regorus = result
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.purl.as_deref() == Some("pkg:nuget/Microsoft.Regorus"))
+            .expect("missing Microsoft.Regorus dependency");
+        assert_eq!(regorus.extracted_requirement.as_deref(), Some("0.9.1"));
+    }
+
+    #[test]
     fn test_assemble_nuget_cpm_uses_directory_build_props_for_version_override() {
         let mut build_props = create_test_file_info(
             "repo/src/Directory.Build.props",

--- a/src/assembly/nuget_cpm_resolve.rs
+++ b/src/assembly/nuget_cpm_resolve.rs
@@ -8,6 +8,19 @@ use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, FileInfo, PackageData, TopLevelDependency};
 
+struct ResolvedPropertyText {
+    rendered: String,
+    resolved_substitutions: usize,
+}
+
+fn is_safe_optional_property_omission(prev: Option<char>, next: Option<char>) -> bool {
+    match (prev, next) {
+        (Some(prev), None) => prev.is_ascii_alphanumeric(),
+        (None, Some(next)) => next.is_ascii_alphanumeric(),
+        _ => false,
+    }
+}
+
 #[derive(Default)]
 struct ResolvedCpmData {
     dependencies: Vec<Dependency>,
@@ -250,7 +263,7 @@ fn resolve_effective_directory_packages_props(
             .dependencies
             .extend(package_data.dependencies.iter().cloned());
     } else {
-        let dependencies = raw_versions
+        let reconstructed_dependencies = raw_versions
             .into_iter()
             .filter_map(|(name, version, condition)| {
                 let resolved_version =
@@ -258,8 +271,13 @@ fn resolve_effective_directory_packages_props(
                 build_central_dependency(name, resolved_version, version, condition)
             })
             .collect::<Vec<_>>();
-        replace_matching_dependencies(&mut resolved.dependencies, &dependencies);
-        resolved.dependencies.extend(dependencies);
+
+        let mut merged_dependencies = package_data.dependencies.clone();
+        replace_matching_dependencies(&mut merged_dependencies, &reconstructed_dependencies);
+        merged_dependencies.extend(reconstructed_dependencies);
+
+        replace_matching_dependencies(&mut resolved.dependencies, &merged_dependencies);
+        resolved.dependencies.extend(merged_dependencies);
     }
 
     resolved
@@ -424,10 +442,7 @@ fn resolve_recorded_directory_packages_import(
         return None;
     }
 
-    let candidate = PathBuf::from(trimmed);
-    if candidate.file_name().and_then(|name| name.to_str()) != Some("Directory.Packages.props") {
-        return None;
-    }
+    let candidate = resolve_msbuild_props_import_path(current_path, trimmed)?;
 
     if candidate.is_absolute() {
         props_by_path.contains_key(&candidate).then_some(candidate)
@@ -458,10 +473,7 @@ fn resolve_recorded_directory_build_import(
         return None;
     }
 
-    let candidate = PathBuf::from(trimmed);
-    if candidate.file_name().and_then(|name| name.to_str()) != Some("Directory.Build.props") {
-        return None;
-    }
+    let candidate = resolve_msbuild_props_import_path(current_path, trimmed)?;
 
     if candidate.is_absolute() {
         props_by_path.contains_key(&candidate).then_some(candidate)
@@ -479,6 +491,15 @@ fn is_get_path_of_file_above_directory_packages_import(project: &str) -> bool {
 fn is_get_path_of_file_above_directory_build_import(project: &str) -> bool {
     project.replace(' ', "")
         == "$([MSBuild]::GetPathOfFileAbove(Directory.Build.props,$(MSBuildThisFileDirectory)..))"
+}
+
+fn resolve_msbuild_props_import_path(current_path: &Path, project: &str) -> Option<PathBuf> {
+    let current_dir = current_path.parent()?;
+    let current_dir_prefix = format!("{}{}", current_dir.display(), std::path::MAIN_SEPARATOR);
+    let normalized = project
+        .replace("$(MSBuildThisFileDirectory)", &current_dir_prefix)
+        .replace('\\', "/");
+    Some(PathBuf::from(normalized.trim()))
 }
 
 fn is_central_package_management_enabled(package_data: &ResolvedCpmData) -> bool {
@@ -735,14 +756,85 @@ fn resolve_string_property_reference(
     properties: &HashMap<String, String>,
 ) -> Option<String> {
     let trimmed = value.trim();
-    if let Some(property_name) = trimmed
-        .strip_prefix("$(")
-        .and_then(|value| value.strip_suffix(')'))
-    {
-        properties.get(property_name).cloned()
-    } else {
-        Some(trimmed.to_string())
+    if trimmed.is_empty() {
+        return None;
     }
+
+    let mut visiting = HashSet::new();
+    let resolved = resolve_property_text(trimmed, properties, &mut visiting, 0)?;
+    let rendered = resolved.rendered.trim();
+    if rendered.is_empty() {
+        None
+    } else {
+        Some(rendered.to_string())
+    }
+}
+
+fn resolve_property_text(
+    value: &str,
+    properties: &HashMap<String, String>,
+    visiting: &mut HashSet<String>,
+    depth: usize,
+) -> Option<ResolvedPropertyText> {
+    if depth >= 10 {
+        return None;
+    }
+
+    if !value.contains("$(") {
+        return Some(ResolvedPropertyText {
+            rendered: value.to_string(),
+            resolved_substitutions: 0,
+        });
+    }
+
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    let mut rendered = String::with_capacity(value.len());
+    let mut resolved_substitutions = 0;
+    let mut had_property_reference = false;
+
+    while index < bytes.len() {
+        if bytes[index] == b'$' && index + 1 < bytes.len() && bytes[index + 1] == b'(' {
+            had_property_reference = true;
+            let start = index + 2;
+            let relative_end = value[start..].find(')')?;
+            let end = start + relative_end;
+            let property_name = value[start..end].trim();
+            if property_name.is_empty() || !visiting.insert(property_name.to_string()) {
+                return None;
+            }
+
+            let raw_value = properties.get(property_name);
+            let resolved = raw_value
+                .and_then(|raw| resolve_property_text(raw, properties, visiting, depth + 1));
+            visiting.remove(property_name);
+
+            if let Some(resolved) = resolved {
+                rendered.push_str(&resolved.rendered);
+                resolved_substitutions += resolved.resolved_substitutions.max(1);
+            } else if !is_safe_optional_property_omission(
+                rendered.chars().last(),
+                value[end + 1..].chars().next(),
+            ) {
+                return None;
+            }
+
+            index = end + 1;
+            continue;
+        }
+
+        rendered.push(bytes[index] as char);
+        index += 1;
+    }
+
+    if had_property_reference && resolved_substitutions == 0 {
+        return None;
+    }
+
+    Some(ResolvedPropertyText {
+        rendered,
+        resolved_substitutions,
+    })
 }
 
 fn resolve_bool_property_reference(
@@ -762,7 +854,7 @@ fn resolve_optional_property_value(
         return None;
     }
 
-    if value.starts_with("$(") && value.ends_with(')') {
+    if value.contains("$(") {
         resolve_string_property_reference(value, properties)
     } else {
         Some(value.to_string())

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -329,6 +329,7 @@ use crate::parsers::utils::MAX_ITERATION_COUNT;
 thread_local! {
     static PARSER_DIAGNOSTIC_STACK: RefCell<Vec<Vec<ScanDiagnostic>>> = const { RefCell::new(Vec::new()) };
     static PARSER_LICENSE_ENGINE_STACK: RefCell<Vec<Option<Arc<LicenseDetectionEngine>>>> = const { RefCell::new(Vec::new()) };
+    static PARSER_SCAN_ROOT_STACK: RefCell<Vec<Option<std::path::PathBuf>>> = const { RefCell::new(Vec::new()) };
 }
 
 #[derive(Debug, Default)]
@@ -410,6 +411,21 @@ where
 
 pub(crate) fn active_parser_license_engine() -> Option<Arc<LicenseDetectionEngine>> {
     PARSER_LICENSE_ENGINE_STACK.with(|stack| stack.borrow().last().cloned().flatten())
+}
+
+pub(crate) fn active_parser_scan_root() -> Option<std::path::PathBuf> {
+    PARSER_SCAN_ROOT_STACK.with(|stack| stack.borrow().last().cloned().flatten())
+}
+
+pub(crate) fn with_parser_scan_root<T>(scan_root: Option<&Path>, f: impl FnOnce() -> T) -> T {
+    PARSER_SCAN_ROOT_STACK.with(|stack| {
+        stack.borrow_mut().push(scan_root.map(Path::to_path_buf));
+    });
+    let result = f();
+    PARSER_SCAN_ROOT_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+    result
 }
 
 pub(crate) fn record_parser_diagnostic(message: String, severity: DiagnosticSeverity) -> bool {

--- a/src/parsers/nuget/directory_props.rs
+++ b/src/parsers/nuget/directory_props.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
+use crate::parsers::active_parser_scan_root;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 
@@ -28,8 +29,9 @@ impl PackageParser for DirectoryBuildPropsParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        let allowed_root = detect_props_resolution_root(path);
         vec![match (
-            resolve_directory_build_props(path, &mut RecursionGuard::new()),
+            resolve_directory_build_props(path, &allowed_root, &mut RecursionGuard::new()),
             parse_directory_build_props_file(path),
         ) {
             (Ok(data), Ok(raw)) => build_directory_build_props_package_data(data, raw),
@@ -49,8 +51,9 @@ impl PackageParser for CentralPackageManagementPropsParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        let allowed_root = detect_props_resolution_root(path);
         vec![match (
-            resolve_directory_packages_props(path, &mut RecursionGuard::new()),
+            resolve_directory_packages_props(path, &allowed_root, &mut RecursionGuard::new()),
             parse_directory_packages_props_file(path),
         ) {
             (Ok(data), Ok(raw)) => build_directory_packages_package_data(data, raw),
@@ -147,6 +150,7 @@ fn build_directory_packages_dependency(
 
 fn resolve_directory_packages_props(
     path: &Path,
+    allowed_root: &Path,
     guard: &mut RecursionGuard<PathBuf>,
 ) -> Result<CentralPackagePropsData, String> {
     if guard.exceeded() {
@@ -165,12 +169,15 @@ fn resolve_directory_packages_props(
     let mut merged = CentralPackagePropsData::default();
 
     for import_project in &raw.import_projects {
-        let Some(import_path) =
-            resolve_import_project_for_directory_packages(path, import_project, &HashMap::new())
-        else {
+        let Some(import_path) = resolve_import_project_for_directory_packages(
+            path,
+            import_project,
+            allowed_root,
+            &HashMap::new(),
+        ) else {
             continue;
         };
-        let imported = resolve_directory_packages_props(&import_path, guard)?;
+        let imported = resolve_directory_packages_props(&import_path, allowed_root, guard)?;
         merge_central_package_props(&mut merged, imported);
     }
 
@@ -219,6 +226,7 @@ fn resolve_directory_packages_props(
 
 fn resolve_directory_build_props(
     path: &Path,
+    allowed_root: &Path,
     guard: &mut RecursionGuard<PathBuf>,
 ) -> Result<BuildPropsData, String> {
     if guard.exceeded() {
@@ -237,12 +245,15 @@ fn resolve_directory_build_props(
     let mut merged = BuildPropsData::default();
 
     for import_project in &raw.import_projects {
-        let Some(import_path) =
-            resolve_import_project_for_directory_build(path, import_project, &HashMap::new())
-        else {
+        let Some(import_path) = resolve_import_project_for_directory_build(
+            path,
+            import_project,
+            allowed_root,
+            &HashMap::new(),
+        ) else {
             continue;
         };
-        let imported = resolve_directory_build_props(&import_path, guard)?;
+        let imported = resolve_directory_build_props(&import_path, allowed_root, guard)?;
         merge_build_props_data(&mut merged, imported);
     }
 
@@ -744,7 +755,7 @@ fn is_supported_directory_packages_import(project: &str) -> bool {
     }
 
     let candidate = PathBuf::from(trimmed);
-    candidate.file_name().and_then(|name| name.to_str()) == Some("Directory.Packages.props")
+    candidate.extension().and_then(|ext| ext.to_str()) == Some("props")
 }
 
 fn is_supported_directory_build_import(project: &str) -> bool {
@@ -758,7 +769,7 @@ fn is_supported_directory_build_import(project: &str) -> bool {
     }
 
     let candidate = PathBuf::from(trimmed);
-    candidate.file_name().and_then(|name| name.to_str()) == Some("Directory.Build.props")
+    candidate.extension().and_then(|ext| ext.to_str()) == Some("props")
 }
 
 fn is_get_path_of_file_above_import(project: &str) -> bool {
@@ -776,6 +787,7 @@ fn is_get_path_of_file_above_build_import(project: &str) -> bool {
 fn resolve_import_project_for_directory_build(
     current_path: &Path,
     project: &str,
+    allowed_root: &Path,
     known_props_paths: &HashMap<PathBuf, &PackageData>,
 ) -> Option<PathBuf> {
     let trimmed = project.trim();
@@ -783,12 +795,13 @@ fn resolve_import_project_for_directory_build(
         let start_dir = current_path.parent()?.parent()?;
         for ancestor in start_dir.ancestors() {
             let candidate = ancestor.join("Directory.Build.props");
-            if known_props_paths.is_empty() {
-                if candidate.exists() {
-                    return Some(candidate);
-                }
-            } else if known_props_paths.contains_key(&candidate) {
-                return Some(candidate);
+            if let Some(resolved) = resolve_checked_props_import(
+                candidate,
+                current_path,
+                allowed_root,
+                known_props_paths,
+            ) {
+                return Some(resolved);
             }
         }
         return None;
@@ -798,25 +811,8 @@ fn resolve_import_project_for_directory_build(
         return None;
     }
 
-    let candidate = PathBuf::from(trimmed);
-    if candidate.is_absolute() {
-        if known_props_paths.is_empty() {
-            candidate.exists().then_some(candidate)
-        } else {
-            known_props_paths
-                .contains_key(&candidate)
-                .then_some(candidate)
-        }
-    } else {
-        let resolved = current_path.parent()?.join(candidate);
-        if known_props_paths.is_empty() {
-            resolved.exists().then_some(resolved)
-        } else {
-            known_props_paths
-                .contains_key(&resolved)
-                .then_some(resolved)
-        }
-    }
+    let candidate = resolve_msbuild_props_import_path(current_path, trimmed)?;
+    resolve_checked_props_import(candidate, current_path, allowed_root, known_props_paths)
 }
 
 fn merge_build_props_data(target: &mut BuildPropsData, source: BuildPropsData) {
@@ -838,6 +834,7 @@ fn merge_build_props_data(target: &mut BuildPropsData, source: BuildPropsData) {
 fn resolve_import_project_for_directory_packages(
     current_path: &Path,
     project: &str,
+    allowed_root: &Path,
     known_props_paths: &HashMap<PathBuf, &PackageData>,
 ) -> Option<PathBuf> {
     let trimmed = project.trim();
@@ -845,12 +842,13 @@ fn resolve_import_project_for_directory_packages(
         let start_dir = current_path.parent()?.parent()?;
         for ancestor in start_dir.ancestors() {
             let candidate = ancestor.join("Directory.Packages.props");
-            if known_props_paths.is_empty() {
-                if candidate.exists() {
-                    return Some(candidate);
-                }
-            } else if known_props_paths.contains_key(&candidate) {
-                return Some(candidate);
+            if let Some(resolved) = resolve_checked_props_import(
+                candidate,
+                current_path,
+                allowed_root,
+                known_props_paths,
+            ) {
+                return Some(resolved);
             }
         }
         return None;
@@ -860,25 +858,53 @@ fn resolve_import_project_for_directory_packages(
         return None;
     }
 
-    let candidate = PathBuf::from(trimmed);
-    if candidate.is_absolute() {
-        if known_props_paths.is_empty() {
-            candidate.exists().then_some(candidate)
-        } else {
-            known_props_paths
-                .contains_key(&candidate)
-                .then_some(candidate)
-        }
+    let candidate = resolve_msbuild_props_import_path(current_path, trimmed)?;
+    resolve_checked_props_import(candidate, current_path, allowed_root, known_props_paths)
+}
+
+fn resolve_msbuild_props_import_path(current_path: &Path, project: &str) -> Option<PathBuf> {
+    let current_dir = current_path.parent()?;
+    let current_dir_prefix = format!("{}{}", current_dir.display(), std::path::MAIN_SEPARATOR);
+    let normalized = project
+        .replace("$(MSBuildThisFileDirectory)", &current_dir_prefix)
+        .replace('\\', "/");
+    Some(PathBuf::from(normalized.trim()))
+}
+
+fn resolve_checked_props_import(
+    candidate: PathBuf,
+    current_path: &Path,
+    allowed_root: &Path,
+    known_props_paths: &HashMap<PathBuf, &PackageData>,
+) -> Option<PathBuf> {
+    let resolved = if candidate.is_absolute() {
+        candidate
     } else {
-        let resolved = current_path.parent()?.join(candidate);
-        if known_props_paths.is_empty() {
-            resolved.exists().then_some(resolved)
-        } else {
-            known_props_paths
-                .contains_key(&resolved)
-                .then_some(resolved)
-        }
+        current_path.parent()?.join(candidate)
+    };
+
+    let canonical_allowed_root = allowed_root.canonicalize().ok()?;
+    let canonical_resolved = resolved.canonicalize().ok()?;
+    if !canonical_resolved.starts_with(&canonical_allowed_root) {
+        return None;
     }
+
+    if known_props_paths.is_empty() {
+        Some(canonical_resolved)
+    } else {
+        known_props_paths
+            .contains_key(&canonical_resolved)
+            .then_some(canonical_resolved)
+    }
+}
+
+fn detect_props_resolution_root(path: &Path) -> PathBuf {
+    if let Some(scan_root) = active_parser_scan_root() {
+        return scan_root;
+    }
+    path.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| path.to_path_buf())
 }
 
 crate::register_parser!(

--- a/src/parsers/nuget/nuget_test.rs
+++ b/src/parsers/nuget/nuget_test.rs
@@ -1098,7 +1098,9 @@ mod tests {
         )
         .unwrap();
 
-        let package_data = CentralPackageManagementPropsParser::extract_first_package(&child_props);
+        let package_data = crate::parsers::with_parser_scan_root(Some(temp_dir.path()), || {
+            CentralPackageManagementPropsParser::extract_first_package(&child_props)
+        });
         assert_eq!(package_data.dependencies.len(), 1);
         assert_eq!(
             package_data.dependencies[0]
@@ -1123,6 +1125,120 @@ mod tests {
                 "$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))"
             )
         );
+    }
+
+    #[test]
+    fn test_directory_packages_props_respects_active_scan_root_for_parent_imports() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root_props = temp_dir.path().join("Directory.Packages.props");
+        std::fs::write(
+            &root_props,
+            r#"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let child_dir = temp_dir.path().join("src");
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let child_props = child_dir.join("Directory.Packages.props");
+        std::fs::write(
+            &child_props,
+            r#"<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+</Project>"#,
+        )
+        .unwrap();
+
+        let package_data = crate::parsers::with_parser_scan_root(Some(&child_dir), || {
+            CentralPackageManagementPropsParser::extract_first_package(&child_props)
+        });
+        assert!(package_data.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_directory_packages_props_resolves_composed_property_versions() {
+        let xml = r#"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionSuffix>preview.3</VersionSuffix>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="$(VersionPrefix)-$(VersionSuffix)" />
+  </ItemGroup>
+</Project>"#;
+
+        let (_temp_dir, path) = write_directory_packages_props(xml);
+
+        let package_data = CentralPackageManagementPropsParser::extract_first_package(&path);
+        assert_eq!(package_data.dependencies.len(), 1);
+        let dep = &package_data.dependencies[0];
+        assert_eq!(dep.purl.as_deref(), Some("pkg:nuget/Newtonsoft.Json"));
+        assert_eq!(
+            dep.extracted_requirement.as_deref(),
+            Some("1.4.0-preview.3")
+        );
+        let extra = dep.extra_data.as_ref().unwrap();
+        assert_eq!(
+            extra
+                .get("version_expression")
+                .and_then(|value| value.as_str()),
+            Some("$(VersionPrefix)-$(VersionSuffix)")
+        );
+    }
+
+    #[test]
+    fn test_directory_packages_props_resolves_optional_suffix_composition() {
+        let xml = r#"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <RegorusPackageVersion>0.9.1</RegorusPackageVersion>
+    <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Regorus" Version="$(RegorusPackageVersion)$(RegorusPackageVersionSuffix)" />
+  </ItemGroup>
+</Project>"#;
+
+        let (_temp_dir, path) = write_directory_packages_props(xml);
+
+        let package_data = CentralPackageManagementPropsParser::extract_first_package(&path);
+        assert_eq!(package_data.dependencies.len(), 1);
+        let dep = &package_data.dependencies[0];
+        assert_eq!(dep.purl.as_deref(), Some("pkg:nuget/Microsoft.Regorus"));
+        assert_eq!(dep.extracted_requirement.as_deref(), Some("0.9.1"));
+        let extra = dep.extra_data.as_ref().unwrap();
+        assert_eq!(
+            extra
+                .get("version_expression")
+                .and_then(|value| value.as_str()),
+            Some("$(RegorusPackageVersion)$(RegorusPackageVersionSuffix)")
+        );
+    }
+
+    #[test]
+    fn test_directory_packages_props_leaves_partially_unresolved_composed_versions_empty() {
+        let xml = r#"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <VersionPrefix>1.4.0</VersionPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="$(VersionPrefix)-$(VersionSuffix)" />
+  </ItemGroup>
+</Project>"#;
+
+        let (_temp_dir, path) = write_directory_packages_props(xml);
+
+        let package_data = CentralPackageManagementPropsParser::extract_first_package(&path);
+        assert!(package_data.dependencies.is_empty());
     }
 
     #[test]
@@ -1154,7 +1270,9 @@ mod tests {
         )
         .unwrap();
 
-        let package_data = DirectoryBuildPropsParser::extract_first_package(&child_props);
+        let package_data = crate::parsers::with_parser_scan_root(Some(temp_dir.path()), || {
+            DirectoryBuildPropsParser::extract_first_package(&child_props)
+        });
         assert_eq!(package_data.package_type, Some(PackageType::Nuget));
         assert_eq!(
             package_data.datasource_id,
@@ -1259,7 +1377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_directory_packages_props_ignores_non_cpm_import_targets() {
+    fn test_directory_packages_props_extracts_versions_from_imported_props_files() {
         let temp_dir = tempfile::tempdir().unwrap();
         let build_props = temp_dir.path().join("Directory.Build.props");
         std::fs::write(
@@ -1289,14 +1407,149 @@ mod tests {
         )
         .unwrap();
 
-        let package_data = CentralPackageManagementPropsParser::extract_first_package(&child_props);
-        assert_eq!(package_data.dependencies.len(), 0);
+        let package_data = crate::parsers::with_parser_scan_root(Some(temp_dir.path()), || {
+            CentralPackageManagementPropsParser::extract_first_package(&child_props)
+        });
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:nuget/Newtonsoft.Json")
+        );
+        assert_eq!(
+            package_data.dependencies[0]
+                .extracted_requirement
+                .as_deref(),
+            Some("13.0.3")
+        );
         assert!(
             package_data
                 .extra_data
                 .as_ref()
                 .and_then(|data| data.get("import_projects"))
-                .is_none()
+                .and_then(|value| value.as_array())
+                .is_some_and(|values| !values.is_empty())
+        );
+    }
+
+    #[test]
+    fn test_directory_packages_props_extracts_versions_from_msbuild_this_file_directory_imports() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let packages_dir = temp_dir.path().join("eng").join("packages");
+        std::fs::create_dir_all(&packages_dir).unwrap();
+        let general_props = packages_dir.join("General.props");
+        std::fs::write(
+            &general_props,
+            r#"<Project>
+  <PropertyGroup>
+    <ManageVersions>true</ManageVersions>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let root_props = temp_dir.path().join("Directory.Packages.props");
+        std::fs::write(
+            &root_props,
+            r#"<Project>
+  <Import Project="$(MSBuildThisFileDirectory)\eng\packages\General.props" />
+</Project>"#,
+        )
+        .unwrap();
+
+        let package_data = crate::parsers::with_parser_scan_root(Some(temp_dir.path()), || {
+            CentralPackageManagementPropsParser::extract_first_package(&root_props)
+        });
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:nuget/Newtonsoft.Json")
+        );
+        assert_eq!(
+            package_data.dependencies[0]
+                .extracted_requirement
+                .as_deref(),
+            Some("13.0.3")
+        );
+        assert_eq!(
+            package_data
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("import_projects"))
+                .and_then(|value| value.as_array())
+                .and_then(|values| values.first())
+                .and_then(|value| value.as_str()),
+            Some("$(MSBuildThisFileDirectory)\\eng\\packages\\General.props")
+        );
+    }
+
+    #[test]
+    fn test_directory_packages_props_does_not_follow_external_props_imports() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let external_dir = tempfile::tempdir().unwrap();
+        let external_props = external_dir.path().join("General.props");
+        std::fs::write(
+            &external_props,
+            r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let root_props = temp_dir.path().join("Directory.Packages.props");
+        std::fs::write(
+            &root_props,
+            format!(
+                "<Project>\n  <Import Project=\"{}\" />\n</Project>",
+                external_props.display()
+            ),
+        )
+        .unwrap();
+
+        let package_data = CentralPackageManagementPropsParser::extract_first_package(&root_props);
+        assert!(package_data.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_directory_build_props_does_not_follow_external_props_imports() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let external_dir = tempfile::tempdir().unwrap();
+        let external_props = external_dir.path().join("General.props");
+        std::fs::write(
+            &external_props,
+            r#"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let root_props = temp_dir.path().join("Directory.Build.props");
+        std::fs::write(
+            &root_props,
+            format!(
+                "<Project>\n  <Import Project=\"{}\" />\n</Project>",
+                external_props.display()
+            ),
+        )
+        .unwrap();
+
+        let package_data = DirectoryBuildPropsParser::extract_first_package(&root_props);
+        let extra_data = package_data
+            .extra_data
+            .as_ref()
+            .expect("missing extra_data");
+        assert!(
+            extra_data
+                .get("property_values")
+                .and_then(|value| value.as_object())
+                .is_none_or(|map| map.is_empty())
         );
     }
 

--- a/src/parsers/nuget/utils.rs
+++ b/src/parsers/nuget/utils.rs
@@ -3,7 +3,20 @@
 
 use std::collections::{HashMap, HashSet};
 
-pub(super) fn resolve_string_property_reference(
+struct ResolvedPropertyText {
+    rendered: String,
+    resolved_substitutions: usize,
+}
+
+fn is_safe_optional_property_omission(prev: Option<char>, next: Option<char>) -> bool {
+    match (prev, next) {
+        (Some(prev), None) => prev.is_ascii_alphanumeric(),
+        (None, Some(next)) => next.is_ascii_alphanumeric(),
+        _ => false,
+    }
+}
+
+pub(crate) fn resolve_string_property_reference(
     value: &str,
     properties: &HashMap<String, String>,
 ) -> Option<String> {
@@ -13,7 +26,13 @@ pub(super) fn resolve_string_property_reference(
     }
 
     let mut visiting = HashSet::new();
-    resolve_property_text(trimmed, properties, &mut visiting, 0)
+    let resolved = resolve_property_text(trimmed, properties, &mut visiting, 0)?;
+    let rendered = resolved.rendered.trim();
+    if rendered.is_empty() {
+        None
+    } else {
+        Some(rendered.to_string())
+    }
 }
 
 fn resolve_property_text(
@@ -21,21 +40,27 @@ fn resolve_property_text(
     properties: &HashMap<String, String>,
     visiting: &mut HashSet<String>,
     depth: usize,
-) -> Option<String> {
+) -> Option<ResolvedPropertyText> {
     if depth >= 10 {
         return None;
     }
 
     if !value.contains("$(") {
-        return Some(value.to_string());
+        return Some(ResolvedPropertyText {
+            rendered: value.to_string(),
+            resolved_substitutions: 0,
+        });
     }
 
     let bytes = value.as_bytes();
     let mut index = 0;
     let mut rendered = String::with_capacity(value.len());
+    let mut resolved_substitutions = 0;
+    let mut had_property_reference = false;
 
     while index < bytes.len() {
         if bytes[index] == b'$' && index + 1 < bytes.len() && bytes[index + 1] == b'(' {
+            had_property_reference = true;
             let start = index + 2;
             let relative_end = value[start..].find(')')?;
             let end = start + relative_end;
@@ -44,10 +69,21 @@ fn resolve_property_text(
                 return None;
             }
 
-            let raw_value = properties.get(property_name)?;
-            let resolved = resolve_property_text(raw_value, properties, visiting, depth + 1)?;
+            let raw_value = properties.get(property_name);
+            let resolved = raw_value
+                .and_then(|raw| resolve_property_text(raw, properties, visiting, depth + 1));
             visiting.remove(property_name);
-            rendered.push_str(&resolved);
+
+            if let Some(resolved) = resolved {
+                rendered.push_str(&resolved.rendered);
+                resolved_substitutions += resolved.resolved_substitutions.max(1);
+            } else if !is_safe_optional_property_omission(
+                rendered.chars().last(),
+                value[end + 1..].chars().next(),
+            ) {
+                return None;
+            }
+
             index = end + 1;
             continue;
         }
@@ -56,10 +92,17 @@ fn resolve_property_text(
         index += 1;
     }
 
-    Some(rendered)
+    if had_property_reference && resolved_substitutions == 0 {
+        return None;
+    }
+
+    Some(ResolvedPropertyText {
+        rendered,
+        resolved_substitutions,
+    })
 }
 
-pub(super) fn resolve_bool_property_reference(
+pub(crate) fn resolve_bool_property_reference(
     value: Option<&str>,
     properties: &HashMap<String, String>,
 ) -> Option<bool> {
@@ -67,7 +110,7 @@ pub(super) fn resolve_bool_property_reference(
     Some(resolved.eq_ignore_ascii_case("true"))
 }
 
-pub(super) fn resolve_optional_property_value(
+pub(crate) fn resolve_optional_property_value(
     value: Option<&str>,
     properties: &HashMap<String, String>,
 ) -> Option<String> {
@@ -76,7 +119,7 @@ pub(super) fn resolve_optional_property_value(
         return None;
     }
 
-    if value.starts_with("$(") && value.ends_with(')') {
+    if value.contains("$(") {
         resolve_string_property_reference(value, properties)
     } else {
         Some(value.to_string())

--- a/src/scanner/collect.rs
+++ b/src/scanner/collect.rs
@@ -40,6 +40,17 @@ impl CollectedPaths {
     pub fn directory_count(&self) -> usize {
         self.directories.len()
     }
+
+    pub fn scan_root(&self) -> Option<&Path> {
+        self.directories
+            .first()
+            .map(|(path, _)| path.as_path())
+            .or_else(|| {
+                self.files
+                    .first()
+                    .and_then(|(path, _)| path.parent().or(Some(path.as_path())))
+            })
+    }
 }
 
 pub fn collect_paths<P: AsRef<Path>>(
@@ -323,5 +334,23 @@ fn merge_collected(accumulator: &mut CollectionAccumulator, collected: Collected
         if accumulator.dir_seen.insert(path.clone()) {
             accumulator.directories.push((path, metadata));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_paths;
+    use std::fs;
+
+    #[test]
+    fn file_scan_root_uses_parent_directory() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let file_path = temp_dir.path().join("Directory.Packages.props");
+        fs::write(&file_path, "<Project />").expect("write props file");
+
+        let collected = collect_paths(&file_path, 0, &[]);
+        assert_eq!(collected.file_count(), 1);
+        assert_eq!(collected.directory_count(), 0);
+        assert_eq!(collected.scan_root(), Some(temp_dir.path()));
     }
 }

--- a/src/scanner/process/orchestrator.rs
+++ b/src/scanner/process/orchestrator.rs
@@ -6,6 +6,7 @@ use super::special_cases::process_directory;
 use super::spill::{FileInfoSpillStore, MemoryMode, retain_or_spill_chunk};
 use crate::license_detection::LicenseDetectionEngine;
 use crate::models::FileInfo;
+use crate::parsers::with_parser_scan_root;
 use crate::progress::ScanProgress;
 use crate::scanner::collect::CollectedPaths;
 use crate::scanner::{LicenseScanOptions, ProcessResult, TextDetectionOptions};
@@ -23,14 +24,16 @@ pub fn process_collected(
         .files
         .par_iter()
         .map(|(path, metadata)| {
-            let file_entry = process_file(
-                path,
-                metadata,
-                progress.as_ref(),
-                license_engine.clone(),
-                license_options,
-                text_options,
-            );
+            let file_entry = with_parser_scan_root(collected.scan_root(), || {
+                process_file(
+                    path,
+                    metadata,
+                    progress.as_ref(),
+                    license_engine.clone(),
+                    license_options,
+                    text_options,
+                )
+            });
             progress.file_completed(path, metadata.len(), &file_entry.scan_diagnostics);
             file_entry
         })
@@ -62,14 +65,16 @@ pub fn process_collected_sequential(
         Vec::with_capacity(collected.files.len() + collected.directories.len());
 
     for (path, metadata) in &collected.files {
-        let file_entry = process_file(
-            path,
-            metadata,
-            progress.as_ref(),
-            license_engine.clone(),
-            license_options,
-            text_options,
-        );
+        let file_entry = with_parser_scan_root(collected.scan_root(), || {
+            process_file(
+                path,
+                metadata,
+                progress.as_ref(),
+                license_engine.clone(),
+                license_options,
+                text_options,
+            )
+        });
         progress.file_completed(path, metadata.len(), &file_entry.scan_diagnostics);
         all_files.push(file_entry);
     }
@@ -114,14 +119,16 @@ pub fn process_collected_with_memory_limit(
         let processed_chunk: Vec<FileInfo> = chunk
             .par_iter()
             .map(|(path, metadata)| {
-                let file_entry = process_file(
-                    path,
-                    metadata,
-                    progress.as_ref(),
-                    license_engine.clone(),
-                    license_options,
-                    text_options,
-                );
+                let file_entry = with_parser_scan_root(collected.scan_root(), || {
+                    process_file(
+                        path,
+                        metadata,
+                        progress.as_ref(),
+                        license_engine.clone(),
+                        license_options,
+                        text_options,
+                    )
+                });
                 progress.file_completed(path, metadata.len(), &file_entry.scan_diagnostics);
                 file_entry
             })
@@ -184,14 +191,16 @@ pub fn process_collected_with_memory_limit_sequential(
     for chunk in collected.files.chunks(chunk_size) {
         let mut processed_chunk: Vec<FileInfo> = Vec::with_capacity(chunk.len());
         for (path, metadata) in chunk {
-            let file_entry = process_file(
-                path,
-                metadata,
-                progress.as_ref(),
-                license_engine.clone(),
-                license_options,
-                text_options,
-            );
+            let file_entry = with_parser_scan_root(collected.scan_root(), || {
+                process_file(
+                    path,
+                    metadata,
+                    progress.as_ref(),
+                    license_engine.clone(),
+                    license_options,
+                    text_options,
+                )
+            });
             progress.file_completed(path, metadata.len(), &file_entry.scan_diagnostics);
             processed_chunk.push(file_entry);
         }


### PR DESCRIPTION
## Summary

- bound NuGet `Directory.Packages.props` / `Directory.Build.props` import following to the actual active scan root and deny out-of-scope `.props` reads
- preserve imported ordinary `.props` central package versions during assembly while keeping partially unresolved composed expressions unresolved
- record the resulting real-world end state in `docs/BENCHMARKS.md` with refreshed standalone `dotnet/extensions` and new `microsoft/regorus` compare-output snapshots

## Issues

- Covers: bounded NuGet CPM import and composition follow-up from PR #826 plus the blocker fixes uncovered during post-implementation review
- Closes:

## Scope and exclusions

- Included:
  - parser scan-root plumbing in `src/parsers/mod.rs`, `src/scanner/collect.rs`, and `src/scanner/process/orchestrator.rs`
  - NuGet `.props` import/path handling and composed property resolution in `src/parsers/nuget/` and `src/assembly/nuget_cpm_resolve.rs`
  - focused parser and assembly regression coverage for out-of-root import denial, partial-resolution fail-closed behavior, and imported-version preservation
  - benchmark/docs updates for:
    - `microsoft/regorus @ 7f42115` from `.provenant/compare-runs/20260430T114610Z-regorus-348`
    - `dotnet/extensions @ 7171956` refresh from `.provenant/compare-runs/20260430T115315Z-extensions-9749`
- Explicit exclusions:
  - no full MSBuild evaluation
  - no conditioned `PropertyGroup` or `ItemGroup` evaluation beyond the existing bounded behavior
  - no support for `Directory.Build.targets`, wildcard imports, or arbitrary non-literal import graphs
  - no scorecard edit, since the NuGet verification row is already marked verified

## Intentional differences from Python

- Provenant continues to prefer bounded static resolution over broad evaluator behavior.
- It now resolves composed central `PackageVersion` expressions and bounded repository-local `.props` imports only when the imported file stays under the active scan root.
- It intentionally fails closed on partially unresolved composed expressions instead of collapsing them into misleading concrete-looking versions.

## Follow-up work

- Created or intentionally deferred:
  - deferred: broader conditioned MSBuild semantics for project/package versions outside the current bounded slice
  - deferred: any future support for non-CPM import graphs or `Directory.Build.targets`

## Expected-output fixture changes

- Files changed:
  - no golden fixture files were regenerated; coverage was added in unit tests and compare-output evidence instead
- Why the new expected output is correct:
  - the parser now denies `.props` imports that escape the active scan root, so out-of-scope property bags are no longer read or surfaced
  - imported ordinary `.props` package versions are preserved during assembly even when local raw `PackageVersion` entries also exist
  - final standalone compare-output runs confirm the user-visible end state:
    - `microsoft/regorus` resolves `Microsoft.Regorus` to `0.9.1` in central props and consumer dependencies
    - `dotnet/extensions` root and nested `Directory.Packages.props` surfaces now carry imported central package-version dependency metadata instead of empty imported-props placeholders