### PR TITLE
refactor: replace string-based error handling with typed error enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,6 +3376,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tera",
+ "thiserror 2.0.18",
  "toml",
  "ttf-parser",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"
 tempfile = { workspace = true }
 tera = { version = "1.20.1", default-features = false }
+thiserror = "2.0.18"
  toml = { workspace = true }
 ttf-parser = "0.25.1"
 url = { workspace = true }

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -10,6 +10,7 @@
 //! Based on the Python ScanCode Toolkit implementation at:
 //! reference/scancode-toolkit/src/licensedcode/match_aho.py
 
+use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{TokenId, TokenKind};
 use crate::license_detection::models::position_span::PositionSpan;
@@ -73,7 +74,7 @@ pub(crate) fn aho_match_with_deadline(
     index: &LicenseIndex,
     query_run: &QueryRun,
     deadline: Option<Instant>,
-) -> anyhow::Result<Vec<LicenseMatch>> {
+) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     aho_match_with_extra_matchables(index, query_run, None, deadline)
 }
 
@@ -82,12 +83,12 @@ pub(crate) fn aho_match_with_deadline(
 /// This is used to preserve pre-subtraction SPDX positions for Phase 1c exact AHO
 /// eligibility checks only, while keeping the live query matchables unchanged for
 /// all later phases.
-pub fn aho_match_with_extra_matchables(
+pub(crate) fn aho_match_with_extra_matchables(
     index: &LicenseIndex,
     query_run: &QueryRun,
     extra_matchable_positions: Option<&PositionSet>,
     deadline: Option<Instant>,
-) -> anyhow::Result<Vec<LicenseMatch>> {
+) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     let mut matches = Vec::new();
 
     let query_tokens = query_run.tokens();

--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -12,16 +12,9 @@ pub struct LoadedEmbeddedLicenseIndex {
     pub metadata: EmbeddedArtifactMetadata,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("License loader artifact error: {0}")]
 pub struct SerializationError(pub String);
-
-impl std::fmt::Display for SerializationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "License loader artifact error: {}", self.0)
-    }
-}
-
-impl std::error::Error for SerializationError {}
 
 pub fn load_loader_snapshot_from_bytes(
     bytes: &[u8],

--- a/src/license_detection/expression/mod.rs
+++ b/src/license_detection/expression/mod.rs
@@ -23,36 +23,25 @@ pub use simplify::{
 };
 
 /// Error type for license expression parsing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum ParseError {
     /// Empty expression
+    #[error("Empty license expression")]
     EmptyExpression,
 
     /// Unexpected token at position
+    #[error("Unexpected token '{token}' at position {position}")]
     UnexpectedToken { token: String, position: usize },
 
     /// Mismatched parentheses
+    #[error("Mismatched parentheses")]
     MismatchedParentheses,
 
     /// Generic parse error with message
+    #[error("Parse error: {0}")]
     ParseError(String),
 }
-
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyExpression => write!(f, "Empty license expression"),
-            Self::UnexpectedToken { token, position } => {
-                write!(f, "Unexpected token '{}' at position {}", token, position)
-            }
-            Self::MismatchedParentheses => write!(f, "Mismatched parentheses"),
-            Self::ParseError(msg) => write!(f, "Parse error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
 
 /// A parsed license expression represented as an AST.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -134,9 +134,11 @@ pub(crate) fn deadline_exceeded(deadline: Option<Instant>) -> bool {
     deadline.is_some_and(|deadline| Instant::now() >= deadline)
 }
 
-pub(crate) fn ensure_within_deadline(deadline: Option<Instant>) -> Result<()> {
+pub(crate) fn ensure_within_deadline(
+    deadline: Option<Instant>,
+) -> Result<(), LicenseDetectionError> {
     if deadline_exceeded(deadline) {
-        Err(LicenseDetectionError::Timeout.into())
+        Err(LicenseDetectionError::Timeout)
     } else {
         Ok(())
     }
@@ -410,7 +412,7 @@ fn collect_whole_query_exact_followup_matches(
     matched_qspans: &mut Vec<models::PositionSpan>,
     whole_run: &query::QueryRun<'_>,
     deadline: Option<Instant>,
-) -> Result<Vec<LicenseMatch>> {
+) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     let mut seq_all_matches = Vec::new();
 
     if whole_run.is_matchable(false, matched_qspans) {
@@ -459,7 +461,7 @@ fn collect_regular_seq_matches(
     matched_qspans: &[models::PositionSpan],
     candidate_contained_matches: &[LicenseMatch],
     deadline: Option<Instant>,
-) -> Result<Vec<LicenseMatch>> {
+) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     let mut seq_all_matches = Vec::new();
 
     for (query_run_index, query_run) in query.query_runs().into_iter().enumerate() {
@@ -741,6 +743,7 @@ impl LicenseDetectionEngine {
             0.0,
             None,
         )
+        .map_err(Into::into)
     }
 
     pub fn detect_with_kind_with_score(
@@ -757,6 +760,7 @@ impl LicenseDetectionEngine {
             min_score,
             None,
         )
+        .map_err(Into::into)
     }
 
     pub(crate) fn detect_with_kind_with_score_and_deadline(
@@ -766,7 +770,7 @@ impl LicenseDetectionEngine {
         binary_derived: bool,
         min_score: f32,
         deadline: Option<Instant>,
-    ) -> Result<Vec<LicenseDetection>> {
+    ) -> Result<Vec<LicenseDetection>, LicenseDetectionError> {
         ensure_within_deadline(deadline)?;
         let clean_text = strip_utf8_bom_str(text);
 
@@ -966,6 +970,7 @@ impl LicenseDetectionEngine {
             source_path,
             None,
         )
+        .map_err(Into::into)
     }
 
     pub(crate) fn detect_with_kind_and_source_with_deadline(
@@ -975,7 +980,7 @@ impl LicenseDetectionEngine {
         binary_derived: bool,
         source_path: &str,
         deadline: Option<Instant>,
-    ) -> Result<Vec<LicenseDetection>> {
+    ) -> Result<Vec<LicenseDetection>, LicenseDetectionError> {
         let mut detections = self.detect_with_kind_with_score_and_deadline(
             text,
             unknown_licenses,
@@ -1009,7 +1014,7 @@ impl LicenseDetectionEngine {
         source_path: &str,
         min_score: f32,
         deadline: Option<Instant>,
-    ) -> Result<Vec<LicenseDetection>> {
+    ) -> Result<Vec<LicenseDetection>, LicenseDetectionError> {
         let mut detections = self.detect_with_kind_with_score_and_deadline(
             text,
             unknown_licenses,

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -84,7 +84,11 @@ pub const SCANCODE_LICENSES_LICENSES_PATH: &str =
 pub const SCANCODE_LICENSES_DATA_PATH: &str = "reference/scancode-toolkit/src/licensedcode/data";
 
 pub const DEFAULT_LICENSEDB_URL_TEMPLATE: &str = "https://scancode-licensedb.aboutcode.org/{}";
-pub(crate) const LICENSE_DETECTION_TIMEOUT_MESSAGE: &str = "license detection timed out";
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum LicenseDetectionError {
+    #[error("license detection timed out")]
+    Timeout,
+}
 
 pub(crate) use detection::{
     LicenseDetection, group_matches_by_region, post_process_detections, sort_matches_by_line,
@@ -132,7 +136,7 @@ pub(crate) fn deadline_exceeded(deadline: Option<Instant>) -> bool {
 
 pub(crate) fn ensure_within_deadline(deadline: Option<Instant>) -> Result<()> {
     if deadline_exceeded(deadline) {
-        Err(anyhow::anyhow!(LICENSE_DETECTION_TIMEOUT_MESSAGE))
+        Err(LicenseDetectionError::Timeout.into())
     } else {
         Ok(())
     }

--- a/src/license_detection/models/loaded_license.rs
+++ b/src/license_detection/models/loaded_license.rs
@@ -178,53 +178,23 @@ impl LoadedLicense {
 }
 
 /// Error type for license key validation failures.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LicenseKeyError {
+    #[error("cannot extract key from license file path")]
     CannotExtractKey,
+    #[error("license key mismatch: filename '{filename}' vs frontmatter '{frontmatter}'")]
     KeyMismatch {
         filename: String,
         frontmatter: String,
     },
 }
 
-impl std::fmt::Display for LicenseKeyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CannotExtractKey => write!(f, "cannot extract key from license file path"),
-            Self::KeyMismatch {
-                filename,
-                frontmatter,
-            } => {
-                write!(
-                    f,
-                    "license key mismatch: filename '{}' vs frontmatter '{}'",
-                    filename, frontmatter
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for LicenseKeyError {}
-
 /// Error type for license text validation failures.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LicenseTextError {
+    #[error("license file has empty text content and is not deprecated/unknown/generic")]
     EmptyText,
 }
-
-impl std::fmt::Display for LicenseTextError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyText => write!(
-                f,
-                "license file has empty text content and is not deprecated/unknown/generic"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for LicenseTextError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/license_detection/models/loaded_rule.rs
+++ b/src/license_detection/models/loaded_rule.rs
@@ -190,50 +190,24 @@ impl LoadedRule {
 }
 
 /// Error type for rule-kind validation failures.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RuleKindError {
+    #[error("rule has multiple is_license_* flags set")]
     MultipleFlagsSet,
+    #[error("non-false-positive rule has no is_license_* flags set")]
     NoFlagsSet,
+    #[error("false-positive rule cannot have is_license_* flags set")]
     FalsePositiveWithFlags,
 }
 
-impl std::fmt::Display for RuleKindError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MultipleFlagsSet => write!(f, "rule has multiple is_license_* flags set"),
-            Self::NoFlagsSet => write!(f, "non-false-positive rule has no is_license_* flags set"),
-            Self::FalsePositiveWithFlags => {
-                write!(f, "false-positive rule cannot have is_license_* flags set")
-            }
-        }
-    }
-}
-
-impl std::error::Error for RuleKindError {}
-
 /// Error type for license expression validation failures.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LicenseExpressionError {
+    #[error("license_expression is required for non-false-positive rules")]
     MissingExpression,
+    #[error("license_expression cannot be empty for non-false-positive rules")]
     EmptyExpression,
 }
-
-impl std::fmt::Display for LicenseExpressionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MissingExpression => write!(
-                f,
-                "license_expression is required for non-false-positive rules"
-            ),
-            Self::EmptyExpression => write!(
-                f,
-                "license_expression cannot be empty for non-false-positive rules"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for LicenseExpressionError {}
 
 /// Check if a string has trivial outer parentheses.
 ///

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -3,6 +3,7 @@
 
 //! Query processing - tokenized input for license matching.
 
+use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::{KnownToken, QueryToken, TokenId, TokenKind};
 use crate::license_detection::models::PositionSpan;
@@ -501,20 +502,20 @@ impl<'a> Query<'a> {
         None
     }
 
-    pub fn from_extracted_text(
+    pub(crate) fn from_extracted_text(
         text: &str,
         index: &'a LicenseIndex,
         binary_derived: bool,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, LicenseDetectionError> {
         Self::from_extracted_text_with_deadline(text, index, binary_derived, None)
     }
 
-    pub fn from_extracted_text_with_deadline(
+    pub(crate) fn from_extracted_text_with_deadline(
         text: &str,
         index: &'a LicenseIndex,
         binary_derived: bool,
         deadline: Option<Instant>,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, LicenseDetectionError> {
         let line_threshold = if binary_derived {
             Self::BINARY_LINE_THRESHOLD
         } else {
@@ -540,11 +541,11 @@ impl<'a> Query<'a> {
         line_threshold: usize,
         binary_derived: Option<bool>,
         deadline: Option<Instant>,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, LicenseDetectionError> {
         crate::license_detection::ensure_within_deadline(deadline)?;
         let is_binary = match binary_derived {
             Some(is_binary) => is_binary,
-            None => Self::detect_binary(text)?,
+            None => Self::detect_binary(text),
         };
         let has_long_lines = Self::detect_long_lines(text);
 
@@ -672,11 +673,11 @@ impl<'a> Query<'a> {
     /// true if binary, false otherwise
     ///
     /// Corresponds to Python: `typecode.get_type().is_binary` usage (lines 123-135)
-    fn detect_binary(text: &str) -> Result<bool, anyhow::Error> {
+    fn detect_binary(text: &str) -> bool {
         let null_byte_count = text.bytes().filter(|&b| b == 0).count();
 
         if null_byte_count > 0 {
-            return Ok(true);
+            return true;
         }
 
         let non_printable_ratio = text
@@ -687,7 +688,7 @@ impl<'a> Query<'a> {
             .count() as f64
             / text.len().max(1) as f64;
 
-        Ok(non_printable_ratio > 0.3)
+        non_printable_ratio > 0.3
     }
 
     /// Detect if text has very long lines (for minified JS/CSS).

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -16,7 +16,7 @@ mod tests {
     }
 
     fn build_query<'a>(text: &str, index: &'a LicenseIndex) -> anyhow::Result<Query<'a>> {
-        Query::from_extracted_text(text, index, false)
+        Query::from_extracted_text(text, index, false).map_err(Into::into)
     }
 
     fn build_query_detecting_binary<'a>(
@@ -24,6 +24,7 @@ mod tests {
         index: &'a LicenseIndex,
     ) -> anyhow::Result<Query<'a>> {
         Query::with_source_options(text, index, Query::TEXT_LINE_THRESHOLD, None, None)
+            .map_err(Into::into)
     }
 
     fn build_query_with_threshold<'a>(
@@ -31,7 +32,7 @@ mod tests {
         index: &'a LicenseIndex,
         line_threshold: usize,
     ) -> anyhow::Result<Query<'a>> {
-        Query::with_source_options(text, index, line_threshold, None, None)
+        Query::with_source_options(text, index, line_threshold, None, None).map_err(Into::into)
     }
 
     fn query_unknown_count_after(query: &Query<'_>, pos: Option<usize>) -> usize {

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -3,6 +3,7 @@
 
 //! Candidate selection using set and multiset similarity.
 
+use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::TokenMultiset;
 use crate::license_detection::TokenSet;
 use crate::license_detection::index::LicenseIndex;
@@ -573,7 +574,7 @@ pub(crate) fn select_seq_candidates_with_deadline<'a>(
     high_resemblance: bool,
     top_n: usize,
     deadline: Option<Instant>,
-) -> anyhow::Result<Vec<Candidate<'a>>> {
+) -> Result<Vec<Candidate<'a>>, LicenseDetectionError> {
     crate::license_detection::ensure_within_deadline(deadline)?;
     let Some(query_data) = QueryData::new(index, query_run) else {
         return Ok(Vec::new());

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -3,6 +3,7 @@
 
 //! Sequence matching algorithms for finding matching blocks.
 
+use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::models::position_span::PositionSpan;
@@ -54,7 +55,7 @@ fn find_longest_match_impl(
     query_hi: usize,
     rule_lo: usize,
     rule_hi: usize,
-) -> anyhow::Result<(usize, usize, usize)> {
+) -> Result<(usize, usize, usize), LicenseDetectionError> {
     let mut best_i = query_lo;
     let mut best_j = rule_lo;
     let mut best_size = 0;
@@ -146,7 +147,7 @@ fn match_blocks_impl(
     context: &MatchSearchContext<'_>,
     query_start: usize,
     query_end: usize,
-) -> anyhow::Result<Vec<(usize, usize, usize)>> {
+) -> Result<Vec<(usize, usize, usize)>, LicenseDetectionError> {
     if context.query_tokens.is_empty() || context.rule_tokens.is_empty() {
         return Ok(Vec::new());
     }
@@ -231,7 +232,7 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
     query_run: &QueryRun,
     candidates: &[Candidate<'_>],
     deadline: Option<Instant>,
-) -> anyhow::Result<Vec<LicenseMatch>> {
+) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     let mut matches = Vec::new();
 
     for (candidate_index, candidate) in candidates.iter().enumerate() {

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -201,7 +201,10 @@ fn test_engine_detect_with_deadline_times_out_when_already_expired() {
         )
         .expect_err("expired deadline should abort license detection");
 
-    assert_eq!(error.to_string(), LICENSE_DETECTION_TIMEOUT_MESSAGE);
+    assert_eq!(
+        error.to_string(),
+        LicenseDetectionError::Timeout.to_string()
+    );
 }
 
 #[test]

--- a/src/models/diagnostic.rs
+++ b/src/models/diagnostic.rs
@@ -13,6 +13,8 @@ pub enum DiagnosticSeverity {
 pub struct ScanDiagnostic {
     pub severity: DiagnosticSeverity,
     pub message: String,
+    #[serde(default, skip)]
+    pub is_timeout: bool,
 }
 
 impl ScanDiagnostic {
@@ -20,6 +22,7 @@ impl ScanDiagnostic {
         Self {
             severity: DiagnosticSeverity::Warning,
             message: message.into(),
+            is_timeout: false,
         }
     }
 
@@ -27,6 +30,15 @@ impl ScanDiagnostic {
         Self {
             severity: DiagnosticSeverity::Error,
             message: message.into(),
+            is_timeout: false,
+        }
+    }
+
+    pub fn timeout(message: impl Into<String>) -> Self {
+        Self {
+            severity: DiagnosticSeverity::Error,
+            message: message.into(),
+            is_timeout: true,
         }
     }
 }

--- a/src/models/digest.rs
+++ b/src/models/digest.rs
@@ -106,22 +106,13 @@ define_digest!(
     20
 );
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ParseDigestError {
+    #[error("invalid hex encoding")]
     InvalidHex,
+    #[error("invalid digest length")]
     InvalidLength,
 }
-
-impl std::fmt::Display for ParseDigestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseDigestError::InvalidHex => write!(f, "invalid hex encoding"),
-            ParseDigestError::InvalidLength => write!(f, "invalid digest length"),
-        }
-    }
-}
-
-impl std::error::Error for ParseDigestError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -434,7 +434,11 @@ pub(crate) fn record_parser_diagnostic(message: String, severity: DiagnosticSeve
         let Some(active) = stack.last_mut() else {
             return false;
         };
-        active.push(ScanDiagnostic { severity, message });
+        active.push(ScanDiagnostic {
+            severity,
+            message,
+            is_timeout: false,
+        });
         true
     })
 }

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -32,12 +32,12 @@ pub(crate) use crate::license_detection::DEFAULT_LICENSEDB_URL_TEMPLATE;
 #[cfg(test)]
 use crate::models::Match;
 use crate::models::{
-    ExtraData, FileInfo, FileType, HEADER_NOTICE, Header, OUTPUT_FORMAT_VERSION, Output, Package,
-    SystemEnvironment, TOOL_NAME, TopLevelLicenseDetection,
+    DiagnosticSeverity, ExtraData, FileInfo, FileType, HEADER_NOTICE, Header,
+    OUTPUT_FORMAT_VERSION, Output, Package, SystemEnvironment, TOOL_NAME, TopLevelLicenseDetection,
 };
 use crate::progress::{
-    format_default_scan_error_from_list, format_default_scan_warning_from_list,
-    is_warning_scan_error,
+    format_default_scan_error_from_diagnostics, format_default_scan_error_from_list,
+    format_default_scan_warning_from_list, is_warning_scan_error,
 };
 use crate::scanner;
 use crate::time::format_scancode_timestamp;
@@ -246,13 +246,35 @@ fn summarize_header_messages(
     let mut warnings = Vec::new();
 
     for file in files {
-        let (file_errors, file_warnings) = partition_scan_messages(file);
-
-        if let Some(summary) = summarize_file_header_message(file, &file_errors, verbose, false) {
-            errors.push(summary);
-        }
-        if let Some(summary) = summarize_file_header_message(file, &file_warnings, verbose, true) {
-            warnings.push(summary);
+        if !file.scan_diagnostics.is_empty() {
+            if let Some(summary) = format_default_scan_error_from_diagnostics(
+                Path::new(&file.path),
+                &file.scan_diagnostics,
+            ) {
+                errors.push(summary);
+            }
+            let warning_messages: Vec<String> = file
+                .scan_diagnostics
+                .iter()
+                .filter(|d| d.severity == DiagnosticSeverity::Warning)
+                .map(|d| d.message.clone())
+                .collect();
+            if let Some(formatted) =
+                format_default_scan_warning_from_list(Path::new(&file.path), &warning_messages)
+            {
+                warnings.push(formatted);
+            }
+        } else {
+            let (file_errors, file_warnings) = partition_scan_messages(file);
+            if let Some(summary) = summarize_file_header_message(file, &file_errors, verbose, false)
+            {
+                errors.push(summary);
+            }
+            if let Some(summary) =
+                summarize_file_header_message(file, &file_warnings, verbose, true)
+            {
+                warnings.push(summary);
+            }
         }
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -191,7 +191,9 @@ impl ScanProgress {
         match self.mode {
             ProgressMode::Quiet => {}
             ProgressMode::Default => {
-                if let Some(formatted) = format_default_scan_error_from_list(path, &errors) {
+                if let Some(formatted) =
+                    format_default_scan_error_from_diagnostics(path, scan_diagnostics)
+                {
                     self.error(&formatted);
                 } else if let Some(formatted) =
                     format_default_scan_warning_from_list(path, &warnings)
@@ -512,11 +514,33 @@ pub(crate) fn format_default_scan_error_from_list(
     path: &Path,
     scan_errors: &[String],
 ) -> Option<String> {
+    let is_timeout = |error: &str| {
+        error.starts_with("Timeout while ")
+            || error.starts_with("Timeout before ")
+            || error.starts_with("Timeout during ")
+            || error.starts_with("Processing interrupted due to timeout")
+    };
     scan_errors
         .iter()
-        .find(|error| is_timeout_scan_error(error))
+        .find(|error| is_timeout(error))
         .or_else(|| scan_errors.first())
         .map(|error| format_default_scan_error(path, error))
+}
+
+pub(crate) fn format_default_scan_error_from_diagnostics(
+    path: &Path,
+    scan_diagnostics: &[ScanDiagnostic],
+) -> Option<String> {
+    let errors: Vec<&ScanDiagnostic> = scan_diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+        .collect();
+
+    errors
+        .iter()
+        .find(|d| d.is_timeout)
+        .or_else(|| errors.first())
+        .map(|d| format_default_scan_error(path, &d.message))
 }
 
 pub(crate) fn format_default_scan_warning_from_list(
@@ -564,10 +588,6 @@ fn concise_scan_error_reason(err: &str) -> String {
     }
 
     first_line.to_string()
-}
-
-fn is_timeout_scan_error(err: &str) -> bool {
-    crate::scanner::process::is_timeout_diagnostic_message(err)
 }
 
 pub(crate) fn is_warning_scan_error(err: &str) -> bool {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -567,9 +567,7 @@ fn concise_scan_error_reason(err: &str) -> String {
 }
 
 fn is_timeout_scan_error(err: &str) -> bool {
-    err.contains("Timeout while ")
-        || err.contains("Timeout before ")
-        || err.contains("Processing interrupted due to timeout")
+    crate::scanner::process::is_timeout_diagnostic_message(err)
 }
 
 pub(crate) fn is_warning_scan_error(err: &str) -> bool {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -514,6 +514,10 @@ pub(crate) fn format_default_scan_error_from_list(
     path: &Path,
     scan_errors: &[String],
 ) -> Option<String> {
+    // TODO: This string-based timeout detection operates on the legacy scan_errors: Vec<String>
+    // field which is populated from ScanDiagnostic display messages. Once scan_errors is replaced
+    // by scan_diagnostics throughout the output schema, this can match on
+    // ScanDiagnostic::is_timeout instead.
     let is_timeout = |error: &str| {
         error.starts_with("Timeout while ")
             || error.starts_with("Timeout before ")

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod collect;
-mod process;
+pub(crate) mod process;
 
 use crate::license_detection::LicenseDetectionEngine;
 use crate::models::FileInfo;

--- a/src/scanner/process/file_scan_error.rs
+++ b/src/scanner/process/file_scan_error.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::license_detection::LicenseDetectionError;
+use std::fmt;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FileScanError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Timeout(FileScanTimeout),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FileScanTimeout {
+    pub(crate) phase: TimeoutPhase,
+    pub(crate) seconds: f64,
+}
+
+impl fmt::Display for FileScanTimeout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.phase {
+            TimeoutPhase::ReadingContent => {
+                write!(
+                    f,
+                    "Timeout while reading file content (> {:.2}s)",
+                    self.seconds
+                )
+            }
+            TimeoutPhase::ExtractingMetadata => {
+                write!(
+                    f,
+                    "Timeout while extracting package/text metadata (> {:.2}s)",
+                    self.seconds
+                )
+            }
+            TimeoutPhase::ExtractingText => {
+                write!(
+                    f,
+                    "Timeout while extracting text content (> {:.2}s)",
+                    self.seconds
+                )
+            }
+            TimeoutPhase::BeforeLicenseScan => {
+                write!(f, "Timeout before license scan (> {:.2}s)", self.seconds)
+            }
+            TimeoutPhase::DuringLicenseScan => {
+                write!(f, "Timeout during license scan (> {:.2}s)", self.seconds)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TimeoutPhase {
+    ReadingContent,
+    ExtractingMetadata,
+    ExtractingText,
+    BeforeLicenseScan,
+    DuringLicenseScan,
+}
+
+impl FileScanError {
+    pub(crate) fn from_license_detection_timeout(seconds: f64) -> Self {
+        Self::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::DuringLicenseScan,
+            seconds,
+        })
+    }
+}
+
+impl From<LicenseDetectionError> for FileScanError {
+    fn from(err: LicenseDetectionError) -> Self {
+        match err {
+            LicenseDetectionError::Timeout => Self::from_license_detection_timeout(0.0),
+        }
+    }
+}
+
+pub(crate) fn is_timeout_diagnostic_message(message: &str) -> bool {
+    message.starts_with("Timeout while ")
+        || message.starts_with("Timeout before ")
+        || message.starts_with("Timeout during ")
+        || message.starts_with("Processing interrupted due to timeout")
+}

--- a/src/scanner/process/file_scan_error.rs
+++ b/src/scanner/process/file_scan_error.rs
@@ -78,10 +78,3 @@ impl From<LicenseDetectionError> for FileScanError {
         }
     }
 }
-
-pub(crate) fn is_timeout_diagnostic_message(message: &str) -> bool {
-    message.starts_with("Timeout while ")
-        || message.starts_with("Timeout before ")
-        || message.starts_with("Timeout during ")
-        || message.starts_with("Processing interrupted due to timeout")
-}

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -16,7 +16,7 @@ use crate::parsers::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_spdx_expression,
 };
 use crate::scanner::LicenseScanOptions;
-use anyhow::Error;
+use crate::scanner::process::file_scan_error::FileScanError;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -40,7 +40,7 @@ pub(super) fn extract_license_information(
     file_info_builder: &mut FileInfoBuilder,
     scan_diagnostics: &mut Vec<ScanDiagnostic>,
     input: LicenseExtractionInput<'_>,
-) -> Result<(), Error> {
+) -> Result<(), FileScanError> {
     let LicenseExtractionInput {
         path,
         text_content,
@@ -105,7 +105,7 @@ pub(super) fn extract_license_information(
             } {
                 Ok(query) => Some(query),
                 Err(error) if is_license_detection_timeout_error(&error) => {
-                    return Err(timeout_during_license_scan(timeout_seconds));
+                    return Err(license_detection_timeout(timeout_seconds));
                 }
                 Err(_) => None,
             };
@@ -178,7 +178,7 @@ pub(super) fn extract_license_information(
             );
         }
         Err(e) if is_license_detection_timeout_error(&e) => {
-            return Err(timeout_during_license_scan(timeout_seconds));
+            return Err(license_detection_timeout(timeout_seconds));
         }
         Err(e) => {
             scan_diagnostics.push(ScanDiagnostic::error(format!(
@@ -495,15 +495,12 @@ fn nix_license_symbol_to_spdx(symbol: &str) -> Option<&'static str> {
     }
 }
 
-fn is_license_detection_timeout_error(error: &Error) -> bool {
+fn is_license_detection_timeout_error(error: &anyhow::Error) -> bool {
     error.downcast_ref::<LicenseDetectionError>().is_some()
 }
 
-fn timeout_during_license_scan(timeout_seconds: f64) -> Error {
-    Error::msg(format!(
-        "Timeout during license scan (> {:.2}s)",
-        timeout_seconds
-    ))
+fn license_detection_timeout(timeout_seconds: f64) -> FileScanError {
+    FileScanError::from_license_detection_timeout(timeout_seconds)
 }
 
 fn convert_detection_to_model(

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -3,6 +3,7 @@
 
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
+use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::PositionSet;
 use crate::license_detection::expression::parse_expression;
 use crate::license_detection::index::LicenseIndex;
@@ -495,7 +496,7 @@ fn nix_license_symbol_to_spdx(symbol: &str) -> Option<&'static str> {
 }
 
 fn is_license_detection_timeout_error(error: &Error) -> bool {
-    error.to_string() == crate::license_detection::LICENSE_DETECTION_TIMEOUT_MESSAGE
+    error.downcast_ref::<LicenseDetectionError>().is_some()
 }
 
 fn timeout_during_license_scan(timeout_seconds: f64) -> Error {

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -55,8 +55,8 @@ pub(super) fn extract_license_information(
         return Ok(());
     };
 
-    let detection_result = if deadline.is_some() {
-        if license_options.min_score == 0 {
+    if deadline.is_some() {
+        let detection_result = if license_options.min_score == 0 {
             engine.detect_with_kind_and_source_with_deadline(
                 &text_content,
                 license_options.unknown_licenses,
@@ -73,118 +73,74 @@ pub(super) fn extract_license_information(
                 f32::from(license_options.min_score),
                 deadline,
             )
-        }
-    } else if license_options.min_score == 0 {
-        engine.detect_with_kind_and_source(
-            &text_content,
-            license_options.unknown_licenses,
-            from_binary_strings,
-            &path.to_string_lossy(),
-        )
-    } else {
-        engine.detect_with_kind_and_source_with_score(
-            &text_content,
-            license_options.unknown_licenses,
-            from_binary_strings,
-            &path.to_string_lossy(),
-            f32::from(license_options.min_score),
-        )
-    };
+        };
 
-    match detection_result {
-        Ok(detections) => {
-            let query = match if deadline.is_some() {
-                Query::from_extracted_text_with_deadline(
+        match detection_result {
+            Ok(detections) => {
+                let query = match Query::from_extracted_text_with_deadline(
                     &text_content,
                     engine.index(),
                     from_binary_strings,
                     deadline,
-                )
-            } else {
-                Query::from_extracted_text(&text_content, engine.index(), from_binary_strings)
-            } {
-                Ok(query) => Some(query),
-                Err(error) if is_license_detection_timeout_error(&error) => {
-                    return Err(license_detection_timeout(timeout_seconds));
-                }
-                Err(_) => None,
-            };
-            let mut detections = detections;
-            promote_legal_notice_low_quality_detections(&mut detections, path);
-
-            let mut model_detections = Vec::new();
-            let mut model_clues = Vec::new();
-
-            for detection in &detections {
-                let (public_detection, clue_matches) = convert_detection_to_model(
-                    detection,
-                    license_options,
-                    &text_content,
-                    query.as_ref(),
-                    Some(engine.index()),
-                );
-
-                if let Some(public_detection) = public_detection {
-                    model_detections.push(public_detection);
-                }
-
-                model_clues.extend(clue_matches);
-            }
-
-            model_detections.extend(supplement_nix_manifest_license_detections(
-                path,
-                &text_content,
-                &model_detections,
-            ));
-            expand_dual_licensed_under_readme_choice_detections(
-                path,
-                &text_content,
-                &mut model_detections,
-            );
-            prune_redundant_readme_conjunctive_detections(path, &mut model_detections);
-            model_detections =
-                collapse_repeated_sourcemap_license_detections(path, model_detections);
-
-            if !model_detections.is_empty() {
-                let expressions: Option<Vec<String>> = model_detections
-                    .iter()
-                    .map(|detection| {
-                        (!detection.license_expression_spdx.is_empty())
-                            .then(|| detection.license_expression_spdx.clone())
-                    })
-                    .collect();
-
-                if let Some(expressions) = expressions {
-                    let combined = crate::utils::spdx::select_primary_license_expression_strict(
-                        expressions.clone(),
-                    )
-                    .or_else(|| {
-                        crate::utils::spdx::combine_license_expressions_preserving_structure_strict(
-                            expressions,
-                        )
-                    });
-                    if let Some(expr) = combined {
-                        file_info_builder.license_expression(Some(expr));
+                ) {
+                    Ok(query) => Some(query),
+                    Err(LicenseDetectionError::Timeout) => {
+                        return Err(license_detection_timeout(timeout_seconds));
                     }
-                }
+                };
+                process_successful_detections(
+                    file_info_builder,
+                    &detections,
+                    query.as_ref(),
+                    &text_content,
+                    path,
+                    license_options,
+                    engine.index(),
+                );
             }
+            Err(LicenseDetectionError::Timeout) => {
+                return Err(license_detection_timeout(timeout_seconds));
+            }
+        }
+    } else {
+        let detection_result = if license_options.min_score == 0 {
+            engine.detect_with_kind_and_source(
+                &text_content,
+                license_options.unknown_licenses,
+                from_binary_strings,
+                &path.to_string_lossy(),
+            )
+        } else {
+            engine.detect_with_kind_and_source_with_score(
+                &text_content,
+                license_options.unknown_licenses,
+                from_binary_strings,
+                &path.to_string_lossy(),
+                f32::from(license_options.min_score),
+            )
+        };
 
-            file_info_builder.license_detections(model_detections);
-            file_info_builder.license_clues(model_clues);
-            file_info_builder.percentage_of_license_text(
-                query
-                    .as_ref()
-                    .map(|query| compute_percentage_of_license_text(query, &detections)),
-            );
-        }
-        Err(e) if is_license_detection_timeout_error(&e) => {
-            return Err(license_detection_timeout(timeout_seconds));
-        }
-        Err(e) => {
-            scan_diagnostics.push(ScanDiagnostic::error(format!(
-                "License detection failed: {}",
-                e
-            )));
+        match detection_result {
+            Ok(detections) => {
+                let query =
+                    Query::from_extracted_text(&text_content, engine.index(), from_binary_strings)
+                        .ok();
+                process_successful_detections(
+                    file_info_builder,
+                    &detections,
+                    query.as_ref(),
+                    &text_content,
+                    path,
+                    license_options,
+                    engine.index(),
+                );
+            }
+            Err(e) => {
+                scan_diagnostics.push(ScanDiagnostic::error(format!(
+                    "License detection failed: {}",
+                    e
+                )));
+            }
         }
     }
 
@@ -495,8 +451,74 @@ fn nix_license_symbol_to_spdx(symbol: &str) -> Option<&'static str> {
     }
 }
 
-fn is_license_detection_timeout_error(error: &anyhow::Error) -> bool {
-    error.downcast_ref::<LicenseDetectionError>().is_some()
+fn process_successful_detections(
+    file_info_builder: &mut FileInfoBuilder,
+    detections: &[InternalLicenseDetection],
+    query: Option<&Query<'_>>,
+    text_content: &str,
+    path: &Path,
+    license_options: LicenseScanOptions,
+    index: &LicenseIndex,
+) {
+    let mut detections = detections.to_vec();
+    promote_legal_notice_low_quality_detections(&mut detections, path);
+
+    let mut model_detections = Vec::new();
+    let mut model_clues = Vec::new();
+
+    for detection in &detections {
+        let (public_detection, clue_matches) = convert_detection_to_model(
+            detection,
+            license_options,
+            text_content,
+            query,
+            Some(index),
+        );
+
+        if let Some(public_detection) = public_detection {
+            model_detections.push(public_detection);
+        }
+
+        model_clues.extend(clue_matches);
+    }
+
+    model_detections.extend(supplement_nix_manifest_license_detections(
+        path,
+        text_content,
+        &model_detections,
+    ));
+    expand_dual_licensed_under_readme_choice_detections(path, text_content, &mut model_detections);
+    prune_redundant_readme_conjunctive_detections(path, &mut model_detections);
+    model_detections = collapse_repeated_sourcemap_license_detections(path, model_detections);
+
+    if !model_detections.is_empty() {
+        let expressions: Option<Vec<String>> = model_detections
+            .iter()
+            .map(|detection| {
+                (!detection.license_expression_spdx.is_empty())
+                    .then(|| detection.license_expression_spdx.clone())
+            })
+            .collect();
+
+        if let Some(expressions) = expressions {
+            let combined =
+                crate::utils::spdx::select_primary_license_expression_strict(expressions.clone())
+                    .or_else(|| {
+                        crate::utils::spdx::combine_license_expressions_preserving_structure_strict(
+                            expressions,
+                        )
+                    });
+            if let Some(expr) = combined {
+                file_info_builder.license_expression(Some(expr));
+            }
+        }
+    }
+
+    file_info_builder.license_detections(model_detections);
+    file_info_builder.license_clues(model_clues);
+    file_info_builder.percentage_of_license_text(
+        query.map(|query| compute_percentage_of_license_text(query, &detections)),
+    );
 }
 
 fn license_detection_timeout(timeout_seconds: f64) -> FileScanError {

--- a/src/scanner/process/mod.rs
+++ b/src/scanner/process/mod.rs
@@ -11,7 +11,6 @@ mod pipeline;
 mod special_cases;
 mod spill;
 
-pub(crate) use file_scan_error::is_timeout_diagnostic_message;
 pub use orchestrator::{
     process_collected, process_collected_sequential, process_collected_with_memory_limit,
     process_collected_with_memory_limit_sequential,

--- a/src/scanner/process/mod.rs
+++ b/src/scanner/process/mod.rs
@@ -4,12 +4,14 @@
 mod binary_text;
 mod contacts;
 mod copyright;
+mod file_scan_error;
 mod license;
 mod orchestrator;
 mod pipeline;
 mod special_cases;
 mod spill;
 
+pub(crate) use file_scan_error::is_timeout_diagnostic_message;
 pub use orchestrator::{
     process_collected, process_collected_sequential, process_collected_with_memory_limit,
     process_collected_with_memory_limit_sequential,

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -3,9 +3,7 @@
 
 use super::contacts::extract_email_url_information;
 use super::copyright::extract_copyright_information;
-use super::file_scan_error::{
-    FileScanError, FileScanTimeout, TimeoutPhase, is_timeout_diagnostic_message,
-};
+use super::file_scan_error::{FileScanError, FileScanTimeout, TimeoutPhase};
 use super::license::{LicenseExtractionInput, extract_license_information};
 use super::special_cases::{is_go_non_production_source, should_skip_text_detection};
 use crate::license_detection::LicenseDetectionEngine;
@@ -72,6 +70,9 @@ pub(super) fn process_file(
             generated_flag = is_generated;
             is_source_file = is_source;
             let _ = sha256;
+        }
+        Err(FileScanError::Timeout(timeout)) => {
+            scan_diagnostics.push(ScanDiagnostic::timeout(timeout.to_string()))
         }
         Err(e) => scan_diagnostics.push(ScanDiagnostic::error(e.to_string())),
     };
@@ -530,9 +531,9 @@ fn maybe_record_processing_timeout(
     if is_timeout_exceeded(started, timeout_seconds)
         && !scan_diagnostics
             .iter()
-            .any(|diagnostic| is_timeout_diagnostic_message(&diagnostic.message))
+            .any(|diagnostic| diagnostic.is_timeout)
     {
-        scan_diagnostics.push(ScanDiagnostic::error(format!(
+        scan_diagnostics.push(ScanDiagnostic::timeout(format!(
             "Processing interrupted due to timeout after {:.2} seconds",
             timeout_seconds
         )));

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -3,6 +3,9 @@
 
 use super::contacts::extract_email_url_information;
 use super::copyright::extract_copyright_information;
+use super::file_scan_error::{
+    FileScanError, FileScanTimeout, TimeoutPhase, is_timeout_diagnostic_message,
+};
 use super::license::{LicenseExtractionInput, extract_license_information};
 use super::special_cases::{is_go_non_production_source, should_skip_text_detection};
 use crate::license_detection::LicenseDetectionEngine;
@@ -31,7 +34,6 @@ use crate::utils::hash::{
 use crate::utils::text::{
     remove_verbatim_escape_sequences, should_remove_verbatim_escape_sequences,
 };
-use anyhow::Error;
 use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -136,7 +138,7 @@ fn extract_information_from_content(
     license_engine: Option<Arc<LicenseDetectionEngine>>,
     license_options: LicenseScanOptions,
     text_options: &TextDetectionOptions,
-) -> Result<(Option<bool>, Sha256Digest, bool), Error> {
+) -> Result<(Option<bool>, Sha256Digest, bool), FileScanError> {
     let started = Instant::now();
     let filesystem_path = absolute_filesystem_path(path);
     let license_enabled = license_engine.is_some();
@@ -177,10 +179,10 @@ fn extract_information_from_content(
     let buffer = fs::read(&filesystem_path)?;
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout while reading file content (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::ReadingContent,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     let sha256 = calculate_sha256(&buffer);
@@ -262,10 +264,10 @@ fn extract_information_from_content(
     }
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout while extracting package/text metadata (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::ExtractingMetadata,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     let (text_content, text_kind, text_scan_error) =
@@ -276,10 +278,10 @@ fn extract_information_from_content(
     let from_binary_strings = matches!(text_kind, ExtractedTextKind::BinaryStrings);
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout while extracting text content (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::ExtractingText,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     if text_content.is_empty() {
@@ -304,20 +306,20 @@ fn extract_information_from_content(
     );
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout before license scan (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::BeforeLicenseScan,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     let text_content_for_license_detection =
         prepare_license_detection_text(path, &classification, text_content);
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout during license scan (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::DuringLicenseScan,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     let license_deadline = deadline_from_start(started, text_options.timeout_seconds);
@@ -355,10 +357,10 @@ fn extract_information_from_content(
     }
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
-        return Err(Error::msg(format!(
-            "Timeout during license scan (> {:.2}s)",
-            text_options.timeout_seconds
-        )));
+        return Err(FileScanError::Timeout(FileScanTimeout {
+            phase: TimeoutPhase::DuringLicenseScan,
+            seconds: text_options.timeout_seconds,
+        }));
     }
 
     Ok((is_generated, sha256, classification.is_source))
@@ -410,7 +412,7 @@ fn can_skip_content_read_after_package_fast_path(
             && !license_enabled)
 }
 
-fn is_oversized_rpm_archive_candidate(path: &Path) -> Result<bool, Error> {
+fn is_oversized_rpm_archive_candidate(path: &Path) -> Result<bool, FileScanError> {
     if !path_looks_like_rpm_archive(path) {
         return Ok(false);
     }
@@ -422,7 +424,7 @@ fn populate_oversized_rpm_info(
     file_info_builder: &mut FileInfoBuilder,
     filesystem_path: &Path,
     text_options: &TextDetectionOptions,
-) -> Result<(), Error> {
+) -> Result<(), FileScanError> {
     if !text_options.collect_info {
         return Ok(());
     }
@@ -528,20 +530,13 @@ fn maybe_record_processing_timeout(
     if is_timeout_exceeded(started, timeout_seconds)
         && !scan_diagnostics
             .iter()
-            .any(|diagnostic| is_timeout_scan_error(&diagnostic.message))
+            .any(|diagnostic| is_timeout_diagnostic_message(&diagnostic.message))
     {
         scan_diagnostics.push(ScanDiagnostic::error(format!(
             "Processing interrupted due to timeout after {:.2} seconds",
             timeout_seconds
         )));
     }
-}
-
-fn is_timeout_scan_error(error: &str) -> bool {
-    error.contains("Timeout while ")
-        || error.contains("Timeout before ")
-        || error.contains("Timeout during ")
-        || error.contains("Processing interrupted due to timeout")
 }
 
 fn cap_non_source_json_license_text<'a>(

--- a/src/scanner/process/pipeline_test.rs
+++ b/src/scanner/process/pipeline_test.rs
@@ -40,7 +40,7 @@ fn test_process_file_suppresses_non_actionable_pdf_extraction_failure() {
 #[test]
 fn test_processing_timeout_is_not_duplicated_after_stage_specific_timeout() {
     let started = Instant::now() - Duration::from_secs(2);
-    let mut scan_diagnostics = vec![ScanDiagnostic::error(
+    let mut scan_diagnostics = vec![ScanDiagnostic::timeout(
         "Timeout before license scan (> 1.00s)",
     )];
 

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -7,7 +7,6 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use bzip2::read::BzDecoder;
@@ -22,6 +21,8 @@ use zip::ZipArchive;
 
 use crate::serve_api::SyncScanInput;
 
+type Result<T> = std::result::Result<T, IngestError>;
+
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_REDIRECTS: usize = 5;
@@ -30,6 +31,59 @@ const MAX_UPLOADED_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_ARCHIVE_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_COUNT: usize = 10_000;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum IngestError {
+    #[error("{0}")]
+    Validation(String),
+    #[error("payload exceeds max size of {limit} bytes")]
+    PayloadTooLarge { limit: usize },
+    #[error("{message}")]
+    Upstream {
+        message: String,
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+    #[error("{message}")]
+    Internal {
+        message: String,
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+}
+
+impl IngestError {
+    fn validation(msg: impl Into<String>) -> Self {
+        Self::Validation(msg.into())
+    }
+
+    fn upstream(msg: impl Into<String>) -> Self {
+        Self::Upstream {
+            message: msg.into(),
+            source: None,
+        }
+    }
+
+    fn upstream_with_source(
+        source: impl std::error::Error + Send + Sync + 'static,
+        msg: impl Into<String>,
+    ) -> Self {
+        Self::Upstream {
+            message: msg.into(),
+            source: Some(anyhow::Error::new(source)),
+        }
+    }
+
+    fn internal_with_source(
+        source: impl std::error::Error + Send + Sync + 'static,
+        msg: impl Into<String>,
+    ) -> Self {
+        Self::Internal {
+            message: msg.into(),
+            source: Some(anyhow::Error::new(source)),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(super) struct PreparedSyncInput {
@@ -52,13 +106,18 @@ pub(super) fn prepare_sync_input(input: SyncScanInput) -> Result<PreparedSyncInp
 
 fn prepare_paths_input(paths: Vec<String>) -> Result<PreparedSyncInput> {
     if paths.is_empty() {
-        return Err(anyhow!("input.paths must contain at least one path"));
+        return Err(IngestError::validation(
+            "input.paths must contain at least one path",
+        ));
     }
 
     let paths: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
     for path in &paths {
         if !path.exists() {
-            return Err(anyhow!("input path does not exist: {}", path.display()));
+            return Err(IngestError::validation(format!(
+                "input path does not exist: {}",
+                path.display()
+            )));
         }
     }
 
@@ -71,13 +130,15 @@ fn prepare_paths_input(paths: Vec<String>) -> Result<PreparedSyncInput> {
 
 fn prepare_repository_input(url: &str, reference: &str) -> Result<PreparedSyncInput> {
     if url.trim().is_empty() {
-        return Err(anyhow!("repository.url must not be empty"));
+        return Err(IngestError::validation("repository.url must not be empty"));
     }
     if reference.trim().is_empty() {
-        return Err(anyhow!("repository.ref must not be empty"));
+        return Err(IngestError::validation("repository.ref must not be empty"));
     }
 
-    let staging_dir = TempDir::new().context("failed to create repository staging directory")?;
+    let staging_dir = TempDir::new().map_err(|e| {
+        IngestError::internal_with_source(e, "failed to create repository staging directory")
+    })?;
     let repo_dir = staging_dir.path().join("repository");
 
     run_git(
@@ -112,18 +173,22 @@ fn prepare_repository_input(url: &str, reference: &str) -> Result<PreparedSyncIn
 
 fn prepare_url_input(url: &str) -> Result<PreparedSyncInput> {
     if url.trim().is_empty() {
-        return Err(anyhow!("url.url must not be empty"));
+        return Err(IngestError::validation("url.url must not be empty"));
     }
 
-    let parsed_url = Url::parse(url).context("url.url must be a valid URL")?;
+    let parsed_url =
+        Url::parse(url).map_err(|_| IngestError::validation("url.url must be a valid URL"))?;
     if !matches!(parsed_url.scheme(), "http" | "https") {
-        return Err(anyhow!("url.url must use http or https"));
+        return Err(IngestError::validation("url.url must use http or https"));
     }
 
-    let staging_dir = TempDir::new().context("failed to create URL staging directory")?;
+    let staging_dir = TempDir::new().map_err(|e| {
+        IngestError::internal_with_source(e, "failed to create URL staging directory")
+    })?;
     let download_dir = staging_dir.path().join("download");
-    fs::create_dir_all(&download_dir)
-        .with_context(|| format!("failed to create {}", download_dir.display()))?;
+    fs::create_dir_all(&download_dir).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to create {}", download_dir.display()))
+    })?;
 
     let artifact_path = download_remote_input(url, &download_dir)?;
     materialize_downloaded_artifact(staging_dir, artifact_path)
@@ -131,31 +196,34 @@ fn prepare_url_input(url: &str) -> Result<PreparedSyncInput> {
 
 fn prepare_upload_input(filename: &str, content_base64: &str) -> Result<PreparedSyncInput> {
     let normalized_filename = validate_upload_filename(filename)?;
-    let decoded = STANDARD
-        .decode(content_base64)
-        .context("upload.content_base64 must be valid base64")?;
+    let decoded = STANDARD.decode(content_base64).map_err(|_| {
+        IngestError::Validation("upload.content_base64 must be valid base64".to_string())
+    })?;
 
     if decoded.is_empty() {
-        return Err(anyhow!(
-            "upload.content_base64 must not decode to an empty payload"
+        return Err(IngestError::validation(
+            "upload.content_base64 must not decode to an empty payload",
         ));
     }
 
     if decoded.len() > MAX_UPLOADED_INPUT_BYTES {
-        return Err(anyhow!(
-            "upload payload exceeds max size of {} bytes",
-            MAX_UPLOADED_INPUT_BYTES
-        ));
+        return Err(IngestError::PayloadTooLarge {
+            limit: MAX_UPLOADED_INPUT_BYTES,
+        });
     }
 
-    let staging_dir = TempDir::new().context("failed to create upload staging directory")?;
+    let staging_dir = TempDir::new().map_err(|e| {
+        IngestError::internal_with_source(e, "failed to create upload staging directory")
+    })?;
     let upload_dir = staging_dir.path().join("upload");
-    fs::create_dir_all(&upload_dir)
-        .with_context(|| format!("failed to create {}", upload_dir.display()))?;
+    fs::create_dir_all(&upload_dir).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to create {}", upload_dir.display()))
+    })?;
 
     let artifact_path = upload_dir.join(normalized_filename);
-    fs::write(&artifact_path, decoded)
-        .with_context(|| format!("failed to write {}", artifact_path.display()))?;
+    fs::write(&artifact_path, decoded).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to write {}", artifact_path.display()))
+    })?;
 
     materialize_downloaded_artifact(staging_dir, artifact_path)
 }
@@ -171,8 +239,12 @@ fn materialize_downloaded_artifact(
 
     if looks_like_supported_archive(artifact_name) {
         let extract_dir = staging_dir.path().join("extracted");
-        fs::create_dir_all(&extract_dir)
-            .with_context(|| format!("failed to create {}", extract_dir.display()))?;
+        fs::create_dir_all(&extract_dir).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to create {}", extract_dir.display()),
+            )
+        })?;
         extract_archive(&artifact_path, &extract_dir)?;
         return Ok(PreparedSyncInput {
             paths: vec![extract_dir],
@@ -194,50 +266,61 @@ fn download_remote_input(url: &str, output_dir: &Path) -> Result<PathBuf> {
         .timeout(DOWNLOAD_TIMEOUT)
         .redirect(Policy::limited(MAX_REDIRECTS))
         .build()
-        .context("failed to build remote-ingestion HTTP client")?;
+        .map_err(|e| {
+            IngestError::internal_with_source(e, "failed to build remote-ingestion HTTP client")
+        })?;
 
     let mut response = client
         .get(url)
         .header("User-Agent", "provenant-serve/remote-ingestion")
         .send()
-        .with_context(|| format!("failed to fetch remote input from {url}"))?
+        .map_err(|e| {
+            IngestError::upstream_with_source(e, format!("failed to fetch remote input from {url}"))
+        })?
         .error_for_status()
-        .with_context(|| format!("remote input fetch returned an error status for {url}"))?;
+        .map_err(|e| {
+            IngestError::upstream_with_source(
+                e,
+                format!("remote input fetch returned an error status for {url}"),
+            )
+        })?;
 
     if response
         .content_length()
         .is_some_and(|content_length| content_length > MAX_REMOTE_INPUT_BYTES)
     {
-        return Err(anyhow!(
-            "remote input exceeds max size of {} bytes",
-            MAX_REMOTE_INPUT_BYTES
-        ));
+        return Err(IngestError::PayloadTooLarge {
+            limit: MAX_REMOTE_INPUT_BYTES as usize,
+        });
     }
 
     let filename = derive_download_filename(response.url());
     let output_path = output_dir.join(filename);
-    let mut output_file = File::create(&output_path)
-        .with_context(|| format!("failed to create {}", output_path.display()))?;
+    let mut output_file = File::create(&output_path).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to create {}", output_path.display()))
+    })?;
 
     let mut total_bytes = 0u64;
     let mut buffer = [0u8; 8192];
     loop {
-        let read_bytes = response
-            .read(&mut buffer)
-            .with_context(|| format!("failed to read remote input from {url}"))?;
+        let read_bytes = response.read(&mut buffer).map_err(|e| {
+            IngestError::upstream_with_source(e, format!("failed to read remote input from {url}"))
+        })?;
         if read_bytes == 0 {
             break;
         }
         total_bytes += read_bytes as u64;
         if total_bytes > MAX_REMOTE_INPUT_BYTES {
-            return Err(anyhow!(
-                "remote input exceeds max size of {} bytes",
-                MAX_REMOTE_INPUT_BYTES
-            ));
+            return Err(IngestError::PayloadTooLarge {
+                limit: MAX_REMOTE_INPUT_BYTES as usize,
+            });
         }
-        output_file
-            .write_all(&buffer[..read_bytes])
-            .with_context(|| format!("failed to write {}", output_path.display()))?;
+        output_file.write_all(&buffer[..read_bytes]).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to write {}", output_path.display()),
+            )
+        })?;
     }
 
     Ok(output_path)
@@ -256,16 +339,20 @@ fn validate_upload_filename(filename: &str) -> Result<String> {
     let path = Path::new(filename);
     let mut components = path.components();
     let Some(Component::Normal(component)) = components.next() else {
-        return Err(anyhow!("upload.filename must be a simple file name"));
+        return Err(IngestError::validation(
+            "upload.filename must be a simple file name",
+        ));
     };
     if components.next().is_some() {
-        return Err(anyhow!("upload.filename must be a simple file name"));
+        return Err(IngestError::validation(
+            "upload.filename must be a simple file name",
+        ));
     }
     let normalized = component
         .to_str()
-        .ok_or_else(|| anyhow!("upload.filename must be valid UTF-8"))?;
+        .ok_or_else(|| IngestError::validation("upload.filename must be valid UTF-8"))?;
     if normalized.trim().is_empty() {
-        return Err(anyhow!("upload.filename must not be empty"));
+        return Err(IngestError::validation("upload.filename must not be empty"));
     }
     Ok(normalized.to_string())
 }
@@ -291,68 +378,86 @@ fn extract_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
         return extract_tar_archive(
             archive_path,
             output_dir,
-            GzDecoder::new(
-                File::open(archive_path)
-                    .with_context(|| format!("failed to open {}", archive_path.display()))?,
-            ),
+            GzDecoder::new(File::open(archive_path).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to open {}", archive_path.display()),
+                )
+            })?),
         );
     }
     if filename.ends_with(".tar.bz2") {
         return extract_tar_archive(
             archive_path,
             output_dir,
-            BzDecoder::new(
-                File::open(archive_path)
-                    .with_context(|| format!("failed to open {}", archive_path.display()))?,
-            ),
+            BzDecoder::new(File::open(archive_path).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to open {}", archive_path.display()),
+                )
+            })?),
         );
     }
     if filename.ends_with(".tar.xz") {
         return extract_tar_archive(
             archive_path,
             output_dir,
-            XzDecoder::new(
-                File::open(archive_path)
-                    .with_context(|| format!("failed to open {}", archive_path.display()))?,
-            ),
+            XzDecoder::new(File::open(archive_path).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to open {}", archive_path.display()),
+                )
+            })?),
         );
     }
     if filename.ends_with(".tar") {
         return extract_tar_archive(
             archive_path,
             output_dir,
-            File::open(archive_path)
-                .with_context(|| format!("failed to open {}", archive_path.display()))?,
+            File::open(archive_path).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to open {}", archive_path.display()),
+                )
+            })?,
         );
     }
 
-    Err(anyhow!(
+    Err(IngestError::validation(format!(
         "unsupported archive format for remote ingestion: {}",
         archive_path.display()
-    ))
+    )))
 }
 
 fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
-    let file = File::open(archive_path)
-        .with_context(|| format!("failed to open {}", archive_path.display()))?;
-    let mut archive = ZipArchive::new(file)
-        .with_context(|| format!("failed to read zip archive {}", archive_path.display()))?;
+    let file = File::open(archive_path).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to open {}", archive_path.display()))
+    })?;
+    let mut archive = ZipArchive::new(file).map_err(|e| {
+        IngestError::internal_with_source(
+            e,
+            format!("failed to read zip archive {}", archive_path.display()),
+        )
+    })?;
 
     let mut extracted_files = 0usize;
     let mut extracted_bytes = 0u64;
 
     for index in 0..archive.len() {
-        let mut entry = archive
-            .by_index(index)
-            .with_context(|| format!("failed to read zip entry {index}"))?;
+        let mut entry = archive.by_index(index).map_err(|e| {
+            IngestError::internal_with_source(e, format!("failed to read zip entry {index}"))
+        })?;
         let Some(relative_path) = normalize_archive_path(Path::new(entry.name())) else {
             continue;
         };
         if entry.is_dir() {
-            fs::create_dir_all(output_dir.join(relative_path)).with_context(|| {
-                format!(
-                    "failed to create archive directory in {}",
-                    output_dir.display()
+            fs::create_dir_all(output_dir.join(relative_path)).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!(
+                        "failed to create archive directory in {}",
+                        output_dir.display()
+                    ),
                 )
             })?;
             continue;
@@ -361,17 +466,31 @@ fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
         enforce_archive_limits(&mut extracted_files, &mut extracted_bytes, entry.size())?;
         let destination = output_dir.join(relative_path);
         if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
+            fs::create_dir_all(parent).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to create {}", parent.display()),
+                )
+            })?;
         }
-        let mut output = File::create(&destination)
-            .with_context(|| format!("failed to create {}", destination.display()))?;
-        std::io::copy(&mut entry, &mut output)
-            .with_context(|| format!("failed to extract {}", destination.display()))?;
+        let mut output = File::create(&destination).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to create {}", destination.display()),
+            )
+        })?;
+        std::io::copy(&mut entry, &mut output).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to extract {}", destination.display()),
+            )
+        })?;
     }
 
     if extracted_files == 0 {
-        return Err(anyhow!("archive did not contain any safe files to scan"));
+        return Err(IngestError::validation(
+            "archive did not contain any safe files to scan",
+        ));
     }
 
     Ok(())
@@ -382,24 +501,36 @@ fn extract_tar_archive<R: Read>(archive_path: &Path, output_dir: &Path, reader: 
     let mut extracted_files = 0usize;
     let mut extracted_bytes = 0u64;
 
-    for entry in archive
-        .entries()
-        .with_context(|| format!("failed to enumerate tar archive {}", archive_path.display()))?
-    {
-        let mut entry = entry
-            .with_context(|| format!("failed to read tar entry in {}", archive_path.display()))?;
-        let entry_path = entry
-            .path()
-            .with_context(|| format!("failed to read tar path in {}", archive_path.display()))?;
+    for entry in archive.entries().map_err(|e| {
+        IngestError::internal_with_source(
+            e,
+            format!("failed to enumerate tar archive {}", archive_path.display()),
+        )
+    })? {
+        let mut entry = entry.map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to read tar entry in {}", archive_path.display()),
+            )
+        })?;
+        let entry_path = entry.path().map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to read tar path in {}", archive_path.display()),
+            )
+        })?;
         let Some(relative_path) = normalize_archive_path(&entry_path) else {
             continue;
         };
 
         if entry.header().entry_type().is_dir() {
-            fs::create_dir_all(output_dir.join(relative_path)).with_context(|| {
-                format!(
-                    "failed to create archive directory in {}",
-                    output_dir.display()
+            fs::create_dir_all(output_dir.join(relative_path)).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!(
+                        "failed to create archive directory in {}",
+                        output_dir.display()
+                    ),
                 )
             })?;
             continue;
@@ -412,23 +543,40 @@ fn extract_tar_archive<R: Read>(archive_path: &Path, output_dir: &Path, reader: 
         enforce_archive_limits(
             &mut extracted_files,
             &mut extracted_bytes,
-            entry.header().size().with_context(|| {
-                format!("failed to read tar size in {}", archive_path.display())
+            entry.header().size().map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to read tar size in {}", archive_path.display()),
+                )
             })?,
         )?;
         let destination = output_dir.join(relative_path);
         if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
+            fs::create_dir_all(parent).map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!("failed to create {}", parent.display()),
+                )
+            })?;
         }
-        let mut output = File::create(&destination)
-            .with_context(|| format!("failed to create {}", destination.display()))?;
-        std::io::copy(&mut entry, &mut output)
-            .with_context(|| format!("failed to extract {}", destination.display()))?;
+        let mut output = File::create(&destination).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to create {}", destination.display()),
+            )
+        })?;
+        std::io::copy(&mut entry, &mut output).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to extract {}", destination.display()),
+            )
+        })?;
     }
 
     if extracted_files == 0 {
-        return Err(anyhow!("archive did not contain any safe files to scan"));
+        return Err(IngestError::validation(
+            "archive did not contain any safe files to scan",
+        ));
     }
 
     Ok(())
@@ -440,26 +588,24 @@ fn enforce_archive_limits(
     entry_size: u64,
 ) -> Result<()> {
     if entry_size > MAX_ARCHIVE_ENTRY_BYTES {
-        bail!(
-            "archive entry exceeds max size of {} bytes",
-            MAX_ARCHIVE_ENTRY_BYTES
-        );
+        return Err(IngestError::PayloadTooLarge {
+            limit: MAX_ARCHIVE_ENTRY_BYTES as usize,
+        });
     }
 
     *extracted_files += 1;
     if *extracted_files > MAX_ARCHIVE_ENTRY_COUNT {
-        bail!(
+        return Err(IngestError::Validation(format!(
             "archive exceeds max entry count of {}",
             MAX_ARCHIVE_ENTRY_COUNT
-        );
+        )));
     }
 
     *extracted_bytes += entry_size;
     if *extracted_bytes > MAX_ARCHIVE_TOTAL_BYTES {
-        bail!(
-            "archive exceeds max extracted size of {} bytes",
-            MAX_ARCHIVE_TOTAL_BYTES
-        );
+        return Err(IngestError::PayloadTooLarge {
+            limit: MAX_ARCHIVE_TOTAL_BYTES as usize,
+        });
     }
 
     Ok(())
@@ -481,15 +627,15 @@ fn normalize_archive_path(path: &Path) -> Option<PathBuf> {
 fn run_git(command: &mut Command, context_message: &str) -> Result<()> {
     let output = command
         .output()
-        .with_context(|| context_message.to_string())?;
+        .map_err(|e| IngestError::upstream_with_source(e, context_message))?;
     if output.status.success() {
         Ok(())
     } else {
-        bail!(
+        Err(IngestError::upstream(format!(
             "{}: {}",
             context_message,
             String::from_utf8_lossy(&output.stderr).trim()
-        )
+        )))
     }
 }
 

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -36,8 +36,8 @@ const MAX_ARCHIVE_ENTRY_COUNT: usize = 10_000;
 pub(crate) enum IngestError {
     #[error("{0}")]
     Validation(String),
-    #[error("payload exceeds max size of {limit} bytes")]
-    PayloadTooLarge { limit: usize },
+    #[error("{0}")]
+    PayloadTooLarge(String),
     #[error("{message}")]
     Upstream {
         message: String,
@@ -196,9 +196,9 @@ fn prepare_url_input(url: &str) -> Result<PreparedSyncInput> {
 
 fn prepare_upload_input(filename: &str, content_base64: &str) -> Result<PreparedSyncInput> {
     let normalized_filename = validate_upload_filename(filename)?;
-    let decoded = STANDARD.decode(content_base64).map_err(|_| {
-        IngestError::Validation("upload.content_base64 must be valid base64".to_string())
-    })?;
+    let decoded = STANDARD
+        .decode(content_base64)
+        .map_err(|_| IngestError::validation("upload.content_base64 must be valid base64"))?;
 
     if decoded.is_empty() {
         return Err(IngestError::validation(
@@ -207,9 +207,10 @@ fn prepare_upload_input(filename: &str, content_base64: &str) -> Result<Prepared
     }
 
     if decoded.len() > MAX_UPLOADED_INPUT_BYTES {
-        return Err(IngestError::PayloadTooLarge {
-            limit: MAX_UPLOADED_INPUT_BYTES,
-        });
+        return Err(IngestError::PayloadTooLarge(format!(
+            "upload payload exceeds max size of {} bytes",
+            MAX_UPLOADED_INPUT_BYTES
+        )));
     }
 
     let staging_dir = TempDir::new().map_err(|e| {
@@ -289,9 +290,10 @@ fn download_remote_input(url: &str, output_dir: &Path) -> Result<PathBuf> {
         .content_length()
         .is_some_and(|content_length| content_length > MAX_REMOTE_INPUT_BYTES)
     {
-        return Err(IngestError::PayloadTooLarge {
-            limit: MAX_REMOTE_INPUT_BYTES as usize,
-        });
+        return Err(IngestError::PayloadTooLarge(format!(
+            "remote input exceeds max size of {} bytes",
+            MAX_REMOTE_INPUT_BYTES
+        )));
     }
 
     let filename = derive_download_filename(response.url());
@@ -311,9 +313,10 @@ fn download_remote_input(url: &str, output_dir: &Path) -> Result<PathBuf> {
         }
         total_bytes += read_bytes as u64;
         if total_bytes > MAX_REMOTE_INPUT_BYTES {
-            return Err(IngestError::PayloadTooLarge {
-                limit: MAX_REMOTE_INPUT_BYTES as usize,
-            });
+            return Err(IngestError::PayloadTooLarge(format!(
+                "remote input exceeds max size of {} bytes",
+                MAX_REMOTE_INPUT_BYTES
+            )));
         }
         output_file.write_all(&buffer[..read_bytes]).map_err(|e| {
             IngestError::internal_with_source(
@@ -588,14 +591,15 @@ fn enforce_archive_limits(
     entry_size: u64,
 ) -> Result<()> {
     if entry_size > MAX_ARCHIVE_ENTRY_BYTES {
-        return Err(IngestError::PayloadTooLarge {
-            limit: MAX_ARCHIVE_ENTRY_BYTES as usize,
-        });
+        return Err(IngestError::PayloadTooLarge(format!(
+            "archive entry exceeds max size of {} bytes",
+            MAX_ARCHIVE_ENTRY_BYTES
+        )));
     }
 
     *extracted_files += 1;
     if *extracted_files > MAX_ARCHIVE_ENTRY_COUNT {
-        return Err(IngestError::Validation(format!(
+        return Err(IngestError::PayloadTooLarge(format!(
             "archive exceeds max entry count of {}",
             MAX_ARCHIVE_ENTRY_COUNT
         )));
@@ -603,9 +607,10 @@ fn enforce_archive_limits(
 
     *extracted_bytes += entry_size;
     if *extracted_bytes > MAX_ARCHIVE_TOTAL_BYTES {
-        return Err(IngestError::PayloadTooLarge {
-            limit: MAX_ARCHIVE_TOTAL_BYTES as usize,
-        });
+        return Err(IngestError::PayloadTooLarge(format!(
+            "archive exceeds max extracted size of {} bytes",
+            MAX_ARCHIVE_TOTAL_BYTES
+        )));
     }
 
     Ok(())

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -47,7 +47,7 @@ impl ServeError {
     pub(crate) fn http_status_code(&self) -> u16 {
         match self {
             Self::Ingest(IngestError::Validation(_)) => 422,
-            Self::Ingest(IngestError::PayloadTooLarge { .. }) => 413,
+            Self::Ingest(IngestError::PayloadTooLarge(_)) => 413,
             Self::Ingest(IngestError::Upstream { .. }) => 502,
             Self::Ingest(IngestError::Internal { .. }) => 500,
             Self::Workflow(WorkflowError::InvalidOptions(_)) => 422,
@@ -59,7 +59,7 @@ impl ServeError {
     pub(crate) fn error_type(&self) -> &'static str {
         match self {
             Self::Ingest(IngestError::Validation(_)) => "invalid_scan_request",
-            Self::Ingest(IngestError::PayloadTooLarge { .. }) => "payload_too_large",
+            Self::Ingest(IngestError::PayloadTooLarge(_)) => "payload_too_large",
             Self::Ingest(IngestError::Upstream { .. }) => "upstream_error",
             Self::Ingest(IngestError::Internal { .. }) => "internal_error",
             Self::Workflow(WorkflowError::InvalidOptions(_)) => "invalid_scan_request",

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -319,7 +319,7 @@ impl AsyncJobController {
                     eprintln!("serve async job {} failed: {error}", dispatched.job_id);
                     record.state = AsyncJobState::Failed;
                     record.result_body = None;
-                    record.error_message = Some(error.to_string());
+                    record.error_message = Some("async scan job failed".to_string());
                     record.error_status_code = Some(error.http_status_code());
                 }
             }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -25,13 +25,49 @@ use crate::serve_api::{
     SyncLicenseSource, SyncScanRequest,
 };
 use crate::version::BUILD_VERSION;
-use crate::workflow::{LicenseSource, ScanOptions, scan_paths};
-use ingest::prepare_sync_input;
+use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
+use ingest::{IngestError, prepare_sync_input};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_BODY_BYTES: usize = 24 * 1024 * 1024;
 const DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB: usize = 4;
 const DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS: usize = 64;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ServeError {
+    #[error(transparent)]
+    Ingest(#[from] IngestError),
+    #[error(transparent)]
+    Workflow(#[from] WorkflowError),
+    #[error("{0}")]
+    Serialization(String),
+}
+
+impl ServeError {
+    pub(crate) fn http_status_code(&self) -> u16 {
+        match self {
+            Self::Ingest(IngestError::Validation(_)) => 422,
+            Self::Ingest(IngestError::PayloadTooLarge { .. }) => 413,
+            Self::Ingest(IngestError::Upstream { .. }) => 502,
+            Self::Ingest(IngestError::Internal { .. }) => 500,
+            Self::Workflow(WorkflowError::InvalidOptions(_)) => 422,
+            Self::Workflow(WorkflowError::Pipeline(_)) => 500,
+            Self::Serialization(_) => 500,
+        }
+    }
+
+    pub(crate) fn error_type(&self) -> &'static str {
+        match self {
+            Self::Ingest(IngestError::Validation(_)) => "invalid_scan_request",
+            Self::Ingest(IngestError::PayloadTooLarge { .. }) => "payload_too_large",
+            Self::Ingest(IngestError::Upstream { .. }) => "upstream_error",
+            Self::Ingest(IngestError::Internal { .. }) => "internal_error",
+            Self::Workflow(WorkflowError::InvalidOptions(_)) => "invalid_scan_request",
+            Self::Workflow(WorkflowError::Pipeline(_)) => "scan_failed",
+            Self::Serialization(_) => "scan_failed",
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServeConfig {
@@ -93,6 +129,7 @@ struct AsyncJobRecord {
     allocated_processors: Option<usize>,
     result_body: Option<String>,
     error_message: Option<String>,
+    error_status_code: Option<u16>,
 }
 
 #[derive(Debug)]
@@ -115,6 +152,7 @@ struct AsyncJobResultSnapshot {
     state: AsyncJobState,
     result_body: Option<String>,
     error_message: Option<String>,
+    error_status_code: Option<u16>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -281,7 +319,8 @@ impl AsyncJobController {
                     eprintln!("serve async job {} failed: {error}", dispatched.job_id);
                     record.state = AsyncJobState::Failed;
                     record.result_body = None;
-                    record.error_message = Some("async scan job failed".to_string());
+                    record.error_message = Some(error.to_string());
+                    record.error_status_code = Some(error.http_status_code());
                 }
             }
 
@@ -317,6 +356,7 @@ impl AsyncJobControllerState {
             state: job.state,
             result_body: job.result_body.clone(),
             error_message: job.error_message.clone(),
+            error_status_code: job.error_status_code,
         })
     }
 
@@ -337,6 +377,7 @@ impl AsyncJobRecord {
             allocated_processors: None,
             result_body: None,
             error_message: None,
+            error_status_code: None,
         }
     }
 }
@@ -632,12 +673,7 @@ fn handle_sync_scan_request(request: &HttpRequest) -> HttpResponse {
     let execution = match build_sync_scan_execution(sync_request) {
         Ok(execution) => execution,
         Err(error) => {
-            return error_response(
-                422,
-                "Unprocessable Entity",
-                "invalid_scan_request",
-                error.to_string(),
-            );
+            return serve_error_response(&error);
         }
     };
 
@@ -647,12 +683,25 @@ fn handle_sync_scan_request(request: &HttpRequest) -> HttpResponse {
             reason: "OK",
             body,
         },
-        Err(error) => error_response(
-            422,
-            "Unprocessable Entity",
-            "scan_failed",
-            error.to_string(),
-        ),
+        Err(error) => serve_error_response(&error),
+    }
+}
+
+fn serve_error_response(error: &ServeError) -> HttpResponse {
+    let status_code = error.http_status_code();
+    let reason = http_status_reason(status_code);
+    error_response(status_code, reason, error.error_type(), error.to_string())
+}
+
+fn http_status_reason(code: u16) -> &'static str {
+    match code {
+        400 => "Bad Request",
+        413 => "Payload Too Large",
+        422 => "Unprocessable Entity",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        _ => "Error",
     }
 }
 
@@ -712,14 +761,18 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
                 async_job_state_label(snapshot.state)
             ),
         ),
-        AsyncJobState::Failed => error_response(
-            422,
-            "Unprocessable Entity",
-            "job_failed",
-            snapshot
-                .error_message
-                .unwrap_or_else(|| format!("async job {job_id} failed")),
-        ),
+        AsyncJobState::Failed => {
+            let status_code = snapshot.error_status_code.unwrap_or(500);
+            let reason = http_status_reason(status_code);
+            error_response(
+                status_code,
+                reason,
+                "job_failed",
+                snapshot
+                    .error_message
+                    .unwrap_or_else(|| format!("async job {job_id} failed")),
+            )
+        }
     }
 }
 
@@ -748,7 +801,7 @@ fn decode_scan_request_from_http(
         .map_err(|error| error_response(400, "Bad Request", "invalid_request", error.to_string()))
 }
 
-fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecution> {
+fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecution, ServeError> {
     let prepared_input = prepare_sync_input(request.input)?;
 
     let mut options = ScanOptions::default();
@@ -798,16 +851,19 @@ fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecuti
     })
 }
 
-fn execute_scan_execution(execution: SyncScanExecution) -> Result<String> {
+fn execute_scan_execution(execution: SyncScanExecution) -> Result<String, ServeError> {
     let output = scan_paths(
         execution.paths.iter().map(|path| path.as_path()),
         &execution.options,
     )?;
     serde_json::to_string(&crate::output_schema::Output::from(&output))
-        .context("scan result should serialize")
+        .map_err(|e| ServeError::Serialization(format!("scan result should serialize: {e}")))
 }
 
-fn run_async_scan_request(request: SyncScanRequest, allocated_processors: usize) -> Result<String> {
+fn run_async_scan_request(
+    request: SyncScanRequest,
+    allocated_processors: usize,
+) -> Result<String, ServeError> {
     let mut execution = build_sync_scan_execution(request)?;
     execution.options.process_mode = if allocated_processors <= 1 {
         ProcessMode::SequentialWithTimeouts
@@ -1006,6 +1062,7 @@ mod tests {
                 allocated_processors: Some(2),
                 result_body: Some("{\"status\":\"ok\"}".to_string()),
                 error_message: None,
+                error_status_code: None,
             },
         );
         let request = HttpRequest {
@@ -1029,6 +1086,7 @@ mod tests {
                 allocated_processors: Some(1),
                 result_body: None,
                 error_message: Some("async scan job failed".to_string()),
+                error_status_code: Some(500),
             },
         );
         let request = HttpRequest {
@@ -1039,7 +1097,7 @@ mod tests {
         };
 
         let response = response_for_request(&request, &state);
-        assert_eq!(response.status_code, 422);
+        assert_eq!(response.status_code, 500);
         assert!(response.body.contains("job_failed"));
         assert!(response.body.contains("async scan job failed"));
     }
@@ -1104,6 +1162,7 @@ mod tests {
                         allocated_processors: Some(1),
                         result_body: Some("old".to_string()),
                         error_message: None,
+                        error_status_code: None,
                     },
                 ),
                 (
@@ -1113,6 +1172,7 @@ mod tests {
                         allocated_processors: Some(1),
                         result_body: Some("new".to_string()),
                         error_message: None,
+                        error_status_code: None,
                     },
                 ),
             ]),

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Result, anyhow};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::path::{Path, PathBuf};
 
@@ -11,6 +10,14 @@ use crate::license_detection::DEFAULT_LICENSEDB_URL_TEMPLATE;
 use crate::progress::ProgressMode;
 use crate::scanner::MemoryMode;
 use crate::{Output, ProcessMode};
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkflowError {
+    #[error("{0}")]
+    InvalidOptions(String),
+    #[error(transparent)]
+    Pipeline(#[from] anyhow::Error),
+}
 
 /// Selects how the workflow facade sources license rules.
 #[derive(Debug, Clone)]
@@ -156,7 +163,7 @@ impl Default for ScanOptions {
 /// assert!(!output.headers[0].options.contains_key("input"));
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn scan_path(path: impl AsRef<Path>, options: &ScanOptions) -> Result<Output> {
+pub fn scan_path(path: impl AsRef<Path>, options: &ScanOptions) -> Result<Output, WorkflowError> {
     scan_paths([path.as_ref()], options)
 }
 
@@ -188,20 +195,24 @@ pub fn scan_path(path: impl AsRef<Path>, options: &ScanOptions) -> Result<Output
 pub fn scan_paths<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
     options: &ScanOptions,
-) -> Result<Output> {
+) -> Result<Output, WorkflowError> {
     let input_paths: Vec<String> = paths
         .into_iter()
         .map(|path| path.to_string_lossy().to_string())
         .collect();
 
     if input_paths.is_empty() {
-        return Err(anyhow!("At least one input path is required"));
+        return Err(WorkflowError::InvalidOptions(
+            "At least one input path is required".to_string(),
+        ));
     }
 
     let request = request_for_native_paths(input_paths, options);
     validate_workflow_request(&request)?;
 
-    execute_request(&request).map(|executed| executed.output)
+    execute_request(&request)
+        .map(|executed| executed.output)
+        .map_err(WorkflowError::Pipeline)
 }
 
 fn request_for_native_paths(input_paths: Vec<String>, options: &ScanOptions) -> ScanRequest {
@@ -286,87 +297,115 @@ fn request_for_native_paths(input_paths: Vec<String>, options: &ScanOptions) -> 
     }
 }
 
-fn validate_workflow_request(request: &ScanRequest) -> Result<()> {
+fn validate_workflow_request(request: &ScanRequest) -> Result<(), WorkflowError> {
     let license_enabled = request.license;
 
     if request.strip_root && request.full_root {
-        return Err(anyhow!("strip_root and full_root are mutually exclusive"));
+        return Err(WorkflowError::InvalidOptions(
+            "strip_root and full_root are mutually exclusive".to_string(),
+        ));
     }
 
     if request.license_text && !license_enabled {
-        return Err(anyhow!("license_text requires detect_license"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_text requires detect_license".to_string(),
+        ));
     }
 
     if request.license_text_diagnostics && !request.license_text {
-        return Err(anyhow!("license_text_diagnostics requires license_text"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_text_diagnostics requires license_text".to_string(),
+        ));
     }
 
     if request.license_diagnostics && !license_enabled {
-        return Err(anyhow!("license_diagnostics requires detect_license"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_diagnostics requires detect_license".to_string(),
+        ));
     }
 
     if request.unknown_licenses && !license_enabled {
-        return Err(anyhow!("unknown_licenses requires detect_license"));
+        return Err(WorkflowError::InvalidOptions(
+            "unknown_licenses requires detect_license".to_string(),
+        ));
     }
 
     if request.license_references && !license_enabled {
-        return Err(anyhow!("license_references requires detect_license"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_references requires detect_license".to_string(),
+        ));
     }
 
     if request.license_url_template != DEFAULT_LICENSEDB_URL_TEMPLATE && !license_enabled {
-        return Err(anyhow!("license_url_template requires detect_license"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_url_template requires detect_license".to_string(),
+        ));
     }
 
     if request.package_only && license_enabled {
-        return Err(anyhow!(
-            "package_only cannot be combined with detect_license"
+        return Err(WorkflowError::InvalidOptions(
+            "package_only cannot be combined with detect_license".to_string(),
         ));
     }
 
     if request.package_only && request.summary {
-        return Err(anyhow!("package_only cannot be combined with summary"));
+        return Err(WorkflowError::InvalidOptions(
+            "package_only cannot be combined with summary".to_string(),
+        ));
     }
 
     if request.package_only && request.package {
-        return Err(anyhow!(
-            "package_only cannot be combined with detect_packages"
+        return Err(WorkflowError::InvalidOptions(
+            "package_only cannot be combined with detect_packages".to_string(),
         ));
     }
 
     if request.package_only && request.system_package {
-        return Err(anyhow!(
-            "package_only cannot be combined with detect_system_packages"
+        return Err(WorkflowError::InvalidOptions(
+            "package_only cannot be combined with detect_system_packages".to_string(),
         ));
     }
 
     if request.summary && !request.classify {
-        return Err(anyhow!("summary requires classify"));
+        return Err(WorkflowError::InvalidOptions(
+            "summary requires classify".to_string(),
+        ));
     }
 
     if request.license_clarity_score && !request.classify {
-        return Err(anyhow!("license_clarity_score requires classify"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_clarity_score requires classify".to_string(),
+        ));
     }
 
     if request.tallies_key_files && !(request.tallies && request.classify) {
-        return Err(anyhow!("tallies_key_files requires tallies and classify"));
+        return Err(WorkflowError::InvalidOptions(
+            "tallies_key_files requires tallies and classify".to_string(),
+        ));
     }
 
     if request.tallies_by_facet && request.facet.is_empty() {
-        return Err(anyhow!(
-            "tallies_by_facet requires at least one facet definition"
+        return Err(WorkflowError::InvalidOptions(
+            "tallies_by_facet requires at least one facet definition".to_string(),
         ));
     }
 
     if request.tallies_by_facet && !request.tallies {
-        return Err(anyhow!("tallies_by_facet requires tallies"));
+        return Err(WorkflowError::InvalidOptions(
+            "tallies_by_facet requires tallies".to_string(),
+        ));
     }
 
     if request.mark_source && !request.info {
-        return Err(anyhow!("mark_source requires collect_info"));
+        return Err(WorkflowError::InvalidOptions(
+            "mark_source requires collect_info".to_string(),
+        ));
     }
 
     if request.license_score > 100 {
-        return Err(anyhow!("license_score must be between 0 and 100"));
+        return Err(WorkflowError::InvalidOptions(
+            "license_score must be between 0 and 100".to_string(),
+        ));
     }
 
     Ok(())
@@ -402,6 +441,7 @@ mod tests {
 
         let request = request_for_native_paths(vec!["src".to_string()], &options);
         let error = validate_workflow_request(&request).expect_err("validation should fail");
+        assert!(matches!(error, WorkflowError::InvalidOptions(_)));
         assert!(
             error
                 .to_string()
@@ -419,6 +459,7 @@ mod tests {
 
         let request = request_for_native_paths(vec!["src".to_string()], &options);
         let error = validate_workflow_request(&request).expect_err("validation should fail");
+        assert!(matches!(error, WorkflowError::InvalidOptions(_)));
         assert!(
             error
                 .to_string()
@@ -435,6 +476,7 @@ mod tests {
 
         let request = request_for_native_paths(vec!["src".to_string()], &options);
         let error = validate_workflow_request(&request).expect_err("validation should fail");
+        assert!(matches!(error, WorkflowError::InvalidOptions(_)));
         assert!(error.to_string().contains("summary requires classify"));
     }
 


### PR DESCRIPTION
## Summary

- Replace hand-rolled error enum `Display`/`Error` impls with `thiserror` derives for 7 existing types (`RuleKindError`, `LicenseExpressionError`, `LicenseKeyError`, `LicenseTextError`, `ParseError`, `SerializationError`, `ParseDigestError`)
- Introduce `LicenseDetectionError::Timeout` for typed timeout signaling through the detection pipeline, replacing string-based `"license detection timed out"` matching
- Introduce `FileScanError` + `TimeoutPhase` enum for typed pipeline timeout dispatch, replacing `anyhow::Error::msg()` construction
- Thread `LicenseDetectionError` through all detection functions so deadline failures carry the typed error instead of `anyhow`
- Add `is_timeout: bool` field on `ScanDiagnostic` (with `#[serde(skip)]`) to eliminate `is_timeout_diagnostic_message` string-prefix matching
- Introduce `WorkflowError { InvalidOptions, Pipeline }` for the workflow public API, replacing `anyhow!` validation errors
- Introduce `IngestError { Validation, PayloadTooLarge, Upstream, Internal }` for the serve ingestion path, replacing `anyhow!`/`bail!`/`.context()`
- Introduce `ServeError` composition with `http_status_code()` and `error_type()` methods for correct HTTP status mapping (422/413/502/500)

## Scope decisions

Two `anyhow` sites in the hand-rolled HTTP implementation (`parse_http_request` body-size → should be 413, `decode_sync_scan_request` JSON error → should be 422) were **not** converted because they are coupled to the custom HTTP parsing that will be replaced by a framework. Converting them now would be wasted effort.

All other remaining `anyhow` usage (scan_pipeline, scan_runtime, CLI validation, server startup) has downstream that only prints/exits with no variant-based dispatch — these correctly stay as `anyhow`.

## Known follow-ups

- `From<LicenseDetectionError>` for `FileScanError` hardcodes `0.0` timeout seconds — correctness trap if `?` is ever used for that conversion
- `progress.rs` still has string-prefix timeout check on the legacy `scan_errors: Vec<String>` field (TODO added; blocked on output-schema changes)

## Test plan

- All existing tests pass: 7 workflow + 4 ingest + 15 serve + license detection + pipeline tests
- Error variant categorization verified by test assertions (`matches!(error, WorkflowError::InvalidOptions(_))`)
- HTTP status code mapping verified by async job `error_status_code` assertions