### PR TITLE
fix(benchmarks): improve reviewed Rust benchmark snapshots

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 189 of 189 recorded runs, with a **12.0× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 190 of 190 recorded runs, with a **12.0× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 189 of 189 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 189 of 189 recorded runs, with a **12.0× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -523,7 +523,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 11
 - Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `9.77s`; ScanCode `70.75s`
-- Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) with zero reduced shared-profile compare deltas, including exact README dual-license and URL handling on the maintained common profile
+- Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) while preserving the repository's `Apache-2.0 OR MIT` README license semantics and normalizing docs.rs and Keep a Changelog links without trailing-slash drift
 
 ##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **9.83× faster**
 
@@ -782,7 +782,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 42
 - Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `10.05s`; ScanCode `74.96s`
-- Matched Cargo workspace package and dependency coverage (`2` vs `2` packages, `190` vs `190` dependencies) with zero reduced shared-profile compare deltas, including exact README dual-license and URL handling across the root manifest and docs surfaces
+- Matched Cargo workspace package and dependency coverage (`2` vs `2` packages, `190` vs `190` dependencies) while preserving the repository's dual-license README and manifest semantics, recovering SVG-linked URL evidence, and avoiding trailing-slash URL drift across the docs surfaces
 
 ##### [rust-lang/cargo @ b54fe55](https://github.com/rust-lang/cargo/tree/b54fe551a982d75d299e0d54daeac70cb854eef0) — **8.35× faster**
 
@@ -797,6 +797,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `61.49s`; ScanCode `1879.48s`
 - Largely matched native-tree package and dependency extraction (`341` vs `344` packages, `5771` vs `5921` dependencies) with better nested Cargo lock dependency visibility across mixed workspaces, additional Nix package visibility, and more specific versioned Cargo package identities where ScanCode emits generic lockfile rows or versionless crate names
+
+##### [rustcrypto/aeads @ 9d05d81](https://github.com/rustcrypto/aeads/tree/9d05d810c81719a8859d960220a637da8a2cdcd1) — **8.16× faster**
+
+- Files: 268
+- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.06s`; ScanCode `82.06s`
+- Matched Cargo workspace package and dependency coverage (`14` vs `14` packages, `209` vs `209` dependencies) while preserving the member-crate `Apache-2.0 OR MIT` README semantics, keeping archived NCC Group review URLs intact in `aes-gcm` and `chacha20poly1305`, surfacing a concrete `mgm` lockfile package identity where ScanCode stays anonymous, and filtering weak `team of volunteers` SECURITY.md maintainer prose out of author output
 
 ##### [systemd/systemd @ 89d705a](https://github.com/systemd/systemd/tree/89d705a892b3476de14e548f3f9b0af96207d4b0) — **23.26× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](benchmarks/scan-duration-vs-files.svg)
 
-> Provenant is faster on 187 of 187 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 189 of 189 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -518,6 +518,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `11.49s`; ScanCode `76.28s`
 - Direct Arch source-package visibility on committed `.SRCINFO` (`1` vs `0` file-level package records) with broader dependency extraction (`26` vs `0`) across runtime, make, check, and optional package metadata, plus copyright and holder recovery on the repo-owned `LICENSE` and `REUSE.toml` surfaces that ScanCode leaves empty
 
+##### [Amanieu/atomic-rs @ 44c213a](https://github.com/Amanieu/atomic-rs/tree/44c213a73cb4e5c4cf04fd6fd6f76dc95092aebf) — **7.24× faster**
+
+- Files: 11
+- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `9.77s`; ScanCode `70.75s`
+- Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) with zero reduced shared-profile compare deltas, including exact README dual-license and URL handling on the maintained common profile
+
 ##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **9.83× faster**
 
 - Files: 11,496
@@ -769,6 +776,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `13.65s`; ScanCode `168.27s`
 - Broader RPM package and dependency extraction (`352` vs `327` packages, `1441` vs `0` dependencies) from committed `.rpm` fixture trees and sibling `.spec` metadata, with normalized RPM header license expressions and cleaner rejection of config or doc false positives such as `baseurl` and `doxygen. Using` as holder or author data
+
+##### [marshallpierce/rust-base64 @ 13f4fe8](https://github.com/marshallpierce/rust-base64/tree/13f4fe86e565b3a8ed9402d3b8b1bcf83ab9817c) — **7.46× faster**
+
+- Files: 42
+- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.05s`; ScanCode `74.96s`
+- Matched Cargo workspace package and dependency coverage (`2` vs `2` packages, `190` vs `190` dependencies) with zero reduced shared-profile compare deltas, including exact README dual-license and URL handling across the root manifest and docs surfaces
 
 ##### [rust-lang/cargo @ b54fe55](https://github.com/rust-lang/cargo/tree/b54fe551a982d75d299e0d54daeac70cb854eef0) — **8.35× faster**
 

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -218,6 +218,9 @@ ScanCode: 130.94s</title></rect>
     <rect x="476.75" y="420.44" width="8" height="8" fill="#d97706" rx="1.5"><title>r-lib/devtools @ a3447b9
 Files: 266
 ScanCode: 80.85s</title></rect>
+    <rect x="477.26" y="419.74" width="8" height="8" fill="#d97706" rx="1.5"><title>rustcrypto/aeads @ 9d05d81
+Files: 268
+ScanCode: 82.06s</title></rect>
     <rect x="479.04" y="416.95" width="8" height="8" fill="#d97706" rx="1.5"><title>Plack/Plack @ b3984f1
 Files: 275
 ScanCode: 87.06s</title></rect>
@@ -787,6 +790,9 @@ Provenant: 10.86s</title></circle>
     <circle cx="480.75" cy="526.73" r="4.5" fill="#2563eb"><title>r-lib/devtools @ a3447b9
 Files: 266
 Provenant: 9.28s</title></circle>
+    <circle cx="481.26" cy="522.92" r="4.5" fill="#2563eb"><title>rustcrypto/aeads @ 9d05d81
+Files: 268
+Provenant: 10.06s</title></circle>
     <circle cx="483.04" cy="523.01" r="4.5" fill="#2563eb"><title>Plack/Plack @ b3984f1
 Files: 275
 Provenant: 10.04s</title></circle>

--- a/docs/benchmarks/scan-duration-vs-files.svg
+++ b/docs/benchmarks/scan-duration-vs-files.svg
@@ -125,6 +125,9 @@ ScanCode: 89.38s</title></rect>
     <rect x="215.47" y="425.14" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/grep @ 29d2e10
 Files: 6
 ScanCode: 73.20s</title></rect>
+    <rect x="257.23" y="426.75" width="8" height="8" fill="#d97706" rx="1.5"><title>Amanieu/atomic-rs @ 44c213a
+Files: 11
+ScanCode: 70.75s</title></rect>
     <rect x="257.23" y="327.58" width="8" height="8" fill="#d97706" rx="1.5"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 ScanCode: 577.11s</title></rect>
@@ -143,6 +146,9 @@ ScanCode: 73.99s</title></rect>
     <rect x="346.19" y="491.51" width="8" height="8" fill="#d97706" rx="1.5"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
 ScanCode: 17.97s</title></rect>
+    <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
+Files: 42
+ScanCode: 74.96s</title></rect>
     <rect x="362.93" y="430.28" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 ScanCode: 65.66s</title></rect>
@@ -688,6 +694,9 @@ Provenant: 24.22s</title></circle>
     <circle cx="219.47" cy="521.94" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/grep @ 29d2e10
 Files: 6
 Provenant: 10.27s</title></circle>
+    <circle cx="261.23" cy="524.30" r="4.5" fill="#2563eb"><title>Amanieu/atomic-rs @ 44c213a
+Files: 11
+Provenant: 9.77s</title></circle>
     <circle cx="261.23" cy="400.68" r="4.5" fill="#2563eb"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 Provenant: 133.69s</title></circle>
@@ -706,6 +715,9 @@ Provenant: 11.06s</title></circle>
     <circle cx="350.19" cy="520.89" r="4.5" fill="#2563eb"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
 Provenant: 10.50s</title></circle>
+    <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
+Files: 42
+Provenant: 10.05s</title></circle>
     <circle cx="366.93" cy="530.00" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 Provenant: 8.66s</title></circle>

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1120,10 +1120,10 @@ fn resources_by_path(value: &Value) -> BTreeMap<String, Value> {
         .into_iter()
         .flatten()
         .filter_map(|entry| {
-            entry
-                .get("path")
-                .and_then(Value::as_str)
-                .map(|path| (normalize_compare_path(path), entry.clone()))
+            entry.get("path").and_then(Value::as_str).and_then(|path| {
+                let normalized = normalize_compare_path(path);
+                (normalized != "<root>").then_some((normalized, entry.clone()))
+            })
         })
         .collect()
 }
@@ -1155,9 +1155,7 @@ fn metric_values(entry: &Value, metric: &str) -> Vec<String> {
                     .and_then(Value::as_str)
                     .map(normalize_license_expression),
                 "license_clues" | "license_policy" => Some(canonical_value_string(item)),
-                "package_data" => package_identity(item)
-                    .map(str::to_string)
-                    .or_else(|| package_fallback_identity(item)),
+                "package_data" => package_metric_identity(item),
                 "copyrights" => item
                     .get("copyright")
                     .and_then(Value::as_str)
@@ -1188,6 +1186,26 @@ fn package_identity(item: &Value) -> Option<&str> {
     item.get("purl")
         .and_then(Value::as_str)
         .or_else(|| item.get("package_url").and_then(Value::as_str))
+}
+
+fn package_metric_identity(item: &Value) -> Option<String> {
+    if is_cargo_lock_placeholder_like(item) {
+        return Some("type=cargo|datasource_id=cargo_lock".to_string());
+    }
+
+    package_identity(item)
+        .map(str::to_string)
+        .or_else(|| package_fallback_identity(item))
+}
+
+fn is_cargo_lock_placeholder_like(item: &Value) -> bool {
+    let datasource = item.get("datasource_id").and_then(Value::as_str);
+    let package_type = item
+        .get("type")
+        .or_else(|| item.get("package_type"))
+        .and_then(Value::as_str);
+
+    datasource == Some("cargo_lock") && package_type == Some("cargo")
 }
 
 fn package_fallback_identity(item: &Value) -> Option<String> {
@@ -1689,10 +1707,7 @@ fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
                 .and_then(Value::as_str)
                 .map(normalize_license_expression)
                 .unwrap_or_else(|| "<unknown>".to_string());
-            let count = item
-                .get("detection_count")
-                .and_then(Value::as_i64)
-                .unwrap_or(1);
+            let count = top_level_license_detection_count(item) as i64;
             let entry = counter.entry(key).or_insert((0_i64, 0_i64));
             if label == "scancode" {
                 entry.0 += count;
@@ -1712,6 +1727,43 @@ fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
             }))
         })
         .collect()
+}
+
+fn top_level_license_detection_count(item: &Value) -> usize {
+    let Some(reference_matches) = item.get("reference_matches").and_then(Value::as_array) else {
+        return item
+            .get("detection_count")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .unwrap_or(1);
+    };
+
+    let identities: BTreeSet<String> = reference_matches
+        .iter()
+        .map(|match_item| {
+            let expr = match_item
+                .get("license_expression_spdx")
+                .or_else(|| match_item.get("license_expression"))
+                .and_then(Value::as_str)
+                .map(normalize_license_expression)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            let path = match_item
+                .get("from_file")
+                .and_then(Value::as_str)
+                .map(normalize_compare_path)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            format!("{expr}@{path}")
+        })
+        .collect();
+
+    if identities.is_empty() {
+        item.get("detection_count")
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .unwrap_or(1)
+    } else {
+        identities.len()
+    }
 }
 
 fn top_level_package_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1189,23 +1189,9 @@ fn package_identity(item: &Value) -> Option<&str> {
 }
 
 fn package_metric_identity(item: &Value) -> Option<String> {
-    if is_cargo_lock_placeholder_like(item) {
-        return Some("type=cargo|datasource_id=cargo_lock".to_string());
-    }
-
     package_identity(item)
         .map(str::to_string)
         .or_else(|| package_fallback_identity(item))
-}
-
-fn is_cargo_lock_placeholder_like(item: &Value) -> bool {
-    let datasource = item.get("datasource_id").and_then(Value::as_str);
-    let package_type = item
-        .get("type")
-        .or_else(|| item.get("package_type"))
-        .and_then(Value::as_str);
-
-    datasource == Some("cargo_lock") && package_type == Some("cargo")
 }
 
 fn package_fallback_identity(item: &Value) -> Option<String> {

--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -76,9 +76,10 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
         let looks_like_handle = !bare_handle.is_empty()
             && (handle.starts_with('@')
                 || bare_handle.chars().any(|ch| ch.is_ascii_digit())
-                || bare_handle
-                    .chars()
-                    .all(|ch| !ch.is_ascii_alphabetic() || ch.is_ascii_lowercase()));
+                || (bare_handle.len() >= 3
+                    && bare_handle
+                        .chars()
+                        .all(|ch| !ch.is_ascii_alphabetic() || ch.is_ascii_lowercase())));
         if looks_like_handle {
             return refine_author(base);
         }

--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -39,6 +39,17 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
 ) -> Option<String> {
     static TRAILING_HANDLE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\s*\(@[A-Za-z0-9_.-]+\)\s*$").unwrap());
+    static TRAILING_COMMA_HANDLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)
+                ^(?P<base>.+?),
+                \s*
+                (?P<handle>@?[A-Za-z0-9_.-]+)
+                \s*$
+            ",
+        )
+        .unwrap()
+    });
 
     let trimmed = candidate.trim();
     if trimmed.is_empty() {
@@ -48,6 +59,29 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
     let without_handle = TRAILING_HANDLE_RE.replace(trimmed, "").trim().to_string();
     if without_handle != trimmed {
         return refine_author(&without_handle);
+    }
+
+    if let Some(captures) = TRAILING_COMMA_HANDLE_RE.captures(trimmed) {
+        let base = captures
+            .name("base")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        let handle = captures
+            .name("handle")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        let bare_handle = handle.trim_start_matches('@');
+        let looks_like_handle = !bare_handle.is_empty()
+            && (handle.starts_with('@')
+                || bare_handle.chars().any(|ch| ch.is_ascii_digit())
+                || bare_handle
+                    .chars()
+                    .all(|ch| !ch.is_ascii_alphabetic() || ch.is_ascii_lowercase()));
+        if looks_like_handle {
+            return refine_author(base);
+        }
     }
 
     refine_author(trimmed)

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -183,6 +183,34 @@ fn test_extract_toml_singular_author_array_with_handle() {
 }
 
 #[test]
+fn test_extract_toml_singular_author_array_with_comma_handle_suffix() {
+    let input = "authors = [\"RustCrypto Developers, zer0x64\"]\n";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors.iter().any(|a| a.author == "RustCrypto Developers"),
+        "authors: {authors:?}"
+    );
+    assert!(
+        !authors
+            .iter()
+            .any(|a| a.author == "RustCrypto Developers, zer0x64"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_extract_toml_singular_author_array_keeps_company_suffix() {
+    let input = "authors = [\"Jane Street Group, LLC\"]\n";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors.iter().any(|a| a.author == "Jane Street Group, LLC"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_extract_created_by_author_with_handle() {
     let input = "Created by Tom Breloff (@tbreloff)\n";
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -915,6 +915,21 @@ fn test_detect_copyright_with_short_holder_and_trailing_punct_email() {
 }
 
 #[test]
+fn test_detect_copyright_with_year_range_and_angle_email_keeps_email() {
+    let input = "Copyright (c) 2021-2023 Sebastian Ramacher <sebastian.ramacher@ait.ac.at>";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+
+    assert_eq!(c.len(), 1, "Should detect one copyright, got: {:?}", c);
+    assert_eq!(
+        c[0].copyright, "Copyright (c) 2021-2023 Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",
+        "Copyright text: {:?}",
+        c[0].copyright
+    );
+    assert_eq!(h.len(), 1, "Should detect one holder, got: {:?}", h);
+    assert_eq!(h[0].holder, "Sebastian Ramacher");
+}
+
+#[test]
 fn test_detect_copyright_with_malformed_first_year_range() {
     let input = "Copyright (C) 20010-2011 Hauke Heibel <hauke.heibel@gmail.com>";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -177,6 +177,7 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "performing",
         "volunteer",
         "volunteers",
+        "automatically generated",
         "donald becker",
     ]
     .into_iter()
@@ -1170,10 +1171,30 @@ pub fn refine_copyright(s: &str) -> Option<String> {
         }
     }
 
+    static YEAR_RANGE_ANGLE_EMAIL_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+                ^copyright\s*\(c\)\s+
+                (?:19\d{2}|20\d{2}|\?\?\?\?)
+                (?:\s*[-–/]\s*(?:\d{2,4}|\?\?\?\?))?
+                (?:\s*,\s*(?:19\d{2}|20\d{2}|\?\?\?\?))*
+                \s+.+?<[^>\s]+@[^>\s]+>\.?$
+            ",
+        )
+        .unwrap()
+    });
+    if YEAR_RANGE_ANGLE_EMAIL_COPY_RE.is_match(original.as_str()) && !result.contains('@') {
+        let restored = strip_trailing_period(&original);
+        let restored = restored.trim().to_string();
+        if !restored.is_empty() {
+            return Some(restored);
+        }
+    }
+
     static YEAR_ONLY_WITH_OBF_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?ix)^copyright\s*\(c\)\s*(?:19\d{2}|20\d{2})\s+[a-z0-9][a-z0-9._-]{0,63}\s+at\s+[a-z0-9][a-z0-9._-]{0,63}\s+dot\s+[a-z]{2,12}$",
-        )
+            )
         .unwrap()
     });
     if YEAR_ONLY_WITH_OBF_EMAIL_RE.is_match(result.as_str()) {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -158,7 +158,6 @@ static AUTHORS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "compatible",
         "guice",
         "incorporated",
-        "ds",
         "guide",
         "grants",
         "recommend",
@@ -1176,7 +1175,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
             r"(?ix)
                 ^copyright\s*\(c\)\s+
                 (?:19\d{2}|20\d{2}|\?\?\?\?)
-                (?:\s*[-–/]\s*(?:\d{2,4}|\?\?\?\?))?
+                \s*[-–/]\s*(?:\d{2,4}|\?\?\?\?)
                 (?:\s*,\s*(?:19\d{2}|20\d{2}|\?\?\?\?))*
                 \s+.+?<[^>\s]+@[^>\s]+>\.?$
             ",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -729,6 +729,17 @@ fn test_refine_copyright_keeps_year_range_angle_email_suffix() {
 }
 
 #[test]
+fn test_refine_copyright_strips_trailing_by_person_after_holder() {
+    let result = refine_copyright(
+        "Copyright (C) 2004 Nokia Corporation by Tony Lindrgen <tony@atomide.com>",
+    );
+    assert_eq!(
+        result,
+        Some("Copyright (C) 2004 Nokia Corporation".to_string())
+    );
+}
+
+#[test]
 fn test_refine_copyright_strips_fsf_address_tail() {
     let result = refine_copyright(
         "Copyright (c) 1989 Free Software Foundation, Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -102,6 +102,7 @@ fn test_refine_author_drops_generic_role_and_prose_fragments() {
     assert_eq!(refine_author("review"), None);
     assert_eq!(refine_author("reviewer"), None);
     assert_eq!(refine_author("volunteers"), None);
+    assert_eq!(refine_author("Automatically generated"), None);
     assert_eq!(refine_author("Guide"), None);
     assert_eq!(refine_author("maintainers with write access"), None);
     assert_eq!(refine_author("schedule and monitor workflows"), None);
@@ -711,6 +712,19 @@ fn test_refine_copyright_keeps_plain_email_after_comma() {
     assert_eq!(
         result,
         Some("Parts (c) 1999 David Airlie, airlied@linux.ie".to_string())
+    );
+}
+
+#[test]
+fn test_refine_copyright_keeps_year_range_angle_email_suffix() {
+    let result = refine_copyright(
+        "Copyright (c) 2021-2023 Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",
+    );
+    assert_eq!(
+        result,
+        Some(
+            "Copyright (c) 2021-2023 Sebastian Ramacher <sebastian.ramacher@ait.ac.at>".to_string()
+        )
     );
 }
 

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -87,6 +87,8 @@ const JUNK_URLS: &[&str] = &[
     "http://www.w3.org/markup/dtd/xhtml-rdfa-1.dtd",
     "http://www.w3.org/1999/02/22-rdf-syntax-ns",
     "http://www.w3.org/1999/xhtml",
+    // Keep xlink namespace URLs: they appear in shipped SVGs and are real referenced URLs,
+    // unlike the broader XML namespace/schema noise filtered below.
     "http://www.w3.org/1999/xmlschema",
     "http://www.w3.org/1999/xmlschema-instance",
     "http://www.w3.org/2000/svg",

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -581,7 +581,14 @@ fn has_alternative_license_notice(matches: &[LicenseMatch], source_text: Option<
         .join("\n")
         .to_ascii_lowercase();
 
-    region.contains("alternatively") && region.contains("may be used under the terms of")
+    let python_alternative_notice =
+        region.contains("alternatively") && region.contains("may be used under the terms of");
+    let rust_dual_license_notice = (region.contains("licensed under either of")
+        && region.contains("at your option"))
+        || region.contains("dual-licensed under")
+        || region.contains("dual licensed under");
+
+    python_alternative_notice || rust_dual_license_notice
 }
 
 fn is_supplemental_alternative_match(expression: &str) -> bool {
@@ -1572,6 +1579,125 @@ mod tests {
         assert_eq!(
             result.as_deref(),
             Ok("(Apache-2.0 OR BSL-1.0) AND LicenseRef-scancode-warranty-disclaimer")
+        );
+    }
+
+    #[test]
+    fn test_determine_spdx_expression_uses_or_for_rust_dual_license_notice() {
+        let mut apache_choice = create_test_match_full(
+            "apache-2.0",
+            "3-seq",
+            3,
+            3,
+            MatchScore::from_percentage(100.0),
+            16,
+            16,
+            100.0,
+            100,
+            "apache-2.0_910.RULE",
+        );
+        apache_choice.license_expression = "apache-2.0".to_string();
+        apache_choice.license_expression_spdx = Some("Apache-2.0".to_string());
+
+        let mut mit_choice = create_test_match_full(
+            "mit",
+            "3-seq",
+            4,
+            4,
+            MatchScore::from_percentage(100.0),
+            3,
+            3,
+            100.0,
+            100,
+            "mit_14.RULE",
+        );
+        mit_choice.license_expression = "mit".to_string();
+        mit_choice.license_expression_spdx = Some("MIT".to_string());
+
+        let mut apache_reference = create_test_match_full(
+            "apache-2.0",
+            "2-aho",
+            10,
+            10,
+            MatchScore::from_percentage(100.0),
+            2,
+            2,
+            100.0,
+            100,
+            "apache-2.0_57.RULE",
+        );
+        apache_reference.license_expression = "apache-2.0".to_string();
+        apache_reference.license_expression_spdx = Some("Apache-2.0".to_string());
+
+        let notice = concat!(
+            "## License\n\n",
+            "Licensed under either of:\n\n",
+            " * Apache License, Version 2.0\n",
+            " * MIT license\n\n",
+            "at your option.\n\n",
+            "### Contribution\n\n",
+            "Unless you explicitly state otherwise, any contribution intentionally submitted\n",
+            "for inclusion in the work by you, as defined in the Apache-2.0 license, shall be\n",
+            "dual licensed as above, without any additional terms or conditions.\n",
+        );
+
+        let result =
+            determine_spdx_expression(&[apache_choice, mit_choice, apache_reference], Some(notice));
+
+        assert!(
+            matches!(
+                result.as_deref(),
+                Ok("Apache-2.0 OR MIT") | Ok("MIT OR Apache-2.0")
+            ),
+            "result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_determine_spdx_expression_uses_or_for_dual_licensed_under_notice() {
+        let mut mit_choice = create_test_match_full(
+            "mit",
+            "3-seq",
+            3,
+            3,
+            MatchScore::from_percentage(100.0),
+            3,
+            3,
+            100.0,
+            100,
+            "mit_14.RULE",
+        );
+        mit_choice.license_expression = "mit".to_string();
+        mit_choice.license_expression_spdx = Some("MIT".to_string());
+
+        let mut mit_or_apache = create_test_match_full(
+            "mit OR apache-2.0",
+            "3-seq",
+            3,
+            3,
+            MatchScore::from_percentage(85.71),
+            6,
+            6,
+            100.0,
+            100,
+            "mit_or_apache-2.0_22.RULE",
+        );
+        mit_or_apache.license_expression = "mit OR apache-2.0".to_string();
+        mit_or_apache.license_expression_spdx = Some("MIT OR Apache-2.0".to_string());
+
+        let notice = concat!(
+            "## License\n\n",
+            "This project is dual-licensed under MIT and Apache 2.0.\n",
+        );
+
+        let result = determine_spdx_expression(&[mit_choice, mit_or_apache], Some(notice));
+
+        assert!(
+            matches!(
+                result.as_deref(),
+                Ok("Apache-2.0 OR MIT") | Ok("MIT OR Apache-2.0")
+            ),
+            "result: {result:?}"
         );
     }
 

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -269,8 +269,13 @@ impl FileInfo {
             let expressions = license_detections
                 .iter()
                 .map(|detection| detection.license_expression.clone());
-            license_expression =
-                crate::utils::spdx::combine_license_expressions_preserving_structure(expressions);
+            let expressions: Vec<String> = expressions.collect();
+            license_expression = crate::utils::spdx::select_primary_license_expression(
+                expressions.clone(),
+            )
+            .or_else(|| {
+                crate::utils::spdx::combine_license_expressions_preserving_structure(expressions)
+            });
         }
 
         let mut file_info = FileInfo {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -414,6 +414,35 @@ mod tests {
     }
 
     #[test]
+    fn test_detected_license_expression_spdx_prefers_covering_joined_expression() {
+        let mut internal = sample_internal_output();
+        internal.files[0].license_detections = vec![
+            crate::models::LicenseDetection {
+                license_expression: "apache-2.0 OR mit".to_string(),
+                license_expression_spdx: "Apache-2.0 OR MIT".to_string(),
+                matches: vec![],
+                detection_log: vec![],
+                identifier: None,
+            },
+            crate::models::LicenseDetection {
+                license_expression: "apache-2.0".to_string(),
+                license_expression_spdx: "Apache-2.0".to_string(),
+                matches: vec![],
+                detection_log: vec![],
+                identifier: None,
+            },
+        ];
+        internal.files[0].license_expression = None;
+
+        let schema_file = OutputFileInfo::from(&internal.files[0]);
+        let schema_value = serde_json::to_value(&schema_file).expect("file info serializes");
+        assert_eq!(
+            schema_value["detected_license_expression_spdx"],
+            "Apache-2.0 OR MIT"
+        );
+    }
+
+    #[test]
     fn test_json_lines_writer_sorts_files_by_path_for_reproducibility() {
         let mut internal = sample_internal_output();
         internal.files.reverse();

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -118,19 +118,35 @@ impl OutputFileInfo {
     }
 
     pub(crate) fn detected_license_expression_spdx(&self) -> Option<String> {
-        crate::utils::spdx::combine_license_expressions_preserving_structure(
-            self.license_detections
+        {
+            let expressions: Vec<String> = self
+                .license_detections
                 .iter()
                 .filter(|detection| !detection.license_expression_spdx.is_empty())
-                .map(|detection| detection.license_expression_spdx.clone()),
-        )
+                .map(|detection| detection.license_expression_spdx.clone())
+                .collect();
+            crate::utils::spdx::select_primary_license_expression(expressions.clone()).or_else(
+                || {
+                    crate::utils::spdx::combine_license_expressions_preserving_structure(
+                        expressions,
+                    )
+                },
+            )
+        }
         .or_else(|| {
-            crate::utils::spdx::combine_license_expressions_preserving_structure(
-                self.package_data
-                    .iter()
-                    .flat_map(|package_data| package_data.license_detections.iter())
-                    .filter(|detection| !detection.license_expression_spdx.is_empty())
-                    .map(|detection| detection.license_expression_spdx.clone()),
+            let expressions: Vec<String> = self
+                .package_data
+                .iter()
+                .flat_map(|package_data| package_data.license_detections.iter())
+                .filter(|detection| !detection.license_expression_spdx.is_empty())
+                .map(|detection| detection.license_expression_spdx.clone())
+                .collect();
+            crate::utils::spdx::select_primary_license_expression(expressions.clone()).or_else(
+                || {
+                    crate::utils::spdx::combine_license_expressions_preserving_structure(
+                        expressions,
+                    )
+                },
             )
         })
         .or_else(|| {

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -26,7 +26,7 @@ use crate::parser_warn as warn;
 use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::json;
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::path::Path;
 use toml::Value;
 
@@ -184,8 +184,52 @@ fn select_identity_package(packages: &[Value]) -> Option<&toml::map::Map<String,
         .collect();
 
     match local_packages.as_slice() {
-        [only] => Some(*only),
         [] => packages.first().and_then(|package| package.as_table()),
+        [only] => Some(*only),
+        _ => select_unique_root_like_local_package(&local_packages),
+    }
+}
+
+fn select_unique_root_like_local_package<'a>(
+    local_packages: &[&'a toml::map::Map<String, Value>],
+) -> Option<&'a toml::map::Map<String, Value>> {
+    let local_keys: HashSet<(String, String)> = local_packages
+        .iter()
+        .filter_map(|table| package_key_from_table(table))
+        .map(|(name, version)| (name.to_string(), version.to_string()))
+        .collect();
+
+    let referenced_local_keys: HashSet<(String, String)> = local_packages
+        .iter()
+        .flat_map(|table| {
+            table
+                .get("dependencies")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .filter_map(|dep| {
+                    let parsed = parse_dependency_string(dep);
+                    (!parsed.name.is_empty() && !parsed.version.is_empty())
+                        .then(|| (parsed.name.to_string(), parsed.version.to_string()))
+                })
+                .filter(|key| local_keys.contains(key))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let root_candidates: Vec<_> = local_packages
+        .iter()
+        .copied()
+        .filter(|table| {
+            package_key_from_table(table).is_some_and(|(name, version)| {
+                !referenced_local_keys.contains(&(name.to_string(), version.to_string()))
+            })
+        })
+        .collect();
+
+    match root_candidates.as_slice() {
+        [only] => Some(*only),
         _ => None,
     }
 }

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -63,19 +63,20 @@ impl PackageParser for CargoLockParser {
             }
         };
 
-        let root_package = select_root_package(packages);
+        let identity_package = select_identity_package(packages);
+        let dependency_root_package = select_dependency_root_package(packages);
 
-        let name = root_package
+        let name = identity_package
             .and_then(|p| p.get("name"))
             .and_then(|v| v.as_str())
             .map(|s| truncate_field(s.to_string()));
 
-        let version = root_package
+        let version = identity_package
             .and_then(|p| p.get("version"))
             .and_then(|v| v.as_str())
             .map(|s| truncate_field(s.to_string()));
 
-        let checksum = root_package
+        let checksum = identity_package
             .and_then(|p| p.get("checksum"))
             .and_then(|v| v.as_str())
             .map(|s| truncate_field(s.to_string()));
@@ -92,7 +93,7 @@ impl PackageParser for CargoLockParser {
             _ => (None, None),
         };
 
-        let dependencies = extract_all_dependencies(packages, root_package);
+        let dependencies = extract_all_dependencies(packages, dependency_root_package);
 
         let purl = match (&name, &version) {
             (Some(n), Some(v)) => PackageUrl::new("cargo", n).ok().and_then(|mut p| {
@@ -167,12 +168,26 @@ fn read_cargo_lock(path: &Path) -> Result<Value, String> {
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
 
-fn select_root_package(packages: &[Value]) -> Option<&toml::map::Map<String, Value>> {
+fn select_dependency_root_package(packages: &[Value]) -> Option<&toml::map::Map<String, Value>> {
     packages
         .iter()
         .filter_map(|package| package.as_table())
         .find(|table| table.get("source").is_none())
         .or_else(|| packages.first().and_then(|package| package.as_table()))
+}
+
+fn select_identity_package(packages: &[Value]) -> Option<&toml::map::Map<String, Value>> {
+    let local_packages: Vec<_> = packages
+        .iter()
+        .filter_map(|package| package.as_table())
+        .filter(|table| table.get("source").is_none())
+        .collect();
+
+    match local_packages.as_slice() {
+        [only] => Some(*only),
+        [] => packages.first().and_then(|package| package.as_table()),
+        _ => None,
+    }
 }
 
 fn extract_all_dependencies(

--- a/src/parsers/cargo_lock_test.rs
+++ b/src/parsers/cargo_lock_test.rs
@@ -33,9 +33,7 @@ mod tests {
         let package_data = CargoLockParser::extract_first_package(&lock_path);
 
         assert_eq!(package_data.package_type, Some(PackageType::Cargo));
-        // The first package is alphabetically first, not the root
-        assert!(package_data.name.is_some());
-        assert!(package_data.version.is_some());
+        // Workspace lockfiles may not have a unique root-like local package identity.
         assert!(!package_data.dependencies.is_empty());
     }
 

--- a/src/parsers/cargo_lock_test.rs
+++ b/src/parsers/cargo_lock_test.rs
@@ -475,4 +475,46 @@ checksum = "serde-checksum"
         );
         assert_eq!(benchsuite_dep.is_direct, Some(true));
     }
+
+    #[test]
+    fn test_extract_workspace_lockfile_omits_arbitrary_package_identity() {
+        let content = r#"
+[[package]]
+name = "aead-stream"
+version = "0.6.0-rc.3"
+dependencies = ["serde 1.0.228"]
+
+[[package]]
+name = "workspace-tool"
+version = "0.1.0"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "serde-checksum"
+"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let lock_path = temp_dir.path().join("Cargo.lock");
+        std::fs::write(&lock_path, content).unwrap();
+
+        let package_data = CargoLockParser::extract_first_package(&lock_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::CargoLock));
+        assert_eq!(package_data.package_type, Some(PackageType::Cargo));
+        assert_eq!(package_data.name, None);
+        assert_eq!(package_data.version, None);
+        assert_eq!(package_data.purl, None);
+
+        let dependency_purls: Vec<_> = package_data
+            .dependencies
+            .iter()
+            .filter_map(|dep| dep.purl.as_deref())
+            .collect();
+
+        assert!(dependency_purls.contains(&"pkg:cargo/aead-stream@0.6.0-rc.3"));
+        assert!(dependency_purls.contains(&"pkg:cargo/workspace-tool@0.1.0"));
+        assert!(dependency_purls.contains(&"pkg:cargo/serde@1.0.228"));
+    }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1849,6 +1849,109 @@ mod tests {
     }
 
     #[test]
+    fn scanner_prefers_dual_license_readme_expression_over_supplemental_mentions() {
+        let scanned = scan_single_file_with_license_engine(
+            "README.md",
+            concat!(
+                "## License\n\n",
+                "Licensed under either of:\n\n",
+                " * [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)\n",
+                " * [MIT license](https://opensource.org/licenses/MIT)\n\n",
+                "at your option.\n\n",
+                "### Contribution\n\n",
+                "Unless you explicitly state otherwise, any contribution intentionally submitted\n",
+                "for inclusion in the work by you, as defined in the Apache-2.0 license, shall be\n",
+                "dual licensed as above, without any additional terms or conditions.\n",
+            ),
+            &TextDetectionOptions::default(),
+        );
+
+        assert!(
+            matches!(
+                scanned.license_expression.as_deref(),
+                Some("Apache-2.0 OR MIT") | Some("MIT OR Apache-2.0")
+            ),
+            "license expression: {:?}",
+            scanned.license_expression
+        );
+        assert!(
+            !scanned
+                .license_detections
+                .iter()
+                .any(|detection| detection.license_expression_spdx == "Apache-2.0"),
+            "detections: {:?}",
+            scanned.license_detections
+        );
+    }
+
+    #[test]
+    fn scanner_drops_redundant_conjunctive_readme_detection_when_or_notice_exists() {
+        let scanned = scan_single_file_with_license_engine(
+            "README.md",
+            concat!(
+                "## License\n\n",
+                "Licensed under either of:\n\n",
+                " * [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)\n",
+                " * [MIT license](https://opensource.org/licenses/MIT)\n\n",
+                "at your option.\n\n",
+                "### Contribution\n\n",
+                "Unless you explicitly state otherwise, any contribution intentionally submitted\n",
+                "for inclusion in the work by you, as defined in the Apache-2.0 license, shall be\n",
+                "dual licensed as above, without any additional terms or conditions.\n\n",
+                "[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg\n",
+            ),
+            &TextDetectionOptions::default(),
+        );
+
+        assert!(
+            !scanned
+                .license_detections
+                .iter()
+                .any(|detection| { detection.license_expression_spdx == "Apache-2.0 AND MIT" })
+        );
+    }
+
+    #[test]
+    fn scanner_drops_unknown_placeholder_from_dual_license_readme_notice() {
+        let scanned = scan_single_file_with_license_engine(
+            "README.md",
+            concat!(
+                "## License\n\n",
+                "This project is dual-licensed under MIT and Apache 2.0.\n",
+            ),
+            &TextDetectionOptions::default(),
+        );
+
+        assert!(
+            matches!(
+                scanned.license_expression.as_deref(),
+                Some("Apache-2.0 OR MIT") | Some("MIT OR Apache-2.0")
+            ),
+            "license expression: {:?}",
+            scanned.license_expression
+        );
+        assert!(scanned.license_detections.iter().any(|detection| {
+            detection
+                .license_expression_spdx
+                .contains("Apache-2.0 OR MIT")
+                || detection
+                    .license_expression_spdx
+                    .contains("MIT OR Apache-2.0")
+        }));
+        assert!(!scanned.license_detections.iter().any(|detection| {
+            detection.license_expression_spdx == "LicenseRef-scancode-unknown-license-reference"
+        }));
+        assert!(
+            scanned
+                .license_detections
+                .iter()
+                .any(|detection| detection.license_expression_spdx == "MIT"),
+            "detections: {:?}",
+            scanned.license_detections
+        );
+    }
+
+    #[test]
     fn scanner_sets_is_source_only_when_info_enabled() {
         let without_info = TextDetectionOptions {
             collect_info: false,

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -142,6 +142,13 @@ fn ranges_overlap(
 }
 
 fn is_binary_string_copyright_candidate(text: &str) -> bool {
+    if text
+        .chars()
+        .any(|ch| ch.is_control() && !ch.is_whitespace())
+    {
+        return false;
+    }
+
     if contains_year(text) {
         return true;
     }
@@ -163,6 +170,10 @@ fn is_binary_string_copyright_candidate(text: &str) -> bool {
         return false;
     }
 
+    if !contains_year(text) && has_suspicious_binary_digit_noise(original_tail) {
+        return false;
+    }
+
     let alpha_tokens: Vec<&str> = tail
         .split_whitespace()
         .filter(|token| token.chars().any(|c| c.is_alphabetic()))
@@ -177,6 +188,10 @@ fn is_binary_string_copyright_candidate(text: &str) -> bool {
 
     if !has_explicit_copyright_marker(text) {
         return false;
+    }
+
+    if original_tail.chars().any(|ch| ch.is_ascii_digit()) {
+        return has_plausible_digit_bearing_holder(original_tail);
     }
 
     has_binary_name_like_shape(original_tail)
@@ -196,6 +211,68 @@ fn extract_binary_string_author_supplements(text_content: &str) -> Vec<AuthorDet
     }
 
     authors
+}
+
+fn has_suspicious_binary_digit_noise(text: &str) -> bool {
+    let tokens: Vec<&str> = text
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        return false;
+    }
+
+    let digit_tokens: Vec<&str> = tokens
+        .iter()
+        .copied()
+        .filter(|token| token.chars().any(|ch| ch.is_ascii_digit()))
+        .collect();
+    if digit_tokens.is_empty() {
+        return false;
+    }
+
+    let weak_digit_tokens = digit_tokens
+        .iter()
+        .filter(|token| token.chars().filter(|ch| ch.is_ascii_alphabetic()).count() < 2)
+        .count();
+    let has_symbolic_token = tokens.iter().any(|token| {
+        token.chars().any(|ch| {
+            !ch.is_ascii_alphanumeric()
+                && !matches!(ch, '.' | '\'' | '&' | '-' | '_' | ',' | '(' | ')')
+        })
+    });
+
+    (has_symbolic_token && weak_digit_tokens > 0)
+        || (digit_tokens.len() >= 2 && weak_digit_tokens == digit_tokens.len())
+}
+
+fn has_plausible_digit_bearing_holder(text: &str) -> bool {
+    let tokens: Vec<&str> = text
+        .split_whitespace()
+        .filter(|token| token.chars().any(|ch| ch.is_ascii_alphabetic()))
+        .collect();
+    if tokens.is_empty() {
+        return false;
+    }
+
+    let has_company_suffix = tokens
+        .iter()
+        .any(|token| is_company_like_suffix(token.trim_matches(|ch: char| !ch.is_alphanumeric())));
+    let uppercase_like = tokens
+        .iter()
+        .filter(|token| {
+            token
+                .chars()
+                .find(|ch| ch.is_ascii_alphabetic())
+                .is_some_and(|ch| ch.is_ascii_uppercase())
+        })
+        .count();
+    let strong_digit_token = tokens.iter().any(|token| {
+        token.chars().any(|ch| ch.is_ascii_digit())
+            && token.chars().filter(|ch| ch.is_ascii_alphabetic()).count() >= 2
+    });
+
+    strong_digit_token && (has_company_suffix || uppercase_like >= 1)
 }
 
 fn extract_patch_header_author_supplements(text_content: &str) -> Vec<AuthorDetection> {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -17,6 +17,52 @@ fn test_binary_string_copyright_candidate_rejects_gibberish_holder_text() {
 }
 
 #[test]
+fn test_binary_string_copyright_candidate_rejects_control_char_gibberish() {
+    let gibberish = "(c) K0\u{000e}q6 b$L";
+    assert!(!is_binary_string_copyright_candidate(gibberish));
+}
+
+#[test]
+fn test_binary_string_copyright_candidate_rejects_digit_bearing_gibberish_without_year() {
+    let gibberish = "(c) K0 b$L";
+    assert!(!is_binary_string_copyright_candidate(gibberish));
+}
+
+#[test]
+fn test_binary_string_copyright_candidate_keeps_digit_bearing_company_name_without_year() {
+    let notice = "Copyright (c) 3Com Corporation";
+    assert!(is_binary_string_copyright_candidate(notice));
+}
+
+#[test]
+fn test_extract_copyright_information_drops_binary_string_gibberish_notice() {
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(
+        &mut builder,
+        Path::new("fixture.blb"),
+        "(c) K0\n b$L",
+        120.0,
+        true,
+    );
+
+    let file = builder
+        .name("fixture.blb".to_string())
+        .base_name("fixture".to_string())
+        .extension(".blb".to_string())
+        .path("fixture.blb".to_string())
+        .file_type(FileType::File)
+        .size(9)
+        .build()
+        .expect("builder should produce file info");
+    assert!(
+        file.copyrights.is_empty(),
+        "copyrights: {:?}",
+        file.copyrights
+    );
+}
+
+#[test]
 fn test_binary_string_copyright_candidate_keeps_real_notice() {
     let notice = "Copyright nexB and others (c) 2012";
     assert!(is_binary_string_copyright_candidate(notice));

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -135,6 +135,12 @@ pub(super) fn extract_license_information(
                 &text_content,
                 &model_detections,
             ));
+            expand_dual_licensed_under_readme_choice_detections(
+                path,
+                &text_content,
+                &mut model_detections,
+            );
+            prune_redundant_readme_conjunctive_detections(path, &mut model_detections);
 
             if !model_detections.is_empty() {
                 let expressions: Vec<String> = model_detections
@@ -144,10 +150,14 @@ pub(super) fn extract_license_information(
                     .collect();
 
                 if !expressions.is_empty() {
-                    let combined =
+                    let combined = crate::utils::spdx::select_primary_license_expression(
+                        expressions.clone(),
+                    )
+                    .or_else(|| {
                         crate::utils::spdx::combine_license_expressions_preserving_structure(
                             expressions,
-                        );
+                        )
+                    });
                     if let Some(expr) = combined {
                         file_info_builder.license_expression(Some(expr));
                     }
@@ -553,6 +563,196 @@ fn is_legal_notice_like_path(path: &Path) -> bool {
                 || base_name.starts_with(pattern)
                 || base_name.ends_with(pattern)
         })
+}
+
+fn prune_redundant_readme_conjunctive_detections(
+    path: &Path,
+    detections: &mut Vec<PublicLicenseDetection>,
+) {
+    if !is_readme_like_path(path) || detections.len() < 2 {
+        return;
+    }
+
+    let concrete_ranges: Vec<(usize, usize)> = detections
+        .iter()
+        .filter(|detection| !detection_is_unknown_reference(detection))
+        .filter_map(detection_line_range)
+        .collect();
+
+    let alternative_key_sets: Vec<(HashSet<String>, (usize, usize))> = detections
+        .iter()
+        .filter_map(|detection| {
+            let expression = detection_expression_ast(detection)?;
+            expression_contains_or(&expression).then_some((detection, expression))
+        })
+        .filter_map(|(detection, expression)| {
+            let range = detection_line_range(detection)?;
+            Some((
+                expression
+                    .license_keys()
+                    .into_iter()
+                    .map(|key| key.to_ascii_lowercase())
+                    .collect(),
+                range,
+            ))
+        })
+        .collect();
+
+    if alternative_key_sets.is_empty() {
+        return;
+    }
+
+    detections.retain(|detection| {
+        if detection_is_unknown_reference(detection)
+            && let Some((start, end)) = detection_line_range(detection)
+            && concrete_ranges.iter().any(|(other_start, other_end)| {
+                ranges_overlap(start, end, *other_start, *other_end)
+            })
+        {
+            return false;
+        }
+
+        let Some(expression) = detection_expression_ast(detection) else {
+            return true;
+        };
+
+        if expression_contains_or(&expression) || !expression_contains_and(&expression) {
+            return true;
+        }
+
+        let Some((start, end)) = detection_line_range(detection) else {
+            return true;
+        };
+
+        let keys: HashSet<String> = expression
+            .license_keys()
+            .into_iter()
+            .map(|key| key.to_ascii_lowercase())
+            .collect();
+
+        !alternative_key_sets
+            .iter()
+            .any(|(candidate_keys, (other_start, other_end))| {
+                *candidate_keys == keys && ranges_overlap(start, end, *other_start, *other_end)
+            })
+    });
+}
+
+fn expand_dual_licensed_under_readme_choice_detections(
+    path: &Path,
+    text_content: &str,
+    detections: &mut Vec<PublicLicenseDetection>,
+) {
+    if !is_readme_like_path(path) || !has_dual_licensed_under_notice_text(text_content) {
+        return;
+    }
+
+    let mut extras = Vec::new();
+
+    for detection in detections.iter() {
+        if !detection.license_expression_spdx.contains(" OR ") {
+            continue;
+        }
+
+        let Some((start, end)) = detection_line_range(detection) else {
+            continue;
+        };
+
+        for detection_match in &detection.matches {
+            let single_spdx = detection_match.license_expression_spdx.trim();
+            if single_spdx.is_empty()
+                || single_spdx.contains(" OR ")
+                || single_spdx.contains(" AND ")
+                || single_spdx.contains(" WITH ")
+            {
+                continue;
+            }
+
+            let already_present = detections.iter().chain(extras.iter()).any(|existing| {
+                existing.license_expression_spdx == single_spdx
+                    && detection_line_range(existing).is_some_and(|range| range == (start, end))
+            });
+            if already_present {
+                continue;
+            }
+
+            extras.push(PublicLicenseDetection {
+                license_expression: detection_match.license_expression.clone(),
+                license_expression_spdx: detection_match.license_expression_spdx.clone(),
+                matches: vec![detection_match.clone()],
+                detection_log: detection.detection_log.clone(),
+                identifier: None,
+            });
+        }
+    }
+
+    detections.extend(extras);
+}
+
+fn is_readme_like_path(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("readme"))
+}
+
+fn has_dual_licensed_under_notice_text(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("dual-licensed under") || lower.contains("dual licensed under")
+}
+
+fn detection_expression_ast(
+    detection: &PublicLicenseDetection,
+) -> Option<crate::license_detection::expression::LicenseExpression> {
+    let expression = if !detection.license_expression_spdx.is_empty() {
+        detection.license_expression_spdx.as_str()
+    } else if !detection.license_expression.is_empty() {
+        detection.license_expression.as_str()
+    } else {
+        return None;
+    };
+
+    parse_expression(expression).ok()
+}
+
+fn detection_is_unknown_reference(detection: &PublicLicenseDetection) -> bool {
+    detection.license_expression == "unknown-license-reference"
+        || detection.license_expression_spdx == "LicenseRef-scancode-unknown-license-reference"
+}
+
+fn detection_line_range(detection: &PublicLicenseDetection) -> Option<(usize, usize)> {
+    let start = detection.matches.iter().map(|m| m.start_line.get()).min()?;
+    let end = detection.matches.iter().map(|m| m.end_line.get()).max()?;
+    Some((start, end))
+}
+
+fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
+    a_start <= b_end && b_start <= a_end
+}
+
+fn expression_contains_or(
+    expression: &crate::license_detection::expression::LicenseExpression,
+) -> bool {
+    match expression {
+        crate::license_detection::expression::LicenseExpression::Or { .. } => true,
+        crate::license_detection::expression::LicenseExpression::And { left, right }
+        | crate::license_detection::expression::LicenseExpression::With { left, right } => {
+            expression_contains_or(left) || expression_contains_or(right)
+        }
+        _ => false,
+    }
+}
+
+fn expression_contains_and(
+    expression: &crate::license_detection::expression::LicenseExpression,
+) -> bool {
+    match expression {
+        crate::license_detection::expression::LicenseExpression::And { .. } => true,
+        crate::license_detection::expression::LicenseExpression::Or { left, right }
+        | crate::license_detection::expression::LicenseExpression::With { left, right } => {
+            expression_contains_and(left) || expression_contains_and(right)
+        }
+        _ => false,
+    }
 }
 
 fn match_has_exact_reference_url(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -4,7 +4,7 @@
 use super::{
     LicenseExtractionInput, MAX_OUTPUT_MATCHED_TEXT_BYTES, MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH,
     compute_percentage_of_license_text, convert_detection_to_model, extract_license_information,
-    promote_legal_notice_low_quality_detections,
+    promote_legal_notice_low_quality_detections, prune_redundant_readme_conjunctive_detections,
 };
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
@@ -14,7 +14,10 @@ use crate::license_detection::models::License;
 use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleKind};
 use crate::license_detection::query::Query;
-use crate::models::{FileInfoBuilder, LineNumber, MatchScore, ScanDiagnostic};
+use crate::models::{
+    FileInfoBuilder, LicenseDetection as PublicLicenseDetection, LineNumber, Match, MatchScore,
+    ScanDiagnostic,
+};
 use crate::scanner::LicenseScanOptions;
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
@@ -109,6 +112,37 @@ fn make_internal_notice_match(
         coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
         candidate_resemblance: 0.0,
         candidate_containment: 0.0,
+    }
+}
+
+fn make_public_detection(
+    expr: &str,
+    expr_spdx: &str,
+    start_line: usize,
+    end_line: usize,
+) -> PublicLicenseDetection {
+    PublicLicenseDetection {
+        license_expression: expr.to_string(),
+        license_expression_spdx: expr_spdx.to_string(),
+        matches: vec![Match {
+            license_expression: expr.to_string(),
+            license_expression_spdx: expr_spdx.to_string(),
+            from_file: Some("README.md".to_string()),
+            start_line: LineNumber::new(start_line).unwrap(),
+            end_line: LineNumber::new(end_line).unwrap(),
+            matcher: Some("3-seq".to_string()),
+            score: MatchScore::MAX,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: Some("test.RULE".to_string()),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: Vec::new(),
+        identifier: None,
     }
 }
 
@@ -425,6 +459,21 @@ fn test_promote_legal_notice_low_quality_detections_ignores_true_clue_rules() {
     promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("NOTICE"));
 
     assert!(detections[1].license_expression.is_none());
+}
+
+#[test]
+fn test_prune_redundant_readme_conjunctive_detections_keeps_non_overlapping_and_notice() {
+    let mut detections = vec![
+        make_public_detection("apache-2.0 OR mit", "Apache-2.0 OR MIT", 10, 12),
+        make_public_detection("apache-2.0 AND mit", "Apache-2.0 AND MIT", 40, 42),
+    ];
+
+    prune_redundant_readme_conjunctive_detections(
+        std::path::Path::new("README.md"),
+        &mut detections,
+    );
+
+    assert_eq!(detections.len(), 2, "detections: {detections:#?}");
 }
 
 #[test]

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -302,10 +302,19 @@ pub(crate) fn extract_text_for_detection_with_diagnostics(
     let is_svg_text = lower_extension(path).as_deref() == Some("svg")
         || detected_format.media_type() == "image/svg+xml";
     let should_try_decoded_text = looks_like_textual_bytes(bytes) || is_svg_text;
+    let decoded_is_utf8 = std::str::from_utf8(bytes).is_ok();
+    let path_suggests_text = ext.as_deref().is_some_and(|extension| {
+        PLAIN_TEXT_EXTENSIONS.contains(&extension) || detect_language(path, bytes).is_some()
+    });
 
     if !large_opaque_binary && should_try_decoded_text {
         let decoded = decode_bytes_to_string(bytes);
-        if !decoded.is_empty() && (is_svg_text || looks_like_decoded_text(&decoded)) {
+        if !decoded.is_empty()
+            && (is_svg_text
+                || decoded_is_utf8
+                || path_suggests_text
+                || looks_like_decoded_text(&decoded))
+        {
             let combined =
                 combine_extracted_text_fragments(windows_executable_metadata_text, decoded);
             return (combined, ExtractedTextKind::Decoded, None);
@@ -2674,6 +2683,23 @@ mod tests {
 
         assert_eq!(kind, ExtractedTextKind::Decoded);
         assert!(text.contains("creativecommons.org/licenses/publicdomain"));
+    }
+
+    #[test]
+    fn test_extract_text_for_detection_preserves_blank_comment_lines_in_utf8_source() {
+        let path = Path::new("testdata/plugin_email_url/files/IMarkerActionFilter.java");
+        let bytes = std::fs::read(path).expect("failed to read java fixture");
+
+        let (text, kind) = extract_text_for_detection(path, &bytes);
+
+        assert_eq!(kind, ExtractedTextKind::Decoded);
+        let lines: Vec<_> = text.lines().collect();
+        assert_eq!(lines.get(2).copied(), Some(" *"));
+        assert_eq!(
+            lines.get(3).copied(),
+            Some(" *https://github.com/rpm-software-management")
+        );
+        assert_eq!(lines.get(5).copied(), Some("https://gitlab.com/Conan_Kudo"));
     }
 
     #[test]

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -50,6 +50,8 @@ const MAX_IMAGE_METADATA_TEXT_BYTES: usize = 32 * 1024;
 const BINARY_CONTROL_CHAR_THRESHOLD_DIVISOR: usize = 10;
 const LARGE_OPAQUE_BINARY_SKIP_BYTES: usize = 512 * 1024;
 const JSON_VALIDATION_MAX_BYTES: usize = 4 * 1024 * 1024;
+const MAX_XMP_PACKET_BYTES: usize = 256 * 1024;
+const MAX_PDF_TEXT_EXTRACTION_BYTES: usize = 32 * 1024 * 1024;
 const PLAIN_TEXT_EXTENSIONS: &[&str] = &[
     "rst", "rest", "md", "txt", "log", "json", "xml", "yaml", "yml", "toml", "ini",
 ];
@@ -140,10 +142,13 @@ pub(crate) fn augment_license_detection_text<'a>(path: &Path, text: &'a str) -> 
     }
 
     let mut hints = Vec::new();
+    let has_dual_license_notice = has_dual_license_notice_text(text);
     if text.contains("CC BY 4.0") || text.contains("creativecommons.org/licenses/by/4.0") {
         hints.push("Creative Commons Attribution 4.0 International License".to_string());
     }
-    if text.contains("Apache License (Version 2.0)") || text.contains("Apache License, Version 2.0")
+    if !has_dual_license_notice
+        && (text.contains("Apache License (Version 2.0)")
+            || text.contains("Apache License, Version 2.0"))
     {
         hints.push(
             "Licensed under the Apache License, Version 2.0. http://www.apache.org/licenses/LICENSE-2.0"
@@ -151,7 +156,9 @@ pub(crate) fn augment_license_detection_text<'a>(path: &Path, text: &'a str) -> 
         );
     }
 
-    hints.extend(extract_shields_license_badge_hints(text));
+    if !has_dual_license_notice {
+        hints.extend(extract_shields_license_badge_hints(text));
+    }
 
     if hints.is_empty() {
         Cow::Borrowed(text)
@@ -207,6 +214,13 @@ fn extract_shields_license_badge_hints(text: &str) -> Vec<String> {
     hints.sort();
     hints.dedup();
     hints
+}
+
+fn has_dual_license_notice_text(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    (lower.contains("licensed under either of") && lower.contains("at your option"))
+        || lower.contains("dual-licensed under")
+        || lower.contains("dual licensed under")
 }
 
 fn canonical_shields_license_hint(candidate: &str) -> String {
@@ -285,9 +299,13 @@ pub(crate) fn extract_text_for_detection_with_diagnostics(
         return (String::new(), ExtractedTextKind::None, None);
     }
 
-    if !large_opaque_binary {
+    let is_svg_text = lower_extension(path).as_deref() == Some("svg")
+        || detected_format.media_type() == "image/svg+xml";
+    let should_try_decoded_text = looks_like_textual_bytes(bytes) || is_svg_text;
+
+    if !large_opaque_binary && should_try_decoded_text {
         let decoded = decode_bytes_to_string(bytes);
-        if !decoded.is_empty() {
+        if !decoded.is_empty() && (is_svg_text || looks_like_decoded_text(&decoded)) {
             let combined =
                 combine_extracted_text_fragments(windows_executable_metadata_text, decoded);
             return (combined, ExtractedTextKind::Decoded, None);
@@ -409,12 +427,27 @@ fn decode_utf16_units(bytes: &[u8], is_le: bool, require_text_shape: bool) -> Op
         return (!decoded.contains('\0')).then_some(decoded);
     }
 
+    if !looks_like_decoded_text(&decoded) {
+        return None;
+    }
+
+    Some(decoded)
+}
+
+fn looks_like_decoded_text(decoded: &str) -> bool {
+    if decoded
+        .chars()
+        .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
+    {
+        return false;
+    }
+
     let visible = decoded
         .chars()
         .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'))
         .count();
     if visible < 3 || decoded.contains('\0') {
-        return None;
+        return false;
     }
 
     let alpha = decoded.chars().filter(|ch| ch.is_alphabetic()).count();
@@ -447,11 +480,7 @@ fn decode_utf16_units(bytes: &[u8], is_le: bool, require_text_shape: bool) -> Op
     let whitespace = decoded.chars().filter(|ch| ch.is_whitespace()).count();
 
     let textish = alpha + punctuation + whitespace;
-    if textish + (visible / 5) < visible || (alpha == 0 && punctuation < 2) {
-        return None;
-    }
-
-    Some(decoded)
+    textish + (visible / 5) >= visible && (alpha > 0 || punctuation >= 2)
 }
 
 fn detect_utf16_endianness(bytes: &[u8]) -> Option<bool> {
@@ -1675,7 +1704,7 @@ fn extract_raw_xmp_packet(bytes: &[u8], format: ImageFormat) -> Option<Vec<u8>> 
     if let Ok(mut decoder) = reader.into_decoder()
         && let Ok(Some(xmp)) = decoder.xmp_metadata()
     {
-        return Some(xmp);
+        return (xmp.len() <= MAX_XMP_PACKET_BYTES).then_some(xmp);
     }
 
     match format {
@@ -1744,12 +1773,15 @@ fn parse_png_itxt_xmp(data: &[u8]) -> Option<Vec<u8>> {
 
     let text_bytes = &data[cursor..];
     if compression_flag == 1 {
-        let mut decoder = ZlibDecoder::new(text_bytes);
+        let decoder = ZlibDecoder::new(text_bytes);
         let mut decoded = Vec::new();
-        decoder.read_to_end(&mut decoded).ok()?;
-        Some(decoded)
+        decoder
+            .take((MAX_XMP_PACKET_BYTES + 1) as u64)
+            .read_to_end(&mut decoded)
+            .ok()?;
+        (decoded.len() <= MAX_XMP_PACKET_BYTES).then_some(decoded)
     } else {
-        Some(text_bytes.to_vec())
+        (text_bytes.len() <= MAX_XMP_PACKET_BYTES).then(|| text_bytes.to_vec())
     }
 }
 
@@ -1926,6 +1958,16 @@ fn normalize_metadata_value(value: &str) -> String {
 fn extract_pdf_text(path: &Path, bytes: &[u8]) -> (String, Option<String>) {
     if bytes.len() < 5 || &bytes[..5] != b"%PDF-" {
         return (String::new(), None);
+    }
+
+    if bytes.len() > MAX_PDF_TEXT_EXTRACTION_BYTES {
+        return (
+            String::new(),
+            Some(format!(
+                "PDF text extraction skipped because file exceeds {} bytes",
+                MAX_PDF_TEXT_EXTRACTION_BYTES
+            )),
+        );
     }
 
     let mut failures = Vec::new();
@@ -2209,13 +2251,15 @@ pub fn extract_printable_strings(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use image::ImageFormat;
     use std::path::Path;
 
     use crate::copyright::detect_copyrights;
 
     use super::{
-        ExtractedTextKind, LARGE_OPAQUE_BINARY_SKIP_BYTES, classify_file_info,
-        extract_printable_strings, extract_text_for_detection,
+        ExtractedTextKind, LARGE_OPAQUE_BINARY_SKIP_BYTES, MAX_PDF_TEXT_EXTRACTION_BYTES,
+        MAX_XMP_PACKET_BYTES, classify_file_info, extract_printable_strings,
+        extract_raw_xmp_packet, extract_text_for_detection,
         extract_text_for_detection_with_diagnostics, format_metadata_field, format_xmp_value,
         is_non_actionable_pdf_failure, normalize_mime_type, normalize_pdf_heading_comparison_text,
         values_to_text, windows_metadata_or_empty_result,
@@ -2321,6 +2365,23 @@ mod tests {
 
         assert_eq!(kind, ExtractedTextKind::Pdf);
         assert!(text.contains("Redistribution and use in source and binary forms"));
+    }
+
+    #[test]
+    fn test_extract_text_for_detection_skips_oversized_pdf_payload() {
+        let mut bytes = b"%PDF-1.7\n".to_vec();
+        bytes.resize(MAX_PDF_TEXT_EXTRACTION_BYTES + 1, b'0');
+
+        let (text, kind, scan_error) =
+            extract_text_for_detection_with_diagnostics(Path::new("oversized.pdf"), &bytes);
+
+        assert!(text.is_empty());
+        assert_eq!(kind, ExtractedTextKind::None);
+        assert!(
+            scan_error
+                .as_deref()
+                .is_some_and(|message| message.contains("PDF text extraction skipped"))
+        );
     }
 
     #[test]
@@ -2505,6 +2566,26 @@ mod tests {
         assert_ne!(kind, ExtractedTextKind::None);
         assert!(text.contains("asn@redhat.com"));
         assert!(text.contains("https://publicsuffix.org/"));
+    }
+
+    #[test]
+    fn test_extract_text_for_detection_avoids_latin1_decode_for_binary_blob_noise() {
+        let bytes = vec![
+            0x28, 0x63, 0x29, 0x20, 0x4b, 0x30, 0x0e, 0x71, 0x86, 0x20, 0x62, 0x24, 0x4c,
+        ];
+
+        let (text, kind) = extract_text_for_detection(Path::new("fixture.blb"), &bytes);
+
+        assert_eq!(kind, ExtractedTextKind::BinaryStrings);
+        assert_eq!(text, "(c) K0\n b$L");
+    }
+
+    #[test]
+    fn test_extract_raw_xmp_packet_rejects_oversized_png_itxt_payload() {
+        let xmp = "A".repeat(MAX_XMP_PACKET_BYTES + 1);
+        let bytes = build_png_with_xmp(&xmp);
+
+        assert!(extract_raw_xmp_packet(&bytes, ImageFormat::Png).is_none());
     }
 
     #[test]

--- a/src/utils/spdx.rs
+++ b/src/utils/spdx.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::license_detection::expression::{
-    LicenseExpression, parse_expression, simplify_expression,
+    LicenseExpression, expression_to_string, parse_expression, simplify_expression,
     simplify_expression_preserving_structure,
 };
 
@@ -30,6 +30,48 @@ pub fn combine_license_expressions_preserving_structure(
     expressions: impl IntoIterator<Item = String>,
 ) -> Option<String> {
     combine_license_expressions_with_relation_and_mode(expressions, ExpressionRelation::And, true)
+}
+
+pub fn select_primary_license_expression(
+    expressions: impl IntoIterator<Item = String>,
+) -> Option<String> {
+    let mut unique = Vec::new();
+
+    for expression in expressions {
+        let trimmed = expression.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if !unique.iter().any(|existing: &String| existing == trimmed) {
+            unique.push(trimmed.to_string());
+        }
+    }
+
+    if unique.is_empty() {
+        return None;
+    }
+
+    if unique.len() == 1 {
+        return unique.into_iter().next();
+    }
+
+    let joined: Vec<String> = unique
+        .iter()
+        .filter(|expression| is_joined_expression(expression))
+        .cloned()
+        .collect();
+
+    if joined.len() != 1 {
+        return None;
+    }
+
+    let candidate = &joined[0];
+    unique
+        .iter()
+        .filter(|expression| *expression != candidate)
+        .all(|expression| expression_covers(candidate, expression))
+        .then(|| candidate.clone())
 }
 
 pub(crate) fn combine_license_expressions_with_relation_preserving_structure(
@@ -239,6 +281,91 @@ fn wrap_compound_expression(expression: &str) -> String {
     }
 }
 
+fn is_joined_expression(expression: &str) -> bool {
+    let upper = expression.to_ascii_uppercase();
+    upper.contains(" AND ") || upper.contains(" OR ") || upper.contains(" WITH ")
+}
+
+fn expression_covers(container: &str, contained: &str) -> bool {
+    let Ok(parsed_container) = parse_expression(container) else {
+        return false;
+    };
+    let Ok(parsed_contained) = parse_expression(contained) else {
+        return false;
+    };
+
+    let simplified_container = simplify_expression(&parsed_container);
+    let simplified_contained = simplify_expression(&parsed_contained);
+
+    expression_covers_ast(&simplified_container, &simplified_contained)
+}
+
+fn expression_covers_ast(container: &LicenseExpression, contained: &LicenseExpression) -> bool {
+    if expression_to_string(container) == expression_to_string(contained) {
+        return true;
+    }
+
+    match (container, contained) {
+        (LicenseExpression::And { .. }, LicenseExpression::And { .. }) => {
+            let container_args = flat_and_args(container);
+            let contained_args = flat_and_args(contained);
+            contained_args.iter().all(|contained_arg| {
+                container_args.iter().any(|container_arg| {
+                    expression_to_string(container_arg) == expression_to_string(contained_arg)
+                })
+            })
+        }
+        (LicenseExpression::Or { .. }, LicenseExpression::Or { .. }) => {
+            let container_args = flat_or_args(container);
+            let contained_args = flat_or_args(contained);
+            contained_args.iter().all(|contained_arg| {
+                container_args.iter().any(|container_arg| {
+                    expression_to_string(container_arg) == expression_to_string(contained_arg)
+                })
+            })
+        }
+        (LicenseExpression::And { .. }, _) => {
+            flat_and_args(container).iter().any(|container_arg| {
+                expression_to_string(container_arg) == expression_to_string(contained)
+            })
+        }
+        (LicenseExpression::Or { .. }, _) => flat_or_args(container).iter().any(|container_arg| {
+            expression_to_string(container_arg) == expression_to_string(contained)
+        }),
+        _ => false,
+    }
+}
+
+fn flat_and_args(expr: &LicenseExpression) -> Vec<&LicenseExpression> {
+    let mut args = Vec::new();
+    collect_flat_args(expr, true, &mut args);
+    args
+}
+
+fn flat_or_args(expr: &LicenseExpression) -> Vec<&LicenseExpression> {
+    let mut args = Vec::new();
+    collect_flat_args(expr, false, &mut args);
+    args
+}
+
+fn collect_flat_args<'a>(
+    expr: &'a LicenseExpression,
+    and_operator: bool,
+    args: &mut Vec<&'a LicenseExpression>,
+) {
+    match expr {
+        LicenseExpression::And { left, right } if and_operator => {
+            collect_flat_args(left, and_operator, args);
+            collect_flat_args(right, and_operator, args);
+        }
+        LicenseExpression::Or { left, right } if !and_operator => {
+            collect_flat_args(left, and_operator, args);
+            collect_flat_args(right, and_operator, args);
+        }
+        _ => args.push(expr),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,5 +429,36 @@ mod tests {
         );
 
         assert_eq!(result.as_deref(), Some("MIT"));
+    }
+
+    #[test]
+    fn select_primary_license_expression_prefers_joined_expression_covering_fragment() {
+        let result = select_primary_license_expression(vec![
+            "Apache-2.0 OR MIT".to_string(),
+            "Apache-2.0".to_string(),
+        ]);
+
+        assert_eq!(result.as_deref(), Some("Apache-2.0 OR MIT"));
+    }
+
+    #[test]
+    fn select_primary_license_expression_prefers_joined_expression_covering_all_singles() {
+        let result = select_primary_license_expression(vec![
+            "MIT".to_string(),
+            "Apache-2.0 OR MIT".to_string(),
+            "Apache-2.0".to_string(),
+        ]);
+
+        assert_eq!(result.as_deref(), Some("Apache-2.0 OR MIT"));
+    }
+
+    #[test]
+    fn select_primary_license_expression_returns_none_when_joined_expression_does_not_cover_rest() {
+        let result = select_primary_license_expression(vec![
+            "Apache-2.0 OR MIT".to_string(),
+            "GPL-2.0-only".to_string(),
+        ]);
+
+        assert_eq!(result, None);
     }
 }

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -2024,10 +2024,10 @@ fn resources_by_path(value: &Value) -> BTreeMap<String, Value> {
         .into_iter()
         .flatten()
         .filter_map(|entry| {
-            entry
-                .get("path")
-                .and_then(Value::as_str)
-                .map(|path| (normalize_compare_path(path), entry.clone()))
+            entry.get("path").and_then(Value::as_str).and_then(|path| {
+                let normalized = normalize_compare_path(path);
+                (normalized != "<root>").then_some((normalized, entry.clone()))
+            })
         })
         .collect()
 }
@@ -2059,9 +2059,7 @@ fn metric_values(entry: &Value, metric: &str) -> Vec<String> {
                     .and_then(Value::as_str)
                     .map(normalize_license_expression),
                 "license_clues" | "license_policy" => Some(canonical_value_string(item)),
-                "package_data" => package_identity(item)
-                    .map(str::to_string)
-                    .or_else(|| package_fallback_identity(item)),
+                "package_data" => package_metric_identity(item),
                 "copyrights" => item
                     .get("copyright")
                     .and_then(Value::as_str)
@@ -2078,7 +2076,10 @@ fn metric_values(entry: &Value, metric: &str) -> Vec<String> {
                     .get("email")
                     .and_then(Value::as_str)
                     .map(str::to_string),
-                "urls" => item.get("url").and_then(Value::as_str).map(str::to_string),
+                "urls" => item
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .map(normalize_url_value),
                 "scan_errors" => scan_error_identity(item).map(str::to_string),
                 _ => None,
             }?;
@@ -2092,6 +2093,26 @@ fn package_identity(item: &Value) -> Option<&str> {
     item.get("purl")
         .and_then(Value::as_str)
         .or_else(|| item.get("package_url").and_then(Value::as_str))
+}
+
+fn package_metric_identity(item: &Value) -> Option<String> {
+    if is_cargo_lock_placeholder_like(item) {
+        return Some("type=cargo|datasource_id=cargo_lock".to_string());
+    }
+
+    package_identity(item)
+        .map(str::to_string)
+        .or_else(|| package_fallback_identity(item))
+}
+
+fn is_cargo_lock_placeholder_like(item: &Value) -> bool {
+    let datasource = item.get("datasource_id").and_then(Value::as_str);
+    let package_type = item
+        .get("type")
+        .or_else(|| item.get("package_type"))
+        .and_then(Value::as_str);
+
+    datasource == Some("cargo_lock") && package_type == Some("cargo")
 }
 
 fn package_fallback_identity(item: &Value) -> Option<String> {
@@ -2138,6 +2159,16 @@ fn normalize_compare_path(path: &str) -> String {
             .trim_start_matches("input/")
             .to_string()
     }
+}
+
+fn normalize_url_value(value: &str) -> String {
+    let normalized = normalize_text(value);
+    if let Some(stripped) = normalized.strip_suffix('/')
+        && (stripped.starts_with("http://") || stripped.starts_with("https://"))
+    {
+        return stripped.to_string();
+    }
+    normalized
 }
 
 fn normalize_license_expression(value: &str) -> String {
@@ -2496,7 +2527,7 @@ fn top_level_counts(value: &Value) -> TopLevelCounts {
             ("dependencies", dependency_count as i64),
             (
                 "license_detections",
-                array_len(value, "license_detections") as i64,
+                top_level_license_detection_count(value) as i64,
             ),
             (
                 "license_references",
@@ -2519,6 +2550,20 @@ fn top_level_counts(value: &Value) -> TopLevelCounts {
             ),
         ]),
     }
+}
+
+fn top_level_license_detection_count(value: &Value) -> usize {
+    value
+        .get("license_detections")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .flat_map(top_level_license_detection_identities)
+                .collect::<BTreeSet<_>>()
+                .len()
+        })
+        .unwrap_or(0)
 }
 
 fn file_entry_count(value: &Value) -> usize {
@@ -2580,7 +2625,7 @@ fn file_package_data_dependency_count(value: &Value) -> usize {
 }
 
 fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
-    let mut counter = BTreeMap::new();
+    let mut counter: BTreeMap<String, (BTreeSet<String>, BTreeSet<String>)> = BTreeMap::new();
     for (label, value) in [("scancode", scancode), ("provenant", provenant)] {
         for item in value
             .get("license_detections")
@@ -2595,19 +2640,90 @@ fn top_level_license_deltas(scancode: &Value, provenant: &Value) -> Vec<Value> {
                 .and_then(Value::as_str)
                 .map(normalize_license_expression)
                 .unwrap_or_else(|| "<unknown>".to_string());
-            let count = item
-                .get("detection_count")
-                .and_then(Value::as_i64)
-                .unwrap_or(1);
-            let entry = counter.entry(key).or_insert((0_i64, 0_i64));
+            let entry = counter
+                .entry(key)
+                .or_insert_with(|| (BTreeSet::new(), BTreeSet::new()));
+            let identities = top_level_license_detection_identities(item);
             if label == "scancode" {
-                entry.0 += count;
+                entry.0.extend(identities);
             } else {
-                entry.1 += count;
+                entry.1.extend(identities);
             }
         }
     }
-    counter.into_iter().filter_map(|(key, (sc, pr))| (sc != pr).then_some(json!({"license_expression": key, "scancode": sc, "provenant": pr, "delta": pr - sc}))).collect()
+    counter
+        .into_iter()
+        .filter_map(|(key, (sc, pr))| {
+            let sc = sc.len() as i64;
+            let pr = pr.len() as i64;
+            (sc != pr).then_some(json!({
+                "license_expression": key,
+                "scancode": sc,
+                "provenant": pr,
+                "delta": pr - sc
+            }))
+        })
+        .collect()
+}
+
+fn top_level_license_detection_identities(item: &Value) -> BTreeSet<String> {
+    let top_level_expr = item
+        .get("license_expression_spdx")
+        .or_else(|| item.get("license_expression"))
+        .or_else(|| item.get("identifier"))
+        .and_then(Value::as_str)
+        .map(normalize_license_expression)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "<unknown>".to_string());
+
+    let Some(reference_matches) = item.get("reference_matches").and_then(Value::as_array) else {
+        return BTreeSet::from([top_level_expr]);
+    };
+
+    let has_concrete_reference_match = reference_matches.iter().any(|match_item| {
+        match_item
+            .get("license_expression_spdx")
+            .or_else(|| match_item.get("license_expression"))
+            .and_then(Value::as_str)
+            .map(normalize_license_expression)
+            .is_some_and(|expr| !is_unknown_license_reference(&expr))
+    });
+
+    let identities: BTreeSet<String> = reference_matches
+        .iter()
+        .filter_map(|match_item| {
+            let match_expr = match_item
+                .get("license_expression_spdx")
+                .or_else(|| match_item.get("license_expression"))
+                .and_then(Value::as_str)
+                .map(normalize_license_expression)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            if has_concrete_reference_match && is_unknown_license_reference(&match_expr) {
+                return None;
+            }
+            let path = match_item
+                .get("from_file")
+                .and_then(Value::as_str)
+                .map(normalize_compare_path)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            let identity_expr = if is_unknown_license_reference(&top_level_expr) {
+                match_expr.as_str()
+            } else {
+                top_level_expr.as_str()
+            };
+            Some(format!("{identity_expr}@{path}"))
+        })
+        .collect();
+
+    if identities.is_empty() {
+        BTreeSet::from([top_level_expr])
+    } else {
+        identities
+    }
+}
+
+fn is_unknown_license_reference(expr: &str) -> bool {
+    expr == "<unknown>" || expr.starts_with("LicenseRef-scancode-unknown-license-reference")
 }
 
 fn top_level_package_differences(scancode: &Value, provenant: &Value) -> Vec<ValueDifferenceEntry> {
@@ -4801,6 +4917,154 @@ mod tests {
         assert!(policy_values[0].contains("boost-1.0"));
         assert_eq!(clue_values.len(), 1);
         assert!(clue_values[0].contains("license_expression"));
+    }
+
+    #[test]
+    fn metric_values_normalize_trailing_slash_urls() {
+        let entry = json!({
+            "urls": [
+                {"url": "https://docs.rs/serde/latest/serde/"},
+                {"url": "https://keepachangelog.com/en/1.0.0"}
+            ]
+        });
+
+        let values = metric_values(&entry, "urls");
+
+        assert_eq!(
+            values,
+            vec![
+                "https://docs.rs/serde/latest/serde".to_string(),
+                "https://keepachangelog.com/en/1.0.0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn top_level_counts_deduplicate_license_detection_reference_match_identities() {
+        let value = json!({
+            "license_detections": [
+                {
+                    "license_expression_spdx": "Apache-2.0 OR MIT",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "Apache-2.0 OR MIT",
+                            "from_file": "README.md"
+                        }
+                    ]
+                },
+                {
+                    "license_expression_spdx": "MIT OR Apache-2.0",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "MIT OR Apache-2.0",
+                            "from_file": "README.md"
+                        }
+                    ]
+                }
+            ],
+            "packages": [],
+            "dependencies": [],
+            "files": [],
+            "license_references": [],
+            "license_rule_references": []
+        });
+
+        let counts = top_level_counts(&value);
+
+        assert_eq!(counts.count("license_detections"), 1);
+    }
+
+    #[test]
+    fn top_level_counts_ignore_unknown_reference_when_concrete_match_exists() {
+        let value = json!({
+            "license_detections": [
+                {
+                    "license_expression_spdx": "MIT OR Apache-2.0",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+                            "from_file": "README.md"
+                        },
+                        {
+                            "license_expression_spdx": "MIT OR Apache-2.0",
+                            "from_file": "README.md"
+                        }
+                    ]
+                },
+                {
+                    "license_expression_spdx": "MIT",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "MIT",
+                            "from_file": "README.md"
+                        }
+                    ]
+                }
+            ],
+            "packages": [],
+            "dependencies": [],
+            "files": [],
+            "license_references": [],
+            "license_rule_references": []
+        });
+
+        let counts = top_level_counts(&value);
+
+        assert_eq!(counts.count("license_detections"), 2);
+    }
+
+    #[test]
+    fn top_level_license_deltas_ignore_nested_reference_expression_variants() {
+        let scancode = json!({
+            "license_detections": [
+                {
+                    "license_expression_spdx": "MIT OR Apache-2.0",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "MIT OR Apache-2.0",
+                            "from_file": "README.md"
+                        }
+                    ]
+                },
+                {
+                    "license_expression_spdx": "MIT OR Apache-2.0",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "MIT OR Apache-2.0",
+                            "from_file": "Cargo.toml"
+                        }
+                    ]
+                }
+            ]
+        });
+        let provenant = json!({
+            "license_detections": [
+                {
+                    "license_expression_spdx": "Apache-2.0 OR MIT",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "MIT",
+                            "from_file": "README.md"
+                        },
+                        {
+                            "license_expression_spdx": "Apache-2.0 OR MIT",
+                            "from_file": "README.md"
+                        }
+                    ]
+                },
+                {
+                    "license_expression_spdx": "Apache-2.0 OR MIT",
+                    "reference_matches": [
+                        {
+                            "license_expression_spdx": "Apache-2.0 OR MIT",
+                            "from_file": "Cargo.toml"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        assert!(top_level_license_deltas(&scancode, &provenant).is_empty());
     }
 
     #[test]

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -2653,27 +2653,15 @@ fn top_level_license_detection_identities(item: &Value) -> BTreeSet<String> {
         return BTreeSet::from([top_level_expr]);
     };
 
-    let has_concrete_reference_match = reference_matches.iter().any(|match_item| {
-        match_item
-            .get("license_expression_spdx")
-            .or_else(|| match_item.get("license_expression"))
-            .and_then(Value::as_str)
-            .map(normalize_license_expression)
-            .is_some_and(|expr| !is_unknown_license_reference(&expr))
-    });
-
     let identities: BTreeSet<String> = reference_matches
         .iter()
-        .filter_map(|match_item| {
+        .map(|match_item| {
             let match_expr = match_item
                 .get("license_expression_spdx")
                 .or_else(|| match_item.get("license_expression"))
                 .and_then(Value::as_str)
                 .map(normalize_license_expression)
                 .unwrap_or_else(|| "<unknown>".to_string());
-            if has_concrete_reference_match && is_unknown_license_reference(&match_expr) {
-                return None;
-            }
             let path = match_item
                 .get("from_file")
                 .and_then(Value::as_str)
@@ -2684,7 +2672,7 @@ fn top_level_license_detection_identities(item: &Value) -> BTreeSet<String> {
             } else {
                 top_level_expr.as_str()
             };
-            Some(format!("{identity_expr}@{path}"))
+            format!("{identity_expr}@{path}")
         })
         .collect();
 
@@ -4925,45 +4913,6 @@ mod tests {
         let counts = top_level_counts(&value);
 
         assert_eq!(counts.count("license_detections"), 1);
-    }
-
-    #[test]
-    fn top_level_counts_ignore_unknown_reference_when_concrete_match_exists() {
-        let value = json!({
-            "license_detections": [
-                {
-                    "license_expression_spdx": "MIT OR Apache-2.0",
-                    "reference_matches": [
-                        {
-                            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
-                            "from_file": "README.md"
-                        },
-                        {
-                            "license_expression_spdx": "MIT OR Apache-2.0",
-                            "from_file": "README.md"
-                        }
-                    ]
-                },
-                {
-                    "license_expression_spdx": "MIT",
-                    "reference_matches": [
-                        {
-                            "license_expression_spdx": "MIT",
-                            "from_file": "README.md"
-                        }
-                    ]
-                }
-            ],
-            "packages": [],
-            "dependencies": [],
-            "files": [],
-            "license_references": [],
-            "license_rule_references": []
-        });
-
-        let counts = top_level_counts(&value);
-
-        assert_eq!(counts.count("license_detections"), 2);
     }
 
     #[test]

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -2076,10 +2076,7 @@ fn metric_values(entry: &Value, metric: &str) -> Vec<String> {
                     .get("email")
                     .and_then(Value::as_str)
                     .map(str::to_string),
-                "urls" => item
-                    .get("url")
-                    .and_then(Value::as_str)
-                    .map(normalize_url_value),
+                "urls" => item.get("url").and_then(Value::as_str).map(str::to_string),
                 "scan_errors" => scan_error_identity(item).map(str::to_string),
                 _ => None,
             }?;
@@ -2096,23 +2093,9 @@ fn package_identity(item: &Value) -> Option<&str> {
 }
 
 fn package_metric_identity(item: &Value) -> Option<String> {
-    if is_cargo_lock_placeholder_like(item) {
-        return Some("type=cargo|datasource_id=cargo_lock".to_string());
-    }
-
     package_identity(item)
         .map(str::to_string)
         .or_else(|| package_fallback_identity(item))
-}
-
-fn is_cargo_lock_placeholder_like(item: &Value) -> bool {
-    let datasource = item.get("datasource_id").and_then(Value::as_str);
-    let package_type = item
-        .get("type")
-        .or_else(|| item.get("package_type"))
-        .and_then(Value::as_str);
-
-    datasource == Some("cargo_lock") && package_type == Some("cargo")
 }
 
 fn package_fallback_identity(item: &Value) -> Option<String> {
@@ -2159,16 +2142,6 @@ fn normalize_compare_path(path: &str) -> String {
             .trim_start_matches("input/")
             .to_string()
     }
-}
-
-fn normalize_url_value(value: &str) -> String {
-    let normalized = normalize_text(value);
-    if let Some(stripped) = normalized.strip_suffix('/')
-        && (stripped.starts_with("http://") || stripped.starts_with("https://"))
-    {
-        return stripped.to_string();
-    }
-    normalized
 }
 
 fn normalize_license_expression(value: &str) -> String {
@@ -4917,26 +4890,6 @@ mod tests {
         assert!(policy_values[0].contains("boost-1.0"));
         assert_eq!(clue_values.len(), 1);
         assert!(clue_values[0].contains("license_expression"));
-    }
-
-    #[test]
-    fn metric_values_normalize_trailing_slash_urls() {
-        let entry = json!({
-            "urls": [
-                {"url": "https://docs.rs/serde/latest/serde/"},
-                {"url": "https://keepachangelog.com/en/1.0.0"}
-            ]
-        });
-
-        let values = metric_values(&entry, "urls");
-
-        assert_eq!(
-            values,
-            vec![
-                "https://docs.rs/serde/latest/serde".to_string(),
-                "https://keepachangelog.com/en/1.0.0".to_string(),
-            ]
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- improve Rust benchmark-review outcomes by fixing scanner behavior around dual-license README handling, weak author noise, bounded extracted-text recovery, and workspace-root Cargo lockfile identity
- keep the compare workflow generic by removing compare-only URL collapsing and avoiding ecosystem-specific package-data equivalence rules in the benchmark compare path
- add reviewed `docs/BENCHMARKS.md` snapshots for `Amanieu/atomic-rs`, `marshallpierce/rust-base64`, and `rustcrypto/aeads`, then regenerate the benchmark chart and headline stats

## Scope and exclusions

- Included:
  - generic scanner fixes for dual-license README notices, weak author noise, binary copyright preservation, extracted-text recovery, and Cargo workspace lockfile identity
  - compare-path cleanup so benchmark review stays generic and literal where it should, instead of hiding URL or package-identity differences
  - reviewed benchmark rows for `atomic-rs`, `rust-base64`, and `aeads`
- Explicit exclusions:
  - no ecosystem-specific compare exception framework was introduced; compare stays generic and the remaining reviewed differences are expressed in benchmark notes instead

## Dual-license handling details

- README dual-license notices such as `licensed under either of ... at your option` and `dual-licensed under ...` are now treated as true alternative-license signals instead of being flattened into conjunctive output.
- On the detection side, the scanner now combines the substantive README matches with `OR` semantics when the surrounding notice text clearly describes an alternative-license choice, while still keeping genuinely supplemental material such as warranty-disclaimer fragments separate.
- On the result-shaping side, the branch adds joined-expression selection logic so that when a README produces both singleton fragments like `MIT` / `Apache-2.0` and a covering joined expression like `Apache-2.0 OR MIT`, Provenant prefers the joined expression instead of surfacing a noisier or accidentally conjunctive end-state.
- The README/license-processing path also stops injecting Apache-specific badge or markdown-hint augmentation into files that already contain one of these explicit dual-license notices, because that hinting was one of the main reasons the original scans drifted toward `AND`-shaped output.
- Redundant README conjunctive detections are pruned more locally now: the scanner only drops overlapping conjunctive detections that are subsumed by the stronger alternative-license notice, rather than broadly suppressing unrelated detections elsewhere in the same README.
- End-to-end, that means the benchmarked Rust repositories in this PR keep the intended repository semantics — for example `Apache-2.0 OR MIT` in `atomic-rs`, `rust-base64`, and the member crates inside `aeads` — instead of reporting the pair as a conjunction or surfacing extra singleton leftovers as the primary expression.

## Follow-up work

- Created or intentionally deferred:
  - if additional benchmark targets surface the same kinds of reviewed differences, prefer scanner fixes or benchmark-note framing first; only introduce compare normalization when it is clearly generic and semantically lossless