### PR TITLE
fix(copyright): handle curl holder and author edge cases

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -574,11 +574,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `31.31s`; ScanCode `533.84s`
 - Matched Go package coverage (`2` vs `2`) with slightly richer dependency extraction (`652` vs `651`) from vendored `mkdocs-reqs.txt` and committed Python sidecar requirements, while preserving Go module inventory parity on the root `go.mod` and `go.sum` surfaces
 
-##### [curl/curl @ 40d57c9](https://github.com/curl/curl/tree/40d57c9f588c42ed3f75fe0ba9b12aa18170a404) — **10.57× faster**
+##### [curl/curl @ 2bb5c9b](https://github.com/curl/curl/tree/2bb5c9b5552d37f08a439f2bec400009321d325c) — **14.87× faster**
 
-- Files: 4,195
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `23.00s`; ScanCode `243.12s`
+- Files: 4,266
+- Run context: 2026-04-30 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `40.75s`; ScanCode `606.05s`
 - Matched ScanCode's file-level Autotools `configure.ac` coverage while promoting one top-level Autotools package (`1` vs `0`), with the real `pkg:autotools/curl` identity instead of a generic input placeholder, plus extra Docker package and dependency visibility from the committed `Dockerfile`
 
 ##### [Debian/apt @ 6b12812](https://github.com/Debian/apt/tree/6b128124271e94bdb0f4e7850d9286170d712b04) — **15.11× faster**

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -449,9 +449,9 @@ ScanCode: 446.79s</title></rect>
     <rect x="664.50" y="341.57" width="8" height="8" fill="#d97706" rx="1.5"><title>yairm210/Unciv @ d54f33c
 Files: 4057
 ScanCode: 429.19s</title></rect>
-    <rect x="666.81" y="368.42" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 40d57c9
-Files: 4195
-ScanCode: 243.12s</title></rect>
+    <rect x="667.96" y="325.26" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
+Files: 4266
+ScanCode: 606.05s</title></rect>
     <rect x="668.53" y="283.27" width="8" height="8" fill="#d97706" rx="1.5"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
 ScanCode: 1473.92s</title></rect>
@@ -1003,9 +1003,9 @@ Provenant: 23.74s</title></circle>
     <circle cx="668.50" cy="486.03" r="4.5" fill="#2563eb"><title>yairm210/Unciv @ d54f33c
 Files: 4057
 Provenant: 21.96s</title></circle>
-    <circle cx="670.81" cy="483.84" r="4.5" fill="#2563eb"><title>curl/curl @ 40d57c9
-Files: 4195
-Provenant: 23.00s</title></circle>
+    <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
+Files: 4266
+Provenant: 40.75s</title></circle>
     <circle cx="672.53" cy="425.98" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
 Provenant: 78.26s</title></circle>

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -300,7 +300,7 @@ pub fn extract_lowercase_username_angle_email_copyrights(
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static USER_EMAIL_COPYRIGHT_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"^[Cc]opyright\s*(?:\([Cc]\)\s*)?(19\d{2}|20\d{2})\s+([a-z0-9][a-z0-9_\-]{2,63})\s*<\s*([^>\s]+@[^>\s]+)\s*>\s*[\.,;:]*\s*$",
+            r"^[Cc]opyright\s*(?:\([Cc]\)\s*)?(?:(19\d{2}|20\d{2})\s+)?([a-z0-9][a-z0-9_\-]{2,63})\s*(,?)\s*<\s*([^>\s]+@[^>\s]+)\s*>\s*[\.,;:]*\s*$",
         )
         .unwrap()
     });
@@ -317,12 +317,18 @@ pub fn extract_lowercase_username_angle_email_copyrights(
 
             let year = cap.get(1).map(|m| m.as_str()).unwrap_or("").trim();
             let user = cap.get(2).map(|m| m.as_str()).unwrap_or("").trim();
-            let email = cap.get(3).map(|m| m.as_str()).unwrap_or("").trim();
-            if year.is_empty() || user.is_empty() || email.is_empty() {
+            let comma = cap.get(3).map(|m| m.as_str()).unwrap_or("").trim();
+            let email = cap.get(4).map(|m| m.as_str()).unwrap_or("").trim();
+            if user.is_empty() || email.is_empty() {
                 continue;
             }
 
-            let cr_raw = format!("Copyright (c) {year} {user} <{email}>");
+            let separator = if comma == "," { "," } else { "" };
+            let cr_raw = if year.is_empty() {
+                format!("Copyright (c) {user}{separator} <{email}>")
+            } else {
+                format!("Copyright (c) {year} {user}{separator} <{email}>")
+            };
             if let Some(cr) = refine_copyright(&cr_raw) {
                 copyrights.push(CopyrightDetection {
                     copyright: cr,
@@ -347,7 +353,7 @@ pub fn extract_lowercase_username_paren_email_copyrights(
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
     static USER_EMAIL_PARENS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"\b[Cc]opyright\s*(?:\([Cc]\)\s*)?(19\d{2}|20\d{2})\s+([a-z0-9][a-z0-9_\-]{2,63})\s*\(\s*([^\)\s]+@[^\)\s]+)\s*\)",
+            r"\b[Cc]opyright\s*(?:\([Cc]\)\s*)?(?:(19\d{2}|20\d{2})\s+)?([a-z0-9][a-z0-9_\-]{2,63})\s*\(\s*([^\)\s]+@[^\)\s]+)\s*\)",
         )
         .unwrap()
     });
@@ -361,11 +367,15 @@ pub fn extract_lowercase_username_paren_email_copyrights(
                 let year = cap.get(1).map(|m| m.as_str()).unwrap_or("").trim();
                 let user = cap.get(2).map(|m| m.as_str()).unwrap_or("").trim();
                 let email = cap.get(3).map(|m| m.as_str()).unwrap_or("").trim();
-                if year.is_empty() || user.is_empty() || email.is_empty() {
+                if user.is_empty() || email.is_empty() {
                     continue;
                 }
 
-                let cr_raw = format!("copyright {year} {user} ({email})");
+                let cr_raw = if year.is_empty() {
+                    format!("copyright {user} ({email})")
+                } else {
+                    format!("copyright {year} {user} ({email})")
+                };
                 if let Some(cr) = refine_copyright(&cr_raw) {
                     copyrights.push(CopyrightDetection {
                         copyright: cr,

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -122,6 +122,27 @@ fn test_dash_obfuscated_email_is_kept_in_copyright() {
 }
 
 #[test]
+fn test_lowercase_username_angle_email_copyright_without_year_is_extracted() {
+    let input = "Copyright (C) kpcyrd, <kpcyrd@archlinux.org>\n";
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights.iter().any(|c| {
+            c.copyright == "Copyright (c) kpcyrd, <kpcyrd@archlinux.org>"
+                || c.copyright == "Copyright (C) kpcyrd, <kpcyrd@archlinux.org>"
+        }),
+        "copyrights: {:?}",
+        copyrights.iter().map(|c| &c.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "kpcyrd"),
+        "holders: {:?}",
+        holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_trailing_copy_year_suffix_is_kept() {
     let input = "Copyright base-x contributors (c) 2016";
 

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -24,6 +24,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_initials_before_angle_email(&a);
     a = normalize_obfuscated_angle_contact(&a);
     a = strip_trailing_comma_year_after_angle_email(&a);
+    a = strip_trailing_comma_year(&a);
     a = strip_trailing_comma_month_year(&a);
     a = strip_trailing_comma_email_matching_name(&a);
     a = strip_trailing_comma_and(&a);
@@ -31,6 +32,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_caller_specificaly_clause(&a);
     a = truncate_json_metadata_tail(&a);
     a = truncate_distribution_metadata_tail(&a);
+    a = truncate_better_known_as_clause(&a);
     a = normalize_slash_spacing(&a);
     a = normalize_slash_author_pairs(&a);
     a = strip_trailing_status_works(&a);
@@ -721,6 +723,19 @@ fn strip_trailing_comma_year_after_angle_email(s: &str) -> String {
     s.to_string()
 }
 
+fn strip_trailing_comma_year(s: &str) -> String {
+    static COMMA_YEAR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^(?P<prefix>.+?),\s*(?P<year>19\d{2}|20\d{2})\s*$").unwrap());
+    let trimmed = s.trim();
+    if let Some(cap) = COMMA_YEAR_RE.captures(trimmed) {
+        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+        if !prefix.is_empty() && prefix.chars().any(|ch| ch.is_alphabetic()) {
+            return prefix.to_string();
+        }
+    }
+    s.to_string()
+}
+
 fn strip_trailing_comma_month_year(s: &str) -> String {
     static COMMA_MM_YYYY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^(?P<prefix>.+),\s*\d{1,2}/\d{4}\s*$").unwrap());
@@ -800,6 +815,19 @@ fn truncate_branched_from_clause(s: &str) -> String {
         LazyLock::new(|| Regex::new(r"(?i)^(?P<prefix>.+?)\s+Branched\s+from\b.*$").unwrap());
     let trimmed = s.trim();
     if let Some(cap) = BRANCHED_RE.captures(trimmed) {
+        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+        if !prefix.is_empty() {
+            return prefix.to_string();
+        }
+    }
+    s.to_string()
+}
+
+fn truncate_better_known_as_clause(s: &str) -> String {
+    static BETTER_KNOWN_AS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^(?P<prefix>.+?),\s*better\s+known\s+as\b.*$").unwrap());
+    let trimmed = s.trim();
+    if let Some(cap) = BETTER_KNOWN_AS_RE.captures(trimmed) {
         let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
         if !prefix.is_empty() {
             return prefix.to_string();

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -727,6 +727,9 @@ fn strip_trailing_comma_year(s: &str) -> String {
     static COMMA_YEAR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^(?P<prefix>.+?),\s*(?P<year>19\d{2}|20\d{2})\s*$").unwrap());
     let trimmed = s.trim();
+    if looks_like_markup_data_identifier(trimmed) {
+        return s.to_string();
+    }
     if let Some(cap) = COMMA_YEAR_RE.captures(trimmed) {
         let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
         if !prefix.is_empty() && prefix.chars().any(|ch| ch.is_alphabetic()) {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1430,6 +1430,19 @@ fn test_refine_author_keeps_obfuscated_angle_contact_author() {
 }
 
 #[test]
+fn test_refine_author_strips_trailing_comma_year() {
+    let result = refine_author("Paul Vixie, 1996");
+    assert_eq!(result, Some("Paul Vixie".to_string()));
+}
+
+#[test]
+fn test_refine_author_strips_better_known_as_clause() {
+    let result =
+        refine_author("Alexander Peslyak, better known as Solar Designer <solar at openwall.com>");
+    assert_eq!(result, Some("Alexander Peslyak".to_string()));
+}
+
+#[test]
 fn test_refine_author_strips_distribution_metadata_tails() {
     assert_eq!(
         refine_author("Armin Ronacher Author-email armin.ronacher@active-4.com"),


### PR DESCRIPTION
## Summary

- detect yearless lowercase copyright holder lines so curl headers such as `lib/vtls/rustls.c` keep the `kpcyrd` copyright and holder entries
- trim noisy author suffixes like trailing `, 1996` years and `better known as ...` aliases, with focused regression coverage for the refiner changes
- refresh the maintained curl benchmark snapshot and generated chart from compare run `.provenant/compare-runs/20260430T141953Z-curl-97313/`

## Issues

- Covers: curl benchmark verification and copyright/author parity cleanup for the maintained `docs/BENCHMARKS.md` curl row

## Scope and exclusions

- Included: shared copyright detector/refiner fixes, targeted regression tests, and the updated curl benchmark row plus regenerated benchmark SVG
- Explicit exclusions: no parser golden fixtures or copyright golden YAML expectations changed; no attempt to replace the maintained benchmark timing with later variable local reruns

## Intentional differences from Python

- none intended beyond the existing Rust-owned cleanup where Provenant keeps cleaner author values instead of retaining trailing year or alias noise

## Follow-up work

- Created or intentionally deferred: investigate local timing variance from later curl reruns (`20260430T144251Z-curl-30855` and `20260430T144600Z-curl-35416`) before updating the maintained benchmark snapshot again

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: the targeted author and holder golden suites passed unchanged, so the shared heuristic fixes improved the curl compare artifacts without requiring fixture updates