### PR TITLE
refactor: remove unnecessary dependencies from dependency audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,7 +3413,6 @@ dependencies = [
  "rkyv",
  "rpm",
  "rusqlite",
- "rustc_version_runtime",
  "rustpython-ruff_python_ast",
  "rustpython-ruff_python_parser",
  "rusty-axml",
@@ -3981,16 +3980,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustc_version_runtime"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
-dependencies = [
- "rustc_version",
  "semver",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,12 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxcar"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,15 +2028,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2978,41 +2963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pep440_rs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
-dependencies = [
- "once_cell",
- "serde",
- "unicode-width 0.2.2",
- "unscanny",
- "version-ranges",
-]
-
-[[package]]
-name = "pep508_rs"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
-dependencies = [
- "boxcar",
- "indexmap",
- "itertools 0.13.0",
- "once_cell",
- "pep440_rs",
- "regex",
- "rustc-hash 2.1.2",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
- "unicode-width 0.2.2",
- "url",
- "urlencoding",
- "version-ranges",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,7 +3352,6 @@ dependencies = [
  "os_info",
  "packageurl",
  "pdf_oxide",
- "pep508_rs",
  "postcard",
  "prost",
  "quick-xml 0.40.1",
@@ -5058,12 +5007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
-name = "unscanny"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5081,12 +5024,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -5116,15 +5053,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,6 @@ object = { version = "0.39.1", default-features = false, features = ["read_core"
 os_info = "3.14.0"
 packageurl = "0.6.0"
 pdf_oxide = "0.3.53"
-pep508_rs = "0.9.2"
 postcard = { workspace = true }
 prost = { version = "0.14.3", features = ["derive"] }
 quick-xml = "0.40.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha1 = "0.11.0"
 sha2 = { workspace = true }
-smallvec = { version = "1.15.1", features = ["write"] }
+smallvec = "1.15.1"
 starlark_syntax = "0.13.0"
 strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ rpm = { version = "0.23.5", default-features = false, features = ["payload", "gz
 ruff_python_ast = { version = "0.15.8", package = "rustpython-ruff_python_ast" }
 ruff_python_parser = { version = "0.15.8", package = "rustpython-ruff_python_parser" }
 rusqlite = { version = "0.39.0", features = ["bundled"], optional = true }
-rustc_version_runtime = "0.3.0"
 rusty-axml = "0.2.1"
 schemars = { version = "1.2.1", features = ["derive"] }
 serde = { workspace = true }

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,8 @@ fn main() {
 
     println!("cargo:rustc-env=PROVENANT_BUILD_VERSION={build_version}");
 
+    set_rustc_version();
+
     generate_legalese_artifact();
 }
 
@@ -126,6 +128,18 @@ fn generate_overlay_entries(dir: &Path, extension: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn set_rustc_version() {
+    let output = Command::new(env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string()))
+        .arg("--version")
+        .output()
+        .expect("failed to run rustc --version");
+    let version = String::from_utf8(output.stdout)
+        .unwrap_or_else(|_| "unknown".to_string())
+        .trim()
+        .to_string();
+    println!("cargo:rustc-env=PROVENANT_RUSTC_VERSION={version}");
 }
 
 fn derive_build_version(package_version: &str) -> String {

--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,5 @@ allow = [
     "bzip2-1.0.6",
 ]
 exceptions = [
-    { crate = "option-ext", allow = ["MPL-2.0"] },
-    { crate = "version-ranges", allow = ["MPL-2.0"] },
+    { crate = "option-ext", allow = ["MPL-2.0"] }
 ]

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -1023,7 +1023,8 @@ fn extract_pip_dependencies(pip_deps: &[Value]) -> Vec<Dependency> {
         .take(MAX_ITERATION_COUNT)
         .filter_map(|pip_dep| {
             if let Some(pip_req_str) = pip_dep.as_str()
-                && let Ok(parsed_req) = pip_req_str.parse::<pep508_rs::Requirement>()
+                && let Some(parsed_req) =
+                    crate::parsers::pep508::parse_pep508_requirement(pip_req_str)
             {
                 create_pip_dependency(parsed_req, "dependencies", Some(pip_req_str))
             } else {
@@ -1034,20 +1035,24 @@ fn extract_pip_dependencies(pip_deps: &[Value]) -> Vec<Dependency> {
 }
 
 fn create_pip_dependency(
-    parsed_req: pep508_rs::Requirement,
+    parsed_req: crate::parsers::pep508::Pep508Requirement,
     scope: &str,
     raw_requirement: Option<&str>,
 ) -> Option<Dependency> {
-    let name = truncate_field(parsed_req.name.to_string());
+    let name = truncate_field(parsed_req.name);
 
     if name == "pip" || name == "python" {
         return None;
     }
 
-    let specs = parsed_req.version_or_url.as_ref().map(|v| match v {
-        pep508_rs::VersionOrUrl::VersionSpecifier(spec) => truncate_field(spec.to_string()),
-        pep508_rs::VersionOrUrl::Url(url) => truncate_field(url.to_string()),
-    });
+    let specs = if parsed_req.is_name_at_url {
+        parsed_req
+            .url
+            .as_ref()
+            .map(|url| truncate_field(url.clone()))
+    } else {
+        parsed_req.specifiers.clone()
+    };
 
     let extracted_requirement = if let Some(raw) = raw_requirement {
         let raw = raw.trim();

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -319,7 +319,7 @@ fn current_system_environment() -> SystemEnvironment {
             env::consts::ARCH,
         ),
         platform_version: platform_version.unwrap_or_else(|| "unknown".to_string()),
-        rust_version: rustc_version_runtime::version().to_string(),
+        rust_version: env!("PROVENANT_RUSTC_VERSION").to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `rustc_version_runtime` with build-time `env!("PROVENANT_RUSTC_VERSION")` macro via `build.rs`, eliminating a runtime dependency that only read `rustc --version` at startup
- Replace `pep508_rs` with the existing local `crate::parsers::pep508::parse_pep508_requirement` in conda parser, removing `pep508_rs` and its transitive dependency `pep440_rs` (and 8 other transitive crates)
- Remove unused `smallvec` `write` feature — the codebase only uses `SmallVec<[u16; 64]>`, not `SmallVec<u8>`, so the `Write` impl from the `write` feature is never needed
- Clean up stale `version-ranges` license exception from `deny.toml` (crate removed with `pep508_rs`)

## Test plan

- [x] `cargo check` passes after each change
- [x] All 56 conda tests pass after pep508_rs replacement
- [x] Pre-commit hooks (cargo-deny, clippy, rustfmt, cargo-sort, license-headers) pass on all three commits