### PR TITLE
feat(serve): add bounded async scan jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prefer release binaries? Download precompiled archives from [GitHub Releases](ht
 - Broader package and dependency extraction across [many ecosystems](docs/SUPPORTED_FORMATS.md), including beyond-parity parsers and improvements in overlapping parser families
 - [Documented parser and detection fixes](docs/improvements/README.md) that reduce noisy results and false-positive classes, including better bare-word GPL/LGPL clue handling
 - Native workflows such as `--incremental` cache reuse and `--paths-file` rooted file lists for CI or changed-file scans
-- A self-hosted `provenant serve` HTTP service for remote and polyglot integrations that would otherwise need to manage CLI subprocesses or pre-stage only server-local paths
+- A self-hosted `provenant serve` HTTP service with warm process reuse, remote-friendly inputs, and async job handling for automation. See the [Serve API Guide](docs/SERVE_API_GUIDE.md)
 - Single self-contained binary for simpler installation and CI use
 - [ScanCode-compatible](docs/SCANCODE_COMPARISON.md) workflows and output formats, including ScanCode-style JSON, SPDX, CycloneDX, YAML, JSON Lines, HTML, and custom templates
 - [Security-first](docs/adr/0004-security-first-parsing.md) static parsing with explicit safeguards and compatibility-focused tradeoffs where needed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prefer release binaries? Download precompiled archives from [GitHub Releases](ht
 - Broader package and dependency extraction across [many ecosystems](docs/SUPPORTED_FORMATS.md), including beyond-parity parsers and improvements in overlapping parser families
 - [Documented parser and detection fixes](docs/improvements/README.md) that reduce noisy results and false-positive classes, including better bare-word GPL/LGPL clue handling
 - Native workflows such as `--incremental` cache reuse and `--paths-file` rooted file lists for CI or changed-file scans
-- A self-hosted `provenant serve` HTTP service mode for integrations that would otherwise need to manage CLI subprocesses
+- A self-hosted `provenant serve` HTTP service for remote and polyglot integrations that would otherwise need to manage CLI subprocesses or pre-stage only server-local paths
 - Single self-contained binary for simpler installation and CI use
 - [ScanCode-compatible](docs/SCANCODE_COMPARISON.md) workflows and output formats, including ScanCode-style JSON, SPDX, CycloneDX, YAML, JSON Lines, HTML, and custom templates
 - [Security-first](docs/adr/0004-security-first-parsing.md) static parsing with explicit safeguards and compatibility-focused tradeoffs where needed
@@ -56,6 +56,7 @@ Prefer release binaries? Download precompiled archives from [GitHub Releases](ht
 - Include and exclude filtering, path normalization, and scan-result filtering
 - Incremental reuse for repeated scans of the same tree
 - Explicit rooted selected-file scans via `--paths-file`
+- Long-lived HTTP scanning via `provenant serve`, including sync/async requests, remote-friendly inputs, and job polling
 - Security-first parsing with explicit safeguards and compatibility-focused tradeoffs where needed
 
 ## Installation

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -29,7 +29,7 @@ Provenant also ships a long-lived HTTP service shell:
 provenant serve --help
 ```
 
-`provenant serve` starts a long-lived HTTP service with `/livez`, `/readyz`, `/version`, and synchronous `POST /v1/scans` support for operator-mode local paths plus remote-ingestion inputs (`input.type=repository`, `url`, and bounded `upload`). For request/response examples, see the [Serve API Guide](SERVE_API_GUIDE.md).
+`provenant serve` starts a long-lived HTTP service with `/livez`, `/readyz`, `/version`, synchronous `POST /v1/scans`, asynchronous `POST /v1/scans:async`, and async job polling via `/v1/jobs/{id}` plus `/v1/jobs/{id}/result`. It supports operator-mode local paths plus remote-ingestion inputs (`input.type=repository`, `url`, and bounded `upload`). For request/response examples, see the [Serve API Guide](SERVE_API_GUIDE.md).
 
 ## Start Here: A Strong Default Scan
 

--- a/docs/SERVE_API_GUIDE.md
+++ b/docs/SERVE_API_GUIDE.md
@@ -146,18 +146,27 @@ Upload input is a bounded JSON upload path for smaller archives, SBOMs, or other
 
 The payload is base64 encoded and identified by a file name. Archive uploads use the same archive extraction behavior as remote URL inputs.
 
-```json
+One practical shell workflow is:
+
+```sh
+CONTENT_BASE64=$(base64 < snapshot.zip | tr -d '\n')
+
+curl -sS \
+  -X POST http://127.0.0.1:8080/v1/scans \
+  -H 'Content-Type: application/json' \
+  --data-binary @- <<EOF
 {
   "input": {
     "type": "upload",
     "filename": "snapshot.zip",
-    "content_base64": "UEsDB..."
+    "content_base64": "${CONTENT_BASE64}"
   },
   "options": {
     "detect_license": { "type": "embedded" },
     "detect_packages": true
   }
 }
+EOF
 ```
 
 The response body is the same ScanCode-compatible JSON shape Provenant already exposes through its existing output schema.

--- a/docs/SERVE_API_GUIDE.md
+++ b/docs/SERVE_API_GUIDE.md
@@ -22,6 +22,9 @@ The current service surface includes:
 - `GET /readyz`
 - `GET /version`
 - synchronous `POST /v1/scans`
+- asynchronous `POST /v1/scans:async`
+- `GET /v1/jobs/{id}`
+- `GET /v1/jobs/{id}/result`
 
 ## Check service health
 
@@ -159,6 +162,68 @@ The payload is base64 encoded and identified by a file name. Archive uploads use
 
 The response body is the same ScanCode-compatible JSON shape Provenant already exposes through its existing output schema.
 
+## Run an asynchronous scan
+
+Send the same JSON request shape to `POST /v1/scans:async` when you want a durable job handle instead of waiting for the final scan result on the submission request.
+
+Example:
+
+```sh
+curl -sS \
+  -X POST http://127.0.0.1:8080/v1/scans:async \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "input": {
+      "type": "url",
+      "url": "https://github.com/aboutcode-org/scancode.io/archive/refs/heads/main.zip"
+    },
+    "options": {
+      "detect_license": { "type": "embedded" },
+      "detect_packages": true,
+      "collect_info": true
+    }
+  }'
+```
+
+Expected acceptance shape:
+
+```json
+{
+  "status": "accepted",
+  "job_id": "job-7d0f4d8a0d784264a8fe632fe3ffc4fd",
+  "state": "pending",
+  "status_url": "/v1/jobs/job-7d0f4d8a0d784264a8fe632fe3ffc4fd",
+  "result_url": "/v1/jobs/job-7d0f4d8a0d784264a8fe632fe3ffc4fd/result"
+}
+```
+
+The service may keep the job in `pending` until bounded execution capacity is available. Once it starts work, the job moves to `running`, and then to `succeeded` or `failed`.
+
+Check job state:
+
+```sh
+curl -sS http://127.0.0.1:8080/v1/jobs/job-7d0f4d8a0d784264a8fe632fe3ffc4fd
+```
+
+Example status response:
+
+```json
+{
+  "job_id": "job-7d0f4d8a0d784264a8fe632fe3ffc4fd",
+  "state": "running",
+  "result_ready": false,
+  "allocated_processors": 4
+}
+```
+
+Fetch the completed result:
+
+```sh
+curl -sS http://127.0.0.1:8080/v1/jobs/job-7d0f4d8a0d784264a8fe632fe3ffc4fd/result
+```
+
+Before completion, `GET /v1/jobs/{id}/result` returns a non-success `job_not_ready` error. After completion, it returns the same ScanCode-compatible JSON shape as the synchronous route.
+
 ## Common request options
 
 The request body currently supports scan options that map onto the shared Provenant scan pipeline, including:
@@ -201,12 +266,13 @@ The first practical default is usually a local-path equivalent of CLI `-clupe`:
 
 The current API surface is intentionally narrow:
 
-- only synchronous `POST /v1/scans` is implemented
-- sync inputs currently support local paths, repository refs, remote URLs, and bounded JSON uploads
-- async routes are not implemented yet
+- synchronous and asynchronous scan submission use the same request body shape
+- inputs currently support local paths, repository refs, remote URLs, and bounded JSON uploads
+- async jobs run under bounded background execution and may wait in `pending` before starting
 - upload input is JSON-only and bounded; multipart upload is not implemented
 - remote URL input currently supports only `http` and `https`
-- auth, job persistence, and async job APIs are not implemented yet
+- auth is not implemented
+- async job state and result retention are bounded in-memory service state, not durable external persistence
 
 ## Machine-readable contract
 

--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -15,13 +15,6 @@ implementation-plans/
 └── infrastructure/        # Plugin system, caching, progress tracking
 ```
 
-## Active Plans
-
-### Infrastructure (`infrastructure/`)
-
-- **[SERVE_PLAN.md](infrastructure/SERVE_PLAN.md)** - End-to-end plan and shell rollout for `provenant serve`
-  - Status: 🟡 Active — tracks the planned end-state `provenant serve` contract until the service surface is stable enough to move into evergreen docs
-
 ## Historical Rollout Records and Reference Documents
 
 These topics are implemented. Some remain useful as completed historical records, while others point to the evergreen maintainer document that now owns the live contract.
@@ -63,6 +56,9 @@ These topics are implemented. Some remain useful as completed historical records
   - Status: 🟢 Complete — shaping-specific CLI behavior now lives in `src/scan_result_shaping/`, scanner path selection, and the main orchestration pipeline; remaining non-shaping parity follow-up is tracked in adjacent plans
 
 ### Infrastructure (`infrastructure/`)
+
+- **[SERVE_PLAN.md](infrastructure/SERVE_PLAN.md)** - End-to-end `provenant serve` rollout and contract record
+  - Status: 🟢 Complete — the planned sync/async self-hosted service contract is implemented, and the live user-facing HTTP surface now lives in [`../SERVE_API_GUIDE.md`](../SERVE_API_GUIDE.md)
 
 - **[CACHING_PLAN.md](infrastructure/CACHING_PLAN.md)** - Incremental scanning
   - Status: 🟢 Complete — incremental scanning, XDG cache defaults, and cache lock coordination are implemented; the plan remains as the rollout record

--- a/docs/implementation-plans/infrastructure/SERVE_PLAN.md
+++ b/docs/implementation-plans/infrastructure/SERVE_PLAN.md
@@ -105,6 +105,20 @@ The intended priority is therefore:
 
 In practice, this means path-based operator scans, some small uploads, and some bounded remote URL scans may fit the synchronous route, while repository scans and larger remote fetches are expected to lean heavily on the async route.
 
+### Async execution and admission control
+
+Async job submission should not imply that every request immediately starts a full-power scan.
+
+The service should own execution scheduling explicitly:
+
+- async submissions should enter a service-managed queue or equivalent pending state when execution capacity is not yet available
+- the service should enforce a bounded number of concurrently running scan jobs instead of starting an unbounded number of scans in parallel
+- the service should treat maximum running jobs and per-scan processing parallelism as service- or operator-controlled execution limits rather than caller-controlled API contract fields
+- the service should prefer queueing and backpressure over CPU oversubscription when multiple clients submit expensive scans concurrently
+- async job state should make queued or pending work visible so callers can distinguish "accepted but not running yet" from active execution and terminal completion
+
+This matters because the shared scan pipeline can use most available CPUs for a single scan. In a long-lived API deployment, allowing multiple requests to each claim near-host-wide parallelism would overload the service. The intended contract is therefore create-submit-poll-fetch with bounded execution. The service should be free to run more than one async scan when configured capacity allows it, but it should not hard-wire a policy of launching every accepted job immediately at maximum local parallelism.
+
 ### CLI vs service boundary
 
 `provenant serve` should not exist merely as “the CLI, but over HTTP.”
@@ -192,9 +206,15 @@ This route should accept scan requests that exceed the desired synchronous execu
 
 This is the preferred route family for repository scans, larger uploads, slower remote URL fetches, and other workloads where fetch and staging are part of the request lifecycle.
 
+Accepted jobs may remain queued or pending until service execution capacity is available. The route is an admission point into bounded background execution, not a promise that every accepted request begins scanning immediately.
+
+The end-state contract should permit more than one job to run concurrently when the service has been configured with capacity for that, while still allowing conservative deployments to keep tighter limits.
+
 ### `GET /v1/jobs/{id}`
 
 This route should expose async job state, including terminal success/failure, without requiring clients to infer job semantics from transport errors.
+
+The status surface should make at least pending, running, succeeded, and failed states explicit.
 
 ### `GET /v1/jobs/{id}/result`
 
@@ -211,6 +231,9 @@ This route should return the completed scan result for async jobs using the same
 - the service continues to support trusted local-path scans only as an explicit operator-mode transport
 - `POST /v1/scans:async` returns a durable job handle for larger workloads
 - `GET /v1/jobs/{id}` and `GET /v1/jobs/{id}/result` return stable async status/result contracts
+- async submission remains safe under multiple concurrent client requests because the service queues or otherwise bounds background execution instead of launching an unbounded number of scans immediately
+- async job status can represent queued or pending work before execution begins
+- the async contract does not force a single-running-job policy; it allows multiple concurrent jobs when service-configured execution limits permit that safely
 - at least one repository-driven or remote-URL-driven input flow works cleanly for ECS/Fargate-style deployments without requiring callers to pre-mount files onto the scanner host
 - the async API is straightforward to drive from external CI, webhook, or cron-based automation without requiring a built-in scheduler
 - starting a second shell on an occupied port exits non-zero with a deterministic bind failure

--- a/docs/implementation-plans/infrastructure/SERVE_PLAN.md
+++ b/docs/implementation-plans/infrastructure/SERVE_PLAN.md
@@ -1,15 +1,15 @@
-# `provenant serve` Plan and Contract
+# `provenant serve` Rollout Record and Contract
 
-> **Status**: 🟡 Active implementation plan — this document defines the intended end-state `provenant serve` contract
+> **Status**: 🟢 Complete historical rollout record — this document records the implemented end-state `provenant serve` contract
 > **Related docs**: [`../../SERVE_API_GUIDE.md`](../../SERVE_API_GUIDE.md) for the implemented HTTP surface and [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md) for runtime placement
 > **Priority**: P1 — define the full self-hosted service shape up front
 > **Tracking issue**: [`#834`](https://github.com/mstykow/provenant/issues/834)
 
 ## Overview
 
-`provenant serve` is the planned **self-hosted long-lived HTTP scanner service** built on top of the shared app/workflow pipeline introduced in the stacked base PR.
+`provenant serve` is the implemented **self-hosted long-lived HTTP scanner service** built on top of the shared app/workflow pipeline introduced in the stacked base PR.
 
-This document defines the **end-state service contract**.
+This document records the **implemented end-state service contract**.
 
 ## Product goals
 

--- a/docs/openapi/provenant-serve.openapi.json
+++ b/docs/openapi/provenant-serve.openapi.json
@@ -128,6 +128,161 @@
           }
         }
       }
+    },
+    "/v1/scans:async": {
+      "post": {
+        "summary": "Submit an asynchronous scan job",
+        "operationId": "postAsyncScan",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncScanRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Scan job accepted for bounded background execution.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncScanAcceptedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid HTTP request or malformed JSON body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported media type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service has no remaining async admission capacity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/{id}": {
+      "get": {
+        "summary": "Inspect asynchronous job state",
+        "operationId": "getAsyncJobStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current async job state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobStatusResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Async job was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/{id}/result": {
+      "get": {
+        "summary": "Fetch completed asynchronous job result",
+        "operationId": "getAsyncJobResult",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Completed ScanCode-compatible scan result output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Current ScanCode-compatible output JSON returned by the shared Provenant output schema."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Async job was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Async job has not completed yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Async job completed with a failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -217,6 +372,103 @@
           "message",
           "api_version"
         ]
+      },
+      "AsyncJobState": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "AsyncJobState",
+        "type": "string",
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed"
+        ]
+      },
+      "AsyncScanAcceptedResponse": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "AsyncScanAcceptedResponse",
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "job_id": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/$defs/AsyncJobState"
+          },
+          "status_url": {
+            "type": "string"
+          },
+          "result_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "job_id",
+          "state",
+          "status_url",
+          "result_url"
+        ],
+        "$defs": {
+          "AsyncJobState": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "succeeded",
+              "failed"
+            ]
+          }
+        }
+      },
+      "AsyncJobStatusResponse": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "AsyncJobStatusResponse",
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/$defs/AsyncJobState"
+          },
+          "result_ready": {
+            "type": "boolean"
+          },
+          "allocated_processors": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "job_id",
+          "state",
+          "result_ready"
+        ],
+        "$defs": {
+          "AsyncJobState": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "succeeded",
+              "failed"
+            ]
+          }
+        }
       },
       "SyncScanRequest": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -3,7 +3,7 @@
 
 mod ingest;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
@@ -14,12 +14,15 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow};
 use serde_json::json;
 use tempfile::TempDir;
+use uuid::Uuid;
 
+use crate::ProcessMode;
 use crate::cli::ServeArgs;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::serve_api::{
-    API_VERSION, ServeErrorResponse, ServeLivenessResponse, ServeReadinessResponse,
-    ServeVersionResponse, SyncLicenseSource, SyncScanRequest,
+    API_VERSION, AsyncJobState, AsyncJobStatusResponse, AsyncScanAcceptedResponse,
+    ServeErrorResponse, ServeLivenessResponse, ServeReadinessResponse, ServeVersionResponse,
+    SyncLicenseSource, SyncScanRequest,
 };
 use crate::version::BUILD_VERSION;
 use crate::workflow::{LicenseSource, ScanOptions, scan_paths};
@@ -27,6 +30,8 @@ use ingest::prepare_sync_input;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_BODY_BYTES: usize = 24 * 1024 * 1024;
+const DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB: usize = 4;
+const DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS: usize = 64;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServeConfig {
@@ -57,6 +62,64 @@ enum ReadinessState {
 #[derive(Debug)]
 struct ServeState {
     readiness: Arc<Mutex<ReadinessState>>,
+    jobs: AsyncJobController,
+}
+
+#[derive(Debug, Clone)]
+struct AsyncJobController {
+    inner: Arc<Mutex<AsyncJobControllerState>>,
+    processor_budget: usize,
+    max_processors_per_job: usize,
+    max_retained_terminal_jobs: usize,
+}
+
+#[derive(Debug)]
+struct AsyncJobControllerState {
+    active_processors: usize,
+    jobs: HashMap<String, AsyncJobRecord>,
+    pending: VecDeque<PendingAsyncJob>,
+    completed: VecDeque<String>,
+}
+
+#[derive(Debug)]
+struct PendingAsyncJob {
+    job_id: String,
+    request: SyncScanRequest,
+}
+
+#[derive(Debug)]
+struct AsyncJobRecord {
+    state: AsyncJobState,
+    allocated_processors: Option<usize>,
+    result_body: Option<String>,
+    error_message: Option<String>,
+}
+
+#[derive(Debug)]
+struct DispatchedAsyncJob {
+    job_id: String,
+    request: SyncScanRequest,
+    allocated_processors: usize,
+}
+
+#[derive(Debug, Clone)]
+struct AsyncJobSnapshot {
+    job_id: String,
+    state: AsyncJobState,
+    allocated_processors: Option<usize>,
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct AsyncJobResultSnapshot {
+    state: AsyncJobState,
+    result_body: Option<String>,
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AsyncSubmitError {
+    QueueFull,
 }
 
 #[derive(Debug)]
@@ -65,6 +128,229 @@ struct HttpRequest {
     path: String,
     headers: HashMap<String, String>,
     body: Vec<u8>,
+}
+
+impl AsyncJobController {
+    fn new() -> Self {
+        let processor_budget = default_async_processor_budget();
+        Self::with_limits(
+            processor_budget,
+            processor_budget.clamp(1, DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB),
+            DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS,
+        )
+    }
+
+    fn with_limits(
+        processor_budget: usize,
+        max_processors_per_job: usize,
+        max_retained_terminal_jobs: usize,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(AsyncJobControllerState {
+                active_processors: 0,
+                jobs: HashMap::new(),
+                pending: VecDeque::new(),
+                completed: VecDeque::new(),
+            })),
+            processor_budget: processor_budget.max(1),
+            max_processors_per_job: max_processors_per_job.max(1),
+            max_retained_terminal_jobs: max_retained_terminal_jobs.max(1),
+        }
+    }
+
+    fn submit(
+        &self,
+        request: SyncScanRequest,
+    ) -> std::result::Result<AsyncScanAcceptedResponse, AsyncSubmitError> {
+        let (response, dispatches) = {
+            let mut inner = self
+                .inner
+                .lock()
+                .expect("serve async job lock should not be poisoned");
+            if inner.non_terminal_jobs() >= self.max_non_terminal_jobs() {
+                return Err(AsyncSubmitError::QueueFull);
+            }
+
+            let job_id = format!("job-{}", Uuid::new_v4().simple());
+            inner.jobs.insert(job_id.clone(), AsyncJobRecord::pending());
+            inner.pending.push_back(PendingAsyncJob {
+                job_id: job_id.clone(),
+                request,
+            });
+            let dispatches = self.schedule_locked(&mut inner);
+            let snapshot = inner
+                .status_snapshot(&job_id)
+                .expect("submitted async job should be present");
+            (
+                AsyncScanAcceptedResponse {
+                    status: "accepted".to_string(),
+                    job_id: job_id.clone(),
+                    state: snapshot.state,
+                    status_url: format!("/v1/jobs/{job_id}"),
+                    result_url: format!("/v1/jobs/{job_id}/result"),
+                },
+                dispatches,
+            )
+        };
+
+        self.spawn_dispatches(dispatches);
+        Ok(response)
+    }
+
+    fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
+        self.inner
+            .lock()
+            .expect("serve async job lock should not be poisoned")
+            .status_snapshot(job_id)
+    }
+
+    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
+        self.inner
+            .lock()
+            .expect("serve async job lock should not be poisoned")
+            .result_snapshot(job_id)
+    }
+
+    fn max_non_terminal_jobs(&self) -> usize {
+        self.processor_budget.saturating_mul(4).max(4)
+    }
+
+    fn schedule_locked(&self, inner: &mut AsyncJobControllerState) -> Vec<DispatchedAsyncJob> {
+        let mut dispatches = Vec::new();
+
+        while !inner.pending.is_empty() {
+            let available_processors = self
+                .processor_budget
+                .saturating_sub(inner.active_processors);
+            if available_processors == 0 {
+                break;
+            }
+
+            let allocated_processors = available_processors.min(self.max_processors_per_job).max(1);
+            let PendingAsyncJob { job_id, request } = inner
+                .pending
+                .pop_front()
+                .expect("pending async job should still exist");
+            let record = inner
+                .jobs
+                .get_mut(&job_id)
+                .expect("queued async job should have metadata");
+            record.state = AsyncJobState::Running;
+            record.allocated_processors = Some(allocated_processors);
+            record.error_message = None;
+            inner.active_processors += allocated_processors;
+            dispatches.push(DispatchedAsyncJob {
+                job_id,
+                request,
+                allocated_processors,
+            });
+        }
+
+        dispatches
+    }
+
+    fn spawn_dispatches(&self, dispatches: Vec<DispatchedAsyncJob>) {
+        for dispatched in dispatches {
+            let controller = self.clone();
+            thread::spawn(move || controller.run_job(dispatched));
+        }
+    }
+
+    fn run_job(&self, dispatched: DispatchedAsyncJob) {
+        let result = run_async_scan_request(dispatched.request, dispatched.allocated_processors);
+        let follow_up_dispatches = {
+            let mut inner = self
+                .inner
+                .lock()
+                .expect("serve async job lock should not be poisoned");
+            inner.active_processors = inner
+                .active_processors
+                .saturating_sub(dispatched.allocated_processors);
+
+            let record = inner
+                .jobs
+                .get_mut(&dispatched.job_id)
+                .expect("running async job should have metadata");
+            match result {
+                Ok(result_body) => {
+                    record.state = AsyncJobState::Succeeded;
+                    record.result_body = Some(result_body);
+                    record.error_message = None;
+                }
+                Err(error) => {
+                    eprintln!("serve async job {} failed: {error}", dispatched.job_id);
+                    record.state = AsyncJobState::Failed;
+                    record.result_body = None;
+                    record.error_message = Some("async scan job failed".to_string());
+                }
+            }
+
+            inner.completed.push_back(dispatched.job_id.clone());
+            inner.evict_completed_jobs(self.max_retained_terminal_jobs);
+
+            self.schedule_locked(&mut inner)
+        };
+
+        self.spawn_dispatches(follow_up_dispatches);
+    }
+}
+
+impl AsyncJobControllerState {
+    fn non_terminal_jobs(&self) -> usize {
+        self.jobs
+            .values()
+            .filter(|job| matches!(job.state, AsyncJobState::Pending | AsyncJobState::Running))
+            .count()
+    }
+
+    fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
+        self.jobs.get(job_id).map(|job| AsyncJobSnapshot {
+            job_id: job_id.to_string(),
+            state: job.state,
+            allocated_processors: job.allocated_processors,
+            error_message: job.error_message.clone(),
+        })
+    }
+
+    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
+        self.jobs.get(job_id).map(|job| AsyncJobResultSnapshot {
+            state: job.state,
+            result_body: job.result_body.clone(),
+            error_message: job.error_message.clone(),
+        })
+    }
+
+    fn evict_completed_jobs(&mut self, max_retained_terminal_jobs: usize) {
+        while self.completed.len() > max_retained_terminal_jobs {
+            let Some(job_id) = self.completed.pop_front() else {
+                break;
+            };
+            self.jobs.remove(&job_id);
+        }
+    }
+}
+
+impl AsyncJobRecord {
+    fn pending() -> Self {
+        Self {
+            state: AsyncJobState::Pending,
+            allocated_processors: None,
+            result_body: None,
+            error_message: None,
+        }
+    }
+}
+
+impl AsyncJobSnapshot {
+    fn into_status_response(self) -> AsyncJobStatusResponse {
+        AsyncJobStatusResponse {
+            job_id: self.job_id,
+            state: self.state,
+            result_ready: matches!(self.state, AsyncJobState::Succeeded),
+            allocated_processors: self.allocated_processors,
+            message: self.error_message,
+        }
+    }
 }
 
 pub(crate) fn run(args: &ServeArgs) -> Result<()> {
@@ -84,7 +370,10 @@ pub(crate) fn run(args: &ServeArgs) -> Result<()> {
         local_addr
     );
 
-    let state = ServeState { readiness };
+    let state = ServeState {
+        readiness,
+        jobs: AsyncJobController::new(),
+    };
     serve_forever(listener, state)
 }
 
@@ -125,6 +414,11 @@ fn serve_forever(listener: TcpListener, state: ServeState) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn default_async_processor_budget() -> usize {
+    let cpus = thread::available_parallelism().map_or(1, |count| count.get());
+    if cpus > 1 { cpus - 1 } else { 1 }
 }
 
 fn handle_connection(mut stream: TcpStream, state: &ServeState) -> Result<()> {
@@ -227,6 +521,35 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
         .expect("serve readiness lock should not be poisoned")
         .clone();
 
+    if let Some(job_route) = parse_job_route(&request.path) {
+        return match job_route {
+            JobRoute::Status(job_id) => {
+                if request.method == "GET" {
+                    handle_job_status_request(job_id, state)
+                } else {
+                    error_response(
+                        405,
+                        "Method Not Allowed",
+                        "method_not_allowed",
+                        format!("use GET /v1/jobs/{job_id} to inspect async job state"),
+                    )
+                }
+            }
+            JobRoute::Result(job_id) => {
+                if request.method == "GET" {
+                    handle_job_result_request(job_id, state)
+                } else {
+                    error_response(
+                        405,
+                        "Method Not Allowed",
+                        "method_not_allowed",
+                        format!("use GET /v1/jobs/{job_id}/result to fetch async job output"),
+                    )
+                }
+            }
+        };
+    }
+
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", "/livez") => serialize_response(
             200,
@@ -285,17 +608,12 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
             "method_not_allowed",
             "use POST /v1/scans for synchronous scan execution".to_string(),
         ),
+        ("POST", "/v1/scans:async") => handle_async_scan_request(request, state),
         (_, "/v1/scans:async") => error_response(
-            501,
-            "Not Implemented",
-            "not_implemented",
-            "async scan routes are not implemented yet".to_string(),
-        ),
-        (_, path) if path.starts_with("/v1/jobs/") => error_response(
-            501,
-            "Not Implemented",
-            "not_implemented",
-            "async job routes are not implemented yet".to_string(),
+            405,
+            "Method Not Allowed",
+            "method_not_allowed",
+            "use POST /v1/scans:async for asynchronous scan submission".to_string(),
         ),
         _ => json_response(
             404,
@@ -306,24 +624,9 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
 }
 
 fn handle_sync_scan_request(request: &HttpRequest) -> HttpResponse {
-    if !request
-        .headers
-        .get("content-type")
-        .is_some_and(|value| value.starts_with("application/json"))
-    {
-        return error_response(
-            415,
-            "Unsupported Media Type",
-            "unsupported_media_type",
-            "POST /v1/scans requires Content-Type: application/json".to_string(),
-        );
-    }
-
-    let sync_request = match decode_sync_scan_request(&request.body) {
+    let sync_request = match decode_scan_request_from_http(request, "POST /v1/scans") {
         Ok(sync_request) => sync_request,
-        Err(error) => {
-            return error_response(400, "Bad Request", "invalid_request", error.to_string());
-        }
+        Err(response) => return response,
     };
 
     let execution = match build_sync_scan_execution(sync_request) {
@@ -338,11 +641,12 @@ fn handle_sync_scan_request(request: &HttpRequest) -> HttpResponse {
         }
     };
 
-    match scan_paths(
-        execution.paths.iter().map(|path| path.as_path()),
-        &execution.options,
-    ) {
-        Ok(output) => serialize_response(200, "OK", &crate::output_schema::Output::from(&output)),
+    match execute_scan_execution(execution) {
+        Ok(body) => HttpResponse {
+            status_code: 200,
+            reason: "OK",
+            body,
+        },
         Err(error) => error_response(
             422,
             "Unprocessable Entity",
@@ -352,8 +656,96 @@ fn handle_sync_scan_request(request: &HttpRequest) -> HttpResponse {
     }
 }
 
+fn handle_async_scan_request(request: &HttpRequest, state: &ServeState) -> HttpResponse {
+    let sync_request = match decode_scan_request_from_http(request, "POST /v1/scans:async") {
+        Ok(sync_request) => sync_request,
+        Err(response) => return response,
+    };
+
+    match state.jobs.submit(sync_request) {
+        Ok(response) => serialize_response(202, "Accepted", &response),
+        Err(AsyncSubmitError::QueueFull) => error_response(
+            503,
+            "Service Unavailable",
+            "server_busy",
+            "async job queue is full; try again later".to_string(),
+        ),
+    }
+}
+
+fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
+    match state.jobs.status_snapshot(job_id) {
+        Some(snapshot) => serialize_response(200, "OK", &snapshot.into_status_response()),
+        None => error_response(
+            404,
+            "Not Found",
+            "job_not_found",
+            format!("async job {job_id} was not found"),
+        ),
+    }
+}
+
+fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
+    let Some(snapshot) = state.jobs.result_snapshot(job_id) else {
+        return error_response(
+            404,
+            "Not Found",
+            "job_not_found",
+            format!("async job {job_id} was not found"),
+        );
+    };
+
+    match snapshot.state {
+        AsyncJobState::Succeeded => HttpResponse {
+            status_code: 200,
+            reason: "OK",
+            body: snapshot
+                .result_body
+                .expect("successful async job should retain result body"),
+        },
+        AsyncJobState::Pending | AsyncJobState::Running => error_response(
+            409,
+            "Conflict",
+            "job_not_ready",
+            format!(
+                "async job {job_id} is currently {}",
+                async_job_state_label(snapshot.state)
+            ),
+        ),
+        AsyncJobState::Failed => error_response(
+            422,
+            "Unprocessable Entity",
+            "job_failed",
+            snapshot
+                .error_message
+                .unwrap_or_else(|| format!("async job {job_id} failed")),
+        ),
+    }
+}
+
 fn decode_sync_scan_request(body: &[u8]) -> Result<SyncScanRequest> {
     serde_json::from_slice(body).context("request body must be valid JSON")
+}
+
+fn decode_scan_request_from_http(
+    request: &HttpRequest,
+    route_label: &str,
+) -> std::result::Result<SyncScanRequest, HttpResponse> {
+    if !request
+        .headers
+        .get("content-type")
+        .is_some_and(|value| value.starts_with("application/json"))
+    {
+        return Err(error_response(
+            415,
+            "Unsupported Media Type",
+            "unsupported_media_type",
+            format!("{route_label} requires Content-Type: application/json"),
+        ));
+    }
+
+    decode_sync_scan_request(&request.body)
+        .map_err(|error| error_response(400, "Bad Request", "invalid_request", error.to_string()))
 }
 
 fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecution> {
@@ -404,6 +796,52 @@ fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecuti
         options,
         _staging_dir: prepared_input.staging_dir,
     })
+}
+
+fn execute_scan_execution(execution: SyncScanExecution) -> Result<String> {
+    let output = scan_paths(
+        execution.paths.iter().map(|path| path.as_path()),
+        &execution.options,
+    )?;
+    serde_json::to_string(&crate::output_schema::Output::from(&output))
+        .context("scan result should serialize")
+}
+
+fn run_async_scan_request(request: SyncScanRequest, allocated_processors: usize) -> Result<String> {
+    let mut execution = build_sync_scan_execution(request)?;
+    execution.options.process_mode = if allocated_processors <= 1 {
+        ProcessMode::SequentialWithTimeouts
+    } else {
+        ProcessMode::Parallel(allocated_processors)
+    };
+    execute_scan_execution(execution)
+}
+
+fn async_job_state_label(state: AsyncJobState) -> &'static str {
+    match state {
+        AsyncJobState::Pending => "pending",
+        AsyncJobState::Running => "running",
+        AsyncJobState::Succeeded => "succeeded",
+        AsyncJobState::Failed => "failed",
+    }
+}
+
+enum JobRoute<'a> {
+    Status(&'a str),
+    Result(&'a str),
+}
+
+fn parse_job_route(path: &str) -> Option<JobRoute<'_>> {
+    let suffix = path.strip_prefix("/v1/jobs/")?;
+    if let Some(job_id) = suffix.strip_suffix("/result") {
+        return is_valid_job_id(job_id).then_some(JobRoute::Result(job_id));
+    }
+
+    is_valid_job_id(suffix).then_some(JobRoute::Status(suffix))
+}
+
+fn is_valid_job_id(job_id: &str) -> bool {
+    !job_id.is_empty() && !job_id.contains('/')
 }
 
 fn json_response(status_code: u16, reason: &'static str, body: serde_json::Value) -> HttpResponse {
@@ -461,12 +899,34 @@ mod tests {
     use super::*;
     use crate::serve_api::{SyncScanInput, SyncScanOptions};
 
+    fn dummy_async_request() -> SyncScanRequest {
+        SyncScanRequest {
+            input: SyncScanInput::Paths {
+                paths: vec!["/tmp".to_string()],
+            },
+            options: SyncScanOptions::default(),
+        }
+    }
+
     fn ready_state() -> ServeState {
         ServeState {
             readiness: Arc::new(Mutex::new(ReadinessState::Ready {
                 spdx_license_list_version: "3.28".to_string(),
             })),
+            jobs: AsyncJobController::with_limits(2, 2, 8),
         }
+    }
+
+    fn ready_state_with_job(job_id: &str, record: AsyncJobRecord) -> ServeState {
+        let state = ready_state();
+        state
+            .jobs
+            .inner
+            .lock()
+            .expect("test async job lock should not be poisoned")
+            .jobs
+            .insert(job_id.to_string(), record);
+        state
     }
 
     #[test]
@@ -494,7 +954,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_routes_return_not_implemented_contract() {
+    fn async_scan_route_requires_post() {
         let request = HttpRequest {
             method: "GET".to_string(),
             path: "/v1/scans:async".to_string(),
@@ -502,8 +962,169 @@ mod tests {
             body: Vec::new(),
         };
         let response = response_for_request(&request, &ready_state());
-        assert_eq!(response.status_code, 501);
-        assert!(response.body.contains("not_implemented"));
+        assert_eq!(response.status_code, 405);
+        assert!(response.body.contains("method_not_allowed"));
+    }
+
+    #[test]
+    fn pending_job_status_reports_pending_state() {
+        let state = ready_state_with_job("job-1", AsyncJobRecord::pending());
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: "/v1/jobs/job-1".to_string(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+
+        let response = response_for_request(&request, &state);
+        assert_eq!(response.status_code, 200);
+        assert!(response.body.contains("\"state\":\"pending\""));
+        assert!(response.body.contains("\"result_ready\":false"));
+    }
+
+    #[test]
+    fn pending_job_result_reports_not_ready() {
+        let state = ready_state_with_job("job-2", AsyncJobRecord::pending());
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: "/v1/jobs/job-2/result".to_string(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+
+        let response = response_for_request(&request, &state);
+        assert_eq!(response.status_code, 409);
+        assert!(response.body.contains("job_not_ready"));
+    }
+
+    #[test]
+    fn completed_job_result_returns_stored_body() {
+        let state = ready_state_with_job(
+            "job-3",
+            AsyncJobRecord {
+                state: AsyncJobState::Succeeded,
+                allocated_processors: Some(2),
+                result_body: Some("{\"status\":\"ok\"}".to_string()),
+                error_message: None,
+            },
+        );
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: "/v1/jobs/job-3/result".to_string(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+
+        let response = response_for_request(&request, &state);
+        assert_eq!(response.status_code, 200);
+        assert_eq!(response.body, "{\"status\":\"ok\"}");
+    }
+
+    #[test]
+    fn failed_job_result_returns_failure_contract() {
+        let state = ready_state_with_job(
+            "job-4",
+            AsyncJobRecord {
+                state: AsyncJobState::Failed,
+                allocated_processors: Some(1),
+                result_body: None,
+                error_message: Some("async scan job failed".to_string()),
+            },
+        );
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: "/v1/jobs/job-4/result".to_string(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+
+        let response = response_for_request(&request, &state);
+        assert_eq!(response.status_code, 422);
+        assert!(response.body.contains("job_failed"));
+        assert!(response.body.contains("async scan job failed"));
+    }
+
+    #[test]
+    fn async_job_controller_rejects_submit_when_queue_is_full() {
+        let controller = AsyncJobController::with_limits(1, 1, 8);
+        {
+            let mut inner = controller
+                .inner
+                .lock()
+                .expect("test async job lock should not be poisoned");
+            for index in 0..controller.max_non_terminal_jobs() {
+                inner
+                    .jobs
+                    .insert(format!("job-{index}"), AsyncJobRecord::pending());
+            }
+        }
+
+        let result = controller.submit(dummy_async_request());
+        assert!(matches!(result, Err(AsyncSubmitError::QueueFull)));
+    }
+
+    #[test]
+    fn scheduler_leaves_extra_jobs_pending_when_budget_is_exhausted() {
+        let controller = AsyncJobController::with_limits(4, 2, 8);
+        let mut inner = AsyncJobControllerState {
+            active_processors: 0,
+            jobs: HashMap::new(),
+            pending: VecDeque::new(),
+            completed: VecDeque::new(),
+        };
+
+        for job_id in ["job-a", "job-b", "job-c"] {
+            inner
+                .jobs
+                .insert(job_id.to_string(), AsyncJobRecord::pending());
+            inner.pending.push_back(PendingAsyncJob {
+                job_id: job_id.to_string(),
+                request: dummy_async_request(),
+            });
+        }
+
+        let dispatches = controller.schedule_locked(&mut inner);
+        assert_eq!(dispatches.len(), 2);
+        assert_eq!(inner.active_processors, 4);
+        assert_eq!(inner.pending.len(), 1);
+        assert_eq!(inner.jobs["job-a"].state, AsyncJobState::Running);
+        assert_eq!(inner.jobs["job-b"].state, AsyncJobState::Running);
+        assert_eq!(inner.jobs["job-c"].state, AsyncJobState::Pending);
+    }
+
+    #[test]
+    fn completed_jobs_are_evicted_when_retention_limit_is_exceeded() {
+        let mut inner = AsyncJobControllerState {
+            active_processors: 0,
+            jobs: HashMap::from([
+                (
+                    "job-old".to_string(),
+                    AsyncJobRecord {
+                        state: AsyncJobState::Succeeded,
+                        allocated_processors: Some(1),
+                        result_body: Some("old".to_string()),
+                        error_message: None,
+                    },
+                ),
+                (
+                    "job-new".to_string(),
+                    AsyncJobRecord {
+                        state: AsyncJobState::Succeeded,
+                        allocated_processors: Some(1),
+                        result_body: Some("new".to_string()),
+                        error_message: None,
+                    },
+                ),
+            ]),
+            pending: VecDeque::new(),
+            completed: VecDeque::from(["job-old".to_string(), "job-new".to_string()]),
+        };
+
+        inner.evict_completed_jobs(1);
+
+        assert!(!inner.jobs.contains_key("job-old"));
+        assert!(inner.jobs.contains_key("job-new"));
+        assert_eq!(inner.completed.len(), 1);
     }
 
     #[test]

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -37,6 +37,35 @@ pub struct ServeErrorResponse {
     pub api_version: String,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AsyncJobState {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AsyncScanAcceptedResponse {
+    pub status: String,
+    pub job_id: String,
+    pub state: AsyncJobState,
+    pub status_url: String,
+    pub result_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AsyncJobStatusResponse {
+    pub job_id: String,
+    pub state: AsyncJobState,
+    pub result_ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allocated_processors: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SyncScanRequest {
     pub input: SyncScanInput,
@@ -257,6 +286,137 @@ pub fn openapi_document() -> Value {
                         }
                     }
                 }
+            },
+            "/v1/scans:async": {
+                "post": {
+                    "summary": "Submit an asynchronous scan job",
+                    "operationId": "postAsyncScan",
+                    "requestBody": {
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/SyncScanRequest"}
+                            }
+                        }
+                    },
+                    "responses": {
+                        "202": {
+                            "description": "Scan job accepted for bounded background execution.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/AsyncScanAcceptedResponse"}
+                                }
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid HTTP request or malformed JSON body.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        },
+                        "415": {
+                            "description": "Unsupported media type.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        },
+                        "503": {
+                            "description": "Service has no remaining async admission capacity.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/v1/jobs/{id}": {
+                "get": {
+                    "summary": "Inspect asynchronous job state",
+                    "operationId": "getAsyncJobStatus",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "schema": {"type": "string"}
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Current async job state.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/AsyncJobStatusResponse"}
+                                }
+                            }
+                        },
+                        "404": {
+                            "description": "Async job was not found.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/v1/jobs/{id}/result": {
+                "get": {
+                    "summary": "Fetch completed asynchronous job result",
+                    "operationId": "getAsyncJobResult",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "schema": {"type": "string"}
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Completed ScanCode-compatible scan result output.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "description": "Current ScanCode-compatible output JSON returned by the shared Provenant output schema."
+                                    }
+                                }
+                            }
+                        },
+                        "404": {
+                            "description": "Async job was not found.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        },
+                        "409": {
+                            "description": "Async job has not completed yet.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        },
+                        "422": {
+                            "description": "Async job completed with a failure.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "components": {
@@ -265,6 +425,9 @@ pub fn openapi_document() -> Value {
                 "ServeReadinessResponse": schema_json::<ServeReadinessResponse>(),
                 "ServeVersionResponse": schema_json::<ServeVersionResponse>(),
                 "ServeErrorResponse": schema_json::<ServeErrorResponse>(),
+                "AsyncJobState": schema_json::<AsyncJobState>(),
+                "AsyncScanAcceptedResponse": schema_json::<AsyncScanAcceptedResponse>(),
+                "AsyncJobStatusResponse": schema_json::<AsyncJobStatusResponse>(),
                 "SyncScanRequest": schema_json::<SyncScanRequest>(),
                 "SyncScanInput": schema_json::<SyncScanInput>(),
                 "SyncLicenseSource": schema_json::<SyncLicenseSource>(),

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -47,6 +47,27 @@ fn wait_for_http_status(port: u16, path: &str, expected: u16) -> String {
     }
 }
 
+fn wait_for_job_state(port: u16, path: &str, expected: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(response) = raw_http_request(port, "GET", path, None, None)
+            && response_status(&response) == 200
+        {
+            let json = response_json_body(&response);
+            if json["state"] == expected {
+                return json;
+            }
+            assert_ne!(json["state"], "failed", "async job failed: {json}");
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {path} to reach state {expected}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 fn raw_http_request(
     port: u16,
     method: &str,
@@ -850,6 +871,140 @@ fn serve_shell_scans_uploaded_archive_input() {
         file_paths.contains(&"upload-root/LICENSE"),
         "response paths were: {file_paths:?}"
     );
+
+    child.kill().expect("serve child should terminate");
+    child.wait().expect("serve child wait should succeed");
+}
+
+#[test]
+fn serve_shell_runs_async_url_scan_and_returns_result() {
+    let zip_bytes = create_zip_archive_bytes(&[("repo-main/README.md", "downloaded fixture\n")]);
+    let (fixture_port, fixture_handle) = spawn_static_http_server(zip_bytes, "application/zip");
+    let port = reserve_local_port();
+    let mut child = provenant_command()
+        .args(["serve", "--bind", &format!("127.0.0.1:{port}")])
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn provenant serve");
+
+    let _ = wait_for_http_status(port, "/readyz", 200);
+
+    let request_body = serde_json::json!({
+        "input": {
+            "type": "url",
+            "url": format!("http://127.0.0.1:{fixture_port}/repo.zip"),
+        },
+        "options": {
+            "collect_info": true,
+        }
+    })
+    .to_string();
+
+    let accepted = raw_http_request(
+        port,
+        "POST",
+        "/v1/scans:async",
+        Some(&request_body),
+        Some("application/json"),
+    )
+    .expect("async URL scan request should succeed");
+
+    assert_eq!(response_status(&accepted), 202);
+    let accepted_json = response_json_body(&accepted);
+    assert_eq!(accepted_json["status"], "accepted");
+    assert!(matches!(
+        accepted_json["state"].as_str(),
+        Some("pending" | "running" | "succeeded")
+    ));
+
+    let status_url = accepted_json["status_url"]
+        .as_str()
+        .expect("status_url should be a string")
+        .to_string();
+    let result_url = accepted_json["result_url"]
+        .as_str()
+        .expect("result_url should be a string")
+        .to_string();
+
+    let early_result = raw_http_request(port, "GET", &result_url, None, None)
+        .expect("early async result request should return an HTTP response");
+    assert_eq!(response_status(&early_result), 409);
+    let early_result_json = response_json_body(&early_result);
+    assert_eq!(early_result_json["status"], "job_not_ready");
+
+    let final_status = wait_for_job_state(port, &status_url, "succeeded");
+    assert_eq!(final_status["result_ready"], true);
+
+    let result = wait_for_http_status(port, &result_url, 200);
+    let response_json = response_json_body(&result);
+    let file_paths: Vec<_> = response_json["files"]
+        .as_array()
+        .expect("files should be an array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert!(
+        file_paths.contains(&"repo-main/README.md"),
+        "response paths were: {file_paths:?}"
+    );
+    assert!(
+        file_paths
+            .iter()
+            .all(|path| !path.contains("tmp") && !path.contains("var/folders")),
+        "temporary staging leaked into response paths: {file_paths:?}"
+    );
+
+    fixture_handle.join().expect("fixture server should exit");
+    child.kill().expect("serve child should terminate");
+    child.wait().expect("serve child wait should succeed");
+}
+
+#[test]
+fn serve_shell_reports_async_job_failure_without_internal_details() {
+    let port = reserve_local_port();
+    let mut child = provenant_command()
+        .args(["serve", "--bind", &format!("127.0.0.1:{port}")])
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn provenant serve");
+
+    let _ = wait_for_http_status(port, "/readyz", 200);
+
+    let request_body = serde_json::json!({
+        "input": {
+            "type": "url",
+            "url": "file:///tmp/input.txt",
+        }
+    })
+    .to_string();
+
+    let accepted = raw_http_request(
+        port,
+        "POST",
+        "/v1/scans:async",
+        Some(&request_body),
+        Some("application/json"),
+    )
+    .expect("async invalid URL scan request should return acceptance response");
+
+    assert_eq!(response_status(&accepted), 202);
+    let accepted_json = response_json_body(&accepted);
+    let status_url = accepted_json["status_url"]
+        .as_str()
+        .expect("status_url should be a string")
+        .to_string();
+    let result_url = accepted_json["result_url"]
+        .as_str()
+        .expect("result_url should be a string")
+        .to_string();
+
+    let final_status = wait_for_job_state(port, &status_url, "failed");
+    assert_eq!(final_status["message"], "async scan job failed");
+
+    let result = wait_for_http_status(port, &result_url, 422);
+    let result_json = response_json_body(&result);
+    assert_eq!(result_json["status"], "job_failed");
+    assert_eq!(result_json["message"], "async scan job failed");
 
     child.kill().expect("serve child should terminate");
     child.wait().expect("serve child wait should succeed");


### PR DESCRIPTION
## Summary

- add `POST /v1/scans:async`, `GET /v1/jobs/{id}`, and `GET /v1/jobs/{id}/result` on top of the existing sync serve stack
- run async scans under bounded in-memory scheduling with pending/running/succeeded/failed job state, randomized job IDs, bounded retained terminal jobs, and sanitized failure messages
- update the generated OpenAPI artifact, evergreen serve docs, focused serve tests, and the implementation-plan status now that the full serve rollout is complete

## Issues

- Covers:
- Closes: #834

## Scope and exclusions

- Included: async serve routing and job registry in `src/serve/mod.rs`, async API schemas in `src/serve_api.rs`, generated `docs/openapi/provenant-serve.openapi.json`, serve integration/unit coverage, `docs/SERVE_API_GUIDE.md`, `docs/CLI_GUIDE.md`, `README.md`, and the completed rollout wording in `docs/implementation-plans/infrastructure/SERVE_PLAN.md` plus `docs/implementation-plans/README.md`
- Explicit exclusions: auth, tenancy, quotas, billing, durable external job persistence, multipart uploads, provider-specific object-store adapters, and built-in scheduler/orchestration features

## Intentional differences from Python

- async job state and results are retained in bounded in-memory service state rather than a durable orchestration backend

## Follow-up work

- Created or intentionally deferred: no additional serve-plan slice remains after this stack lands; durable persistence and auth remain intentionally out of scope for the current service contract