### PR TITLE
fix(copyright): verify lodash benchmark parity

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 194 of 194 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 195 of 195 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -345,6 +345,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `15.56s`; ScanCode `303.29s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and cleaner Unicode-preserving author normalization across locale files and vendored docs
+
+##### [lodash/lodash @ cb0b9b9](https://github.com/lodash/lodash/tree/cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e) — **15.67× faster**
+
+- Files: 159
+- Run context: 2026-05-07 · lodash-29622 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `10.90s`; ScanCode `170.82s`
+- Matched npm package and dependency coverage on the repo-root `package.json` and `package-lock.json`, with source-faithful copyright recovery across `lodash.js`, `dist/lodash*.js`, and `LICENSE`, plus encoded-query URL preservation and extra Firebug asset URL visibility where ScanCode flattens or misses the underlying source text
 
 ##### [metabase/metabase @ 10997b1](https://github.com/metabase/metabase/tree/10997b10908414ab05773b085a56a37fcdebcd1a) — **25.67× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -194,6 +194,9 @@ ScanCode: 157.63s</title></rect>
     <rect x="439.98" y="396.02" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 ScanCode: 135.56s</title></rect>
+    <rect x="441.29" y="385.10" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
+Files: 159
+ScanCode: 170.82s</title></rect>
     <rect x="450.98" y="397.47" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
 Files: 183
 ScanCode: 131.47s</title></rect>
@@ -778,6 +781,9 @@ Provenant: 11.99s</title></circle>
     <circle cx="443.98" cy="507.20" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 Provenant: 14.03s</title></circle>
+    <circle cx="445.29" cy="519.13" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
+Files: 159
+Provenant: 10.90s</title></circle>
     <circle cx="454.98" cy="519.74" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
 Files: 183
 Provenant: 10.76s</title></circle>

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -797,7 +797,9 @@ pub fn extract_copyright_holder_url_without_year_lines(
 
             let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
             let holder_lower = holder_raw.to_ascii_lowercase();
+            let first_word = holder_lower.split_whitespace().next().unwrap_or("");
             if holder_raw.split_whitespace().count() < 2
+                || matches!(first_word, "content" | "header" | "notice" | "year")
                 || holder_lower.starts_with("notice")
                 || holder_lower.contains("license")
                 || holder_lower.starts_with("released under")

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -756,6 +756,83 @@ pub fn extract_c_holder_without_year_lines(
     (copyrights, holders)
 }
 
+pub fn extract_copyright_holder_url_without_year_lines(
+    groups: &[Vec<(usize, String)>],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    static YEAR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b(?:19\d{2}|20\d{2})\b").unwrap());
+    static COPYRIGHT_HOLDER_URL_NO_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^copyright\s+
+            (?P<holder>[A-Z][^<]{3,}?)
+            \s*
+            (?P<url><https?://[^>]+>|https?://\S+)
+            \s*$
+        ",
+        )
+        .unwrap()
+    });
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    for group in groups {
+        for (ln, line) in group {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let normalized = trimmed
+                .trim_start_matches(['*', '/', '#', ';', '%', '!'])
+                .trim_start();
+            if YEAR_RE.is_match(normalized) {
+                continue;
+            }
+
+            let Some(cap) = COPYRIGHT_HOLDER_URL_NO_YEAR_RE.captures(normalized) else {
+                continue;
+            };
+
+            let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+            let holder_lower = holder_raw.to_ascii_lowercase();
+            if holder_raw.split_whitespace().count() < 2
+                || holder_lower.starts_with("notice")
+                || holder_lower.contains("license")
+                || holder_lower.starts_with("released under")
+                || holder_lower.starts_with("based on")
+            {
+                continue;
+            }
+
+            let url_raw = cap.name("url").map(|m| m.as_str()).unwrap_or("").trim();
+            if url_raw.is_empty() {
+                continue;
+            }
+
+            let raw = format!("Copyright {holder_raw} {url_raw}");
+            if let Some(cr) = refine_copyright(&raw) {
+                copyrights.push(CopyrightDetection {
+                    copyright: cr,
+                    start_line: LineNumber::new(*ln).expect("invalid line number"),
+                    end_line: LineNumber::new(*ln).expect("invalid line number"),
+                });
+            }
+
+            if let Some(holder) = refine_holder_in_copyright_context(holder_raw) {
+                holders.push(HolderDetection {
+                    holder,
+                    start_line: LineNumber::new(*ln).expect("invalid line number"),
+                    end_line: LineNumber::new(*ln).expect("invalid line number"),
+                });
+            }
+        }
+    }
+
+    (copyrights, holders)
+}
+
 pub fn extract_versioned_project_c_holder_banner_lines(
     groups: &[Vec<(usize, String)>],
     existing_copyrights: &[CopyrightDetection],

--- a/src/copyright/detector/phases/primary.rs
+++ b/src/copyright/detector/phases/primary.rs
@@ -232,6 +232,13 @@ fn run_group_based_extractions(
     copyrights.extend(new_c);
     holders.extend(new_h);
 
+    let (mut new_c, mut new_h) =
+        super::super::pattern_extract::extract_copyright_holder_url_without_year_lines(groups);
+    seen.dedup_new_copyrights(&mut new_c, 0);
+    seen.dedup_new_holders(&mut new_h, 0);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
     let (new_c, new_h) = super::super::pattern_extract::extract_three_digit_copyright_year_lines(
         prepared_cache,
         copyrights,

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -587,6 +587,22 @@ fn test_detect_multiline_header_copyright_without_year_and_with_url() {
 }
 
 #[test]
+fn test_ignore_generic_lowercase_copyright_prose_with_url_suffixes() {
+    for input in [
+        "copyright content SSENSE / rel apple-touch-icon http://www.ssense.com/nl/icons/apple-touch-icon.png",
+        "copyright header of example files e592c53 (https://github.com/http-party/node-http-proxy/commit/e592c53d1a23b7920d603a9e9ac294fc0e841f6d)",
+        "copyright year 69cbf7a (https://github.com/PrismJS/prism/commit/69cbf7a)",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+        assert!(
+            copyrights.is_empty(),
+            "input={input:?} copyrights={copyrights:?}"
+        );
+        assert!(holders.is_empty(), "input={input:?} holders={holders:?}");
+    }
+}
+
+#[test]
 fn test_detect_versioned_project_banner_with_leading_year_before_holder() {
     let content = "/*! X-editable - v1.5.0 Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(content);

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -552,6 +552,41 @@ fn test_detect_versioned_project_banner_with_mixed_case_brand_holder() {
 }
 
 #[test]
+fn test_detect_multiline_header_copyright_without_year_and_with_url() {
+    let content = concat!(
+        "/**\n",
+        " * @license\n",
+        " * Lodash <https://lodash.com/>\n",
+        " * Copyright OpenJS Foundation and other contributors <https://openjsf.org/>\n",
+        " * Released under MIT license <https://lodash.com/license>\n",
+        " * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>\n",
+        " * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors\n",
+        " */\n",
+    );
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+
+    assert!(
+        copyrights.iter().any(|c| {
+            c.copyright == "Copyright OpenJS Foundation and other contributors https://openjsf.org"
+        }),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders
+            .iter()
+            .any(|h| h.holder == "OpenJS Foundation and other contributors"),
+        "holders: {holders:?}"
+    );
+    assert!(
+        copyrights.iter().any(|c| {
+            c.copyright
+                == "Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors"
+        }),
+        "copyrights: {copyrights:?}"
+    );
+}
+
+#[test]
 fn test_detect_versioned_project_banner_with_leading_year_before_holder() {
     let content = "/*! X-editable - v1.5.0 Copyright (c) 2013 Vitaliy Potapov; Licensed MIT */\n";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(content);

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -40,9 +40,6 @@ const JUNK_EXACT_DOMAIN_NAMES: &[&str] = &[
     "other.com",
 ];
 
-const JUNK_DOMAIN_SUFFIXES: &[&str] =
-    &[".png", ".jpg", ".gif", ".jpeg", ".local", ".blank", ".fill"];
-
 const JUNK_EMAIL_AND_HOST_SUFFIXES: &[&str] = &[
     ".png",
     ".jpg",
@@ -249,6 +246,9 @@ pub(crate) fn classify_url(url: &str) -> bool {
     }
 
     let normalized = url.to_lowercase().trim_end_matches('/').to_string();
+    if has_embedded_nested_scheme_in_path(&normalized) {
+        return false;
+    }
     if JUNK_URLS.contains(&normalized.as_str()) {
         return false;
     }
@@ -258,12 +258,15 @@ pub(crate) fn classify_url(url: &str) -> bool {
     {
         return false;
     }
-    if JUNK_DOMAIN_SUFFIXES
-        .iter()
-        .any(|suffix| normalized.ends_with(suffix))
-    {
-        return false;
-    }
-
     true
+}
+
+fn has_embedded_nested_scheme_in_path(url: &str) -> bool {
+    let Some(first_scheme_idx) = url.find("://") else {
+        return false;
+    };
+
+    let rest = &url[first_scheme_idx + 3..];
+    let pathish_prefix_end = rest.find(['?', '#']).unwrap_or(rest.len());
+    rest[..pathish_prefix_end].contains("://")
 }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -246,6 +246,39 @@ mod tests {
     }
 
     #[test]
+    fn test_find_urls_keeps_query_asterisk_in_url() {
+        let text = "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D%22";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(
+            urls[0].url,
+            "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D%22"
+        );
+    }
+
+    #[test]
+    fn test_find_urls_keeps_npm_package_url_ending_with_fill() {
+        let text = "[npm](https://www.npmjs.com/package/lodash.fill \"See the npm package\")";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(urls[0].url, "https://www.npmjs.com/package/lodash.fill");
+    }
+
+    #[test]
+    fn test_find_urls_drops_nested_scheme_artifact_in_path() {
+        let text =
+            "https://getfirebug.com/releases/lite/latest/skin/xp/chrome://firebug/skin/group.gif";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert!(urls.is_empty(), "urls: {urls:#?}");
+    }
+
+    #[test]
     fn test_find_urls_filters_code_variable_host_artifacts() {
         let text = "loginUrl = \"http://os.environ['DD_BASE_URL']/login\"";
         let config = DetectionConfig::default();

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -58,7 +58,7 @@ fn end_of_url_cleaner(url: &str) -> String {
             .replace("&amp;", "&")
     };
 
-    for marker in ['\\', '<', '>', '(', ')', '[', ']', '"', '\'', '`', '*'] {
+    for marker in ['\\', '<', '>', '(', ')', '[', ']', '"', '\'', '`'] {
         if let Some((before, _)) = cleaned.split_once(marker) {
             cleaned = before.to_string();
         }
@@ -78,6 +78,7 @@ fn end_of_url_cleaner(url: &str) -> String {
     }
 
     cleaned = trim_trailing_template_openers(&cleaned);
+    cleaned = cleaned.trim_end_matches('*').to_string();
 
     cleaned
         .trim_end_matches(|c: char| [',', '.', ':', ';', '!', '?'].contains(&c))


### PR DESCRIPTION
## Summary

- verify `lodash/lodash @ cb0b9b9` with the final optimized compare run at `.provenant/compare-runs/20260507T163913Z-lodash-29622`
- recover the missing OpenJS copyright extraction in `lodash.js` and sibling bundled surfaces, with focused regression coverage
- keep real npm/query/asset URLs while filtering nested-scheme junk, then record the benchmark row and refresh the chart

## Scope and exclusions

- Included: copyright detector extraction for no-year holder+URL banner lines, URL finder normalization/junk filtering, `docs/BENCHMARKS.md`, and `docs/scan-duration-vs-files.svg`
- Explicit exclusions: no golden fixture updates and no broader ScanCode-compat rendering changes beyond the reviewed source-faithful/canonical behavior already accepted for this target

## Intentional differences from Python

- Preserve source-faithful copyright and URL values where the source text contains angle-bracket URLs or percent-encoded query content, and keep reviewed Firebug asset URLs that ScanCode misses

## Follow-up work

- Created or intentionally deferred: none