### PR TITLE
fix(license): standardize LicenseRef-scancode namespace

### DIFF
--- a/docs/HOW_TO_ADD_A_PARSER.md
+++ b/docs/HOW_TO_ADD_A_PARSER.md
@@ -141,6 +141,15 @@ field, populate:
 Use the shared helper in `src/parsers/license_normalization.rs` instead of writing parser-specific
 normalization logic.
 
+When a parser emits an SPDX-side `LicenseRef-*` identifier, use the shared
+`LicenseRef-scancode-*` namespace.
+
+This applies to parser-side declared-license normalization too. If the normalized key is already
+backed by the shared ScanCode-compatible license dataset or public output contract, reuse that
+dataset-owned SPDX identifier instead of inventing a parser-local variant. In practice this means
+parser outputs such as `public-domain`, `proprietary-license`, and
+`unknown-license-reference` should use their existing `LicenseRef-scancode-*` identifiers.
+
 If the license surface is weak or ambiguous, keep the parser raw-only:
 
 - preserve `extracted_license_statement`

--- a/docs/LICENSE_DETECTION_ARCHITECTURE.md
+++ b/docs/LICENSE_DETECTION_ARCHITECTURE.md
@@ -63,6 +63,16 @@ license-reference generation is explicitly requested.
 
 This document is the evergreen maintainer reference for the current public license-detection surface. It documents the live contract and module layout; it is not a claim that every downstream parity gap is closed.
 
+### `LicenseRef-*` namespace convention
+
+Provenant uses the shared `LicenseRef-scancode-*` namespace for SPDX-side `LicenseRef` identifiers.
+
+If a license key is backed by the loaded ScanCode-compatible license dataset or by the public
+output contract built on that dataset, reuse the dataset-owned `LicenseRef-scancode-*` identifier
+instead of minting a tool-specific variant. This applies across detection output, SPDX-LID
+fallbacks such as `unknown-spdx`, and parser-side declared-license normalization for keys such as
+`public-domain`, `proprietary-license`, and `unknown-license-reference`.
+
 ### Initialization Flow
 
 ```text

--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -875,7 +875,7 @@ fn build_alpine_license_data(
     if extracted == "custom:multiple" {
         return build_declared_license_data_from_pair(
             "unknown-license-reference",
-            "LicenseRef-provenant-unknown-license-reference",
+            "LicenseRef-scancode-unknown-license-reference",
             DeclaredLicenseMatchMetadata::single_line(extracted),
         );
     }
@@ -1763,7 +1763,7 @@ p:so:libtest.so.1
         );
         assert_eq!(
             pkg.declared_license_expression_spdx.as_deref(),
-            Some("LicenseRef-provenant-unknown-license-reference")
+            Some("LicenseRef-scancode-unknown-license-reference")
         );
         let matched = pkg.license_detections[0].matches[0].matched_text.as_deref();
         assert_eq!(matched, Some("custom:multiple"));

--- a/src/parsers/debian/copyright.rs
+++ b/src/parsers/debian/copyright.rs
@@ -362,7 +362,7 @@ fn normalize_debian_license_name(license_name: &str) -> NormalizedDeclaredLicens
         "LGPL-3+" => NormalizedDeclaredLicense::new("lgpl-3.0-plus", "LGPL-3.0-or-later"),
         "BSD-4-clause" => NormalizedDeclaredLicense::new("bsd-original-uc", "BSD-4-Clause-UC"),
         "public-domain" => {
-            NormalizedDeclaredLicense::new("public-domain", "LicenseRef-provenant-public-domain")
+            NormalizedDeclaredLicense::new("public-domain", "LicenseRef-scancode-public-domain")
         }
         other => normalize_declared_license_key(other)
             .unwrap_or_else(|| NormalizedDeclaredLicense::new(other.to_ascii_lowercase(), other)),
@@ -771,5 +771,16 @@ Copyright (C) 2015-2018 Example Corp";
         );
         assert_eq!(target.license_detections.len(), 1);
         assert_eq!(target.other_license_detections.len(), 1);
+    }
+
+    #[test]
+    fn test_normalize_debian_public_domain_uses_scancode_license_ref() {
+        let normalized = normalize_debian_license_name("public-domain");
+
+        assert_eq!(normalized.declared_license_expression, "public-domain");
+        assert_eq!(
+            normalized.declared_license_expression_spdx,
+            "LicenseRef-scancode-public-domain"
+        );
     }
 }

--- a/src/parsers/maven/pom/licenses.rs
+++ b/src/parsers/maven/pom/licenses.rs
@@ -110,7 +110,7 @@ fn normalize_maven_license_name(name: &str) -> Option<NormalizedDeclaredLicense>
     match name.trim() {
         "Public Domain" | "public domain" => Some(NormalizedDeclaredLicense::new(
             "public-domain",
-            "LicenseRef-provenant-public-domain",
+            "LicenseRef-scancode-public-domain",
         )),
         other => normalize_declared_license_key(other),
     }

--- a/src/parsers/maven/pom_test.rs
+++ b/src/parsers/maven/pom_test.rs
@@ -940,6 +940,10 @@ mod tests {
             package_data.declared_license_expression.as_deref(),
             Some("public-domain")
         );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("LicenseRef-scancode-public-domain")
+        );
     }
 
     #[test]

--- a/src/parsers/rpm_parser.rs
+++ b/src/parsers/rpm_parser.rs
@@ -819,8 +819,8 @@ fn canonicalize_rpm_license_statement(statement: &str) -> String {
         ("MPLv2.0", "MPL-2.0"),
         ("MPLv1.1", "MPL-1.1"),
         ("BSD with advertising", "BSD-4-Clause-UC"),
-        ("Public Domain", "LicenseRef-provenant-public-domain"),
-        ("public domain", "LicenseRef-provenant-public-domain"),
+        ("Public Domain", "LicenseRef-scancode-public-domain"),
+        ("public domain", "LicenseRef-scancode-public-domain"),
         ("OpenLDAP", "OLDAP-2.8"),
         ("OpenSSL", "OpenSSL"),
         ("Sleepycat", "Sleepycat"),
@@ -1414,11 +1414,11 @@ mod tests {
         );
         assert_eq!(
             pkg.declared_license_expression.as_deref(),
-            Some("licenseref-provenant-public-domain")
+            Some("licenseref-scancode-public-domain")
         );
         assert_eq!(
             pkg.declared_license_expression_spdx.as_deref(),
-            Some("LicenseRef-provenant-public-domain")
+            Some("LicenseRef-scancode-public-domain")
         );
         assert_eq!(pkg.license_detections.len(), 1);
     }

--- a/testdata/alpine/apkbuild/linux-firmware/APKBUILD.expected.json
+++ b/testdata/alpine/apkbuild/linux-firmware/APKBUILD.expected.json
@@ -7,15 +7,15 @@
     "parties": [],
     "homepage_url": "https://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git;a=summary",
     "declared_license_expression": "unknown-license-reference",
-    "declared_license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
     "license_detections": [
       {
         "license_expression": "unknown-license-reference",
-        "license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
         "matches": [
           {
             "license_expression": "unknown-license-reference",
-            "license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
             "start_line": 1,
             "end_line": 1,
             "matcher": "1-spdx-id",

--- a/testdata/chef/basic/test_package.json.expected
+++ b/testdata/chef/basic/test_package.json.expected
@@ -23,15 +23,15 @@
   "copyright": null,
   "holder": null,
   "declared_license_expression": "public-domain",
-  "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
   "license_detections": [
     {
       "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
       "matches": [
         {
           "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
           "from_file": null,
           "start_line": 1,
           "end_line": 1,

--- a/testdata/chef/basic/test_package_code_view_url_and_bug_tracking_url.json.expected
+++ b/testdata/chef/basic/test_package_code_view_url_and_bug_tracking_url.json.expected
@@ -23,15 +23,15 @@
   "copyright": null,
   "holder": null,
   "declared_license_expression": "public-domain",
-  "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
   "license_detections": [
     {
       "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
       "matches": [
         {
           "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
           "from_file": null,
           "start_line": 1,
           "end_line": 1,

--- a/testdata/chef/basic/test_package_dependencies.json.expected
+++ b/testdata/chef/basic/test_package_dependencies.json.expected
@@ -23,15 +23,15 @@
   "copyright": null,
   "holder": null,
   "declared_license_expression": "public-domain",
-  "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
   "license_detections": [
     {
       "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
       "matches": [
         {
           "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
           "from_file": null,
           "start_line": 1,
           "end_line": 1,

--- a/testdata/chef/basic/test_package_parties.json.expected
+++ b/testdata/chef/basic/test_package_parties.json.expected
@@ -31,15 +31,15 @@
   "copyright": null,
   "holder": null,
   "declared_license_expression": "public-domain",
-  "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
   "license_detections": [
     {
       "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
       "matches": [
         {
           "license_expression": "public-domain",
-  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+  "license_expression_spdx": "LicenseRef-scancode-public-domain",
           "from_file": null,
           "start_line": 1,
           "end_line": 1,

--- a/testdata/cocoapods-golden/podspec/flutter_paytabs_bridge.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/flutter_paytabs_bridge.podspec.expected.json
@@ -32,15 +32,15 @@
     "copyright": null,
     "holder": null,
     "declared_license_expression": "unknown-license-reference",
-    "declared_license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+    "declared_license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
     "license_detections": [
       {
         "license_expression": "unknown-license-reference",
-        "license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+        "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
         "matches": [
           {
             "license_expression": "unknown-license-reference",
-            "license_expression_spdx": "LicenseRef-provenant-unknown-license-reference",
+            "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
             "from_file": null,
             "start_line": 1,
             "end_line": 1,

--- a/testdata/rpm/setup-2.5.49-b1.src.rpm.expected.json
+++ b/testdata/rpm/setup-2.5.49-b1.src.rpm.expected.json
@@ -37,16 +37,16 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": "licenseref-provenant-public-domain",
-    "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+    "declared_license_expression": "licenseref-scancode-public-domain",
+    "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
     "license_detections": [
       {
-        "license_expression": "licenseref-provenant-public-domain",
-        "license_expression_spdx": "LicenseRef-provenant-public-domain",
+        "license_expression": "licenseref-scancode-public-domain",
+        "license_expression_spdx": "LicenseRef-scancode-public-domain",
         "matches": [
           {
-            "license_expression": "licenseref-provenant-public-domain",
-            "license_expression_spdx": "LicenseRef-provenant-public-domain",
+            "license_expression": "licenseref-scancode-public-domain",
+            "license_expression_spdx": "LicenseRef-scancode-public-domain",
             "from_file": null,
             "start_line": 1,
             "end_line": 1,

--- a/testdata/summarycode-golden/tallies/packages/expected.json
+++ b/testdata/summarycode-golden/tallies/packages/expected.json
@@ -25,15 +25,15 @@
       "copyright": null,
       "holder": null,
       "declared_license_expression": "public-domain",
-      "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+      "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
       "license_detections": [
         {
           "license_expression": "public-domain",
-          "license_expression_spdx": "LicenseRef-provenant-public-domain",
+          "license_expression_spdx": "LicenseRef-scancode-public-domain",
           "matches": [
             {
               "license_expression": "public-domain",
-              "license_expression_spdx": "LicenseRef-provenant-public-domain",
+              "license_expression_spdx": "LicenseRef-scancode-public-domain",
               "from_file": "scan/aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
               "start_line": 1,
               "end_line": 1,
@@ -1199,15 +1199,15 @@
           "copyright": null,
           "holder": null,
           "declared_license_expression": "public-domain",
-          "declared_license_expression_spdx": "LicenseRef-provenant-public-domain",
+          "declared_license_expression_spdx": "LicenseRef-scancode-public-domain",
           "license_detections": [
             {
               "license_expression": "public-domain",
-              "license_expression_spdx": "LicenseRef-provenant-public-domain",
+              "license_expression_spdx": "LicenseRef-scancode-public-domain",
               "matches": [
                 {
                   "license_expression": "public-domain",
-                  "license_expression_spdx": "LicenseRef-provenant-public-domain",
+                  "license_expression_spdx": "LicenseRef-scancode-public-domain",
                   "from_file": "scan/aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
                   "start_line": 1,
                   "end_line": 1,


### PR DESCRIPTION
## Summary

- Document that SPDX-side `LicenseRef` identifiers should use the shared `LicenseRef-scancode-*` namespace across detection output and parser-side declared-license normalization.
- Align parser-owned `public-domain` and `unknown-license-reference` mappings with the upstream ScanCode-backed SPDX identifiers instead of local `LicenseRef-provenant-*` variants.
- Update focused parser tests and expected-output fixtures to match the standardized namespace.

## Scope and exclusions

- Included: contributor docs, parser normalization paths, and directly affected expected JSON fixtures.
- Explicit exclusions: broader license-detection behavior changes and any unrelated output-shaping cleanup.

## Expected-output fixture changes

- Files changed: parser `.expected.json` and summary/tallies expected output fixtures that previously used `LicenseRef-provenant-public-domain` or `LicenseRef-provenant-unknown-license-reference`.
- Why the new expected output is correct: the shared ScanCode-compatible license dataset already defines `public-domain` and `unknown-license-reference` with `LicenseRef-scancode-*` SPDX identifiers, so parser-side normalized output should reuse those dataset-backed public identifiers.