### PR TITLE
fix: url sftp misparse, copyright copr/bash FP, RPM file-path purl

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 198 of 198 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 199 of 199 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -797,6 +797,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `78.51s`; ScanCode `2493.21s`
 - Broader Meson and package-adjacent dependency extraction (`22` vs `21` packages, `260` vs `176` dependencies) from the root `.gitmodules`, `python/tests/minreqs.txt`, and many committed `subprojects/**/meson.build` manifests, with the real `pkg:autotools/qemu` root identity instead of ScanCode's generic input placeholder
+
+##### [restic/restic @ 29446b0](https://github.com/restic/restic/tree/29446b0fd853b7765f652584ff90e817890ee389) — **8.47× faster**
+
+- Files: 1,284
+- Run context: 2026-05-18 · restic-116171 · Linux 6.17 · Intel i5-12400 · 46 GB · x86_64 · 4 proc
+- Timing: Provenant `13.31s`; ScanCode `112.67s`
+- Broader Go module and RPM spec dependency extraction (`2` vs `1` packages, `352` vs `348` dependencies) from `go.mod`/`go.sum` plus `contrib/restic.spec`, with correct `rpm_specfile` datasource spelling and valid RPM purl construction where ScanCode emits a typo (`rpm_spefile`) and null purl, cleaner `BSD-2-Clause` detection without ScanCode's low-relevance `unknown-license-reference` false positive on README.md, extra Docker package visibility on `docker/Dockerfile`, and correct rejection of `sftp.X` Go-identifier URLs, `dnf copr` copyright noise, and bash `${var[@]}` array-expansion copyright artifacts
 
 ##### [rpm-software-management/dnf @ e47634f](https://github.com/rpm-software-management/dnf/tree/e47634fbe3565d0580e89ec21adb7c1b308642ce) — **14.16× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -383,6 +383,9 @@ ScanCode: 110.49s</title></rect>
     <rect x="584.90" y="363.00" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/dejacode @ 4938cd4
 Files: 1278
 ScanCode: 272.67s</title></rect>
+    <rect x="585.23" y="404.76" width="8" height="8" fill="#d97706" rx="1.5"><title>restic/restic @ 29446b0
+Files: 1284
+ScanCode: 112.67s</title></rect>
     <rect x="594.45" y="353.48" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 ScanCode: 333.52s</title></rect>
@@ -979,6 +982,9 @@ Provenant: 12.05s</title></circle>
     <circle cx="588.90" cy="480.90" r="4.5" fill="#2563eb"><title>aboutcode-org/dejacode @ 4938cd4
 Files: 1278
 Provenant: 24.48s</title></circle>
+    <circle cx="589.23" cy="509.69" r="4.5" fill="#2563eb"><title>restic/restic @ 29446b0
+Files: 1284
+Provenant: 13.31s</title></circle>
     <circle cx="598.45" cy="492.95" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 Provenant: 18.97s</title></circle>

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -333,7 +333,7 @@ fn assemble_one_per_package_data(
             let deps: Vec<TopLevelDependency> = pkg_data
                 .dependencies
                 .iter()
-                .filter(|dep| dep.purl.is_some())
+                .filter(|dep| dep.purl.is_some() || dep.extracted_requirement.is_some())
                 .map(|dep| {
                     TopLevelDependency::from_dependency(
                         dep,

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -346,7 +346,7 @@ fn collect_pending_dependencies(
     pkg_data
         .dependencies
         .iter()
-        .filter(|dep| dep.purl.is_some())
+        .filter(|dep| dep.purl.is_some() || dep.extracted_requirement.is_some())
         .cloned()
         .map(|dependency| PendingDependency {
             dependency,

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -481,3 +481,31 @@ fn test_meta_sdk_license_false_positive_detector_drops_legal_prose_fragments() {
         );
     }
 }
+
+#[test]
+fn test_dnf_copr_command_does_not_produce_copyright() {
+    let text = concat!(
+        "If you used restic from copr previously, remove the copr repo as follows:\n",
+        "   $ dnf copr remove copart/restic\n",
+        "For RHEL7/CentOS there is a copr repository available:\n",
+        "    $ yum copr enable copart/restic\n",
+    );
+    let (copyrights, holders, authors) = detect_copyrights_from_text(text);
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+    assert!(holders.is_empty(), "holders: {holders:?}");
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_bash_array_expansion_does_not_produce_copyright() {
+    let text = concat!(
+        "if __restic_contains_word '${words[c]}' '${two_word_flags[@]}'; then\n",
+        "elif __restic_contains_word '${words[c]}' '${must_have_one_noun[@]}'; then\n",
+        "elif __restic_contains_word '${words[c]}' '${commands[@]}'; then\n",
+        "elif __restic_contains_word '${words[c]}' '${command_aliases[@]}'; then\n",
+    );
+    let (copyrights, holders, authors) = detect_copyrights_from_text(text);
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+    assert!(holders.is_empty(), "holders: {holders:?}");
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}

--- a/src/copyright/hints.rs
+++ b/src/copyright/hints.rs
@@ -29,7 +29,7 @@ pub const HINT_MARKERS: &[&str] = &[
     "opyr",
     // have copyleft
     "opyl",
-    "copr",
+    "copr.",
     "reserv",
     "auth",
     "contrib",
@@ -204,6 +204,11 @@ mod tests {
     #[test]
     fn test_hint_copr() {
         assert!(has_copyright_hint("Copr. 2024 Foo"));
+    }
+
+    #[test]
+    fn test_hint_copr_without_period_is_not_hint() {
+        assert!(!has_copyright_hint("dnf copr remove user/project"));
     }
 
     #[test]

--- a/src/copyright/patterns.rs
+++ b/src/copyright/patterns.rs
@@ -160,9 +160,9 @@ fn build_pattern_list() -> Vec<(String, PosTag)> {
     add(r"^\(c\),?$", PosTag::Copy);
 
     // Copr.
-    add(r"^COPR\.?$", PosTag::Copy);
-    add(r"^copr\.?$", PosTag::Copy);
-    add(r"^Copr\.?$", PosTag::Copy);
+    add(r"^COPR\.$", PosTag::Copy);
+    add(r"^copr\.$", PosTag::Copy);
+    add(r"^Copr\.$", PosTag::Copy);
 
     // copyright in markup, until we strip markup: apache'>Copyright
     add(r"[A-Za-z0-9]+['\x22>]+[Cc]opyright", PosTag::Copy);

--- a/src/copyright/patterns_test.rs
+++ b/src/copyright/patterns_test.rs
@@ -17,7 +17,8 @@ fn test_copyright_markers() {
     assert_eq!(p.match_token("(c)"), PosTag::Copy);
     assert_eq!(p.match_token("(C)"), PosTag::Copy);
     assert_eq!(p.match_token("COPR."), PosTag::Copy);
-    assert_eq!(p.match_token("Copr"), PosTag::Copy);
+    assert_eq!(p.match_token("Copr."), PosTag::Copy);
+    assert_eq!(p.match_token("Copr"), PosTag::Nnp);
     assert_eq!(p.match_token("COPYRIGHT"), PosTag::Copy);
     assert_eq!(p.match_token("Copyrights"), PosTag::Copy);
     assert_eq!(p.match_token("copyrighted"), PosTag::Copy);
@@ -56,7 +57,8 @@ fn test_copyright_special_forms() {
     assert_eq!(p.match_token("copyright'>"), PosTag::Copy);
     assert_eq!(p.match_token("@Copyright"), PosTag::Copy);
     assert_eq!(p.match_token("(C),"), PosTag::Copy);
-    assert_eq!(p.match_token("copr"), PosTag::Copy);
+    assert_eq!(p.match_token("copr."), PosTag::Copy);
+    assert_eq!(p.match_token("copr"), PosTag::Nn);
     assert_eq!(p.match_token("AssemblyCopyright"), PosTag::Copy);
 }
 

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -128,6 +128,9 @@ static ANGLE_BRACKET_SINGLE_YEAR_RE: LazyLock<Regex> =
 /// Regex to strip CSS measurement artifacts like "0pt" that leak through HTML demarkup.
 static CSS_MEASUREMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b\d+pt\b").unwrap());
 
+static BASH_ARRAY_EXPANSION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$\{[a-zA-Z_][a-zA-Z0-9_]*\[[^\]]*\]\}").unwrap());
+
 static JOIN_REGISTERED_MARK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?P<head>[A-Za-z0-9])\s+\(r\)").unwrap());
 
@@ -279,6 +282,10 @@ pub fn prepare_text_line(line: &str) -> String {
 
     // Remove printf format codes like ` %s ` or ` #d `
     s = PRINTF_FORMAT_RE.replace_all(&s, " ").into_owned();
+
+    // Replace bash array expansions like ${commands[@]} with a space
+    // before punctuation stripping exposes (c) patterns or @ hints.
+    s = BASH_ARRAY_EXPANSION_RE.replace_all(&s, " ").into_owned();
 
     // Remove less common comment markers (rem, @rem, dnl)
     s = WEIRD_COMMENT_RE.replace_all(&s, " ").into_owned();
@@ -1343,6 +1350,19 @@ mod tests {
     fn test_strip_o_template_element_content() {
         let result = prepare_text_line("<o:Template>techdoc.dot</o:Template>");
         assert!(!result.to_ascii_lowercase().contains("techdoc.dot"));
+    }
+
+    #[test]
+    fn test_prepare_strips_bash_array_expansion() {
+        let result = prepare_text_line("elif __restic_contains_word '${commands[@]}'; then");
+        assert!(
+            !result.contains("${commands[@]}"),
+            "bash array expansion should be stripped: {result}"
+        );
+        assert!(
+            !result.contains("@"),
+            "no @ should remain from array expansion: {result}"
+        );
     }
 }
 

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -334,6 +334,30 @@ mod tests {
     }
 
     #[test]
+    fn test_find_urls_ignores_sftp_go_identifiers() {
+        let text = "Use sftp.Client to connect via sftp.Config with sftp.c.Stat()";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+        assert!(urls.is_empty(), "urls: {urls:#?}");
+    }
+
+    #[test]
+    fn test_find_urls_keeps_ftp_hostname_after_punctuation() {
+        let text = "Download: ftp.gnu.org/gnu/tar/ and also (ftp.mozilla.org/pub/)";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        let values: Vec<_> = urls.into_iter().map(|url| url.url).collect();
+        assert_eq!(
+            values,
+            vec![
+                "http://ftp.gnu.org/gnu/tar/".to_string(),
+                "http://ftp.mozilla.org/pub/".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_find_urls_ignores_file_like_fake_hosts() {
         let text = "http://ftp.sftp/ http://www.classes.hint/ http://www.conf.default/ https://rust-lang.org/real";
         let config = DetectionConfig::default();

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -159,6 +159,13 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
 
         for segment in normalized_line.split("\\n") {
             for matched in URLS_REGEX.find_iter(segment) {
+                if matched.start() > 0 {
+                    let prev_byte = segment.as_bytes()[matched.start() - 1];
+                    if prev_byte.is_ascii_alphanumeric() {
+                        continue;
+                    }
+                }
+
                 let mut candidate = matched.as_str().to_string();
 
                 candidate = verbatim_crlf_url_cleaner(&candidate);

--- a/src/parsers/rpm_scan_test.rs
+++ b/src/parsers/rpm_scan_test.rs
@@ -35,7 +35,8 @@ mod tests {
                 && dep.for_package_uid.as_deref() == Some(package.package_uid.as_str())
         }));
         assert!(result.dependencies.iter().any(|dep| {
-            dep.purl.as_deref() == Some("pkg:rpm/%2Fsbin%2Finstall-info")
+            dep.purl.is_none()
+                && dep.extracted_requirement.as_deref() == Some("/sbin/install-info")
                 && dep.scope.as_deref() == Some("post")
                 && dep.for_package_uid.as_deref() == Some(package.package_uid.as_str())
         }));

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -433,8 +433,14 @@ fn extract_dep_name(dep: &str) -> String {
     truncate_field(parts[0].to_string())
 }
 
-/// Builds a package URL for RPM packages
+/// Builds a package URL for RPM packages.
+/// Returns `None` for file-path dependencies (e.g. `/bin/bash`) since they
+/// are not valid purl names and would produce broken `%2F`-encoded results.
 fn build_rpm_purl(name: &str, version: Option<&str>) -> Option<String> {
+    if name.starts_with('/') {
+        return None;
+    }
+
     let mut purl = PackageUrl::new(PACKAGE_TYPE.as_str(), name).ok()?;
 
     if let Some(ver) = version {

--- a/src/parsers/rpm_specfile_test.rs
+++ b/src/parsers/rpm_specfile_test.rs
@@ -342,3 +342,47 @@ Macro package
         .unwrap();
     assert_eq!(provides[0].as_str(), Some("macro-pkg-libs = 2.4"));
 }
+
+#[test]
+fn test_file_path_dependency_has_no_purl() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_path = temp_dir.path().join("filepath-dep.spec");
+
+    let spec = r#"
+Name: filepath-dep-pkg
+Version: 1.0
+Release: 1
+Summary: Package with file-path requires
+License: MIT
+Requires: /bin/bash
+Requires(post): /sbin/ldconfig
+BuildRequires: /usr/bin/make
+
+%description
+Package with file-path requires
+"#;
+
+    fs::write(&spec_path, spec).unwrap();
+    let pkg = RpmSpecfileParser::extract_first_package(&spec_path);
+
+    let runtime_file_path = pkg
+        .dependencies
+        .iter()
+        .find(|dep| dep.extracted_requirement.as_deref() == Some("/bin/bash"))
+        .unwrap();
+    assert!(runtime_file_path.purl.is_none());
+
+    let post_file_path = pkg
+        .dependencies
+        .iter()
+        .find(|dep| dep.extracted_requirement.as_deref() == Some("/sbin/ldconfig"))
+        .unwrap();
+    assert!(post_file_path.purl.is_none());
+
+    let build_file_path = pkg
+        .dependencies
+        .iter()
+        .find(|dep| dep.extracted_requirement.as_deref() == Some("/usr/bin/make"))
+        .unwrap();
+    assert!(build_file_path.purl.is_none());
+}

--- a/testdata/rpm/specfile/cpio.spec.expected.json
+++ b/testdata/rpm/specfile/cpio.spec.expected.json
@@ -38,7 +38,7 @@
         "is_direct": true
       },
       {
-        "purl": "pkg:rpm/%2Fsbin%2Finstall-info",
+        "purl": null,
         "extracted_requirement": "/sbin/install-info",
         "scope": "post",
         "is_runtime": true,
@@ -46,7 +46,7 @@
         "is_direct": true
       },
       {
-        "purl": "pkg:rpm/%2Fsbin%2Finstall-info",
+        "purl": null,
         "extracted_requirement": "/sbin/install-info",
         "scope": "preun",
         "is_runtime": true,


### PR DESCRIPTION
## Summary

- Fix URL detector  misparse: skip  regex matches preceded by alphanumeric characters (e.g.  in Go code no longer produces )
- Fix copyright  false positive: require period on  hint marker so  commands don't trigger copyright detection
- Fix bash array expansion copyright FP: strip  patterns before punctuation processing so bash code doesn't produce  copyright artifacts
- Fix RPM file-path dependency purl encoding:  now gets  instead of 
- Add restic/restic v0.18.1 benchmark entry (8.47x faster)

## Issues

- Covers: restic/restic benchmark verification

## Scope and exclusions

- Included: URL finder post-filter, copyright hint/POS tagger/prepare pipeline, RPM specfile purl guard, assembly dep filter, golden update, benchmark entry
- Explicit exclusions: go.mod PURL case-normalization differences (cosmetic), email per-occurrence vs dedup (both defensible)

## Intentional differences from Python

-  without trailing period is no longer treated as a copyright abbreviation — Python ScanCode also doesn't match bare  in its copyright detector, so this is a fix toward parity
- File-path RPM dependencies (, ) now emit  with  preserved; ScanCode emits no dependencies for RPM spec files at all, so this is an improvement

## Follow-up work

- Created or intentionally deferred: Provenant-only  author attribution on CHANGELOG.md (minor false positive, deferred)

## Expected-output fixture changes

- Files changed: `testdata/rpm/specfile/cpio.spec.expected.json`
- Why the new expected output is correct: File-path dependency `/sbin/install-info` should have `purl: null` instead of `pkg:rpm/%2Fsbin%2Finstall-info` — file paths are not valid RPM package names and URL-encoding slashes in the purl name field produces broken identifiers