### PR TITLE
fix(benchmark): verify apache hadoop target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 192 of 192 recorded runs, with a **12.1× median speedup** and **11.2× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 193 of 193 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -438,6 +438,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-26 · camel-80585 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `469.31s`; ScanCode `5338.67s`
 - Broader Maven dependency extraction (`14818` vs `7645`) from the large multi-module reactor, archetype template POMs, and mixed package-adjacent Helm, Docker, and Cargo surfaces, plus restored UTF-16 template license detection and broader notice-author recovery across Apache/Spring/OpenShift acknowledgements, with zero scan-file errors where ScanCode times out on the committed `camel-sbom.json` and `camel-sbom.xml`
+
+##### [apache/hadoop @ dbcc7cd](https://github.com/apache/hadoop/tree/dbcc7cd797100e6b32cd84f85b53a5193a5f9af0) — **16.42× faster**
+
+- Files: 16,370
+- Run context: 2026-05-06 · 20260506T074747Z-hadoop-28100 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `278.63s`; ScanCode `4575.96s`
+- Broader dependency extraction (`5849` vs `3794`) and slightly broader package visibility (`123` vs `122`) from the large multi-module Maven reactor, classifier/type-aware WAR identities, committed vcpkg metadata, and property-preserving Maven coordinates, with cleaner sourcemap/minified-banner party handling and reviewed remaining legal-text/author differences
 
 ##### [apache/kafka @ 0d9fe51](https://github.com/apache/kafka/tree/0d9fe518b616725fecd96162297fee89a7b7a6a5) — **14.02× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -593,6 +593,9 @@ ScanCode: 807.63s</title></rect>
     <rect x="757.62" y="257.15" width="8" height="8" fill="#d97706" rx="1.5"><title>flutter/flutter @ 238d79a
 Files: 15670
 ScanCode: 2561.81s</title></rect>
+    <rect x="760.63" y="229.74" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/hadoop @ dbcc7cd
+Files: 16370
+ScanCode: 4575.96s</title></rect>
     <rect x="767.28" y="288.09" width="8" height="8" fill="#d97706" rx="1.5"><title>metabase/metabase @ 10997b1
 Files: 18030
 ScanCode: 1330.92s</title></rect>
@@ -1171,6 +1174,9 @@ Provenant: 33.41s</title></circle>
     <circle cx="761.62" cy="403.97" r="4.5" fill="#2563eb"><title>flutter/flutter @ 238d79a
 Files: 15670
 Provenant: 124.69s</title></circle>
+    <circle cx="764.63" cy="365.98" r="4.5" fill="#2563eb"><title>apache/hadoop @ dbcc7cd
+Files: 16370
+Provenant: 278.63s</title></circle>
     <circle cx="771.28" cy="445.44" r="4.5" fill="#2563eb"><title>metabase/metabase @ 10997b1
 Files: 18030
 Provenant: 51.84s</title></circle>

--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -90,6 +90,27 @@ fn has_copyright_indicators(line: &str) -> bool {
         || has_c_sign_before_year(bytes)
 }
 
+/// Check whether a long or obvious-code line should still be treated as copyright-relevant.
+///
+/// This is narrower than `has_copyright_indicators()`: it keeps explicit author markers such as
+/// `@author`, `author:`, `authors:`, and `written by`, but does not let incidental substrings like
+/// `authentication` keep huge minified code lines inside copyright candidate groups.
+fn has_long_line_copyright_indicators(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    contains_ascii_ci(bytes, b"opyr")
+        || contains_ascii_ci(bytes, b"opyl")
+        || has_explicit_author_marker(bytes)
+        || has_c_sign_before_year(bytes)
+}
+
+fn has_explicit_author_marker(bytes: &[u8]) -> bool {
+    contains_ascii_ci(bytes, b"@author")
+        || contains_ascii_ci(bytes, b"author:")
+        || contains_ascii_ci(bytes, b"authors:")
+        || contains_ascii_ci(bytes, b"author(s):")
+        || contains_ascii_ci(bytes, b"written by")
+}
+
 /// Case-insensitive ASCII substring search without allocation.
 fn contains_ascii_ci(haystack: &[u8], needle: &[u8]) -> bool {
     if needle.len() > haystack.len() {
@@ -131,7 +152,7 @@ fn is_encoded_data_line(line: &str) -> bool {
     }
 
     // Quick check: if the line contains strong copyright indicators, never skip.
-    if has_copyright_indicators(line) {
+    if has_long_line_copyright_indicators(line) {
         return false;
     }
 
@@ -212,10 +233,8 @@ fn is_code_line_with_false_c(line: &str) -> bool {
         return false;
     }
 
-    let lower = line.to_lowercase();
-
     // Check if the ONLY copyright hint is `(c)` — if there's a real "copyright" word, keep it.
-    if lower.contains("opyr") || lower.contains("opyl") || lower.contains("auth") {
+    if has_long_line_copyright_indicators(line) {
         return false;
     }
 
@@ -437,7 +456,7 @@ where
         }
 
         // Skip long lines without copyright indicators (minified JS, binary data).
-        if line.len() > MAX_LINE_LENGTH && !has_copyright_indicators(line) {
+        if line.len() > MAX_LINE_LENGTH && !has_long_line_copyright_indicators(line) {
             if in_copyright > 0 {
                 in_copyright -= 1;
                 if in_copyright == 0 && !candidates.is_empty() {
@@ -694,7 +713,7 @@ where
                 prev_was_single_line_markup_comment = false;
                 continue;
             }
-            if is_obvious_code_line(line) && !has_copyright_indicators(line) {
+            if is_obvious_code_line(line) && !has_long_line_copyright_indicators(line) {
                 if !candidates.is_empty() {
                     groups.push(std::mem::take(&mut candidates));
                 }
@@ -1237,6 +1256,22 @@ mod tests {
     }
 
     #[test]
+    fn test_long_line_indicators_keep_explicit_author_markers() {
+        assert!(has_long_line_copyright_indicators("@author John Doe"));
+        assert!(has_long_line_copyright_indicators("author: John Doe"));
+        assert!(has_long_line_copyright_indicators(
+            "authors: Jane Doe, John Doe"
+        ));
+        assert!(has_long_line_copyright_indicators("written by Jane Doe"));
+    }
+
+    #[test]
+    fn test_long_line_indicators_ignore_incidental_auth_substrings() {
+        let line = "!function(){var authenticationToken=this.authenticationToken;return this.removeEventListener('x',handler),document.createElement('div').appendChild(node),node.className='editable'}";
+        assert!(!has_long_line_copyright_indicators(line));
+    }
+
+    #[test]
     fn test_indicators_c_sign_with_year() {
         assert!(has_copyright_indicators("(c)2024 Acme Inc."));
         assert!(has_copyright_indicators("(C) 1996 Id Software"));
@@ -1541,6 +1576,39 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_skips_huge_minified_auth_lines_after_x_editable_header() {
+        let lines = vec![
+            (1, "/*! X-editable - v1.5.0".to_string()),
+            (2, "* In-place editing with Twitter Bootstrap".to_string()),
+            (3, "* http://vitalets.github.io/x-editable".to_string()),
+            (
+                4,
+                "* Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */".to_string(),
+            ),
+            (5, make_minified_auth_line(32_001)),
+            (6, make_minified_auth_line(32_203)),
+            (7, make_minified_auth_line(9_776)),
+        ];
+
+        let groups = collect_candidate_lines(lines);
+
+        assert!(
+            groups
+                .iter()
+                .flat_map(|group| group.iter())
+                .any(|(ln, _)| *ln == 4),
+            "groups: {groups:?}"
+        );
+        assert!(
+            !groups
+                .iter()
+                .flat_map(|group| group.iter())
+                .any(|(ln, _)| *ln >= 5),
+            "groups: {groups:?}"
+        );
+    }
+
+    #[test]
     fn test_versioned_banner_holder_from_prepared_extracts_holder() {
         let prepared =
             "! jQuery v3.7.1 (c) OpenJS Foundation and other contributors jquery.org/license";
@@ -1548,5 +1616,18 @@ mod tests {
             versioned_banner_holder_from_prepared(prepared),
             Some("OpenJS Foundation and other contributors".to_string())
         );
+    }
+
+    fn make_minified_auth_line(target_len: usize) -> String {
+        let chunk = concat!(
+            "!function(){var authenticationToken=this.authenticationToken;",
+            "return this.removeEventListener('x',handler),",
+            "document.createElement('div').appendChild(node),",
+            "node.className='editable',this.addEventListener('x',handler),",
+            "this.setAttribute('data-auth','1'),this.innerHTML=node.className;}"
+        );
+        let mut line = chunk.repeat(target_len / chunk.len() + 1);
+        line.truncate(target_len);
+        line
     }
 }

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -388,6 +388,215 @@ pub fn detect_copyrights_from_text_with_deadline(
     (copyrights, holders, authors)
 }
 
+#[cfg(test)]
+#[derive(Debug)]
+pub(super) struct PhaseBoundaryDetections {
+    pub(super) after_group_loop_copyrights: Vec<CopyrightDetection>,
+    pub(super) after_group_loop_holders: Vec<HolderDetection>,
+    pub(super) after_primary_copyrights: Vec<CopyrightDetection>,
+    pub(super) after_primary_holders: Vec<HolderDetection>,
+    pub(super) after_postprocess_copyrights: Vec<CopyrightDetection>,
+    pub(super) after_postprocess_holders: Vec<HolderDetection>,
+}
+
+#[cfg(test)]
+pub(super) fn detect_copyright_phase_boundaries(content: &str) -> PhaseBoundaryDetections {
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+    let mut authors = Vec::new();
+
+    if content.is_empty() {
+        return PhaseBoundaryDetections {
+            after_group_loop_copyrights: Vec::new(),
+            after_group_loop_holders: Vec::new(),
+            after_primary_copyrights: Vec::new(),
+            after_primary_holders: Vec::new(),
+            after_postprocess_copyrights: Vec::new(),
+            after_postprocess_holders: Vec::new(),
+        };
+    }
+
+    let normalized = normalize_split_angle_bracket_urls(content);
+    let expanded = maybe_expand_copyrighted_by_href_urls(normalized.as_ref());
+    let did_expand_href = matches!(expanded, Cow::Owned(_));
+    let content = expanded.as_ref();
+    let line_number_index = LineNumberIndex::new(content);
+
+    let allow_not_copyrighted_prefix = NOT_COPYRIGHTED_RE.find_iter(content).count() == 1;
+    let raw_lines: Vec<&str> = content.lines().collect();
+    let prepared_cache = PreparedLineCache::new(&raw_lines);
+
+    let groups =
+        collect_candidate_lines(raw_lines.iter().enumerate().map(|(i, line)| (i + 1, *line)));
+    let mut seen = seen_text::SeenTextSets::from_existing(&copyrights, &holders, &authors);
+
+    for group in &groups {
+        if group.is_empty() {
+            continue;
+        }
+
+        let tokens = get_tokens(group);
+        if tokens.is_empty() {
+            continue;
+        }
+
+        let tree = parse(tokens);
+        let has_top_level_nodes = tree.iter().any(|n| {
+            matches!(
+                n.label(),
+                Some(TreeLabel::Copyright) | Some(TreeLabel::Copyright2) | Some(TreeLabel::Author)
+            )
+        });
+        let analysis = analyze_tree(&tree);
+
+        if has_top_level_nodes {
+            let (new_c, new_h, new_a) =
+                extract_from_tree_nodes(&tree, allow_not_copyrighted_prefix);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            seen.register_authors(&new_a);
+            let copyrights_before = copyrights.len();
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            authors.extend(new_a);
+
+            if let Some(det) = extract_original_author_additional_contributors(&tree)
+                && seen.authors.insert(det.author.clone())
+            {
+                authors.push(det);
+            }
+
+            if copyrights.len() == copyrights_before
+                && analysis.has_copy_like_token
+                && analysis.has_authorish_boundary_token
+                && analysis.is_single_line_group
+            {
+                let (new_c, new_h) = extract_bare_copyrights(&tree);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
+                let (new_c, new_h) =
+                    extract_copyrights_from_spans(&tree, allow_not_copyrighted_prefix);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
+            }
+
+            if copyrights.len() == copyrights_before
+                && analysis.has_copy_like_token
+                && analysis.has_year_token
+            {
+                let (new_c, new_h) =
+                    extract_copyrights_from_spans(&tree, allow_not_copyrighted_prefix);
+                seen.register_copyrights(&new_c);
+                seen.register_holders(&new_h);
+                copyrights.extend(new_c);
+                holders.extend(new_h);
+            }
+        } else {
+            let (new_c, new_h) = extract_bare_copyrights(&tree);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            let (new_c, new_h, new_a) = extract_from_spans(&tree, allow_not_copyrighted_prefix);
+            seen.register_copyrights(&new_c);
+            seen.register_holders(&new_h);
+            seen.register_authors(&new_a);
+            copyrights.extend(new_c);
+            holders.extend(new_h);
+            authors.extend(new_a);
+            let mut new_a = extract_orphaned_by_authors(&tree);
+            seen.dedup_new_authors(&mut new_a, 0);
+            authors.extend(new_a);
+
+            if let Some(det) = extract_original_author_additional_contributors(&tree)
+                && seen.authors.insert(det.author.clone())
+            {
+                authors.push(det);
+            }
+        }
+
+        fix_truncated_contributors_authors(&tree, &mut authors);
+        seen.rebuild_authors_from(&authors);
+        let (mut new_c, mut new_h) = extract_holder_is_name(&tree);
+        seen.dedup_new_copyrights(&mut new_c, 0);
+        seen.dedup_new_holders(&mut new_h, 0);
+        copyrights.extend(new_c);
+        holders.extend(new_h);
+        apply_written_by_for_markers(group, &mut copyrights, &mut holders);
+        extend_multiline_copyright_c_year_holder_continuations(
+            group,
+            &mut copyrights,
+            &mut holders,
+        );
+        extend_multiline_copyright_c_no_year_names(group, &mut copyrights[..], &mut holders[..]);
+        extend_authors_see_url_copyrights(group, &mut copyrights[..], &mut holders[..]);
+        extend_leading_dash_suffixes(group, &mut copyrights[..], &mut holders[..]);
+        extend_dash_obfuscated_email_suffixes(&raw_lines, group, &mut copyrights[..], &holders[..]);
+        extend_trailing_copy_year_suffixes(&raw_lines, group, &mut copyrights[..]);
+        extend_trailing_lowercase_holder_suffixes(
+            &raw_lines,
+            group,
+            &mut copyrights[..],
+            &mut holders,
+        );
+        extend_w3c_registered_org_list_suffixes(group, &mut copyrights[..], &mut holders[..]);
+        extend_software_in_the_public_interest_holder(group, &mut copyrights, &mut holders);
+    }
+
+    let mut fallback = fallback_year_only_copyrights(&groups);
+    seen.dedup_new_copyrights(&mut fallback, 0);
+    fallback.retain(|det| {
+        !copyrights.iter().any(|c| {
+            c.copyright
+                .to_ascii_lowercase()
+                .contains(&det.copyright.to_ascii_lowercase())
+        })
+    });
+    copyrights.extend(fallback);
+
+    let after_group_loop_copyrights = copyrights.clone();
+    let after_group_loop_holders = holders.clone();
+
+    let prepared_lines = prepared_cache.materialize();
+
+    phases::run_phase_primary_extractions(
+        content,
+        &groups,
+        &line_number_index,
+        &prepared_lines,
+        &mut copyrights,
+        &mut holders,
+        &mut seen,
+    );
+
+    let after_primary_copyrights = copyrights.clone();
+    let after_primary_holders = holders.clone();
+
+    phases::run_phase_postprocess(
+        content,
+        &raw_lines,
+        &prepared_lines,
+        did_expand_href,
+        &mut copyrights,
+        &mut holders,
+        &mut authors,
+        &mut seen,
+    );
+
+    PhaseBoundaryDetections {
+        after_group_loop_copyrights,
+        after_group_loop_holders,
+        after_primary_copyrights,
+        after_primary_holders,
+        after_postprocess_copyrights: copyrights,
+        after_postprocess_holders: holders,
+    }
+}
+
 mod author_heuristics;
 mod pattern_extract;
 mod phases;

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -783,12 +783,13 @@ pub fn extract_versioned_project_c_holder_banner_lines(
                 continue;
             };
 
-            let first_token = holder_raw.split_whitespace().next().unwrap_or("");
-            let starts_upper = holder_raw
+            let holder_for_gate = strip_leading_year_prefix_for_versioned_banner_gate(&holder_raw);
+            let first_token = holder_for_gate.split_whitespace().next().unwrap_or("");
+            let starts_upper = holder_for_gate
                 .chars()
                 .next()
                 .is_some_and(|c| c.is_ascii_uppercase());
-            let starts_mixed_case_brand = holder_raw
+            let starts_mixed_case_brand = holder_for_gate
                 .chars()
                 .next()
                 .is_some_and(|c| c.is_ascii_lowercase())
@@ -822,6 +823,24 @@ pub fn extract_versioned_project_c_holder_banner_lines(
     }
 
     (copyrights, holders)
+}
+
+fn strip_leading_year_prefix_for_versioned_banner_gate(holder_raw: &str) -> String {
+    static LEADING_YEAR_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^
+            (?:19\d{2}|20\d{2})
+            (?:\s*[-–]\s*(?:19\d{2}|20\d{2}|present|current_year))?
+            [\s,;:]+",
+        )
+        .expect("valid versioned banner leading year regex")
+    });
+
+    LEADING_YEAR_PREFIX_RE
+        .replace(holder_raw, "")
+        .trim()
+        .to_string()
 }
 
 pub fn extract_c_years_then_holder_lines(
@@ -942,6 +961,9 @@ pub fn extract_copyright_c_years_holder_lines(
             };
             let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
             let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+            let holder_raw = postprocess_transforms::strip_trailing_license_tail(holder_raw)
+                .unwrap_or_else(|| holder_raw.to_string());
+            let holder_raw = holder_raw.trim();
             if years.is_empty() || holder_raw.is_empty() {
                 continue;
             }

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -8,7 +8,6 @@ pub fn strip_trailing_license_tail(s: &str) -> Option<String> {
     if !(lower.contains("/license")
         || lower.contains("/licenses")
         || lower.contains(" licensed")
-        || lower.contains(" license")
         || lower.contains(" released under"))
     {
         return None;
@@ -20,7 +19,7 @@ pub fn strip_trailing_license_tail(s: &str) -> Option<String> {
         if lower.contains("/license") || lower.contains("/licenses") {
             return Some(idx);
         }
-        if lower == "license" || lower == "licenses" || lower == "licensed" {
+        if lower == "licensed" {
             return Some(idx);
         }
         if lower == "released"

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-fn strip_trailing_license_tail(s: &str) -> Option<String> {
+pub fn strip_trailing_license_tail(s: &str) -> Option<String> {
     let lower = s.to_ascii_lowercase();
     if !(lower.contains("/license")
         || lower.contains("/licenses")

--- a/src/copyright/detector/postprocess_transforms/metadata_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/metadata_repairs.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::copyright::candidates::is_raw_versioned_project_banner_line;
+use crate::copyright::candidates::{
+    is_raw_versioned_project_banner_line, versioned_banner_holder_from_prepared,
+};
 use crate::copyright::detector::token_utils;
+use crate::copyright::prepare::prepare_text_line;
 
 pub fn drop_json_description_metadata_copyrights_and_holders(
     raw_lines: &[&str],
@@ -15,11 +18,11 @@ pub fn drop_json_description_metadata_copyrights_and_holders(
 
     let mut retained_spans: HashSet<(usize, usize)> = HashSet::new();
     copyrights.retain(|copyright| {
-        if copyright.start_line == copyright.end_line
-            && raw_lines
-                .get(copyright.start_line.get().saturating_sub(1))
-                .is_some_and(|line| is_raw_versioned_project_banner_line(line))
-        {
+        if span_is_versioned_project_banner(
+            raw_lines,
+            copyright.start_line.get(),
+            copyright.end_line.get(),
+        ) {
             retained_spans.insert((copyright.start_line.get(), copyright.end_line.get()));
             return true;
         }
@@ -53,11 +56,11 @@ pub fn drop_json_description_metadata_copyrights_and_holders(
         if retained_spans.contains(&(holder.start_line.get(), holder.end_line.get())) {
             return true;
         }
-        if holder.start_line == holder.end_line
-            && raw_lines
-                .get(holder.start_line.get().saturating_sub(1))
-                .is_some_and(|line| is_raw_versioned_project_banner_line(line))
-        {
+        if span_is_versioned_project_banner(
+            raw_lines,
+            holder.start_line.get(),
+            holder.end_line.get(),
+        ) {
             return true;
         }
         let Some(window) =
@@ -73,6 +76,36 @@ pub fn drop_json_description_metadata_copyrights_and_holders(
             || lower.contains("\"url\"");
         !description_like || JSON_COPYRIGHT_KEY_RE.is_match(&window)
     });
+}
+
+fn span_is_versioned_project_banner(
+    raw_lines: &[&str],
+    start_line: usize,
+    end_line: usize,
+) -> bool {
+    if start_line == 0
+        || end_line == 0
+        || start_line > raw_lines.len()
+        || end_line > raw_lines.len()
+    {
+        return false;
+    }
+
+    if start_line == end_line
+        && raw_lines
+            .get(start_line.saturating_sub(1))
+            .is_some_and(|line| is_raw_versioned_project_banner_line(line))
+    {
+        return true;
+    }
+
+    let window_start = start_line.saturating_sub(3).max(1);
+    let prepared = raw_lines[window_start - 1..end_line]
+        .iter()
+        .map(|line| prepare_text_line(line))
+        .collect::<Vec<_>>()
+        .join(" ");
+    versioned_banner_holder_from_prepared(&prepared).is_some()
 }
 
 pub fn drop_markup_declaration_and_versioninfo_copyrights_and_holders(

--- a/src/copyright/detector/postprocess_transforms/year_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/year_repairs.rs
@@ -815,6 +815,9 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
         Regex::new(r"(?i)^copyright\s*\(c\)\s*(?:19|20)\d{2}-\d{2}-\d{2}\s+(?P<holder>.+)$")
             .expect("valid iso-date copyright holder regex")
     });
+    static LEADING_AND_ONWARDS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^and\s+onwards\b[\s,;:.-]*").expect("valid leading and onwards regex")
+    });
     static LEADING_YEARISH_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?ix)^
@@ -900,6 +903,8 @@ pub fn derive_holder_from_simple_copyright_string(s: &str) -> Option<String> {
     if let Some(rest) = holder_raw.strip_prefix("by ") {
         holder_raw = rest.trim();
     }
+    let holder_raw_cleaned = LEADING_AND_ONWARDS_RE.replace(holder_raw, "");
+    holder_raw = holder_raw_cleaned.trim();
 
     if let Some(cap) = EMBEDDED_C_MARKER_RE.captures(holder_raw)
         && let Some(head) = cap.name("head").map(|m| m.as_str().trim())

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -137,6 +137,18 @@ fn test_derive_holder_from_simple_copyright_string_strips_and_onwards_prefix() {
 }
 
 #[test]
+fn test_strip_trailing_license_tail_keeps_see_license_prose() {
+    assert_eq!(
+        strip_trailing_license_tail("Tyler Kellen. See LICENSE for further details"),
+        None
+    );
+    assert_eq!(
+        strip_trailing_license_tail("Tyler Kellen; Licensed MIT"),
+        Some("Tyler Kellen".to_string())
+    );
+}
+
+#[test]
 fn test_refine_final_authors_keeps_structured_metadata_collectives() {
     let mut authors = vec![
         AuthorDetection {

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -127,6 +127,16 @@ fn test_derive_holder_from_simple_copyright_string_keeps_leading_digits() {
 }
 
 #[test]
+fn test_derive_holder_from_simple_copyright_string_strips_and_onwards_prefix() {
+    assert_eq!(
+        derive_holder_from_simple_copyright_string(
+            "Copyright 2006 and onwards The Apache Software Foundation."
+        ),
+        Some("The Apache Software Foundation".to_string())
+    );
+}
+
+#[test]
 fn test_refine_final_authors_keeps_structured_metadata_collectives() {
     let mut authors = vec![
         AuthorDetection {

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -505,6 +505,242 @@ fn test_detect_versioned_project_banner_with_mixed_case_brand_holder() {
 }
 
 #[test]
+fn test_detect_versioned_project_banner_with_leading_year_before_holder() {
+    let content = "/*! X-editable - v1.5.0 Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Vitaliy Potapov"),
+        "holders: {holders:?}"
+    );
+}
+
+#[test]
+fn test_detect_multiline_versioned_project_banner_with_trailing_license_tail() {
+    let content = "/*! X-editable - v1.5.0\n\
+                   * In-place editing with Twitter Bootstrap\n\
+                   * http://vitalets.github.io/x-editable\n\
+                   * Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Vitaliy Potapov"),
+        "holders: {holders:?}"
+    );
+    assert!(
+        !copyrights
+            .iter()
+            .any(|c| c.copyright.contains("Licensed MIT")),
+        "copyrights: {copyrights:?}"
+    );
+}
+
+#[test]
+fn test_detect_multiline_x_editable_header_still_works_with_huge_minified_auth_lines() {
+    let header = "/*! X-editable - v1.5.0\n\
+                  * In-place editing with Twitter Bootstrap\n\
+                  * http://vitalets.github.io/x-editable\n\
+                  * Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n";
+    let content = format!(
+        "{header}{}\n{}\n{}\n",
+        make_minified_auth_line(32_001),
+        make_minified_auth_line(32_203),
+        make_minified_auth_line(9_776),
+    );
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(&content);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Vitaliy Potapov"),
+        "holders: {holders:?}"
+    );
+}
+
+#[test]
+fn test_detect_multiline_x_editable_actual_line5_shape_survives_postprocess_boundary() {
+    let content = format!(
+        "/*! X-editable - v1.5.0\n* In-place editing with Twitter Bootstrap, jQuery UI or pure jQuery\n* http://github.com/vitalets/x-editable\n* Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n{}\n",
+        make_bootstrap_editable_actual_line5_shape(),
+    );
+
+    let boundaries = super::detect_copyright_phase_boundaries(&content);
+
+    assert!(
+        boundaries
+            .after_group_loop_copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "after_group_loop_copyrights: {:?}",
+        boundaries.after_group_loop_copyrights
+    );
+    assert!(
+        boundaries
+            .after_group_loop_holders
+            .iter()
+            .any(|h| h.holder == "Vitaliy Potapov"),
+        "after_group_loop_holders: {:?}",
+        boundaries.after_group_loop_holders
+    );
+    assert!(
+        boundaries
+            .after_primary_copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "after_primary_copyrights: {:?}",
+        boundaries.after_primary_copyrights
+    );
+    assert!(
+        boundaries
+            .after_primary_holders
+            .iter()
+            .any(|h| h.holder == "Vitaliy Potapov"),
+        "after_primary_holders: {:?}",
+        boundaries.after_primary_holders
+    );
+    assert!(
+        boundaries
+            .after_postprocess_copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "after_postprocess_copyrights: {:?}",
+        boundaries.after_postprocess_copyrights
+    );
+    assert!(
+        boundaries
+            .after_postprocess_holders
+            .iter()
+            .any(|h| h.holder == "Vitaliy Potapov"),
+        "after_postprocess_holders: {:?}",
+        boundaries.after_postprocess_holders
+    );
+}
+
+#[test]
+fn test_detect_multiline_x_editable_actual_line5_shape_end_to_end() {
+    let content = format!(
+        "/*! X-editable - v1.5.0\n* In-place editing with Twitter Bootstrap, jQuery UI or pure jQuery\n* http://github.com/vitalets/x-editable\n* Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n{}\n",
+        make_bootstrap_editable_actual_line5_shape(),
+    );
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(&content);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013 Vitaliy Potapov"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Vitaliy Potapov"),
+        "holders: {holders:?}"
+    );
+}
+
+#[test]
+fn test_detect_bloomfilter_exact_file_shape_phase_boundary_keeps_onelab() {
+    let content = "/**
+ *
+ * Copyright (c) 2005, European Commission project OneLab under contract 034819 (http://www.one-lab.org)
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or 
+ * without modification, are permitted provided that the following 
+ * conditions are met:
+ *  - Redistributions of source code must retain the above copyright 
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in 
+ *    the documentation and/or other materials provided with the distribution.
+ */
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * \"License\"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hadoop.util.bloom;
+
+/**
+ * Originally created by
+ * <a href=\"http://www.one-lab.org\">European Commission One-Lab Project 034819</a>.
+ */
+public class BloomFilter {}
+";
+    let boundaries = super::detect_copyright_phase_boundaries(content);
+
+    assert!(
+        boundaries
+            .after_group_loop_copyrights
+            .iter()
+            .any(|c| { c.copyright == "Copyright (c) 2005, European Commission project OneLab" }),
+        "after_group_loop_copyrights: {:?}",
+        boundaries.after_group_loop_copyrights,
+    );
+    assert!(
+        boundaries
+            .after_group_loop_holders
+            .iter()
+            .any(|h| h.holder == "European Commission project OneLab"),
+        "after_group_loop_holders: {:?}",
+        boundaries.after_group_loop_holders,
+    );
+    assert!(
+        boundaries
+            .after_primary_copyrights
+            .iter()
+            .any(|c| { c.copyright == "Copyright (c) 2005, European Commission project OneLab" }),
+        "after_primary_copyrights: {:?}",
+        boundaries.after_primary_copyrights,
+    );
+    assert!(
+        boundaries
+            .after_primary_holders
+            .iter()
+            .any(|h| h.holder == "European Commission project OneLab"),
+        "after_primary_holders: {:?}",
+        boundaries.after_primary_holders,
+    );
+    assert!(
+        boundaries.after_postprocess_copyrights.iter().any(|c| {
+            c.copyright
+                .starts_with("Copyright (c) 2005, European Commission project OneLab")
+        }),
+        "after_postprocess_copyrights: {:?}",
+        boundaries.after_postprocess_copyrights,
+    );
+    assert!(
+        boundaries
+            .after_postprocess_holders
+            .iter()
+            .any(|h| h.holder == "European Commission project OneLab"),
+        "after_postprocess_holders: {:?}",
+        boundaries.after_postprocess_holders,
+    );
+}
+
+#[test]
 fn test_detect_postscript_percent_copyright_prefix() {
     let content = "%%Copyright: -----------------------------------------------------------\n\
 %%Copyright: Copyright 1990-2009 Adobe Systems Incorporated.\n\
@@ -522,6 +758,47 @@ fn test_detect_postscript_percent_copyright_prefix() {
         hs.iter().any(|s| s == "Adobe Systems Incorporated"),
         "{hs:#?}"
     );
+}
+
+fn make_minified_auth_line(target_len: usize) -> String {
+    let chunk = concat!(
+        "!function(){var authenticationToken=this.authenticationToken;",
+        "return this.removeEventListener('x',handler),",
+        "document.createElement('div').appendChild(node),",
+        "node.className='editable',this.addEventListener('x',handler),",
+        "this.setAttribute('data-auth','1'),this.innerHTML=node.className;}"
+    );
+    let mut line = chunk.repeat(target_len / chunk.len() + 1);
+    line.truncate(target_len);
+    line
+}
+
+fn make_bootstrap_editable_actual_line5_shape() -> String {
+    let prefix = concat!(
+        "!function(a){\"use strict\";var b=function(b,c){this.options=a.extend({},a.fn.editableform.defaults,c),",
+        "this.$div=a(b),this.options.scope||(this.options.scope=this)};b.prototype={constructor:b,initInput:function(){",
+        "this.input=this.options.input,this.value=this.input.str2value(this.options.value),this.input.prerender()},",
+        "initTemplate:function(){this.$form=a(a.fn.editableform.template)},initButtons:function(){var b=this.$form.find(\".editable-buttons\");",
+        "b.append(a.fn.editableform.buttons),\"bottom\"===this.options.showbuttons&&b.addClass(\"editable-buttons-bottom\")},",
+        "render:function(){this.$loading=a(a.fn.editableform.loading),this.$div.empty().append(this.$loading),this.initTemplate(),",
+        "this.options.showbuttons?this.initButtons():this.$form.find(\".editable-buttons\").remove(),this.showLoading(),",
+        "this.isSaving=!1,this.$div.triggerHandler(\"rendering\"),this.initInput(),this.$form.find(\"div.editable-input\")"
+    );
+    let visible = concat!(
+        ",\"value\"===a&&this.setValue(b)},setValue:function(a,b){this.value=b?this.input.str2value(a):a,",
+        "this.$form&&this.$form.is(\":visible\")&&this.input.value2input(this.value)}},a.fn.editableform=function(c){",
+        "var d=arguments;return this.each(function(){var e=a(this),f="
+    );
+    let url = concat!(
+        "n.editableutils.inherit(b,a.fn.editabletypes.text),b.defaults=a.extend({},a.fn.editabletypes.text.defaults,",
+        "{tpl:'<input type=\"url\">'}),a.fn.editabletypes.url=b}(window.jQuery),function(a){\"use strict\";",
+        "var b=function(a){this.init(\"tel\",a,b.defaults)};a.fn.edita"
+    );
+
+    let mut line = prefix.repeat(3);
+    line.push_str(visible);
+    line.push_str(url);
+    line
 }
 
 #[test]

--- a/src/copyright/detector/tree_walk/copyright.rs
+++ b/src/copyright/detector/tree_walk/copyright.rs
@@ -1645,6 +1645,28 @@ pub fn should_start_absorbing(
         _ => false,
     };
     if is_name_like_first {
+        let same_line = last_line.is_some_and(|line| {
+            detector::token_utils::collect_all_leaves(first)
+                .first()
+                .is_some_and(|token| token.start_line == line)
+        });
+        let node_has_holder = detector::token_utils::build_holder_from_node(
+            copyright_node,
+            detector::NON_HOLDER_LABELS,
+            detector::NON_HOLDER_POS_TAGS,
+        )
+        .is_some();
+        if same_line
+            && node_has_holder
+            && is_same_line_legal_tail_boundary(
+                tree,
+                start + 1,
+                last_line.expect("same_line checked"),
+            )
+        {
+            return true;
+        }
+
         return has_company_signal_nearby(tree, start);
     }
 
@@ -1742,6 +1764,18 @@ fn has_company_signal_nearby(tree: &[ParseNode], start: usize) -> bool {
         }
     }
     false
+}
+
+fn is_same_line_legal_tail_boundary(tree: &[ParseNode], start: usize, line: LineNumber) -> bool {
+    let end = std::cmp::min(start + 3, tree.len());
+    tree[start..end].iter().any(|node| match node {
+        ParseNode::Leaf(token) => {
+            token.start_line == line
+                && token.tag == PosTag::Junk
+                && !token.value.eq_ignore_ascii_case("file")
+        }
+        _ => false,
+    })
 }
 
 fn last_leaf_ends_with_comma(node: &ParseNode) -> bool {

--- a/src/copyright/detector/tree_walk_test.rs
+++ b/src/copyright/detector/tree_walk_test.rs
@@ -389,3 +389,56 @@ fn test_oprofile_authors_copyright() {
         "Should detect 'OProfile authors' holder. prepared={prepared_line:?} tokens={token_debug:?} got: {h:?}",
     );
 }
+
+#[test]
+fn test_collect_trailing_orphan_tokens_absorbs_name_before_legal_tail() {
+    let text = "Copyright (c) 2005, European Commission project OneLab under contract 034819 (http://www.one-lab.org)";
+    let prepared = super::super::super::prepare::prepare_text_line(text);
+    let tokens = get_tokens(&[(1, prepared)]);
+    let tree = parse(tokens);
+    let (copyright_idx, copyright_node) = tree
+        .iter()
+        .enumerate()
+        .find(|(_i, n)| {
+            matches!(
+                n.label(),
+                Some(TreeLabel::Copyright) | Some(TreeLabel::Copyright2)
+            )
+        })
+        .expect("Should parse a COPYRIGHT node");
+    let start = copyright_idx + 1;
+
+    assert!(
+        should_start_absorbing(copyright_node, &tree, start),
+        "Should absorb trailing holder continuation before legal tail; tree={tree:#?}"
+    );
+
+    let (trailing, _skip) = collect_trailing_orphan_tokens(copyright_node, &tree, start);
+    let trailing_values: Vec<&str> = trailing.iter().map(|t| t.value.as_str()).collect();
+
+    assert!(
+        trailing.iter().any(|t| t.value == "OneLab"),
+        "Trailing tokens should include OneLab, got: {trailing_values:?}"
+    );
+    assert!(
+        !trailing
+            .iter()
+            .any(|t| t.value.eq_ignore_ascii_case("under")),
+        "Trailing tokens should stop before legal tail, got: {trailing_values:?}"
+    );
+
+    let (copyrights, holders, _authors) = super::super::detect_copyrights_from_text(text);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| { c.copyright == "Copyright (c) 2005, European Commission project OneLab" }),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders
+            .iter()
+            .any(|h| h.holder == "European Commission project OneLab"),
+        "holders: {holders:?}"
+    );
+}

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1262,6 +1262,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_original_authors(&c);
     c = strip_trailing_mountain_view_ca(&c);
     c = strip_trailing_comma_after_respective_authors(&c);
+    c = strip_trailing_ansi_escape_suffix(&c);
     c = c.trim_end_matches(char::is_whitespace).to_string();
     c = c.trim_matches('\'').to_string();
     c = wrap_trailing_and_urls_in_parens(&c);
@@ -1798,6 +1799,15 @@ fn strip_trailing_locale_timestamp_before_terminal_year_in_copyright(s: &str) ->
         return format!("{} {}", prefix.trim_end_matches(&[',', ' '][..]), year);
     }
     prefix.trim_end_matches(&[',', ' '][..]).to_string()
+}
+
+fn strip_trailing_ansi_escape_suffix(s: &str) -> String {
+    static ANSI_ESCAPE_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)\s+x1b(?:\s+\d+(?:;\d+)*[a-z])+\s*$")
+            .expect("valid ansi escape suffix regex")
+    });
+
+    ANSI_ESCAPE_SUFFIX_RE.replace(s, "").trim().to_string()
 }
 
 fn strip_trailing_quote_before_email(s: &str) -> String {
@@ -2907,6 +2917,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     }
     h = strip_trailing_at_sign(&h);
     h = strip_trailing_mountain_view_ca(&h);
+    h = strip_trailing_ansi_escape_suffix(&h);
     h = h.trim_matches(&[',', ' '][..]).to_string();
     h = strip_trailing_period(&h);
     h = h.trim_matches(&[',', ' '][..]).to_string();

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -2789,6 +2789,14 @@ fn strip_parenthesized_emails(s: &str) -> String {
     normalize_whitespace(&PAREN_EMAIL_RE.replace_all(s, " "))
 }
 
+fn strip_leading_and_onwards_holder_prefix(s: &str) -> String {
+    static AND_ONWARDS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?:and\s+)?onwards\b[\s,;:.-]*")
+            .expect("valid leading onwards holder regex")
+    });
+    normalize_whitespace(&AND_ONWARDS_RE.replace(s, " "))
+}
+
 fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     if s.is_empty() {
         return None;
@@ -2858,6 +2866,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
 
     if in_copyright_context {
         h = strip_trailing_short_surname_paren_list_in_holder(&h);
+        h = strip_leading_and_onwards_holder_prefix(&h);
     }
 
     // Strip leading date-like prefix (digits, dashes, slashes).

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1831,6 +1831,22 @@ fn test_refine_holder_in_copyright_context_strips_onwards_prefix() {
 }
 
 #[test]
+fn test_refine_copyright_strips_trailing_ansi_escape_suffix() {
+    assert_eq!(
+        refine_copyright("(c) 1996 Id Software, inc. x1b 21;1H"),
+        Some("(c) 1996 Id Software, inc.".to_string())
+    );
+}
+
+#[test]
+fn test_refine_holder_in_copyright_context_strips_trailing_ansi_escape_suffix() {
+    assert_eq!(
+        refine_holder_in_copyright_context("Id Software, inc. x1b 21;1H"),
+        Some("Id Software, inc.".to_string())
+    );
+}
+
+#[test]
 fn test_refine_holder_strips_trailing_placeholder_dollar() {
     assert_eq!(
         refine_holder("Markus Franz Xaver Johannes Oberhumer $"),

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1819,6 +1819,18 @@ fn test_refine_holder_in_copyright_context_strips_no_rights_reserved_clause() {
 }
 
 #[test]
+fn test_refine_holder_in_copyright_context_strips_onwards_prefix() {
+    assert_eq!(
+        refine_holder_in_copyright_context("and onwards The Apache Software Foundation"),
+        Some("The Apache Software Foundation".to_string())
+    );
+    assert_eq!(
+        refine_holder_in_copyright_context("onwards The Apache Software Foundation"),
+        Some("The Apache Software Foundation".to_string())
+    );
+}
+
+#[test]
 fn test_refine_holder_strips_trailing_placeholder_dollar() {
     assert_eq!(
         refine_holder("Markus Franz Xaver Johannes Oberhumer $"),

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -23,6 +23,9 @@ pub(super) fn extract_copyright_information(
     timeout_seconds: f64,
     from_binary_strings: bool,
 ) {
+    let text_content = crate::utils::sourcemap::detection_text(path, text_content);
+    let text_content = text_content.as_ref();
+
     if copyright::is_credits_file(path) {
         let author_detections = copyright::detect_credits_authors(text_content);
         if !author_detections.is_empty() {
@@ -663,6 +666,8 @@ fn looks_like_comment_author_source_line(line: &str) -> bool {
 
 fn normalize_comment_author_line(line: &str) -> String {
     line.trim()
+        .trim_start_matches("<!--")
+        .trim_start()
         .trim_end_matches("*/")
         .trim_end_matches("-->")
         .trim()

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -91,6 +91,44 @@ fn test_extract_copyright_information_preserves_raw_text_and_normalized_shadow()
 }
 
 #[test]
+fn test_extract_copyright_information_uses_embedded_sourcemap_sources_for_parties() {
+    let text = r#"{"version":3,"comment":"Copyright 1999 Wrong Corp.","sourcesContent":["/* Copyright 2024 Example Corp. */\n"]}"#;
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("bundle.js.map"), text, 120.0, false);
+
+    let file = builder
+        .name("bundle.js.map".to_string())
+        .base_name("bundle.js".to_string())
+        .extension(".map".to_string())
+        .path("bundle.js.map".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(file.copyrights[0].copyright, "Copyright 2024 Example Corp.");
+    assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
+    assert_eq!(file.holders[0].holder, "Example Corp.");
+    assert!(
+        file.copyrights
+            .iter()
+            .all(|copyright| !copyright.copyright.contains("Wrong Corp"))
+    );
+    assert!(
+        file.holders
+            .iter()
+            .all(|holder| !holder.holder.contains("Wrong Corp"))
+    );
+}
+
+#[test]
 fn test_extract_copyright_information_multiline_native_projection_avoids_comment_wrappers() {
     let text = "/*\n * Copyright 2024 Example Corp.\n * All rights reserved.\n */\n";
     let mut builder = FileInfoBuilder::default();
@@ -183,6 +221,79 @@ fn test_extract_copyright_information_xml_comment_projection_preserves_native_sy
     assert_eq!(
         file.copyrights[0].normalized_copyright.as_deref(),
         Some("Copyright (c) 2024 Example Corp.")
+    );
+}
+
+#[test]
+fn test_extract_copyright_information_bloomfilter_exact_file_shape_keeps_onelab() {
+    let text = "/**
+ *
+ * Copyright (c) 2005, European Commission project OneLab under contract 034819 (http://www.one-lab.org)
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or 
+ * without modification, are permitted provided that the following 
+ * conditions are met:
+ *  - Redistributions of source code must retain the above copyright 
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in 
+ *    the documentation and/or other materials provided with the distribution.
+ */
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * \"License\"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hadoop.util.bloom;
+
+/**
+ * Originally created by
+ * <a href=\"http://www.one-lab.org\">European Commission One-Lab Project 034819</a>.
+ */
+public class BloomFilter {}
+";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(
+        &mut builder,
+        Path::new("BloomFilter.java"),
+        text,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("BloomFilter.java".to_string())
+        .base_name("BloomFilter".to_string())
+        .extension(".java".to_string())
+        .path("BloomFilter.java".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(
+        file.copyrights.iter().any(|c| {
+            c.normalized_copyright.as_deref()
+                == Some("Copyright (c) 2005, European Commission project OneLab")
+        }),
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert!(
+        file.holders
+            .iter()
+            .any(|h| h.holder == "European Commission project OneLab"),
+        "holders: {:?}",
+        file.holders
     );
 }
 
@@ -517,6 +628,16 @@ fn test_extract_comment_author_supplements_handles_c_style_translator_headers() 
             "S A Sureshkumar (saskumar@live.com)",
         ]
     );
+}
+
+#[test]
+fn test_extract_comment_author_supplements_handles_html_comment_by_line() {
+    let text = "<!-- Checkstyle XML Style Sheet by Stephane Bailliez <sbailliez@apache.org> -->\n";
+
+    let authors = extract_comment_author_supplements(text);
+    let values: Vec<_> = authors.into_iter().map(|author| author.author).collect();
+
+    assert_eq!(values, vec!["Stephane Bailliez <sbailliez@apache.org>"]);
 }
 
 #[test]

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -141,6 +141,8 @@ pub(super) fn extract_license_information(
                 &mut model_detections,
             );
             prune_redundant_readme_conjunctive_detections(path, &mut model_detections);
+            model_detections =
+                collapse_repeated_sourcemap_license_detections(path, model_detections);
 
             if !model_detections.is_empty() {
                 let expressions: Vec<String> = model_detections
@@ -248,6 +250,114 @@ fn supplement_nix_manifest_license_detections(
     }
 
     synthesized
+}
+
+fn collapse_repeated_sourcemap_license_detections(
+    path: &Path,
+    detections: Vec<PublicLicenseDetection>,
+) -> Vec<PublicLicenseDetection> {
+    if !crate::utils::sourcemap::is_sourcemap(path) || detections.len() <= 1 {
+        return detections;
+    }
+
+    let mut deduplicated: Vec<PublicLicenseDetection> = Vec::new();
+
+    for detection in detections {
+        if let Some(existing) = deduplicated.iter_mut().find(|existing| {
+            existing.license_expression == detection.license_expression
+                && existing.license_expression_spdx == detection.license_expression_spdx
+        }) {
+            merge_public_detection(existing, detection);
+        } else {
+            deduplicated.push(detection);
+        }
+    }
+
+    let concrete_detections = deduplicated
+        .iter()
+        .filter(|detection| is_concrete_sourcemap_detection(detection))
+        .cloned()
+        .collect::<Vec<_>>();
+    if concrete_detections.len() <= 1 {
+        return deduplicated;
+    }
+
+    let combined = combine_sourcemap_detections(concrete_detections);
+    let mut combined = Some(combined);
+    let mut collapsed = Vec::with_capacity(deduplicated.len());
+
+    for detection in deduplicated {
+        if is_concrete_sourcemap_detection(&detection) {
+            if let Some(combined) = combined.take() {
+                collapsed.push(combined);
+            }
+            continue;
+        }
+
+        collapsed.push(detection);
+    }
+
+    collapsed
+}
+
+fn is_concrete_sourcemap_detection(detection: &PublicLicenseDetection) -> bool {
+    !detection_is_unknown_reference(detection)
+        && (!detection.license_expression.is_empty()
+            || !detection.license_expression_spdx.is_empty())
+}
+
+fn combine_sourcemap_detections(detections: Vec<PublicLicenseDetection>) -> PublicLicenseDetection {
+    let mut detections = detections.into_iter();
+    let mut combined = detections
+        .next()
+        .expect("sourcemap combination requires at least one detection");
+    let mut combined_license_expressions = vec![combined.license_expression.clone()];
+    let mut combined_spdx_expressions = if combined.license_expression_spdx.is_empty() {
+        Vec::new()
+    } else {
+        vec![combined.license_expression_spdx.clone()]
+    };
+
+    for detection in detections {
+        combined_license_expressions.push(detection.license_expression.clone());
+        if !detection.license_expression_spdx.is_empty() {
+            combined_spdx_expressions.push(detection.license_expression_spdx.clone());
+        }
+        merge_public_detection(&mut combined, detection);
+    }
+
+    combined.license_expression =
+        crate::utils::spdx::combine_license_expressions_preserving_structure(
+            combined_license_expressions,
+        )
+        .unwrap_or_else(|| combined.license_expression.clone());
+    combined.license_expression_spdx =
+        crate::utils::spdx::combine_license_expressions_preserving_structure(
+            combined_spdx_expressions,
+        )
+        .unwrap_or_else(|| combined.license_expression_spdx.clone());
+    combined
+}
+
+fn merge_public_detection(
+    existing: &mut PublicLicenseDetection,
+    detection: PublicLicenseDetection,
+) {
+    for detection_log in detection.detection_log {
+        if !existing.detection_log.contains(&detection_log) {
+            existing.detection_log.push(detection_log);
+        }
+    }
+
+    for matched_region in detection.matches {
+        if !existing.matches.contains(&matched_region) {
+            existing.matches.push(matched_region);
+        }
+    }
+
+    if existing.identifier.is_none() {
+        existing.identifier = detection.identifier;
+    }
 }
 
 fn collect_detected_license_keys(detections: &[PublicLicenseDetection]) -> HashSet<String> {

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -19,6 +19,7 @@ use crate::models::{
     ScanDiagnostic,
 };
 use crate::scanner::LicenseScanOptions;
+use std::path::Path;
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
@@ -695,4 +696,48 @@ fn test_extract_license_information_maps_timeout_to_stage_error() {
 
     assert!(scan_diagnostics.is_empty());
     assert_eq!(error.to_string(), "Timeout during license scan (> 1.00s)");
+}
+
+#[test]
+fn test_collapse_repeated_sourcemap_license_detections_combines_concrete_detections() {
+    let mut first = make_public_detection("mit", "MIT", 1, 3);
+    first.identifier = Some("mit-first".to_string());
+    first.detection_log = vec!["first-log".to_string()];
+
+    let mut second = make_public_detection("mit", "MIT", 10, 12);
+    second.identifier = Some("mit-second".to_string());
+    second.detection_log = vec!["second-log".to_string()];
+
+    let mut third = make_public_detection("cc-by-3.0", "CC-BY-3.0", 20, 24);
+    third.identifier = Some("cc-by".to_string());
+
+    let sourcemap_result = super::collapse_repeated_sourcemap_license_detections(
+        Path::new("bundle.js.map"),
+        vec![first.clone(), second.clone(), third.clone()],
+    );
+
+    assert_eq!(
+        sourcemap_result.len(),
+        1,
+        "detections: {:?}",
+        sourcemap_result
+    );
+    assert_eq!(sourcemap_result[0].license_expression, "mit AND cc-by-3.0");
+    assert_eq!(
+        sourcemap_result[0].license_expression_spdx,
+        "MIT AND CC-BY-3.0"
+    );
+    assert_eq!(sourcemap_result[0].identifier.as_deref(), Some("mit-first"));
+    assert_eq!(sourcemap_result[0].matches.len(), 3);
+    assert_eq!(
+        sourcemap_result[0].detection_log,
+        vec!["first-log".to_string(), "second-log".to_string()]
+    );
+
+    let plain_result = super::collapse_repeated_sourcemap_license_detections(
+        Path::new("bundle.js"),
+        vec![first, second, third],
+    );
+
+    assert_eq!(plain_result.len(), 3);
 }

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -370,13 +370,7 @@ fn prepare_license_detection_text(
     text_content: String,
 ) -> String {
     let text_content = if crate::utils::sourcemap::is_sourcemap(path) {
-        if let Some(sourcemap_content) =
-            crate::utils::sourcemap::extract_sourcemap_content(&text_content)
-        {
-            sourcemap_content
-        } else {
-            text_content
-        }
+        crate::utils::sourcemap::detection_text(path, &text_content).into_owned()
     } else if should_remove_verbatim_escape_sequences(path, classification.is_source) {
         remove_verbatim_escape_sequences(&text_content)
     } else {

--- a/src/utils/sourcemap.rs
+++ b/src/utils/sourcemap.rs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Source map file processing for license detection.
+//! Source map file processing for scanner text detection.
 //!
 //! Source map files (.js.map, .css.map) are JSON files containing embedded
 //! source code in a `sourcesContent` array. This module extracts that content
-//! for license detection.
+//! so the scanner can detect licenses and parties from the embedded sources
+//! instead of from the raw source map JSON wrapper.
 
+use std::borrow::Cow;
 use std::path::Path;
 
 /// Check if a file is a source map file based on extension.
@@ -43,6 +45,17 @@ pub fn extract_sourcemap_content(json_text: &str) -> Option<String> {
     } else {
         Some(combined)
     }
+}
+
+/// Return the text scanners should inspect for this file.
+pub fn detection_text<'a>(path: &Path, text: &'a str) -> Cow<'a, str> {
+    if !is_sourcemap(path) {
+        return Cow::Borrowed(text);
+    }
+
+    extract_sourcemap_content(text)
+        .map(Cow::Owned)
+        .unwrap_or_else(|| Cow::Borrowed(text))
 }
 
 /// Replace verbatim escaped CR/LF characters with actual newlines.
@@ -141,6 +154,16 @@ mod tests {
         assert!(result.is_some());
         let content = result.unwrap();
         assert!(content.contains("actual"));
+    }
+
+    #[test]
+    fn test_detection_text_prefers_embedded_sources_for_sourcemaps() {
+        let path = PathBuf::from("bundle.js.map");
+        let raw = r#"{"version":3,"comment":"Copyright 1999 Wrong Corp.","sourcesContent":["/* Copyright 2024 Example Corp. */\n"]}"#;
+
+        let result = detection_text(&path, raw);
+
+        assert_eq!(result.as_ref(), "/* Copyright 2024 Example Corp. */\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- verify `apache/hadoop` at `dbcc7cd797100e6b32cd84f85b53a5193a5f9af0` with a benchmark-grade `compare-outputs` run and record the result in `docs/BENCHMARKS.md`
- fix generic sourcemap, copyright, metadata-cleanup, tree-walk, and comment-author paths exposed by Hadoop parity review
- regenerate `docs/scan-duration-vs-files.svg` after adding the Hadoop timing row (`278.63s` vs `4575.96s`, `16.42×` faster)

## Issues

- Covers: Hadoop benchmark verification for `https://github.com/apache/hadoop` at `dbcc7cd797100e6b32cd84f85b53a5193a5f9af0`
- Closes:

## Scope and exclusions

- Included:
  - generic sourcemap license/party handling improvements
  - generic copyright/holder extraction and metadata-cleanup fixes exposed by Hadoop
  - Hadoop benchmark entry and regenerated benchmark chart
- Explicit exclusions:
  - no parser `.expected.json` or golden fixture updates
  - no attempt to chase reviewed JDiff/CHANGELOG/NOTICE noise that did not justify another general fix

## Intentional differences from Python

- keep reviewed differences where Provenant is deliberately cleaner or more specific, including de-duplicated repeated MIT sourcemap detections and rejecting ScanCode's `Apache-2.0 AND LGPL-2.1-only` over-assertion on plain Apache notice headers

## Follow-up work

- Created or intentionally deferred:
  - deferred low-value NOTICE/author cleanup that did not justify another robust generic fix after the Hadoop review

## Validation

- `cargo test test_collapse_repeated_sourcemap_license_detections_combines_concrete_detections`
- `cargo test test_detect_multiline_x_editable_actual_line5_shape_survives_postprocess_boundary`
- `cargo test test_detect_multiline_x_editable_actual_line5_shape_end_to_end`
- `cargo test test_collect_trailing_orphan_tokens_absorbs_name_before_legal_tail`
- `cargo test test_derive_holder_from_simple_copyright_string_strips_and_onwards_prefix`
- `cargo test test_extract_comment_author_supplements_handles_html_comment_by_line`
- `npm run check:docs`
- `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/apache/hadoop.git --repo-ref 7b92f0bc7f8fb8f243635493da76e8f59475ef87 --profile common`

## Benchmark evidence

- Target snapshot: `apache/hadoop @ dbcc7cd797100e6b32cd84f85b53a5193a5f9af0`
- Compare artifacts: `.provenant/compare-runs/20260506T074747Z-hadoop-28100`
- Files: `16,370`
- Timing: Provenant `278.63s`; ScanCode `4575.96s` (`16.42×` faster)

## Expected-output fixture changes

- Files changed: None
- Why the new expected output is correct: no golden or `.expected` fixtures changed; this branch updates runtime behavior and benchmark docs only