### PR TITLE
fix(scan-result-shaping): remove root directory entry when --strip-root is set

### DIFF
--- a/src/post_processing/test_utils.rs
+++ b/src/post_processing/test_utils.rs
@@ -424,7 +424,7 @@ pub(crate) fn strip_root_prefix_for_test(path: &Path, root: &Path) -> Option<Pat
 }
 
 #[cfg(feature = "golden-tests")]
-pub fn normalize_paths_for_test(files: &mut [FileInfo], scan_root: &str) {
+pub fn normalize_paths_for_test(files: &mut Vec<FileInfo>, scan_root: &str) {
     normalize_paths(files, scan_root, true, false);
 }
 
@@ -488,15 +488,6 @@ pub(crate) fn compute_fixture_output(
             .to_str()
             .expect("fixture path should be UTF-8"),
     );
-    if let Some(root_name) = resolved_scan_root
-        .scan_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        && !files.iter().any(|file| file.path == root_name)
-    {
-        files.push(dir(root_name));
-    }
     let mut assembly_result = assembly::assemble(&mut files);
     for package in &mut assembly_result.packages {
         package.backfill_license_provenance();

--- a/src/scan_result_shaping/core_test.rs
+++ b/src/scan_result_shaping/core_test.rs
@@ -938,3 +938,92 @@ fn normalize_top_level_output_paths_only_applies_strip_root() {
     assert_eq!(packages[0].datafile_paths, vec!["package.json"]);
     assert_eq!(dependencies[0].datafile_path, "package.json");
 }
+
+#[test]
+fn normalize_paths_strip_root_removes_root_directory_entry() {
+    let mut files = vec![
+        dir("project"),
+        dir("project/src"),
+        file("project/src/main.rs"),
+        file("project/README.md"),
+    ];
+    normalize_paths(&mut files, "project", true, false);
+
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert!(
+        !paths.contains(&"project"),
+        "root directory entry should be removed with --strip-root, got: {paths:?}"
+    );
+    assert!(paths.contains(&"src"), "child directory should remain");
+    assert!(paths.contains(&"src/main.rs"), "child file should remain");
+    assert!(
+        paths.contains(&"README.md"),
+        "root-level file should remain"
+    );
+}
+
+#[test]
+fn normalize_paths_strip_root_keeps_root_entry_for_single_file_scan() {
+    let mut files = vec![file("project/README.md")];
+    normalize_paths(&mut files, "project/README.md", true, false);
+
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert!(
+        paths.contains(&"README.md"),
+        "single file entry should remain with --strip-root, got: {paths:?}"
+    );
+}
+
+#[test]
+fn normalize_paths_strip_root_keeps_root_entry_for_single_directory_scan() {
+    let mut files = vec![dir("project")];
+    normalize_paths(&mut files, "project", true, false);
+
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["project"],
+        "single directory root should remain with --strip-root, got: {paths:?}"
+    );
+}
+
+#[test]
+fn normalize_paths_strip_root_removes_root_but_keeps_same_named_child() {
+    let mut files = vec![
+        dir("project"),
+        dir("project/project"),
+        file("project/project/inner.txt"),
+    ];
+    normalize_paths(&mut files, "project", true, false);
+
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(
+        paths.len(),
+        2,
+        "should have exactly 2 entries (child dir + file), got: {paths:?}"
+    );
+    assert!(
+        paths.contains(&"project"),
+        "child directory named 'project' should remain after root is removed"
+    );
+    assert!(
+        paths.contains(&"project/inner.txt"),
+        "file under same-named child should remain"
+    );
+}
+
+#[test]
+fn normalize_paths_without_strip_root_keeps_root_directory_entry() {
+    let mut files = vec![
+        dir("project"),
+        dir("project/src"),
+        file("project/src/main.rs"),
+    ];
+    normalize_paths(&mut files, "project", false, false);
+
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert!(
+        paths.contains(&"project"),
+        "root directory entry should be kept without --strip-root"
+    );
+}

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -540,11 +540,21 @@ fn normalize_ignorable_value(value: &str, trim_slashes: bool) -> String {
 }
 
 pub(crate) fn normalize_paths(
-    files: &mut [FileInfo],
+    files: &mut Vec<FileInfo>,
     scan_root: &str,
     strip_root: bool,
     full_root: bool,
 ) {
+    if strip_root {
+        let root_is_directory = files.iter().any(|entry| {
+            entry.path == scan_root && entry.file_type == crate::models::FileType::Directory
+        });
+        let has_single_resource = files.len() <= 1;
+        if root_is_directory && !has_single_resource {
+            files.retain(|entry| entry.path != scan_root);
+        }
+    }
+
     for entry in files.iter_mut() {
         if let Some(normalized_path) =
             normalize_path_value(&entry.path, scan_root, strip_root, full_root)


### PR DESCRIPTION
## Summary

- `--strip-root` now excludes the root directory entry from the `files` output array, matching ScanCode's `skip_root=True` behavior
- Fixes a duplicate-path collision bug when a child directory shares the root's name (e.g., `myproject/myproject/inner.txt` produced two entries with path `myproject`)
- Single-resource scans (one file or one empty directory) preserve the root entry, consistent with ScanCode's `has_single_resource` exception

## Details

Previously, `normalize_paths` with `--strip-root` would keep the root directory entry in the output but rename its path to just the basename (e.g., `/tmp/myproject` → `myproject`). ScanCode instead uses `skip_root=True` in `Codebase.walk()` to exclude the root entry entirely. This divergence caused duplicate path entries in the collision case and was a general parity bug.

The fix adds a dedicated step at the start of `normalize_paths` that removes the root directory entry when `strip_root=true` and the scan has more than one resource. The path normalization loop continues unchanged after removal.

The `normalize_paths_for_test` signature was updated from `&mut [FileInfo]` to `&mut Vec<FileInfo>`, and a workaround in golden test utilities that re-added the root entry after normalization was removed (no longer needed).

## Test coverage

- `normalize_paths_strip_root_removes_root_directory_entry` — root dir removed, children kept
- `normalize_paths_strip_root_keeps_root_entry_for_single_file_scan` — single-resource file exception
- `normalize_paths_strip_root_keeps_root_entry_for_single_directory_scan` — single-resource empty-dir exception
- `normalize_paths_strip_root_removes_root_but_keeps_same_named_child` — collision case no longer produces duplicates
- `normalize_paths_without_strip_root_keeps_root_directory_entry` — default behavior unchanged