### PR TITLE
fix(finder): preserve archive URLs and short font emails

### DIFF
--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -246,7 +246,9 @@ pub(crate) fn classify_url(url: &str) -> bool {
     }
 
     let normalized = url.to_lowercase().trim_end_matches('/').to_string();
-    if has_embedded_nested_scheme_in_path(&normalized) {
+    if has_embedded_nested_scheme_in_path(&normalized)
+        && !is_archive_capture_url_with_embedded_target(&normalized)
+    {
         return false;
     }
     if JUNK_URLS.contains(&normalized.as_str()) {
@@ -269,4 +271,9 @@ fn has_embedded_nested_scheme_in_path(url: &str) -> bool {
     let rest = &url[first_scheme_idx + 3..];
     let pathish_prefix_end = rest.find(['?', '#']).unwrap_or(rest.len());
     rest[..pathish_prefix_end].contains("://")
+}
+
+fn is_archive_capture_url_with_embedded_target(url: &str) -> bool {
+    url.starts_with("http://web.archive.org/web/")
+        || url.starts_with("https://web.archive.org/web/")
 }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -279,6 +279,32 @@ mod tests {
     }
 
     #[test]
+    fn test_find_urls_keeps_wayback_archive_capture_with_embedded_http_target() {
+        let text = "http://web.archive.org/web/20160201063255/http://download.microsoft.com/download/foo.exe";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(
+            urls[0].url,
+            "http://web.archive.org/web/20160201063255/http://download.microsoft.com/download/foo.exe"
+        );
+    }
+
+    #[test]
+    fn test_find_urls_keeps_wayback_archive_capture_with_embedded_https_target() {
+        let text = "https://web.archive.org/web/20231103044404/https://raphlinus.github.io/graphics/2020/04/21/blurred-rounded-rects.html";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(
+            urls[0].url,
+            "https://web.archive.org/web/20231103044404/https://raphlinus.github.io/graphics/2020/04/21/blurred-rounded-rects.html"
+        );
+    }
+
+    #[test]
     fn test_find_urls_filters_code_variable_host_artifacts() {
         let text = "loginUrl = \"http://os.environ['DD_BASE_URL']/login\"";
         let config = DetectionConfig::default();

--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -21,8 +21,12 @@ pub(super) fn extract_email_url_information(
         return;
     }
 
+    let applies_gettext_exception = is_gettext_mo_path(path);
+    let is_font_metadata_path = !from_binary_strings && is_font_metadata_contact_path(path);
     let apply_binary_contact_filters =
-        (from_binary_strings || is_font_metadata_contact_path(path)) && !is_gettext_mo_path(path);
+        (from_binary_strings || is_font_metadata_path) && !applies_gettext_exception;
+    let font_metadata_lines =
+        is_font_metadata_path.then(|| text_content.lines().collect::<Vec<_>>());
 
     if text_options.detect_emails {
         let config = DetectionConfig {
@@ -33,7 +37,15 @@ pub(super) fn extract_email_url_information(
         let mut seen_email_spans = HashSet::new();
         let emails = finder::find_emails(text_content, &config)
             .into_iter()
-            .filter(|d| !apply_binary_contact_filters || is_binary_string_email_candidate(&d.email))
+            .filter(|d| {
+                !apply_binary_contact_filters
+                    || is_binary_string_email_candidate(&d.email)
+                    || is_short_font_metadata_email_alias(
+                        font_metadata_lines.as_deref(),
+                        &d.email,
+                        d.start_line,
+                    )
+            })
             .filter(|d| seen_email_spans.insert((d.email.clone(), d.start_line, d.end_line)))
             .map(|d| OutputEmail {
                 email: d.email,
@@ -89,6 +101,61 @@ fn is_gettext_mo_path(path: &Path) -> bool {
 
 fn is_font_metadata_contact_path(path: &Path) -> bool {
     is_supported_font_path(path)
+}
+
+fn is_short_font_metadata_email_alias(
+    font_metadata_lines: Option<&[&str]>,
+    email: &str,
+    line_number: LineNumber,
+) -> bool {
+    let raw_line = font_metadata_lines
+        .and_then(|lines| lines.get(line_number.get() - 1).copied())
+        .map(|line| {
+            line.trim().trim_matches(|c: char| {
+                matches!(
+                    c,
+                    '<' | '>' | '(' | ')' | '[' | ']' | '"' | '\'' | '`' | ',' | ';'
+                )
+            })
+        })
+        .unwrap_or("");
+    let normalized_email = email.to_ascii_lowercase();
+    let raw_line_lower = raw_line.to_ascii_lowercase();
+    let Some(email_start) = raw_line_lower.find(&normalized_email) else {
+        return false;
+    };
+    let email_end = email_start + normalized_email.len();
+    let prefix = &raw_line[email_start.saturating_sub(email_start)..email_start];
+    let suffix = &raw_line[email_end..];
+    let extra = [prefix, suffix].concat();
+    if !extra.is_empty()
+        && (extra.contains(char::is_whitespace)
+            || extra.contains('@')
+            || extra.chars().count() > 12
+            || extra.chars().filter(|c| c.is_ascii_alphanumeric()).count() > 2)
+    {
+        return false;
+    }
+
+    let Some((local, domain)) = email.rsplit_once('@') else {
+        return false;
+    };
+    let Some((host, tld)) = domain.rsplit_once('.') else {
+        return false;
+    };
+
+    !local.is_empty()
+        && local.len() <= 2
+        && local.chars().any(|c| c.is_ascii_alphabetic())
+        && local
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '%' | '+' | '-'))
+        && !host.is_empty()
+        && host.len() <= 2
+        && host.chars().all(|c| c.is_ascii_alphanumeric())
+        && (2..=3).contains(&tld.len())
+        && tld.chars().all(|c| c.is_ascii_alphabetic())
+        && raw_line.chars().any(|c| c.is_ascii_uppercase())
 }
 
 fn collect_binary_url_salvage_detections(text_content: &str) -> Vec<OutputURL> {

--- a/src/scanner/process/contacts_test.rs
+++ b/src/scanner/process/contacts_test.rs
@@ -265,6 +265,42 @@ fn test_extract_email_url_information_applies_binary_filters_to_font_paths() {
 }
 
 #[test]
+fn test_extract_email_url_information_keeps_short_uppercase_font_metadata_email() {
+    let mut builder = FileInfoBuilder::default();
+    let options = TextDetectionOptions {
+        detect_emails: true,
+        detect_urls: true,
+        ..TextDetectionOptions::default()
+    };
+
+    extract_email_url_information(
+        &mut builder,
+        Path::new("font.ttf"),
+        "xx/A@0.CC\nhttp://www.apache.org/licenses/LICENSE-2.0",
+        &options,
+        false,
+    );
+
+    let file = builder
+        .name("font.ttf".to_string())
+        .base_name("font".to_string())
+        .extension(".ttf".to_string())
+        .path("font.ttf".to_string())
+        .file_type(FileType::File)
+        .size(1)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(file.emails.len(), 1, "emails: {:?}", file.emails);
+    assert_eq!(file.emails[0].email, "a@0.cc");
+    assert_eq!(file.urls.len(), 1, "urls: {:?}", file.urls);
+    assert_eq!(
+        file.urls[0].url,
+        "http://www.apache.org/licenses/LICENSE-2.0"
+    );
+}
+
+#[test]
 fn test_extract_email_url_information_prefers_unique_text_emails_before_cap() {
     let mut builder = FileInfoBuilder::default();
     let options = TextDetectionOptions {


### PR DESCRIPTION
## Summary

- preserve valid Wayback capture URLs with embedded targets instead of dropping them as generic nested-scheme artifacts, with focused finder coverage for HTTP and HTTPS archive shapes
- keep short uppercase font metadata emails such as Roboto's `A@0.CC` without reopening the existing junk-font filter path, with targeted contacts coverage
- verify Flutter against `.provenant/compare-runs/20260508T075208Z-flutter-49697`, where the targeted archive-URL and font-email regressions are resolved and the remaining Doxyfile `libiconv` delta is triaged as ScanCode counting duplicate slash/non-slash variants while Provenant emits the canonical URL once

## Issues

- Covers: Flutter compare-output regression triage and rerun verification
- Closes: none

## Scope and exclusions

- Included: `src/finder/junk_data.rs`, `src/finder/mod.rs`, `src/scanner/process/contacts.rs`, `src/scanner/process/contacts_test.rs`, focused unit coverage, direct one-file validation for `Roboto-Medium.ttf`, and the final Flutter `compare-outputs` rerun
- Explicit exclusions: benchmark doc refreshes, broader URL de-duplication parity changes, and separate follow-up work for repeated text URL count parity beyond the triaged `libiconv` duplicate case

## Intentional differences from Python

- Provenant continues to preserve canonical Wayback capture URLs instead of ScanCode's malformed one-slash archive strings, and it continues to normalize extracted email values to lowercase

## Follow-up work

- Created or intentionally deferred: revisit repeated per-file URL count parity only if duplicate text URL occurrences become materially important beyond the triaged `libiconv` slash/non-slash duplication in Flutter's Doxyfiles

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no checked-in expected fixtures changed; correctness was validated with focused unit tests, a direct Roboto scan, and the final Flutter compare rerun