### PR TITLE
fix(verification): close react-i18next compare gaps

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 185 of 185 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 186 of 186 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -869,6 +869,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `37.11s`; ScanCode `849.94s`
 - Far broader Dart/Flutter monorepo package and dependency extraction (`293` vs `201` packages, `2087` vs `1167` dependencies) from many package and example `pubspec.yaml` manifests plus committed podspec and Android `build.gradle.kts` inputs, with contributor-roster visibility across `AUTHORS` files that ScanCode leaves empty
+
+##### [i18next/react-i18next @ cb20d18](https://github.com/i18next/react-i18next/tree/cb20d1886bbb113f8005c4324e962e161a449ab9) — **13.77× faster**
+
+- Files: 590
+- Run context: 2026-05-01 · react-i18next-4977 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `14.82s`; ScanCode `204.00s`
+- Broader mixed-surface package and dependency extraction (`17` vs `1` packages, `21579` vs `911` dependencies) across committed example-app `package.json`, React Native CocoaPods `Podfile`, Android `AndroidManifest.xml`, Gemfile, NuGet `packages.config`, and Buck surfaces, with concrete Flipper coordinates where ScanCode preserves `${FLIPPER_VERSION}` placeholders and Unicode-preserving author normalization for `Jan Mühlemann`
 
 ##### [Mantle/Mantle @ 2a8e212](https://github.com/Mantle/Mantle/tree/2a8e2123a3931038179ee06105c9e6ec336b12ea) — **11.03× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -272,6 +272,9 @@ ScanCode: 155.71s</title></rect>
     <rect x="529.99" y="373.16" width="8" height="8" fill="#d97706" rx="1.5"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 ScanCode: 219.94s</title></rect>
+    <rect x="531.64" y="376.71" width="8" height="8" fill="#d97706" rx="1.5"><title>i18next/react-i18next @ cb20d18
+Files: 590
+ScanCode: 204.00s</title></rect>
     <rect x="532.45" y="403.78" width="8" height="8" fill="#d97706" rx="1.5"><title>Windows 10 KB5050109 servicing stack update extracted snapshot
 Files: 597
 ScanCode: 115.03s</title></rect>
@@ -829,6 +832,9 @@ Provenant: 13.32s</title></circle>
     <circle cx="533.99" cy="505.42" r="4.5" fill="#2563eb"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 Provenant: 14.57s</title></circle>
+    <circle cx="535.64" cy="504.61" r="4.5" fill="#2563eb"><title>i18next/react-i18next @ cb20d18
+Files: 590
+Provenant: 14.82s</title></circle>
     <circle cx="536.45" cy="513.77" r="4.5" fill="#2563eb"><title>Windows 10 KB5050109 servicing stack update extracted snapshot
 Files: 597
 Provenant: 12.21s</title></circle>

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -293,6 +293,12 @@ pub fn detect_copyrights_from_text_with_deadline(
         extend_leading_dash_suffixes(group, &mut copyrights[..], &mut holders[..]);
         extend_dash_obfuscated_email_suffixes(&raw_lines, group, &mut copyrights[..], &holders[..]);
         extend_trailing_copy_year_suffixes(&raw_lines, group, &mut copyrights[..]);
+        extend_trailing_lowercase_holder_suffixes(
+            &raw_lines,
+            group,
+            &mut copyrights[..],
+            &mut holders,
+        );
         extend_w3c_registered_org_list_suffixes(group, &mut copyrights[..], &mut holders[..]);
         extend_software_in_the_public_interest_holder(group, &mut copyrights, &mut holders);
     }
@@ -394,8 +400,8 @@ use postprocess_transforms::{
     extend_authors_see_url_copyrights, extend_dash_obfuscated_email_suffixes,
     extend_leading_dash_suffixes, extend_multiline_copyright_c_no_year_names,
     extend_multiline_copyright_c_year_holder_continuations, extend_trailing_copy_year_suffixes,
-    extend_w3c_registered_org_list_suffixes, refine_final_copyrights,
-    restore_linux_foundation_copyrights_from_raw_lines,
+    extend_trailing_lowercase_holder_suffixes, extend_w3c_registered_org_list_suffixes,
+    refine_final_copyrights, restore_linux_foundation_copyrights_from_raw_lines,
 };
 pub(super) use token_utils::collect_all_leaves;
 use token_utils::{

--- a/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
@@ -1242,6 +1242,68 @@ pub fn extend_trailing_copy_year_suffixes(
     }
 }
 
+pub fn extend_trailing_lowercase_holder_suffixes(
+    raw_lines: &[&str],
+    group: &[(usize, String)],
+    copyrights: &mut [CopyrightDetection],
+    holders: &mut Vec<HolderDetection>,
+) {
+    static LOWERCASE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)^\s*(?i:copyright)\s*\((?i:c)\)\s*
+            (?P<years>(?:19\d{2}|20\d{2})(?:\s*[-–/]\s*(?:19\d{2}|20\d{2}|\d{2}|present|current_year|today\.year))*)
+            \s+(?P<holder>[a-z][a-z0-9._-]{1,63})
+            \.?\s*$",
+        )
+        .unwrap()
+    });
+
+    for (ln, _) in group {
+        let Some(raw) = raw_lines.get(ln.saturating_sub(1)) else {
+            continue;
+        };
+        let Some(cap) = LOWERCASE_TAIL_RE.captures(raw) else {
+            continue;
+        };
+        let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
+        let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+        if years.is_empty() || holder_raw.is_empty() {
+            continue;
+        }
+
+        let Some(refined_full) = refine_copyright(raw.trim()) else {
+            continue;
+        };
+        let Some(refined_holder) = refine_holder_in_copyright_context(holder_raw) else {
+            continue;
+        };
+
+        for c in copyrights
+            .iter_mut()
+            .filter(|c| c.start_line.get() == *ln && c.end_line.get() == *ln)
+        {
+            if c.copyright == refined_full {
+                continue;
+            }
+            if c.copyright.to_ascii_lowercase().starts_with("copyright")
+                && c.copyright.contains(years)
+            {
+                c.copyright = refined_full.clone();
+            }
+        }
+
+        if !holders.iter().any(|h| {
+            h.start_line.get() == *ln && h.end_line.get() == *ln && h.holder == refined_holder
+        }) {
+            holders.push(HolderDetection {
+                holder: refined_holder.clone(),
+                start_line: LineNumber::new(*ln).expect("invalid line number"),
+                end_line: LineNumber::new(*ln).expect("invalid line number"),
+            });
+        }
+    }
+}
+
 pub fn extend_w3c_registered_org_list_suffixes(
     group: &[(usize, String)],
     copyrights: &mut [CopyrightDetection],

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -242,6 +242,26 @@ fn test_current_year_placeholder_copyright_holder_detected() {
 }
 
 #[test]
+fn test_lowercase_project_name_after_present_year_range_is_kept() {
+    let input = "Copyright (c) 2015-present i18next";
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2015-present i18next"),
+        "copyrights: {:?}",
+        copyrights.iter().map(|c| &c.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "i18next"),
+        "holders: {:?}",
+        holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_copyright_prefix_preserved_multiline_debian() {
     let input = "Copyright:\n\n    Copyright \u{00A9} 1999-2009  Red Hat, Inc.\n    Copyright \u{00A9} 1998       Tom Tromey\n    Copyright \u{00A9} 1999       Free Software Foundation, Inc.";
     let (c, _h, _a) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -508,6 +508,7 @@ fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || trimmed.contains("??")
         || contains_member_access_code_token(trimmed)
         || contains_unicode_escape_token_run(trimmed)
+        || contains_html_entity_decoder_artifact(trimmed)
         || contains_xml_markup_declaration_token(trimmed)
         || contains_regex_or_template_marker(trimmed)
         || has_windows_versioninfo_markers
@@ -570,6 +571,7 @@ fn is_junk_holder_code_fragment(s: &str) -> bool {
         || contains_member_access_code_token(trimmed)
         || contains_code_call_fragment(trimmed)
         || contains_unicode_escape_token_run(trimmed)
+        || contains_html_entity_decoder_artifact(trimmed)
         || contains_xml_markup_declaration_token(trimmed)
         || contains_regex_or_template_marker(trimmed)
         || has_windows_versioninfo_markers
@@ -647,6 +649,21 @@ fn contains_regex_or_template_marker(s: &str) -> bool {
         || trimmed.contains("^ ")
         || trimmed.contains(" d+")
         || trimmed.contains(" ?")
+}
+
+fn contains_html_entity_decoder_artifact(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    lower.contains("u00a0")
+        || lower.contains("hellip")
+        || lower.contains("x2f")
+        || lower.contains("reg 174")
+        || lower.contains("copy 169")
+        || lower.contains("&ndash")
+        || lower.contains("&mdash")
+        || lower.contains("&trade")
+        || lower.contains("&copy")
+        || lower.contains("&#169")
+        || lower.contains("&#174")
 }
 
 fn contains_generated_resource_token(s: &str) -> bool {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1723,6 +1723,11 @@ fn test_refine_copyright_keeps_affiliate_s_parenthetical_phrase() {
 }
 
 #[test]
+fn test_is_junk_copyright_drops_html_entity_regex_fragments() {
+    assert!(is_junk_copyright("(c) 169 reg 174 hellip 8230 x2F 47 /g"));
+}
+
+#[test]
 fn test_refine_copyright_strips_trailing_javadoc_tags() {
     let result = refine_copyright("copyright 2005 Michal Migurski @version 1.0");
     assert_eq!(result, Some("copyright 2005 Michal Migurski".to_string()));

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -439,6 +439,12 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
             );
             break;
         }
+
+        if let Some(next_index) = parse_control_flow_block(tokens, i, &mut deps) {
+            i = next_index;
+            continue;
+        }
+
         // Skip nested blocks (closures like `{ transitive = true }`)
         if tokens[i] == Tok::OpenBrace {
             let mut depth = 1;
@@ -623,6 +629,37 @@ fn parse_block(tokens: &[Tok]) -> Vec<RawDep> {
     }
 
     deps
+}
+
+fn parse_control_flow_block(tokens: &[Tok], start: usize, deps: &mut Vec<RawDep>) -> Option<usize> {
+    let Tok::Ident(keyword) = tokens.get(start)? else {
+        return None;
+    };
+
+    if keyword != "if" && keyword != "else" {
+        return None;
+    }
+
+    let mut block_start = start + 1;
+    if keyword == "if" {
+        if tokens.get(block_start) != Some(&Tok::OpenParen) {
+            return None;
+        }
+        let cond_end = find_matching_paren(tokens, block_start)?;
+        block_start = cond_end + 1;
+    } else if let Some(Tok::Ident(next)) = tokens.get(block_start)
+        && next == "if"
+    {
+        return parse_control_flow_block(tokens, block_start, deps);
+    }
+
+    if tokens.get(block_start) != Some(&Tok::OpenBrace) {
+        return None;
+    }
+
+    let block_end = find_matching_brace(tokens, block_start)?;
+    deps.extend(parse_block(&tokens[block_start + 1..block_end]));
+    Some(block_end + 1)
 }
 
 fn is_skip_keyword(name: &str) -> bool {
@@ -2362,6 +2399,40 @@ dependencies {
             dependency.purl.as_deref() == Some("pkg:maven/io.ktor/ktor-server-test-host@2.3.10")
                 && dependency.extracted_requirement.as_deref() == Some("2.3.10")
                 && dependency.scope.as_deref() == Some("testImplementation")
+        }));
+    }
+
+    #[test]
+    fn test_conditional_dependencies_inside_if_blocks_are_extracted() {
+        let temp_dir = tempdir().unwrap();
+        let build_gradle = temp_dir.path().join("build.gradle");
+        std::fs::write(
+            &build_gradle,
+            r#"
+def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
+
+dependencies {
+    implementation("com.facebook.react:react-android")
+
+    if (hermesEnabled.toBoolean()) {
+        implementation("com.facebook.react:hermes-android")
+    } else {
+        implementation jscFlavor
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let package_data = GradleParser::extract_first_package(&build_gradle);
+
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/com.facebook.react/react-android")
+                && dependency.scope.as_deref() == Some("implementation")
+        }));
+        assert!(package_data.dependencies.iter().any(|dependency| {
+            dependency.purl.as_deref() == Some("pkg:maven/com.facebook.react/hermes-android")
+                && dependency.scope.as_deref() == Some("implementation")
         }));
     }
 


### PR DESCRIPTION
## Summary

- preserve lowercase project-name copyright tails such as `Copyright (c) 2015-present i18next` while filtering bundled HTML-entity decoder regex junk out of copyright and holder detection
- descend into conditional `if/else` blocks inside Gradle dependency closures so React Native example apps keep static dependencies such as `com.facebook.react:hermes-android`
- record the verified `i18next/react-i18next @ cb20d18` compare snapshot in `docs/BENCHMARKS.md` and regenerate the benchmark chart

## Issues

- Covers: follow-up verification work for the CocoaPods row target `i18next/react-i18next`

## Scope and exclusions

- Included:
  - copyright detector/refiner cleanup in `src/copyright/**` for lowercase project tails and HTML-entity decoder artifact suppression
  - Gradle parser improvement in `src/parsers/gradle.rs` for conditional dependency extraction inside `dependencies { ... }`
  - benchmark documentation update in `docs/BENCHMARKS.md` and `docs/benchmarks/scan-duration-vs-files.svg`
- Explicit exclusions:
  - no scorecard status change; the CocoaPods row was already marked verified before this follow-up
  - no broad URL-normalization rewrite for trailing-slash differences in README and Gradle wrapper docs

## Intentional differences from Python

- This branch keeps concrete resolved dependency coordinates when static local values are available, such as resolved Flipper versions in the React Native examples, instead of preserving `${FLIPPER_VERSION}` placeholders.
- Remaining compare deltas are limited to Unicode-preserving author normalization (`Jan Mühlemann`) and HTML-entity decoder test-noise patterns rather than meaningful parser blind spots.

## Follow-up work

- Created or intentionally deferred:
  - deferred: broad trailing-slash URL normalization alignment for README and Gradle wrapper documentation links
  - deferred: further cleanup of HTML-entity decoder test-fixture noise, since the remaining deltas are in synthetic decoder assertions rather than real project metadata surfaces
  - compare artifacts:
    - baseline: `.provenant/compare-runs/20260501T072233Z-react-i18next-43501`
    - improved rerun: `.provenant/compare-runs/20260501T082746Z-react-i18next-18917`
  - validation run during implementation:
    - `cargo test test_lowercase_project_name_after_present_year_range_is_kept`
    - `cargo test test_is_junk_copyright_drops_html_entity_regex_fragments`
    - `cargo test test_conditional_dependencies_inside_if_blocks_are_extracted`
    - `cargo test test_gradle_scan_resolves_buildsrc_kotlin_constants`
    - `cargo test tests::test_golden_copyrights --test copyright_golden --features golden-tests`
    - `cargo test tests::test_golden_summary_fixtures_match_expected_summary_blocks --test post_processing_golden --features golden-tests`
    - `cargo test test_scanner_detects_copyrights_in_windows_dll_strings --test scanner_integration`
    - `cargo test copyright::detector::tests_structured_metadata::`
    - `cargo test copyright::refiner::tests::`

