### PR TITLE
fix(package-detection): tighten Unciv verification gaps

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 183 of 183 recorded runs, with a **11.9× median speedup** and **11.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 184 of 184 recorded runs, with a **12.0× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -459,6 +459,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `145.05s`; ScanCode `1879.67s`
 - Broader Gradle package and dependency extraction (`73` vs `68` packages, `1675` vs `1541` dependencies) from committed `build.gradle`, `build.gradle.kts`, `gradle.lockfile`, and `.module` metadata across docs and test fixtures
+
+##### [yairm210/Unciv @ d54f33c](https://github.com/yairm210/Unciv/tree/d54f33c881ad2de1ac7136540f59ad8596143ce5) — **19.54× faster**
+
+- Files: 4,057
+- Run context: 2026-04-30 · Unciv-90826 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `21.96s`; ScanCode `429.19s`
+- Far broader Gradle dependency extraction (`51` vs `6` dependencies) from the root multi-project `build.gradle.kts`, module-local `android/build.gradle.kts`, and `buildSrc/build.gradle.kts`, with concrete version recovery for property-backed Kotlin DSL quoted configuration calls such as `"implementation"("io.ktor:ktor-client-core:$ktorVersion")`, `"implementation"("com.badlogicgames.gdx:gdx-tools:$gdxVersion")`, and `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")` where ScanCode leaves `$kotlinVersion` / `$gdxVersion` unresolved and misses most of the centralized root build graph
 
 ##### [playframework/playframework @ c2c114f](https://github.com/playframework/playframework/tree/c2c114ff31eff1557bef65cc3f586fbc53c974a6) — **18.23× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -446,6 +446,9 @@ ScanCode: 525.35s</title></rect>
     <rect x="657.46" y="339.67" width="8" height="8" fill="#d97706" rx="1.5"><title>renovatebot/renovate @ 91a7213
 Files: 3663
 ScanCode: 446.79s</title></rect>
+    <rect x="664.50" y="341.57" width="8" height="8" fill="#d97706" rx="1.5"><title>yairm210/Unciv @ d54f33c
+Files: 4057
+ScanCode: 429.19s</title></rect>
     <rect x="666.81" y="368.42" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 40d57c9
 Files: 4195
 ScanCode: 243.12s</title></rect>
@@ -997,6 +1000,9 @@ Provenant: 27.54s</title></circle>
     <circle cx="661.46" cy="482.35" r="4.5" fill="#2563eb"><title>renovatebot/renovate @ 91a7213
 Files: 3663
 Provenant: 23.74s</title></circle>
+    <circle cx="668.50" cy="486.03" r="4.5" fill="#2563eb"><title>yairm210/Unciv @ d54f33c
+Files: 4057
+Provenant: 21.96s</title></circle>
     <circle cx="670.81" cy="483.84" r="4.5" fill="#2563eb"><title>curl/curl @ 40d57c9
 Files: 4195
 Provenant: 23.00s</title></circle>

--- a/docs/improvements/gradle-parser.md
+++ b/docs/improvements/gradle-parser.md
@@ -9,6 +9,7 @@ Rust now goes beyond the current Python ScanCode Gradle handling in several conc
 3. resolves TOML-backed `libs.versions.toml` version-catalog aliases such as `libs.androidx.appcompat` to real Maven package identifiers
 4. preserves parent path segments for local project dependencies like `project(":libs:download")`
 5. merges all discovered `dependencies {}` blocks in a build file instead of only parsing the first one
+6. parses Kotlin DSL quoted configuration names such as `"implementation"("io.ktor:ktor-client-core:3.2.3")` instead of dropping those central dependency declarations
 
 ## Python Status
 
@@ -52,10 +53,16 @@ Rust now goes beyond the current Python ScanCode Gradle handling in several conc
 - Rust now parses every discovered `dependencies {}` block in a single `build.gradle` / `build.gradle.kts` file instead of stopping after the first block.
 - This includes repeated top-level blocks and later nested blocks that the current token parser already recognizes lexically.
 
+### Kotlin DSL quoted configuration names
+
+- Kotlin DSL also allows configuration names to be called as quoted strings, for example `"implementation"("group:artifact:version")` and `"implementation"(project(":core"))`.
+- Rust now treats these quoted configuration names the same way it treats unquoted identifiers, including ordinary Maven coordinates, nested `project(":...")` references, and trailing exclusion closures.
+- This keeps centralized multi-project Gradle builds scannable when they route module dependencies through root-level `project(":module") { dependencies { ... } }` blocks using quoted Kotlin DSL configuration calls.
+
 ### Template POM guardrail
 
 - Rust also skips placeholder-only Maven coordinates like `${groupId}` / `${artifactId}` / `${version}` instead of emitting junk package identifiers.
 
 ## Coverage
 
-Coverage spans scope classification, all discovered dependency-block parsing, version-catalog alias resolution, Gradle POM license extraction, and placeholder-coordinate guardrails.
+Coverage spans scope classification, all discovered dependency-block parsing, Kotlin DSL quoted configuration names, version-catalog alias resolution, Gradle POM license extraction, and placeholder-coordinate guardrails.

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -60,6 +60,10 @@ pub fn refine_author(s: &str) -> Option<String> {
         return None;
     }
 
+    if looks_like_translation_placeholder_author(&a) {
+        return None;
+    }
+
     if !a.chars().any(|ch| ch.is_alphabetic()) {
         return None;
     }
@@ -290,12 +294,39 @@ fn looks_like_file_reference_note_author(s: &str) -> bool {
         )
         .unwrap()
     });
+    static CREDIT_FILE_REFERENCE_NOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^
+            (?:see|see\ also|refer\ to|consult)
+            \s+
+            (?:the\s+)?
+            (?:authors?|credits?)
+            \s+file
+            $
+            ",
+        )
+        .unwrap()
+    });
 
     let trimmed = s.trim();
+    if CREDIT_FILE_REFERENCE_NOTE_RE.is_match(trimmed) {
+        return true;
+    }
     FILE_REFERENCE_NOTE_RE
         .captures(trimmed)
         .and_then(|caps| caps.name("target").map(|m| m.as_str()))
         .is_some_and(|target| target.chars().any(|ch| ch.is_ascii_alphabetic()))
+}
+
+fn looks_like_translation_placeholder_author(s: &str) -> bool {
+    static AUTHOR_PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?iu)^[\p{L}\p{M}][\p{L}\p{M}\s._'-]{0,32}[:：]\s*author$")
+            .expect("valid translation author placeholder regex")
+    });
+
+    let trimmed = s.trim();
+    trimmed.eq_ignore_ascii_case("Requires translation") || AUTHOR_PLACEHOLDER_RE.is_match(trimmed)
 }
 
 fn contains_no_copyright_clause(s: &str) -> bool {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -881,6 +881,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_inc_after_today_year_placeholder(&c);
     c = truncate_trailing_boilerplate(&c);
     c = strip_trailing_author_label(&c);
+    c = strip_trailing_credit_file_reference_clause(&c);
     c = strip_trailing_isc_after_inc(&c);
     c = strip_trailing_caps_after_company_suffix(&c);
     c = strip_trailing_javadoc_tags(&c);
@@ -938,6 +939,9 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     {
         return None;
     }
+    if looks_like_document_form_reference(&result) {
+        return None;
+    }
     if is_post_refine_copyright_code_fragment(&result)
         || is_junk_copyright_of_header(&result)
         || is_junk_copyrighted_works_header(&result)
@@ -989,6 +993,64 @@ fn strip_trailing_obfuscated_email_after_dash(s: &str) -> String {
     }
 
     prefix.to_string()
+}
+
+fn strip_trailing_credit_file_reference_clause(s: &str) -> String {
+    let trimmed = s.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !(lower.starts_with("copyright") || lower.starts_with("(c)")) {
+        return s.to_string();
+    }
+
+    for marker in [
+        " see authors file",
+        " see author file",
+        " see credits file",
+        " see credit file",
+        " refer to authors file",
+        " refer to credits file",
+        " consult authors file",
+        " consult credits file",
+    ] {
+        if let Some(index) = lower.find(marker) {
+            let prefix = trimmed[..index]
+                .trim_end_matches(&[',', ';', ':', ' '][..])
+                .trim();
+            if prefix.chars().any(|ch| ch.is_ascii_digit()) {
+                return prefix.to_string();
+            }
+        }
+    }
+
+    s.to_string()
+}
+
+fn looks_like_credit_file_reference_note(s: &str) -> bool {
+    static CREDIT_FILE_REFERENCE_NOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^
+            (?:see|see\ also|refer\ to|consult)
+            \s+
+            (?:the\s+)?
+            (?:authors?|credits?)
+            \s+file
+            $
+            ",
+        )
+        .unwrap()
+    });
+
+    CREDIT_FILE_REFERENCE_NOTE_RE.is_match(s.trim())
+}
+
+fn looks_like_document_form_reference(s: &str) -> bool {
+    static DOCUMENT_FORM_REFERENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?:copyright\s+)?office\s+[A-Z]{1,6}-\d{1,6}[A-Z]?$")
+            .expect("valid document form reference regex")
+    });
+
+    DOCUMENT_FORM_REFERENCE_RE.is_match(s.trim())
 }
 
 fn strip_trailing_secondary_angle_email_after_comma(s: &str) -> String {
@@ -2064,6 +2126,10 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     h = strip_trailing_single_digit_token(&h);
     h = strip_trailing_period(&h);
     h = h.trim().to_string();
+
+    if looks_like_credit_file_reference_note(&h) || looks_like_document_form_reference(&h) {
+        return None;
+    }
 
     let lower = h.to_lowercase();
     if h.trim_end_matches('.').eq_ignore_ascii_case("YOUR NAME") {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -139,6 +139,14 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
         refine_author("Flutter and Dart have told us they plan to work contributors"),
         None
     );
+    assert_eq!(refine_author("Requires translation"), None);
+    assert_eq!(refine_author("Autor: author"), None);
+    assert_eq!(refine_author("Auctor: author"), None);
+    assert_eq!(refine_author("See AUTHORS file"), None);
+    assert_eq!(
+        refine_author("Author: Jane Doe"),
+        Some("Jane Doe".to_string())
+    );
 }
 
 #[test]
@@ -147,6 +155,16 @@ fn test_refine_holder_discards_symbol_table_run_junk() {
         refine_holder("(r), & 175, & 176, & 177, & 178, & 179, & 180, & 181, & 182, & 183"),
         None
     );
+}
+
+#[test]
+fn test_refine_holder_drops_authors_file_reference_note() {
+    assert_eq!(refine_holder("See AUTHORS file"), None);
+}
+
+#[test]
+fn test_refine_holder_drops_document_form_reference_noise() {
+    assert_eq!(refine_holder("Office FL-108"), None);
 }
 
 // ── strip_some_punct ─────────────────────────────────────────────
@@ -467,6 +485,19 @@ fn test_refine_copyright_keeps_confidential_and_proprietary_phrase() {
         result,
         Some("(c) Example Corp. and affiliates. Confidential and proprietary".to_string())
     );
+}
+
+#[test]
+fn test_refine_copyright_strips_trailing_authors_file_reference_clause() {
+    assert_eq!(
+        refine_copyright("Copyright 2015 See AUTHORS file"),
+        Some("Copyright 2015".to_string())
+    );
+}
+
+#[test]
+fn test_refine_copyright_drops_document_form_reference_noise() {
+    assert_eq!(refine_copyright("Copyright Office FL-108"), None);
 }
 
 #[test]

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -469,19 +469,9 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             && let Some(end) = find_matching_paren(tokens, i + 1)
         {
             let inner = &tokens[i + 2..end];
-            if let Some(Tok::Ident(inner_fn)) = inner.first()
-                && inner_fn == "project"
-                && inner.len() > 1
-                && inner[1] == Tok::OpenParen
-                && let Some(project_end) = find_matching_paren(inner, 1)
-            {
-                let project_tokens = &inner[2..project_end];
-                if let Some(rd) = parse_project_ref(project_tokens, scope_name) {
-                    deps.push(rd);
-                }
-                i = end + 1;
-                continue;
-            }
+            parse_paren_content(scope_name, inner, &mut deps);
+            i = end + 1;
+            continue;
         }
 
         let scope_name = match &tokens[i] {
@@ -2553,7 +2543,7 @@ dependencies {
     }
 
     #[test]
-    fn test_kotlin_quoted_scope_not_extracted() {
+    fn test_kotlin_quoted_scope_string_dependency_extracted() {
         let content = r#"
 dependencies {
     "js"("jquery:jquery:3.2.1@js")
@@ -2561,7 +2551,12 @@ dependencies {
 "#;
         let tokens = lex(content);
         let deps = extract_dependencies(&tokens);
-        assert_eq!(deps.len(), 0);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].scope, Some("js".to_string()));
+        assert_eq!(
+            deps[0].purl,
+            Some("pkg:maven/jquery/jquery@3.2.1%40js".to_string())
+        );
     }
 
     #[test]
@@ -2587,6 +2582,25 @@ subprojects {
                 .and_then(|data| data.get("project_path"))
                 .and_then(|value| value.as_str()),
             Some("utils:test-utils")
+        );
+    }
+
+    #[test]
+    fn test_kotlin_quoted_scope_string_dependency_with_closure_extracted() {
+        let content = r#"
+dependencies {
+    "implementation"("com.badlogicgames.gdx:gdx-tools:1.14.0") {
+        exclude("com.badlogicgames.gdx", "gdx-backend-lwjgl")
+    }
+}
+"#;
+        let tokens = lex(content);
+        let deps = extract_dependencies(&tokens);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].scope, Some("implementation".to_string()));
+        assert_eq!(
+            deps[0].purl,
+            Some("pkg:maven/com.badlogicgames.gdx/gdx-tools@1.14.0".to_string())
         );
     }
 

--- a/src/parsers/gradle_golden_test.rs
+++ b/src/parsers/gradle_golden_test.rs
@@ -202,6 +202,14 @@ mod golden_tests {
     }
 
     #[test]
+    fn test_golden_kotlin_quoted_scope() {
+        run_golden(
+            "testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts",
+            "testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts-expected.json",
+        );
+    }
+
+    #[test]
     fn test_golden_groovy_and_kotlin2() {
         run_golden(
             "testdata/gradle-golden/kotlin/groovy-and-kotlin2/build.gradle.kts",

--- a/src/parsers/windows_executable.rs
+++ b/src/parsers/windows_executable.rs
@@ -14,6 +14,7 @@ use packageurl::PackageUrl;
 use crate::models::{DatasourceId, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
 use crate::register_parser;
+use crate::utils::file::extract_printable_strings;
 
 use super::ParsePackagesResult;
 use super::license_normalization::{
@@ -85,31 +86,34 @@ pub(crate) fn extract_windows_executable_metadata_text(bytes: &[u8]) -> Option<S
         Ok(FileKind::Pe32) => parse_pe_version_info::<pe::ImageNtHeaders32>(bytes),
         Ok(FileKind::Pe64) => parse_pe_version_info::<pe::ImageNtHeaders64>(bytes),
         _ => return None,
-    }?;
+    };
     let fallback_strings = extract_utf16_version_string_fallback(bytes);
+    let security_notice_lines = extract_windows_security_directory_notice_lines(bytes);
 
     let mut lines = Vec::new();
-    for string_table in &parsed.string_tables {
-        for key in [
-            "ProductName",
-            "FileDescription",
-            "CompanyName",
-            "LegalCopyright",
-            "License",
-            "LegalTrademarks",
-            "LegalTrademarks1",
-            "LegalTrademarks2",
-            "LegalTrademarks3",
-            "Comments",
-            "URL",
-            "WWW",
-        ] {
-            if let Some(value) = string_table.get(key).map(|value| value.trim())
-                && !value.is_empty()
-            {
-                let line = format!("{key}: {value}");
-                if !lines.contains(&line) {
-                    lines.push(line);
+    if let Some(parsed) = &parsed {
+        for string_table in &parsed.string_tables {
+            for key in [
+                "ProductName",
+                "FileDescription",
+                "CompanyName",
+                "LegalCopyright",
+                "License",
+                "LegalTrademarks",
+                "LegalTrademarks1",
+                "LegalTrademarks2",
+                "LegalTrademarks3",
+                "Comments",
+                "URL",
+                "WWW",
+            ] {
+                if let Some(value) = string_table.get(key).map(|value| value.trim())
+                    && !value.is_empty()
+                {
+                    let line = format!("{key}: {value}");
+                    if !lines.contains(&line) {
+                        lines.push(line);
+                    }
                 }
             }
         }
@@ -141,14 +145,192 @@ pub(crate) fn extract_windows_executable_metadata_text(bytes: &[u8]) -> Option<S
         }
     }
 
-    if let Some(version) = parsed.fixed.and_then(|fixed| fixed.product_version) {
+    if let Some(version) = parsed
+        .and_then(|fixed| fixed.fixed)
+        .and_then(|fixed| fixed.product_version)
+    {
         let line = format!("ProductVersion: {version}");
         if !lines.contains(&line) {
             lines.push(line);
         }
     }
 
+    for line in security_notice_lines {
+        if !lines.contains(&line) {
+            lines.push(line);
+        }
+    }
+
     (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+fn extract_windows_security_directory_notice_lines(bytes: &[u8]) -> Vec<String> {
+    match FileKind::parse(bytes) {
+        Ok(FileKind::Pe32) => {
+            extract_windows_security_directory_notice_lines_for::<pe::ImageNtHeaders32>(bytes)
+        }
+        Ok(FileKind::Pe64) => {
+            extract_windows_security_directory_notice_lines_for::<pe::ImageNtHeaders64>(bytes)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn extract_windows_security_directory_notice_lines_for<Pe: object::read::pe::ImageNtHeaders>(
+    bytes: &[u8],
+) -> Vec<String> {
+    let Ok(pe) = object::read::pe::PeFile::<Pe>::parse(bytes) else {
+        return Vec::new();
+    };
+    let Some(data_dir) = pe.data_directory(pe::IMAGE_DIRECTORY_ENTRY_SECURITY) else {
+        return Vec::new();
+    };
+    let (offset, size) = data_dir.address_range();
+    let offset = offset as usize;
+    let size = size as usize;
+    if size == 0 {
+        return Vec::new();
+    }
+    let Some(end) = offset.checked_add(size) else {
+        return Vec::new();
+    };
+    let Some(security_bytes) = bytes.get(offset..end) else {
+        return Vec::new();
+    };
+
+    let mut lines = Vec::new();
+    let mut cursor = 0usize;
+    let mut count = 0usize;
+    while cursor + 8 <= security_bytes.len() && count < MAX_ITERATION_COUNT {
+        count += 1;
+        let length = u32::from_le_bytes([
+            security_bytes[cursor],
+            security_bytes[cursor + 1],
+            security_bytes[cursor + 2],
+            security_bytes[cursor + 3],
+        ]) as usize;
+        if length < 8 {
+            break;
+        }
+        let Some(blob) = security_bytes.get(cursor + 8..cursor + length) else {
+            break;
+        };
+        collect_security_directory_notice_lines(blob, &mut lines);
+        cursor += (length + 7) & !7;
+    }
+
+    if lines.is_empty() {
+        collect_security_directory_notice_lines(security_bytes, &mut lines);
+    }
+
+    lines
+}
+
+fn collect_security_directory_notice_lines(bytes: &[u8], lines: &mut Vec<String>) {
+    for candidate in [
+        extract_printable_strings(bytes),
+        extract_relaxed_ascii_text(bytes),
+        extract_relaxed_utf16_text(bytes, true),
+        extract_relaxed_utf16_text(bytes, false),
+    ] {
+        for line in extract_legal_notice_sentences(&candidate) {
+            if !lines.contains(&line) {
+                lines.push(line);
+            }
+        }
+    }
+}
+
+fn extract_relaxed_ascii_text(bytes: &[u8]) -> String {
+    let mut text = String::with_capacity(bytes.len());
+    let mut pending_space = false;
+    for &byte in bytes {
+        if matches!(byte, 0x20..=0x7e) {
+            if pending_space && !text.is_empty() && !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push(byte as char);
+            pending_space = false;
+        } else if !text.is_empty() {
+            pending_space = true;
+        }
+    }
+    text
+}
+
+fn extract_relaxed_utf16_text(bytes: &[u8], little_endian: bool) -> String {
+    let units = bytes
+        .chunks_exact(2)
+        .map(|chunk| {
+            if little_endian {
+                u16::from_le_bytes([chunk[0], chunk[1]])
+            } else {
+                u16::from_be_bytes([chunk[0], chunk[1]])
+            }
+        })
+        .collect::<Vec<_>>();
+    let decoded = String::from_utf16_lossy(&units);
+    let mut text = String::with_capacity(decoded.len());
+    let mut pending_space = false;
+    for ch in decoded.chars() {
+        if ch.is_ascii_graphic() || ch == ' ' {
+            if pending_space && !text.is_empty() && !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push(ch);
+            pending_space = false;
+        } else if !text.is_empty() {
+            pending_space = true;
+        }
+    }
+    text
+}
+
+fn extract_legal_notice_sentences(text: &str) -> Vec<String> {
+    fn looks_like_legal_notice(sentence: &str) -> bool {
+        let lower = sentence.to_ascii_lowercase();
+        let word_count = sentence
+            .split_whitespace()
+            .filter(|word| word.chars().any(|ch| ch.is_ascii_alphabetic()))
+            .count();
+        if word_count < 6 {
+            return false;
+        }
+        [
+            "certificate constitutes acceptance",
+            "relying party agreement",
+            "all rights reserved",
+            "rights reserved",
+            "proprietary",
+            "private",
+            "limit liability",
+            "terms and conditions",
+            "licensed under",
+            "license",
+        ]
+        .iter()
+        .any(|marker| lower.contains(marker))
+    }
+
+    let mut sentences = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        current.push(ch);
+        if matches!(ch, '.' | ';') {
+            let sentence = current.split_whitespace().collect::<Vec<_>>().join(" ");
+            let sentence = sentence.trim();
+            if sentence.len() >= 24 && looks_like_legal_notice(sentence) {
+                sentences.push(sentence.to_string());
+            }
+            current.clear();
+        }
+    }
+    let sentence = current.split_whitespace().collect::<Vec<_>>().join(" ");
+    let sentence = sentence.trim();
+    if sentence.len() >= 24 && looks_like_legal_notice(sentence) {
+        sentences.push(sentence.to_string());
+    }
+    sentences
 }
 
 fn parse_windows_executable_bytes(path: &Path, bytes: &[u8]) -> Vec<PackageData> {
@@ -876,6 +1058,7 @@ mod tests {
 
     use super::{
         FixedVersionInfo, ParsedVersionInfo, build_windows_executable_package, decode_utf16_bytes,
+        extract_legal_notice_sentences, extract_relaxed_utf16_text,
         extract_utf16_version_string_fallback, extract_windows_executable_metadata_text,
         merge_parsed_version_infos, parse_fixed_version_info, parse_version_info_bytes,
         preferred_windows_version_strings_with_fallback, read_u32_le,
@@ -946,6 +1129,85 @@ mod tests {
             text.contains("License: This program is free software"),
             "{text}"
         );
+    }
+
+    #[test]
+    fn extracts_legal_notice_sentences_from_relaxed_utf16_text() {
+        let notice = "use of this Certificate constitutes acceptance of the DigiCert CP/CPS and the Relying Party Agreement which limit liability and are incorporated herein by reference.";
+        let bytes = notice
+            .encode_utf16()
+            .flat_map(|unit| unit.to_le_bytes())
+            .collect::<Vec<_>>();
+
+        let text = extract_relaxed_utf16_text(&bytes, true);
+        let lines = extract_legal_notice_sentences(&text);
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("DigiCert CP/CPS")
+                    && line.contains("Relying Party Agreement")),
+            "lines={lines:?}"
+        );
+    }
+
+    #[test]
+    fn extracts_windows_executable_metadata_text_from_security_directory_notice() {
+        let phrase = "use of this Certificate constitutes acceptance of the DigiCert CP/CPS and the Relying Party Agreement which limit liability and are incorporated herein by reference.";
+        let cert_payload = phrase
+            .encode_utf16()
+            .flat_map(|unit| unit.to_le_bytes())
+            .collect::<Vec<_>>();
+        let cert_len = (8 + cert_payload.len()) as u32;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&cert_len.to_le_bytes());
+        bytes.extend_from_slice(&0x0200u16.to_le_bytes());
+        bytes.extend_from_slice(&0x0002u16.to_le_bytes());
+        bytes.extend_from_slice(&cert_payload);
+
+        let mut aligned = bytes.clone();
+        while !aligned.len().is_multiple_of(8) {
+            aligned.push(0);
+        }
+
+        let offset = 0x200usize;
+        let size = aligned.len();
+        let optional_header_size = 224usize;
+        let pe_header_offset = 0x80usize;
+        let nt_headers_offset = pe_header_offset + 4;
+        let optional_header_offset = nt_headers_offset + 20;
+        let data_directory_offset = optional_header_offset + 96;
+        let security_directory_offset =
+            data_directory_offset + pe::IMAGE_DIRECTORY_ENTRY_SECURITY * 8;
+        let total_len = offset + size;
+        let mut pe_bytes = vec![0u8; total_len];
+
+        pe_bytes[0..2].copy_from_slice(b"MZ");
+        pe_bytes[0x3c..0x40].copy_from_slice(&(pe_header_offset as u32).to_le_bytes());
+        pe_bytes[pe_header_offset..pe_header_offset + 4].copy_from_slice(b"PE\0\0");
+
+        pe_bytes[nt_headers_offset..nt_headers_offset + 2]
+            .copy_from_slice(&0x014cu16.to_le_bytes());
+        pe_bytes[nt_headers_offset + 16..nt_headers_offset + 18]
+            .copy_from_slice(&(optional_header_size as u16).to_le_bytes());
+
+        pe_bytes[optional_header_offset..optional_header_offset + 2]
+            .copy_from_slice(&0x010bu16.to_le_bytes());
+        pe_bytes[optional_header_offset + 92..optional_header_offset + 96]
+            .copy_from_slice(&16u32.to_le_bytes());
+        pe_bytes[security_directory_offset..security_directory_offset + 4]
+            .copy_from_slice(&(offset as u32).to_le_bytes());
+        pe_bytes[security_directory_offset + 4..security_directory_offset + 8]
+            .copy_from_slice(&(size as u32).to_le_bytes());
+        pe_bytes[offset..offset + size].copy_from_slice(&aligned);
+
+        let text =
+            extract_windows_executable_metadata_text(&pe_bytes).expect("security metadata text");
+        assert!(
+            text.contains("use of this Certificate constitutes acceptance"),
+            "{text}"
+        );
+        assert!(text.contains("DigiCert CP/CPS"), "{text}");
     }
 
     #[test]

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -122,6 +122,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use object::pe;
     use tempfile::TempDir;
 
     use crate::cache::build_collection_exclude_patterns;
@@ -1696,6 +1697,94 @@ mod tests {
                 }),
             "license expression: {:?}",
             scanned.license_expression
+        );
+    }
+
+    #[test]
+    fn scanner_detects_license_from_windows_executable_security_notice() {
+        fn synthetic_pe_with_security_notice(notice: &str) -> Vec<u8> {
+            let cert_payload = notice
+                .encode_utf16()
+                .flat_map(|unit| unit.to_le_bytes())
+                .collect::<Vec<_>>();
+            let cert_len = (8 + cert_payload.len()) as u32;
+            let mut cert = Vec::new();
+            cert.extend_from_slice(&cert_len.to_le_bytes());
+            cert.extend_from_slice(&0x0200u16.to_le_bytes());
+            cert.extend_from_slice(&0x0002u16.to_le_bytes());
+            cert.extend_from_slice(&cert_payload);
+            while !cert.len().is_multiple_of(8) {
+                cert.push(0);
+            }
+
+            let offset = 0x200usize;
+            let size = cert.len();
+            let optional_header_size = 224usize;
+            let pe_header_offset = 0x80usize;
+            let nt_headers_offset = pe_header_offset + 4;
+            let optional_header_offset = nt_headers_offset + 20;
+            let data_directory_offset = optional_header_offset + 96;
+            let security_directory_offset =
+                data_directory_offset + pe::IMAGE_DIRECTORY_ENTRY_SECURITY * 8;
+            let total_len = offset + size;
+            let mut bytes = vec![0u8; total_len];
+
+            bytes[0..2].copy_from_slice(b"MZ");
+            bytes[0x3c..0x40].copy_from_slice(&(pe_header_offset as u32).to_le_bytes());
+            bytes[pe_header_offset..pe_header_offset + 4].copy_from_slice(b"PE\0\0");
+
+            bytes[nt_headers_offset..nt_headers_offset + 2]
+                .copy_from_slice(&0x014cu16.to_le_bytes());
+            bytes[nt_headers_offset + 16..nt_headers_offset + 18]
+                .copy_from_slice(&(optional_header_size as u16).to_le_bytes());
+
+            bytes[optional_header_offset..optional_header_offset + 2]
+                .copy_from_slice(&0x010bu16.to_le_bytes());
+            bytes[optional_header_offset + 92..optional_header_offset + 96]
+                .copy_from_slice(&16u32.to_le_bytes());
+            bytes[security_directory_offset..security_directory_offset + 4]
+                .copy_from_slice(&(offset as u32).to_le_bytes());
+            bytes[security_directory_offset + 4..security_directory_offset + 8]
+                .copy_from_slice(&(size as u32).to_le_bytes());
+            bytes[offset..offset + size].copy_from_slice(&cert);
+
+            bytes
+        }
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let file_path = temp_dir.path().join("signed.dll");
+        let fixture = synthetic_pe_with_security_notice(
+            "use of this Certificate constitutes acceptance of the DigiCert CP/CPS and the Relying Party Agreement which limit liability and are incorporated herein by reference.",
+        );
+        fs::write(&file_path, fixture).expect("write PE fixture");
+
+        let progress = Arc::new(ScanProgress::new(ProgressMode::Quiet));
+        let collected = collect_paths(temp_dir.path(), 0, &[]);
+        let engine =
+            Arc::new(LicenseDetectionEngine::from_embedded().expect("initialize license engine"));
+        let result = process_collected(
+            &collected,
+            progress,
+            Some(engine),
+            LicenseScanOptions::default(),
+            &TextDetectionOptions::default(),
+        );
+        let scanned = result
+            .files
+            .into_iter()
+            .find(|entry| {
+                entry.file_type == FileType::File && entry.path == file_path.to_string_lossy()
+            })
+            .expect("scanned file entry");
+
+        assert!(
+            scanned
+                .license_expression
+                .as_deref()
+                .is_some_and(|expression| expression.contains("proprietary-license")),
+            "license expression: {:?}, detections: {:#?}",
+            scanned.license_expression,
+            scanned.license_detections
         );
     }
 

--- a/testdata/gradle-golden/README.md
+++ b/testdata/gradle-golden/README.md
@@ -47,13 +47,19 @@ The current Rust implementation uses a custom token-based parser and supports th
    "testImplementation"(project(":utils:test-utils"))
    ```
 
-7. **Limited malformed-string recovery**:
+7. **Quoted Kotlin DSL configuration names**:
+
+   ```kotlin
+   "implementation"("io.ktor:ktor-client-core:$ktorVersion")
+   ```
+
+8. **Limited malformed-string recovery**:
 
    ```groovy
    implementation "com.fasterxml.jackson:jackson-bom:2.12.2'
    ```
 
-8. **Multiple `dependencies {}` blocks in one build file**:
+9. **Multiple `dependencies {}` blocks in one build file**:
 
    ```groovy
    dependencies {
@@ -101,7 +107,7 @@ The Python ScanCode Toolkit implementation uses **pygmars** (a token-based parse
 
 - No parser-only Gradle goldens remain ignored.
 - The cleanup now exercises `groovy4`, `groovy-no-parens`, `kotlin2`, and `end2end` directly instead of masking them behind `#[ignore]`.
-- Additional parser goldens now cover TOML-backed version catalog alias resolution, committed `buildSrc` Kotlin constant resolution, and Gradle POM license metadata extraction.
+- Additional parser goldens now cover TOML-backed version catalog alias resolution, committed `buildSrc` Kotlin constant resolution, Kotlin DSL quoted configuration names, and Gradle POM license metadata extraction.
 - Remaining failures, if any, should now represent real parser regressions rather than deferred fixtures.
 
 ## Path Forward: Full Feature Parity

--- a/testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json
+++ b/testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json
@@ -4,7 +4,7 @@
     "namespace": null,
     "name": null,
     "version": null,
-    "qualifiers": {},
+    "qualifiers": null,
     "subpath": null,
     "primary_language": null,
     "description": null,
@@ -33,9 +33,23 @@
           {
             "license_expression": "apache-2.0",
             "license_expression_spdx": "Apache-2.0",
-            "score": 100.0
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 6,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "apache-2.0_required_phrase_11.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_required_phrase_11.RULE",
+            "matched_text": "- license:\n    name: Apache-2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0\n",
+            "matched_text_diagnostics": null,
+            "referenced_filenames": null
           }
-        ]
+        ],
+        "detection_log": [],
+        "identifier": null
       }
     ],
     "other_license_expression": null,
@@ -47,7 +61,7 @@
     "file_references": [],
     "is_private": false,
     "is_virtual": false,
-    "extra_data": {},
+    "extra_data": null,
     "dependencies": [
       {
         "purl": "pkg:maven/org.eclipse.jgit/org.eclipse.jgit@%24jgitVersion",
@@ -57,8 +71,8 @@
         "is_optional": false,
         "is_pinned": true,
         "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "resolved_package": null,
+        "extra_data": null
       },
       {
         "purl": "pkg:maven/detekt-rules",
@@ -68,8 +82,21 @@
         "is_optional": false,
         "is_pinned": false,
         "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "resolved_package": null,
+        "extra_data": {
+          "project_path": "detekt-rules"
+        }
+      },
+      {
+        "purl": "pkg:maven/io.gitlab.arturbosch.detekt/detekt-formatting@%24detektPluginVersion",
+        "extracted_requirement": "$detektPluginVersion",
+        "scope": "detektPlugins",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
       },
       {
         "purl": "pkg:maven/utils/test-utils",
@@ -79,8 +106,32 @@
         "is_optional": true,
         "is_pinned": false,
         "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "resolved_package": null,
+        "extra_data": {
+          "project_path": "utils:test-utils"
+        }
+      },
+      {
+        "purl": "pkg:maven/io.kotest/kotest-runner-junit5@%24kotestVersion",
+        "extracted_requirement": "$kotestVersion",
+        "scope": "testImplementation",
+        "is_runtime": false,
+        "is_optional": true,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
+      },
+      {
+        "purl": "pkg:maven/io.kotest/kotest-assertions-core@%24kotestVersion",
+        "extracted_requirement": "$kotestVersion",
+        "scope": "testImplementation",
+        "is_runtime": false,
+        "is_optional": true,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
       },
       {
         "purl": "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8@%24kotlinPluginVersion",
@@ -90,8 +141,8 @@
         "is_optional": false,
         "is_pinned": true,
         "is_direct": true,
-        "resolved_package": {},
-        "extra_data": {}
+        "resolved_package": null,
+        "extra_data": null
       }
     ],
     "repository_homepage_url": null,

--- a/testdata/gradle-golden/kotlin/kotlin5/build.gradle.kts-expected.json
+++ b/testdata/gradle-golden/kotlin/kotlin5/build.gradle.kts-expected.json
@@ -4,7 +4,7 @@
     "namespace": null,
     "name": null,
     "version": null,
-    "qualifiers": {},
+    "qualifiers": null,
     "subpath": null,
     "primary_language": null,
     "description": null,
@@ -35,8 +35,20 @@
     "file_references": [],
     "is_private": false,
     "is_virtual": false,
-    "extra_data": {},
-    "dependencies": [],
+    "extra_data": null,
+    "dependencies": [
+      {
+        "purl": "pkg:maven/jquery/jquery@3.2.1%40js",
+        "extracted_requirement": "3.2.1@js",
+        "scope": "js",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
+      }
+    ],
     "repository_homepage_url": null,
     "repository_download_url": null,
     "api_data_url": null,

--- a/testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts
+++ b/testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts
@@ -1,0 +1,11 @@
+val ktorVersion: String by project
+
+dependencies {
+    "implementation"("io.ktor:ktor-client-core:$ktorVersion")
+
+    "implementation"("com.badlogicgames.gdx:gdx-tools:1.14.0") {
+        exclude("com.badlogicgames.gdx", "gdx-backend-lwjgl")
+    }
+
+    "testImplementation"(project(":utils:test-utils"))
+}

--- a/testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts-expected.json
+++ b/testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts-expected.json
@@ -1,0 +1,82 @@
+[
+  {
+    "type": "maven",
+    "namespace": null,
+    "name": null,
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "primary_language": null,
+    "description": null,
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": null,
+    "dependencies": [
+      {
+        "purl": "pkg:maven/io.ktor/ktor-client-core@2.3.10",
+        "extracted_requirement": "2.3.10",
+        "scope": "implementation",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
+      },
+      {
+        "purl": "pkg:maven/com.badlogicgames.gdx/gdx-tools@1.14.0",
+        "extracted_requirement": "1.14.0",
+        "scope": "implementation",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": true,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": null
+      },
+      {
+        "purl": "pkg:maven/utils/test-utils",
+        "extracted_requirement": "",
+        "scope": "testImplementation",
+        "is_runtime": false,
+        "is_optional": true,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": {
+          "project_path": "utils:test-utils"
+        }
+      }
+    ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "build_gradle",
+    "purl": null
+  }
+]

--- a/testdata/gradle-golden/kotlin/quoted-scope/gradle.properties
+++ b/testdata/gradle-golden/kotlin/quoted-scope/gradle.properties
@@ -1,0 +1,1 @@
+ktorVersion=2.3.10


### PR DESCRIPTION
## Summary

- support Kotlin DSL quoted configuration calls like `\"implementation\"(\"group:artifact:$version\")` in the Gradle parser, add dedicated golden coverage for quoted-scope fixtures, and document the new behavior in the Gradle parser docs
- trim reusable author/holder/copyright noise buckets surfaced by the Unciv compare run, including translation placeholders such as `Requires translation` / `Autor: author`, `See AUTHORS file` reference notes, and `Office FL-108` document-form noise
- recover signed Windows PE certificate notice text for license scanning so the bundled Discord RPC DLLs now surface proprietary-license detections, and record `yairm210/Unciv @ d54f33c` in `docs/BENCHMARKS.md` with the regenerated benchmark chart

## Issues

- Covers: Unciv verification follow-up from `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md`
- Closes:

## Scope and exclusions

- Included:
  - `src/parsers/gradle.rs`, `src/parsers/gradle_golden_test.rs`, and Gradle golden fixtures for quoted Kotlin DSL configuration names, including refreshed `kotlin2` / `kotlin5` expectations that were causing parser-golden CI drift
  - `src/copyright/refiner/author.rs`, `src/copyright/refiner/mod.rs`, and `src/copyright/refiner/tests.rs` for bounded placeholder/reference/document-noise cleanup
  - `src/parsers/windows_executable.rs` and `src/scanner/mod.rs` for signed PE security-directory notice extraction plus focused synthetic regression tests
  - `docs/improvements/gradle-parser.md`, `testdata/gradle-golden/README.md`, `docs/BENCHMARKS.md`, and `docs/benchmarks/scan-duration-vs-files.svg`
- Explicit exclusions:
  - no cross-file Gradle/root-`LICENSE` package-license backfill to match ScanCode's extra top-level `MPL-2.0` count on `build.gradle.kts`
  - no attempt to suppress the remaining `Mercantile City-States...` translation-fragment author noise or recover the missing real credit lines in `docs/Credits.md`
  - no further count-shape parity work for duplicated proprietary detections where ScanCode splits two certificate matches and Provenant merges them into one detection object with two matches

## Intentional differences from Python

- Provenant now prefers dropping obvious translation placeholders and file-reference/document-form noise from author/holder/copyright output instead of preserving those strings as if they were real attributions.
- It now extracts legal-notice prose from signed Windows PE security directories for license scanning, but it still does not mirror ScanCode's heuristic attribution of the repo `LICENSE` onto the root `build.gradle.kts` package metadata.

## Follow-up work

- Created or intentionally deferred:
  - deferred: decide separately whether the ScanCode-only `build.gradle.kts` `MPL-2.0` package-license shaping is worth a general post-processing heuristic
  - deferred: evaluate broader translation-fragment/real-credits cleanup after the low-risk placeholder/reference buckets in this PR
  - deferred: consider whether repeated identical PE certificate notices should stay merged into one detection with multiple matches or be split to mirror ScanCode's per-file count shape more closely

## Expected-output fixture changes

- Files changed: `testdata/gradle-golden/kotlin/quoted-scope/build.gradle.kts-expected.json`, `testdata/gradle-golden/kotlin/kotlin2/build.gradle.kts-expected.json`, `testdata/gradle-golden/kotlin/kotlin5/build.gradle.kts-expected.json`
- Why the new expected output is correct:
  - the Gradle parser now handles quoted Kotlin DSL configuration names the same way it handles unquoted scopes, so quoted calls, quoted `project(\":...\")` references, and quoted calls with trailing exclusion closures now produce real dependency records instead of being dropped