### PR TITLE
fix(copyright): skip 'author of X' span extraction

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -509,3 +509,15 @@ fn test_bash_array_expansion_does_not_produce_copyright() {
     assert!(holders.is_empty(), "holders: {holders:?}");
     assert!(authors.is_empty(), "authors: {authors:?}");
 }
+
+#[test]
+fn test_author_of_work_does_not_produce_author() {
+    let text = "We've added the ability to use rclone to store backup data on all\nbackends that it supports. This was done in collaboration with\nNick, the author of rclone.\n";
+    let (copyrights, holders, authors) = detect_copyrights_from_text(text);
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+    assert!(holders.is_empty(), "holders: {holders:?}");
+    assert!(
+        !authors.iter().any(|a| a.author == "rclone"),
+        "authors should not contain 'rclone': {authors:?}"
+    );
+}

--- a/src/copyright/detector/tree_walk/copyright.rs
+++ b/src/copyright/detector/tree_walk/copyright.rs
@@ -2522,6 +2522,9 @@ pub fn extract_from_spans(
             let start = i;
             let start_line = token.start_line;
             i += 1;
+            if i < all_leaves.len() && all_leaves[i].tag == PosTag::Of {
+                continue;
+            }
             while i < all_leaves.len() && detector::token_utils::is_author_span_token(all_leaves[i])
             {
                 let t = all_leaves[i];


### PR DESCRIPTION
## Summary

- Fix false-positive author extraction from "author of X" patterns (e.g. "Nick, the author of rclone" no longer produces author "rclone")

## Issues

- Covers: restic/restic benchmark follow-up (deferred from #877)

## Scope and exclusions

- Included: author span extraction break on `Auth` + `Of` token sequence, false-positive test
- Explicit exclusions: no changes to grammar rules or refiner

## Intentional differences from Python

- None — this is a false-positive fix that improves parity

## Expected-output fixture changes

- None