### PR TITLE
refactor(license-detection): introduce RuleId newtype replacing bare usize rule IDs

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -13,7 +13,7 @@
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleId};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::QueryRun;
 use crate::models::LineNumber;
@@ -123,7 +123,7 @@ pub fn aho_match_with_extra_matchables(
             continue;
         }
 
-        let rid = RuleId::new(ac_match.pattern);
+        let rid = ac_match.rule_id;
 
         let matched_length = qend - qstart;
 

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -13,7 +13,7 @@
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleId};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::QueryRun;
 use crate::models::LineNumber;
@@ -123,20 +123,21 @@ pub fn aho_match_with_extra_matchables(
             continue;
         }
 
-        let rid = ac_match.pattern;
-        if rid >= index.rules_by_rid.len() {
+        let rid_raw = ac_match.pattern;
+        if rid_raw >= index.rules_by_rid.len() {
             continue;
         }
 
+        let rid = RuleId::new(rid_raw);
+
         let matched_length = qend - qstart;
 
-        // Skip zero-length matches (empty patterns)
         if matched_length == 0 {
             continue;
         }
 
-        let rule = &index.rules_by_rid[rid];
-        let rule_tids = &index.tids_by_rid[rid];
+        let rule = &index.rules_by_rid[rid.raw()];
+        let rule_tids = &index.tids_by_rid[rid.raw()];
         let rule_length = rule.tokens.len();
 
         let match_coverage = if rule_length > 0 {

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -123,12 +123,7 @@ pub fn aho_match_with_extra_matchables(
             continue;
         }
 
-        let rid_raw = ac_match.pattern;
-        if rid_raw >= index.rules_by_rid.len() {
-            continue;
-        }
-
-        let rid = RuleId::new(rid_raw);
+        let rid = RuleId::new(ac_match.pattern);
 
         let matched_length = qend - qstart;
 
@@ -136,8 +131,12 @@ pub fn aho_match_with_extra_matchables(
             continue;
         }
 
-        let rule = &index.rules_by_rid[rid.raw()];
-        let rule_tids = &index.tids_by_rid[rid.raw()];
+        let Some(rule) = index.rule(rid) else {
+            continue;
+        };
+        let Some(rule_tids) = index.rule_tokens(rid) else {
+            continue;
+        };
         let rule_length = rule.tokens.len();
 
         let match_coverage = if rule_length > 0 {

--- a/src/license_detection/automaton.rs
+++ b/src/license_detection/automaton.rs
@@ -8,6 +8,7 @@
 //! The daachorse library provides ~85% smaller binary size and built-in
 //! serialization support.
 
+use crate::license_detection::models::RuleId;
 use daachorse::DoubleArrayAhoCorasick;
 use rancor::Fallible;
 use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
@@ -49,8 +50,8 @@ where
 /// A match found by the automaton.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Match {
-    /// Pattern ID (index into the original pattern list).
-    pub pattern: usize,
+    /// The rule ID associated with the matched pattern.
+    pub rule_id: RuleId,
     /// Start position in haystack (bytes, inclusive).
     pub start: usize,
     /// End position in haystack (bytes, exclusive).
@@ -171,7 +172,7 @@ impl Iterator for FindOverlappingIter {
             // start at even byte positions. Odd positions would span tokens.
             if m.start() % 2 == 0 {
                 return Some(Match {
-                    pattern: m.value() as usize,
+                    rule_id: RuleId::new(m.value() as usize),
                     start: m.start(),
                     end: m.end(),
                 });
@@ -302,8 +303,8 @@ mod tests {
 
         let matches: Vec<_> = ac.find_overlapping_iter(b"hello world").collect();
         assert_eq!(matches.len(), 2);
-        assert_eq!(matches[0].pattern, 42);
-        assert_eq!(matches[1].pattern, 99);
+        assert_eq!(matches[0].rule_id, RuleId::new(42));
+        assert_eq!(matches[1].rule_id, RuleId::new(99));
     }
 
     #[test]
@@ -315,8 +316,8 @@ mod tests {
 
         let matches: Vec<_> = ac.find_overlapping_iter(b"hello").collect();
         assert_eq!(matches.len(), 2);
-        let mut values: Vec<usize> = matches.iter().map(|m| m.pattern).collect();
+        let mut values: Vec<RuleId> = matches.iter().map(|m| m.rule_id).collect();
         values.sort();
-        assert_eq!(values, vec![10, 20]);
+        assert_eq!(values, vec![RuleId::new(10), RuleId::new(20)]);
     }
 }

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -650,7 +650,7 @@ mod tests {
 
     fn create_test_match(coverage: f32, rule_identifier: &str) -> LicenseMatch {
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),
@@ -693,7 +693,7 @@ mod tests {
         let start_line = LineNumber::new(start_line).expect("valid start_line");
         let end_line = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: license_expression.to_string(),
             license_expression_spdx: Some(license_expression.to_string()),
             from_file: Some("test.txt".to_string()),

--- a/src/license_detection/detection/grouping.rs
+++ b/src/license_detection/detection/grouping.rs
@@ -223,7 +223,7 @@ mod tests {
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),
@@ -262,7 +262,7 @@ mod tests {
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),

--- a/src/license_detection/detection/identifier.rs
+++ b/src/license_detection/detection/identifier.rs
@@ -170,7 +170,7 @@ mod tests {
 
     fn create_test_match() -> LicenseMatch {
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -712,7 +712,7 @@ mod tests {
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -65,7 +65,7 @@ mod tests {
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
-            rid: 0,
+            rid: crate::license_detection::models::RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("test.txt".to_string()),

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -59,8 +59,12 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
     let query_hash = compute_hash(query_run.tokens());
 
     if let Some(rid) = index.rid_by_hash.get(&query_hash) {
-        let rule = &index.rules_by_rid[rid.raw()];
-        let itokens = &index.tids_by_rid[rid.raw()];
+        let Some(rule) = index.rule(*rid) else {
+            return matches;
+        };
+        let Some(itokens) = index.rule_tokens(*rid) else {
+            return matches;
+        };
 
         let rule_length = rule.tokens.len();
 

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -58,9 +58,9 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
     let mut matches = Vec::new();
     let query_hash = compute_hash(query_run.tokens());
 
-    if let Some(&rid) = index.rid_by_hash.get(&query_hash) {
-        let rule = &index.rules_by_rid[rid];
-        let itokens = &index.tids_by_rid[rid];
+    if let Some(rid) = index.rid_by_hash.get(&query_hash) {
+        let rule = &index.rules_by_rid[rid.raw()];
+        let itokens = &index.tids_by_rid[rid.raw()];
 
         let rule_length = rule.tokens.len();
 
@@ -105,7 +105,7 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
             rule_length,
             match_coverage,
             rule_relevance: rule.relevance,
-            rid,
+            rid: *rid,
             rule_identifier: rule.identifier.clone(),
             rule_url: rule.rule_url().unwrap_or_default(),
             matched_text: None,

--- a/src/license_detection/hash_match_test.rs
+++ b/src/license_detection/hash_match_test.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::license_detection::index::IndexedRuleMetadata;
 use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::models::Rule;
+use crate::license_detection::models::RuleId;
 use crate::license_detection::test_utils::{create_mock_query_with_tokens, create_test_index};
 use crate::models::MatchScore;
 
@@ -145,7 +146,9 @@ fn test_hash_match_no_match() {
     let rules_by_rid = create_test_rules_by_rid();
     let tids_by_rid = vec![tids(&[0, 1]), tids(&[2, 3, 4])];
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[5, 6, 7])), 0);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[5, 6, 7])), RuleId::new(0));
     index.rules_by_rid = rules_by_rid;
     index.tids_by_rid = tids_by_rid;
 
@@ -166,7 +169,9 @@ fn test_hash_match_with_match() {
     let rules_by_rid = create_test_rules_by_rid();
     let tids_by_rid = vec![tids(&[0, 1]), tids(&[2, 3, 4])];
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 0);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(0));
     index.rules_by_rid = rules_by_rid;
     index.tids_by_rid = tids_by_rid;
 
@@ -184,7 +189,9 @@ fn test_hash_match_with_match() {
 fn test_hash_match_uses_precomputed_spdx_expression() {
     let mut index = create_test_index(&[("mit", 0), ("license", 1)], 2);
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 0);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(0));
     index.rules_by_rid = vec![create_test_rules_by_rid()[0].clone()];
     index.tids_by_rid = vec![tids(&[0, 1])];
     index.rule_metadata_by_identifier.insert(
@@ -210,7 +217,9 @@ fn test_hash_match_hispan_filters_legalese() {
     let rules_by_rid = create_test_rules_by_rid();
     let tids_by_rid = vec![tids(&[0, 1]), tids(&[2, 3, 4])];
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 0);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(0));
     index.rules_by_rid = rules_by_rid;
     index.tids_by_rid = tids_by_rid;
 
@@ -274,8 +283,12 @@ fn test_hash_match_multiple_rules_same_hash() {
     let rules_by_rid = create_test_rules_by_rid();
     let tids_by_rid = vec![tids(&[0, 1]), tids(&[2, 3, 4])];
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 0);
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 1);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(0));
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(1));
     index.rules_by_rid = rules_by_rid;
     index.tids_by_rid = tids_by_rid;
 
@@ -297,7 +310,9 @@ fn test_hash_match_returns_correct_license_expression() {
     let rules_by_rid = create_test_rules_by_rid();
     let tids_by_rid = vec![tids(&[0, 1])];
 
-    index.rid_by_hash.insert(compute_hash(&tids(&[0, 1])), 0);
+    index
+        .rid_by_hash
+        .insert(compute_hash(&tids(&[0, 1])), RuleId::new(0));
     index.rules_by_rid = rules_by_rid;
     index.tids_by_rid = tids_by_rid;
 

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -17,7 +17,7 @@ use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{
     KnownToken, TokenDictionary, TokenId, TokenKind,
 };
-use crate::license_detection::models::{License, LoadedLicense, LoadedRule, Rule};
+use crate::license_detection::models::{License, LoadedLicense, LoadedRule, Rule, RuleId};
 use crate::license_detection::rules::legalese;
 use crate::license_detection::rules::thresholds::{
     SMALL_RULE, TINY_RULE, compute_thresholds_occurrences, compute_thresholds_unique,
@@ -67,7 +67,7 @@ const DEPRECATED_SPDX_SUBS: &[(&str, &str)] = &[
     ),
 ];
 
-fn add_deprecated_spdx_aliases(rid_by_spdx_key: &mut HashMap<String, usize>) {
+fn add_deprecated_spdx_aliases(rid_by_spdx_key: &mut HashMap<String, RuleId>) {
     for (deprecated, replacement) in DEPRECATED_SPDX_SUBS {
         if let Some(&rid) = rid_by_spdx_key.get(*replacement) {
             rid_by_spdx_key.insert(deprecated.to_string(), rid);
@@ -353,16 +353,16 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
             .filter_map(|&token| dictionary.lookup(token).map(|token| token.id)),
     );
 
-    let mut rid_by_hash: HashMap<[u8; 20], usize> = HashMap::new();
+    let mut rid_by_hash: HashMap<[u8; 20], RuleId> = HashMap::new();
     let mut rules_by_rid: Vec<Rule> = Vec::with_capacity(rules.len());
     let mut tids_by_rid: Vec<Vec<TokenId>> = Vec::with_capacity(rules.len());
-    let mut sets_by_rid: HashMap<usize, TokenSet> = HashMap::new();
-    let mut msets_by_rid: HashMap<usize, TokenMultiset> = HashMap::new();
-    let mut high_sets_by_rid: HashMap<usize, TokenSet> = HashMap::new();
-    let mut high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>> = HashMap::new();
-    let mut false_positive_rids: HashSet<usize> = HashSet::new();
-    let mut approx_matchable_rids: HashSet<usize> = HashSet::new();
-    let mut rids_by_high_tid: HashMap<TokenId, HashSet<usize>> = HashMap::new();
+    let mut sets_by_rid: HashMap<RuleId, TokenSet> = HashMap::new();
+    let mut msets_by_rid: HashMap<RuleId, TokenMultiset> = HashMap::new();
+    let mut high_sets_by_rid: HashMap<RuleId, TokenSet> = HashMap::new();
+    let mut high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>> = HashMap::new();
+    let mut false_positive_rids: HashSet<RuleId> = HashSet::new();
+    let mut approx_matchable_rids: HashSet<RuleId> = HashSet::new();
+    let mut rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>> = HashMap::new();
 
     let mut rules_builder = AutomatonBuilder::new();
     let mut unknown_automaton_patterns: Vec<Vec<u8>> = Vec::new();
@@ -381,10 +381,11 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     let mut all_rules: Vec<Rule> = license_rules.into_iter().chain(rules).collect();
     all_rules.sort();
 
-    let mut rid_by_spdx_key: HashMap<String, usize> = HashMap::new();
-    let mut unknown_spdx_rid: Option<usize> = None;
+    let mut rid_by_spdx_key: HashMap<String, RuleId> = HashMap::new();
+    let mut unknown_spdx_rid: Option<RuleId> = None;
 
     for (rid, mut rule) in all_rules.into_iter().enumerate() {
+        let rule_id = RuleId::new(rid);
         rule.required_phrase_spans = parse_required_phrase_spans(&rule.text);
         let (rule_tokens, stopwords_by_pos) = tokenize_with_stopwords(&rule.text);
         rule.stopwords_by_pos = stopwords_by_pos;
@@ -419,17 +420,17 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         // Empty patterns (from non-ASCII text like Japanese) would match everywhere
         if !rule_token_ids.is_empty() {
             let pattern = tokens_to_bytes(&rule_token_ids);
-            rules_builder.add_pattern_with_value(&pattern, rid as u32);
+            rules_builder.add_pattern_with_value(&pattern, rule_id.raw() as u32);
         }
 
         if rule.is_false_positive {
-            false_positive_rids.insert(rid);
+            false_positive_rids.insert(rule_id);
             rules_by_rid.push(rule);
             tids_by_rid.push(rule_token_ids);
             continue;
         }
 
-        rid_by_hash.insert(rule_hash, rid);
+        rid_by_hash.insert(rule_hash, rule_id);
 
         // Match Python indexing order: approx-matchable membership is decided
         // before compute_thresholds() later derives final is_small/is_tiny flags.
@@ -448,7 +449,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         }
 
         if is_approx_matchable && !is_weak {
-            approx_matchable_rids.insert(rid);
+            approx_matchable_rids.insert(rule_id);
 
             let mut postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
             for (pos, token) in known_rule_tokens.iter().enumerate() {
@@ -457,30 +458,30 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
                 }
             }
             if !postings.is_empty() {
-                high_postings_by_rid.insert(rid, postings);
+                high_postings_by_rid.insert(rule_id, postings);
             }
         }
 
         let tids_set = TokenSet::from_token_ids(rule_token_ids.iter().copied());
         let mset = TokenMultiset::from_token_ids(&rule_token_ids);
 
-        sets_by_rid.insert(rid, tids_set.clone());
-        msets_by_rid.insert(rid, mset.clone());
+        sets_by_rid.insert(rule_id, tids_set.clone());
+        msets_by_rid.insert(rule_id, mset.clone());
 
         let tids_set_high = tids_set.high_subset(&dictionary);
         let mset_high = mset.high_subset(&dictionary);
 
         if !tids_set_high.is_empty() {
-            high_sets_by_rid.insert(rid, tids_set_high.clone());
+            high_sets_by_rid.insert(rule_id, tids_set_high.clone());
         }
 
         // Build inverted index: map high-value tokens to rules containing them
-        if approx_matchable_rids.contains(&rid) {
+        if approx_matchable_rids.contains(&rule_id) {
             for tid in tids_set_high.iter() {
                 rids_by_high_tid
                     .entry(TokenId::new(tid))
                     .or_default()
-                    .insert(rid);
+                    .insert(rule_id);
             }
         }
 
@@ -508,14 +509,14 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         rule.is_tiny = rule_length < TINY_RULE;
 
         if let Some(ref spdx_key) = rule.spdx_license_key {
-            rid_by_spdx_key.insert(spdx_key.to_lowercase(), rid);
+            rid_by_spdx_key.insert(spdx_key.to_lowercase(), rule_id);
         }
         for alias in &rule.other_spdx_license_keys {
-            rid_by_spdx_key.insert(alias.to_lowercase(), rid);
+            rid_by_spdx_key.insert(alias.to_lowercase(), rule_id);
         }
 
         if rule.license_expression == "unknown-spdx" {
-            unknown_spdx_rid = Some(rid);
+            unknown_spdx_rid = Some(rule_id);
         }
 
         rules_by_rid.push(rule);

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -360,8 +360,6 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     let mut msets_by_rid: HashMap<RuleId, TokenMultiset> = HashMap::new();
     let mut high_sets_by_rid: HashMap<RuleId, TokenSet> = HashMap::new();
     let mut high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>> = HashMap::new();
-    let mut false_positive_rids: HashSet<RuleId> = HashSet::new();
-    let mut approx_matchable_rids: HashSet<RuleId> = HashSet::new();
     let mut rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>> = HashMap::new();
 
     let mut rules_builder = AutomatonBuilder::new();
@@ -424,7 +422,6 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         }
 
         if rule.is_false_positive {
-            false_positive_rids.insert(rule_id);
             rules_by_rid.push(rule);
             tids_by_rid.push(rule_token_ids);
             continue;
@@ -449,8 +446,6 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         }
 
         if is_approx_matchable && !is_weak {
-            approx_matchable_rids.insert(rule_id);
-
             let mut postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
             for (pos, token) in known_rule_tokens.iter().enumerate() {
                 if token.kind == TokenKind::Legalese {
@@ -476,7 +471,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         }
 
         // Build inverted index: map high-value tokens to rules containing them
-        if approx_matchable_rids.contains(&rule_id) {
+        if is_approx_matchable && !is_weak {
             for tid in tids_set_high.iter() {
                 rids_by_high_tid
                     .entry(TokenId::new(tid))
@@ -552,8 +547,6 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         msets_by_rid,
         high_sets_by_rid,
         high_postings_by_rid,
-        false_positive_rids,
-        approx_matchable_rids,
         licenses_by_key,
         rid_by_spdx_key,
         unknown_spdx_rid,

--- a/src/license_detection/index/builder/tests.rs
+++ b/src/license_detection/index/builder/tests.rs
@@ -189,15 +189,18 @@ mod test_cases {
 
         let index = build_index(vec![stored_rule, computed_rule], vec![]);
 
-        let stored = &index.rules_by_rid[find_rid_by_identifier(&index, "stored.RULE")
-            .expect("stored rule should exist")
-            .raw()];
+        let stored = index
+            .rule(find_rid_by_identifier(&index, "stored.RULE").expect("stored rule should exist"))
+            .expect("test rid must be valid");
         assert_eq!(stored.minimum_coverage, Some(99));
         assert!(stored.has_stored_minimum_coverage);
 
-        let computed = &index.rules_by_rid[find_rid_by_identifier(&index, "computed.RULE")
-            .expect("computed rule should exist")
-            .raw()];
+        let computed = index
+            .rule(
+                find_rid_by_identifier(&index, "computed.RULE")
+                    .expect("computed rule should exist"),
+            )
+            .expect("test rid must be valid");
         assert_eq!(computed.minimum_coverage, Some(50));
         assert!(!computed.has_stored_minimum_coverage);
     }
@@ -414,7 +417,7 @@ mod test_cases {
 
         let mut rules_with_empty_tokens = 0;
         for &rid in index.rid_by_hash.values() {
-            let rule = &index.rules_by_rid[rid.raw()];
+            let rule = index.rule(rid).expect("test rid must be valid");
             if rule.tokens.is_empty() {
                 rules_with_empty_tokens += 1;
             }
@@ -438,7 +441,7 @@ mod test_cases {
 
         if !index.approx_matchable_rids.is_empty() {
             for &rid in &index.approx_matchable_rids {
-                let rule = &index.rules_by_rid[rid.raw()];
+                let rule = index.rule(rid).expect("test rid must be valid");
                 assert!(!rule.is_false_positive);
             }
         }
@@ -462,7 +465,7 @@ mod test_cases {
         assert_eq!(index.rid_by_hash.len(), 3);
 
         let rid = find_rid_by_identifier(&index, "auto1.RULE").expect("rule should exist");
-        let rule_tokens = &index.tids_by_rid[rid.raw()];
+        let rule_tokens = index.rule_tokens(rid).expect("test rid must be valid");
         let pattern: Vec<u8> = rule_tokens.iter().flat_map(|t| t.to_le_bytes()).collect();
 
         let matches: Vec<_> = index
@@ -481,7 +484,7 @@ mod test_cases {
         let index = build_index(rules, vec![]);
 
         let rid = find_rid_by_identifier(&index, "thresholds.RULE").expect("rule should exist");
-        let rule = &index.rules_by_rid[rid.raw()];
+        let rule = index.rule(rid).expect("test rid must be valid");
 
         assert!(rule.length_unique > 0, "length_unique should be computed");
         assert!(
@@ -583,7 +586,7 @@ mod test_cases {
 
         let index = build_index(vec![tiny_rule], vec![]);
         let rid = find_rid_by_identifier(&index, "tiny-legalese.RULE").expect("tiny rule");
-        let stored_rule = &index.rules_by_rid[rid.raw()];
+        let stored_rule = index.rule(rid).expect("test rid must be valid");
 
         assert!(stored_rule.is_tiny);
         assert!(index.approx_matchable_rids.contains(&rid));
@@ -602,7 +605,7 @@ mod test_cases {
 
         let index = build_index(vec![reference_rule], vec![]);
         let rid = find_rid_by_identifier(&index, "small-reference.RULE").expect("reference rule");
-        let stored_rule = &index.rules_by_rid[rid.raw()];
+        let stored_rule = index.rule(rid).expect("test rid must be valid");
 
         assert!(stored_rule.is_small);
         assert!(index.approx_matchable_rids.contains(&rid));
@@ -883,7 +886,7 @@ SOFTWARE."#;
             .map(RuleId::new);
 
         if let Some(rid) = target_rid {
-            let rule = &index.rules_by_rid[rid.raw()];
+            let rule = index.rule(rid).expect("test rid must be valid");
             eprintln!("Found rule: {}", rule.identifier);
             eprintln!("License expression: {}", rule.license_expression);
             eprintln!("Ignorable URLs: {:?}", rule.ignorable_urls);
@@ -942,8 +945,8 @@ SOFTWARE."#;
             .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE")
             .map(RuleId::new);
         if let Some(rid) = target_rid {
-            let rule = &index.rules_by_rid[rid.raw()];
-            let rule_tokens = &index.tids_by_rid[rid.raw()];
+            let rule = index.rule(rid).expect("test rid must be valid");
+            let rule_tokens = index.rule_tokens(rid).expect("test rid must be valid");
             eprintln!("\nRule token count: {}", rule_tokens.len());
 
             // Use the indexed set from the index

--- a/src/license_detection/index/builder/tests.rs
+++ b/src/license_detection/index/builder/tests.rs
@@ -9,7 +9,7 @@ mod test_cases {
         ngrams, tokens_to_bytes,
     };
     use crate::license_detection::index::dictionary::{KnownToken, TokenId, TokenKind, tid};
-    use crate::license_detection::models::{License, Rule, RuleKind};
+    use crate::license_detection::models::{License, Rule, RuleId, RuleKind};
 
     fn known_tokens(entries: &[(u16, TokenKind)]) -> Vec<KnownToken> {
         entries
@@ -23,21 +23,22 @@ mod test_cases {
             .collect()
     }
 
-    fn find_rid_by_identifier(index: &LicenseIndex, identifier: &str) -> Option<usize> {
+    fn find_rid_by_identifier(index: &LicenseIndex, identifier: &str) -> Option<RuleId> {
         index
             .rules_by_rid
             .iter()
             .position(|r| r.identifier == identifier)
+            .map(RuleId::new)
     }
 
-    fn find_rid_by_expression(index: &LicenseIndex, expression: &str) -> Vec<usize> {
+    fn find_rid_by_expression(index: &LicenseIndex, expression: &str) -> Vec<RuleId> {
         index
             .rules_by_rid
             .iter()
             .enumerate()
             .filter_map(|(rid, r)| {
                 if r.license_expression == expression {
-                    Some(rid)
+                    Some(RuleId::new(rid))
                 } else {
                     None
                 }
@@ -188,13 +189,15 @@ mod test_cases {
 
         let index = build_index(vec![stored_rule, computed_rule], vec![]);
 
-        let stored = &index.rules_by_rid
-            [find_rid_by_identifier(&index, "stored.RULE").expect("stored rule should exist")];
+        let stored = &index.rules_by_rid[find_rid_by_identifier(&index, "stored.RULE")
+            .expect("stored rule should exist")
+            .raw()];
         assert_eq!(stored.minimum_coverage, Some(99));
         assert!(stored.has_stored_minimum_coverage);
 
-        let computed = &index.rules_by_rid
-            [find_rid_by_identifier(&index, "computed.RULE").expect("computed rule should exist")];
+        let computed = &index.rules_by_rid[find_rid_by_identifier(&index, "computed.RULE")
+            .expect("computed rule should exist")
+            .raw()];
         assert_eq!(computed.minimum_coverage, Some(50));
         assert!(!computed.has_stored_minimum_coverage);
     }
@@ -411,7 +414,7 @@ mod test_cases {
 
         let mut rules_with_empty_tokens = 0;
         for &rid in index.rid_by_hash.values() {
-            let rule = &index.rules_by_rid[rid];
+            let rule = &index.rules_by_rid[rid.raw()];
             if rule.tokens.is_empty() {
                 rules_with_empty_tokens += 1;
             }
@@ -435,7 +438,7 @@ mod test_cases {
 
         if !index.approx_matchable_rids.is_empty() {
             for &rid in &index.approx_matchable_rids {
-                let rule = &index.rules_by_rid[rid];
+                let rule = &index.rules_by_rid[rid.raw()];
                 assert!(!rule.is_false_positive);
             }
         }
@@ -459,7 +462,7 @@ mod test_cases {
         assert_eq!(index.rid_by_hash.len(), 3);
 
         let rid = find_rid_by_identifier(&index, "auto1.RULE").expect("rule should exist");
-        let rule_tokens = &index.tids_by_rid[rid];
+        let rule_tokens = &index.tids_by_rid[rid.raw()];
         let pattern: Vec<u8> = rule_tokens.iter().flat_map(|t| t.to_le_bytes()).collect();
 
         let matches: Vec<_> = index
@@ -478,7 +481,7 @@ mod test_cases {
         let index = build_index(rules, vec![]);
 
         let rid = find_rid_by_identifier(&index, "thresholds.RULE").expect("rule should exist");
-        let rule = &index.rules_by_rid[rid];
+        let rule = &index.rules_by_rid[rid.raw()];
 
         assert!(rule.length_unique > 0, "length_unique should be computed");
         assert!(
@@ -520,11 +523,12 @@ mod test_cases {
         ];
         let index = build_index(rules, vec![]);
 
-        fn find_rid_by_identifier(index: &LicenseIndex, identifier: &str) -> Option<usize> {
+        fn find_rid_by_identifier(index: &LicenseIndex, identifier: &str) -> Option<RuleId> {
             index
                 .rules_by_rid
                 .iter()
                 .position(|r| r.identifier == identifier)
+                .map(RuleId::new)
         }
 
         let regular_rid = find_rid_by_identifier(&index, "regular.RULE").expect("regular rule");
@@ -579,7 +583,7 @@ mod test_cases {
 
         let index = build_index(vec![tiny_rule], vec![]);
         let rid = find_rid_by_identifier(&index, "tiny-legalese.RULE").expect("tiny rule");
-        let stored_rule = &index.rules_by_rid[rid];
+        let stored_rule = &index.rules_by_rid[rid.raw()];
 
         assert!(stored_rule.is_tiny);
         assert!(index.approx_matchable_rids.contains(&rid));
@@ -598,7 +602,7 @@ mod test_cases {
 
         let index = build_index(vec![reference_rule], vec![]);
         let rid = find_rid_by_identifier(&index, "small-reference.RULE").expect("reference rule");
-        let stored_rule = &index.rules_by_rid[rid];
+        let stored_rule = &index.rules_by_rid[rid.raw()];
 
         assert!(stored_rule.is_small);
         assert!(index.approx_matchable_rids.contains(&rid));
@@ -875,10 +879,11 @@ SOFTWARE."#;
         let target_rid = index
             .rules_by_rid
             .iter()
-            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE");
+            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE")
+            .map(RuleId::new);
 
         if let Some(rid) = target_rid {
-            let rule = &index.rules_by_rid[rid];
+            let rule = &index.rules_by_rid[rid.raw()];
             eprintln!("Found rule: {}", rule.identifier);
             eprintln!("License expression: {}", rule.license_expression);
             eprintln!("Ignorable URLs: {:?}", rule.ignorable_urls);
@@ -934,10 +939,11 @@ SOFTWARE."#;
         let target_rid = index
             .rules_by_rid
             .iter()
-            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE");
+            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE")
+            .map(RuleId::new);
         if let Some(rid) = target_rid {
-            let rule = &index.rules_by_rid[rid];
-            let rule_tokens = &index.tids_by_rid[rid];
+            let rule = &index.rules_by_rid[rid.raw()];
+            let rule_tokens = &index.tids_by_rid[rid.raw()];
             eprintln!("\nRule token count: {}", rule_tokens.len());
 
             // Use the indexed set from the index
@@ -1068,7 +1074,8 @@ SOFTWARE."#;
         let mit_or_boost_rid = index
             .rules_by_rid
             .iter()
-            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE");
+            .position(|r| r.identifier == "mit_or_boost-1.0_1.RULE")
+            .map(RuleId::new);
         if let Some(rid) = mit_or_boost_rid {
             eprintln!("\nmit_or_boost-1.0_1.RULE found at rid {}", rid);
         }

--- a/src/license_detection/index/builder/tests.rs
+++ b/src/license_detection/index/builder/tests.rs
@@ -134,8 +134,6 @@ mod test_cases {
         assert!(index.rules_by_rid.is_empty());
         assert!(index.tids_by_rid.is_empty());
         assert!(index.rid_by_hash.is_empty());
-        assert!(index.false_positive_rids.is_empty());
-        assert!(index.approx_matchable_rids.is_empty());
     }
 
     #[test]
@@ -157,7 +155,7 @@ mod test_cases {
                 .values()
                 .any(|&stored_rid| stored_rid == rid)
         );
-        assert!(!index.false_positive_rids.contains(&rid));
+        assert!(!index.rule(rid).is_some_and(|r| r.is_false_positive));
         assert!(index.licenses_by_key.contains_key("mit"));
     }
 
@@ -171,7 +169,7 @@ mod test_cases {
         assert_eq!(index.rules_by_rid.len(), 1);
 
         let rid = find_rid_by_identifier(&index, "fp.RULE").expect("rule should exist");
-        assert!(index.false_positive_rids.contains(&rid));
+        assert!(index.rule(rid).is_some_and(|r| r.is_false_positive));
         assert!(index.rid_by_hash.is_empty());
     }
 
@@ -228,8 +226,8 @@ mod test_cases {
 
         let rid = find_rid_by_identifier(&index, "hp.RULE").expect("rule should exist");
 
-        if !index.approx_matchable_rids.is_empty() {
-            assert!(index.high_postings_by_rid.contains_key(&rid));
+        if index.high_postings_by_rid.contains_key(&rid) {
+            assert!(!index.high_postings_by_rid[&rid].is_empty());
         }
     }
 
@@ -351,11 +349,10 @@ mod test_cases {
 
         assert_eq!(index.rules_by_rid.len(), 3);
         assert_eq!(index.tids_by_rid.len(), 3);
-        assert_eq!(index.false_positive_rids.len(), 1);
         assert_eq!(index.rid_by_hash.len(), 2);
 
         let gpl_rid = find_rid_by_identifier(&index, "gpl.RULE").expect("gpl rule should exist");
-        assert!(index.false_positive_rids.contains(&gpl_rid));
+        assert!(index.rule(gpl_rid).is_some_and(|r| r.is_false_positive));
     }
 
     #[test]
@@ -439,8 +436,8 @@ mod test_cases {
             );
         }
 
-        if !index.approx_matchable_rids.is_empty() {
-            for &rid in &index.approx_matchable_rids {
+        if !index.high_postings_by_rid.is_empty() {
+            for &rid in index.high_postings_by_rid.keys() {
                 let rule = index.rule(rid).expect("test rid must be valid");
                 assert!(!rule.is_false_positive);
             }
@@ -551,8 +548,8 @@ mod test_cases {
             "False positive should not participate in exact matching"
         );
         assert!(
-            index.false_positive_rids.contains(&fp_rid),
-            "False positive should be in false_positive_rids"
+            index.rule(fp_rid).is_some_and(|r| r.is_false_positive),
+            "False positive should be marked on rule"
         );
     }
 
@@ -568,7 +565,7 @@ mod test_cases {
 
         let rid = find_rid_by_identifier(&index, "high_postings.RULE").expect("rule should exist");
 
-        if index.approx_matchable_rids.contains(&rid) {
+        if index.high_postings_by_rid.contains_key(&rid) {
             assert!(
                 index.high_postings_by_rid.contains_key(&rid),
                 "Should have high postings for approx-matchable rule with legalese"
@@ -589,7 +586,6 @@ mod test_cases {
         let stored_rule = index.rule(rid).expect("test rid must be valid");
 
         assert!(stored_rule.is_tiny);
-        assert!(index.approx_matchable_rids.contains(&rid));
         assert!(index.high_postings_by_rid.contains_key(&rid));
         assert!(!compute_is_approx_matchable(stored_rule));
     }
@@ -608,7 +604,6 @@ mod test_cases {
         let stored_rule = index.rule(rid).expect("test rid must be valid");
 
         assert!(stored_rule.is_small);
-        assert!(index.approx_matchable_rids.contains(&rid));
         assert!(index.high_postings_by_rid.contains_key(&rid));
         assert!(!compute_is_approx_matchable(stored_rule));
     }
@@ -676,7 +671,7 @@ SOFTWARE."#;
                     .values()
                     .any(|&stored_rid| stored_rid == rid)
             );
-            assert!(!index.false_positive_rids.contains(&rid));
+            assert!(!index.is_false_positive(rid));
         }
 
         if let Some(rid) = mit_custom_rid {
@@ -686,7 +681,7 @@ SOFTWARE."#;
                     .values()
                     .any(|&stored_rid| stored_rid == rid)
             );
-            assert!(!index.false_positive_rids.contains(&rid));
+            assert!(!index.is_false_positive(rid));
         }
     }
 
@@ -788,10 +783,6 @@ SOFTWARE."#;
         let rid = find_rid_by_identifier(&index, "weak.RULE").expect("rule should exist");
 
         assert!(
-            !index.approx_matchable_rids.contains(&rid),
-            "Weak rule (no legalese tokens) should not be approx_matchable"
-        );
-        assert!(
             !index.high_postings_by_rid.contains_key(&rid),
             "Weak rule should not have high postings"
         );
@@ -809,8 +800,8 @@ SOFTWARE."#;
         let rid = find_rid_by_identifier(&index, "continuous.RULE").expect("rule should exist");
 
         assert!(
-            !index.approx_matchable_rids.contains(&rid),
-            "Continuous rule should not be approx_matchable"
+            !index.high_postings_by_rid.contains_key(&rid),
+            "Continuous rule should not have high postings"
         );
     }
 
@@ -828,8 +819,8 @@ SOFTWARE."#;
         let rid = find_rid_by_identifier(&index, "required.RULE").expect("rule should exist");
 
         assert!(
-            !index.approx_matchable_rids.contains(&rid),
-            "Required phrase should not be approx_matchable"
+            !index.high_postings_by_rid.contains_key(&rid),
+            "Required phrase should not have high postings"
         );
     }
 
@@ -994,11 +985,6 @@ SOFTWARE."#;
             );
 
             // Check if rule is approx_matchable
-            eprintln!(
-                "\nRule is approx_matchable: {}",
-                index.approx_matchable_rids.contains(&rid)
-            );
-
             // Check the threshold values
             eprintln!("\nRule thresholds:");
             eprintln!(

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -42,7 +42,6 @@ pub struct IndexedRuleMetadata {
 /// - **Automaton matching**: `rules_automaton` and `unknown_automaton` for pattern matching
 /// - **Candidate selection**: `sets_by_rid` and `msets_by_rid` for set-based ranking
 /// - **Sequence matching**: `high_postings_by_rid` for high-value token position tracking
-/// - **Rule classification**: `false_positive_rids`, `approx_matchable_rids`
 #[derive(Debug, Clone, Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct LicenseIndex {
     /// Token dictionary mapping token strings to integer IDs.
@@ -141,27 +140,6 @@ pub struct LicenseIndex {
     /// In Python: `postings = {tid: array('h', [positions, ...])}`
     pub high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>>,
 
-    /// Set of rule IDs for false positive rules.
-    ///
-    /// False positive rules are used for exact matching and post-matching
-    /// filtering to subtract spurious matches.
-    ///
-    /// Corresponds to Python: `self.false_positive_rids = set()` (line 230)
-    pub false_positive_rids: HashSet<RuleId>,
-
-    /// Set of rule IDs that can be matched approximately.
-    ///
-    /// Only rules marked as approx-matchable participate in sequence matching.
-    /// Other rules can only be matched exactly using the automaton.
-    ///
-    /// Note: This field is kept for Python parity documentation and test usage.
-    /// The inverted index (`rids_by_high_tid`) now handles candidate filtering
-    /// more efficiently, making direct iteration over this set unnecessary.
-    ///
-    /// Corresponds to Python: `self.approx_matchable_rids = set()` (line 234)
-    #[allow(dead_code)]
-    pub approx_matchable_rids: HashSet<RuleId>,
-
     /// Mapping from ScanCode license key to License object.
     ///
     /// Provides access to license metadata for building SPDX mappings
@@ -195,7 +173,7 @@ pub struct LicenseIndex {
     /// rules for every file, making license detection extremely slow.
     ///
     /// Only contains entries for tokens with ID < len_legalese (high-value tokens).
-    /// Rules not in approx_matchable_rids are excluded from this index.
+    /// Only approx-matchable rules are included in this index.
     pub rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>>,
 
     /// SPDX license list version used to build this index.
@@ -219,6 +197,10 @@ impl LicenseIndex {
             return None;
         }
         self.tids_by_rid.get(id.raw()).map(|v| v.as_slice())
+    }
+
+    pub fn is_false_positive(&self, id: RuleId) -> bool {
+        self.rule(id).is_some_and(|r| r.is_false_positive)
     }
 }
 
@@ -248,8 +230,6 @@ impl LicenseIndex {
             msets_by_rid: HashMap::new(),
             high_sets_by_rid: HashMap::new(),
             high_postings_by_rid: HashMap::new(),
-            false_positive_rids: HashSet::new(),
-            approx_matchable_rids: HashSet::new(),
             licenses_by_key: HashMap::new(),
             rid_by_spdx_key: HashMap::new(),
             unknown_spdx_rid: None,
@@ -328,8 +308,6 @@ mod tests {
         assert!(index.sets_by_rid.is_empty());
         assert!(index.msets_by_rid.is_empty());
         assert!(index.high_postings_by_rid.is_empty());
-        assert!(index.false_positive_rids.is_empty());
-        assert!(index.approx_matchable_rids.is_empty());
         assert!(index.licenses_by_key.is_empty());
     }
 

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -13,6 +13,7 @@ pub use builder::{
 
 use crate::license_detection::automaton::{AsBytes, Automaton};
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId};
+use crate::license_detection::models::RuleId;
 use crate::license_detection::{TokenMultiset, TokenSet};
 use rkyv::Archive;
 use std::collections::{HashMap, HashSet};
@@ -64,10 +65,10 @@ pub struct LicenseIndex {
     /// Each hash maps to exactly one rule ID.
     ///
     /// Note: The hash is a 20-byte SHA1 digest, stored as a key in HashMap.
-    /// In practice, we use a HashMap<[u8; 20], usize>.
+    /// In practice, we use a HashMap<[u8; 20], RuleId>.
     ///
     /// Corresponds to Python: `self.rid_by_hash = {}` (line 216)
-    pub rid_by_hash: HashMap<[u8; 20], usize>,
+    pub rid_by_hash: HashMap<[u8; 20], RuleId>,
 
     /// Rules indexed by rule ID.
     ///
@@ -107,7 +108,7 @@ pub struct LicenseIndex {
     /// Used for efficient candidate selection based on token overlap.
     ///
     /// Corresponds to Python: `self.sets_by_rid = []` (line 212)
-    pub sets_by_rid: HashMap<usize, TokenSet>,
+    pub sets_by_rid: HashMap<RuleId, TokenSet>,
 
     pub rule_metadata_by_identifier: HashMap<String, IndexedRuleMetadata>,
 
@@ -117,7 +118,7 @@ pub struct LicenseIndex {
     /// Used for ranking candidates by token frequency overlap.
     ///
     /// Corresponds to Python: `self.msets_by_rid = []` (line 213)
-    pub msets_by_rid: HashMap<usize, TokenMultiset>,
+    pub msets_by_rid: HashMap<RuleId, TokenMultiset>,
 
     /// High-value token sets per rule for early candidate rejection.
     ///
@@ -126,7 +127,7 @@ pub struct LicenseIndex {
     /// and early rejection of candidates that won't pass the high-token threshold.
     ///
     /// Precomputed during index building to avoid redundant filtering at runtime.
-    pub high_sets_by_rid: HashMap<usize, TokenSet>,
+    pub high_sets_by_rid: HashMap<RuleId, TokenSet>,
 
     /// Inverted index of high-value token positions per rule.
     ///
@@ -138,7 +139,7 @@ pub struct LicenseIndex {
     ///
     /// Corresponds to Python: `self.high_postings_by_rid = []` (line 209)
     /// In Python: `postings = {tid: array('h', [positions, ...])}`
-    pub high_postings_by_rid: HashMap<usize, HashMap<TokenId, Vec<usize>>>,
+    pub high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>>,
 
     /// Set of rule IDs for false positive rules.
     ///
@@ -146,7 +147,7 @@ pub struct LicenseIndex {
     /// filtering to subtract spurious matches.
     ///
     /// Corresponds to Python: `self.false_positive_rids = set()` (line 230)
-    pub false_positive_rids: HashSet<usize>,
+    pub false_positive_rids: HashSet<RuleId>,
 
     /// Set of rule IDs that can be matched approximately.
     ///
@@ -159,7 +160,7 @@ pub struct LicenseIndex {
     ///
     /// Corresponds to Python: `self.approx_matchable_rids = set()` (line 234)
     #[allow(dead_code)]
-    pub approx_matchable_rids: HashSet<usize>,
+    pub approx_matchable_rids: HashSet<RuleId>,
 
     /// Mapping from ScanCode license key to License object.
     ///
@@ -177,14 +178,14 @@ pub struct LicenseIndex {
     /// Keys are stored lowercase for case-insensitive lookup.
     ///
     /// Corresponds to Python: `self.licenses_by_spdx_key` in cache.py
-    pub rid_by_spdx_key: HashMap<String, usize>,
+    pub rid_by_spdx_key: HashMap<String, RuleId>,
 
     /// Rule ID for the unknown-spdx license.
     ///
     /// Used as a fallback when an SPDX identifier is not recognized.
     ///
     /// Corresponds to Python: `get_unknown_spdx_symbol()` in cache.py
-    pub unknown_spdx_rid: Option<usize>,
+    pub unknown_spdx_rid: Option<RuleId>,
 
     /// Inverted index mapping high-value token IDs to rule IDs.
     ///
@@ -195,7 +196,7 @@ pub struct LicenseIndex {
     ///
     /// Only contains entries for tokens with ID < len_legalese (high-value tokens).
     /// Rules not in approx_matchable_rids are excluded from this index.
-    pub rids_by_high_tid: HashMap<TokenId, HashSet<usize>>,
+    pub rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>>,
 
     /// SPDX license list version used to build this index.
     pub spdx_license_list_version: Option<String>,

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -202,7 +202,25 @@ pub struct LicenseIndex {
     pub spdx_license_list_version: Option<String>,
 }
 
-impl LicenseIndex {}
+impl LicenseIndex {
+    /// Returns the rule for the given ID, or `None` if the ID is invalid
+    /// or out of range.
+    pub fn rule(&self, id: RuleId) -> Option<&crate::license_detection::models::Rule> {
+        if id.is_none() {
+            return None;
+        }
+        self.rules_by_rid.get(id.raw())
+    }
+
+    /// Returns the token ID sequence for the given rule, or `None` if the ID
+    /// is invalid or out of range.
+    pub fn rule_tokens(&self, id: RuleId) -> Option<&[TokenId]> {
+        if id.is_none() {
+            return None;
+        }
+        self.tids_by_rid.get(id.raw()).map(|v| v.as_slice())
+    }
+}
 
 impl LicenseIndex {
     /// Create a new empty license index.

--- a/src/license_detection/license_cache.rs
+++ b/src/license_detection/license_cache.rs
@@ -240,8 +240,6 @@ mod tests {
             msets_by_rid: Default::default(),
             high_sets_by_rid: Default::default(),
             high_postings_by_rid: Default::default(),
-            false_positive_rids: Default::default(),
-            approx_matchable_rids: Default::default(),
             licenses_by_key: Default::default(),
             rid_by_spdx_key: Default::default(),
             unknown_spdx_rid: None,

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -29,11 +29,10 @@ pub(super) fn is_candidate_false_positive(m: &LicenseMatch) -> bool {
 }
 
 fn count_unique_licenses(matches: &[LicenseMatch]) -> usize {
-    let mut seen = std::collections::HashSet::new();
-    for m in matches {
-        seen.insert(&m.license_expression);
-    }
-    seen.len()
+    std::collections::HashSet::<&str>::from_iter(
+        matches.iter().map(|m| m.license_expression.as_str()),
+    )
+    .len()
 }
 
 pub(super) fn is_list_of_false_positives(
@@ -49,27 +48,20 @@ pub(super) fn is_list_of_false_positives(
 
     let len_matches = matches.len();
 
-    let is_long_enough_sequence = len_matches >= min_matches;
-
     let len_unique_licenses = count_unique_licenses(matches);
     let unique_proportion = len_unique_licenses as f64 / len_matches as f64;
-    let mut has_enough_licenses = unique_proportion > min_unique_licenses_proportion;
+    let has_enough_licenses = unique_proportion > min_unique_licenses_proportion
+        || len_unique_licenses >= min_unique_licenses;
 
-    if !has_enough_licenses {
-        has_enough_licenses = len_unique_licenses >= min_unique_licenses;
-    }
-
-    let has_enough_candidates = if min_candidate_proportion > 0.0 {
+    let has_enough_candidates = min_candidate_proportion <= 0.0 || {
         let candidates_count = matches
             .iter()
             .filter(|m| is_candidate_false_positive(m))
             .count();
         (candidates_count as f64 / len_matches as f64) > min_candidate_proportion
-    } else {
-        true
     };
 
-    is_long_enough_sequence && has_enough_licenses && has_enough_candidates
+    len_matches >= min_matches && has_enough_licenses && has_enough_candidates
 }
 
 /// Filter matches that are likely false positive license lists.
@@ -82,17 +74,15 @@ pub(super) fn is_list_of_false_positives(
 /// * `matches` - Vector of LicenseMatch to filter
 ///
 /// # Returns
-/// Tuple of (kept matches, discarded matches)
+/// Matches that are not part of a false positive license list
 pub fn filter_false_positive_license_lists_matches(
     matches: Vec<LicenseMatch>,
-) -> (Vec<LicenseMatch>, Vec<LicenseMatch>) {
-    let len_matches = matches.len();
-
-    if len_matches < MIN_SHORT_FP_LIST_LENGTH {
-        return (matches, vec![]);
+) -> Vec<LicenseMatch> {
+    if matches.len() < MIN_SHORT_FP_LIST_LENGTH {
+        return matches;
     }
 
-    if len_matches > MIN_LONG_FP_LIST_LENGTH
+    if matches.len() > MIN_LONG_FP_LIST_LENGTH
         && is_list_of_false_positives(
             &matches,
             MIN_LONG_FP_LIST_LENGTH,
@@ -101,72 +91,62 @@ pub fn filter_false_positive_license_lists_matches(
             0.95,
         )
     {
-        return (vec![], matches);
+        return vec![];
     }
 
     let mut kept = Vec::new();
-    let mut discarded = Vec::new();
-    let mut candidates: Vec<&LicenseMatch> = Vec::new();
+    let mut candidate_start: Option<usize> = None;
+    let mut candidate_last: usize = 0;
 
-    for match_item in &matches {
+    for (i, match_item) in matches.iter().enumerate() {
         let is_candidate = is_candidate_false_positive(match_item);
 
         if is_candidate {
-            let is_close_enough = candidates
-                .last()
-                .map(|last| last.qdistance_to(match_item) <= MAX_DISTANCE_BETWEEN_CANDIDATES)
-                .unwrap_or(true);
+            let is_close_enough = candidate_start.is_none_or(|_| {
+                matches[candidate_last].qdistance_to(match_item) <= MAX_DISTANCE_BETWEEN_CANDIDATES
+            });
 
-            if is_close_enough {
-                candidates.push(match_item);
+            if candidate_start.is_none() || is_close_enough {
+                candidate_start.get_or_insert(i);
+                candidate_last = i;
             } else {
-                let owned: Vec<LicenseMatch> = candidates.iter().map(|m| (*m).clone()).collect();
-                if is_list_of_false_positives(
-                    &owned,
-                    MIN_SHORT_FP_LIST_LENGTH,
-                    MIN_UNIQUE_LICENSES,
-                    MIN_UNIQUE_LICENSES_PROPORTION,
-                    0.0,
-                ) {
-                    discarded.extend(owned);
-                } else {
-                    kept.extend(owned);
-                }
-                candidates.clear();
-                candidates.push(match_item);
+                flush_candidates(&matches, candidate_start.unwrap(), i, &mut kept);
+                candidate_start = Some(i);
+                candidate_last = i;
             }
         } else {
-            let owned: Vec<LicenseMatch> = candidates.iter().map(|m| (*m).clone()).collect();
-            if is_list_of_false_positives(
-                &owned,
-                MIN_SHORT_FP_LIST_LENGTH,
-                MIN_UNIQUE_LICENSES,
-                MIN_UNIQUE_LICENSES_PROPORTION,
-                0.0,
-            ) {
-                discarded.extend(owned);
-            } else {
-                kept.extend(owned);
+            if let Some(start) = candidate_start.take() {
+                flush_candidates(&matches, start, i, &mut kept);
             }
-            candidates.clear();
             kept.push(match_item.clone());
         }
     }
 
-    let owned: Vec<LicenseMatch> = candidates.iter().map(|m| (*m).clone()).collect();
+    if let Some(start) = candidate_start {
+        flush_candidates(&matches, start, matches.len(), &mut kept);
+    }
+
+    kept
+}
+
+fn flush_candidates(
+    matches: &[LicenseMatch],
+    start: usize,
+    end: usize,
+    kept: &mut Vec<LicenseMatch>,
+) {
+    let candidates = &matches[start..end];
     if is_list_of_false_positives(
-        &owned,
+        candidates,
         MIN_SHORT_FP_LIST_LENGTH,
         MIN_UNIQUE_LICENSES,
         MIN_UNIQUE_LICENSES_PROPORTION,
         0.0,
     ) {
-        discarded.extend(owned);
+        // discard all candidates
     } else {
-        kept.extend(owned);
+        kept.extend(candidates.iter().cloned());
     }
-
-    (kept, discarded)
 }
 
 #[cfg(test)]
@@ -311,9 +291,8 @@ mod tests {
             })
             .collect();
 
-        let (kept, discarded) = filter_false_positive_license_lists_matches(matches);
+        let kept = filter_false_positive_license_lists_matches(matches);
         assert_eq!(kept.len(), 10);
-        assert_eq!(discarded.len(), 0);
     }
 
     #[test]
@@ -337,9 +316,8 @@ mod tests {
             })
             .collect();
 
-        let (kept, discarded) = filter_false_positive_license_lists_matches(matches);
+        let kept = filter_false_positive_license_lists_matches(matches);
         assert_eq!(kept.len(), 0);
-        assert_eq!(discarded.len(), 160);
     }
 
     #[test]
@@ -380,10 +358,9 @@ mod tests {
             ));
         }
 
-        let (kept, discarded) = filter_false_positive_license_lists_matches(matches);
+        let kept = filter_false_positive_license_lists_matches(matches);
 
         assert_eq!(kept.len(), 5);
-        assert_eq!(discarded.len(), 15);
     }
 
     #[test]
@@ -428,10 +405,9 @@ mod tests {
             ));
         }
 
-        let (kept, discarded) = filter_false_positive_license_lists_matches(matches);
+        let kept = filter_false_positive_license_lists_matches(matches);
 
         assert_eq!(kept.len(), 1);
-        assert_eq!(discarded.len(), 30);
     }
 
     #[test]

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -172,7 +172,7 @@ pub fn filter_false_positive_license_lists_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::license_detection::models::{MatchCoordinates, PositionSpan};
+    use crate::license_detection::models::{MatchCoordinates, PositionSpan, RuleId};
     use crate::models::LineNumber;
     use crate::models::MatchScore;
 
@@ -193,7 +193,7 @@ mod tests {
     ) -> LicenseMatch {
         let rid = rule_identifier.trim_start_matches('#').parse().unwrap_or(0);
         LicenseMatch {
-            rid,
+            rid: RuleId::new(rid),
             license_expression: license_expression.to_string(),
             license_expression_spdx: Some(license_expression.to_string()),
             from_file: None,

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -80,7 +80,7 @@ pub(crate) fn filter_below_rule_minimum_coverage(
             }
 
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid)
+            if let Some(rule) = index.rules_by_rid.get(rid.raw())
                 && let Some(min_cov) = rule.minimum_coverage
             {
                 return m.coverage() >= f32::from(min_cov);
@@ -114,7 +114,7 @@ pub(crate) fn filter_short_matches_scattered_on_too_many_lines(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid)
+            if let Some(rule) = index.rules_by_rid.get(rid.raw())
                 && rule.is_small
             {
                 let matched_len = m.len();
@@ -162,7 +162,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
     for m in matches {
         let rid = m.rid;
 
-        let rule = match index.rules_by_rid.get(rid) {
+        let rule = match index.rules_by_rid.get(rid.raw()) {
             Some(r) => r,
             None => {
                 kept.push(m.clone());
@@ -540,7 +540,7 @@ pub(crate) fn filter_invalid_matches_to_single_word_gibberish(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid)
+            if let Some(rule) = index.rules_by_rid.get(rid.raw())
                 && rule.length_unique == 1
                 && (rule.is_license_reference() || rule.is_license_clue())
             {
@@ -569,7 +569,7 @@ pub(crate) fn filter_filename_like_single_word_reference_matches(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid)
+            if let Some(rule) = index.rules_by_rid.get(rid.raw())
                 && rule.length_unique == 1
                 && rule.is_license_reference()
                 && rule.relevance < 100
@@ -598,7 +598,7 @@ pub(crate) fn filter_too_short_matches(
             }
 
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid) {
+            if let Some(rule) = index.rules_by_rid.get(rid.raw()) {
                 return !m.is_small(
                     rule.min_matched_length,
                     rule.min_high_matched_length,
@@ -617,6 +617,7 @@ mod tests {
     use super::*;
     use crate::license_detection::models::MatchCoordinates;
     use crate::license_detection::models::Rule;
+    use crate::license_detection::models::RuleId;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::license_detection::unknown_match::MATCH_UNKNOWN;
     use crate::models::LineNumber;
@@ -641,7 +642,7 @@ mod tests {
     ) -> LicenseMatch {
         let matched_len = end_line - start_line + 1;
         let rule_len = matched_len;
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
@@ -681,7 +682,7 @@ mod tests {
         end_token: usize,
         matched_length: usize,
     ) -> LicenseMatch {
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         LicenseMatch {
             rid,
             license_expression: "mit".to_string(),
@@ -720,7 +721,7 @@ mod tests {
     #[test]
     fn test_filter_false_positive_matches_with_false_positive() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(42);
+        let _ = index.false_positive_rids.insert(RuleId::new(42));
 
         let matches = vec![
             create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
@@ -750,8 +751,8 @@ mod tests {
     #[test]
     fn test_filter_false_positive_matches_all_false_positive() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(42);
-        let _ = index.false_positive_rids.insert(43);
+        let _ = index.false_positive_rids.insert(RuleId::new(42));
+        let _ = index.false_positive_rids.insert(RuleId::new(43));
 
         let matches = vec![
             create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
@@ -876,7 +877,7 @@ mod tests {
     #[test]
     fn test_filter_false_positive_matches_mixed_identifiers() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(42);
+        let _ = index.false_positive_rids.insert(RuleId::new(42));
 
         let matches = vec![
             create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -80,7 +80,7 @@ pub(crate) fn filter_below_rule_minimum_coverage(
             }
 
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid.raw())
+            if let Some(rule) = index.rule(rid)
                 && let Some(min_cov) = rule.minimum_coverage
             {
                 return m.coverage() >= f32::from(min_cov);
@@ -114,7 +114,7 @@ pub(crate) fn filter_short_matches_scattered_on_too_many_lines(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid.raw())
+            if let Some(rule) = index.rule(rid)
                 && rule.is_small
             {
                 let matched_len = m.len();
@@ -162,7 +162,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
     for m in matches {
         let rid = m.rid;
 
-        let rule = match index.rules_by_rid.get(rid.raw()) {
+        let rule = match index.rule(rid) {
             Some(r) => r,
             None => {
                 kept.push(m.clone());
@@ -540,7 +540,7 @@ pub(crate) fn filter_invalid_matches_to_single_word_gibberish(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid.raw())
+            if let Some(rule) = index.rule(rid)
                 && rule.length_unique == 1
                 && (rule.is_license_reference() || rule.is_license_clue())
             {
@@ -569,7 +569,7 @@ pub(crate) fn filter_filename_like_single_word_reference_matches(
         .iter()
         .filter(|m| {
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid.raw())
+            if let Some(rule) = index.rule(rid)
                 && rule.length_unique == 1
                 && rule.is_license_reference()
                 && rule.relevance < 100
@@ -598,7 +598,7 @@ pub(crate) fn filter_too_short_matches(
             }
 
             let rid = m.rid;
-            if let Some(rule) = index.rules_by_rid.get(rid.raw()) {
+            if let Some(rule) = index.rule(rid) {
                 return !m.is_small(
                     rule.min_matched_length,
                     rule.min_high_matched_length,

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -388,29 +388,6 @@ pub(crate) fn filter_matches_to_spurious_single_token(
         .collect()
 }
 
-/// Filter matches to false positive rules.
-///
-/// Removes matches whose rule ID is in the index's false_positive_rids set.
-///
-/// Based on Python: `filter_false_positive_matches()` (lines 1950-1970)
-pub(crate) fn filter_false_positive_matches(
-    index: &LicenseIndex,
-    matches: &[LicenseMatch],
-) -> Vec<LicenseMatch> {
-    let mut filtered = Vec::new();
-
-    for m in matches {
-        let rid = m.rid;
-        if index.false_positive_rids.contains(&rid) {
-            continue;
-        }
-
-        filtered.push(m.clone());
-    }
-
-    filtered
-}
-
 /// Check if a matched text is a valid short match.
 ///
 /// A short match is valid if:
@@ -719,60 +696,6 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_false_positive_matches_with_false_positive() {
-        let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(42));
-
-        let matches = vec![
-            create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
-            create_test_match("#1", 15, 25, MatchScore::from_percentage(0.85), 85.0, 100),
-        ];
-
-        let filtered = filter_false_positive_matches(&index, &matches);
-
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].rule_identifier, "#1");
-    }
-
-    #[test]
-    fn test_filter_false_positive_matches_no_false_positive() {
-        let index = LicenseIndex::with_legalese_count(10);
-
-        let matches = vec![
-            create_test_match("#1", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
-            create_test_match("#2", 15, 25, MatchScore::from_percentage(0.85), 85.0, 100),
-        ];
-
-        let filtered = filter_false_positive_matches(&index, &matches);
-
-        assert_eq!(filtered.len(), 2);
-    }
-
-    #[test]
-    fn test_filter_false_positive_matches_all_false_positive() {
-        let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(42));
-        let _ = index.false_positive_rids.insert(RuleId::new(43));
-
-        let matches = vec![
-            create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
-            create_test_match("#43", 15, 25, MatchScore::from_percentage(0.85), 85.0, 100),
-        ];
-
-        let filtered = filter_false_positive_matches(&index, &matches);
-
-        assert_eq!(filtered.len(), 0);
-    }
-
-    #[test]
-    fn test_filter_false_positive_matches_empty() {
-        let index = LicenseIndex::with_legalese_count(10);
-        let matches: Vec<LicenseMatch> = vec![];
-        let filtered = filter_false_positive_matches(&index, &matches);
-        assert_eq!(filtered.len(), 0);
-    }
-
-    #[test]
     fn test_filter_spurious_matches_keeps_non_seq_matchers() {
         let index = LicenseIndex::with_legalese_count(10);
         let query = Query::from_extracted_text("test text", &index, false).unwrap();
@@ -872,31 +795,6 @@ mod tests {
         let matches: Vec<LicenseMatch> = vec![];
         let filtered = filter_spurious_matches(&matches, &query);
         assert_eq!(filtered.len(), 0);
-    }
-
-    #[test]
-    fn test_filter_false_positive_matches_mixed_identifiers() {
-        let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(42));
-
-        let matches = vec![
-            create_test_match("#42", 1, 10, MatchScore::from_percentage(0.9), 90.0, 100),
-            create_test_match(
-                "mit.LICENSE",
-                15,
-                25,
-                MatchScore::from_percentage(0.85),
-                85.0,
-                100,
-            ),
-            create_test_match("#1", 30, 40, MatchScore::from_percentage(0.8), 80.0, 100),
-        ];
-
-        let filtered = filter_false_positive_matches(&index, &matches);
-
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().any(|m| m.rule_identifier == "mit.LICENSE"));
-        assert!(filtered.iter().any(|m| m.rule_identifier == "#1"));
     }
 
     #[test]

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -329,13 +329,11 @@ pub fn filter_overlapping_matches(
                     && current_hilen >= next_hilen
                 {
                     let current_ends = index
-                        .rules_by_rid
-                        .get(matches[i].rid.raw())
+                        .rule(matches[i].rid)
                         .map(|r| r.ends_with_license)
                         .unwrap_or(false);
                     let next_starts = index
-                        .rules_by_rid
-                        .get(matches[j].rid.raw())
+                        .rule(matches[j].rid)
                         .map(|r| r.starts_with_license)
                         .unwrap_or(false);
 

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -330,12 +330,12 @@ pub fn filter_overlapping_matches(
                 {
                     let current_ends = index
                         .rules_by_rid
-                        .get(matches[i].rid)
+                        .get(matches[i].rid.raw())
                         .map(|r| r.ends_with_license)
                         .unwrap_or(false);
                     let next_starts = index
                         .rules_by_rid
-                        .get(matches[j].rid)
+                        .get(matches[j].rid.raw())
                         .map(|r| r.starts_with_license)
                         .unwrap_or(false);
 
@@ -455,6 +455,7 @@ pub fn restore_non_overlapping(
 mod tests {
     use super::*;
     use crate::license_detection::models::MatchCoordinates;
+    use crate::license_detection::models::RuleId;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::models::LineNumber;
     use crate::models::MatchScore;
@@ -478,7 +479,7 @@ mod tests {
     ) -> LicenseMatch {
         let matched_len = end_line - start_line + 1;
         let rule_len = matched_len;
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         let start_line_ln = LineNumber::new(start_line).expect("valid start_line");
         let end_line_ln = LineNumber::new(end_line).expect("valid end_line");
         LicenseMatch {
@@ -518,7 +519,7 @@ mod tests {
         end_token: usize,
         matched_length: usize,
     ) -> LicenseMatch {
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         LicenseMatch {
             rid,
             license_expression: "mit".to_string(),
@@ -965,8 +966,8 @@ mod tests {
     #[test]
     fn test_filter_overlapping_matches_false_positive_skip() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(1);
-        let _ = index.false_positive_rids.insert(2);
+        let _ = index.false_positive_rids.insert(RuleId::new(1));
+        let _ = index.false_positive_rids.insert(RuleId::new(2));
 
         let mut m1 = create_test_match("#1", 1, 20, MatchScore::from_percentage(0.9), 90.0, 100);
         m1.matched_length = 100;

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -114,10 +114,6 @@ pub fn filter_contained_matches(
     (matches, discarded)
 }
 
-fn is_false_positive(m: &LicenseMatch, index: &LicenseIndex) -> bool {
-    index.false_positive_rids.contains(&m.rid)
-}
-
 fn is_strong_exact_match(match_item: &LicenseMatch) -> bool {
     match_item.matcher == MatcherKind::Aho && match_item.coverage() == 100.0
 }
@@ -187,7 +183,7 @@ pub fn filter_overlapping_matches(
             }
 
             let both_fp =
-                is_false_positive(&matches[i], index) && is_false_positive(&matches[j], index);
+                index.is_false_positive(matches[i].rid) && index.is_false_positive(matches[j].rid);
             if both_fp {
                 j += 1;
                 continue;
@@ -453,10 +449,61 @@ pub fn restore_non_overlapping(
 mod tests {
     use super::*;
     use crate::license_detection::models::MatchCoordinates;
+    use crate::license_detection::models::Rule;
     use crate::license_detection::models::RuleId;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::models::LineNumber;
     use crate::models::MatchScore;
+    use std::collections::HashMap;
+
+    fn make_rule(is_false_positive: bool) -> Rule {
+        Rule {
+            identifier: String::new(),
+            license_expression: String::new(),
+            text: String::new(),
+            tokens: Vec::new(),
+            rule_kind: crate::license_detection::models::RuleKind::Text,
+            is_false_positive,
+            is_required_phrase: false,
+            is_from_license: false,
+            relevance: 100,
+            minimum_coverage: None,
+            has_stored_minimum_coverage: false,
+            is_continuous: false,
+            required_phrase_spans: Vec::new(),
+            stopwords_by_pos: HashMap::new(),
+            referenced_filenames: None,
+            ignorable_urls: None,
+            ignorable_emails: None,
+            ignorable_copyrights: None,
+            ignorable_holders: None,
+            ignorable_authors: None,
+            language: None,
+            notes: None,
+            length_unique: 0,
+            high_length_unique: 0,
+            high_length: 0,
+            min_matched_length: 0,
+            min_high_matched_length: 0,
+            min_matched_length_unique: 0,
+            min_high_matched_length_unique: 0,
+            is_small: false,
+            is_tiny: false,
+            starts_with_license: false,
+            ends_with_license: false,
+            is_deprecated: false,
+            spdx_license_key: None,
+            other_spdx_license_keys: Vec::new(),
+        }
+    }
+
+    fn insert_fp_rule(index: &mut LicenseIndex, rid: usize) {
+        while index.rules_by_rid.len() <= rid {
+            index.rules_by_rid.push(make_rule(false));
+            index.tids_by_rid.push(Vec::new());
+        }
+        index.rules_by_rid[rid].is_false_positive = true;
+    }
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
         let trimmed = rule_identifier.trim();
@@ -964,8 +1011,8 @@ mod tests {
     #[test]
     fn test_filter_overlapping_matches_false_positive_skip() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(1));
-        let _ = index.false_positive_rids.insert(RuleId::new(2));
+        insert_fp_rule(&mut index, 1);
+        insert_fp_rule(&mut index, 2);
 
         let mut m1 = create_test_match("#1", 1, 20, MatchScore::from_percentage(0.9), 90.0, 100);
         m1.matched_length = 100;

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -373,6 +373,7 @@ mod tests {
     use super::*;
     use crate::license_detection::index::LicenseIndex;
     use crate::license_detection::models::PositionSpan;
+    use crate::license_detection::models::RuleId;
     use crate::models::LineNumber;
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
@@ -394,7 +395,7 @@ mod tests {
     ) -> LicenseMatch {
         let matched_len = end_line - start_line + 1;
         let rule_len = matched_len;
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         let qspan = PositionSpan::range(start_line, end_line + 1);
         let ispan = PositionSpan::range(0, matched_len);
         let hispan = PositionSpan::range(0, matched_len / 2);
@@ -432,7 +433,7 @@ mod tests {
         end_token: usize,
         matched_length: usize,
     ) -> LicenseMatch {
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         let qspan = PositionSpan::range(start_token, end_token);
         LicenseMatch {
             rid,
@@ -472,7 +473,7 @@ mod tests {
         end_token: usize,
         matched_length: usize,
     ) -> LicenseMatch {
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         LicenseMatch {
             rid,
             license_expression: "mit".to_string(),

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -340,6 +340,7 @@ fn filter_binary_low_coverage_same_expression_seq_bridges(
 mod tests {
     use super::*;
     use crate::license_detection::models::MatchCoordinates;
+    use crate::license_detection::models::RuleId;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::models::LineNumber;
     use crate::models::MatchScore;
@@ -363,7 +364,7 @@ mod tests {
     ) -> LicenseMatch {
         let matched_len = end_line - start_line + 1;
         let rule_len = matched_len;
-        let rid = parse_rule_id(rule_identifier).unwrap_or(0);
+        let rid = parse_rule_id(rule_identifier).map_or(RuleId::NONE, RuleId::new);
         LicenseMatch {
             rid,
             license_expression: "mit".to_string(),
@@ -398,7 +399,7 @@ mod tests {
     #[test]
     fn test_refine_matches_full_pipeline() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(99);
+        let _ = index.false_positive_rids.insert(RuleId::new(99));
 
         let mut m1 = create_test_match("#1", 1, 10, MatchScore::from_percentage(0.5), 100.0, 100);
         m1.rule_length = 100;
@@ -604,7 +605,7 @@ mod tests {
     #[test]
     fn test_refine_matches_complex_scenario() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(999);
+        let _ = index.false_positive_rids.insert(RuleId::new(999));
 
         let mut m1 = create_test_match("#1", 1, 10, MatchScore::from_percentage(0.7), 100.0, 100);
         m1.matched_length = 100;
@@ -693,7 +694,7 @@ mod tests {
     #[test]
     fn test_split_weak_matches_keeps_false_positive_unknown_out_of_weak_bucket() {
         let m = LicenseMatch {
-            rid: 42,
+            rid: RuleId::new(42),
             license_expression: "unknown".to_string(),
             matcher: crate::license_detection::models::MatcherKind::Aho,
             matched_length: 3,
@@ -703,7 +704,7 @@ mod tests {
         };
 
         let mut index = LicenseIndex::with_legalese_count(10);
-        index.false_positive_rids.insert(42);
+        index.false_positive_rids.insert(RuleId::new(42));
 
         let (good, weak) = split_weak_matches(&index, std::slice::from_ref(&m));
         assert!(good.contains(&m));

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -20,8 +20,7 @@ use crate::license_detection::query::Query;
 
 // Internal use only
 use filter_low_quality::{
-    filter_below_rule_minimum_coverage, filter_false_positive_matches,
-    filter_filename_like_single_word_reference_matches,
+    filter_below_rule_minimum_coverage, filter_filename_like_single_word_reference_matches,
     filter_invalid_matches_to_single_word_gibberish, filter_matches_missing_required_phrases,
     filter_matches_to_spurious_single_token, filter_short_matches_scattered_on_too_many_lines,
     filter_spurious_matches, filter_too_short_matches,
@@ -92,22 +91,11 @@ pub fn split_weak_matches(
     index: &LicenseIndex,
     matches: &[LicenseMatch],
 ) -> (Vec<LicenseMatch>, Vec<LicenseMatch>) {
-    let mut good = Vec::new();
-    let mut weak = Vec::new();
-
-    for m in matches {
-        let is_false_positive = index.false_positive_rids.contains(&m.rid);
-        let is_weak = (!is_false_positive && m.has_unknown())
-            || (m.matcher == MatcherKind::Seq && m.len() <= SMALL_RULE && m.coverage() <= 25.0);
-
-        if is_weak {
-            weak.push(m.clone());
-        } else {
-            good.push(m.clone());
-        }
-    }
-
-    (good, weak)
+    matches.iter().cloned().partition(|m| {
+        let is_fp = index.is_false_positive(m.rid);
+        !((!is_fp && m.has_unknown())
+            || (m.matcher == MatcherKind::Seq && m.len() <= SMALL_RULE && m.coverage() <= 25.0))
+    })
 }
 
 /// Main refinement function - applies all refinement operations to match results.
@@ -133,7 +121,7 @@ pub fn split_weak_matches(
 /// The operations are applied in sequence to produce final refined matches.
 ///
 /// # Arguments
-/// * `index` - LicenseIndex containing false_positive_rids and rules_by_rid
+/// * `index` - LicenseIndex containing rules_by_rid
 /// * `matches` - Vector of raw LicenseMatch from all strategies
 /// * `query` - Query object for spurious/gibberish filtering
 ///
@@ -292,9 +280,11 @@ fn refine_matches_internal(
     let (non_contained_final, _) = filter_contained_matches(&final_matches);
 
     let result = if filter_false_positive {
-        let non_fp = filter_false_positive_matches(index, &non_contained_final);
-        let (kept, _discarded) = filter_false_positive_license_lists_matches(non_fp);
-        kept
+        let non_fp: Vec<_> = non_contained_final
+            .into_iter()
+            .filter(|m| !index.is_false_positive(m.rid))
+            .collect();
+        filter_false_positive_license_lists_matches(non_fp)
     } else {
         non_contained_final
     };
@@ -340,8 +330,59 @@ fn filter_binary_low_coverage_same_expression_seq_bridges(
 mod tests {
     use super::*;
     use crate::license_detection::models::MatchCoordinates;
+    use crate::license_detection::models::Rule;
     use crate::license_detection::models::RuleId;
     use crate::license_detection::models::position_span::PositionSpan;
+    use std::collections::HashMap;
+
+    fn make_rule(is_false_positive: bool) -> Rule {
+        Rule {
+            identifier: String::new(),
+            license_expression: String::new(),
+            text: String::new(),
+            tokens: Vec::new(),
+            rule_kind: crate::license_detection::models::RuleKind::Text,
+            is_false_positive,
+            is_required_phrase: false,
+            is_from_license: false,
+            relevance: 100,
+            minimum_coverage: None,
+            has_stored_minimum_coverage: false,
+            is_continuous: false,
+            required_phrase_spans: Vec::new(),
+            stopwords_by_pos: HashMap::new(),
+            referenced_filenames: None,
+            ignorable_urls: None,
+            ignorable_emails: None,
+            ignorable_copyrights: None,
+            ignorable_holders: None,
+            ignorable_authors: None,
+            language: None,
+            notes: None,
+            length_unique: 0,
+            high_length_unique: 0,
+            high_length: 0,
+            min_matched_length: 0,
+            min_high_matched_length: 0,
+            min_matched_length_unique: 0,
+            min_high_matched_length_unique: 0,
+            is_small: false,
+            is_tiny: false,
+            starts_with_license: false,
+            ends_with_license: false,
+            is_deprecated: false,
+            spdx_license_key: None,
+            other_spdx_license_keys: Vec::new(),
+        }
+    }
+
+    fn insert_fp_rule(index: &mut LicenseIndex, rid: usize) {
+        while index.rules_by_rid.len() <= rid {
+            index.rules_by_rid.push(make_rule(false));
+            index.tids_by_rid.push(Vec::new());
+        }
+        index.rules_by_rid[rid].is_false_positive = true;
+    }
     use crate::models::LineNumber;
     use crate::models::MatchScore;
 
@@ -399,7 +440,7 @@ mod tests {
     #[test]
     fn test_refine_matches_full_pipeline() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(99));
+        insert_fp_rule(&mut index, 99);
 
         let mut m1 = create_test_match("#1", 1, 10, MatchScore::from_percentage(0.5), 100.0, 100);
         m1.rule_length = 100;
@@ -605,7 +646,7 @@ mod tests {
     #[test]
     fn test_refine_matches_complex_scenario() {
         let mut index = LicenseIndex::with_legalese_count(10);
-        let _ = index.false_positive_rids.insert(RuleId::new(999));
+        insert_fp_rule(&mut index, 999);
 
         let mut m1 = create_test_match("#1", 1, 10, MatchScore::from_percentage(0.7), 100.0, 100);
         m1.matched_length = 100;
@@ -704,7 +745,7 @@ mod tests {
         };
 
         let mut index = LicenseIndex::with_legalese_count(10);
-        index.false_positive_rids.insert(RuleId::new(42));
+        insert_fp_rule(&mut index, 42);
 
         let (good, weak) = split_weak_matches(&index, std::slice::from_ref(&m));
         assert!(good.contains(&m));

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -388,10 +388,7 @@ fn merge_and_prepare_aho_matches(
             matched_qspans.push(span.clone());
         }
 
-        if index
-            .rules_by_rid
-            .get(m.rid.raw())
-            .is_some_and(|rule| rule.is_license_text())
+        if index.rule(m.rid).is_some_and(|rule| rule.is_license_text())
             && m.rule_length > 120
             && m.coverage() > 98.0
         {

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -390,7 +390,7 @@ fn merge_and_prepare_aho_matches(
 
         if index
             .rules_by_rid
-            .get(m.rid)
+            .get(m.rid.raw())
             .is_some_and(|rule| rule.is_license_text())
             && m.rule_length > 120
             && m.coverage() > 98.0

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
 
+use super::rule_id::RuleId;
 use crate::license_detection::models::RuleKind;
 use crate::license_detection::models::position_span::PositionSpan;
 use crate::license_detection::position_set::PositionSet;
@@ -151,7 +152,7 @@ impl FromStr for MatcherKind {
 pub struct LicenseMatch {
     /// Internal rule ID for fast lookups (index into rules_by_rid).
     /// Not serialized to JSON output.
-    pub rid: usize,
+    pub rid: RuleId,
 
     /// License expression string using ScanCode license keys
     pub license_expression: String,
@@ -313,7 +314,7 @@ impl Serialize for LicenseMatch {
 impl Default for LicenseMatch {
     fn default() -> Self {
         LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: String::new(),
             license_expression_spdx: None,
             from_file: None,

--- a/src/license_detection/models/mod.rs
+++ b/src/license_detection/models/mod.rs
@@ -9,6 +9,7 @@ pub mod loaded_license;
 pub mod loaded_rule;
 pub mod position_span;
 pub mod rule;
+pub mod rule_id;
 
 pub use license::License;
 pub use license_match::{LicenseMatch, MatchCoordinates, MatcherKind};
@@ -16,6 +17,7 @@ pub use loaded_license::LoadedLicense;
 pub use loaded_rule::LoadedRule;
 pub use position_span::PositionSpan;
 pub use rule::{Rule, RuleKind};
+pub use rule_id::RuleId;
 
 #[cfg(test)]
 mod mod_tests;

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::license_detection::index::dictionary::tid;
     use crate::license_detection::models::position_span::PositionSpan;
     use crate::license_detection::models::{
-        License, LicenseMatch, MatchCoordinates, MatcherKind, Rule, RuleKind,
+        License, LicenseMatch, MatchCoordinates, MatcherKind, Rule, RuleId, RuleKind,
     };
     use crate::license_detection::position_set::PositionSet;
     use crate::models::LineNumber;
@@ -96,7 +96,7 @@ mod tests {
 
     fn create_license_match() -> LicenseMatch {
         LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("README.md".to_string()),
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn test_license_match_creation_with_minimal_fields() {
         let match_result = LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: None,
@@ -665,7 +665,7 @@ mod tests {
     #[test]
     fn test_license_match_with_referenced_filenames() {
         let match_result = LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: Some("README.md".to_string()),

--- a/src/license_detection/models/rule_id.rs
+++ b/src/license_detection/models/rule_id.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Newtype wrapper for rule IDs used throughout license detection.
+
+use rkyv::Archive;
+
+/// Internal rule ID used as an index into `LicenseIndex::rules_by_rid`.
+///
+/// Every rule in the license index is assigned a `RuleId` sequentially during
+/// index construction. The ID is used for fast Vec lookups and as a key in
+/// HashMap/HashSet structures on `LicenseIndex`.
+///
+/// # Sentinel value
+///
+/// `RuleId::NONE` (`usize::MAX`) represents an absent or invalid rule ID.
+/// It is used where production code previously relied on `rid: 0` as a sentinel,
+/// which was unsafe because `0` is a valid index pointing to a real rule.
+/// Use `is_valid()` to check whether a `RuleId` refers to a real rule.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[rkyv(derive(Hash, Eq, PartialEq, PartialOrd, Ord))]
+pub struct RuleId(usize);
+
+impl RuleId {
+    /// Sentinel value representing an absent or invalid rule ID.
+    ///
+    /// `usize::MAX` can never be a valid Vec index, so this is guaranteed
+    /// not to alias any real rule.
+    pub const NONE: Self = Self(usize::MAX);
+
+    /// Creates a `RuleId` from a raw `usize` index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `raw` is `usize::MAX` (the sentinel value).
+    /// Use `RuleId::NONE` to construct the sentinel.
+    pub const fn new(raw: usize) -> Self {
+        assert!(
+            raw != usize::MAX,
+            "RuleId::new(usize::MAX) is reserved for RuleId::NONE"
+        );
+        Self(raw)
+    }
+
+    /// Returns the raw `usize` index.
+    ///
+    /// Prefer using `RuleId` directly for indexing and lookups rather than
+    /// extracting the raw value.
+    pub const fn raw(self) -> usize {
+        self.0
+    }
+
+    /// Returns `true` if this `RuleId` refers to a real rule (not the sentinel).
+    pub const fn is_valid(self) -> bool {
+        self.0 != usize::MAX
+    }
+
+    /// Returns `true` if this is the `RuleId::NONE` sentinel.
+    pub const fn is_none(self) -> bool {
+        self.0 == usize::MAX
+    }
+}
+
+impl From<RuleId> for usize {
+    fn from(value: RuleId) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for RuleId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_none() {
+            write!(f, "RuleId::NONE")
+        } else {
+            write!(f, "RuleId({})", self.0)
+        }
+    }
+}

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -8,6 +8,7 @@ use crate::license_detection::TokenSet;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::models::Rule;
+use crate::license_detection::models::RuleId;
 use crate::license_detection::query::QueryRun;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -30,7 +31,7 @@ pub struct ScoresVector {
     /// Ordering key for matched length.
     matched_length: OrderingKey,
     /// Rule ID for tie-breaking
-    pub rid: usize,
+    pub rid: RuleId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,7 +127,7 @@ impl CandidateMetrics {
         quantize_ratio_tenths(self.matched_length as u64, 20)
     }
 
-    fn rounded_score_vector(&self, rid: usize) -> ScoresVector {
+    fn rounded_score_vector(&self, rid: RuleId) -> ScoresVector {
         ScoresVector {
             is_highly_resemblant: self.rounded_is_highly_resemblant(),
             containment: OrderingKey::integer(self.rounded_containment_tenths()),
@@ -136,7 +137,7 @@ impl CandidateMetrics {
         }
     }
 
-    fn full_score_vector(&self, rid: usize) -> ScoresVector {
+    fn full_score_vector(&self, rid: RuleId) -> ScoresVector {
         ScoresVector {
             is_highly_resemblant: self.full_is_highly_resemblant(),
             containment: OrderingKey::ratio(self.matched_length as u64, self.rule_len as u64),
@@ -193,7 +194,7 @@ pub(crate) struct Candidate<'a> {
     /// Full score vector for sorting
     score_vec_full: ScoresVector,
     /// Rule ID
-    pub(super) rid: usize,
+    pub(super) rid: RuleId,
     /// Reference to the rule (borrowed from LicenseIndex)
     pub(super) rule: &'a Rule,
     /// Set of high-value (legalese) tokens in the intersection
@@ -280,10 +281,10 @@ impl Ord for Candidate<'_> {
 fn compare_candidate_rank(
     rounded: &ScoresVector,
     full: &ScoresVector,
-    rid: usize,
+    rid: RuleId,
     other_rounded: &ScoresVector,
     other_full: &ScoresVector,
-    other_rid: usize,
+    other_rid: RuleId,
 ) -> std::cmp::Ordering {
     rounded
         .cmp(other_rounded)
@@ -333,7 +334,7 @@ fn passes_minimum_containment(rule: &Rule, metrics: CandidateMetrics) -> bool {
 }
 
 fn build_ranked_candidate<'a>(
-    rid: usize,
+    rid: RuleId,
     rule: &'a Rule,
     high_set_intersection: TokenSet,
     metrics: CandidateMetrics,
@@ -372,7 +373,7 @@ fn find_set_candidates<'a>(
     high_resemblance: bool,
     deadline: Option<Instant>,
 ) -> Vec<Candidate<'a>> {
-    let candidate_rids: HashSet<usize> = query_data
+    let candidate_rids: HashSet<RuleId> = query_data
         .query_high_set
         .iter()
         .filter_map(|tid| index.rids_by_high_tid.get(&TokenId::new(tid)))
@@ -386,7 +387,7 @@ fn find_set_candidates<'a>(
             return candidates;
         }
 
-        let Some(rule) = index.rules_by_rid.get(rid) else {
+        let Some(rule) = index.rules_by_rid.get(rid.raw()) else {
             continue;
         };
         let Some(rule_set) = index.sets_by_rid.get(&rid) else {
@@ -620,7 +621,7 @@ mod tests {
     use super::*;
     use crate::license_detection::index::dictionary::tid;
 
-    fn candidate<'a>(rid: usize, rule: &'a Rule, metrics: CandidateMetrics) -> Candidate<'a> {
+    fn candidate<'a>(rid: RuleId, rule: &'a Rule, metrics: CandidateMetrics) -> Candidate<'a> {
         Candidate {
             metrics,
             score_vec_rounded: metrics.rounded_score_vector(rid),
@@ -633,8 +634,8 @@ mod tests {
 
     #[test]
     fn test_scores_vector_comparison() {
-        let sv1 = CandidateMetrics::new(9, 10, 10).rounded_score_vector(0);
-        let sv2 = CandidateMetrics::new(5, 10, 10).rounded_score_vector(1);
+        let sv1 = CandidateMetrics::new(9, 10, 10).rounded_score_vector(RuleId::new(0));
+        let sv2 = CandidateMetrics::new(5, 10, 10).rounded_score_vector(RuleId::new(1));
 
         assert!(sv1 > sv2);
     }
@@ -729,8 +730,8 @@ mod tests {
             stopwords_by_pos: std::collections::HashMap::new(),
         };
 
-        let candidate1 = candidate(0, &rule1, CandidateMetrics::new(9, 10, 10));
-        let candidate2 = candidate(1, &rule2, CandidateMetrics::new(5, 10, 10));
+        let candidate1 = candidate(RuleId::new(0), &rule1, CandidateMetrics::new(9, 10, 10));
+        let candidate2 = candidate(RuleId::new(1), &rule2, CandidateMetrics::new(5, 10, 10));
 
         assert!(
             candidate1 > candidate2,
@@ -787,8 +788,8 @@ mod tests {
             ..rule1.clone()
         };
 
-        let candidate1 = candidate(1, &rule1, CandidateMetrics::new(138, 200, 276));
-        let candidate2 = candidate(2, &rule2, CandidateMetrics::new(133, 200, 266));
+        let candidate1 = candidate(RuleId::new(1), &rule1, CandidateMetrics::new(138, 200, 276));
+        let candidate2 = candidate(RuleId::new(2), &rule2, CandidateMetrics::new(133, 200, 266));
 
         let candidates = vec![candidate1, candidate2];
         let filtered = filter_dupes(candidates);
@@ -849,8 +850,8 @@ mod tests {
             ..rule1.clone()
         };
 
-        let candidate1 = candidate(1, &rule1, CandidateMetrics::new(100, 200, 200));
-        let candidate2 = candidate(2, &rule2, CandidateMetrics::new(100, 200, 200));
+        let candidate1 = candidate(RuleId::new(1), &rule1, CandidateMetrics::new(100, 200, 200));
+        let candidate2 = candidate(RuleId::new(2), &rule2, CandidateMetrics::new(100, 200, 200));
 
         let candidates = vec![candidate1, candidate2];
         let filtered = filter_dupes(candidates);
@@ -942,8 +943,16 @@ mod tests {
             stopwords_by_pos: std::collections::HashMap::new(),
         };
 
-        let candidate_sa = candidate(1, &rule_sa, CandidateMetrics::new(100, 110, 111));
-        let candidate_nc_sa = candidate(2, &rule_nc_sa, CandidateMetrics::new(100, 110, 111));
+        let candidate_sa = candidate(
+            RuleId::new(1),
+            &rule_sa,
+            CandidateMetrics::new(100, 110, 111),
+        );
+        let candidate_nc_sa = candidate(
+            RuleId::new(2),
+            &rule_nc_sa,
+            CandidateMetrics::new(100, 110, 111),
+        );
 
         let candidates = vec![candidate_nc_sa, candidate_sa];
         let filtered = filter_dupes(candidates);
@@ -1035,19 +1044,20 @@ mod tests {
             ..rule_a.clone()
         };
 
-        let candidate_low_rid = candidate(1, &rule_z, CandidateMetrics::new(9, 10, 10));
+        let candidate_low_rid =
+            candidate(RuleId::new(1), &rule_z, CandidateMetrics::new(9, 10, 10));
 
         let candidate_high_rid = Candidate {
             score_vec_rounded: ScoresVector {
-                rid: 2,
+                rid: RuleId::new(2),
                 ..candidate_low_rid.score_vec_rounded
             },
             score_vec_full: ScoresVector {
-                rid: 2,
+                rid: RuleId::new(2),
                 ..candidate_low_rid.score_vec_full
             },
             metrics: candidate_low_rid.metrics,
-            rid: 2,
+            rid: RuleId::new(2),
             rule: &rule_a,
             high_set_intersection: TokenSet::new(),
         };
@@ -1055,7 +1065,8 @@ mod tests {
         let mut sorted = [candidate_low_rid, candidate_high_rid];
         sorted.sort_by(|a, b| b.cmp(a));
         assert_eq!(
-            sorted[0].rid, 2,
+            sorted[0].rid,
+            RuleId::new(2),
             "Python final candidate tuple ordering falls back to higher rid after equal scores"
         );
     }

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -387,7 +387,7 @@ fn find_set_candidates<'a>(
             return candidates;
         }
 
-        let Some(rule) = index.rules_by_rid.get(rid.raw()) else {
+        let Some(rule) = index.rule(rid) else {
             continue;
         };
         let Some(rule_set) = index.sets_by_rid.get(&rid) else {

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -240,7 +240,7 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
         }
 
         let rid = candidate.rid;
-        let rule_tokens = index.tids_by_rid.get(rid.raw());
+        let rule_tokens = index.rule_tokens(rid);
         let high_postings: HashMap<TokenId, Vec<usize>> = index
             .high_postings_by_rid
             .get(&rid)

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -240,7 +240,7 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
         }
 
         let rid = candidate.rid;
-        let rule_tokens = index.tids_by_rid.get(rid);
+        let rule_tokens = index.tids_by_rid.get(rid.raw());
         let high_postings: HashMap<TokenId, Vec<usize>> = index
             .high_postings_by_rid
             .get(&rid)

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::license_detection::index::LicenseIndex;
     use crate::license_detection::index::dictionary::{TokenId, TokenKind};
     use crate::license_detection::models::Rule;
+    use crate::license_detection::models::RuleId;
     use crate::license_detection::query::Query;
     use crate::license_detection::test_utils::create_test_index;
     use crate::license_detection::{TokenMultiset, TokenSet};
@@ -66,8 +67,8 @@ mod tests {
         )
     }
 
-    pub(super) fn add_test_rule(index: &mut LicenseIndex, text: &str, expression: &str) -> usize {
-        let rid = index.rules_by_rid.len();
+    pub(super) fn add_test_rule(index: &mut LicenseIndex, text: &str, expression: &str) -> RuleId {
+        let rid = RuleId::new(index.rules_by_rid.len());
         let tokens: Vec<TokenId> = text
             .split_whitespace()
             .filter_map(|word| index.dictionary.get(word))

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -139,7 +139,6 @@ mod tests {
 
         index.rules_by_rid.push(rule.clone());
         index.tids_by_rid.push(tokens.clone());
-        index.approx_matchable_rids.insert(rid);
 
         // Also populate inverted index for high-value tokens
         for &tid in &tokens {

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -22,7 +22,7 @@ use std::sync::LazyLock;
 use crate::license_detection::expression::{LicenseExpression, parse_expression};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleId};
 use crate::license_detection::query::Query;
 use crate::models::LineNumber;
 use crate::models::MatchScore;
@@ -352,7 +352,7 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
                 .get(&resolved_expression)
                 .copied()
                 .or(index.unknown_spdx_rid)
-                .unwrap_or(0);
+                .unwrap_or(RuleId::NONE);
 
             let rule_relevance = 100;
             let rule_identifier =
@@ -577,16 +577,16 @@ fn convert_recovered_expression_to_scancode(
     match expr {
         LicenseExpression::License(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(&rid) = index.rid_by_spdx_key.get(&lookup_key) {
-                LicenseExpression::License(index.rules_by_rid[rid].license_expression.clone())
+            if let Some(rid) = index.rid_by_spdx_key.get(&lookup_key).copied() {
+                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
             } else {
                 LicenseExpression::License("unknown-spdx".to_string())
             }
         }
         LicenseExpression::LicenseRef(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(&rid) = index.rid_by_spdx_key.get(&lookup_key) {
-                LicenseExpression::License(index.rules_by_rid[rid].license_expression.clone())
+            if let Some(rid) = index.rid_by_spdx_key.get(&lookup_key).copied() {
+                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
             } else {
                 LicenseExpression::License("unknown-spdx".to_string())
             }
@@ -725,8 +725,8 @@ fn unknown_spdx_license_ref() -> String {
     UNKNOWN_SPDX_LICENSE_REF.to_string()
 }
 
-fn rule_spdx_expression(index: &LicenseIndex, rid: usize) -> Option<String> {
-    let rule = index.rules_by_rid.get(rid)?;
+fn rule_spdx_expression(index: &LicenseIndex, rid: RuleId) -> Option<String> {
+    let rule = index.rules_by_rid.get(rid.raw())?;
 
     index
         .rule_metadata_by_identifier
@@ -801,8 +801,8 @@ fn resolve_matching_rule_for_expression(
     index: &LicenseIndex,
     expression: &str,
 ) -> Option<ResolvedExpression> {
-    if let Some(&rid) = index.rid_by_spdx_key.get(expression) {
-        let rule = &index.rules_by_rid[rid];
+    if let Some(rid) = index.rid_by_spdx_key.get(expression).copied() {
+        let rule = &index.rules_by_rid[rid.raw()];
         return Some(ResolvedExpression {
             scancode_expression: rule.license_expression.clone(),
             spdx_expression: rule_spdx_expression(index, rid),
@@ -866,7 +866,7 @@ fn resolve_matching_rule_for_expression(
     }
 
     index.unknown_spdx_rid.map(|rid| ResolvedExpression {
-        scancode_expression: index.rules_by_rid[rid].license_expression.clone(),
+        scancode_expression: index.rules_by_rid[rid.raw()].license_expression.clone(),
         spdx_expression: rule_spdx_expression(index, rid)
             .or_else(|| Some(unknown_spdx_license_ref())),
     })
@@ -888,23 +888,15 @@ fn convert_spdx_expression_to_scancode(
     match expr {
         LicenseExpression::License(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(&rid) = index.rid_by_spdx_key.get(&lookup_key) {
-                Some(LicenseExpression::License(
-                    index.rules_by_rid[rid].license_expression.clone(),
-                ))
-            } else {
-                None
-            }
+            index.rid_by_spdx_key.get(&lookup_key).copied().map(|rid| {
+                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
+            })
         }
         LicenseExpression::LicenseRef(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(&rid) = index.rid_by_spdx_key.get(&lookup_key) {
-                Some(LicenseExpression::License(
-                    index.rules_by_rid[rid].license_expression.clone(),
-                ))
-            } else {
-                None
-            }
+            index.rid_by_spdx_key.get(&lookup_key).copied().map(|rid| {
+                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
+            })
         }
         LicenseExpression::And { left, right } => {
             let left_converted = convert_spdx_expression_to_scancode(left, index);

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -577,16 +577,26 @@ fn convert_recovered_expression_to_scancode(
     match expr {
         LicenseExpression::License(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(rid) = index.rid_by_spdx_key.get(&lookup_key).copied() {
-                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
+            if let Some(rule) = index
+                .rid_by_spdx_key
+                .get(&lookup_key)
+                .copied()
+                .and_then(|rid| index.rule(rid))
+            {
+                LicenseExpression::License(rule.license_expression.clone())
             } else {
                 LicenseExpression::License("unknown-spdx".to_string())
             }
         }
         LicenseExpression::LicenseRef(key) => {
             let lookup_key = key.to_lowercase();
-            if let Some(rid) = index.rid_by_spdx_key.get(&lookup_key).copied() {
-                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
+            if let Some(rule) = index
+                .rid_by_spdx_key
+                .get(&lookup_key)
+                .copied()
+                .and_then(|rid| index.rule(rid))
+            {
+                LicenseExpression::License(rule.license_expression.clone())
             } else {
                 LicenseExpression::License("unknown-spdx".to_string())
             }
@@ -726,7 +736,7 @@ fn unknown_spdx_license_ref() -> String {
 }
 
 fn rule_spdx_expression(index: &LicenseIndex, rid: RuleId) -> Option<String> {
-    let rule = index.rules_by_rid.get(rid.raw())?;
+    let rule = index.rule(rid)?;
 
     index
         .rule_metadata_by_identifier
@@ -802,7 +812,7 @@ fn resolve_matching_rule_for_expression(
     expression: &str,
 ) -> Option<ResolvedExpression> {
     if let Some(rid) = index.rid_by_spdx_key.get(expression).copied() {
-        let rule = &index.rules_by_rid[rid.raw()];
+        let rule = index.rule(rid).expect("rid from index must be valid");
         return Some(ResolvedExpression {
             scancode_expression: rule.license_expression.clone(),
             spdx_expression: rule_spdx_expression(index, rid),
@@ -865,10 +875,13 @@ fn resolve_matching_rule_for_expression(
         }
     }
 
-    index.unknown_spdx_rid.map(|rid| ResolvedExpression {
-        scancode_expression: index.rules_by_rid[rid.raw()].license_expression.clone(),
-        spdx_expression: rule_spdx_expression(index, rid)
-            .or_else(|| Some(unknown_spdx_license_ref())),
+    index.unknown_spdx_rid.map(|rid| {
+        let rule = index.rule(rid).expect("unknown_spdx_rid must be valid");
+        ResolvedExpression {
+            scancode_expression: rule.license_expression.clone(),
+            spdx_expression: rule_spdx_expression(index, rid)
+                .or_else(|| Some(unknown_spdx_license_ref())),
+        }
     })
 }
 
@@ -888,15 +901,27 @@ fn convert_spdx_expression_to_scancode(
     match expr {
         LicenseExpression::License(key) => {
             let lookup_key = key.to_lowercase();
-            index.rid_by_spdx_key.get(&lookup_key).copied().map(|rid| {
-                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
-            })
+            index
+                .rid_by_spdx_key
+                .get(&lookup_key)
+                .copied()
+                .and_then(|rid| {
+                    index
+                        .rule(rid)
+                        .map(|r| LicenseExpression::License(r.license_expression.clone()))
+                })
         }
         LicenseExpression::LicenseRef(key) => {
             let lookup_key = key.to_lowercase();
-            index.rid_by_spdx_key.get(&lookup_key).copied().map(|rid| {
-                LicenseExpression::License(index.rules_by_rid[rid.raw()].license_expression.clone())
-            })
+            index
+                .rid_by_spdx_key
+                .get(&lookup_key)
+                .copied()
+                .and_then(|rid| {
+                    index
+                        .rule(rid)
+                        .map(|r| LicenseExpression::License(r.license_expression.clone()))
+                })
         }
         LicenseExpression::And { left, right } => {
             let left_converted = convert_spdx_expression_to_scancode(left, index);

--- a/src/license_detection/spdx_lid/test.rs
+++ b/src/license_detection/spdx_lid/test.rs
@@ -3,6 +3,7 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::license_detection::models::RuleId;
     use crate::license_detection::query::Query;
     use crate::license_detection::spdx_lid::*;
     use crate::license_detection::test_utils::{create_mock_rule_simple, create_test_index};
@@ -30,14 +31,14 @@ mod tests {
         let mut index = create_test_index(&[], 0);
 
         for (spdx_key, license_expression) in entries {
-            let rid = index.rules_by_rid.len();
+            let rid = RuleId::new(index.rules_by_rid.len());
             index
                 .rules_by_rid
                 .push(create_mock_rule_simple(license_expression, 100));
             index.rid_by_spdx_key.insert(spdx_key.to_string(), rid);
         }
 
-        let unknown_rid = index.rules_by_rid.len();
+        let unknown_rid = RuleId::new(index.rules_by_rid.len());
         index
             .rules_by_rid
             .push(create_mock_rule_simple("unknown-spdx", 100));
@@ -431,7 +432,7 @@ mod tests {
     #[test]
     fn test_spdx_lid_match_uses_full_line_span_when_expression_tokens_are_unknown() {
         let mut index = create_test_index(&[("spdx", 0), ("license", 1), ("identifier", 2)], 3);
-        let apache_rid = index.rules_by_rid.len();
+        let apache_rid = RuleId::new(index.rules_by_rid.len());
         index
             .rules_by_rid
             .push(create_mock_rule_simple("apache-2.0", 100));
@@ -655,8 +656,8 @@ mod tests {
             "Should have gpl-2.0+ in SPDX key mappings"
         );
 
-        if let Some(&rid) = index.rid_by_spdx_key.get("gpl-2.0+") {
-            let rule = &index.rules_by_rid[rid];
+        if let Some(rid) = index.rid_by_spdx_key.get("gpl-2.0+").copied() {
+            let rule = &index.rules_by_rid[rid.raw()];
             assert_eq!(
                 rule.license_expression, "gpl-2.0-plus",
                 "GPL-2.0+ should map to gpl-2.0-plus rule"
@@ -699,7 +700,9 @@ mod tests {
             1,
         );
         index.rules_by_rid.push(create_mock_rule_simple("mit", 100));
-        index.rid_by_spdx_key.insert("mit".to_string(), 0);
+        index
+            .rid_by_spdx_key
+            .insert("mit".to_string(), RuleId::new(0));
 
         let text = "NOTICE SPDX-License-Identifier: MIT";
         let query = Query::from_extracted_text(text, &index, false).unwrap();
@@ -718,7 +721,9 @@ mod tests {
             1,
         );
         index.rules_by_rid.push(create_mock_rule_simple("mit", 100));
-        index.rid_by_spdx_key.insert("mit".to_string(), 0);
+        index
+            .rid_by_spdx_key
+            .insert("mit".to_string(), RuleId::new(0));
 
         let plain =
             Query::from_extracted_text("// SPDX-License-Identifier: MIT", &index, false).unwrap();
@@ -795,8 +800,8 @@ mod tests {
         ];
 
         for (spdx_key, expected_expr) in test_cases {
-            if let Some(&rid) = index.rid_by_spdx_key.get(spdx_key) {
-                let rule = &index.rules_by_rid[rid];
+            if let Some(rid) = index.rid_by_spdx_key.get(spdx_key).copied() {
+                let rule = &index.rules_by_rid[rid.raw()];
                 assert_eq!(
                     rule.license_expression, expected_expr,
                     "SPDX key '{}' should map to expression '{}'",

--- a/src/license_detection/spdx_lid/test.rs
+++ b/src/license_detection/spdx_lid/test.rs
@@ -657,7 +657,7 @@ mod tests {
         );
 
         if let Some(rid) = index.rid_by_spdx_key.get("gpl-2.0+").copied() {
-            let rule = &index.rules_by_rid[rid.raw()];
+            let rule = index.rule(rid).expect("test rid must be valid");
             assert_eq!(
                 rule.license_expression, "gpl-2.0-plus",
                 "GPL-2.0+ should map to gpl-2.0-plus rule"
@@ -801,7 +801,7 @@ mod tests {
 
         for (spdx_key, expected_expr) in test_cases {
             if let Some(rid) = index.rid_by_spdx_key.get(spdx_key).copied() {
-                let rule = &index.rules_by_rid[rid.raw()];
+                let rule = index.rule(rid).expect("test rid must be valid");
                 assert_eq!(
                     rule.license_expression, expected_expr,
                     "SPDX key '{}' should map to expression '{}'",

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -366,7 +366,9 @@ fn test_engine_index_populated() {
 
     let mut rules_with_tokens = 0;
     for &rid in index.rid_by_hash.values().take(10) {
-        let rule = &index.rules_by_rid[rid.raw()];
+        let Some(rule) = index.rule(rid) else {
+            continue;
+        };
         if !rule.tokens.is_empty() {
             rules_with_tokens += 1;
             assert!(

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -366,7 +366,7 @@ fn test_engine_index_populated() {
 
     let mut rules_with_tokens = 0;
     for &rid in index.rid_by_hash.values().take(10) {
-        let rule = &index.rules_by_rid[rid];
+        let rule = &index.rules_by_rid[rid.raw()];
         if !rule.tokens.is_empty() {
             rules_with_tokens += 1;
             assert!(

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -357,11 +357,11 @@ fn test_engine_index_populated() {
     );
 
     assert!(
-        !index.approx_matchable_rids.is_empty(),
-        "Should have approx-matchable rules"
+        !index.rid_by_hash.is_empty(),
+        "Should have rules with computed hashes"
     );
 
-    let has_false_positives = !index.false_positive_rids.is_empty();
+    let has_false_positives = index.rules_by_rid.iter().any(|r| r.is_false_positive);
     assert!(has_false_positives, "Should have false positive rules");
 
     let mut rules_with_tokens = 0;
@@ -684,12 +684,10 @@ fn test_engine_index_high_postings() {
     let engine = get_engine();
     let index = engine.index();
 
-    if !index.approx_matchable_rids.is_empty() {
-        let some_approx_rid = index.approx_matchable_rids.iter().next().unwrap();
-        if index.high_postings_by_rid.contains_key(some_approx_rid) {
-            let postings = &index.high_postings_by_rid[some_approx_rid];
-            assert!(!postings.is_empty(), "High postings should have entries");
-        }
+    if !index.high_postings_by_rid.is_empty() {
+        let some_rid = index.high_postings_by_rid.keys().next().unwrap();
+        let postings = &index.high_postings_by_rid[some_rid];
+        assert!(!postings.is_empty(), "High postings should have entries");
     }
 }
 

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind};
+use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleId};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
 use crate::license_detection::tokenize::STOPWORDS;
@@ -268,7 +268,7 @@ fn create_unknown_match_from_qspan(query: &Query, qspan: &PositionSet) -> Option
     let qspan_span = qspan.to_position_span();
 
     LicenseMatch {
-        rid: 0,
+        rid: RuleId::NONE,
         license_expression: "unknown".to_string(),
         license_expression_spdx: None,
         from_file: None,
@@ -811,7 +811,7 @@ mod tests {
             .expect("Failed to create query");
 
         let known_matches = vec![LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "test".to_string(),
             license_expression_spdx: Some("TEST".to_string()),
             from_file: None,
@@ -860,7 +860,7 @@ mod tests {
             .expect("Failed to create query");
 
         let known_matches = vec![LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "test".to_string(),
             license_expression_spdx: Some("TEST".to_string()),
             from_file: None,
@@ -908,7 +908,7 @@ mod tests {
             .expect("Failed to create query");
 
         let known_matches = vec![LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "test".to_string(),
             license_expression_spdx: Some("TEST".to_string()),
             from_file: None,
@@ -991,7 +991,7 @@ mod tests {
             Query::from_extracted_text(text, &index, false).expect("Failed to create query");
 
         let known_matches = vec![LicenseMatch {
-            rid: 0,
+            rid: RuleId::NONE,
             license_expression: "mit".to_string(),
             license_expression_spdx: Some("MIT".to_string()),
             from_file: None,

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -568,7 +568,7 @@ fn normalize_license_key(key: &str, index: &LicenseIndex) -> Option<NormalizedDe
         .rid_by_spdx_key
         .get(&normalized_key.to_ascii_lowercase())
     {
-        let rule_license_expression = index.rules_by_rid[*rid].license_expression.clone();
+        let rule_license_expression = index.rules_by_rid[rid.raw()].license_expression.clone();
         if rule_license_expression.contains("unknown-spdx") {
             return None;
         }

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -568,7 +568,11 @@ fn normalize_license_key(key: &str, index: &LicenseIndex) -> Option<NormalizedDe
         .rid_by_spdx_key
         .get(&normalized_key.to_ascii_lowercase())
     {
-        let rule_license_expression = index.rules_by_rid[rid.raw()].license_expression.clone();
+        let rule_license_expression = index
+            .rule(*rid)
+            .expect("rid from spdx key lookup must be valid")
+            .license_expression
+            .clone();
         if rule_license_expression.contains("unknown-spdx") {
             return None;
         }

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -10,6 +10,7 @@ use crate::license_detection::detection::{
     select_matches_for_expression,
 };
 use crate::license_detection::expression::parse_expression;
+use crate::license_detection::models::RuleId;
 use crate::models::{
     FileInfo, FileType, LicenseDetection, Match, Package, PackageUid, TopLevelLicenseDetection,
 };
@@ -1375,7 +1376,7 @@ fn public_match_to_internal(
     detection_match: &Match,
 ) -> crate::license_detection::models::LicenseMatch {
     crate::license_detection::models::LicenseMatch {
-        rid: 0,
+        rid: RuleId::NONE,
         license_expression: detection_match.license_expression.clone(),
         license_expression_spdx: (!detection_match.license_expression_spdx.is_empty())
             .then(|| detection_match.license_expression_spdx.clone()),

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -13,7 +13,9 @@ use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenDictionary;
 use crate::license_detection::models::License;
 use crate::license_detection::models::position_span::PositionSpan;
-use crate::license_detection::models::{LicenseMatch, MatchCoordinates, MatcherKind, RuleKind};
+use crate::license_detection::models::{
+    LicenseMatch, MatchCoordinates, MatcherKind, RuleId, RuleKind,
+};
 use crate::license_detection::query::Query;
 use crate::models::{
     FileInfoBuilder, LicenseDetection as PublicLicenseDetection, LineNumber, Match, MatchScore,
@@ -38,7 +40,7 @@ static TEST_ENGINE: LazyLock<Arc<LicenseDetectionEngine>> = LazyLock::new(|| {
 
 fn make_internal_match(rule_url: &str) -> LicenseMatch {
     LicenseMatch {
-        rid: 0,
+        rid: RuleId::NONE,
         license_expression: "mit".to_string(),
         license_expression_spdx: Some("MIT".to_string()),
         from_file: None,
@@ -90,7 +92,7 @@ fn make_internal_notice_match(
     end_line: usize,
 ) -> LicenseMatch {
     LicenseMatch {
-        rid: 0,
+        rid: RuleId::NONE,
         license_expression: expr.to_string(),
         license_expression_spdx: Some(expr_spdx.to_string()),
         from_file: Some("NOTICE".to_string()),


### PR DESCRIPTION
## Summary

- Introduce a `RuleId` newtype wrapping `usize` for all internal numeric rule IDs in the license detection pipeline, replacing bare `usize` across ~50+ sites in 33 files.
- Add `LicenseIndex::rule()` and `rule_tokens()` lookup methods so consumers get `Option<&Rule>` / `Option<&[TokenId]>` instead of manually indexing `rules_by_rid` with `.raw()`.
- Type the Aho-Corasick automaton's `Match.rule_id` as `RuleId` (renamed from `Match.pattern: usize`), converting at the iterator boundary.

## Motivation

**Bug fix**: The codebase used `rid: 0` as a sentinel for "no valid rule" in ~15+ sites (e.g., `unknown_match.rs:271`, `spdx_lid/mod.rs:355` with `.unwrap_or(0)`). However, `rid=0` is a **perfectly valid rule ID** — it indexes `389-exception.LICENSE`, a real SPDX exception with 221 tokens of legal text. Any code that defaulted to `rid: 0` would silently alias this real rule, and any code checking `rid != 0` to mean "a match was found" would incorrectly reject a legitimate 389-exception match.

The newtype uses `RuleId::NONE` (internally `usize::MAX`) as the sentinel, which is unreachable as a real Vec index. `LicenseIndex::rule()` and `rule_tokens()` check `id.is_none()` and return `None`, so the sentinel is handled correctly at every lookup site without callers needing to know the sentinel value.

**Type safety**: `rid` was bare `usize` — the same type as pattern IDs, token positions, line numbers, and match lengths. The newtype prevents accidental confusion between these domains at compile time, following the existing `TokenId(u16)` precedent.

## Test plan

- All existing tests pass with `cargo clippy --all-targets --all-features`.
- No behavioral changes — the newtype is structurally identical to `usize` at runtime.
- The sentinel fix (`RuleId::NONE` vs `0`) is the only semantic change; previously no code path actually dereferenced the `rid: 0` sentinel through `rules_by_rid`, so this is a latent bug fix rather than a behavior change observable in current test output.