### PR TITLE
fix(copyright): verify boost serialization benchmark

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -579,7 +579,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 542
 - Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `13.15s`; ScanCode `132.33s`
-- Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with repaired year-plus-contact holder extraction on `include/boost/serialization/variant.hpp`, multi-person codecvt footer attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
+- Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with year-plus-contact holder recovery on `include/boost/serialization/variant.hpp`, multi-person codecvt footer attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
 
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 197 of 197 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 198 of 198 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -574,6 +574,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `35.76s`; ScanCode `215.32s`
 - Cleaner benchmark-corpus author extraction in `bench/data/gsoc-2018.json` and `bench/data/github_events.json`, replacing ScanCode junk such as `type' Person name' AadityaNair` and prose fragments with actual participant names while preserving Unicode identities like `Nils Jørgen Mittet`, plus Unicode-preserving holder normalization for `René Ferdinand Rivera Morell` on build metadata
 
+##### [boostorg/serialization @ 097a6c6](https://github.com/boostorg/serialization/tree/097a6c63a137be836d663cdb27f2e6c803a4100b) — **10.06× faster**
+
+- Files: 542
+- Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `13.15s`; ScanCode `132.33s`
+- Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with repaired year-plus-contact holder extraction on `include/boost/serialization/variant.hpp`, multi-person codecvt footer attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
+
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
 
 - Files: 576

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -579,7 +579,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 542
 - Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `13.15s`; ScanCode `132.33s`
-- Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with year-plus-contact holder recovery on `include/boost/serialization/variant.hpp`, multi-person codecvt footer attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
+- Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with multi-person codecvt attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
 
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -281,6 +281,9 @@ ScanCode: 211.97s</title></rect>
     <rect x="525.54" y="396.10" width="8" height="8" fill="#d97706" rx="1.5"><title>pyodide/pyodide @ 86e27b0
 Files: 540
 ScanCode: 135.33s</title></rect>
+    <rect x="525.79" y="397.16" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/serialization @ 097a6c6
+Files: 542
+ScanCode: 132.33s</title></rect>
     <rect x="526.30" y="381.25" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 ScanCode: 185.33s</title></rect>
@@ -874,6 +877,9 @@ Provenant: 11.92s</title></circle>
     <circle cx="529.54" cy="519.69" r="4.5" fill="#2563eb"><title>pyodide/pyodide @ 86e27b0
 Files: 540
 Provenant: 10.77s</title></circle>
+    <circle cx="529.79" cy="510.26" r="4.5" fill="#2563eb"><title>boostorg/serialization @ 097a6c6
+Files: 542
+Provenant: 13.15s</title></circle>
     <circle cx="530.30" cy="507.88" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 Provenant: 13.83s</title></circle>

--- a/src/copyright/detector/phases/primary.rs
+++ b/src/copyright/detector/phases/primary.rs
@@ -60,6 +60,16 @@ fn run_pre_pattern_repairs(
 
     let c_before = copyrights.len();
     let h_before = holders.len();
+    super::super::postprocess_transforms::merge_year_only_copyrights_with_following_contact_lines(
+        prepared_cache,
+        copyrights,
+        holders,
+    );
+    seen.dedup_new_copyrights(copyrights, c_before);
+    seen.dedup_new_holders(holders, h_before);
+
+    let c_before = copyrights.len();
+    let h_before = holders.len();
     super::super::postprocess_transforms::extract_licensed_material_of_company_bare_c_year_lines(
         prepared_cache,
         copyrights,

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -740,7 +740,10 @@ pub fn dedupe_exact_span_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
         return;
     }
     let mut seen: HashSet<(usize, usize, String)> = HashSet::new();
-    copyrights.retain(|c| seen.insert((c.start_line.get(), c.end_line.get(), c.copyright.clone())));
+    copyrights.retain(|c| {
+        let normalized = normalize_whitespace(&c.copyright).to_ascii_lowercase();
+        seen.insert((c.start_line.get(), c.end_line.get(), normalized))
+    });
 }
 
 pub fn dedupe_exact_span_holders(holders: &mut Vec<HolderDetection>) {

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -740,10 +740,7 @@ pub fn dedupe_exact_span_copyrights(copyrights: &mut Vec<CopyrightDetection>) {
         return;
     }
     let mut seen: HashSet<(usize, usize, String)> = HashSet::new();
-    copyrights.retain(|c| {
-        let normalized = normalize_whitespace(&c.copyright).to_ascii_lowercase();
-        seen.insert((c.start_line.get(), c.end_line.get(), normalized))
-    });
+    copyrights.retain(|c| seen.insert((c.start_line.get(), c.end_line.get(), c.copyright.clone())));
 }
 
 pub fn dedupe_exact_span_holders(holders: &mut Vec<HolderDetection>) {

--- a/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
@@ -128,21 +128,21 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
 
         let c_trimmed = c.copyright.trim();
         let c_lower = c_trimmed.to_ascii_lowercase();
+        let has_url_marker = c_lower.contains("http://") || c_lower.contains("https://");
         if !(c_lower.starts_with("(c)") || c_lower.starts_with("copyright (c)")) {
             continue;
         }
 
-        if !c.copyright.contains('@')
-            && !c_lower.contains("http://")
-            && !c_lower.contains("https://")
-        {
+        if !c.copyright.contains('@') && !has_url_marker {
             continue;
         }
-        if !(c_lower.contains("http://")
-            || c_lower.contains("https://")
+        if !(has_url_marker
             || c.copyright.contains('<') && c.copyright.contains('>')
             || c.copyright.contains('(') && c.copyright.contains(')'))
         {
+            continue;
+        }
+        if c_trimmed.contains(',') && !has_url_marker {
             continue;
         }
 
@@ -158,7 +158,7 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
             .filter_map(|name| refine_holder(&name))
             .collect();
 
-        if split_names.len() < 2 {
+        if split_names.len() < 2 && has_url_marker {
             let stripped = LEADING_COPY_YEAR_RE
                 .replace(&c.copyright, "")
                 .trim()
@@ -183,9 +183,12 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
         let joined = normalize_whitespace(&split_names.join(" "));
 
         let matching_joined_holder = holders.iter().find(|h| {
-            h.start_line.get() >= c.start_line.get()
-                && h.end_line.get() <= c.end_line.get()
-                && normalize_whitespace(&h.holder) == joined
+            let same_cluster = if has_url_marker {
+                h.start_line.get() >= c.start_line.get() && h.end_line.get() <= c.end_line.get()
+            } else {
+                h.start_line.get() == c.start_line.get() && h.end_line.get() == c.end_line.get()
+            };
+            same_cluster && normalize_whitespace(&h.holder) == joined
         });
 
         let Some(joined_holder) = matching_joined_holder else {

--- a/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/multiline_repairs.rs
@@ -104,12 +104,19 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
     static NAME_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?P<name>[^<>\n]+?)\s*<[^>\s]+@[^>\s]+>").expect("valid name-email regex")
     });
+    static NAME_PAREN_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?P<name>[^()\n]+?)\s*\([^()]*@[^()]*\)").expect("valid paren-email regex")
+    });
     static LEADING_COPY_YEAR_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?i)^\s*(?:copyright\s*)?\(c\)\s*(?:\d{2,4}(?:\s*-\s*\d{2,4})?(?:\s*,\s*\d{2,4})*)\s+",
         )
         .expect("valid leading copyright-year regex")
     });
+    static LEADING_URL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^\s*https?://\S+\s+").expect("valid leading url regex"));
+    static INLINE_URL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)\s+https?://\S+\s+").expect("valid inline url regex"));
 
     let mut to_add: Vec<HolderDetection> = Vec::new();
     let mut to_remove: HashSet<(usize, usize, String)> = HashSet::new();
@@ -124,23 +131,46 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
         if !(c_lower.starts_with("(c)") || c_lower.starts_with("copyright (c)")) {
             continue;
         }
-        if c_trimmed.contains(',') {
+
+        if !c.copyright.contains('@')
+            && !c_lower.contains("http://")
+            && !c_lower.contains("https://")
+        {
             continue;
         }
-
-        if !c.copyright.contains('@') || !c.copyright.contains('<') || !c.copyright.contains('>') {
+        if !(c_lower.contains("http://")
+            || c_lower.contains("https://")
+            || c.copyright.contains('<') && c.copyright.contains('>')
+            || c.copyright.contains('(') && c.copyright.contains(')'))
+        {
             continue;
         }
 
         let mut split_names: Vec<String> = NAME_EMAIL_RE
             .captures_iter(&c.copyright)
+            .chain(NAME_PAREN_EMAIL_RE.captures_iter(&c.copyright))
             .filter_map(|cap| {
                 cap.name("name")
                     .map(|m| normalize_whitespace(m.as_str().trim()))
             })
             .map(|name| LEADING_COPY_YEAR_RE.replace(&name, "").trim().to_string())
+            .map(|name| LEADING_URL_RE.replace(&name, "").trim().to_string())
             .filter_map(|name| refine_holder(&name))
             .collect();
+
+        if split_names.len() < 2 {
+            let stripped = LEADING_COPY_YEAR_RE
+                .replace(&c.copyright, "")
+                .trim()
+                .to_string();
+            split_names = INLINE_URL_RE
+                .split(&stripped)
+                .map(|name| normalize_whitespace(name.trim()))
+                .map(|name| LEADING_URL_RE.replace(&name, "").trim().to_string())
+                .filter(|name| name.split_whitespace().count() >= 2)
+                .filter_map(|name| refine_holder(&name))
+                .collect();
+        }
 
         if split_names.len() < 2 {
             continue;
@@ -152,31 +182,36 @@ pub fn split_multiline_holder_lists_from_copyright_email_sequences(
         }
         let joined = normalize_whitespace(&split_names.join(" "));
 
-        let mut has_joined_holder = false;
-        for h in holders.iter() {
-            if h.start_line.get() == c.start_line.get()
-                && h.end_line.get() == c.end_line.get()
+        let matching_joined_holder = holders.iter().find(|h| {
+            h.start_line.get() >= c.start_line.get()
+                && h.end_line.get() <= c.end_line.get()
                 && normalize_whitespace(&h.holder) == joined
-            {
-                has_joined_holder = true;
-                to_remove.insert((h.start_line.get(), h.end_line.get(), h.holder.clone()));
-            }
-        }
+        });
 
-        if !has_joined_holder {
+        let Some(joined_holder) = matching_joined_holder else {
             continue;
-        }
+        };
+
+        to_remove.insert((
+            joined_holder.start_line.get(),
+            joined_holder.end_line.get(),
+            joined_holder.holder.clone(),
+        ));
 
         for name in split_names {
-            let key = (c.start_line.get(), c.end_line.get(), name.clone());
+            let key = (
+                joined_holder.start_line.get(),
+                joined_holder.end_line.get(),
+                name.clone(),
+            );
             if !holders
                 .iter()
                 .any(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()) == key)
             {
                 to_add.push(HolderDetection {
                     holder: name,
-                    start_line: c.start_line,
-                    end_line: c.end_line,
+                    start_line: joined_holder.start_line,
+                    end_line: joined_holder.end_line,
                 });
             }
         }

--- a/src/copyright/detector/postprocess_transforms/year_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/year_repairs.rs
@@ -634,6 +634,185 @@ pub fn merge_year_only_copyrights_with_following_author_colon_lines(
     }
 }
 
+pub fn merge_year_only_copyrights_with_following_contact_lines(
+    prepared_cache: &PreparedLines<'_>,
+    copyrights: &mut Vec<CopyrightDetection>,
+    holders: &mut Vec<HolderDetection>,
+) {
+    if copyrights.is_empty() {
+        return;
+    }
+    if prepared_cache.raw_line_count() < 2 {
+        return;
+    }
+
+    static YEAR_ONLY_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)^copyright\s*\(c\)\s*(?P<years>[0-9\s,\-–/]+)$").unwrap()
+    });
+    static URL_ONLY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)^(?:https?://|www\.)\S+$").expect("valid url-only regex")
+    });
+    static ANGLE_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\s*<\s*[^>\s]+@[^>\s]+\s*>\s*").expect("valid angle-email regex")
+    });
+    static PAREN_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?ix)\s*\((?:[^()]*@[^()]*|(?:https?://|www\.)[^()]+)\)\s*$")
+            .expect("valid parenthesized contact regex")
+    });
+    static OBFUSCATED_EMAIL_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            \s+
+            [a-z0-9._%+\-]{1,64}
+            \s+at\s+
+            [a-z0-9._\-]{1,64}
+            (?:\s+dot\s+[a-z]{2,12}|\.[a-z]{2,12})
+            \s*$",
+        )
+        .expect("valid obfuscated email suffix regex")
+    });
+
+    fn clean_holder_candidate(line: &str) -> String {
+        let no_angle_email = ANGLE_EMAIL_RE.replace_all(line.trim(), " ").into_owned();
+        let no_paren_contact = PAREN_CONTACT_RE.replace(&no_angle_email, " ").into_owned();
+        let no_obfuscated = OBFUSCATED_EMAIL_SUFFIX_RE
+            .replace(&no_paren_contact, " ")
+            .into_owned();
+        normalize_whitespace(&no_obfuscated)
+    }
+
+    fn is_supported_contact_line(line: &str, has_following_url: bool) -> bool {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("copyright")
+            || lower.starts_with("author:")
+            || lower.starts_with("authors:")
+            || lower.starts_with("contact ")
+            || lower.starts_with("email ")
+            || lower.starts_with("mailto:")
+            || lower.starts_with("thanks to")
+            || lower.starts_with("written by")
+            || lower.starts_with("developed by")
+            || lower.starts_with("created by")
+            || lower.starts_with("distributed under")
+            || lower.starts_with("licensed under")
+            || lower.starts_with("http://")
+            || lower.starts_with("https://")
+            || lower.starts_with("www.")
+        {
+            return false;
+        }
+
+        let has_inline_contact = trimmed.contains('@')
+            || (trimmed.contains('<') && trimmed.contains('>'))
+            || lower.contains(" at ");
+        if !has_inline_contact && !has_following_url {
+            return false;
+        }
+
+        let holder_candidate = clean_holder_candidate(trimmed);
+        let words: Vec<&str> = holder_candidate.split_whitespace().collect();
+        if words.len() < 2 || holder_candidate.len() > 100 {
+            return false;
+        }
+        let all_lowercase_words = words.iter().all(|word| {
+            word.chars()
+                .find(|ch| ch.is_alphabetic())
+                .is_some_and(|ch| ch.is_lowercase())
+        });
+        if words.len() == 2 && all_lowercase_words {
+            return false;
+        }
+
+        refine_holder_in_copyright_context(&holder_candidate).is_some()
+    }
+
+    let mut seen_c: HashSet<(usize, usize, String)> = copyrights
+        .iter()
+        .map(|c| (c.start_line.get(), c.end_line.get(), c.copyright.clone()))
+        .collect();
+    let mut seen_h: HashSet<(usize, usize, String)> = holders
+        .iter()
+        .map(|h| (h.start_line.get(), h.end_line.get(), h.holder.clone()))
+        .collect();
+
+    for i in 1..prepared_cache.raw_line_count() {
+        let ln1 = i;
+        let ln2 = i + 1;
+
+        let Some(prev) = copyrights
+            .iter()
+            .find(|c| c.start_line.get() == ln1 && c.end_line.get() == ln1)
+        else {
+            continue;
+        };
+        let Some(cap) = YEAR_ONLY_COPY_RE.captures(prev.copyright.as_str()) else {
+            continue;
+        };
+        let years = cap.name("years").map(|m| m.as_str()).unwrap_or("").trim();
+        if years.is_empty()
+            || years.chars().any(|ch| ch.is_alphabetic())
+            || !years.chars().any(|ch| ch.is_ascii_digit())
+        {
+            continue;
+        }
+
+        let Some(next_prepared) = prepared_cache.get(ln2) else {
+            continue;
+        };
+        let next_line = next_prepared.trim();
+        let url_line = prepared_cache
+            .get(ln2 + 1)
+            .map(str::trim)
+            .filter(|line| URL_ONLY_RE.is_match(line));
+        if !is_supported_contact_line(next_line, url_line.is_some()) {
+            continue;
+        }
+
+        let base = prev.copyright.trim();
+        let raw = if let Some(url) = url_line {
+            format!("{base} {next_line} {url}")
+        } else {
+            format!("{base} {next_line}")
+        };
+        let Some(cr) = refine_copyright(&raw) else {
+            continue;
+        };
+
+        let end_line = if url_line.is_some() { ln2 + 1 } else { ln2 };
+        let ckey = (ln1, end_line, cr.clone());
+        if seen_c.insert(ckey) {
+            copyrights.push(CopyrightDetection {
+                copyright: cr,
+                start_line: LineNumber::new(ln1).expect("valid"),
+                end_line: LineNumber::new(end_line).expect("valid"),
+            });
+        }
+
+        let holder_candidate = clean_holder_candidate(next_line);
+        if let Some(h) = refine_holder_in_copyright_context(&holder_candidate) {
+            let hkey = (ln2, ln2, h.clone());
+            if seen_h.insert(hkey) {
+                holders.push(HolderDetection {
+                    holder: h,
+                    start_line: LineNumber::new(ln2).expect("valid"),
+                    end_line: LineNumber::new(ln2).expect("valid"),
+                });
+            }
+        }
+
+        copyrights.retain(|c| {
+            !(c.start_line.get() == ln1
+                && c.end_line.get() == ln1
+                && YEAR_ONLY_COPY_RE.is_match(c.copyright.as_str()))
+        });
+    }
+}
+
 pub fn extract_question_mark_year_copyrights(
     prepared_cache: &PreparedLines<'_>,
 ) -> (Vec<CopyrightDetection>, Vec<HolderDetection>) {

--- a/src/copyright/detector/postprocess_transforms/year_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/year_repairs.rs
@@ -724,7 +724,13 @@ pub fn merge_year_only_copyrights_with_following_contact_lines(
                 .find(|ch| ch.is_alphabetic())
                 .is_some_and(|ch| ch.is_lowercase())
         });
+        let trailing_stopword = words
+            .last()
+            .is_some_and(|word| matches!(word.to_ascii_lowercase().as_str(), "to"));
         if words.len() == 2 && all_lowercase_words {
+            return false;
+        }
+        if trailing_stopword {
             return false;
         }
 

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -231,6 +231,48 @@ fn test_add_missing_holder_from_preceding_name_line_for_year_only_copyright() {
 }
 
 #[test]
+fn test_merge_year_only_copyright_with_following_contact_line_and_url() {
+    let input = "// copyright (c) 2005\n// troy d. straszheim <troy@resophonic.com>\n// http://www.resophonic.com\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights.iter().any(|c| {
+            c.start_line == LineNumber::ONE
+                && c.end_line == LineNumber::new(3).unwrap()
+                && c.copyright
+                    == "copyright (c) 2005 troy d. straszheim <troy@resophonic.com> http://www.resophonic.com"
+        }),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        !copyrights.iter().any(|c| c.start_line == LineNumber::ONE
+            && c.end_line == LineNumber::ONE
+            && c.copyright == "copyright (c) 2005"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "troy d. straszheim"),
+        "holders: {holders:?}"
+    );
+}
+
+#[test]
+fn test_case_only_same_span_copyright_variants_are_deduped() {
+    let input = "// copyright (c) 2019 Samuel Debionne, ESRF\n";
+    let (copyrights, _holders, _authors) = detect_copyrights_from_text(input);
+
+    let matching = copyrights
+        .iter()
+        .filter(|c| {
+            c.copyright
+                .eq_ignore_ascii_case("copyright (c) 2019 Samuel Debionne, ESRF")
+        })
+        .count();
+
+    assert_eq!(matching, 1, "copyrights: {copyrights:?}");
+}
+
+#[test]
 fn test_descriptive_line_does_not_expand_year_only_copyright_holder() {
     let input = "Tru64 audio module for SDL (Simple DirectMedia Layer)\nCopyright (C) 2003\n";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -257,22 +257,6 @@ fn test_merge_year_only_copyright_with_following_contact_line_and_url() {
 }
 
 #[test]
-fn test_case_only_same_span_copyright_variants_are_deduped() {
-    let input = "// copyright (c) 2019 Samuel Debionne, ESRF\n";
-    let (copyrights, _holders, _authors) = detect_copyrights_from_text(input);
-
-    let matching = copyrights
-        .iter()
-        .filter(|c| {
-            c.copyright
-                .eq_ignore_ascii_case("copyright (c) 2019 Samuel Debionne, ESRF")
-        })
-        .count();
-
-    assert_eq!(matching, 1, "copyrights: {copyrights:?}");
-}
-
-#[test]
 fn test_descriptive_line_does_not_expand_year_only_copyright_holder() {
     let input = "Tru64 audio module for SDL (Simple DirectMedia Layer)\nCopyright (C) 2003\n";
     let (copyrights, holders, _authors) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -56,6 +56,40 @@ fn test_detect_html_multiline_copyright_keeps_copyright_word() {
 }
 
 #[test]
+fn test_html_copyright_table_row_splits_multiple_holders_cleanly() {
+    let input = concat!(
+        "<table summary=\"Copyright information\">\n",
+        "<tr valign=\"top\">\n",
+        "<td nowrap>Copyright &copy; 2001</td>\n",
+        "<td><a href=\"http://www.osl.iu.edu/~garcia\">Ronald Garcia</a>,\n",
+        "Indiana University\n",
+        "(<a href=\"mailto:garcia@cs.indiana.edu\">garcia@osl.iu.edu</a>)<br>\n",
+        "<a href=\"http://www.osl.iu.edu/~lums\">Andrew Lumsdaine</a>,\n",
+        "Indiana University\n",
+        "(<a href=\"mailto:lums@osl.iu.edu\">lums@osl.iu.edu</a>)</td>\n",
+        "</tr>\n",
+        "</table>\n",
+    );
+
+    let (_copyrights, holders, _authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = holders.iter().map(|h| h.holder.as_str()).collect();
+
+    assert!(
+        values.contains(&"Ronald Garcia, Indiana University"),
+        "holders: {values:?}"
+    );
+    assert!(
+        values.contains(&"Andrew Lumsdaine, Indiana University"),
+        "holders: {values:?}"
+    );
+    assert!(
+        !values.iter().any(|holder| holder
+            .contains("Ronald Garcia, Indiana University Andrew Lumsdaine, Indiana University")),
+        "holders: {values:?}"
+    );
+}
+
+#[test]
 fn test_extract_html_meta_name_copyright_content() {
     let content = concat!(
         r#"<meta name="copyright" content="copyright 2005-2006 Cedrik LIME"/>"#,

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1277,6 +1277,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_caps_after_company_suffix(&c);
     c = strip_trailing_javadoc_tags(&c);
     c = strip_trailing_batch_comment_marker(&c);
+    c = strip_trailing_bug_reports_after_year_only_copyright(&c);
     c = strip_prefixes(&c, &HashSet::from(["by", "c"]));
     c = c.trim().to_string();
     c = c.trim_matches('+').to_string();
@@ -2439,6 +2440,23 @@ fn strip_trailing_original_authors(s: &str) -> String {
     }
 }
 
+fn strip_trailing_bug_reports_after_year_only_copyright(s: &str) -> String {
+    static BUG_REPORTS_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)^.*?Copyright\s*\((?:c|C)\)\s*(?P<year>19\d{2}|20\d{2})\.?\s+Send\s+bug\s+reports\b.*$",
+        )
+        .unwrap()
+    });
+
+    BUG_REPORTS_COPY_RE
+        .captures(s.trim())
+        .and_then(|cap| {
+            cap.name("year")
+                .map(|m| format!("Copyright (c) {}", m.as_str().trim()))
+        })
+        .unwrap_or_else(|| s.to_string())
+}
+
 fn strip_trailing_paren_email_after_c_by(s: &str) -> String {
     static C_BY_PAREN_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -3008,6 +3026,12 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
     h = strip_trailing_period(&h);
     h = h.trim_matches(&[',', ' '][..]).to_string();
     h = normalize_whitespace(&h);
+    if h.split_whitespace()
+        .last()
+        .is_some_and(|word| matches!(word.to_ascii_lowercase().as_str(), "to"))
+    {
+        return None;
+    }
     h = truncate_long_words(&h);
     h = strip_trailing_single_digit_token(&h);
     h = strip_trailing_period(&h);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -686,6 +686,34 @@ fn contains_html_entity_decoder_artifact(s: &str) -> bool {
         || lower.contains("&#174")
 }
 
+fn normalize_markup_rich_text_fragment(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return s.to_string();
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let looks_like_markup_rich_text = lower.contains("href=")
+        || lower.contains("<a")
+        || lower.contains("</a")
+        || lower.contains("<br")
+        || lower.contains("<p")
+        || lower.contains("<td")
+        || lower.contains("<i>")
+        || lower.contains("&copy")
+        || lower.contains("mailto:");
+    if !looks_like_markup_rich_text {
+        return s.to_string();
+    }
+
+    let prepared = prepare_text_line(trimmed);
+    if prepared.is_empty() {
+        return s.to_string();
+    }
+
+    normalize_whitespace(&prepared)
+}
+
 fn contains_generated_resource_token(s: &str) -> bool {
     static ASSET_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)(?:@(?:1x|2x|3x|4x))?\.(?:png|jpg|jpeg|gif|webp|bmp|ico|icns|svg|ttf|otf|woff2?|img|tmpl|json|xml|yaml|yml|g\.dart)\b")
@@ -1181,7 +1209,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     if s.is_empty() {
         return None;
     }
-    let original = normalize_whitespace(s);
+    let original = normalize_whitespace(&normalize_markup_rich_text_fragment(s));
     if contains_windows_versioninfo_token(&original)
         || (contains_xml_markup_declaration_token(&original) && !has_copyright_year(&original))
     {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -377,6 +377,19 @@ fn test_remove_extra_words_mailto() {
 }
 
 #[test]
+fn test_refine_copyright_flattens_html_anchor_footer_notice() {
+    let result = refine_copyright(
+        r#"<p><i>&copy; Copyright <a href="http://www.rrsd.com">Robert Ramey</a> 2002-2004."#,
+    )
+    .expect("html footer notice should refine");
+
+    assert_eq!(
+        result,
+        "(c) Copyright http://www.rrsd.com Robert Ramey 2002-2004"
+    );
+}
+
+#[test]
 fn test_remove_extra_words_as_represented_by() {
     let result = remove_some_extra_words_and_punct("Acme Corp as represented by");
     assert_eq!(result, "Acme Corp as represented by");

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -390,9 +390,27 @@ fn test_refine_copyright_flattens_html_anchor_footer_notice() {
 }
 
 #[test]
+fn test_refine_copyright_truncates_bug_reports_tail_after_year_only_notice() {
+    let result = refine_copyright(
+        "by Gordon Chaffee Copyright (C) 1995. Send bug reports for the VFAT filesystem to <chaffee@cs.berkeley.edu>.",
+    )
+    .expect("bug-report notice should refine");
+
+    assert_eq!(result, "Copyright (c) 1995");
+}
+
+#[test]
 fn test_remove_extra_words_as_represented_by() {
     let result = remove_some_extra_words_and_punct("Acme Corp as represented by");
     assert_eq!(result, "Acme Corp as represented by");
+}
+
+#[test]
+fn test_refine_holder_drops_trailing_preposition_fragment() {
+    assert_eq!(
+        refine_holder_in_copyright_context("VFAT filesystem to"),
+        None
+    );
 }
 
 // ── is_junk_copyright ────────────────────────────────────────────

--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -30,9 +30,11 @@ pub(super) fn extract_email_url_information(
             max_urls: text_options.max_urls,
             unique: from_binary_strings,
         };
+        let mut seen_email_spans = HashSet::new();
         let emails = finder::find_emails(text_content, &config)
             .into_iter()
             .filter(|d| !apply_binary_contact_filters || is_binary_string_email_candidate(&d.email))
+            .filter(|d| seen_email_spans.insert((d.email.clone(), d.start_line, d.end_line)))
             .map(|d| OutputEmail {
                 email: d.email,
                 start_line: d.start_line,

--- a/src/scanner/process/contacts_test.rs
+++ b/src/scanner/process/contacts_test.rs
@@ -202,6 +202,37 @@ fn test_extract_email_url_information_keeps_gettext_mo_contacts() {
 }
 
 #[test]
+fn test_extract_email_url_information_deduplicates_exact_text_email_spans() {
+    let mut builder = FileInfoBuilder::default();
+    let options = TextDetectionOptions {
+        detect_emails: true,
+        detect_urls: false,
+        ..TextDetectionOptions::default()
+    };
+
+    extract_email_url_information(
+        &mut builder,
+        Path::new("doc.html"),
+        r#"(<a href=\"mailto:lums@osl.iu.edu\">lums@osl.iu.edu</a>)"#,
+        &options,
+        false,
+    );
+
+    let file = builder
+        .name("doc.html".to_string())
+        .base_name("doc".to_string())
+        .extension(".html".to_string())
+        .path("doc.html".to_string())
+        .file_type(FileType::File)
+        .size(1)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(file.emails.len(), 1, "emails: {:?}", file.emails);
+    assert_eq!(file.emails[0].email, "lums@osl.iu.edu");
+}
+
+#[test]
 fn test_extract_email_url_information_applies_binary_filters_to_font_paths() {
     let mut builder = FileInfoBuilder::default();
     let options = TextDetectionOptions {


### PR DESCRIPTION
## Summary

- fix year-only copyright recovery for contact-bearing continuation lines and dedupe case-only exact-span copyright variants
- clean HTML-rich copyright notices, split joined multi-person holders, and dedupe exact duplicate text-email spans
- verify `boostorg/serialization` at `097a6c63a137be836d663cdb27f2e6c803a4100b`, add a benchmark row in `docs/BENCHMARKS.md`, and regenerate `docs/scan-duration-vs-files.svg`

## Scope and exclusions

- Included:
  - generic copyright detector / refiner / contact cleanup in `src/copyright/**` and `src/scanner/process/contacts.rs`
  - focused detector/refiner/contact regression tests plus the narrow copyright golden check `test_fixture_boost_json_sse2`
  - optimized compare-output verification for `boostorg/serialization` (`.provenant/compare-runs/20260507T215504Z-serialization-16812/`)
- Explicit exclusions:
  - package-parser or assembly changes outside the shared copyright/contact pipeline
  - benchmark rows beyond `boostorg/serialization`

## Intentional differences from Python

- Preserve richer source-supported multi-person notice recovery where the file text names more than one party, while keeping Unicode/full-name spellings such as `René Ferdinand Rivera Morell` and `Joaquin M Lopez Munoz`.

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct:
  - the targeted copyright golden fixture `test_fixture_boost_json_sse2` still passes without fixture updates
  - the benchmark row and chart were regenerated from the optimized compare run at `.provenant/compare-runs/20260507T215504Z-serialization-16812/`