### PR TITLE
test(ci): add no-default-features rpm smoke coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -149,6 +149,36 @@ jobs:
       - name: Run doctests
         run: cargo test -p provenant-cli --doc --profile ci-release --verbose
 
+  no-default-features-smoke:
+    name: No-default-features Smoke Test
+    runs-on: ubuntu-latest
+    if: |
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          submodules: false
+          lfs: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: no-default-features-smoke
+
+      - name: Check no-default-features build
+        run: cargo check --lib --no-default-features
+
+      - name: Run no-default-features parser smoke tests
+        run: |
+          cargo test --lib --no-default-features parsers::rpm_db::tests::test_bdb_parser_is_match -- --exact
+          cargo test --lib --no-default-features parsers::rpm_db_scan_test::tests::test_rpm_bdb_scan_assigns_referenced_files_from_fedora_rootfs -- --exact
+
   windows-build-smoke:
     name: Windows Build Smoke Test
     runs-on: windows-latest

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -81,6 +81,9 @@ fn default_package_data(datasource_id: DatasourceId) -> PackageData {
 
 pub struct RpmBdbDatabaseParser;
 
+// Keep these cfg-split impls mutually exclusive and complete. `PackageParser`
+// impls cannot be composed across feature branches, so the no-default-features
+// build must still define the full BDB parser surface here.
 #[cfg(feature = "rpm-sqlite")]
 impl PackageParser for RpmBdbDatabaseParser {
     const PACKAGE_TYPE: PackageType = PACKAGE_TYPE;


### PR DESCRIPTION
## Summary

- add a dedicated `no-default-features-smoke` CI job to exercise the supported minimal-feature build
- cover the exact RPM DB parser and parser-local scan contract that regressed under `--no-default-features`
- add a small guard comment in `src/parsers/rpm_db.rs` documenting why the cfg-split `PackageParser` impls must stay mutually exclusive and complete

## Issues

- Covers: preventing future `--no-default-features` RPM DB parser regressions

## Scope and exclusions

- Included: CI smoke coverage for the supported no-default-features build and a minimal code-level guard at the cfg-split impl site
- Explicit exclusions: no parser behavior changes, no assembly wiring changes, no documentation or expected-output fixture updates

## Follow-up work

- Created or intentionally deferred: no blocking follow-up; the new smoke commands were verified locally before opening this PR

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: this change only adds CI/build guardrails and a local explanatory comment, with no intended output change