### PR TITLE
fix(license): reduce AGPL false positives in comparative text

### DIFF
--- a/resources/license_detection/index_build_policy.toml
+++ b/resources/license_detection/index_build_policy.toml
@@ -27,6 +27,7 @@ ignored_rules = [
 ignored_licenses = []
 
 [overlay_reasons.rules]
+"agpl-3.0-plus_101.RULE" = "Treat bare AGPL mentions as clue-only evidence so short comparative references stay inspectable without becoming hard detections."
 "apache-2.0_and_lgpl-2.1_1.RULE" = "Keep the mixed Apache-2.0/LGPL-2.1 notice detectable only when both COPYING.LGPL and COPYING.ASL2 references are actually present."
 "apache-2.0_and_lgpl-2.1_2.RULE" = "Preserve a real typoed Apache-2.0/LGPL-2.1 notice seen in the wild without broadening generic dual-license detection."
 "apache-2.0_and_lgpl-2.1_4.RULE" = "Cover the GNU/Linux wording variant of the typoed mixed Apache-2.0/LGPL-2.1 notice while keeping it tight enough to avoid loose partial matches."

--- a/resources/license_detection/overlay/rules/agpl-3.0-plus_101.RULE
+++ b/resources/license_detection/overlay/rules/agpl-3.0-plus_101.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: agpl-3.0-plus
+is_license_clue: yes
+relevance: 50
+notes: Bare versionless AGPL shorthand is too weak for a hard detection; preserve it as clue-only evidence.
+---
+
+AGPL

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -540,6 +540,41 @@ fn test_engine_surfaces_bare_gpl1_as_clue_not_detection() {
 }
 
 #[test]
+fn test_engine_surfaces_bare_agpl_as_clue_not_detection() {
+    let engine = get_engine();
+
+    let detections = engine
+        .detect_with_kind("PyMuPDF without AGPL restrictions", false, false)
+        .expect("Detection should succeed");
+
+    assert!(
+        detections.iter().any(|detection| {
+            detection
+                .detection_log
+                .iter()
+                .any(|log| log == "license-clues")
+                && detection.license_expression.is_none()
+                && detection
+                    .matches
+                    .iter()
+                    .any(|m| m.rule_identifier == "agpl-3.0-plus_101.RULE")
+        }),
+        "bare AGPL should remain visible as clue-only evidence: {:?}",
+        detections
+            .iter()
+            .map(|d| (
+                d.license_expression.as_deref().unwrap_or("none"),
+                d.detection_log.clone(),
+                d.matches
+                    .iter()
+                    .map(|m| m.rule_identifier.as_str())
+                    .collect::<Vec<_>>()
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_engine_groups_same_line_bare_gpl_clue_with_exact_neighbors() {
     let engine = get_engine();
 

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -482,6 +482,13 @@ fn process_successful_detections(
         model_clues.extend(clue_matches);
     }
 
+    prune_contextual_short_reference_matches(
+        path,
+        text_content,
+        license_options.include_diagnostics,
+        &mut model_detections,
+        &mut model_clues,
+    );
     model_detections.extend(supplement_nix_manifest_license_detections(
         path,
         text_content,
@@ -765,6 +772,185 @@ fn prune_redundant_readme_conjunctive_detections(
                 *candidate_keys == keys && ranges_overlap(start, end, *other_start, *other_end)
             })
     });
+}
+
+fn prune_contextual_short_reference_matches(
+    path: &Path,
+    text_content: &str,
+    include_diagnostics: bool,
+    detections: &mut Vec<PublicLicenseDetection>,
+    clues: &mut Vec<Match>,
+) {
+    let source_lines: Vec<&str> = text_content.lines().collect();
+    if source_lines.is_empty() {
+        return;
+    }
+
+    clues.retain(|detection_match| {
+        !should_prune_contextual_short_reference_match(detection_match, &source_lines)
+    });
+
+    detections.retain_mut(|detection| {
+        let original_match_count = detection.matches.len();
+        detection.matches.retain(|detection_match| {
+            !should_prune_contextual_short_reference_match(detection_match, &source_lines)
+        });
+
+        if detection.matches.is_empty() {
+            return false;
+        }
+
+        if detection.matches.len() != original_match_count {
+            refresh_public_detection_after_context_prune(detection, path, include_diagnostics);
+        }
+
+        true
+    });
+}
+
+fn refresh_public_detection_after_context_prune(
+    detection: &mut PublicLicenseDetection,
+    path: &Path,
+    include_diagnostics: bool,
+) {
+    detection.license_expression =
+        crate::utils::spdx::combine_license_expressions_preserving_structure(
+            detection
+                .matches
+                .iter()
+                .map(|detection_match| detection_match.license_expression.clone())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_else(|| detection.matches[0].license_expression.clone());
+    detection.license_expression_spdx =
+        crate::utils::spdx::combine_license_expressions_preserving_structure_strict(
+            detection
+                .matches
+                .iter()
+                .map(|detection_match| detection_match.license_expression_spdx.clone())
+                .filter(|expression| !expression.is_empty())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_default();
+    detection.identifier = None;
+    if include_diagnostics
+        && !detection
+            .detection_log
+            .iter()
+            .any(|log| log == "contextual-short-license-mention-pruned")
+    {
+        detection
+            .detection_log
+            .push("contextual-short-license-mention-pruned".to_string());
+    }
+    crate::models::file_info::enrich_license_detection_provenance(
+        detection,
+        &path.to_string_lossy(),
+    );
+}
+
+fn should_prune_contextual_short_reference_match(
+    detection_match: &Match,
+    source_lines: &[&str],
+) -> bool {
+    if !(is_short_reference_like_public_match(detection_match)
+        || is_unknown_reference_like_public_match(detection_match))
+    {
+        return false;
+    }
+
+    let start_line = detection_match.start_line.get();
+    let end_line = detection_match.end_line.get().min(source_lines.len());
+    if start_line == 0 || start_line > end_line || start_line > source_lines.len() {
+        return false;
+    }
+
+    (start_line..=end_line).any(|line_number| {
+        is_markdown_license_table_row(line_number, source_lines)
+            || is_negative_or_comparative_license_mention_line(source_lines[line_number - 1])
+    })
+}
+
+fn is_short_reference_like_public_match(detection_match: &Match) -> bool {
+    detection_match.matched_length.unwrap_or(usize::MAX) <= 3
+}
+
+fn is_unknown_reference_like_public_match(detection_match: &Match) -> bool {
+    detection_match.license_expression == "unknown-license-reference"
+        || detection_match.license_expression_spdx
+            == "LicenseRef-scancode-unknown-license-reference"
+        || detection_match
+            .rule_identifier
+            .as_deref()
+            .is_some_and(|rule_identifier| rule_identifier.to_ascii_lowercase().contains("unknown"))
+}
+
+fn is_markdown_license_table_row(line_number: usize, source_lines: &[&str]) -> bool {
+    let Some(line) = source_lines.get(line_number.saturating_sub(1)) else {
+        return false;
+    };
+    if !is_markdown_table_line(line) {
+        return false;
+    }
+
+    let mut block_start = line_number - 1;
+    while block_start > 0 && is_markdown_table_line(source_lines[block_start - 1]) {
+        block_start -= 1;
+    }
+
+    let Some(header_line) = source_lines.get(block_start) else {
+        return false;
+    };
+    let Some(separator_line) = source_lines.get(block_start + 1) else {
+        return false;
+    };
+
+    header_line.to_ascii_lowercase().contains("license")
+        && is_markdown_table_separator_line(separator_line)
+        && line_number > block_start + 2
+}
+
+fn is_markdown_table_line(line: &str) -> bool {
+    let trimmed = strip_markdown_table_comment_prefix(line).trim();
+    trimmed.starts_with('|') && trimmed.ends_with('|') && trimmed.matches('|').count() >= 2
+}
+
+fn is_markdown_table_separator_line(line: &str) -> bool {
+    let trimmed = strip_markdown_table_comment_prefix(line).trim();
+    is_markdown_table_line(trimmed)
+        && trimmed
+            .chars()
+            .all(|ch| matches!(ch, '|' | '-' | ':' | ' ' | '\t'))
+}
+
+fn strip_markdown_table_comment_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    for prefix in ["//!", "///", "//", "*"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return rest.trim_start();
+        }
+    }
+    trimmed
+}
+
+fn is_negative_or_comparative_license_mention_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    (lower.contains("no ") && lower.contains("restriction"))
+        || (line_has_possessive_without_license_phrase(&lower))
+        || (lower.contains("unlike ") && line.contains('(') && line.contains(')'))
+        || lower.contains("-licensed alternative")
+        || lower.contains("-licensed alternatives")
+        || line_has_negated_license_shorthand_list(line)
+}
+
+fn line_has_possessive_without_license_phrase(lower: &str) -> bool {
+    lower.contains("without its ") && lower.contains(" license")
+        || lower.contains("without their ") && lower.contains(" license")
+}
+
+fn line_has_negated_license_shorthand_list(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("no ") && line.contains('/') && line.chars().any(|ch| ch.is_ascii_uppercase())
 }
 
 fn expand_dual_licensed_under_readme_choice_detections(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -5,7 +5,7 @@ use super::{
     LicenseExtractionInput, MAX_OUTPUT_MATCHED_TEXT_BYTES, MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH,
     compute_percentage_of_license_text, convert_detection_to_model, extract_license_information,
     normalize_optional_spdx_expression, promote_legal_notice_low_quality_detections,
-    prune_redundant_readme_conjunctive_detections,
+    prune_contextual_short_reference_matches, prune_redundant_readme_conjunctive_detections,
 };
 use crate::license_detection::LicenseDetection as InternalLicenseDetection;
 use crate::license_detection::LicenseDetectionEngine;
@@ -145,6 +145,47 @@ fn make_public_detection(
             referenced_filenames: None,
             matched_text_diagnostics: None,
         }],
+        detection_log: Vec::new(),
+        identifier: None,
+    }
+}
+
+fn make_public_match(
+    expr: &str,
+    expr_spdx: &str,
+    start_line: usize,
+    end_line: usize,
+    matched_length: usize,
+    rule_identifier: &str,
+) -> Match {
+    Match {
+        license_expression: expr.to_string(),
+        license_expression_spdx: expr_spdx.to_string(),
+        from_file: Some("README.md".to_string()),
+        start_line: LineNumber::new(start_line).unwrap(),
+        end_line: LineNumber::new(end_line).unwrap(),
+        matcher: Some("2-aho".to_string()),
+        score: MatchScore::MAX,
+        matched_length: Some(matched_length),
+        match_coverage: Some(100.0),
+        rule_relevance: Some(100),
+        rule_identifier: Some(rule_identifier.to_string()),
+        rule_url: None,
+        matched_text: None,
+        referenced_filenames: None,
+        matched_text_diagnostics: None,
+    }
+}
+
+fn make_public_detection_with_matches(
+    expr: &str,
+    expr_spdx: &str,
+    matches: Vec<Match>,
+) -> PublicLicenseDetection {
+    PublicLicenseDetection {
+        license_expression: expr.to_string(),
+        license_expression_spdx: expr_spdx.to_string(),
+        matches,
         detection_log: Vec::new(),
         identifier: None,
     }
@@ -501,6 +542,287 @@ fn test_prune_redundant_readme_conjunctive_detections_keeps_non_overlapping_and_
     );
 
     assert_eq!(detections.len(), 2, "detections: {detections:#?}");
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_drops_markdown_license_table_rows() {
+    let text = concat!(
+        "| Library | Mean | License |\n",
+        "|---------|------|---------|\n",
+        "| pdf_oxide | 0.8ms | MIT |\n",
+        "| PyMuPDF | 4.6ms | AGPL-3.0 |\n",
+        "| pypdfium2 | 4.1ms | Apache-2.0 |\n",
+    );
+    let mut detections = vec![make_public_detection_with_matches(
+        "agpl-3.0 AND apache-2.0",
+        "AGPL-3.0-only AND Apache-2.0",
+        vec![
+            make_public_match("agpl-3.0", "AGPL-3.0-only", 4, 4, 3, "agpl-3.0_5.RULE"),
+            make_public_match(
+                "apache-2.0",
+                "Apache-2.0",
+                5,
+                5,
+                3,
+                "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            ),
+        ],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("README.md"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert!(detections.is_empty(), "detections: {detections:#?}");
+    assert!(clues.is_empty());
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_drops_doc_comment_markdown_license_table_rows() {
+    let text = concat!(
+        "//! | Library | Mean | License |\n",
+        "//! |---------|------|---------|\n",
+        "//! | pdf_oxide | 0.8ms | MIT |\n",
+        "//! | PyMuPDF | 4.6ms | AGPL-3.0 |\n",
+    );
+    let mut detections = vec![make_public_detection_with_matches(
+        "agpl-3.0",
+        "AGPL-3.0-only",
+        vec![make_public_match(
+            "agpl-3.0",
+            "AGPL-3.0-only",
+            4,
+            4,
+            3,
+            "agpl-3.0_5.RULE",
+        )],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("src/lib.rs"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert!(detections.is_empty(), "detections: {detections:#?}");
+    assert!(clues.is_empty());
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_drops_negative_policy_lines() {
+    let text = "accepted = [\"Apache-2.0\"] # no GPL/AGPL/SSPL\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "agpl-3.0-plus AND mongodb-sspl-1.0",
+        "AGPL-3.0-or-later AND SSPL-1.0",
+        vec![
+            make_public_match(
+                "agpl-3.0-plus",
+                "AGPL-3.0-or-later",
+                1,
+                1,
+                1,
+                "agpl-3.0-plus_101.RULE",
+            ),
+            make_public_match(
+                "mongodb-sspl-1.0",
+                "SSPL-1.0",
+                1,
+                1,
+                1,
+                "mongodb-sspl-1.0_60.RULE",
+            ),
+        ],
+    )];
+    let mut clues = vec![make_public_match(
+        "gpl-1.0-plus",
+        "GPL-1.0-or-later",
+        1,
+        1,
+        1,
+        "gpl_bare_word_only.RULE",
+    )];
+
+    prune_contextual_short_reference_matches(
+        Path::new("deny.toml"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert!(detections.is_empty(), "detections: {detections:#?}");
+    assert!(clues.is_empty(), "clues: {clues:#?}");
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_keeps_dual_license_choice_but_drops_comparative_suffix()
+ {
+    let text = "Dual-licensed under MIT or Apache-2.0 at your option. Unlike AGPL-licensed alternatives, this project is permissive.\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "unknown-license-reference AND apache-2.0 OR mit AND agpl-3.0-plus",
+        "LicenseRef-scancode-unknown-license-reference AND (Apache-2.0 OR MIT) AND AGPL-3.0-or-later",
+        vec![
+            make_public_match(
+                "unknown-license-reference",
+                "LicenseRef-scancode-unknown-license-reference",
+                1,
+                1,
+                4,
+                "lead-in_unknown_30.RULE",
+            ),
+            make_public_match(
+                "apache-2.0 OR mit",
+                "Apache-2.0 OR MIT",
+                1,
+                1,
+                6,
+                "apache-2.0_or_mit_13.RULE",
+            ),
+            make_public_match(
+                "agpl-3.0-plus",
+                "AGPL-3.0-or-later",
+                1,
+                1,
+                1,
+                "agpl-3.0-plus_101.RULE",
+            ),
+        ],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("README.md"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(detections.len(), 1, "detections: {detections:#?}");
+    assert_eq!(detections[0].license_expression_spdx, "Apache-2.0 OR MIT");
+    assert_eq!(detections[0].matches.len(), 1);
+    assert_eq!(
+        detections[0].matches[0].rule_identifier.as_deref(),
+        Some("apache-2.0_or_mit_13.RULE")
+    );
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_drops_unlike_parenthetical_competitor_license() {
+    let text = "- **Permissive license** — MIT / Apache-2.0, unlike PyMuPDF (AGPL-3.0) — use freely in commercial and closed-source projects\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "apache-2.0 OR mit AND agpl-3.0",
+        "(Apache-2.0 OR MIT) AND AGPL-3.0-only",
+        vec![
+            make_public_match(
+                "apache-2.0 OR mit",
+                "Apache-2.0 OR MIT",
+                1,
+                1,
+                6,
+                "apache-2.0_or_mit_44.RULE",
+            ),
+            make_public_match("agpl-3.0", "AGPL-3.0-only", 1, 1, 3, "agpl-3.0_5.RULE"),
+        ],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("python/README.md"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(detections.len(), 1, "detections: {detections:#?}");
+    assert_eq!(detections[0].license_expression_spdx, "Apache-2.0 OR MIT");
+    assert_eq!(detections[0].matches.len(), 1);
+    assert_eq!(
+        detections[0].matches[0].rule_identifier.as_deref(),
+        Some("apache-2.0_or_mit_44.RULE")
+    );
+    assert!(clues.is_empty());
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_respects_include_diagnostics_flag() {
+    let text = "Dual-licensed under MIT or Apache-2.0 at your option. Unlike AGPL-licensed alternatives, this project is permissive.\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "unknown-license-reference AND apache-2.0 OR mit AND agpl-3.0-plus",
+        "LicenseRef-scancode-unknown-license-reference AND (Apache-2.0 OR MIT) AND AGPL-3.0-or-later",
+        vec![
+            make_public_match(
+                "unknown-license-reference",
+                "LicenseRef-scancode-unknown-license-reference",
+                1,
+                1,
+                4,
+                "lead-in_unknown_30.RULE",
+            ),
+            make_public_match(
+                "apache-2.0 OR mit",
+                "Apache-2.0 OR MIT",
+                1,
+                1,
+                6,
+                "apache-2.0_or_mit_13.RULE",
+            ),
+            make_public_match(
+                "agpl-3.0-plus",
+                "AGPL-3.0-or-later",
+                1,
+                1,
+                1,
+                "agpl-3.0-plus_101.RULE",
+            ),
+        ],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("README.md"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(detections.len(), 1);
+    assert_eq!(detections[0].license_expression_spdx, "Apache-2.0 OR MIT");
+    assert!(detections[0].detection_log.is_empty(), "{detections:#?}");
+}
+
+#[test]
+fn test_prune_contextual_short_reference_matches_keeps_short_license_notice_with_without_warranty()
+{
+    let text = "Licensed under the MIT License without warranty.\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "mit",
+        "MIT",
+        vec![make_public_match("mit", "MIT", 1, 1, 2, "mit_126.RULE")],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("README.md"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(detections.len(), 1, "detections: {detections:#?}");
+    assert_eq!(detections[0].license_expression_spdx, "MIT");
+    assert!(clues.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- downgrade bare `AGPL` references to clue-only evidence by replacing the upstream `agpl-3.0-plus_101.RULE` with a checked-in overlay
- prune short license-reference noise from generic comparative contexts such as markdown license tables, doc-comment tables, `unlike X (AGPL-3.0)` prose, and denylist lines like `no GPL/AGPL/SSPL`
- keep legitimate permissive-license detections intact and add focused regressions for the new behavior

## Issues

- Covers:
- Closes:

## Scope and exclusions

- Included:
  - bare AGPL clue-only rule curation plus regenerated `license_index.zst`
  - scanner-side contextual pruning for comparative and policy prose
  - focused engine and scanner regressions
- Explicit exclusions:
  - no BENCHMARKS.md update
  - no broad output-shaping cleanup beyond the AGPL/GPL/SSPL false-positive classes exposed here

## Intentional differences from Python

- bare `AGPL` is treated as clue-only evidence instead of a hard detection
- short AGPL/GPL/SSPL mentions in comparative tables and policy prose are pruned from file-level detections when they are clearly contextual noise rather than actual licensing for the file

## Follow-up work

- Created or intentionally deferred:
  - broader README/license-expression shaping remains out of scope for this PR unless another benchmark target shows it is worth doing generically

## Expected-output fixture changes

- Files changed: `resources/license_detection/license_index.zst`
- Why the new expected output is correct:
  - the embedded license index must change because the checked-in overlay and build policy changed; the regenerated artifact now reflects the reviewed AGPL clue-only curation

## Validation

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact`
- `cargo test --lib prune_contextual_short_reference`
- `cargo test --lib test_engine_surfaces_bare_agpl_as_clue_not_detection`
- `cargo test --test license_detection_golden --features golden-tests test_golden_lic4`
- `cargo test --test license_detection_golden --features golden-tests test_golden_external`
- `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/yfedoseev/pdf_oxide.git --repo-ref ed6177c91430d582873829360d8a7d576f16aff3 --profile common --build-mode fast-iteration`

## Outcome

- scanning `pdf_oxide` no longer hard-detects AGPL from the comparative markdown/doc-comment table entries in `src/lib.rs`
- the top-level `README.md` and denylist-style `deny.toml` prose no longer emit the targeted AGPL/GPL/SSPL false positives
- bare AGPL references remain inspectable as clue-only evidence instead of disappearing entirely
