### PR TITLE
fix(compare): de-noise repeated party deltas

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -276,10 +276,14 @@ pub(crate) fn write_comparison_artifacts(
         let scancode_file = scancode_files.get(path).expect("common path exists");
         let provenant_file = provenant_files.get(path).expect("common path exists");
         for metric in metrics {
-            let sc_count = metric_count(scancode_file, metric);
-            let pr_count = metric_count(provenant_file, metric);
             let sc_values = metric_values(scancode_file, metric);
             let pr_values = metric_values(provenant_file, metric);
+            let sc_counter = value_counter(&sc_values);
+            let pr_counter = value_counter(&pr_values);
+            let sc_signal_counter = metric_signal_counter(metric, &sc_values);
+            let pr_signal_counter = metric_signal_counter(metric, &pr_values);
+            let sc_count = counter_total(&sc_signal_counter);
+            let pr_count = counter_total(&pr_signal_counter);
             if pr_count < sc_count {
                 lower_counts
                     .get_mut(metric)
@@ -305,11 +309,17 @@ pub(crate) fn write_comparison_artifacts(
                         provenant_sample_values: sample_values(&pr_values),
                     });
             }
-            let sc_counter = value_counter(&sc_values);
-            let pr_counter = value_counter(&pr_values);
-            let missing = subtract_counters(&sc_counter, &pr_counter);
-            let extra = subtract_counters(&pr_counter, &sc_counter);
-            if !missing.is_empty() || !extra.is_empty() {
+            let signal_missing = subtract_counters(&sc_signal_counter, &pr_signal_counter);
+            let signal_extra = subtract_counters(&pr_signal_counter, &sc_signal_counter);
+            if !signal_missing.is_empty() || !signal_extra.is_empty() {
+                let missing = filter_counter_to_signal_keys(
+                    &subtract_counters(&sc_counter, &pr_counter),
+                    &signal_missing,
+                );
+                let extra = filter_counter_to_signal_keys(
+                    &subtract_counters(&pr_counter, &sc_counter),
+                    &signal_extra,
+                );
                 value_differences
                     .get_mut(metric)
                     .expect("metric bucket exists")

--- a/src/compare_driver_shared.rs
+++ b/src/compare_driver_shared.rs
@@ -168,6 +168,28 @@ pub fn value_counter(values: &[String]) -> BTreeMap<String, usize> {
     counts
 }
 
+pub fn metric_uses_distinct_signal_values(metric: &str) -> bool {
+    matches!(metric, "copyrights" | "holders" | "authors")
+}
+
+pub fn metric_signal_counter(metric: &str, values: &[String]) -> BTreeMap<String, usize> {
+    if !metric_uses_distinct_signal_values(metric) {
+        return value_counter(values);
+    }
+
+    values
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|value| (value, 1))
+        .collect()
+}
+
+pub fn counter_total(counter: &BTreeMap<String, usize>) -> usize {
+    counter.values().copied().sum()
+}
+
 pub fn subtract_counters(
     left: &BTreeMap<String, usize>,
     right: &BTreeMap<String, usize>,
@@ -180,6 +202,17 @@ pub fn subtract_counters(
         }
     }
     result
+}
+
+pub fn filter_counter_to_signal_keys(
+    counter: &BTreeMap<String, usize>,
+    signal_counter: &BTreeMap<String, usize>,
+) -> BTreeMap<String, usize> {
+    counter
+        .iter()
+        .filter(|(key, _)| signal_counter.contains_key(*key))
+        .map(|(key, value)| (key.clone(), *value))
+        .collect()
 }
 
 pub fn counter_entries(counter: &BTreeMap<String, usize>) -> Vec<ValueCountEntry> {

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -593,6 +593,123 @@ fn create_compare_json_fixtures_with_only_findings_path_difference() -> (TempDir
     )
 }
 
+fn create_compare_json_fixtures_with_repeated_party_noise() -> (TempDir, String, String) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let scancode_file = temp.path().join("scancode-party-noise.json");
+    let provenant_file = temp.path().join("provenant-party-noise.json");
+
+    let repeated_copyright = serde_json::json!({
+        "copyright": "Copyright 2024 Example Corp."
+    });
+    let repeated_holder = serde_json::json!({
+        "holder": "Example Corp."
+    });
+    let repeated_author = serde_json::json!({
+        "author": "Jane Doe"
+    });
+
+    fs::write(
+        &scancode_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "copyrights": [repeated_copyright.clone(), repeated_copyright.clone()],
+                "holders": [repeated_holder.clone(), repeated_holder.clone()],
+                "authors": [repeated_author.clone(), repeated_author.clone()]
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write scancode party-noise fixture");
+
+    fs::write(
+        &provenant_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "copyrights": [repeated_copyright],
+                "holders": [repeated_holder],
+                "authors": [repeated_author]
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write provenant party-noise fixture");
+
+    (
+        temp,
+        scancode_file.to_string_lossy().to_string(),
+        provenant_file.to_string_lossy().to_string(),
+    )
+}
+
+fn create_compare_json_fixtures_with_mixed_party_noise_and_real_difference()
+-> (TempDir, String, String) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let scancode_file = temp.path().join("scancode-party-mixed.json");
+    let provenant_file = temp.path().join("provenant-party-mixed.json");
+
+    fs::write(
+        &scancode_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "authors": [
+                    {"author": "Jane Doe"},
+                    {"author": "Jane Doe"}
+                ]
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write scancode mixed party fixture");
+
+    fs::write(
+        &provenant_file,
+        serde_json::json!({
+            "files": [{
+                "path": "src/lib.rs",
+                "type": "file",
+                "authors": [
+                    {"author": "Jane Doe"},
+                    {"author": "John Doe"}
+                ]
+            }],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write provenant mixed party fixture");
+
+    (
+        temp,
+        scancode_file.to_string_lossy().to_string(),
+        provenant_file.to_string_lossy().to_string(),
+    )
+}
+
 fn normalize_multi_parser_header(output: &mut Value) {
     let header = output["headers"]
         .as_array_mut()
@@ -1858,6 +1975,133 @@ fn compare_subcommand_marks_only_findings_path_buckets_as_filtered_output() {
     assert!(summary_tsv.contains("scancode_only_output_file_paths"));
     assert!(summary_tsv.contains("ScanCode final output"));
     assert!(summary_tsv.contains("filtered these paths away after finding nothing"));
+}
+
+#[test]
+fn compare_subcommand_ignores_duplicate_party_occurrence_noise() {
+    let (_temp, scancode_json, provenant_json) =
+        create_compare_json_fixtures_with_repeated_party_noise();
+    let artifact_temp = TempDir::new().expect("artifact temp dir");
+    let artifact_dir = artifact_temp.path().join("compare-artifacts");
+
+    let output = provenant_command()
+        .args([
+            "compare",
+            "--scancode-json",
+            &scancode_json,
+            "--provenant-json",
+            &provenant_json,
+            "--artifact-dir",
+            artifact_dir.to_str().expect("utf8 artifact path"),
+        ])
+        .output()
+        .expect("failed to run compare subcommand");
+
+    assert!(output.status.success(), "compare should succeed");
+
+    let summary_path = artifact_dir.join("comparison").join("summary.json");
+    let samples_path = artifact_dir
+        .join("comparison")
+        .join("samples")
+        .join("file_metric_value_differences.json");
+    let summary: Value =
+        serde_json::from_str(&fs::read_to_string(&summary_path).expect("summary json")).unwrap();
+    let samples: Value =
+        serde_json::from_str(&fs::read_to_string(&samples_path).expect("samples json")).unwrap();
+
+    assert_eq!(
+        summary["comparison_status"].as_str(),
+        Some("no_detected_differences")
+    );
+
+    for metric in ["copyrights", "holders", "authors"] {
+        assert_eq!(
+            summary["file_metric_summary"][metric]["lower_counts"].as_u64(),
+            Some(0),
+            "metric: {metric}"
+        );
+        assert_eq!(
+            summary["file_metric_summary"][metric]["higher_counts"].as_u64(),
+            Some(0),
+            "metric: {metric}"
+        );
+        assert_eq!(
+            summary["file_metric_summary"][metric]["missing_in_provenant"].as_u64(),
+            Some(0),
+            "metric: {metric}"
+        );
+        assert_eq!(
+            summary["file_metric_summary"][metric]["extra_in_provenant"].as_u64(),
+            Some(0),
+            "metric: {metric}"
+        );
+        assert_eq!(samples[metric], serde_json::json!([]), "metric: {metric}");
+    }
+}
+
+#[test]
+fn compare_subcommand_reports_only_real_party_value_difference() {
+    let (_temp, scancode_json, provenant_json) =
+        create_compare_json_fixtures_with_mixed_party_noise_and_real_difference();
+    let artifact_temp = TempDir::new().expect("artifact temp dir");
+    let artifact_dir = artifact_temp.path().join("compare-artifacts");
+
+    let output = provenant_command()
+        .args([
+            "compare",
+            "--scancode-json",
+            &scancode_json,
+            "--provenant-json",
+            &provenant_json,
+            "--artifact-dir",
+            artifact_dir.to_str().expect("utf8 artifact path"),
+        ])
+        .output()
+        .expect("failed to run compare subcommand");
+
+    assert!(output.status.success(), "compare should succeed");
+
+    let summary: Value = serde_json::from_str(
+        &fs::read_to_string(artifact_dir.join("comparison").join("summary.json"))
+            .expect("summary json"),
+    )
+    .unwrap();
+    let samples: Value = serde_json::from_str(
+        &fs::read_to_string(
+            artifact_dir
+                .join("comparison")
+                .join("samples")
+                .join("file_metric_value_differences.json"),
+        )
+        .expect("samples json"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        summary["file_metric_summary"]["authors"]["lower_counts"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["file_metric_summary"]["authors"]["higher_counts"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        summary["file_metric_summary"]["authors"]["missing_in_provenant"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(
+        summary["file_metric_summary"]["authors"]["extra_in_provenant"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(samples["authors"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        samples["authors"][0]["missing_in_provenant"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        samples["authors"][0]["extra_in_provenant"],
+        serde_json::json!([{"value": "John Doe", "count": 1}])
+    );
 }
 
 #[test]

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -1343,10 +1343,14 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         let scancode_file = scancode_files.get(path).unwrap();
         let provenant_file = provenant_files.get(path).unwrap();
         for metric in metrics {
-            let sc_count = metric_count(scancode_file, metric);
-            let pr_count = metric_count(provenant_file, metric);
             let sc_values = metric_values(scancode_file, metric);
             let pr_values = metric_values(provenant_file, metric);
+            let sc_counter = value_counter(&sc_values);
+            let pr_counter = value_counter(&pr_values);
+            let sc_signal_counter = metric_signal_counter(metric, &sc_values);
+            let pr_signal_counter = metric_signal_counter(metric, &pr_values);
+            let sc_count = counter_total(&sc_signal_counter);
+            let pr_count = counter_total(&pr_signal_counter);
             if pr_count < sc_count {
                 lower_counts.get_mut(metric).unwrap().push(CountDeltaEntry {
                     path: path.clone(),
@@ -1369,11 +1373,17 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
                         provenant_sample_values: sample_values(&pr_values),
                     });
             }
-            let sc_counter = value_counter(&sc_values);
-            let pr_counter = value_counter(&pr_values);
-            let missing = subtract_counters(&sc_counter, &pr_counter);
-            let extra = subtract_counters(&pr_counter, &sc_counter);
-            if !missing.is_empty() || !extra.is_empty() {
+            let signal_missing = subtract_counters(&sc_signal_counter, &pr_signal_counter);
+            let signal_extra = subtract_counters(&pr_signal_counter, &sc_signal_counter);
+            if !signal_missing.is_empty() || !signal_extra.is_empty() {
+                let missing = filter_counter_to_signal_keys(
+                    &subtract_counters(&sc_counter, &pr_counter),
+                    &signal_missing,
+                );
+                let extra = filter_counter_to_signal_keys(
+                    &subtract_counters(&pr_counter, &sc_counter),
+                    &signal_extra,
+                );
                 value_differences
                     .get_mut(metric)
                     .unwrap()
@@ -4072,6 +4082,224 @@ mod tests {
         assert!(summary_tsv.contains("scancode_only_output_file_paths"));
         assert!(summary_tsv.contains("ScanCode final output"));
         assert!(summary_tsv.contains("filtered these paths away after finding nothing"));
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn direct_json_comparison_ignores_duplicate_party_occurrence_noise() {
+        let temp_root = unique_temp_dir("direct-json-party-noise");
+        fs::create_dir_all(&temp_root).unwrap();
+        let mut context = test_context();
+        context.compare_mode = CompareMode::DirectJson;
+        context.scan_args = Vec::new();
+        context.run_dir = temp_root.join("run");
+        context.raw_dir = context.run_dir.join("raw");
+        context.comparison_dir = context.run_dir.join("comparison");
+        context.samples_dir = context.comparison_dir.join("samples");
+        context.run_manifest = context.run_dir.join("run-manifest.json");
+        context.summary_json = context.comparison_dir.join("summary.json");
+        context.summary_tsv = context.comparison_dir.join("summary.tsv");
+        context.scancode_json = context.raw_dir.join("scancode.json");
+        context.provenant_json = context.raw_dir.join("provenant.json");
+        fs::create_dir_all(&context.raw_dir).unwrap();
+        fs::create_dir_all(&context.samples_dir).unwrap();
+
+        fs::write(
+            &context.scancode_json,
+            serde_json::to_string_pretty(&json!({
+                "files": [{
+                    "path": "src/lib.rs",
+                    "type": "file",
+                    "copyrights": [
+                        {"copyright": "Copyright 2024 Example Corp."},
+                        {"copyright": "Copyright 2024 Example Corp."}
+                    ],
+                    "holders": [
+                        {"holder": "Example Corp."},
+                        {"holder": "Example Corp."}
+                    ],
+                    "authors": [
+                        {"author": "Jane Doe"},
+                        {"author": "Jane Doe"}
+                    ]
+                }],
+                "packages": [],
+                "dependencies": [],
+                "license_detections": [],
+                "license_references": [],
+                "license_rule_references": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &context.provenant_json,
+            serde_json::to_string_pretty(&json!({
+                "files": [{
+                    "path": "src/lib.rs",
+                    "type": "file",
+                    "copyrights": [
+                        {"copyright": "Copyright 2024 Example Corp."}
+                    ],
+                    "holders": [
+                        {"holder": "Example Corp."}
+                    ],
+                    "authors": [
+                        {"author": "Jane Doe"}
+                    ]
+                }],
+                "packages": [],
+                "dependencies": [],
+                "license_detections": [],
+                "license_references": [],
+                "license_rule_references": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        generate_comparison_artifacts(&context).unwrap();
+
+        let summary: Value =
+            serde_json::from_str(&fs::read_to_string(&context.summary_json).unwrap()).unwrap();
+        let samples: Value = serde_json::from_str(
+            &fs::read_to_string(
+                context
+                    .samples_dir
+                    .join("file_metric_value_differences.json"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary["comparison_status"],
+            Value::String("no_detected_differences".into())
+        );
+
+        for metric in ["copyrights", "holders", "authors"] {
+            assert_eq!(
+                summary["file_metric_summary"][metric]["lower_counts"],
+                Value::from(0)
+            );
+            assert_eq!(
+                summary["file_metric_summary"][metric]["higher_counts"],
+                Value::from(0)
+            );
+            assert_eq!(
+                summary["file_metric_summary"][metric]["missing_in_provenant"],
+                Value::from(0)
+            );
+            assert_eq!(
+                summary["file_metric_summary"][metric]["extra_in_provenant"],
+                Value::from(0)
+            );
+            assert_eq!(samples[metric], serde_json::json!([]), "metric: {metric}");
+        }
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn direct_json_comparison_reports_only_real_party_value_difference() {
+        let temp_root = unique_temp_dir("direct-json-party-mixed");
+        fs::create_dir_all(&temp_root).unwrap();
+        let mut context = test_context();
+        context.compare_mode = CompareMode::DirectJson;
+        context.scan_args = Vec::new();
+        context.run_dir = temp_root.join("run");
+        context.raw_dir = context.run_dir.join("raw");
+        context.comparison_dir = context.run_dir.join("comparison");
+        context.samples_dir = context.comparison_dir.join("samples");
+        context.run_manifest = context.run_dir.join("run-manifest.json");
+        context.summary_json = context.comparison_dir.join("summary.json");
+        context.summary_tsv = context.comparison_dir.join("summary.tsv");
+        context.scancode_json = context.raw_dir.join("scancode.json");
+        context.provenant_json = context.raw_dir.join("provenant.json");
+        fs::create_dir_all(&context.raw_dir).unwrap();
+        fs::create_dir_all(&context.samples_dir).unwrap();
+
+        fs::write(
+            &context.scancode_json,
+            serde_json::to_string_pretty(&json!({
+                "files": [{
+                    "path": "src/lib.rs",
+                    "type": "file",
+                    "authors": [
+                        {"author": "Jane Doe"},
+                        {"author": "Jane Doe"}
+                    ]
+                }],
+                "packages": [],
+                "dependencies": [],
+                "license_detections": [],
+                "license_references": [],
+                "license_rule_references": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &context.provenant_json,
+            serde_json::to_string_pretty(&json!({
+                "files": [{
+                    "path": "src/lib.rs",
+                    "type": "file",
+                    "authors": [
+                        {"author": "Jane Doe"},
+                        {"author": "John Doe"}
+                    ]
+                }],
+                "packages": [],
+                "dependencies": [],
+                "license_detections": [],
+                "license_references": [],
+                "license_rule_references": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        generate_comparison_artifacts(&context).unwrap();
+
+        let summary: Value =
+            serde_json::from_str(&fs::read_to_string(&context.summary_json).unwrap()).unwrap();
+        let samples: Value = serde_json::from_str(
+            &fs::read_to_string(
+                context
+                    .samples_dir
+                    .join("file_metric_value_differences.json"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary["file_metric_summary"]["authors"]["lower_counts"],
+            Value::from(0)
+        );
+        assert_eq!(
+            summary["file_metric_summary"]["authors"]["higher_counts"],
+            Value::from(1)
+        );
+        assert_eq!(
+            summary["file_metric_summary"]["authors"]["missing_in_provenant"],
+            Value::from(0)
+        );
+        assert_eq!(
+            summary["file_metric_summary"]["authors"]["extra_in_provenant"],
+            Value::from(1)
+        );
+        assert_eq!(samples["authors"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            samples["authors"][0]["missing_in_provenant"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            samples["authors"][0]["extra_in_provenant"],
+            serde_json::json!([{"value": "John Doe", "count": 1}])
+        );
 
         let _ = fs::remove_dir_all(&temp_root);
     }


### PR DESCRIPTION
## Summary

- Change compare signal handling for `copyrights`, `holders`, and `authors` so repeated identical normalized values no longer inflate lower/higher count deltas or missing/extra path summaries.
- Keep real distinct-value differences visible by continuing to emit grouped per-value samples, while filtering duplicate-only residue out of the headline compare signal.
- Apply the same behavior to both direct `provenant compare` and `xtask compare-outputs` so the two entrypoints stay aligned.
- Add focused regressions for both duplicate-only noise and mixed duplicate-plus-real-difference cases in both compare entrypoints.

## Issues

- Covers: compare signal quality for noisy repeated party findings
- Closes:

## Scope and exclusions

- Included:
  - compare-only signal changes for `copyrights`, `holders`, and `authors`
  - shared helper updates in `src/compare_driver_shared.rs`
  - direct compare integration coverage and xtask direct-JSON coverage
- Explicit exclusions:
  - no scanner or detection-pipeline changes
  - no changes to non-party compare metrics such as licenses, packages, emails, urls, or scan errors

## Intentional differences from Python

- None. This changes Provenant's compare signal policy only.

## Follow-up work

- Created or intentionally deferred:
  - if we still see noisy compare output after this, the next likely targets are summary/report presentation choices rather than more scanner-side filtering

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: the compare summary now reflects distinct normalized party values instead of repeated identical occurrences, and the new direct-compare plus xtask tests cover both duplicate-only noise suppression and mixed real-difference cases.