### PR TITLE
fix(benchmark): verify pyodide target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 191 of 191 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 192 of 192 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -199,6 +199,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `12.89s`; ScanCode `186.62s`
 - Broader Pixi and Conda environment coverage (`3` vs `1` packages, `509` vs `84` dependencies) from the repo-root `pixi.toml` plus committed Binder and CI environment manifests, with direct Pixi package identity and cleaner URL normalization across docs and SVG metadata
+
+##### [pyodide/pyodide @ 86e27b0](https://github.com/pyodide/pyodide/tree/86e27b004d06bccd91a937aa5fc2601978642b74) — **12.57× faster**
+
+- Files: 540
+- Run context: 2026-05-05 · pyodide-13754 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.77s`; ScanCode `135.33s`
+- Broader dependency extraction (`796` vs `718`) and slightly broader package visibility (`53` vs `52`) from `environment.yml`, `.gitmodules`, and committed wheel artifacts, with extension-qualified wheel PURLs, richer patch-header author recovery, and the fuller `Pyodide contributors and Mozilla` documentation notice
 
 ##### [python-poetry/poetry @ bfce511](https://github.com/python-poetry/poetry/tree/bfce5118814fa95445e823cb07a59bd77ffe1474) — **4.20× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -272,6 +272,9 @@ ScanCode: 33.50s</title></rect>
     <rect x="523.07" y="374.90" width="8" height="8" fill="#d97706" rx="1.5"><title>nginx/nginx @ 6e14e95
 Files: 521
 ScanCode: 211.97s</title></rect>
+    <rect x="525.54" y="396.10" width="8" height="8" fill="#d97706" rx="1.5"><title>pyodide/pyodide @ 86e27b0
+Files: 540
+ScanCode: 135.33s</title></rect>
     <rect x="526.30" y="381.25" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 ScanCode: 185.33s</title></rect>
@@ -847,6 +850,9 @@ Provenant: 19.91s</title></circle>
     <circle cx="527.07" cy="514.90" r="4.5" fill="#2563eb"><title>nginx/nginx @ 6e14e95
 Files: 521
 Provenant: 11.92s</title></circle>
+    <circle cx="529.54" cy="519.69" r="4.5" fill="#2563eb"><title>pyodide/pyodide @ 86e27b0
+Files: 540
+Provenant: 10.77s</title></circle>
     <circle cx="530.30" cy="507.88" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 Provenant: 13.83s</title></circle>

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -499,7 +499,6 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             DatasourceId::PypiPoetryPyprojectToml,
             DatasourceId::PypiSetupPy,
             DatasourceId::PypiSetupCfg,
-            DatasourceId::PypiWheel,
             DatasourceId::PypiWheelMetadata,
             DatasourceId::PypiEgg,
             DatasourceId::PypiEggPkginfo,

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -3286,6 +3286,34 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_python_standalone_wheel_creates_top_level_package() {
+        let mut files = vec![create_test_file_info(
+            "dist/construct-2.10.68-py3-none-any.whl",
+            DatasourceId::PypiWheel,
+            Some("pkg:pypi/construct@2.10.68?extension=py3-none-any"),
+            Some("construct"),
+            Some("2.10.68"),
+            vec![],
+        )];
+
+        let result = assemble(&mut files);
+
+        assert_eq!(result.packages.len(), 1, "packages: {:#?}", result.packages);
+        let package = &result.packages[0];
+        assert_eq!(package.name.as_deref(), Some("construct"));
+        assert_eq!(package.version.as_deref(), Some("2.10.68"));
+        assert_eq!(
+            package.purl.as_deref(),
+            Some("pkg:pypi/construct@2.10.68?extension=py3-none-any")
+        );
+        assert_eq!(
+            package.datafile_paths,
+            vec!["dist/construct-2.10.68-py3-none-any.whl"]
+        );
+        assert_eq!(files[0].for_packages, vec![package.package_uid.clone()]);
+    }
+
+    #[test]
     fn test_assemble_python_pip_cache_skips_mismatched_second_wheel() {
         let mut files = vec![
             create_test_file_info(

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1262,6 +1262,27 @@ fn test_detect_flutter_product_copyright_assignment_strips_wrapper() {
 }
 
 #[test]
+fn test_detect_python_author_assignment_before_copyright_assignment_stays_clean() {
+    let input = concat!(
+        "author = \"Pyodide contributors\"\n",
+        "copyright = \"2019-2026, Pyodide contributors and Mozilla\"\n",
+    );
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "Copyright 2019-2026, Pyodide contributors and Mozilla"),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter()
+            .any(|ho| ho.holder == "Pyodide contributors and Mozilla"),
+        "holders: {:?}",
+        h.iter().map(|ho| &ho.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_detect_flutter_windows_legalcopyright_template_dropped() {
     let input = r#"VALUE "LegalCopyright", "Copyright (C) {{year}} {{organization}}. All rights reserved." "\0""#;
     let (c, h, _a) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -2875,6 +2875,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     h = strip_trailing_holder_prose_clause(&h);
     h = h.trim_matches(&['/', ' ', '~'][..]).to_string();
     h = refine_names(&h, prefixes);
+    h = strip_repeated_leading_holder_prefix(&h);
     h = strip_trailing_company_co_ltd(&h);
     h = strip_suffixes(&h, &HOLDERS_SUFFIXES);
     h = strip_trailing_ampas_acronym(&h);
@@ -3337,8 +3338,8 @@ use self::author::{normalize_angle_bracket_comma_spacing, strip_trailing_company
 
 use self::utils::{
     normalize_comma_spacing, normalize_whitespace, refine_names, remove_dupe_holder,
-    strip_trailing_incomplete_as_represented_by, strip_trailing_url, strip_trailing_url_slash,
-    truncate_long_words,
+    strip_repeated_leading_holder_prefix, strip_trailing_incomplete_as_represented_by,
+    strip_trailing_url, strip_trailing_url_slash, truncate_long_words,
 };
 
 #[cfg(test)]

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1193,6 +1193,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = normalize_b_dot_angle_emails(&c);
     c = strip_nickname_quotes(&c);
     c = strip_leading_author_label_in_copyright(&c);
+    c = strip_leading_duplicate_phrase_before_embedded_copyright(&c);
     c = strip_leading_licensed_material_of(&c);
     c = strip_leading_version_number_before_c(&c);
     c = strip_trailing_parenthesized_descriptor_after_by_holder(&c);
@@ -1367,6 +1368,10 @@ fn strip_known_copyright_wrappers(s: &str) -> String {
         )
         .expect("valid assignment copyright wrapper regex")
     });
+    static PLAIN_COPYRIGHT_ASSIGNMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?ix)^copyright\s*=\s*(?P<value>.+?)\s*;?\s*$"#)
+            .expect("valid plain copyright assignment regex")
+    });
     static APPLICATION_LEGALESE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"(?ix)^applicationLegalese\s*:\s*(?P<value>.+?)\s*,?\s*$"#)
             .expect("valid applicationLegalese wrapper regex")
@@ -1403,6 +1408,18 @@ fn strip_known_copyright_wrappers(s: &str) -> String {
             if value.starts_with("Copyright") || value.starts_with('©') {
                 return prepare_text_line(value).trim().to_string();
             }
+        }
+    }
+
+    if let Some(captures) = PLAIN_COPYRIGHT_ASSIGNMENT_RE.captures(trimmed) {
+        let value = captures
+            .name("value")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim()
+            .trim_matches(&['\'', '"'][..]);
+        if !value.is_empty() {
+            return synthesize_copyright_from_assignment_value(value);
         }
     }
 
@@ -1958,7 +1975,108 @@ fn strip_trailing_author_label(s: &str) -> String {
     prefix.to_string()
 }
 
+fn extract_copyright_assignment_value_after_author_assignment(s: &str) -> Option<String> {
+    static AUTHOR_ASSIGNMENT_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?ix)
+            ^(?:@?authors?)\s*=\s*(?:"[^"]*"|'[^']*'|.+?)\s+
+            copyright\s*=\s*(?P<rest>.+?)\s*$
+            "#,
+        )
+        .expect("valid author assignment before copyright regex")
+    });
+
+    let trimmed = s.trim();
+    let captures = AUTHOR_ASSIGNMENT_COPY_RE.captures(trimmed)?;
+    let rest = captures
+        .name("rest")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim()
+        .trim_matches(&['\'', '"'][..]);
+    if rest.is_empty() {
+        None
+    } else {
+        Some(normalize_whitespace(rest))
+    }
+}
+
+fn synthesize_copyright_from_assignment_value(value: &str) -> String {
+    let prepared = prepare_text_line(value).trim().to_string();
+    if prepared.is_empty() {
+        String::new()
+    } else if prepared.starts_with("Copyright") || prepared.starts_with('©') {
+        prepared
+    } else {
+        format!("Copyright {prepared}")
+    }
+}
+
+fn strip_leading_duplicate_phrase_before_embedded_copyright(s: &str) -> String {
+    static EMBEDDED_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<prefix>.+?)\s+copyright\s+(?P<rest>.+)$")
+            .expect("valid embedded copyright regex")
+    });
+    static LEADING_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)^(?P<years>(?:19\d{2}|20\d{2}|CURRENT_YEAR|\?\?\?\?)(?:\s*[-–/]\s*(?:19\d{2}|20\d{2}|\d{2}|CURRENT_YEAR|\?\?\?\?))?(?:\s*,\s*(?:19\d{2}|20\d{2}|CURRENT_YEAR|\?\?\?\?))*(?:\s*,)?)\s+(?P<tail>.+)$",
+        )
+        .expect("valid leading year regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = EMBEDDED_COPY_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = normalize_whitespace(
+        captures
+            .name("prefix")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim(),
+    );
+    if prefix.split_whitespace().count() < 2 {
+        return s.to_string();
+    }
+
+    let rest = normalize_whitespace(
+        captures
+            .name("rest")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim(),
+    );
+    let Some(year_captures) = LEADING_YEAR_RE.captures(&rest) else {
+        return s.to_string();
+    };
+    let years = year_captures
+        .name("years")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim();
+    let tail = year_captures
+        .name("tail")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim();
+    if years.is_empty() || tail.is_empty() {
+        return s.to_string();
+    }
+
+    let prefix_lower = prefix.to_ascii_lowercase();
+    let tail_lower = tail.to_ascii_lowercase();
+    if tail_lower != prefix_lower && !tail_lower.starts_with(&format!("{prefix_lower} ")) {
+        return s.to_string();
+    }
+
+    normalize_whitespace(&format!("Copyright {years} {tail}"))
+}
+
 fn strip_leading_author_label_in_copyright(s: &str) -> String {
+    if let Some(rest) = extract_copyright_assignment_value_after_author_assignment(s) {
+        return synthesize_copyright_from_assignment_value(&rest);
+    }
+
     static LEADING_AUTHOR_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?:@?author)\s+(?P<rest>.+\(c\)\s*(?:19|20)\d{2}.*)$")
             .expect("valid leading author copyright regex")
@@ -1975,6 +2093,10 @@ fn strip_leading_author_label_in_copyright(s: &str) -> String {
 }
 
 fn strip_leading_author_label_in_holder(s: &str) -> String {
+    if let Some(rest) = extract_copyright_assignment_value_after_author_assignment(s) {
+        return rest;
+    }
+
     static LEADING_AUTHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?:@?author)\b[:\s]+(?P<rest>.+)$").expect("valid leading author regex")
     });
@@ -2687,6 +2809,9 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     h = strip_trailing_lowercase_handle_angle_email(&h);
     h = strip_trailing_quote_before_email(&h);
     h = strip_nickname_quotes(&h);
+    if let Some(rest) = extract_copyright_assignment_value_after_author_assignment(&h) {
+        h = rest;
+    }
     h = strip_leading_author_label_in_holder(&h);
     h = strip_angle_bracketed_www_domains(&h);
     if in_copyright_context {

--- a/src/copyright/refiner/utils.rs
+++ b/src/copyright/refiner/utils.rs
@@ -320,17 +320,6 @@ pub(super) fn remove_dupe_holder(h: &str) -> String {
     );
 
     let mut words: Vec<&str> = s.split_whitespace().collect();
-    for repeat_len in (2..=(words.len() / 2)).rev() {
-        if words[..repeat_len] == words[repeat_len..(repeat_len * 2)]
-            && words[..repeat_len]
-                .iter()
-                .any(|word| word.chars().any(|ch| ch.is_alphabetic()))
-        {
-            words.drain(repeat_len..(repeat_len * 2));
-            break;
-        }
-    }
-
     let is_all_caps_word = |w: &str| {
         let mut has_alpha = false;
         for c in w.chars() {
@@ -365,6 +354,29 @@ pub(super) fn remove_dupe_holder(h: &str) -> String {
 
     s = words.join(" ");
     s
+}
+
+pub(super) fn strip_repeated_leading_holder_prefix(h: &str) -> String {
+    let words: Vec<&str> = h.split_whitespace().collect();
+    if words.len() < 5 {
+        return h.to_string();
+    }
+
+    for repeat_len in (2..=(words.len() / 2)).rev() {
+        let repeated_end = repeat_len * 2;
+        if repeated_end >= words.len() {
+            continue;
+        }
+        if words[..repeat_len] == words[repeat_len..repeated_end]
+            && words[..repeat_len]
+                .iter()
+                .any(|word| word.chars().any(|ch| ch.is_alphabetic()))
+        {
+            return words[repeat_len..].join(" ");
+        }
+    }
+
+    h.to_string()
 }
 
 /// Drop trailing words longer than 80 characters (garbled/binary data).

--- a/src/copyright/refiner/utils.rs
+++ b/src/copyright/refiner/utils.rs
@@ -320,6 +320,17 @@ pub(super) fn remove_dupe_holder(h: &str) -> String {
     );
 
     let mut words: Vec<&str> = s.split_whitespace().collect();
+    for repeat_len in (2..=(words.len() / 2)).rev() {
+        if words[..repeat_len] == words[repeat_len..(repeat_len * 2)]
+            && words[..repeat_len]
+                .iter()
+                .any(|word| word.chars().any(|ch| ch.is_alphabetic()))
+        {
+            words.drain(repeat_len..(repeat_len * 2));
+            break;
+        }
+    }
+
     let is_all_caps_word = |w: &str| {
         let mut has_alpha = false;
         for c in w.chars() {

--- a/src/finder/host.rs
+++ b/src/finder/host.rs
@@ -7,6 +7,16 @@ use url::Url;
 
 use super::junk_data::{classify_host, classify_ip};
 
+fn is_well_formed_host_label(label: &str) -> bool {
+    !label.is_empty()
+        && !label.starts_with('-')
+        && !label.ends_with('-')
+        && label.chars().any(|ch| ch.is_ascii_alphanumeric())
+        && label
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+}
+
 fn is_private_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
@@ -44,6 +54,10 @@ pub(crate) fn is_good_host(host: &str) -> bool {
     }
 
     let labels: Vec<&str> = host.split('.').collect();
+    if labels.iter().any(|label| !is_well_formed_host_label(label)) {
+        return false;
+    }
+
     if labels.len() >= 3
         && labels[..labels.len() - 1]
             .iter()

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -283,4 +283,22 @@ mod tests {
         let values: Vec<_> = urls.into_iter().map(|url| url.url).collect();
         assert_eq!(values, vec!["https://rust-lang.org/real".to_string()]);
     }
+
+    #[test]
+    fn test_find_urls_ignores_ellipsis_placeholder_hosts() {
+        let text = "Fetch https://.../script.py after download.";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert!(urls.is_empty(), "urls: {urls:#?}");
+    }
+
+    #[test]
+    fn test_find_urls_ignores_braced_placeholder_hosts() {
+        let text = "Download from http://{httpserver.host/ when tests boot.";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert!(urls.is_empty(), "urls: {urls:#?}");
+    }
 }

--- a/src/parsers/python/scan_test.rs
+++ b/src/parsers/python/scan_test.rs
@@ -184,6 +184,37 @@ mod tests {
     }
 
     #[test]
+    fn test_python_standalone_wheel_scan_assembles_distribution_metadata() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        std::fs::copy(
+            "testdata/python/golden/pip_cache/wheels/construct/construct-2.10.68-py3-none-any.whl",
+            temp_dir.path().join("construct-2.10.68-py3-none-any.whl"),
+        )
+        .expect("copy wheel fixture");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        let package = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("construct"))
+            .expect("standalone wheel should assemble a construct package");
+
+        assert_eq!(package.package_type, Some(PackageType::Pypi));
+        assert_eq!(package.version.as_deref(), Some("2.10.68"));
+        assert_eq!(
+            package.purl.as_deref(),
+            Some("pkg:pypi/construct@2.10.68?extension=py3-none-any")
+        );
+        assert_file_links_to_package(
+            &files,
+            "/construct-2.10.68-py3-none-any.whl",
+            &package.package_uid,
+            DatasourceId::PypiWheel,
+        );
+    }
+
+    #[test]
     fn test_python_pip_inspect_scan_assembles_with_pyproject() {
         let temp_dir = tempfile::TempDir::new().expect("create temp dir");
         fs::write(

--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -3,6 +3,7 @@
 
 use super::binary_text::{is_binary_string_email_candidate, normalize_binary_string_url};
 use crate::finder::{self, DetectionConfig};
+use crate::models::LineNumber;
 use crate::models::{FileInfoBuilder, OutputEmail, OutputURL};
 use crate::scanner::TextDetectionOptions;
 use crate::utils::font::is_supported_font_path;
@@ -67,6 +68,7 @@ pub(super) fn extract_email_url_information(
             })
             .collect::<Vec<_>>();
         if apply_binary_contact_filters {
+            urls.extend(collect_binary_url_salvage_detections(text_content));
             let mut seen = HashSet::new();
             urls.retain(|url| seen.insert(url.url.clone()));
             if text_options.max_urls > 0 && urls.len() > text_options.max_urls {
@@ -85,6 +87,33 @@ fn is_gettext_mo_path(path: &Path) -> bool {
 
 fn is_font_metadata_contact_path(path: &Path) -> bool {
     is_supported_font_path(path)
+}
+
+fn collect_binary_url_salvage_detections(text_content: &str) -> Vec<OutputURL> {
+    text_content
+        .lines()
+        .enumerate()
+        .flat_map(|(line_index, line)| {
+            let line_number = LineNumber::from_0_indexed(line_index);
+            line.split_whitespace().filter_map(move |token| {
+                let candidate = token.trim_matches(|c: char| {
+                    matches!(
+                        c,
+                        '<' | '>' | '(' | ')' | '[' | ']' | '"' | '\'' | '`' | ',' | ';'
+                    )
+                });
+                if !candidate.contains("://") {
+                    return None;
+                }
+                let url = normalize_binary_string_url(candidate)?;
+                Some(OutputURL {
+                    url,
+                    start_line: line_number,
+                    end_line: line_number,
+                })
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -383,6 +383,44 @@ fn test_extract_copyright_information_strips_locale_timestamp_from_raw_projectio
 }
 
 #[test]
+fn test_extract_copyright_information_projects_clean_python_assignment_metadata() {
+    let text = concat!(
+        "author = \"Pyodide contributors\"\n",
+        "copyright = \"2019-2026, Pyodide contributors and Mozilla\"\n",
+    );
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("docs/conf.py"), text, 120.0, false);
+
+    let file = builder
+        .name("conf.py".to_string())
+        .base_name("conf".to_string())
+        .extension(".py".to_string())
+        .path("docs/conf.py".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright 2019-2026, Pyodide contributors and Mozilla"
+    );
+    assert_eq!(
+        file.copyrights[0].normalized_copyright.as_deref(),
+        Some("Copyright 2019-2026, Pyodide contributors and Mozilla")
+    );
+    assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
+    assert_eq!(file.holders[0].holder, "Pyodide contributors and Mozilla");
+}
+
+#[test]
 fn test_binary_string_copyright_candidate_keeps_real_notice() {
     let notice = "Copyright nexB and others (c) 2012";
     assert!(is_binary_string_copyright_candidate(notice));


### PR DESCRIPTION
## Summary

- Verify `pyodide/pyodide@86e27b0` with `compare-outputs` on the latest `main`-based branch and add a durable benchmark row plus regenerated `docs/scan-duration-vs-files.svg`.
- Fix the real regressions the target exposed: standalone wheel archives now assemble into top-level packages, assignment-style `author =` / `copyright =` metadata no longer bleeds into copyright or holder output, and placeholder-host URLs like `https://.../script.py` are filtered structurally.
- Keep the final reviewed compare artifact at `.provenant/compare-runs/20260505T205118Z-pyodide-13754` for auditability; the verified end state is `53` vs `52` packages, `796` vs `718` dependencies, and `10.77s` vs `135.33s` wall-clock time.

## Scope and exclusions

- Included: assembly/refiner/finder code fixes, focused regression tests, the new `docs/BENCHMARKS.md` row for `pyodide/pyodide`, and the regenerated benchmark chart/headline stats.
- Explicit exclusions: no golden expected fixtures changed.

## Intentional differences from Python

- Keep extension-qualified wheel PURLs for committed `.whl` artifacts instead of collapsing them to less specific unqualified PyPI identities.
- Keep the fuller `docs/conf.py` documentation notice and holder (`Pyodide contributors and Mozilla`) rather than ScanCode's shorter `Pyodide contributors` rendering.
- Keep extra dependency visibility from `.gitmodules` and `environment.yml`, plus patch-header author recovery on committed patch files.