### PR TITLE
fix(copyright): verify asio benchmark holder normalization

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 196 of 196 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 197 of 197 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -580,6 +580,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `14.57s`; ScanCode `219.94s`
 - Broader Conan, Meson, and Bazel package visibility (`2` vs `1` packages, `3` vs `0` dependencies) from the root `conanfile.py`, `MODULE.bazel`, and committed `meson.build` manifests, with the local `LICENSE` notice in `.conan/test_package/conanfile.py` collapsed to plain `BSL-1.0` instead of ScanCode's extra unknown-reference placeholder
+
+##### [chriskohlhoff/asio @ bd500f0](https://github.com/chriskohlhoff/asio/tree/bd500f0a018db9a845ebaaed5c0318343ae9f497) — **17.58× faster**
+
+- Files: 1,468
+- Run context: 2026-05-07 · asio-38900 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
+- Timing: Provenant `18.97s`; ScanCode `333.52s`
+- More correct root Autotools package identity on `configure.ac` instead of ScanCode's generic input placeholder, plus cleaner holder normalization on `include/asio.hpp` and the Oliver Kowalke C++ notice set; the remaining ScanCode edge is limited to two multiline continuation headers and a small Perl author/copyright-email-tail set
 
 ##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **23.90× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -380,6 +380,9 @@ ScanCode: 110.49s</title></rect>
     <rect x="584.90" y="363.00" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/dejacode @ 4938cd4
 Files: 1278
 ScanCode: 272.67s</title></rect>
+    <rect x="594.45" y="353.48" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
+Files: 1468
+ScanCode: 333.52s</title></rect>
     <rect x="596.63" y="368.99" width="8" height="8" fill="#d97706" rx="1.5"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 ScanCode: 240.24s</title></rect>
@@ -970,6 +973,9 @@ Provenant: 12.05s</title></circle>
     <circle cx="588.90" cy="480.90" r="4.5" fill="#2563eb"><title>aboutcode-org/dejacode @ 4938cd4
 Files: 1278
 Provenant: 24.48s</title></circle>
+    <circle cx="598.45" cy="492.95" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
+Files: 1468
+Provenant: 18.97s</title></circle>
     <circle cx="600.63" cy="479.47" r="4.5" fill="#2563eb"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 Provenant: 25.23s</title></circle>

--- a/src/copyright/detector/postprocess_transforms/email_url_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/email_url_repairs.rs
@@ -424,9 +424,9 @@ pub fn strip_lone_obfuscated_angle_email_user_tokens(
         return;
     }
 
-    static ANGLE_OBF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    static BRACKETED_OBF_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?ix)<\s*(?P<user>[a-z0-9][a-z0-9._-]{0,63})\s*(?:\[\s*at\s*\]|at)\s*(?P<host>[a-z0-9][a-z0-9._-]{0,63})\s*(?:\[\s*dot\s*\]|dot)\s*(?P<tld>[a-z]{2,12})\s*>",
+            r"(?ix)(?:<|\()\s*(?P<user>[a-z0-9][a-z0-9._-]{0,63})\s*(?:\[\s*at\s*\]|at)\s*(?P<host>[a-z0-9][a-z0-9._-]{0,63})\s*(?:\[\s*dot\s*\]|dot)\s*(?P<tld>[a-z]{2,12})\s*(?:>|\))",
         )
         .unwrap()
     });
@@ -448,15 +448,38 @@ pub fn strip_lone_obfuscated_angle_email_user_tokens(
         if out.is_empty() { None } else { Some(out) }
     }
 
+    fn strip_trailing_obfuscated_fragment(s: &str, fragment: &str) -> Option<String> {
+        if fragment.is_empty() {
+            return None;
+        }
+        let trimmed = s.trim_end();
+        let lower = trimmed.to_ascii_lowercase();
+        let fragment_lower = fragment.to_ascii_lowercase();
+        if !lower.ends_with(&fragment_lower) {
+            return None;
+        }
+        let prefix = trimmed[..trimmed.len() - fragment.len()].trim_end();
+        if prefix.split_whitespace().count() < 2 {
+            return None;
+        }
+        Some(prefix.to_string())
+    }
+
     for (idx, raw_line) in raw_lines.iter().enumerate() {
         let ln = idx + 1;
-        let Some(cap) = ANGLE_OBF_RE.captures(raw_line) else {
+        let Some(cap) = BRACKETED_OBF_RE.captures(raw_line) else {
             continue;
         };
         let user = cap.name("user").map(|m| m.as_str()).unwrap_or("").trim();
+        let host = cap.name("host").map(|m| m.as_str()).unwrap_or("").trim();
         if user.is_empty() {
             continue;
         }
+        let trailing_fragment = if host.is_empty() {
+            user.to_string()
+        } else {
+            format!("{user} at {host}")
+        };
 
         for c in copyrights
             .iter_mut()
@@ -482,6 +505,16 @@ pub fn strip_lone_obfuscated_angle_email_user_tokens(
         {
             let lower = h.holder.to_ascii_lowercase();
             if lower.contains(" at ") || lower.contains(" dot ") {
+                if let Some(stripped) = strip_trailing_obfuscated_fragment(
+                    h.holder.as_str(),
+                    trailing_fragment.as_str(),
+                ) {
+                    if let Some(refined) = refine_holder(&stripped) {
+                        h.holder = refined;
+                    } else {
+                        h.holder = stripped;
+                    }
+                }
                 continue;
             }
             let Some(stripped) = strip_trailing_word(h.holder.as_str(), user) else {

--- a/src/copyright/detector/tests_copyright_holder_pipeline.rs
+++ b/src/copyright/detector/tests_copyright_holder_pipeline.rs
@@ -179,6 +179,24 @@ fn test_copyright_dash_email_tail_absorbed() {
 }
 
 #[test]
+fn test_parenthesized_obfuscated_email_holder_normalized_once() {
+    let input = "// Copyright (c) 2003-2026 Christopher M. Kohlhoff (chris at kohlhoff dot com)";
+    let (_c, h, _a) = detect_copyrights_from_text(input);
+    let holders: Vec<&str> = h.iter().map(|hh| hh.holder.as_str()).collect();
+
+    assert_eq!(holders, vec!["Christopher M. Kohlhoff"]);
+}
+
+#[test]
+fn test_dotted_local_part_parenthesized_obfuscated_holder_is_normalized() {
+    let input = "// Copyright (c) 2014 Oliver Kowalke (oliver dot kowalke at gmail dot com)";
+    let (_c, h, _a) = detect_copyrights_from_text(input);
+    let holders: Vec<&str> = h.iter().map(|hh| hh.holder.as_str()).collect();
+
+    assert_eq!(holders, vec!["Oliver Kowalke"]);
+}
+
+#[test]
 fn test_w3c_paren_group_debug() {
     let input = "(c) 1998-2008 (W3C) MIT, ERCIM, Keio University";
     let (c, _h, _a) = detect_copyrights_from_text(input);

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -2822,6 +2822,39 @@ fn strip_parenthesized_emails(s: &str) -> String {
     normalize_whitespace(&PAREN_EMAIL_RE.replace_all(s, " "))
 }
 
+fn strip_trailing_parenthesized_obfuscated_email_in_holder(s: &str) -> String {
+    static TRAILING_PAREN_OBFUSCATED_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^(?P<prefix>.+?)
+            \s*
+            \(
+                \s*
+                (?P<local>[a-z0-9][a-z0-9._-]{0,63}(?:\s+dot\s+[a-z0-9][a-z0-9._-]{0,63})*)
+                \s+at\s+
+                (?P<domain>[a-z0-9][a-z0-9._-]{0,63})
+                \s+dot\s+
+                (?P<tld>[a-z]{2,12})
+                \s*
+            \)
+            \s*$",
+        )
+        .unwrap()
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = TRAILING_PAREN_OBFUSCATED_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+
+    let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+    if prefix.split_whitespace().count() < 2 {
+        return s.to_string();
+    }
+
+    prefix.to_string()
+}
+
 fn strip_leading_and_onwards_holder_prefix(s: &str) -> String {
     static AND_ONWARDS_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?:and\s+)?onwards\b[\s,;:.-]*")
@@ -2859,6 +2892,7 @@ fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<String> {
         h = strip_angle_bracketed_emails(&h);
         h = strip_trailing_email_token(&h);
         h = strip_trailing_obfuscated_email_phrase_in_holder(&h);
+        h = strip_trailing_parenthesized_obfuscated_email_in_holder(&h);
     }
     h = strip_trailing_single_letter_obfuscated_email_phrase(&h);
     h = strip_parenthesized_emails(&h);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2265,6 +2265,22 @@ fn test_refine_holder_and_copyright_strip_single_letter_obfuscated_email_tail() 
 }
 
 #[test]
+fn test_refine_holder_in_copyright_context_strips_trailing_parenthesized_obfuscated_email() {
+    assert_eq!(
+        refine_holder_in_copyright_context("Christopher M. Kohlhoff (chris at kohlhoff dot com)"),
+        Some("Christopher M. Kohlhoff".to_string())
+    );
+    assert_eq!(
+        refine_holder_in_copyright_context("Oliver Kowalke (oliver dot kowalke at gmail dot com)"),
+        Some("Oliver Kowalke".to_string())
+    );
+    assert_eq!(
+        refine_holder_in_copyright_context("Peter Dimov (pdimov at gmail dot com), Vinnie Falco"),
+        Some("Peter Dimov (pdimov at gmail dot com), Vinnie Falco".to_string())
+    );
+}
+
+#[test]
 fn test_refine_copyright_drops_exclude_and_mpl_fair_use_noise() {
     assert_eq!(refine_copyright("copyright EXCLUDE"), None);
     assert_eq!(


### PR DESCRIPTION
## Summary

- Verify `chriskohlhoff/asio @ bd500f0a018db9a845ebaaed5c0318343ae9f497` with compare runs at `.provenant/compare-runs/20260507T214919Z-asio-9940`, `.provenant/compare-runs/20260507T221004Z-asio-36166`, and final optimized `.provenant/compare-runs/20260507T221217Z-asio-38900`
- Normalize obfuscated holder tails and partial obfuscated-email fragments so ASIO headers like `include/asio.hpp` emit clean holder names instead of duplicated noisy variants
- Add focused copyright detector/refiner coverage, rerun `cargo test --test copyright_golden --features golden-tests`, and record the optimized benchmark result in `docs/BENCHMARKS.md`

## Scope and exclusions

- Included: generic holder-cleanup improvements exercised by the ASIO benchmark, focused regression tests, benchmark row/doc refresh, and chart regeneration
- Explicit exclusions: no broader compare-normalization changes for the remaining two multiline continuation headers or the small Perl author/copyright-email-tail edge surfaced during ASIO triage

## Intentional differences from Python

- Provenant still preserves some source-faithful obfuscated-email detail in copyright strings where this PR only normalizes holder output; after ASIO triage, the remaining ScanCode-better edge is limited to two multiline continuation headers and a small Perl author/copyright-email-tail set

## Follow-up work

- Created or intentionally deferred:
  - Consider a follow-up for the two `include/asio/ip/address_v6_*` multiline continuation headers if we want full ScanCode parity on that specific notice shape

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: N/A