### PR TITLE
fix(benchmark): verify react-native-background-timer target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 195 of 195 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 196 of 196 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -952,7 +952,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 19
 - Run context: 2026-05-07 · react-native-background-timer-68507 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `9.41s`; ScanCode `97.28s`
-- Broader React Native mobile dependency extraction (`1493` vs `1492`) from the Android `build.gradle` React Native coordinate, plus direct AndroidManifest package visibility and source-faithful party recovery that keeps `ATO Gear` on the iOS native headers and preserves `Dávid Ocetník` instead of ScanCode's ASCII fallback
+- Broader React Native mobile dependency extraction (`1493` vs `1492`) from the Android `build.gradle` React Native coordinate, plus direct AndroidManifest package visibility and Unicode-preserving `Dávid Ocetník` copyright and holder recovery instead of ScanCode's ASCII fallback
 
 ##### [pointfreeco/swift-composable-architecture @ 7517cc3](https://github.com/pointfreeco/swift-composable-architecture/tree/7517cc3) — **12.26× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -947,6 +947,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `11.11s`; ScanCode `122.53s`
 - Matched top-level package coverage (`1` vs `1`) with broader package-adjacent dependency extraction (`11` vs `0`) from `.gitmodules`, `Cartfile.private`, and `Cartfile.resolved`, plus Unicode-preserving author recovery for `Robert Böhnke` and cleaner normalization of repeated workflow contact addresses and GitHub query URLs
 
+##### [ocetnik/react-native-background-timer @ 244ea3e](https://github.com/ocetnik/react-native-background-timer/tree/244ea3e554a6c480f22c818831ea0dd7c0587708) — **10.34× faster**
+
+- Files: 19
+- Run context: 2026-05-07 · react-native-background-timer-68507 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `9.41s`; ScanCode `97.28s`
+- Broader React Native mobile dependency extraction (`1493` vs `1492`) from the Android `build.gradle` React Native coordinate, plus direct AndroidManifest package visibility and source-faithful party recovery that keeps `ATO Gear` on the iOS native headers and preserves `Dávid Ocetník` instead of ScanCode's ASCII fallback
+
 ##### [pointfreeco/swift-composable-architecture @ 7517cc3](https://github.com/pointfreeco/swift-composable-architecture/tree/7517cc3) — **12.26× faster**
 
 - Files: 1,098

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -140,6 +140,9 @@ ScanCode: 72.03s</title></rect>
     <rect x="291.17" y="427.52" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 ScanCode: 69.61s</title></rect>
+    <rect x="294.90" y="411.70" width="8" height="8" fill="#d97706" rx="1.5"><title>ocetnik/react-native-background-timer @ 244ea3e
+Files: 19
+ScanCode: 97.28s</title></rect>
     <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 ScanCode: 73.99s</title></rect>
@@ -727,6 +730,9 @@ Provenant: 10.53s</title></circle>
     <circle cx="295.17" cy="521.76" r="4.5" fill="#2563eb"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 Provenant: 10.31s</title></circle>
+    <circle cx="298.90" cy="526.07" r="4.5" fill="#2563eb"><title>ocetnik/react-native-background-timer @ 244ea3e
+Files: 19
+Provenant: 9.41s</title></circle>
     <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 Provenant: 11.06s</title></circle>

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -318,7 +318,10 @@ fn assemble_one_per_package_data(
                 .datasource_id
                 .is_some_and(|dsid| config.datasource_ids.contains(&dsid));
 
-            if !dsid_matches || pkg_data.purl.is_none() {
+            if !dsid_matches
+                || pkg_data.purl.is_none()
+                || should_skip_placeholder_only_cocoapods_podspec(pkg_data)
+            {
                 continue;
             }
 
@@ -346,6 +349,16 @@ fn assemble_one_per_package_data(
     }
 
     results
+}
+
+fn should_skip_placeholder_only_cocoapods_podspec(pkg_data: &crate::models::PackageData) -> bool {
+    pkg_data.datasource_id == Some(DatasourceId::CocoapodsPodspec)
+        && pkg_data
+            .extra_data
+            .as_ref()
+            .and_then(|data| data.get("dynamic_identity_placeholders"))
+            .and_then(|value| value.as_bool())
+            == Some(true)
 }
 
 /// Group file indices by their parent directory path.

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -351,7 +351,9 @@ fn assemble_one_per_package_data(
     results
 }
 
-fn should_skip_placeholder_only_cocoapods_podspec(pkg_data: &crate::models::PackageData) -> bool {
+pub(super) fn should_skip_placeholder_only_cocoapods_podspec(
+    pkg_data: &crate::models::PackageData,
+) -> bool {
     pkg_data.datasource_id == Some(DatasourceId::CocoapodsPodspec)
         && pkg_data
             .extra_data

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -8,7 +8,9 @@ use glob::Pattern;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
 
-use super::{AssemblerConfig, DirectoryMergeOutput};
+use super::{
+    AssemblerConfig, DirectoryMergeOutput, should_skip_placeholder_only_cocoapods_podspec,
+};
 
 #[derive(Clone, Copy)]
 struct CocoapodsPodspecCandidate {
@@ -441,16 +443,6 @@ fn should_skip_assembly_package_data(package: Option<&Package>, pkg_data: &Packa
                 || should_skip_python_uv_lock_merge(existing_package, pkg_data)
                 || should_skip_python_pip_cache_merge(existing_package, pkg_data)
         })
-}
-
-fn should_skip_placeholder_only_cocoapods_podspec(pkg_data: &PackageData) -> bool {
-    pkg_data.datasource_id == Some(DatasourceId::CocoapodsPodspec)
-        && pkg_data
-            .extra_data
-            .as_ref()
-            .and_then(|data| data.get("dynamic_identity_placeholders"))
-            .and_then(|value| value.as_bool())
-            == Some(true)
 }
 
 fn should_skip_composer_lock_virtual_package(pkg_data: &PackageData) -> bool {

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -434,12 +434,23 @@ fn is_handled_by(pkg_data: &PackageData, config: &AssemblerConfig) -> bool {
 
 fn should_skip_assembly_package_data(package: Option<&Package>, pkg_data: &PackageData) -> bool {
     should_skip_composer_lock_virtual_package(pkg_data)
+        || should_skip_placeholder_only_cocoapods_podspec(pkg_data)
         || package.is_some_and(|existing_package| {
             should_skip_npm_lock_merge(existing_package, pkg_data)
                 || should_skip_bun_lock_merge(existing_package, pkg_data)
                 || should_skip_python_uv_lock_merge(existing_package, pkg_data)
                 || should_skip_python_pip_cache_merge(existing_package, pkg_data)
         })
+}
+
+fn should_skip_placeholder_only_cocoapods_podspec(pkg_data: &PackageData) -> bool {
+    pkg_data.datasource_id == Some(DatasourceId::CocoapodsPodspec)
+        && pkg_data
+            .extra_data
+            .as_ref()
+            .and_then(|data| data.get("dynamic_identity_placeholders"))
+            .and_then(|value| value.as_bool())
+            == Some(true)
 }
 
 fn should_skip_composer_lock_virtual_package(pkg_data: &PackageData) -> bool {

--- a/src/copyright/detector/pattern_extract/extraction/prepared.rs
+++ b/src/copyright/detector/pattern_extract/extraction/prepared.rs
@@ -548,6 +548,69 @@ pub fn extract_all_rights_reserved_by_holder_lines(
     (copyrights, holders)
 }
 
+pub fn extract_copyright_c_all_rights_reserved_no_year_holder_lines(
+    prepared_cache: &PreparedLines<'_>,
+    existing_copyrights: &[CopyrightDetection],
+    existing_holders: &[HolderDetection],
+) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {
+    if prepared_cache.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    static COPYRIGHT_C_RESERVED_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^copyright\s*\(c\)\s*(?P<holder>.+?)\s+all\s+rights\s+reserved\.?$")
+            .unwrap()
+    });
+    static YEAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:19\d{2}|20\d{2})").unwrap());
+
+    let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
+        .iter()
+        .map(|c| (c.start_line.get(), c.copyright.clone()))
+        .collect();
+    let mut seen_h: HashSet<(usize, String)> = existing_holders
+        .iter()
+        .map(|h| (h.start_line.get(), h.holder.clone()))
+        .collect();
+
+    let mut copyrights = Vec::new();
+    let mut holders = Vec::new();
+
+    for line in prepared_cache.iter_non_empty() {
+        let Some(cap) = COPYRIGHT_C_RESERVED_RE.captures(line.prepared) else {
+            continue;
+        };
+
+        let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
+        if holder_raw.is_empty() || YEAR_RE.is_match(holder_raw) {
+            continue;
+        }
+
+        let raw = format!("Copyright (c) {holder_raw}");
+        let Some(refined) = refine_copyright(&raw) else {
+            continue;
+        };
+        if seen_cr.insert((line.line_number.get(), refined.clone())) {
+            copyrights.push(CopyrightDetection {
+                copyright: refined,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
+
+        if let Some(h) = refine_holder_in_copyright_context(holder_raw)
+            && seen_h.insert((line.line_number.get(), h.clone()))
+        {
+            holders.push(HolderDetection {
+                holder: h,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
+    }
+
+    (copyrights, holders)
+}
+
 pub fn extract_holder_is_name_paren_email_lines(
     prepared_cache: &PreparedLines<'_>,
     existing_copyrights: &[CopyrightDetection],

--- a/src/copyright/detector/pattern_extract/extraction/prepared.rs
+++ b/src/copyright/detector/pattern_extract/extraction/prepared.rs
@@ -562,6 +562,9 @@ pub fn extract_copyright_c_all_rights_reserved_no_year_holder_lines(
             .unwrap()
     });
     static YEAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:19\d{2}|20\d{2})").unwrap());
+    static PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\{[^}]*\}|\bdate\s+here\b|\btoday\.year\b|\bcurrent_year\b").unwrap()
+    });
 
     let mut seen_cr: HashSet<(usize, String)> = existing_copyrights
         .iter()
@@ -581,7 +584,10 @@ pub fn extract_copyright_c_all_rights_reserved_no_year_holder_lines(
         };
 
         let holder_raw = cap.name("holder").map(|m| m.as_str()).unwrap_or("").trim();
-        if holder_raw.is_empty() || YEAR_RE.is_match(holder_raw) {
+        if holder_raw.is_empty()
+            || YEAR_RE.is_match(holder_raw)
+            || PLACEHOLDER_RE.is_match(holder_raw)
+        {
             continue;
         }
 

--- a/src/copyright/detector/phases/primary.rs
+++ b/src/copyright/detector/phases/primary.rs
@@ -299,6 +299,17 @@ fn run_group_based_extractions(
     copyrights.extend(new_c);
     holders.extend(new_h);
 
+    let (new_c, new_h) =
+        super::super::pattern_extract::extract_copyright_c_all_rights_reserved_no_year_holder_lines(
+            prepared_cache,
+            copyrights,
+            holders,
+        );
+    seen.register_copyrights(&new_c);
+    seen.register_holders(&new_h);
+    copyrights.extend(new_c);
+    holders.extend(new_h);
+
     let mut new_c =
         super::super::pattern_extract::extract_trailing_bare_c_year_range_suffixes(groups);
     seen.dedup_new_copyrights(&mut new_c, 0);

--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -1831,6 +1831,24 @@ fn test_detect_copyright_c_symbol_with_all_rights_reserved() {
 }
 
 #[test]
+fn test_detect_copyright_c_symbol_without_year_all_rights_reserved_yields_holder() {
+    let (c, h, _a) = detect_copyrights_from_text("Copyright (c) ATO Gear. All rights reserved.");
+
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright.contains("ATO Gear")
+                && !cr.copyright.contains("All rights reserved")),
+        "copyrights: {:?}",
+        c.iter().map(|cr| &cr.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        h.iter().any(|hd| hd.holder == "ATO Gear"),
+        "holders: {:?}",
+        h.iter().map(|hd| &hd.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_detect_copyright_unicode_symbol() {
     let (c, _, _) = detect_copyrights_from_text(
         "/* Copyright \u{00A9} 2000 ACME, Inc., All Rights Reserved */",

--- a/src/copyright/detector/tree_walk/copyright.rs
+++ b/src/copyright/detector/tree_walk/copyright.rs
@@ -2484,7 +2484,8 @@ pub fn extract_from_spans(
                 }
 
                 if !skip_holder_from_span {
-                    let holder_tokens: Vec<&Token> = span
+                    let holder_span = filtered.as_slice();
+                    let holder_tokens: Vec<&Token> = holder_span
                         .iter()
                         .copied()
                         .filter(|t| !detector::NON_HOLDER_POS_TAGS.contains(&t.tag))
@@ -2495,7 +2496,7 @@ pub fn extract_from_spans(
                     ) {
                         holders.push(det);
                     } else {
-                        let holder_tokens_mini: Vec<&Token> = span
+                        let holder_tokens_mini: Vec<&Token> = holder_span
                             .iter()
                             .copied()
                             .filter(|t| !detector::NON_HOLDER_POS_TAGS_MINI.contains(&t.tag))
@@ -2728,7 +2729,8 @@ pub fn extract_copyrights_from_spans(
                 }
 
                 if !skip_holder_from_span {
-                    let holder_tokens: Vec<&Token> = span
+                    let holder_span = filtered.as_slice();
+                    let holder_tokens: Vec<&Token> = holder_span
                         .iter()
                         .copied()
                         .filter(|t| !detector::NON_HOLDER_POS_TAGS.contains(&t.tag))
@@ -2739,7 +2741,7 @@ pub fn extract_copyrights_from_spans(
                     ) {
                         holders.push(det);
                     } else {
-                        let holder_tokens_mini: Vec<&Token> = span
+                        let holder_tokens_mini: Vec<&Token> = holder_span
                             .iter()
                             .copied()
                             .filter(|t| !detector::NON_HOLDER_POS_TAGS_MINI.contains(&t.tag))

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -418,7 +418,7 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^iouoi\b",
         r"(?i)^aiuaey\b",
         r"(?i)^aoth\b",
-        r"(?i)^ato\b",
+        r"(?i)^ato$",
         r"(?i)^aaeamooa\b",
         r"(?i)^eeiaeiaaoa\b",
         r"(?i)^exauauuao\b",

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -784,7 +784,7 @@ fn is_post_refine_copyright_code_fragment(s: &str) -> bool {
 
 fn contains_unicode_escape_token_run(s: &str) -> bool {
     static UNICODE_ESCAPE_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)\bu[0-9a-f]{4}\b").unwrap());
+        LazyLock::new(|| Regex::new(r"(?i)\bu[0-9a-f]{4}[a-z0-9_]*\b").unwrap());
 
     UNICODE_ESCAPE_RE.is_match(s.trim())
 }
@@ -1442,21 +1442,9 @@ fn strip_known_copyright_wrappers(s: &str) -> String {
 }
 
 fn strip_trailing_all_rights_reserved_clause(s: &str) -> String {
-    static ALL_RIGHTS_RESERVED_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?ix)^(?P<prefix>.+?)\.?\s+all\s+rights\s+reserved\.?$")
-            .expect("valid all rights reserved regex")
-    });
-
-    let trimmed = s.trim();
-    let Some(captures) = ALL_RIGHTS_RESERVED_RE.captures(trimmed) else {
+    let Some(prefix) = all_rights_reserved_prefix(s) else {
         return s.to_string();
     };
-
-    let prefix = captures
-        .name("prefix")
-        .map(|m| m.as_str())
-        .unwrap_or("")
-        .trim();
     let lower = prefix.to_ascii_lowercase();
     if prefix.is_empty()
         || !(lower.starts_with("copyright") || lower.starts_with("(c)") || lower.starts_with('©'))
@@ -1492,21 +1480,10 @@ fn strip_trailing_no_rights_reserved_clause(s: &str) -> String {
 }
 
 fn strip_trailing_all_rights_reserved_holder_clause(s: &str) -> String {
-    static ALL_RIGHTS_RESERVED_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?ix)^(?P<prefix>.+?)\.?\s+all\s+rights\s+reserved\.?$").unwrap()
-    });
-
-    let trimmed = s.trim();
-    let Some(captures) = ALL_RIGHTS_RESERVED_RE.captures(trimmed) else {
+    let Some(prefix) = all_rights_reserved_prefix(s) else {
         return s.to_string();
     };
-
-    let prefix = captures
-        .name("prefix")
-        .map(|m| m.as_str())
-        .unwrap_or("")
-        .trim();
-    if prefix.is_empty() || !prefix_has_holder_words(prefix) {
+    if prefix.is_empty() || !prefix_has_holder_words(prefix.as_str()) {
         return s.to_string();
     }
 
@@ -1514,6 +1491,25 @@ fn strip_trailing_all_rights_reserved_holder_clause(s: &str) -> String {
         .trim_end_matches(&[',', ';', ':', '.', ' '][..])
         .trim()
         .to_string()
+}
+
+fn all_rights_reserved_prefix(s: &str) -> Option<String> {
+    static ALL_RIGHTS_RESERVED_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)^(?P<prefix>.+?)\.?\s+all\s+rights\s+reserved\.?$")
+            .expect("valid all rights reserved regex")
+    });
+
+    let trimmed = s.trim();
+    let captures = ALL_RIGHTS_RESERVED_RE.captures(trimmed)?;
+
+    Some(
+        captures
+            .name("prefix")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string(),
+    )
 }
 
 fn strip_trailing_obfuscated_email_after_dash(s: &str) -> String {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1491,6 +1491,31 @@ fn strip_trailing_no_rights_reserved_clause(s: &str) -> String {
         .unwrap_or_else(|| s.to_string())
 }
 
+fn strip_trailing_all_rights_reserved_holder_clause(s: &str) -> String {
+    static ALL_RIGHTS_RESERVED_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)^(?P<prefix>.+?)\.?\s+all\s+rights\s+reserved\.?$").unwrap()
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = ALL_RIGHTS_RESERVED_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+
+    let prefix = captures
+        .name("prefix")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim();
+    if prefix.is_empty() || !prefix_has_holder_words(prefix) {
+        return s.to_string();
+    }
+
+    prefix
+        .trim_end_matches(&[',', ';', ':', '.', ' '][..])
+        .trim()
+        .to_string()
+}
+
 fn strip_trailing_obfuscated_email_after_dash(s: &str) -> String {
     static TRAILING_DASH_OBF_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -2857,6 +2882,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     h = strip_leading_product_operating_system_title(&h);
     h = strip_trailing_everyone_is_permitted_to_copy_clause(&h);
     h = strip_trailing_reserved_font_name_clause(&h);
+    h = strip_trailing_all_rights_reserved_holder_clause(&h);
     h = strip_trailing_no_rights_reserved_clause(&h);
     h = strip_trailing_parenthesized_url_or_domain(&h);
     h = strip_trailing_et_al(&h);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1849,6 +1849,14 @@ fn test_refine_holder_in_copyright_context_strips_no_rights_reserved_clause() {
 }
 
 #[test]
+fn test_refine_holder_in_copyright_context_keeps_ato_gear_notice_holder() {
+    assert_eq!(
+        refine_holder_in_copyright_context("ATO Gear."),
+        Some("ATO Gear".to_string())
+    );
+}
+
+#[test]
 fn test_refine_holder_in_copyright_context_strips_onwards_prefix() {
     assert_eq!(
         refine_holder_in_copyright_context("and onwards The Apache Software Foundation"),

--- a/src/parsers/cocoapods_scan_test.rs
+++ b/src/parsers/cocoapods_scan_test.rs
@@ -3,6 +3,7 @@
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::Path;
 
     use super::super::scan_test_utils::scan_and_assemble;
@@ -140,6 +141,77 @@ mod tests {
             !differentiator_podspec
                 .for_packages
                 .contains(&rx_data_sources.package_uid)
+        );
+    }
+
+    #[test]
+    fn test_cocoapods_scan_skips_top_level_assembly_for_placeholder_only_dynamic_podspec() {
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        let podspec_path = temp_dir
+            .path()
+            .join("react-native-background-timer.podspec");
+        fs::write(
+            &podspec_path,
+            r#"require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name     = package['name']
+  s.version  = package['version']
+  s.summary  = package['description']
+  s.homepage = package['repository']['url']
+  s.license  = package['license']
+  s.author   = package['author']
+  s.source   = { :git => s.homepage, :tag => 'v#{s.version}' }
+  s.dependency 'React-Core'
+end
+"#,
+        )
+        .expect("fixture podspec should be written");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        assert!(
+            result.packages.is_empty(),
+            "packages: {:?}",
+            result.packages
+        );
+        assert!(
+            result.dependencies.is_empty(),
+            "dependencies: {:?}",
+            result.dependencies
+        );
+
+        let podspec = files
+            .iter()
+            .find(|file| {
+                file.path
+                    .ends_with("/react-native-background-timer.podspec")
+            })
+            .expect("podspec should be scanned");
+        assert_eq!(
+            podspec.package_data.len(),
+            1,
+            "package_data: {:?}",
+            podspec.package_data
+        );
+        assert_eq!(
+            podspec.package_data[0].purl.as_deref(),
+            Some("pkg:cocoapods/packagename@packageversion")
+        );
+        assert_eq!(
+            podspec.package_data[0]
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("dynamic_identity_placeholders"))
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert!(
+            podspec.for_packages.is_empty(),
+            "for_packages: {:?}",
+            podspec.for_packages
         );
     }
 }

--- a/src/parsers/cocoapods_scan_test.rs
+++ b/src/parsers/cocoapods_scan_test.rs
@@ -145,25 +145,19 @@ mod tests {
     }
 
     #[test]
-    fn test_cocoapods_scan_skips_top_level_assembly_for_placeholder_only_dynamic_podspec() {
+    fn test_cocoapods_scan_skips_top_level_assembly_for_generic_nonliteral_identity_podspec() {
         let temp_dir = tempfile::tempdir().expect("tempdir should be created");
-        let podspec_path = temp_dir
-            .path()
-            .join("react-native-background-timer.podspec");
+        let podspec_path = temp_dir.path().join("dynamic-identity.podspec");
         fs::write(
             &podspec_path,
-            r#"require 'json'
-
-package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-
-Pod::Spec.new do |s|
-  s.name     = package['name']
-  s.version  = package['version']
+            r#"Pod::Spec.new do |s|
+  s.name     = pod_name
+  s.version  = pod_version
   s.summary  = package['description']
-  s.homepage = package['repository']['url']
-  s.license  = package['license']
-  s.author   = package['author']
-  s.source   = { :git => s.homepage, :tag => 'v#{s.version}' }
+  s.homepage = homepage_url
+  s.license  = license_name
+  s.author   = author_name
+  s.source   = { :git => homepage_url, :tag => 'v#{pod_version}' }
   s.dependency 'React-Core'
 end
 "#,
@@ -185,10 +179,7 @@ end
 
         let podspec = files
             .iter()
-            .find(|file| {
-                file.path
-                    .ends_with("/react-native-background-timer.podspec")
-            })
+            .find(|file| file.path.ends_with("/dynamic-identity.podspec"))
             .expect("podspec should be scanned");
         assert_eq!(
             podspec.package_data.len(),
@@ -198,7 +189,7 @@ end
         );
         assert_eq!(
             podspec.package_data[0].purl.as_deref(),
-            Some("pkg:cocoapods/packagename@packageversion")
+            Some("pkg:cocoapods/pod_name@pod_version")
         );
         assert_eq!(
             podspec.package_data[0]

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -75,6 +75,8 @@ impl PackageParser for PodspecParser {
             }
         };
 
+        let raw_name = extract_raw_field(&content, &NAME_PATTERN);
+        let raw_version = extract_raw_field(&content, &VERSION_PATTERN);
         let name = extract_metadata_field(&content, &NAME_PATTERN).map(truncate_field);
         let version = extract_metadata_field(&content, &VERSION_PATTERN).map(truncate_field);
         let summary = extract_metadata_field(&content, &SUMMARY_PATTERN).map(truncate_field);
@@ -104,12 +106,12 @@ impl PackageParser for PodspecParser {
 
         let dependencies = extract_dependencies(&content);
         let mut extra_data = serde_json::Map::new();
-        let has_dynamic_identity_placeholders = name
+        let has_dynamic_identity_placeholders = raw_name
             .as_deref()
-            .is_some_and(is_podspec_dynamic_placeholder_token)
-            && version
+            .is_some_and(looks_like_nonliteral_podspec_expression)
+            && raw_version
                 .as_deref()
-                .is_some_and(is_podspec_dynamic_placeholder_token);
+                .is_some_and(looks_like_nonliteral_podspec_expression);
         if has_dynamic_identity_placeholders {
             extra_data.insert(
                 "dynamic_identity_placeholders".to_string(),
@@ -269,7 +271,7 @@ fn normalize_podspec_declared_license(
     let Some(raw_license) = extract_field(content, &LICENSE_PATTERN) else {
         return super::license_normalization::empty_declared_license_data();
     };
-    if looks_like_podspec_dynamic_metadata_value(&raw_license) {
+    if looks_like_nonliteral_podspec_expression(&raw_license) {
         return build_declared_license_data_from_pair(
             "unknown".to_string(),
             "LicenseRef-scancode-unknown".to_string(),
@@ -350,18 +352,42 @@ fn looks_like_podspec_dynamic_metadata_value(value: &str) -> bool {
     value.contains("['") || value.contains("[\"")
 }
 
-fn is_podspec_dynamic_placeholder_token(value: &str) -> bool {
+fn looks_like_nonliteral_podspec_expression(value: &str) -> bool {
     let trimmed = value.trim();
-    trimmed.starts_with("package")
-        && trimmed.len() > "package".len()
-        && trimmed
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if matches!(trimmed.chars().next(), Some('\'' | '"'))
+        || trimmed.starts_with("%q{")
+        || trimmed.starts_with("%Q{")
+    {
+        return false;
+    }
+
+    if trimmed
+        .chars()
+        .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | '_' | '+'))
+    {
+        return false;
+    }
+
+    true
 }
 
 fn extract_metadata_field(content: &str, pattern: &Regex) -> Option<String> {
     extract_field(content, pattern)
         .and_then(|value| normalize_podspec_dynamic_metadata_value(&value))
+}
+
+fn extract_raw_field(content: &str, pattern: &Regex) -> Option<String> {
+    for line in content.lines().take(MAX_ITERATION_COUNT) {
+        let cleaned_line = pre_process(line);
+        if let Some(value) = pattern.captures(&cleaned_line).and_then(|caps| caps.get(1)) {
+            return Some(value.as_str().trim().to_string());
+        }
+    }
+    None
 }
 
 /// Extract a single field using a regex pattern
@@ -741,6 +767,18 @@ end
     }
 
     #[test]
+    fn test_detects_nonliteral_podspec_expressions_generically() {
+        assert!(looks_like_nonliteral_podspec_expression("package['name']"));
+        assert!(looks_like_nonliteral_podspec_expression("pod_name"));
+        assert!(looks_like_nonliteral_podspec_expression(
+            "SpecMetadata.version"
+        ));
+        assert!(!looks_like_nonliteral_podspec_expression("'Demo'"));
+        assert!(!looks_like_nonliteral_podspec_expression("\"1.0.0\""));
+        assert!(!looks_like_nonliteral_podspec_expression("1.0.0"));
+    }
+
+    #[test]
     fn test_extract_multiline_description() {
         let content = r#"
 Pod::Spec.new do |s|
@@ -874,21 +912,17 @@ end
     }
 
     #[test]
-    fn test_extract_packages_normalizes_dynamic_benchmark_style_fields() {
+    fn test_extract_packages_marks_dynamic_identity_placeholders_for_nonliteral_fields() {
         let content = r#"
-require 'json'
-
-package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-
 Pod::Spec.new do |s|
 
-  s.name           = package['name']
-  s.version        = package['version']
+  s.name           = pod_name
+  s.version        = pod_version
   s.summary        = package['description']
-  s.homepage       = package['repository']['url']
-  s.license        = package['license']
-  s.author         = package['author']
-  s.source         = { :git => s.homepage, :tag => 'v#{s.version}' }
+  s.homepage       = homepage_url
+  s.license        = license_name
+  s.author         = author_name
+  s.source         = { :git => homepage_url, :tag => 'v#{pod_version}' }
 
   s.requires_arc   = true
   s.ios.deployment_target = '8.0'
@@ -903,26 +937,21 @@ end
 "#;
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let file_path = temp_dir
-            .path()
-            .join("react-native-background-timer.podspec");
+        let file_path = temp_dir.path().join("dynamic-identity.podspec");
         std::fs::write(&file_path, content).unwrap();
 
         let package_data = PodspecParser::extract_first_package(&file_path);
 
-        assert_eq!(package_data.name.as_deref(), Some("packagename"));
-        assert_eq!(package_data.version.as_deref(), Some("packageversion"));
+        assert_eq!(package_data.name.as_deref(), Some("pod_name"));
+        assert_eq!(package_data.version.as_deref(), Some("pod_version"));
         assert_eq!(
             package_data.description.as_deref(),
             Some("packagedescription")
         );
-        assert_eq!(
-            package_data.homepage_url.as_deref(),
-            Some("packagerepositoryurl")
-        );
+        assert_eq!(package_data.homepage_url.as_deref(), Some("homepage_url"));
         assert_eq!(
             package_data.extracted_license_statement.as_deref(),
-            Some("packagelicense")
+            Some("license_name")
         );
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
@@ -933,32 +962,29 @@ end
             Some("LicenseRef-scancode-unknown")
         );
         assert_eq!(package_data.license_detections.len(), 1);
-        assert_eq!(package_data.vcs_url.as_deref(), Some("s.homepage"));
+        assert_eq!(package_data.vcs_url.as_deref(), Some("homepage_url"));
         assert_eq!(
             package_data.repository_homepage_url.as_deref(),
-            Some("https://cocoapods.org/pods/packagename")
+            Some("https://cocoapods.org/pods/pod_name")
         );
         assert_eq!(
             package_data.repository_download_url.as_deref(),
-            Some("s.homepage/archive/refs/tags/packageversion.zip")
+            Some("homepage_url/archive/refs/tags/pod_version.zip")
         );
         assert_eq!(
             package_data.code_view_url.as_deref(),
-            Some("s.homepage/tree/packageversion")
+            Some("homepage_url/tree/pod_version")
         );
         assert_eq!(
             package_data.bug_tracking_url.as_deref(),
-            Some("s.homepage/issues/")
+            Some("homepage_url/issues/")
         );
         assert_eq!(
             package_data.purl.as_deref(),
-            Some("pkg:cocoapods/packagename@packageversion")
+            Some("pkg:cocoapods/pod_name@pod_version")
         );
         assert_eq!(package_data.parties.len(), 1);
-        assert_eq!(
-            package_data.parties[0].name.as_deref(),
-            Some("packageauthor")
-        );
+        assert_eq!(package_data.parties[0].name.as_deref(), Some("author_name"));
         assert_eq!(
             package_data
                 .extra_data

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -268,7 +268,7 @@ fn normalize_podspec_declared_license(
     Option<String>,
     Vec<crate::models::LicenseDetection>,
 ) {
-    let Some(raw_license) = extract_field(content, &LICENSE_PATTERN) else {
+    let Some(raw_license) = extract_raw_field(content, &LICENSE_PATTERN) else {
         return super::license_normalization::empty_declared_license_data();
     };
     if looks_like_nonliteral_podspec_expression(&raw_license) {
@@ -355,6 +355,10 @@ fn looks_like_podspec_dynamic_metadata_value(value: &str) -> bool {
 fn looks_like_nonliteral_podspec_expression(value: &str) -> bool {
     let trimmed = value.trim();
     if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.contains("=>") || trimmed.starts_with('{') {
         return false;
     }
 

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -34,7 +34,10 @@ use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parsers::PackageParser;
-use crate::parsers::license_normalization::normalize_spdx_declared_license;
+use crate::parsers::license_normalization::{
+    DeclaredLicenseMatchMetadata, build_declared_license_data_from_pair,
+    normalize_spdx_declared_license,
+};
 use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 /// Parses CocoaPods specification files (.podspec).
@@ -72,13 +75,13 @@ impl PackageParser for PodspecParser {
             }
         };
 
-        let name = extract_field(&content, &NAME_PATTERN).map(truncate_field);
-        let version = extract_field(&content, &VERSION_PATTERN).map(truncate_field);
-        let summary = extract_field(&content, &SUMMARY_PATTERN).map(truncate_field);
+        let name = extract_metadata_field(&content, &NAME_PATTERN).map(truncate_field);
+        let version = extract_metadata_field(&content, &VERSION_PATTERN).map(truncate_field);
+        let summary = extract_metadata_field(&content, &SUMMARY_PATTERN).map(truncate_field);
         let description =
             merge_summary_and_description(summary.as_deref(), extract_description(&content))
                 .map(truncate_field);
-        let homepage_url = extract_field(&content, &HOMEPAGE_PATTERN).map(truncate_field);
+        let homepage_url = extract_metadata_field(&content, &HOMEPAGE_PATTERN).map(truncate_field);
         let license = extract_license_statement(&content).map(truncate_field);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
             normalize_podspec_declared_license(&content, license.as_deref());
@@ -101,6 +104,18 @@ impl PackageParser for PodspecParser {
 
         let dependencies = extract_dependencies(&content);
         let mut extra_data = serde_json::Map::new();
+        let has_dynamic_identity_placeholders = name
+            .as_deref()
+            .is_some_and(is_podspec_dynamic_placeholder_token)
+            && version
+                .as_deref()
+                .is_some_and(is_podspec_dynamic_placeholder_token);
+        if has_dynamic_identity_placeholders {
+            extra_data.insert(
+                "dynamic_identity_placeholders".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
         if let Some(raw_license) = extract_field(&content, &LICENSE_PATTERN)
             && let Some(license_file) = extract_ruby_hash_file(&raw_license)
         {
@@ -226,6 +241,8 @@ static AUTHOR_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\.authors?\s*=\s*(.+)").expect("valid regex"));
 static SOURCE_GIT_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#":git\s*=>\s*['\"]([^'\"]+)['\"]"#).expect("valid regex"));
+static SOURCE_GIT_DYNAMIC_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#":git\s*(?:=>|=)\s*([^,}]+)"#).expect("valid regex"));
 static SOURCE_HTTP_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#":http\s*=>\s*['\"]([^'\"]+)['\"]"#).expect("valid regex"));
 
@@ -236,7 +253,9 @@ static DEPENDENCY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 fn extract_license_statement(content: &str) -> Option<String> {
-    extract_field(content, &LICENSE_PATTERN).map(|value| normalize_ruby_hash_literal(&value))
+    extract_field(content, &LICENSE_PATTERN)
+        .map(|value| normalize_ruby_hash_literal(&value))
+        .and_then(|value| normalize_podspec_dynamic_metadata_value(&value))
 }
 
 fn normalize_podspec_declared_license(
@@ -250,6 +269,15 @@ fn normalize_podspec_declared_license(
     let Some(raw_license) = extract_field(content, &LICENSE_PATTERN) else {
         return super::license_normalization::empty_declared_license_data();
     };
+    if looks_like_podspec_dynamic_metadata_value(&raw_license) {
+        return build_declared_license_data_from_pair(
+            "unknown".to_string(),
+            "LicenseRef-scancode-unknown".to_string(),
+            DeclaredLicenseMatchMetadata::single_line(
+                extracted_license_statement.unwrap_or(raw_license.as_str()),
+            ),
+        );
+    }
     let normalized_candidate = if raw_license.contains("=>") || raw_license.contains('=') {
         extract_ruby_hash_type(&raw_license)
             .map(|license_type| canonicalize_cocoapods_license_type(&license_type))
@@ -300,6 +328,42 @@ fn normalize_ruby_hash_literal(value: &str) -> String {
         .join(" ")
 }
 
+fn normalize_podspec_dynamic_metadata_value(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if looks_like_podspec_dynamic_metadata_value(trimmed) {
+        let normalized = trimmed
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        return (!normalized.is_empty()).then_some(normalized);
+    }
+
+    Some(trimmed.to_string())
+}
+
+fn looks_like_podspec_dynamic_metadata_value(value: &str) -> bool {
+    value.contains("['") || value.contains("[\"")
+}
+
+fn is_podspec_dynamic_placeholder_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.starts_with("package")
+        && trimmed.len() > "package".len()
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+}
+
+fn extract_metadata_field(content: &str, pattern: &Regex) -> Option<String> {
+    extract_field(content, pattern)
+        .and_then(|value| normalize_podspec_dynamic_metadata_value(&value))
+}
+
 /// Extract a single field using a regex pattern
 fn extract_field(content: &str, pattern: &Regex) -> Option<String> {
     for line in content.lines().take(MAX_ITERATION_COUNT) {
@@ -326,7 +390,7 @@ fn extract_description(content: &str) -> Option<String> {
             if value_str.contains("<<-") {
                 return extract_multiline_description(&lines, i);
             } else {
-                return Some(clean_string(value_str));
+                return normalize_podspec_dynamic_metadata_value(&clean_string(value_str));
             }
         }
     }
@@ -404,6 +468,9 @@ fn extract_authors(content: &str) -> Vec<(String, Option<String>)> {
                 }
             } else {
                 let cleaned = clean_string(value_str);
+                let Some(cleaned) = normalize_podspec_dynamic_metadata_value(&cleaned) else {
+                    continue;
+                };
                 let (name, email) = parse_author_string(&cleaned);
                 authors.push((name, email));
             }
@@ -428,6 +495,15 @@ fn extract_source_url(content: &str) -> Option<String> {
             && let Some(url) = caps.get(1)
         {
             return Some(clean_string(url.as_str()));
+        }
+
+        if let Some(caps) = SOURCE_GIT_DYNAMIC_PATTERN.captures(value)
+            && let Some(url) = caps.get(1)
+        {
+            let cleaned = clean_string(url.as_str());
+            if !cleaned.is_empty() {
+                return Some(cleaned);
+            }
         }
 
         if let Some(caps) = SOURCE_HTTP_PATTERN.captures(value)
@@ -626,12 +702,41 @@ Pod::Spec.new do |s|
 end
 "#;
         assert_eq!(
-            extract_field(content, &NAME_PATTERN),
+            extract_metadata_field(content, &NAME_PATTERN),
             Some("AFNetworking".to_string())
         );
         assert_eq!(
-            extract_field(content, &VERSION_PATTERN),
+            extract_metadata_field(content, &VERSION_PATTERN),
             Some("4.0.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_dynamic_metadata_field_uses_stable_placeholder() {
+        let content = r#"
+Pod::Spec.new do |s|
+  s.name = package['name']
+  s.version = package['version']
+  s.summary = package['description']
+  s.homepage = package['repository']['url']
+end
+"#;
+
+        assert_eq!(
+            extract_metadata_field(content, &NAME_PATTERN),
+            Some("packagename".to_string())
+        );
+        assert_eq!(
+            extract_metadata_field(content, &VERSION_PATTERN),
+            Some("packageversion".to_string())
+        );
+        assert_eq!(
+            extract_metadata_field(content, &SUMMARY_PATTERN),
+            Some("packagedescription".to_string())
+        );
+        assert_eq!(
+            extract_metadata_field(content, &HOMEPAGE_PATTERN),
+            Some("packagerepositoryurl".to_string())
         );
     }
 
@@ -765,6 +870,107 @@ end
                 .referenced_filenames
                 .as_ref(),
             Some(&vec!["LICENSE.txt".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_packages_normalizes_dynamic_benchmark_style_fields() {
+        let content = r#"
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+
+  s.name           = package['name']
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.homepage       = package['repository']['url']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.source         = { :git => s.homepage, :tag => 'v#{s.version}' }
+
+  s.requires_arc   = true
+  s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = '9.0'
+
+  s.preserve_paths = 'README.md', 'package.json', 'index.js'
+  s.source_files   = 'ios/*.{h,m}'
+
+  s.dependency 'React-Core'
+
+end
+"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir
+            .path()
+            .join("react-native-background-timer.podspec");
+        std::fs::write(&file_path, content).unwrap();
+
+        let package_data = PodspecParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.name.as_deref(), Some("packagename"));
+        assert_eq!(package_data.version.as_deref(), Some("packageversion"));
+        assert_eq!(
+            package_data.description.as_deref(),
+            Some("packagedescription")
+        );
+        assert_eq!(
+            package_data.homepage_url.as_deref(),
+            Some("packagerepositoryurl")
+        );
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("packagelicense")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("unknown")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("LicenseRef-scancode-unknown")
+        );
+        assert_eq!(package_data.license_detections.len(), 1);
+        assert_eq!(package_data.vcs_url.as_deref(), Some("s.homepage"));
+        assert_eq!(
+            package_data.repository_homepage_url.as_deref(),
+            Some("https://cocoapods.org/pods/packagename")
+        );
+        assert_eq!(
+            package_data.repository_download_url.as_deref(),
+            Some("s.homepage/archive/refs/tags/packageversion.zip")
+        );
+        assert_eq!(
+            package_data.code_view_url.as_deref(),
+            Some("s.homepage/tree/packageversion")
+        );
+        assert_eq!(
+            package_data.bug_tracking_url.as_deref(),
+            Some("s.homepage/issues/")
+        );
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:cocoapods/packagename@packageversion")
+        );
+        assert_eq!(package_data.parties.len(), 1);
+        assert_eq!(
+            package_data.parties[0].name.as_deref(),
+            Some("packageauthor")
+        );
+        assert_eq!(
+            package_data
+                .extra_data
+                .as_ref()
+                .and_then(|data| data.get("dynamic_identity_placeholders"))
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:cocoapods/React-Core")
         );
     }
 }

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -91,6 +91,43 @@ fn test_extract_copyright_information_preserves_raw_text_and_normalized_shadow()
 }
 
 #[test]
+fn test_extract_copyright_information_keeps_raw_notice_and_holder_for_no_year_c_symbol() {
+    let text = "// Copyright (c) ATO Gear. All rights reserved.\n";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(
+        &mut builder,
+        Path::new("RNBackgroundTimer.h"),
+        text,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("RNBackgroundTimer.h".to_string())
+        .base_name("RNBackgroundTimer".to_string())
+        .extension(".h".to_string())
+        .path("RNBackgroundTimer.h".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright (c) ATO Gear. All rights reserved."
+    );
+    assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
+    assert_eq!(file.holders[0].holder, "ATO Gear");
+}
+
+#[test]
 fn test_extract_copyright_information_uses_embedded_sourcemap_sources_for_parties() {
     let text = r#"{"version":3,"comment":"Copyright 1999 Wrong Corp.","sourcesContent":["/* Copyright 2024 Example Corp. */\n"]}"#;
     let mut builder = FileInfoBuilder::default();


### PR DESCRIPTION
## Summary

- Verify `ocetnik/react-native-background-timer@244ea3e554a6c480f22c818831ea0dd7c0587708` with the full `compare-outputs` benchmark loop and record the optimized result in `docs/BENCHMARKS.md`.
- Recover `ATO Gear` holder extraction for `ios/RNBackgroundTimer.h` and `ios/RNBackgroundTimer.m` while preserving raw file-level copyright text, including `All rights reserved.`.
- Stop hoisting placeholder-only dynamic CocoaPods podspec identities into assembled top-level package results, and regenerate `docs/scan-duration-vs-files.svg`.

## Scope and exclusions

- Included:
  - Final optimized compare run: `.provenant/compare-runs/20260507T171635Z-react-native-background-timer-68507`
  - Benchmark snapshot: `ocetnik/react-native-background-timer@244ea3e554a6c480f22c818831ea0dd7c0587708`
  - Benchmark timing: Provenant `9.41s`; ScanCode `97.28s`
- Explicit exclusions:
  - No general Ruby execution or broad podspec AST evaluation; this keeps podspec handling bounded and static.
  - No unrelated benchmark-row refreshes outside this target.

## Intentional differences from Python

- Preserve Unicode party text such as `Dávid Ocetník` in `LICENSE` instead of degrading it to ASCII; this reviewed delta remains an intentional Provenant data-fidelity advantage.
- Preserve raw file-level copyright text in output while using normalized internal holder cleanup to recover `ATO Gear` from the iOS native headers.

## Follow-up work

- Created or intentionally deferred:
  - If future CocoaPods benchmarks need more than placeholder suppression, a bounded same-file variable-resolution pass in the podspec parser is the next step.