### PR TITLE
fix(license): add PulseAudio LGPL overlay rule

### DIFF
--- a/resources/license_detection/index_build_policy.toml
+++ b/resources/license_detection/index_build_policy.toml
@@ -37,6 +37,7 @@ ignored_licenses = []
 "gpl1_bare_word_only.RULE" = "Treat bare GPL1 mentions as clue-only evidence because they are too weak to assert a concrete GPL license by themselves."
 "gpl_bare_word_only.RULE" = "Treat bare GPL mentions as clue-only evidence so short shorthand stays inspectable without becoming a false-positive hard detection."
 "mit_attribution_no_endorsement.RULE" = "Preserve correct MIT-family classification for this vendor-specific variant without letting the embedded Sinusoidal Systems AB names drive the match."
+"lgpl-2.0-plus_pulseaudio_url_1.RULE" = "Cover the current PulseAudio LGPL-2.0-or-later notice variant that ends with the gnu.org URL so it wins over the weak AGPL notice overmatch on the same text."
 "stable-diffusion-2022-08-22_required_phrase_1.RULE" = "Keep the dated Stable Diffusion August 22, 2022 CreativeML variant from collapsing into a different license variant during detection."
 "unknown_10.RULE" = "Narrow the upstream unknown-license-reference rule to the reviewed 'See LICENSE file for details' shape with a required LICENSE filename instead of letting broader mentions overmatch."
 

--- a/resources/license_detection/overlay/rules/lgpl-2.0-plus_pulseaudio_url_1.RULE
+++ b/resources/license_detection/overlay/rules/lgpl-2.0-plus_pulseaudio_url_1.RULE
@@ -1,0 +1,19 @@
+---
+license_expression: lgpl-2.0-plus
+is_license_notice: yes
+relevance: 100
+notes: PulseAudio LGPL notice variant with the modern gnu.org URL footer; keep this separate from the older FSF postal-address variants.
+---
+
+PulseAudio is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+PulseAudio is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.

--- a/testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in
+++ b/testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in
@@ -1,0 +1,16 @@
+#!@PA_BINARY@ -nF
+#
+# This file is part of PulseAudio.
+#
+# PulseAudio is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# PulseAudio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.

--- a/testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in.yml
+++ b/testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in.yml
@@ -1,0 +1,4 @@
+license_expressions:
+  - lgpl-2.0-plus
+detected_license_expressions:
+  - lgpl-2.0-plus

--- a/tests/license_detection_golden.rs
+++ b/tests/license_detection_golden.rs
@@ -713,4 +713,13 @@ mod golden_tests {
         )
         .unwrap();
     }
+    #[test]
+    fn test_golden_pulseaudio_default_pa_regression() {
+        run_explicit_golden(
+            Path::new("testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in"),
+            Path::new("testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in.yml"),
+            false,
+        )
+        .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- add a PulseAudio-specific LGPL-2.0-or-later overlay rule for the modern gnu.org URL-footer notice variant
- add an owned PulseAudio golden regression for the `default.pa.in` LGPL-2.0 notice
- register the new regression in the license golden suite

## Issues

- Covers: PulseAudio compare-output verification for `https://github.com/pulseaudio/pulseaudio`
- Closes: none

## Scope and exclusions

- Included:
  - dataset curation in `resources/license_detection/overlay/rules/`
  - embedded index refresh in `resources/license_detection/license_index.zst`
  - owned golden regression in `testdata/license-golden/provenant-regressions/`
  - license golden suite registration in `tests/license_detection_golden.rs`
- Explicit exclusions:
  - no LGPL-2.1 variant handling yet
  - no copyright detector/refiner cleanup
  - no benchmark documentation update

## Expected-output fixture changes

- Files changed: `testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in`, `testdata/license-golden/provenant-regressions/pulseaudio-default.pa.in.yml`, `tests/license_detection_golden.rs`
- Why the new expected output is correct:
  - `pulseaudio-default.pa.in` is an LGPL-2.0-or-later notice variant with the gnu.org URL footer and now resolves through `lgpl-2.0-plus_pulseaudio_url_1.RULE`
  - focused validation runs:
    - `cargo test --test license_detection_golden --features golden-tests test_golden_pulseaudio_default_pa_regression`

## Outcome

- the modern PulseAudio `default.pa.in` notice resolves as LGPL-2.0-or-later instead of overmatching weak AGPL reference text
- the new regression fixture keeps that exact notice variant covered in the golden suite
