### PR TITLE
fix(parsers): gate rpm db impls by sqlite feature

### DIFF
--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -45,6 +45,7 @@ const RPM_NDB_PATH_SUFFIXES: &[&str] = &[
     "var/lib/rpm/Packages.db",
     "usr/lib/sysimage/rpm/Packages.db",
 ];
+#[cfg(feature = "rpm-sqlite")]
 const RPM_SQLITE_PATH_SUFFIXES: &[&str] = &[
     "var/lib/rpm/rpmdb.sqlite",
     "usr/lib/sysimage/rpm/rpmdb.sqlite",
@@ -80,6 +81,7 @@ fn default_package_data(datasource_id: DatasourceId) -> PackageData {
 
 pub struct RpmBdbDatabaseParser;
 
+#[cfg(feature = "rpm-sqlite")]
 impl PackageParser for RpmBdbDatabaseParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
 
@@ -118,6 +120,23 @@ impl PackageParser for RpmBdbDatabaseParser {
 
 #[cfg(not(feature = "rpm-sqlite"))]
 impl PackageParser for RpmBdbDatabaseParser {
+    const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;
+
+    fn is_match(path: &Path) -> bool {
+        path_matches_any_suffix(path, RPM_BDB_PATH_SUFFIXES)
+    }
+
+    fn extract_packages(path: &Path) -> Vec<PackageData> {
+        match parse_rpm_database(path, DatasourceId::RpmInstalledDatabaseBdb) {
+            Ok(pkgs) if !pkgs.is_empty() => pkgs,
+            Ok(_) => vec![default_package_data(DatasourceId::RpmInstalledDatabaseBdb)],
+            Err(e) => {
+                warn!("Failed to parse RPM BDB database {:?}: {}", path, e);
+                vec![default_package_data(DatasourceId::RpmInstalledDatabaseBdb)]
+            }
+        }
+    }
+
     fn metadata() -> Vec<super::metadata::ParserMetadata> {
         vec![super::metadata::ParserMetadata {
             description: "RPM installed package database",


### PR DESCRIPTION
## Summary

- make the `RpmBdbDatabaseParser` trait impls mutually exclusive across `rpm-sqlite` feature states
- restore the required `PackageParser` members on the non-`rpm-sqlite` impl to fix the `--no-default-features` build
- gate the SQLite-only path suffix constant so the non-SQLite build stays clean

## Issues

- Covers: RPM DB parser feature-gating regression in `src/parsers/rpm_db.rs`

## Scope and exclusions

- Included: one-file parser fix for cfg-gated trait impl completeness and SQLite-only constant gating
- Explicit exclusions: no parser behavior changes outside the cfg split, no assembly wiring changes, no documentation or fixture updates

## Follow-up work

- Created or intentionally deferred: no blocking follow-up; five-agent review and focused local QA passed for default-feature and `--no-default-features` paths

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this fix only resolves a cfg-gated compile/trait-completeness issue and does not intentionally change parser output