### PR TITLE
fix(copyright): improve zlib verification attribution

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 186 of 186 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 187 of 187 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -692,6 +692,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `419.63s`; ScanCode `2606.91s`
 - Direct Meson package visibility on the root `meson.build` plus declared dependency extraction (`2` vs `0` packages, `2` vs `0` dependencies) for `boost` and `python2`, with Debian copyright metadata carrying a Debian namespace instead of an unqualified source-package row
+
+##### [madler/zlib @ f9dd600](https://github.com/madler/zlib/tree/f9dd6009be3ed32415edf1e89d1bc38380ecb95d) — **12.06× faster**
+
+- Files: 261
+- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.86s`; ScanCode `130.94s`
+- Broader native-build package and dependency visibility (`5` vs `0` packages, `3` vs `0` dependencies) from the root `configure`, `MODULE.bazel`, and committed `.csproj` surfaces, with the real `pkg:autotools/zlib` identity instead of ScanCode's generic input placeholder, direct Bazel and NuGet surface coverage, and the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c`
 
 ##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **24.79× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -206,6 +206,9 @@ ScanCode: 87.31s</title></rect>
     <rect x="475.18" y="444.77" width="8" height="8" fill="#d97706" rx="1.5"><title>libevent/libevent @ 4829651
 Files: 260
 ScanCode: 48.32s</title></rect>
+    <rect x="475.44" y="397.66" width="8" height="8" fill="#d97706" rx="1.5"><title>madler/zlib @ f9dd600
+Files: 261
+ScanCode: 130.94s</title></rect>
     <rect x="476.75" y="420.44" width="8" height="8" fill="#d97706" rx="1.5"><title>r-lib/devtools @ a3447b9
 Files: 266
 ScanCode: 80.85s</title></rect>
@@ -766,6 +769,9 @@ Provenant: 12.01s</title></circle>
     <circle cx="479.18" cy="515.90" r="4.5" fill="#2563eb"><title>libevent/libevent @ 4829651
 Files: 260
 Provenant: 11.67s</title></circle>
+    <circle cx="479.44" cy="519.30" r="4.5" fill="#2563eb"><title>madler/zlib @ f9dd600
+Files: 261
+Provenant: 10.86s</title></circle>
     <circle cx="480.75" cy="526.73" r="4.5" fill="#2563eb"><title>r-lib/devtools @ a3447b9
 Files: 266
 Provenant: 9.28s</title></circle>

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -371,6 +371,127 @@ pub(in super::super) fn extract_dash_bullet_attribution_authors(
         .collect()
 }
 
+fn looks_like_plaintext_roster_author_candidate(who: &str) -> bool {
+    let trimmed = who.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.contains('@') || trimmed.contains("http://") || trimmed.contains("https://") {
+        return true;
+    }
+
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    (2..=5).contains(&words.len())
+        && words
+            .iter()
+            .all(|word| looks_like_contributed_person_name_token(word))
+        && !words
+            .iter()
+            .any(|word| is_contributed_non_person_token(word))
+}
+
+pub(in super::super) fn extract_plaintext_roster_by_authors(
+    prepared_cache: &PreparedLines<'_>,
+) -> Vec<AuthorDetection> {
+    if prepared_cache.is_empty() {
+        return Vec::new();
+    }
+
+    static PATH_ROSTER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^\s*(?:[^\s:]+/[^\s]*|[^\s:]+/)\s+by\s+(?P<who>.+)$").unwrap()
+    });
+    static DATE_ROSTER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^\s*(?:[A-Z][a-z]{2,8}\s+\d{1,2},\s+\d{4}|\d{4}-\d{2}-\d{2})\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+    static INCLUDES_BY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^\s*includes?\b.+?\bby\s+(?P<who>.+)$").unwrap());
+    static CONTINUATION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^\s*and\s+(?P<who>.+)$").unwrap());
+
+    let mut authors = Vec::new();
+    let mut allow_continuation = false;
+
+    for line in prepared_cache.iter_non_empty() {
+        let trimmed = line.raw.trim();
+        let mut matched_roster = false;
+        let mut matched_continuation = false;
+        let who = if let Some(cap) = PATH_ROSTER_RE.captures(trimmed) {
+            matched_roster = true;
+            cap.name("who").map(|m| m.as_str().trim())
+        } else if let Some(cap) = DATE_ROSTER_RE.captures(trimmed) {
+            matched_roster = true;
+            cap.name("who").map(|m| m.as_str().trim())
+        } else if let Some(cap) = INCLUDES_BY_RE.captures(trimmed) {
+            matched_roster = true;
+            cap.name("who").map(|m| m.as_str().trim())
+        } else if allow_continuation {
+            matched_continuation = true;
+            CONTINUATION_RE
+                .captures(trimmed)
+                .and_then(|cap| cap.name("who").map(|m| m.as_str().trim()))
+        } else {
+            None
+        };
+
+        allow_continuation = matched_roster || (matched_continuation && who.is_some());
+
+        let Some(who) = who else {
+            continue;
+        };
+        let who = trim_attribution_tail(who);
+        if !looks_like_plaintext_roster_author_candidate(&who) {
+            continue;
+        }
+        let Some(author) = refine_author(&who) else {
+            continue;
+        };
+        authors.push(AuthorDetection {
+            author,
+            start_line: line.line_number,
+            end_line: line.line_number,
+        });
+    }
+
+    authors
+}
+
+pub(in super::super) fn extract_written_on_top_of_by_authors(
+    content: &str,
+) -> Vec<AuthorDetection> {
+    if content.is_empty() {
+        return Vec::new();
+    }
+
+    static WRITTEN_ON_TOP_OF_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?is)\bwritten\s+on\s+top\s+of\b.{0,400}?\bby\s+(?P<who>(?:[^<\n]{0,160}?<[^>\s]+@[^>\s]+>|[^\(\n]{0,160}?\((?:[^\)\s]+@[^\)\s]+|https?://[^\)\s]+)\)|[A-Z][\p{L}'.-]+(?:\s+[A-Z][\p{L}'.-]+){0,5}))(?:(?:\s*,\s*(?:is|was)\b)|[.;,]|$)",
+        )
+        .unwrap()
+    });
+
+    WRITTEN_ON_TOP_OF_BY_RE
+        .captures_iter(content)
+        .filter_map(|line| {
+            let whole = line.get(0)?;
+            let who = line.name("who").map(|m| m.as_str()).unwrap_or("").trim();
+            if who.is_empty() {
+                return None;
+            }
+            let author = refine_author(who)?;
+            let line_number = line_number_for_offset(content, whole.start());
+            Some(AuthorDetection {
+                author,
+                start_line: line_number,
+                end_line: line_number,
+            })
+        })
+        .collect()
+}
+
 pub(in super::super) fn extract_name_contributed_authors(
     prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -591,6 +591,80 @@ fn test_dash_bullet_changelog_lines_extract_individual_authors() {
 }
 
 #[test]
+fn test_plaintext_roster_lines_extract_individual_authors() {
+    let input = concat!(
+        "ada/        by Dmitriy Anisimkov <anisimkov@yahoo.com>\n",
+        "        Support for Ada\n",
+        "iostream3/  by Ludwig Schwardt <schwardt@sun.ac.za>\n",
+        "            and Kevin Ruland <kevin@rodin.wustl.edu>\n",
+        "            and Mark Adler <madler@alumni.caltech.edu>\n",
+        "minizip/    by Gilles Vollant <info@winimage.com>\n",
+        "        Includes Zip64 support by Mathias Svensson <mathias@result42.com>\n",
+        "pascal/     by Bob Dellaca <bobdl@xtra.co.nz> et al.\n",
+        "        Support for Pascal\n",
+    );
+
+    let (_c, _h, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Dmitriy Anisimkov <anisimkov@yahoo.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Ludwig Schwardt <schwardt@sun.ac.za>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Kevin Ruland <kevin@rodin.wustl.edu>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Mark Adler <madler@alumni.caltech.edu>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Gilles Vollant <info@winimage.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Mathias Svensson <mathias@result42.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Bob Dellaca <bobdl@xtra.co.nz> et al"),
+        "authors: {values:?}"
+    );
+    assert!(
+        !values
+            .iter()
+            .any(|value| *value == "Support for Ada" || *value == "Support for Pascal"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_written_on_top_of_line_extracts_author() {
+    let input = concat!(
+        "An experimental package to read and write files in the .zip format, written on top of\n",
+        "zlib by Gilles Vollant <info@winimage.com>, is available in the\n",
+        "contrib/minizip directory of zlib.\n",
+    );
+
+    let (_c, _h, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.author == "Gilles Vollant <info@winimage.com>"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_author_colon_dash_bullet_hwmon_roster_extracts_individual_authors() {
     let input = "Authors:\n\t- Mark M. Hoffman <mhoffman@lightlink.com>\n\t- Ported to 2.6 by Eric J. Bowersox <ericb@aspsys.com>\n\t- Adapted to 2.6.20 by Carsten Emde <ce@osadl.org>\n\t- Modified for mainline integration by Hans J. Koch <hjk@hansjkoch.de>\n";
 

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -151,6 +151,14 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    let mut new_a = super::author_heuristics::extract_plaintext_roster_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
+    let mut new_a = super::author_heuristics::extract_written_on_top_of_by_authors(content);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let mut new_a = super::author_heuristics::extract_json_excerpt_developed_by_authors(content);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -27,6 +27,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_comma_year(&a);
     a = strip_trailing_comma_month_year(&a);
     a = strip_trailing_comma_email_matching_name(&a);
+    a = truncate_trailing_clause_after_contact(&a);
     a = strip_trailing_comma_and(&a);
     a = truncate_bug_reports_clause(&a);
     a = truncate_caller_specificaly_clause(&a);
@@ -1025,6 +1026,39 @@ fn strip_trailing_comma_email_matching_name(s: &str) -> String {
 
     if !name_key.is_empty() && (local_key == name_key || local_key.contains(&name_key)) {
         return name.to_string();
+    }
+
+    s.to_string()
+}
+
+fn truncate_trailing_clause_after_contact(s: &str) -> String {
+    static CONTACT_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^(?P<prefix>.+?(?:<[^>\s]+@[^>\s]+>|\((?:[^\)\s]+@[^\)\s]+|https?://[^\)\s]+)\)))\s*(?:\.\s*|\s+)(?P<tail>.+)$",
+        )
+        .expect("valid contact-tail truncation regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = CONTACT_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+    let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
+    if prefix.is_empty() || tail.is_empty() {
+        return s.to_string();
+    }
+
+    let tail_lower = tail.to_ascii_lowercase();
+    let prose_like_tail = [
+        "the ", "a ", "an ", "i ", "since ", "this ", "these ", "those ", "is ", "was ", "visit ",
+        "for ",
+    ]
+    .iter()
+    .any(|prefix_text| tail_lower.starts_with(prefix_text));
+
+    if prose_like_tail {
+        return prefix.to_string();
     }
 
     s.to_string()

--- a/src/copyright/refiner/authors_junk_patterns.rs
+++ b/src/copyright/refiner/authors_junk_patterns.rs
@@ -104,6 +104,8 @@ pub(super) static AUTHORS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^the task'?s numa mempolicy\b.*$",
         r"(?i)^the authors laboriously took the trouble\b.*$",
         r"(?i)^laboriously took the trouble\b.*$",
+        r"(?i)^support\s+for\b.*$",
+        r"(?i)^addresses\s+\.+.*$",
     ];
     patterns.iter().filter_map(|p| Regex::new(p).ok()).collect()
 });

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -150,6 +150,22 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
 }
 
 #[test]
+fn test_refine_author_truncates_trailing_prose_after_contact() {
+    assert_eq!(
+        refine_author("Mark Brown <broonie@sirena.org.uk>. The -d tempdir option"),
+        Some("Mark Brown <broonie@sirena.org.uk>".to_string())
+    );
+    assert_eq!(
+        refine_author("Ryan Haksi (//cryogen@infoserve.net) I need random access"),
+        Some("Ryan Haksi (//cryogen@infoserve.net)".to_string())
+    );
+    assert_eq!(
+        refine_author("Jean-Loup Gailly <gzip@prep.ai.mit.edu> . Since this"),
+        Some("Jean-Loup Gailly <gzip@prep.ai.mit.edu>".to_string())
+    );
+}
+
+#[test]
 fn test_refine_holder_discards_symbol_table_run_junk() {
     assert_eq!(
         refine_holder("(r), & 175, & 176, & 177, & 178, & 179, & 180, & 181, & 182, & 183"),


### PR DESCRIPTION
## Summary

- improve generic author extraction for plaintext contributor rosters and wrapped `written on top of ... by` prose, plus trim prose tails after contact-bearing attributions
- verify `madler/zlib` with `compare-outputs --profile common`, rerun narrow copyright golden coverage, and record the benchmark snapshot in `docs/BENCHMARKS.md`
- regenerate `docs/benchmarks/scan-duration-vs-files.svg` after adding the zlib row

## Issues

- Covers: `madler/zlib` verification work from `docs/implementation-plans/package-detection/PARSER_VERIFICATION_SCORECARD.md`

## Scope and exclusions

- Included:
  - generic copyright/author heuristic fixes in the shared detector pipeline
  - focused regression tests for the new author-extraction paths
  - zlib compare-output verification and benchmark documentation update
- Explicit exclusions:
  - no scorecard status change, because the Autotools row is already marked verified
  - no parser or golden fixture updates were needed

## Intentional differences from Python

- Provenant keeps the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c` instead of collapsing it to plain `Zlib`

## Follow-up work

- Created or intentionally deferred:
  - no new follow-up item created; the remaining compare tail is limited to legacy attribution/doc differences outside this benchmark row’s recorded end-state advantages

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: shared detector changes passed `test_golden_authors` and `test_golden_ics`, so no owned fixture drift required an update

## Verification

- `cargo test plaintext_roster_lines_extract_individual_authors --lib`
- `cargo test written_on_top_of_line_extracts_author --lib`
- `cargo test refine_author_truncates_trailing_prose_after_contact --lib`
- `cargo test written_by_author_email_for_project_is_extracted --lib`
- `cargo test --features golden-tests test_golden_authors --test copyright_golden`
- `cargo test --features golden-tests test_golden_ics --test copyright_golden`
- `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/madler/zlib.git --repo-ref f9dd6009be3ed32415edf1e89d1bc38380ecb95d --profile common`
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`

## Compare artifacts

- Final compare run: `.provenant/compare-runs/20260501T105917Z-zlib-47314/`
- Prior triage run: `.provenant/compare-runs/20260501T104122Z-zlib-6507/`
