### PR TITLE
refactor(serve): replace hand-rolled HTTP with tiny_http, remove http crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -1681,6 +1693,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -3339,7 +3357,6 @@ dependencies = [
  "flate2",
  "glob",
  "hex",
- "http",
  "image",
  "indicatif",
  "indicatif-log-bridge",
@@ -3378,6 +3395,7 @@ dependencies = [
  "tempfile",
  "tera",
  "thiserror 2.0.18",
+ "tiny_http",
  "toml",
  "ttf-parser",
  "url",
@@ -4715,6 +4733,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,6 @@ file-identify = "0.4.0"
 flate2 = "1.1.9"
  glob = { workspace = true }
 hex = "0.4.3"
-http = "1.4.0"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "tiff", "webp"] }
 indicatif = "0.18.4"
 indicatif-log-bridge = "0.2.3"
@@ -155,6 +154,7 @@ tar = "0.4.45"
 tempfile = { workspace = true }
 tera = { version = "1.20.1", default-features = false }
 thiserror = "2.0.18"
+tiny_http = "0.12.0"
  toml = { workspace = true }
 ttf-parser = "0.25.1"
 url = { workspace = true }

--- a/docs/openapi/provenant-serve.openapi.json
+++ b/docs/openapi/provenant-serve.openapi.json
@@ -79,7 +79,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncScanRequest"
+                "$ref": "#/components/schemas/ServeScanRequest"
               }
             }
           }
@@ -138,7 +138,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncScanRequest"
+                "$ref": "#/components/schemas/ServeScanRequest"
               }
             }
           }
@@ -470,16 +470,16 @@
           }
         }
       },
-      "SyncScanRequest": {
+      "ServeScanRequest": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SyncScanRequest",
+        "title": "ServeScanRequest",
         "type": "object",
         "properties": {
           "input": {
-            "$ref": "#/$defs/SyncScanInput"
+            "$ref": "#/$defs/ServeScanInput"
           },
           "options": {
-            "$ref": "#/$defs/SyncScanOptions",
+            "$ref": "#/$defs/ServeScanOptions",
             "default": {
               "collect_info": false,
               "detect_license": {
@@ -519,7 +519,7 @@
           "input"
         ],
         "$defs": {
-          "SyncScanInput": {
+          "ServeScanInput": {
             "oneOf": [
               {
                 "type": "object",
@@ -598,7 +598,7 @@
               }
             ]
           },
-          "SyncScanOptions": {
+          "ServeScanOptions": {
             "type": "object",
             "properties": {
               "collect_info": {
@@ -606,7 +606,7 @@
                 "default": false
               },
               "detect_license": {
-                "$ref": "#/$defs/SyncLicenseSource",
+                "$ref": "#/$defs/ServeLicenseSource",
                 "default": {
                   "type": "disabled"
                 }
@@ -733,7 +733,7 @@
               }
             }
           },
-          "SyncLicenseSource": {
+          "ServeLicenseSource": {
             "oneOf": [
               {
                 "type": "object",
@@ -779,9 +779,9 @@
           }
         }
       },
-      "SyncScanInput": {
+      "ServeScanInput": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SyncScanInput",
+        "title": "ServeScanInput",
         "oneOf": [
           {
             "type": "object",
@@ -860,9 +860,9 @@
           }
         ]
       },
-      "SyncLicenseSource": {
+      "ServeLicenseSource": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SyncLicenseSource",
+        "title": "ServeLicenseSource",
         "oneOf": [
           {
             "type": "object",
@@ -906,9 +906,9 @@
           }
         ]
       },
-      "SyncScanOptions": {
+      "ServeScanOptions": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SyncScanOptions",
+        "title": "ServeScanOptions",
         "type": "object",
         "properties": {
           "collect_info": {
@@ -916,7 +916,7 @@
             "default": false
           },
           "detect_license": {
-            "$ref": "#/$defs/SyncLicenseSource",
+            "$ref": "#/$defs/ServeLicenseSource",
             "default": {
               "type": "disabled"
             }
@@ -1043,7 +1043,7 @@
           }
         },
         "$defs": {
-          "SyncLicenseSource": {
+          "ServeLicenseSource": {
             "oneOf": [
               {
                 "type": "object",

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -19,7 +19,9 @@ use tempfile::TempDir;
 use url::Url;
 use zip::ZipArchive;
 
-use crate::serve_api::SyncScanInput;
+use crate::ProcessMode;
+use crate::serve_api::{SyncLicenseSource, SyncScanInput, SyncScanRequest};
+use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
 
 type Result<T> = std::result::Result<T, IngestError>;
 
@@ -641,6 +643,91 @@ fn run_git(command: &mut Command, context_message: &str) -> Result<()> {
             context_message,
             String::from_utf8_lossy(&output.stderr).trim()
         )))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ScanError {
+    #[error(transparent)]
+    Workflow(#[from] WorkflowError),
+    #[error("{0}")]
+    Serialization(String),
+}
+
+#[derive(Debug)]
+pub(super) struct SyncScanExecution {
+    paths: Vec<PathBuf>,
+    options: ScanOptions,
+    _staging_dir: Option<TempDir>,
+}
+
+impl SyncScanExecution {
+    pub(super) fn new(request: SyncScanRequest) -> Result<Self> {
+        let prepared_input = prepare_sync_input(request.input)?;
+
+        let mut options = ScanOptions::default();
+        options.collect_info = request.options.collect_info;
+        options.detect_license = match request.options.detect_license {
+            SyncLicenseSource::Disabled => LicenseSource::Disabled,
+            SyncLicenseSource::Embedded => LicenseSource::Embedded,
+            SyncLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
+        };
+        options.detect_packages = request.options.detect_packages;
+        options.detect_system_packages = request.options.detect_system_packages;
+        options.detect_packages_in_compiled = request.options.detect_packages_in_compiled;
+        options.detect_copyrights = request.options.detect_copyrights;
+        options.detect_emails = request.options.detect_emails;
+        options.detect_urls = request.options.detect_urls;
+        options.detect_generated = request.options.detect_generated;
+        options.include = request.options.include;
+        options.exclude = request.options.exclude;
+        if prepared_input.strip_staging_root {
+            options.strip_root = true;
+            options.full_root = false;
+        } else {
+            options.strip_root = request.options.strip_root;
+            options.full_root = request.options.full_root;
+        }
+        options.license_text = request.options.license_text;
+        options.license_text_diagnostics = request.options.license_text_diagnostics;
+        options.license_diagnostics = request.options.license_diagnostics;
+        options.unknown_licenses = request.options.unknown_licenses;
+        options.license_score = request.options.license_score;
+        options.only_findings = request.options.only_findings;
+        options.mark_source = request.options.mark_source;
+        options.classify = request.options.classify;
+        options.summary = request.options.summary;
+        options.license_clarity_score = request.options.license_clarity_score;
+        options.license_references = request.options.license_references;
+        options.tallies = request.options.tallies;
+        options.tallies_key_files = request.options.tallies_key_files;
+        options.tallies_with_details = request.options.tallies_with_details;
+        options.facets = request.options.facets;
+        options.tallies_by_facet = request.options.tallies_by_facet;
+
+        Ok(Self {
+            paths: prepared_input.paths,
+            options,
+            _staging_dir: prepared_input.staging_dir,
+        })
+    }
+
+    pub(super) fn execute(self) -> std::result::Result<String, ScanError> {
+        let output = scan_paths(self.paths.iter().map(|p| p.as_path()), &self.options)?;
+        serde_json::to_string(&crate::output_schema::Output::from(&output))
+            .map_err(|e| ScanError::Serialization(format!("scan result should serialize: {e}")))
+    }
+
+    pub(super) fn run_async(
+        mut self,
+        allocated_processors: usize,
+    ) -> std::result::Result<String, ScanError> {
+        self.options.process_mode = if allocated_processors <= 1 {
+            ProcessMode::SequentialWithTimeouts
+        } else {
+            ProcessMode::Parallel(allocated_processors)
+        };
+        self.execute()
     }
 }
 

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -739,21 +739,6 @@ mod tests {
     }
 
     #[test]
-    fn sync_scan_execution_rejects_non_http_url() {
-        use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
-
-        let error = SyncScanExecution::new(ServeScanRequest {
-            input: ServeScanInput::Url {
-                url: "file:///tmp/input.txt".to_string(),
-            },
-            options: ServeScanOptions::default(),
-        })
-        .expect_err("unsupported URL scheme should fail");
-
-        assert!(error.to_string().contains("http or https"));
-    }
-
-    #[test]
     fn upload_input_rejects_invalid_base64() {
         let error = prepare_upload_input("input.txt", "%%%%")
             .expect_err("invalid base64 upload should fail");

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -749,4 +749,16 @@ mod tests {
     fn normalize_archive_path_rejects_parent_dirs() {
         assert!(normalize_archive_path(Path::new("../escape.txt")).is_none());
     }
+
+    #[test]
+    fn normalize_archive_path_strips_cur_dir_components() {
+        let result = normalize_archive_path(Path::new("./foo.txt"));
+        assert_eq!(result.as_deref(), Some(Path::new("foo.txt")));
+    }
+
+    #[test]
+    fn detect_archive_format_returns_none_for_unsupported() {
+        assert!(detect_archive_format("data.rar").is_none());
+        assert!(detect_archive_format("readme.txt").is_none());
+    }
 }

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -20,8 +20,55 @@ use url::Url;
 use zip::ZipArchive;
 
 use crate::ProcessMode;
-use crate::serve_api::{SyncLicenseSource, SyncScanInput, SyncScanRequest};
+use crate::serve_api::{SyncLicenseSource, SyncScanInput, SyncScanOptions, SyncScanRequest};
 use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
+
+impl From<SyncLicenseSource> for LicenseSource {
+    fn from(source: SyncLicenseSource) -> Self {
+        match source {
+            SyncLicenseSource::Disabled => LicenseSource::Disabled,
+            SyncLicenseSource::Embedded => LicenseSource::Embedded,
+            SyncLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
+        }
+    }
+}
+
+impl From<SyncScanOptions> for ScanOptions {
+    fn from(options: SyncScanOptions) -> Self {
+        Self {
+            collect_info: options.collect_info,
+            detect_license: LicenseSource::from(options.detect_license),
+            detect_packages: options.detect_packages,
+            detect_system_packages: options.detect_system_packages,
+            detect_packages_in_compiled: options.detect_packages_in_compiled,
+            detect_copyrights: options.detect_copyrights,
+            detect_emails: options.detect_emails,
+            detect_urls: options.detect_urls,
+            detect_generated: options.detect_generated,
+            include: options.include,
+            exclude: options.exclude,
+            strip_root: options.strip_root,
+            full_root: options.full_root,
+            license_text: options.license_text,
+            license_text_diagnostics: options.license_text_diagnostics,
+            license_diagnostics: options.license_diagnostics,
+            unknown_licenses: options.unknown_licenses,
+            license_score: options.license_score,
+            only_findings: options.only_findings,
+            mark_source: options.mark_source,
+            classify: options.classify,
+            summary: options.summary,
+            license_clarity_score: options.license_clarity_score,
+            license_references: options.license_references,
+            tallies: options.tallies,
+            tallies_key_files: options.tallies_key_files,
+            tallies_with_details: options.tallies_with_details,
+            facets: options.facets,
+            tallies_by_facet: options.tallies_by_facet,
+            ..Self::default()
+        }
+    }
+}
 
 type Result<T> = std::result::Result<T, IngestError>;
 
@@ -87,26 +134,21 @@ impl IngestError {
     }
 }
 
-#[derive(Debug)]
-pub(super) struct PreparedSyncInput {
-    pub(super) paths: Vec<PathBuf>,
-    pub(super) staging_dir: Option<TempDir>,
-    pub(super) strip_staging_root: bool,
-}
-
-pub(super) fn prepare_sync_input(input: SyncScanInput) -> Result<PreparedSyncInput> {
-    match input {
-        SyncScanInput::Paths { paths } => prepare_paths_input(paths),
-        SyncScanInput::Repository { url, reference } => prepare_repository_input(&url, &reference),
-        SyncScanInput::Url { url } => prepare_url_input(&url),
-        SyncScanInput::Upload {
-            filename,
-            content_base64,
-        } => prepare_upload_input(&filename, &content_base64),
+impl SyncScanInput {
+    fn prepare(self) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
+        match self {
+            Self::Paths { paths } => prepare_paths_input(paths),
+            Self::Repository { url, reference } => prepare_repository_input(&url, &reference),
+            Self::Url { url } => prepare_url_input(&url),
+            Self::Upload {
+                filename,
+                content_base64,
+            } => prepare_upload_input(&filename, &content_base64),
+        }
     }
 }
 
-fn prepare_paths_input(paths: Vec<String>) -> Result<PreparedSyncInput> {
+fn prepare_paths_input(paths: Vec<String>) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
     if paths.is_empty() {
         return Err(IngestError::validation(
             "input.paths must contain at least one path",
@@ -123,14 +165,10 @@ fn prepare_paths_input(paths: Vec<String>) -> Result<PreparedSyncInput> {
         }
     }
 
-    Ok(PreparedSyncInput {
-        paths,
-        staging_dir: None,
-        strip_staging_root: false,
-    })
+    Ok((paths, None))
 }
 
-fn prepare_repository_input(url: &str, reference: &str) -> Result<PreparedSyncInput> {
+fn prepare_repository_input(url: &str, reference: &str) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
     if url.trim().is_empty() {
         return Err(IngestError::validation("repository.url must not be empty"));
     }
@@ -166,14 +204,10 @@ fn prepare_repository_input(url: &str, reference: &str) -> Result<PreparedSyncIn
         "failed to checkout fetched repository ref",
     )?;
 
-    Ok(PreparedSyncInput {
-        paths: vec![repo_dir],
-        staging_dir: Some(staging_dir),
-        strip_staging_root: true,
-    })
+    Ok((vec![repo_dir], Some(staging_dir)))
 }
 
-fn prepare_url_input(url: &str) -> Result<PreparedSyncInput> {
+fn prepare_url_input(url: &str) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
     if url.trim().is_empty() {
         return Err(IngestError::validation("url.url must not be empty"));
     }
@@ -196,7 +230,10 @@ fn prepare_url_input(url: &str) -> Result<PreparedSyncInput> {
     materialize_downloaded_artifact(staging_dir, artifact_path)
 }
 
-fn prepare_upload_input(filename: &str, content_base64: &str) -> Result<PreparedSyncInput> {
+fn prepare_upload_input(
+    filename: &str,
+    content_base64: &str,
+) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
     let normalized_filename = validate_upload_filename(filename)?;
     let decoded = STANDARD
         .decode(content_base64)
@@ -234,7 +271,7 @@ fn prepare_upload_input(filename: &str, content_base64: &str) -> Result<Prepared
 fn materialize_downloaded_artifact(
     staging_dir: TempDir,
     artifact_path: PathBuf,
-) -> Result<PreparedSyncInput> {
+) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
     let artifact_name = artifact_path
         .file_name()
         .and_then(|name| name.to_str())
@@ -249,18 +286,10 @@ fn materialize_downloaded_artifact(
             )
         })?;
         extract_archive(&artifact_path, &extract_dir)?;
-        return Ok(PreparedSyncInput {
-            paths: vec![extract_dir],
-            staging_dir: Some(staging_dir),
-            strip_staging_root: true,
-        });
+        return Ok((vec![extract_dir], Some(staging_dir)));
     }
 
-    Ok(PreparedSyncInput {
-        paths: vec![artifact_path],
-        staging_dir: Some(staging_dir),
-        strip_staging_root: true,
-    })
+    Ok((vec![artifact_path], Some(staging_dir)))
 }
 
 fn download_remote_input(url: &str, output_dir: &Path) -> Result<PathBuf> {
@@ -663,52 +692,18 @@ pub(super) struct SyncScanExecution {
 
 impl SyncScanExecution {
     pub(super) fn new(request: SyncScanRequest) -> Result<Self> {
-        let prepared_input = prepare_sync_input(request.input)?;
+        let (paths, _staging_dir) = request.input.prepare()?;
 
-        let mut options = ScanOptions::default();
-        options.collect_info = request.options.collect_info;
-        options.detect_license = match request.options.detect_license {
-            SyncLicenseSource::Disabled => LicenseSource::Disabled,
-            SyncLicenseSource::Embedded => LicenseSource::Embedded,
-            SyncLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
-        };
-        options.detect_packages = request.options.detect_packages;
-        options.detect_system_packages = request.options.detect_system_packages;
-        options.detect_packages_in_compiled = request.options.detect_packages_in_compiled;
-        options.detect_copyrights = request.options.detect_copyrights;
-        options.detect_emails = request.options.detect_emails;
-        options.detect_urls = request.options.detect_urls;
-        options.detect_generated = request.options.detect_generated;
-        options.include = request.options.include;
-        options.exclude = request.options.exclude;
-        if prepared_input.strip_staging_root {
+        let mut options = ScanOptions::from(request.options);
+        if _staging_dir.is_some() {
             options.strip_root = true;
             options.full_root = false;
-        } else {
-            options.strip_root = request.options.strip_root;
-            options.full_root = request.options.full_root;
         }
-        options.license_text = request.options.license_text;
-        options.license_text_diagnostics = request.options.license_text_diagnostics;
-        options.license_diagnostics = request.options.license_diagnostics;
-        options.unknown_licenses = request.options.unknown_licenses;
-        options.license_score = request.options.license_score;
-        options.only_findings = request.options.only_findings;
-        options.mark_source = request.options.mark_source;
-        options.classify = request.options.classify;
-        options.summary = request.options.summary;
-        options.license_clarity_score = request.options.license_clarity_score;
-        options.license_references = request.options.license_references;
-        options.tallies = request.options.tallies;
-        options.tallies_key_files = request.options.tallies_key_files;
-        options.tallies_with_details = request.options.tallies_with_details;
-        options.facets = request.options.facets;
-        options.tallies_by_facet = request.options.tallies_by_facet;
 
         Ok(Self {
-            paths: prepared_input.paths,
+            paths,
             options,
-            _staging_dir: prepared_input.staging_dir,
+            _staging_dir,
         })
     }
 

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -745,6 +745,38 @@ mod tests {
     }
 
     #[test]
+    fn sync_scan_execution_rejects_empty_paths() {
+        use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
+
+        let error = SyncScanExecution::new(ServeScanRequest {
+            input: ServeScanInput::Paths { paths: Vec::new() },
+            options: ServeScanOptions::default(),
+        })
+        .expect_err("empty paths should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("input.paths must contain at least one path")
+        );
+    }
+
+    #[test]
+    fn sync_scan_execution_rejects_non_http_url() {
+        use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
+
+        let error = SyncScanExecution::new(ServeScanRequest {
+            input: ServeScanInput::Url {
+                url: "file:///tmp/input.txt".to_string(),
+            },
+            options: ServeScanOptions::default(),
+        })
+        .expect_err("unsupported URL scheme should fail");
+
+        assert!(error.to_string().contains("http or https"));
+    }
+
+    #[test]
     fn upload_input_rejects_invalid_base64() {
         let error = prepare_upload_input("input.txt", "%%%%")
             .expect_err("invalid base64 upload should fail");

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -277,7 +277,7 @@ fn materialize_downloaded_artifact(
         .and_then(|name| name.to_str())
         .unwrap_or("downloaded");
 
-    if looks_like_supported_archive(artifact_name) {
+    if let Some(format) = detect_archive_format(artifact_name) {
         let extract_dir = staging_dir.path().join("extracted");
         fs::create_dir_all(&extract_dir).map_err(|e| {
             IngestError::internal_with_source(
@@ -285,7 +285,7 @@ fn materialize_downloaded_artifact(
                 format!("failed to create {}", extract_dir.display()),
             )
         })?;
-        extract_archive(&artifact_path, &extract_dir)?;
+        extract_archive(&artifact_path, &extract_dir, format)?;
         return Ok((vec![extract_dir], Some(staging_dir)));
     }
 
@@ -391,82 +391,85 @@ fn validate_upload_filename(filename: &str) -> Result<String> {
     Ok(normalized.to_string())
 }
 
-fn looks_like_supported_archive(filename: &str) -> bool {
-    let filename = filename.to_ascii_lowercase();
-    [".zip", ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tar.xz"]
-        .iter()
-        .any(|suffix| filename.ends_with(suffix))
+enum ArchiveFormat {
+    Zip,
+    Tar,
+    TarGz,
+    TarBz2,
+    TarXz,
 }
 
-fn extract_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
-    let filename = archive_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-
+fn detect_archive_format(filename: &str) -> Option<ArchiveFormat> {
+    let filename = filename.to_ascii_lowercase();
     if filename.ends_with(".zip") {
-        return extract_zip_archive(archive_path, output_dir);
+        return Some(ArchiveFormat::Zip);
     }
     if filename.ends_with(".tar.gz") || filename.ends_with(".tgz") {
-        return extract_tar_archive(
-            archive_path,
-            output_dir,
-            GzDecoder::new(File::open(archive_path).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to open {}", archive_path.display()),
-                )
-            })?),
-        );
+        return Some(ArchiveFormat::TarGz);
     }
     if filename.ends_with(".tar.bz2") {
-        return extract_tar_archive(
-            archive_path,
-            output_dir,
-            BzDecoder::new(File::open(archive_path).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to open {}", archive_path.display()),
-                )
-            })?),
-        );
+        return Some(ArchiveFormat::TarBz2);
     }
     if filename.ends_with(".tar.xz") {
-        return extract_tar_archive(
-            archive_path,
-            output_dir,
-            XzDecoder::new(File::open(archive_path).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to open {}", archive_path.display()),
-                )
-            })?),
-        );
+        return Some(ArchiveFormat::TarXz);
     }
     if filename.ends_with(".tar") {
-        return extract_tar_archive(
-            archive_path,
-            output_dir,
-            File::open(archive_path).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to open {}", archive_path.display()),
-                )
-            })?,
-        );
+        return Some(ArchiveFormat::Tar);
     }
-
-    Err(IngestError::validation(format!(
-        "unsupported archive format for remote ingestion: {}",
-        archive_path.display()
-    )))
+    None
 }
 
-fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
+fn extract_archive(archive_path: &Path, output_dir: &Path, format: ArchiveFormat) -> Result<()> {
     let file = File::open(archive_path).map_err(|e| {
         IngestError::internal_with_source(e, format!("failed to open {}", archive_path.display()))
     })?;
+
+    match format {
+        ArchiveFormat::Zip => extract_zip_archive(archive_path, file, output_dir),
+        ArchiveFormat::TarGz => extract_tar_archive(archive_path, GzDecoder::new(file), output_dir),
+        ArchiveFormat::TarBz2 => {
+            extract_tar_archive(archive_path, BzDecoder::new(file), output_dir)
+        }
+        ArchiveFormat::TarXz => extract_tar_archive(archive_path, XzDecoder::new(file), output_dir),
+        ArchiveFormat::Tar => extract_tar_archive(archive_path, file, output_dir),
+    }
+}
+
+fn extract_entry(
+    output_dir: &Path,
+    relative_path: &Path,
+    entry_size: u64,
+    extracted_files: &mut usize,
+    extracted_bytes: &mut u64,
+    entry_reader: &mut dyn std::io::Read,
+    archive_context: &str,
+) -> Result<()> {
+    enforce_archive_limits(extracted_files, extracted_bytes, entry_size)?;
+
+    let destination = output_dir.join(relative_path);
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            IngestError::internal_with_source(e, format!("failed to create {}", parent.display()))
+        })?;
+    }
+    let mut output = File::create(&destination).map_err(|e| {
+        IngestError::internal_with_source(e, format!("failed to create {}", destination.display()))
+    })?;
+    std::io::copy(entry_reader, &mut output).map_err(|e| {
+        IngestError::internal_with_source(
+            e,
+            format!(
+                "failed to extract {}{}",
+                archive_context,
+                relative_path.display()
+            ),
+        )
+    })?;
+
+    Ok(())
+}
+
+fn extract_zip_archive(archive_path: &Path, file: File, output_dir: &Path) -> Result<()> {
     let mut archive = ZipArchive::new(file).map_err(|e| {
         IngestError::internal_with_source(
             e,
@@ -476,6 +479,7 @@ fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
 
     let mut extracted_files = 0usize;
     let mut extracted_bytes = 0u64;
+    let archive_context = format!("{}/", archive_path.display());
 
     for index in 0..archive.len() {
         let mut entry = archive.by_index(index).map_err(|e| {
@@ -497,28 +501,15 @@ fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
             continue;
         }
 
-        enforce_archive_limits(&mut extracted_files, &mut extracted_bytes, entry.size())?;
-        let destination = output_dir.join(relative_path);
-        if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to create {}", parent.display()),
-                )
-            })?;
-        }
-        let mut output = File::create(&destination).map_err(|e| {
-            IngestError::internal_with_source(
-                e,
-                format!("failed to create {}", destination.display()),
-            )
-        })?;
-        std::io::copy(&mut entry, &mut output).map_err(|e| {
-            IngestError::internal_with_source(
-                e,
-                format!("failed to extract {}", destination.display()),
-            )
-        })?;
+        extract_entry(
+            output_dir,
+            &relative_path,
+            entry.size(),
+            &mut extracted_files,
+            &mut extracted_bytes,
+            &mut entry,
+            &archive_context,
+        )?;
     }
 
     if extracted_files == 0 {
@@ -530,10 +521,11 @@ fn extract_zip_archive(archive_path: &Path, output_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn extract_tar_archive<R: Read>(archive_path: &Path, output_dir: &Path, reader: R) -> Result<()> {
+fn extract_tar_archive<R: Read>(archive_path: &Path, reader: R, output_dir: &Path) -> Result<()> {
     let mut archive = Archive::new(reader);
     let mut extracted_files = 0usize;
     let mut extracted_bytes = 0u64;
+    let archive_context = format!("{}/", archive_path.display());
 
     for entry in archive.entries().map_err(|e| {
         IngestError::internal_with_source(
@@ -574,37 +566,22 @@ fn extract_tar_archive<R: Read>(archive_path: &Path, output_dir: &Path, reader: 
             continue;
         }
 
-        enforce_archive_limits(
+        let entry_size = entry.header().size().map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!("failed to read tar size in {}", archive_path.display()),
+            )
+        })?;
+
+        extract_entry(
+            output_dir,
+            &relative_path,
+            entry_size,
             &mut extracted_files,
             &mut extracted_bytes,
-            entry.header().size().map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to read tar size in {}", archive_path.display()),
-                )
-            })?,
+            &mut entry,
+            &archive_context,
         )?;
-        let destination = output_dir.join(relative_path);
-        if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent).map_err(|e| {
-                IngestError::internal_with_source(
-                    e,
-                    format!("failed to create {}", parent.display()),
-                )
-            })?;
-        }
-        let mut output = File::create(&destination).map_err(|e| {
-            IngestError::internal_with_source(
-                e,
-                format!("failed to create {}", destination.display()),
-            )
-        })?;
-        std::io::copy(&mut entry, &mut output).map_err(|e| {
-            IngestError::internal_with_source(
-                e,
-                format!("failed to extract {}", destination.display()),
-            )
-        })?;
     }
 
     if extracted_files == 0 {

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -20,21 +20,21 @@ use url::Url;
 use zip::ZipArchive;
 
 use crate::ProcessMode;
-use crate::serve_api::{SyncLicenseSource, SyncScanInput, SyncScanOptions, SyncScanRequest};
+use crate::serve_api::{ServeLicenseSource, ServeScanInput, ServeScanOptions, ServeScanRequest};
 use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
 
-impl From<SyncLicenseSource> for LicenseSource {
-    fn from(source: SyncLicenseSource) -> Self {
+impl From<ServeLicenseSource> for LicenseSource {
+    fn from(source: ServeLicenseSource) -> Self {
         match source {
-            SyncLicenseSource::Disabled => LicenseSource::Disabled,
-            SyncLicenseSource::Embedded => LicenseSource::Embedded,
-            SyncLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
+            ServeLicenseSource::Disabled => LicenseSource::Disabled,
+            ServeLicenseSource::Embedded => LicenseSource::Embedded,
+            ServeLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
         }
     }
 }
 
-impl From<SyncScanOptions> for ScanOptions {
-    fn from(options: SyncScanOptions) -> Self {
+impl From<ServeScanOptions> for ScanOptions {
+    fn from(options: ServeScanOptions) -> Self {
         Self {
             collect_info: options.collect_info,
             detect_license: LicenseSource::from(options.detect_license),
@@ -134,7 +134,7 @@ impl IngestError {
     }
 }
 
-impl SyncScanInput {
+impl ServeScanInput {
     fn prepare(self) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
         match self {
             Self::Paths { paths } => prepare_paths_input(paths),
@@ -691,7 +691,7 @@ pub(super) struct SyncScanExecution {
 }
 
 impl SyncScanExecution {
-    pub(super) fn new(request: SyncScanRequest) -> Result<Self> {
+    pub(super) fn new(request: ServeScanRequest) -> Result<Self> {
         let (paths, _staging_dir) = request.input.prepare()?;
 
         let mut options = ScanOptions::from(request.options);

--- a/src/serve/job_controller.rs
+++ b/src/serve/job_controller.rs
@@ -8,7 +8,7 @@ use std::thread;
 use uuid::Uuid;
 
 use crate::serve_api::{
-    AsyncJobState, AsyncJobStatusResponse, AsyncScanAcceptedResponse, SyncScanRequest,
+    AsyncJobState, AsyncJobStatusResponse, AsyncScanAcceptedResponse, ServeScanRequest,
 };
 
 const DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB: usize = 4;
@@ -38,7 +38,7 @@ struct AsyncJobControllerState {
 #[derive(Debug)]
 struct PendingAsyncJob {
     job_id: String,
-    request: SyncScanRequest,
+    request: ServeScanRequest,
 }
 
 #[derive(Debug)]
@@ -53,7 +53,7 @@ pub(super) struct AsyncJobRecord {
 #[derive(Debug)]
 pub(super) struct DispatchedAsyncJob {
     pub(super) job_id: String,
-    pub(super) request: SyncScanRequest,
+    pub(super) request: ServeScanRequest,
     pub(super) allocated_processors: usize,
 }
 
@@ -108,7 +108,7 @@ impl AsyncJobController {
 
     pub(super) fn submit(
         &self,
-        request: SyncScanRequest,
+        request: ServeScanRequest,
     ) -> std::result::Result<(AsyncScanAcceptedResponse, Vec<DispatchedAsyncJob>), AsyncSubmitError>
     {
         let mut inner = self
@@ -330,14 +330,14 @@ impl AsyncJobSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::serve_api::{SyncScanInput, SyncScanOptions};
+    use crate::serve_api::{ServeScanInput, ServeScanOptions};
 
-    fn dummy_async_request() -> SyncScanRequest {
-        SyncScanRequest {
-            input: SyncScanInput::Paths {
+    fn dummy_async_request() -> ServeScanRequest {
+        ServeScanRequest {
+            input: ServeScanInput::Paths {
                 paths: vec!["/tmp".to_string()],
             },
-            options: SyncScanOptions::default(),
+            options: ServeScanOptions::default(),
         }
     }
 

--- a/src/serve/job_controller.rs
+++ b/src/serve/job_controller.rs
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use uuid::Uuid;
+
+use crate::serve_api::{
+    AsyncJobState, AsyncJobStatusResponse, AsyncScanAcceptedResponse, SyncScanRequest,
+};
+
+const DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB: usize = 4;
+const DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS: usize = 64;
+
+pub(super) enum JobOutcome {
+    Succeeded { result_body: String },
+    Failed { message: String, status_code: u16 },
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AsyncJobController {
+    inner: Arc<Mutex<AsyncJobControllerState>>,
+    processor_budget: usize,
+    max_processors_per_job: usize,
+    max_retained_terminal_jobs: usize,
+}
+
+#[derive(Debug)]
+struct AsyncJobControllerState {
+    active_processors: usize,
+    jobs: HashMap<String, AsyncJobRecord>,
+    pending: VecDeque<PendingAsyncJob>,
+    completed: VecDeque<String>,
+}
+
+#[derive(Debug)]
+struct PendingAsyncJob {
+    job_id: String,
+    request: SyncScanRequest,
+}
+
+#[derive(Debug)]
+pub(super) struct AsyncJobRecord {
+    pub(super) state: AsyncJobState,
+    pub(super) allocated_processors: Option<usize>,
+    pub(super) result_body: Option<String>,
+    pub(super) error_message: Option<String>,
+    pub(super) error_status_code: Option<u16>,
+}
+
+#[derive(Debug)]
+pub(super) struct DispatchedAsyncJob {
+    pub(super) job_id: String,
+    pub(super) request: SyncScanRequest,
+    pub(super) allocated_processors: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AsyncJobSnapshot {
+    job_id: String,
+    state: AsyncJobState,
+    allocated_processors: Option<usize>,
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AsyncJobResultSnapshot {
+    pub(super) state: AsyncJobState,
+    pub(super) result_body: Option<String>,
+    pub(super) error_message: Option<String>,
+    pub(super) error_status_code: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum AsyncSubmitError {
+    QueueFull,
+}
+
+impl AsyncJobController {
+    pub(super) fn new() -> Self {
+        let processor_budget = default_async_processor_budget();
+        Self::with_limits(
+            processor_budget,
+            processor_budget.clamp(1, DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB),
+            DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS,
+        )
+    }
+
+    pub(super) fn with_limits(
+        processor_budget: usize,
+        max_processors_per_job: usize,
+        max_retained_terminal_jobs: usize,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(AsyncJobControllerState {
+                active_processors: 0,
+                jobs: HashMap::new(),
+                pending: VecDeque::new(),
+                completed: VecDeque::new(),
+            })),
+            processor_budget: processor_budget.max(1),
+            max_processors_per_job: max_processors_per_job.max(1),
+            max_retained_terminal_jobs: max_retained_terminal_jobs.max(1),
+        }
+    }
+
+    pub(super) fn submit(
+        &self,
+        request: SyncScanRequest,
+    ) -> std::result::Result<(AsyncScanAcceptedResponse, Vec<DispatchedAsyncJob>), AsyncSubmitError>
+    {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("serve async job lock should not be poisoned");
+        if inner.non_terminal_jobs() >= self.max_non_terminal_jobs() {
+            return Err(AsyncSubmitError::QueueFull);
+        }
+
+        let job_id = format!("job-{}", Uuid::new_v4().simple());
+        inner.jobs.insert(job_id.clone(), AsyncJobRecord::pending());
+        inner.pending.push_back(PendingAsyncJob {
+            job_id: job_id.clone(),
+            request,
+        });
+        let dispatches = self.schedule_locked(&mut inner);
+        let snapshot = inner
+            .status_snapshot(&job_id)
+            .expect("submitted async job should be present");
+        let response = AsyncScanAcceptedResponse {
+            status: "accepted".to_string(),
+            job_id: job_id.clone(),
+            state: snapshot.state,
+            status_url: format!("/v1/jobs/{job_id}"),
+            result_url: format!("/v1/jobs/{job_id}/result"),
+        };
+        Ok((response, dispatches))
+    }
+
+    pub(super) fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
+        self.inner
+            .lock()
+            .expect("serve async job lock should not be poisoned")
+            .status_snapshot(job_id)
+    }
+
+    pub(super) fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
+        self.inner
+            .lock()
+            .expect("serve async job lock should not be poisoned")
+            .result_snapshot(job_id)
+    }
+
+    pub(super) fn complete_job(
+        &self,
+        job_id: String,
+        allocated_processors: usize,
+        outcome: JobOutcome,
+    ) -> Vec<DispatchedAsyncJob> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("serve async job lock should not be poisoned");
+        inner.active_processors = inner.active_processors.saturating_sub(allocated_processors);
+
+        let record = inner
+            .jobs
+            .get_mut(&job_id)
+            .expect("running async job should have metadata");
+        match outcome {
+            JobOutcome::Succeeded { result_body } => {
+                record.state = AsyncJobState::Succeeded;
+                record.result_body = Some(result_body);
+                record.error_message = None;
+            }
+            JobOutcome::Failed {
+                message,
+                status_code,
+            } => {
+                record.state = AsyncJobState::Failed;
+                record.result_body = None;
+                record.error_message = Some(message);
+                record.error_status_code = Some(status_code);
+            }
+        }
+
+        inner.completed.push_back(job_id);
+        inner.evict_completed_jobs(self.max_retained_terminal_jobs);
+
+        self.schedule_locked(&mut inner)
+    }
+
+    #[cfg(test)]
+    pub(super) fn insert_job(&self, job_id: String, record: AsyncJobRecord) {
+        self.inner
+            .lock()
+            .expect("serve async job lock should not be poisoned")
+            .jobs
+            .insert(job_id, record);
+    }
+
+    fn max_non_terminal_jobs(&self) -> usize {
+        self.processor_budget.saturating_mul(4).max(4)
+    }
+
+    fn schedule_locked(&self, inner: &mut AsyncJobControllerState) -> Vec<DispatchedAsyncJob> {
+        let mut dispatches = Vec::new();
+
+        while !inner.pending.is_empty() {
+            let available_processors = self
+                .processor_budget
+                .saturating_sub(inner.active_processors);
+            if available_processors == 0 {
+                break;
+            }
+
+            let allocated_processors = available_processors.min(self.max_processors_per_job).max(1);
+            let PendingAsyncJob { job_id, request } = inner
+                .pending
+                .pop_front()
+                .expect("pending async job should still exist");
+            let record = inner
+                .jobs
+                .get_mut(&job_id)
+                .expect("queued async job should have metadata");
+            record.state = AsyncJobState::Running;
+            record.allocated_processors = Some(allocated_processors);
+            record.error_message = None;
+            inner.active_processors += allocated_processors;
+            dispatches.push(DispatchedAsyncJob {
+                job_id,
+                request,
+                allocated_processors,
+            });
+        }
+
+        dispatches
+    }
+}
+
+impl AsyncJobControllerState {
+    fn non_terminal_jobs(&self) -> usize {
+        self.jobs
+            .values()
+            .filter(|job| matches!(job.state, AsyncJobState::Pending | AsyncJobState::Running))
+            .count()
+    }
+
+    fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
+        self.jobs.get(job_id).map(|job| AsyncJobSnapshot {
+            job_id: job_id.to_string(),
+            state: job.state,
+            allocated_processors: job.allocated_processors,
+            error_message: job.error_message.clone(),
+        })
+    }
+
+    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
+        self.jobs.get(job_id).map(|job| AsyncJobResultSnapshot {
+            state: job.state,
+            result_body: job.result_body.clone(),
+            error_message: job.error_message.clone(),
+            error_status_code: job.error_status_code,
+        })
+    }
+
+    fn evict_completed_jobs(&mut self, max_retained_terminal_jobs: usize) {
+        while self.completed.len() > max_retained_terminal_jobs {
+            let Some(job_id) = self.completed.pop_front() else {
+                break;
+            };
+            self.jobs.remove(&job_id);
+        }
+    }
+}
+
+impl AsyncJobRecord {
+    pub(super) fn pending() -> Self {
+        Self {
+            state: AsyncJobState::Pending,
+            allocated_processors: None,
+            result_body: None,
+            error_message: None,
+            error_status_code: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn succeeded(result_body: String, allocated_processors: usize) -> Self {
+        Self {
+            state: AsyncJobState::Succeeded,
+            allocated_processors: Some(allocated_processors),
+            result_body: Some(result_body),
+            error_message: None,
+            error_status_code: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn failed(message: String, status_code: u16, allocated_processors: usize) -> Self {
+        Self {
+            state: AsyncJobState::Failed,
+            allocated_processors: Some(allocated_processors),
+            result_body: None,
+            error_message: Some(message),
+            error_status_code: Some(status_code),
+        }
+    }
+}
+
+impl AsyncJobSnapshot {
+    pub(super) fn into_status_response(self) -> AsyncJobStatusResponse {
+        AsyncJobStatusResponse {
+            job_id: self.job_id,
+            state: self.state,
+            result_ready: matches!(self.state, AsyncJobState::Succeeded),
+            allocated_processors: self.allocated_processors,
+            message: self.error_message,
+        }
+    }
+}
+
+fn default_async_processor_budget() -> usize {
+    let cpus = thread::available_parallelism().map_or(1, |count| count.get());
+    if cpus > 1 { cpus - 1 } else { 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve_api::{SyncScanInput, SyncScanOptions};
+
+    fn dummy_async_request() -> SyncScanRequest {
+        SyncScanRequest {
+            input: SyncScanInput::Paths {
+                paths: vec!["/tmp".to_string()],
+            },
+            options: SyncScanOptions::default(),
+        }
+    }
+
+    #[test]
+    fn async_job_controller_rejects_submit_when_queue_is_full() {
+        let controller = AsyncJobController::with_limits(1, 1, 8);
+        {
+            let mut inner = controller
+                .inner
+                .lock()
+                .expect("test async job lock should not be poisoned");
+            for index in 0..controller.max_non_terminal_jobs() {
+                inner
+                    .jobs
+                    .insert(format!("job-{index}"), AsyncJobRecord::pending());
+            }
+        }
+
+        let result = controller.submit(dummy_async_request());
+        assert!(matches!(result, Err(AsyncSubmitError::QueueFull)));
+    }
+
+    #[test]
+    fn scheduler_leaves_extra_jobs_pending_when_budget_is_exhausted() {
+        let controller = AsyncJobController::with_limits(4, 2, 8);
+        let mut inner = AsyncJobControllerState {
+            active_processors: 0,
+            jobs: HashMap::new(),
+            pending: VecDeque::new(),
+            completed: VecDeque::new(),
+        };
+
+        for job_id in ["job-a", "job-b", "job-c"] {
+            inner
+                .jobs
+                .insert(job_id.to_string(), AsyncJobRecord::pending());
+            inner.pending.push_back(PendingAsyncJob {
+                job_id: job_id.to_string(),
+                request: dummy_async_request(),
+            });
+        }
+
+        let dispatches = controller.schedule_locked(&mut inner);
+        assert_eq!(dispatches.len(), 2);
+        assert_eq!(inner.active_processors, 4);
+        assert_eq!(inner.pending.len(), 1);
+        assert_eq!(inner.jobs["job-a"].state, AsyncJobState::Running);
+        assert_eq!(inner.jobs["job-b"].state, AsyncJobState::Running);
+        assert_eq!(inner.jobs["job-c"].state, AsyncJobState::Pending);
+    }
+
+    #[test]
+    fn completed_jobs_are_evicted_when_retention_limit_is_exceeded() {
+        let mut inner = AsyncJobControllerState {
+            active_processors: 0,
+            jobs: HashMap::from([
+                (
+                    "job-old".to_string(),
+                    AsyncJobRecord::succeeded("old".to_string(), 1),
+                ),
+                (
+                    "job-new".to_string(),
+                    AsyncJobRecord::succeeded("new".to_string(), 1),
+                ),
+            ]),
+            pending: VecDeque::new(),
+            completed: VecDeque::from(["job-old".to_string(), "job-new".to_string()]),
+        };
+
+        inner.evict_completed_jobs(1);
+
+        assert!(!inner.jobs.contains_key("job-old"));
+        assert!(inner.jobs.contains_key("job-new"));
+        assert_eq!(inner.completed.len(), 1);
+    }
+}

--- a/src/serve/job_controller.rs
+++ b/src/serve/job_controller.rs
@@ -65,12 +65,11 @@ pub(super) struct AsyncJobSnapshot {
     error_message: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-pub(super) struct AsyncJobResultSnapshot {
-    pub(super) state: AsyncJobState,
-    pub(super) result_body: Option<String>,
-    pub(super) error_message: Option<String>,
-    pub(super) error_status_code: Option<u16>,
+pub(super) enum JobResult {
+    Succeeded { result_body: String },
+    Pending,
+    Running,
+    Failed { message: String, status_code: u16 },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -146,11 +145,11 @@ impl AsyncJobController {
             .status_snapshot(job_id)
     }
 
-    pub(super) fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
+    pub(super) fn get_job_result(&self, job_id: &str) -> Option<JobResult> {
         self.inner
             .lock()
             .expect("serve async job lock should not be poisoned")
-            .result_snapshot(job_id)
+            .get_job_result(job_id)
     }
 
     pub(super) fn complete_job(
@@ -262,12 +261,20 @@ impl AsyncJobControllerState {
         })
     }
 
-    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
-        self.jobs.get(job_id).map(|job| AsyncJobResultSnapshot {
-            state: job.state,
-            result_body: job.result_body.clone(),
-            error_message: job.error_message.clone(),
-            error_status_code: job.error_status_code,
+    fn get_job_result(&self, job_id: &str) -> Option<JobResult> {
+        self.jobs.get(job_id).map(|job| match job.state {
+            AsyncJobState::Succeeded => JobResult::Succeeded {
+                result_body: job
+                    .result_body
+                    .clone()
+                    .expect("succeeded job should have result_body"),
+            },
+            AsyncJobState::Pending => JobResult::Pending,
+            AsyncJobState::Running => JobResult::Running,
+            AsyncJobState::Failed => JobResult::Failed {
+                message: job.error_message.clone().unwrap_or_default(),
+                status_code: job.error_status_code.unwrap_or(500),
+            },
         })
     }
 

--- a/src/serve/job_controller.rs
+++ b/src/serve/job_controller.rs
@@ -80,7 +80,7 @@ pub(super) enum AsyncSubmitError {
 
 impl AsyncJobController {
     pub(super) fn new() -> Self {
-        let processor_budget = default_async_processor_budget();
+        let processor_budget = Self::default_processor_budget();
         Self::with_limits(
             processor_budget,
             processor_budget.clamp(1, DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB),
@@ -238,6 +238,11 @@ impl AsyncJobController {
 
         dispatches
     }
+
+    fn default_processor_budget() -> usize {
+        let cpus = thread::available_parallelism().map_or(1, |count| count.get());
+        if cpus > 1 { cpus - 1 } else { 1 }
+    }
 }
 
 impl AsyncJobControllerState {
@@ -320,11 +325,6 @@ impl AsyncJobSnapshot {
             message: self.error_message,
         }
     }
-}
-
-fn default_async_processor_budget() -> usize {
-    let cpus = thread::available_parallelism().map_or(1, |count| count.get());
-    if cpus > 1 { cpus - 1 } else { 1 }
 }
 
 #[cfg(test)]

--- a/src/serve/job_controller.rs
+++ b/src/serve/job_controller.rs
@@ -193,11 +193,18 @@ impl AsyncJobController {
 
     #[cfg(test)]
     pub(super) fn insert_job(&self, job_id: String, record: AsyncJobRecord) {
-        self.inner
+        let mut inner = self
+            .inner
             .lock()
-            .expect("serve async job lock should not be poisoned")
-            .jobs
-            .insert(job_id, record);
+            .expect("serve async job lock should not be poisoned");
+        let is_terminal = matches!(
+            record.state,
+            AsyncJobState::Succeeded | AsyncJobState::Failed
+        );
+        if is_terminal {
+            inner.completed.push_back(job_id.clone());
+        }
+        inner.jobs.insert(job_id, record);
     }
 
     fn max_non_terminal_jobs(&self) -> usize {

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -196,6 +196,7 @@ fn handle_request(mut request: tiny_http::Request, state: &ServeState) -> Result
 fn parse_request(request: &mut tiny_http::Request) -> Result<ParsedRequest, ServeError> {
     let content_length = request.body_length().unwrap_or(0);
 
+    // Early-out: reject oversized Content-Length before reading the body.
     if content_length > MAX_REQUEST_BODY_BYTES {
         return Err(ServeError::Ingest(IngestError::PayloadTooLarge(format!(
             "request body exceeds max size of {} bytes",
@@ -215,6 +216,8 @@ fn parse_request(request: &mut tiny_http::Request) -> Result<ParsedRequest, Serv
             })
         })?;
 
+    // Second check: catches chunked transfer encoding where body_length()
+    // returns 0 and the actual size only becomes known after reading.
     if body.len() > MAX_REQUEST_BODY_BYTES {
         return Err(ServeError::Ingest(IngestError::PayloadTooLarge(format!(
             "request body exceeds max size of {} bytes",

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -19,7 +19,7 @@ use crate::serve::ingest::{IngestError, ScanError, SyncScanExecution};
 use crate::serve::job_controller::{
     AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome,
 };
-use crate::serve_api::{API_VERSION, AsyncJobState, SyncScanRequest};
+use crate::serve_api::{API_VERSION, AsyncJobState, ServeScanRequest};
 use crate::version::BUILD_VERSION;
 use crate::workflow::WorkflowError;
 
@@ -474,7 +474,7 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
 fn decode_scan_request_from_http(
     request: &ParsedRequest,
     route_label: &str,
-) -> std::result::Result<SyncScanRequest, HttpResponse> {
+) -> std::result::Result<ServeScanRequest, HttpResponse> {
     let has_json_content_type = request
         .headers
         .iter()
@@ -488,7 +488,7 @@ fn decode_scan_request_from_http(
         ));
     }
 
-    SyncScanRequest::decode(&request.body).map_err(|error| {
+    ServeScanRequest::decode(&request.body).map_err(|error| {
         HttpResponse::error(StatusCode::from(400), "invalid_request", error.to_string())
     })
 }
@@ -549,7 +549,7 @@ fn is_valid_job_id(job_id: &str) -> bool {
 mod tests {
     use super::*;
     use crate::serve::job_controller::AsyncJobController;
-    use crate::serve_api::{SyncScanInput, SyncScanOptions};
+    use crate::serve_api::{ServeScanInput, ServeScanOptions};
 
     fn test_request(method: Method, path: &str) -> ParsedRequest {
         ParsedRequest {
@@ -668,9 +668,9 @@ mod tests {
 
     #[test]
     fn decode_sync_scan_request_rejects_empty_paths() {
-        let error = SyncScanExecution::new(SyncScanRequest {
-            input: SyncScanInput::Paths { paths: Vec::new() },
-            options: SyncScanOptions::default(),
+        let error = SyncScanExecution::new(ServeScanRequest {
+            input: ServeScanInput::Paths { paths: Vec::new() },
+            options: ServeScanOptions::default(),
         })
         .expect_err("empty paths should fail");
 
@@ -683,11 +683,11 @@ mod tests {
 
     #[test]
     fn url_input_requires_http_or_https() {
-        let error = SyncScanExecution::new(SyncScanRequest {
-            input: SyncScanInput::Url {
+        let error = SyncScanExecution::new(ServeScanRequest {
+            input: ServeScanInput::Url {
                 url: "file:///tmp/input.txt".to_string(),
             },
-            options: SyncScanOptions::default(),
+            options: ServeScanOptions::default(),
         })
         .expect_err("unsupported URL scheme should fail");
 
@@ -697,7 +697,7 @@ mod tests {
     #[test]
     fn decode_sync_scan_request_requires_valid_json() {
         let error =
-            SyncScanRequest::decode(br#"{"input": }"#).expect_err("malformed JSON should fail");
+            ServeScanRequest::decode(br#"{"input": }"#).expect_err("malformed JSON should fail");
 
         assert!(
             error

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -2,38 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod ingest;
+mod job_controller;
 
-use std::collections::{HashMap, VecDeque};
-use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
-use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use http::{HeaderMap, HeaderValue, Method, StatusCode};
+use serde::Serialize;
 use serde_json::json;
 use tempfile::TempDir;
-use uuid::Uuid;
+use tiny_http::{Header, Response, Server, StatusCode};
 
 use crate::ProcessMode;
 use crate::cli::ServeArgs;
 use crate::license_detection::LicenseDetectionEngine;
-use crate::serve_api::{
-    API_VERSION, AsyncJobState, AsyncJobStatusResponse, AsyncScanAcceptedResponse,
-    ServeErrorResponse, ServeLivenessResponse, ServeReadinessResponse, ServeVersionResponse,
-    SyncLicenseSource, SyncScanRequest,
+use crate::serve::ingest::{IngestError, prepare_sync_input};
+use crate::serve::job_controller::{
+    AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome,
 };
+use crate::serve_api::{API_VERSION, AsyncJobState, SyncLicenseSource, SyncScanRequest};
 use crate::version::BUILD_VERSION;
 use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
-use ingest::{IngestError, prepare_sync_input};
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_BODY_BYTES: usize = 24 * 1024 * 1024;
-const DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB: usize = 4;
-const DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS: usize = 64;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ServeError {
@@ -48,13 +41,13 @@ pub(crate) enum ServeError {
 impl ServeError {
     pub(crate) fn http_status_code(&self) -> StatusCode {
         match self {
-            Self::Ingest(IngestError::Validation(_)) => StatusCode::UNPROCESSABLE_ENTITY,
-            Self::Ingest(IngestError::PayloadTooLarge(_)) => StatusCode::PAYLOAD_TOO_LARGE,
-            Self::Ingest(IngestError::Upstream { .. }) => StatusCode::BAD_GATEWAY,
-            Self::Ingest(IngestError::Internal { .. }) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::Workflow(WorkflowError::InvalidOptions(_)) => StatusCode::UNPROCESSABLE_ENTITY,
-            Self::Workflow(WorkflowError::Pipeline(_)) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::Serialization(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Ingest(IngestError::Validation(_)) => StatusCode::from(422),
+            Self::Ingest(IngestError::PayloadTooLarge(_)) => StatusCode::from(413),
+            Self::Ingest(IngestError::Upstream { .. }) => StatusCode::from(502),
+            Self::Ingest(IngestError::Internal { .. }) => StatusCode::from(500),
+            Self::Workflow(WorkflowError::InvalidOptions(_)) => StatusCode::from(422),
+            Self::Workflow(WorkflowError::Pipeline(_)) => StatusCode::from(500),
+            Self::Serialization(_) => StatusCode::from(500),
         }
     }
 
@@ -103,307 +96,66 @@ struct ServeState {
     jobs: AsyncJobController,
 }
 
-#[derive(Debug, Clone)]
-struct AsyncJobController {
-    inner: Arc<Mutex<AsyncJobControllerState>>,
-    processor_budget: usize,
-    max_processors_per_job: usize,
-    max_retained_terminal_jobs: usize,
-}
-
 #[derive(Debug)]
-struct AsyncJobControllerState {
-    active_processors: usize,
-    jobs: HashMap<String, AsyncJobRecord>,
-    pending: VecDeque<PendingAsyncJob>,
-    completed: VecDeque<String>,
+struct SyncScanExecution {
+    paths: Vec<PathBuf>,
+    options: ScanOptions,
+    _staging_dir: Option<TempDir>,
 }
 
-#[derive(Debug)]
-struct PendingAsyncJob {
-    job_id: String,
-    request: SyncScanRequest,
-}
-
-#[derive(Debug)]
-struct AsyncJobRecord {
-    state: AsyncJobState,
-    allocated_processors: Option<usize>,
-    result_body: Option<String>,
-    error_message: Option<String>,
-    error_status_code: Option<u16>,
-}
-
-#[derive(Debug)]
-struct DispatchedAsyncJob {
-    job_id: String,
-    request: SyncScanRequest,
-    allocated_processors: usize,
-}
-
-#[derive(Debug, Clone)]
-struct AsyncJobSnapshot {
-    job_id: String,
-    state: AsyncJobState,
-    allocated_processors: Option<usize>,
-    error_message: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct AsyncJobResultSnapshot {
-    state: AsyncJobState,
-    result_body: Option<String>,
-    error_message: Option<String>,
-    error_status_code: Option<u16>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum AsyncSubmitError {
-    QueueFull,
-}
-
-#[derive(Debug)]
-struct HttpRequest {
-    method: Method,
+struct ParsedRequest {
+    method: tiny_http::Method,
     path: String,
-    headers: HeaderMap,
+    headers: Vec<Header>,
     body: Vec<u8>,
 }
 
-impl AsyncJobController {
-    fn new() -> Self {
-        let processor_budget = default_async_processor_budget();
-        Self::with_limits(
-            processor_budget,
-            processor_budget.clamp(1, DEFAULT_ASYNC_MAX_PROCESSORS_PER_JOB),
-            DEFAULT_ASYNC_RETAINED_TERMINAL_JOBS,
-        )
-    }
+struct HttpResponse {
+    status: StatusCode,
+    body: String,
+}
 
-    fn with_limits(
-        processor_budget: usize,
-        max_processors_per_job: usize,
-        max_retained_terminal_jobs: usize,
-    ) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(AsyncJobControllerState {
-                active_processors: 0,
-                jobs: HashMap::new(),
-                pending: VecDeque::new(),
-                completed: VecDeque::new(),
-            })),
-            processor_budget: processor_budget.max(1),
-            max_processors_per_job: max_processors_per_job.max(1),
-            max_retained_terminal_jobs: max_retained_terminal_jobs.max(1),
-        }
-    }
-
-    fn submit(
-        &self,
-        request: SyncScanRequest,
-    ) -> std::result::Result<AsyncScanAcceptedResponse, AsyncSubmitError> {
-        let (response, dispatches) = {
-            let mut inner = self
-                .inner
-                .lock()
-                .expect("serve async job lock should not be poisoned");
-            if inner.non_terminal_jobs() >= self.max_non_terminal_jobs() {
-                return Err(AsyncSubmitError::QueueFull);
-            }
-
-            let job_id = format!("job-{}", Uuid::new_v4().simple());
-            inner.jobs.insert(job_id.clone(), AsyncJobRecord::pending());
-            inner.pending.push_back(PendingAsyncJob {
-                job_id: job_id.clone(),
-                request,
-            });
-            let dispatches = self.schedule_locked(&mut inner);
-            let snapshot = inner
-                .status_snapshot(&job_id)
-                .expect("submitted async job should be present");
-            (
-                AsyncScanAcceptedResponse {
-                    status: "accepted".to_string(),
-                    job_id: job_id.clone(),
-                    state: snapshot.state,
-                    status_url: format!("/v1/jobs/{job_id}"),
-                    result_url: format!("/v1/jobs/{job_id}/result"),
-                },
-                dispatches,
-            )
-        };
-
-        self.spawn_dispatches(dispatches);
-        Ok(response)
-    }
-
-    fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
-        self.inner
-            .lock()
-            .expect("serve async job lock should not be poisoned")
-            .status_snapshot(job_id)
-    }
-
-    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
-        self.inner
-            .lock()
-            .expect("serve async job lock should not be poisoned")
-            .result_snapshot(job_id)
-    }
-
-    fn max_non_terminal_jobs(&self) -> usize {
-        self.processor_budget.saturating_mul(4).max(4)
-    }
-
-    fn schedule_locked(&self, inner: &mut AsyncJobControllerState) -> Vec<DispatchedAsyncJob> {
-        let mut dispatches = Vec::new();
-
-        while !inner.pending.is_empty() {
-            let available_processors = self
-                .processor_budget
-                .saturating_sub(inner.active_processors);
-            if available_processors == 0 {
-                break;
-            }
-
-            let allocated_processors = available_processors.min(self.max_processors_per_job).max(1);
-            let PendingAsyncJob { job_id, request } = inner
-                .pending
-                .pop_front()
-                .expect("pending async job should still exist");
-            let record = inner
-                .jobs
-                .get_mut(&job_id)
-                .expect("queued async job should have metadata");
-            record.state = AsyncJobState::Running;
-            record.allocated_processors = Some(allocated_processors);
-            record.error_message = None;
-            inner.active_processors += allocated_processors;
-            dispatches.push(DispatchedAsyncJob {
-                job_id,
-                request,
-                allocated_processors,
-            });
-        }
-
-        dispatches
-    }
-
-    fn spawn_dispatches(&self, dispatches: Vec<DispatchedAsyncJob>) {
-        for dispatched in dispatches {
-            let controller = self.clone();
-            thread::spawn(move || controller.run_job(dispatched));
-        }
-    }
-
-    fn run_job(&self, dispatched: DispatchedAsyncJob) {
-        let result = run_async_scan_request(dispatched.request, dispatched.allocated_processors);
-        let follow_up_dispatches = {
-            let mut inner = self
-                .inner
-                .lock()
-                .expect("serve async job lock should not be poisoned");
-            inner.active_processors = inner
-                .active_processors
-                .saturating_sub(dispatched.allocated_processors);
-
-            let record = inner
-                .jobs
-                .get_mut(&dispatched.job_id)
-                .expect("running async job should have metadata");
-            match result {
-                Ok(result_body) => {
-                    record.state = AsyncJobState::Succeeded;
-                    record.result_body = Some(result_body);
-                    record.error_message = None;
-                }
-                Err(error) => {
-                    eprintln!("serve async job {} failed: {error}", dispatched.job_id);
-                    record.state = AsyncJobState::Failed;
-                    record.result_body = None;
-                    record.error_message = Some("async scan job failed".to_string());
-                    record.error_status_code = Some(error.http_status_code().as_u16());
-                }
-            }
-
-            inner.completed.push_back(dispatched.job_id.clone());
-            inner.evict_completed_jobs(self.max_retained_terminal_jobs);
-
-            self.schedule_locked(&mut inner)
-        };
-
-        self.spawn_dispatches(follow_up_dispatches);
+fn json_response<T: Serialize>(status: StatusCode, body: &T) -> HttpResponse {
+    let serialized = serde_json::to_string(body).expect("response body should serialize");
+    HttpResponse {
+        status,
+        body: serialized,
     }
 }
 
-impl AsyncJobControllerState {
-    fn non_terminal_jobs(&self) -> usize {
-        self.jobs
-            .values()
-            .filter(|job| matches!(job.state, AsyncJobState::Pending | AsyncJobState::Running))
-            .count()
-    }
-
-    fn status_snapshot(&self, job_id: &str) -> Option<AsyncJobSnapshot> {
-        self.jobs.get(job_id).map(|job| AsyncJobSnapshot {
-            job_id: job_id.to_string(),
-            state: job.state,
-            allocated_processors: job.allocated_processors,
-            error_message: job.error_message.clone(),
-        })
-    }
-
-    fn result_snapshot(&self, job_id: &str) -> Option<AsyncJobResultSnapshot> {
-        self.jobs.get(job_id).map(|job| AsyncJobResultSnapshot {
-            state: job.state,
-            result_body: job.result_body.clone(),
-            error_message: job.error_message.clone(),
-            error_status_code: job.error_status_code,
-        })
-    }
-
-    fn evict_completed_jobs(&mut self, max_retained_terminal_jobs: usize) {
-        while self.completed.len() > max_retained_terminal_jobs {
-            let Some(job_id) = self.completed.pop_front() else {
-                break;
-            };
-            self.jobs.remove(&job_id);
-        }
-    }
+fn error_response(status: StatusCode, status_str: &'static str, message: String) -> HttpResponse {
+    json_response(
+        status,
+        &crate::serve_api::ServeErrorResponse {
+            status: status_str.to_string(),
+            message,
+            api_version: API_VERSION.to_string(),
+        },
+    )
 }
 
-impl AsyncJobRecord {
-    fn pending() -> Self {
-        Self {
-            state: AsyncJobState::Pending,
-            allocated_processors: None,
-            result_body: None,
-            error_message: None,
-            error_status_code: None,
-        }
-    }
-}
+fn into_tiny_response(response: HttpResponse) -> Response<std::io::Cursor<Vec<u8>>> {
+    let content_type = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+        .expect("Content-Type header should be valid ASCII");
 
-impl AsyncJobSnapshot {
-    fn into_status_response(self) -> AsyncJobStatusResponse {
-        AsyncJobStatusResponse {
-            job_id: self.job_id,
-            state: self.state,
-            result_ready: matches!(self.state, AsyncJobState::Succeeded),
-            allocated_processors: self.allocated_processors,
-            message: self.error_message,
-        }
-    }
+    let body_bytes = response.body.into_bytes();
+    let len = body_bytes.len();
+
+    Response::new(
+        response.status,
+        vec![content_type],
+        std::io::Cursor::new(body_bytes),
+        Some(len),
+        None,
+    )
 }
 
 pub(crate) fn run(args: &ServeArgs) -> Result<()> {
     let config = ServeConfig::try_from(args)?;
-    let bind_addr = resolve_bind_addr(&config.bind)?;
-    let listener = TcpListener::bind(bind_addr)
-        .with_context(|| format!("Failed to bind provenant serve to {}", config.bind))?;
-    let local_addr = listener
-        .local_addr()
-        .context("Failed to read provenant serve local address after bind")?;
+
+    let server = Server::http(&config.bind)
+        .map_err(|e| anyhow!("Failed to bind provenant serve to {}: {e}", config.bind))?;
+    let local_addr = server.server_addr();
 
     let readiness = Arc::new(Mutex::new(ReadinessState::Pending));
     start_warm_init(Arc::clone(&readiness));
@@ -417,13 +169,7 @@ pub(crate) fn run(args: &ServeArgs) -> Result<()> {
         readiness,
         jobs: AsyncJobController::new(),
     };
-    serve_forever(listener, state)
-}
-
-fn resolve_bind_addr(bind: &str) -> Result<SocketAddr> {
-    bind.to_socket_addrs()?
-        .next()
-        .ok_or_else(|| anyhow!("Could not resolve bind address {bind}"))
+    serve_forever(server, state)
 }
 
 fn start_warm_init(readiness: Arc<Mutex<ReadinessState>>) {
@@ -444,133 +190,79 @@ fn start_warm_init(readiness: Arc<Mutex<ReadinessState>>) {
     });
 }
 
-fn serve_forever(listener: TcpListener, state: ServeState) -> Result<()> {
-    for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
-                if let Err(error) = handle_connection(stream, &state) {
-                    eprintln!("serve request handling error: {error}");
-                }
-            }
-            Err(error) => return Err(error.into()),
+fn serve_forever(server: Server, state: ServeState) -> Result<()> {
+    for request in server.incoming_requests() {
+        if let Err(error) = handle_request(request, &state) {
+            eprintln!("serve request handling error: {error}");
         }
     }
 
     Ok(())
 }
 
-fn default_async_processor_budget() -> usize {
-    let cpus = thread::available_parallelism().map_or(1, |count| count.get());
-    if cpus > 1 { cpus - 1 } else { 1 }
-}
-
-fn handle_connection(mut stream: TcpStream, state: &ServeState) -> Result<()> {
-    stream.set_read_timeout(Some(REQUEST_TIMEOUT))?;
-    stream.set_write_timeout(Some(REQUEST_TIMEOUT))?;
-
-    let request = match parse_http_request(&mut stream) {
-        Ok(request) => request,
-        Err(error) => {
-            return write_http_response(
-                &mut stream,
-                error_response(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_request",
-                    error.to_string(),
-                ),
+fn handle_request(mut request: tiny_http::Request, state: &ServeState) -> Result<()> {
+    let parsed = match parse_request(&mut request) {
+        Ok(parsed) => parsed,
+        Err(ServeError::Ingest(IngestError::PayloadTooLarge(_))) => {
+            let response = error_response(
+                StatusCode::from(413),
+                "payload_too_large",
+                "request body exceeds max size".to_string(),
             );
+            request.respond(into_tiny_response(response))?;
+            return Ok(());
+        }
+        Err(error) => {
+            let response =
+                error_response(StatusCode::from(400), "invalid_request", error.to_string());
+            request.respond(into_tiny_response(response))?;
+            return Ok(());
         }
     };
 
-    let response = response_for_request(&request, state);
-    write_http_response(&mut stream, response)
+    let response = response_for_request(&parsed, state);
+    request.respond(into_tiny_response(response))?;
+    Ok(())
 }
 
-fn parse_http_request(stream: &mut TcpStream) -> Result<HttpRequest> {
-    let mut reader = BufReader::new(stream);
-    let mut request_line = String::new();
-    reader.read_line(&mut request_line)?;
-    if request_line.trim().is_empty() {
-        return Err(anyhow!("received empty HTTP request"));
-    }
-
-    let mut headers = HeaderMap::new();
-    loop {
-        let mut header_line = String::new();
-        reader.read_line(&mut header_line)?;
-        if header_line == "\r\n" || header_line.is_empty() {
-            break;
-        }
-
-        let header = header_line.trim_end_matches("\r\n");
-        let Some((name, value)) = header.split_once(':') else {
-            return Err(anyhow!("invalid HTTP header line"));
-        };
-        let header_name = http::HeaderName::from_bytes(name.trim().as_bytes())
-            .map_err(|_| anyhow!("invalid header name: {}", name.trim()))?;
-        let header_value = HeaderValue::from_str(value.trim()).map_err(|_| {
-            anyhow!(
-                "invalid header value for {}: {:?}",
-                name.trim(),
-                value.trim()
-            )
-        })?;
-        headers.append(header_name, header_value);
-    }
-
-    let mut parts = request_line.split_whitespace();
-    let method_str = parts
-        .next()
-        .ok_or_else(|| anyhow!("missing HTTP method in request line"))?;
-    let method = Method::from_bytes(method_str.as_bytes())
-        .map_err(|_| anyhow!("unsupported HTTP method: {method_str}"))?;
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow!("missing HTTP path in request line"))?;
-
-    let content_length = headers
-        .get(CONTENT_LENGTH)
-        .map(|value| {
-            value
-                .to_str()
-                .context("invalid Content-Length header value")?
-                .parse::<usize>()
-                .context("invalid Content-Length header")
-        })
-        .transpose()?
-        .unwrap_or(0);
+fn parse_request(request: &mut tiny_http::Request) -> Result<ParsedRequest, ServeError> {
+    let content_length = request.body_length().unwrap_or(0);
 
     if content_length > MAX_REQUEST_BODY_BYTES {
-        return Err(anyhow!(
+        return Err(ServeError::Ingest(IngestError::PayloadTooLarge(format!(
             "request body exceeds max size of {} bytes",
             MAX_REQUEST_BODY_BYTES
-        ));
+        ))));
     }
 
-    let mut body = vec![0; content_length];
-    if content_length > 0 {
-        reader.read_exact(&mut body)?;
+    let mut body = Vec::with_capacity(content_length);
+    request
+        .as_reader()
+        .take(MAX_REQUEST_BODY_BYTES as u64 + 1)
+        .read_to_end(&mut body)
+        .map_err(|e| {
+            ServeError::Ingest(IngestError::Internal {
+                message: "failed to read request body".to_string(),
+                source: Some(anyhow::Error::new(e)),
+            })
+        })?;
+
+    if body.len() > MAX_REQUEST_BODY_BYTES {
+        return Err(ServeError::Ingest(IngestError::PayloadTooLarge(format!(
+            "request body exceeds max size of {} bytes",
+            MAX_REQUEST_BODY_BYTES
+        ))));
     }
 
-    Ok(HttpRequest {
-        method,
-        path: path.to_string(),
-        headers,
+    Ok(ParsedRequest {
+        method: request.method().clone(),
+        path: request.url().to_string(),
+        headers: request.headers().to_vec(),
         body,
     })
 }
 
-#[derive(Debug)]
-struct HttpResponse(StatusCode, String);
-
-#[derive(Debug)]
-struct SyncScanExecution {
-    paths: Vec<PathBuf>,
-    options: ScanOptions,
-    _staging_dir: Option<TempDir>,
-}
-
-fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpResponse {
+fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResponse {
     let readiness = state
         .readiness
         .lock()
@@ -580,22 +272,22 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
     if let Some(job_route) = parse_job_route(&request.path) {
         return match job_route {
             JobRoute::Status(job_id) => {
-                if request.method == Method::GET {
+                if request.method == tiny_http::Method::Get {
                     handle_job_status_request(job_id, state)
                 } else {
                     error_response(
-                        StatusCode::METHOD_NOT_ALLOWED,
+                        StatusCode::from(405),
                         "method_not_allowed",
                         format!("use GET /v1/jobs/{job_id} to inspect async job state"),
                     )
                 }
             }
             JobRoute::Result(job_id) => {
-                if request.method == Method::GET {
+                if request.method == tiny_http::Method::Get {
                     handle_job_result_request(job_id, state)
                 } else {
                     error_response(
-                        StatusCode::METHOD_NOT_ALLOWED,
+                        StatusCode::from(405),
                         "method_not_allowed",
                         format!("use GET /v1/jobs/{job_id}/result to fetch async job output"),
                     )
@@ -605,16 +297,16 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
     }
 
     match (&request.method, request.path.as_str()) {
-        (m, "/livez") if m == Method::GET => serialize_response(
-            StatusCode::OK,
-            &ServeLivenessResponse {
+        (m, "/livez") if *m == tiny_http::Method::Get => json_response(
+            StatusCode::from(200),
+            &crate::serve_api::ServeLivenessResponse {
                 status: "ok".to_string(),
             },
         ),
-        (m, "/readyz") if m == Method::GET => match readiness {
-            ReadinessState::Pending => serialize_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                &ServeReadinessResponse {
+        (m, "/readyz") if *m == tiny_http::Method::Get => match readiness {
+            ReadinessState::Pending => json_response(
+                StatusCode::from(503),
+                &crate::serve_api::ServeReadinessResponse {
                     status: "warming".to_string(),
                     api_version: None,
                     spdx_license_list_version: None,
@@ -623,18 +315,18 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
             ),
             ReadinessState::Ready {
                 spdx_license_list_version,
-            } => serialize_response(
-                StatusCode::OK,
-                &ServeReadinessResponse {
+            } => json_response(
+                StatusCode::from(200),
+                &crate::serve_api::ServeReadinessResponse {
                     status: "ready".to_string(),
                     api_version: Some(API_VERSION.to_string()),
                     spdx_license_list_version: Some(spdx_license_list_version),
                     message: None,
                 },
             ),
-            ReadinessState::Failed { message } => serialize_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                &ServeReadinessResponse {
+            ReadinessState::Failed { message } => json_response(
+                StatusCode::from(503),
+                &crate::serve_api::ServeReadinessResponse {
                     status: "failed".to_string(),
                     api_version: None,
                     spdx_license_list_version: None,
@@ -642,34 +334,34 @@ fn response_for_request(request: &HttpRequest, state: &ServeState) -> HttpRespon
                 },
             ),
         },
-        (m, "/version") if m == Method::GET => serialize_response(
-            StatusCode::OK,
-            &ServeVersionResponse {
+        (m, "/version") if *m == tiny_http::Method::Get => json_response(
+            StatusCode::from(200),
+            &crate::serve_api::ServeVersionResponse {
                 service: "provenant-serve".to_string(),
                 api_version: API_VERSION.to_string(),
                 tool_version: BUILD_VERSION.to_string(),
             },
         ),
-        (m, "/v1/scans") if m == Method::POST => {
+        (m, "/v1/scans") if *m == tiny_http::Method::Post => {
             handle_sync_scan_request(request).unwrap_or_else(|e| e)
         }
         (_, "/v1/scans") => error_response(
-            StatusCode::METHOD_NOT_ALLOWED,
+            StatusCode::from(405),
             "method_not_allowed",
             "use POST /v1/scans for synchronous scan execution".to_string(),
         ),
-        (m, "/v1/scans:async") if m == Method::POST => {
+        (m, "/v1/scans:async") if *m == tiny_http::Method::Post => {
             handle_async_scan_request(request, state).unwrap_or_else(|e| e)
         }
         (_, "/v1/scans:async") => error_response(
-            StatusCode::METHOD_NOT_ALLOWED,
+            StatusCode::from(405),
             "method_not_allowed",
             "use POST /v1/scans:async for asynchronous scan submission".to_string(),
         ),
-        _ => HttpResponse(
-            StatusCode::NOT_FOUND,
-            json!({ "status": "not_found", "path": request.path }).to_string(),
-        ),
+        _ => HttpResponse {
+            status: StatusCode::from(404),
+            body: json!({ "status": "not_found", "path": request.path }).to_string(),
+        },
     }
 }
 
@@ -685,32 +377,40 @@ impl From<ServeError> for HttpResponse {
     }
 }
 
-fn handle_sync_scan_request(request: &HttpRequest) -> HandlerResult {
+fn handle_sync_scan_request(request: &ParsedRequest) -> HandlerResult {
     let sync_request = decode_scan_request_from_http(request, "POST /v1/scans")?;
     let execution = build_sync_scan_execution(sync_request)?;
     match execute_scan_execution(execution) {
-        Ok(body) => Ok(HttpResponse(StatusCode::OK, body)),
+        Ok(body) => Ok(HttpResponse {
+            status: StatusCode::from(200),
+            body,
+        }),
         Err(error) => Err(error.into()),
     }
 }
 
-fn handle_async_scan_request(request: &HttpRequest, state: &ServeState) -> HandlerResult {
+fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> HandlerResult {
     let sync_request = decode_scan_request_from_http(request, "POST /v1/scans:async")?;
-    match state.jobs.submit(sync_request) {
-        Ok(response) => Ok(serialize_response(StatusCode::ACCEPTED, &response)),
-        Err(AsyncSubmitError::QueueFull) => Err(error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "server_busy",
-            "async job queue is full; try again later".to_string(),
-        )),
-    }
+    let (response, dispatches) =
+        state
+            .jobs
+            .submit(sync_request)
+            .map_err(|AsyncSubmitError::QueueFull| {
+                error_response(
+                    StatusCode::from(503),
+                    "server_busy",
+                    "async job queue is full; try again later".to_string(),
+                )
+            })?;
+    spawn_dispatches(state.jobs.clone(), dispatches);
+    Ok(json_response(StatusCode::from(202), &response))
 }
 
 fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
     match state.jobs.status_snapshot(job_id) {
-        Some(snapshot) => serialize_response(StatusCode::OK, &snapshot.into_status_response()),
+        Some(snapshot) => json_response(StatusCode::from(200), &snapshot.into_status_response()),
         None => error_response(
-            StatusCode::NOT_FOUND,
+            StatusCode::from(404),
             "job_not_found",
             format!("async job {job_id} was not found"),
         ),
@@ -720,21 +420,21 @@ fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
 fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
     let Some(snapshot) = state.jobs.result_snapshot(job_id) else {
         return error_response(
-            StatusCode::NOT_FOUND,
+            StatusCode::from(404),
             "job_not_found",
             format!("async job {job_id} was not found"),
         );
     };
 
     match snapshot.state {
-        AsyncJobState::Succeeded => HttpResponse(
-            StatusCode::OK,
-            snapshot
+        AsyncJobState::Succeeded => HttpResponse {
+            status: StatusCode::from(200),
+            body: snapshot
                 .result_body
                 .expect("successful async job should retain result body"),
-        ),
+        },
         AsyncJobState::Pending | AsyncJobState::Running => error_response(
-            StatusCode::CONFLICT,
+            StatusCode::from(409),
             "job_not_ready",
             format!(
                 "async job {job_id} is currently {}",
@@ -748,8 +448,15 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
         AsyncJobState::Failed => {
             let status_code = snapshot
                 .error_status_code
-                .and_then(|code| StatusCode::from_u16(code).ok())
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                .and_then(|code| {
+                    let status = StatusCode::from(code);
+                    if status.0 >= 400 && status.0 < 600 {
+                        Some(status)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(StatusCode::from(500));
             error_response(
                 status_code,
                 "job_failed",
@@ -766,27 +473,24 @@ fn decode_sync_scan_request(body: &[u8]) -> Result<SyncScanRequest> {
 }
 
 fn decode_scan_request_from_http(
-    request: &HttpRequest,
+    request: &ParsedRequest,
     route_label: &str,
 ) -> std::result::Result<SyncScanRequest, HttpResponse> {
-    if !request.headers.get(CONTENT_TYPE).is_some_and(|value| {
-        value
-            .to_str()
-            .is_ok_and(|v| v.starts_with("application/json"))
-    }) {
+    let has_json_content_type = request
+        .headers
+        .iter()
+        .any(|h| h.field.equiv("Content-Type") && h.value.as_str().starts_with("application/json"));
+
+    if !has_json_content_type {
         return Err(error_response(
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            StatusCode::from(415),
             "unsupported_media_type",
             format!("{route_label} requires Content-Type: application/json"),
         ));
     }
 
     decode_sync_scan_request(&request.body).map_err(|error| {
-        error_response(
-            StatusCode::BAD_REQUEST,
-            "invalid_request",
-            error.to_string(),
-        )
+        error_response(StatusCode::from(400), "invalid_request", error.to_string())
     })
 }
 
@@ -862,6 +566,34 @@ fn run_async_scan_request(
     execute_scan_execution(execution)
 }
 
+fn spawn_dispatches(controller: AsyncJobController, dispatches: Vec<DispatchedAsyncJob>) {
+    for dispatched in dispatches {
+        let controller = controller.clone();
+        thread::spawn(move || {
+            let outcome =
+                match run_async_scan_request(dispatched.request, dispatched.allocated_processors) {
+                    Ok(result_body) => {
+                        eprintln!("serve async job {} succeeded", dispatched.job_id);
+                        JobOutcome::Succeeded { result_body }
+                    }
+                    Err(error) => {
+                        eprintln!("serve async job {} failed: {error}", dispatched.job_id);
+                        JobOutcome::Failed {
+                            message: "async scan job failed".to_string(),
+                            status_code: error.http_status_code().0,
+                        }
+                    }
+                };
+            let follow_up_dispatches = controller.complete_job(
+                dispatched.job_id,
+                dispatched.allocated_processors,
+                outcome,
+            );
+            spawn_dispatches(controller, follow_up_dispatches);
+        });
+    }
+}
+
 enum JobRoute<'a> {
     Status(&'a str),
     Result(&'a str),
@@ -880,63 +612,23 @@ fn is_valid_job_id(job_id: &str) -> bool {
     !job_id.is_empty() && !job_id.contains('/')
 }
 
-fn serialize_response<T: serde::Serialize>(status_code: StatusCode, body: &T) -> HttpResponse {
-    HttpResponse(
-        status_code,
-        serde_json::to_string(body).expect("response body should serialize"),
-    )
-}
-
-fn error_response(status_code: StatusCode, status: &'static str, message: String) -> HttpResponse {
-    serialize_response(
-        status_code,
-        &ServeErrorResponse {
-            status: status.to_string(),
-            message,
-            api_version: API_VERSION.to_string(),
-        },
-    )
-}
-
-fn write_http_response(stream: &mut TcpStream, response: HttpResponse) -> Result<()> {
-    let reason = response.0.canonical_reason().unwrap_or("Error");
-    let payload = format!(
-        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        response.0.as_u16(),
-        reason,
-        response.1.len(),
-        response.1,
-    );
-    stream.write_all(payload.as_bytes())?;
-    stream.flush()?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::serve::job_controller::AsyncJobController;
     use crate::serve_api::{SyncScanInput, SyncScanOptions};
 
-    fn test_request(method: Method, path: &str) -> HttpRequest {
-        HttpRequest {
+    fn test_request(method: tiny_http::Method, path: &str) -> ParsedRequest {
+        ParsedRequest {
             method,
             path: path.to_string(),
-            headers: HeaderMap::new(),
+            headers: Vec::new(),
             body: Vec::new(),
         }
     }
 
-    fn assert_status(response: &HttpResponse, expected: StatusCode) {
-        assert_eq!(response.0, expected);
-    }
-
-    fn dummy_async_request() -> SyncScanRequest {
-        SyncScanRequest {
-            input: SyncScanInput::Paths {
-                paths: vec!["/tmp".to_string()],
-            },
-            options: SyncScanOptions::default(),
-        }
+    fn assert_status(response: &HttpResponse, expected: u16) {
+        assert_eq!(response.status.0, expected);
     }
 
     fn ready_state() -> ServeState {
@@ -948,15 +640,12 @@ mod tests {
         }
     }
 
-    fn ready_state_with_job(job_id: &str, record: AsyncJobRecord) -> ServeState {
+    fn ready_state_with_job(
+        job_id: &str,
+        record: crate::serve::job_controller::AsyncJobRecord,
+    ) -> ServeState {
         let state = ready_state();
-        state
-            .jobs
-            .inner
-            .lock()
-            .expect("test async job lock should not be poisoned")
-            .jobs
-            .insert(job_id.to_string(), record);
+        state.jobs.insert_job(job_id.to_string(), record);
         state
     }
 
@@ -972,160 +661,88 @@ mod tests {
 
     #[test]
     fn readyz_reports_ready_metadata() {
-        let response = response_for_request(&test_request(Method::GET, "/readyz"), &ready_state());
-        assert_status(&response, StatusCode::OK);
-        assert!(response.1.contains("\"status\":\"ready\""));
-        assert!(response.1.contains("\"api_version\":\"v1\""));
+        let response = response_for_request(
+            &test_request(tiny_http::Method::Get, "/readyz"),
+            &ready_state(),
+        );
+        assert_status(&response, 200);
+        assert!(response.body.contains("\"status\":\"ready\""));
+        assert!(response.body.contains("\"api_version\":\"v1\""));
     }
 
     #[test]
     fn async_scan_route_requires_post() {
         let response = response_for_request(
-            &test_request(Method::GET, "/v1/scans:async"),
+            &test_request(tiny_http::Method::Get, "/v1/scans:async"),
             &ready_state(),
         );
-        assert_status(&response, StatusCode::METHOD_NOT_ALLOWED);
-        assert!(response.1.contains("method_not_allowed"));
+        assert_status(&response, 405);
+        assert!(response.body.contains("method_not_allowed"));
     }
 
     #[test]
     fn pending_job_status_reports_pending_state() {
-        let state = ready_state_with_job("job-1", AsyncJobRecord::pending());
-        let response = response_for_request(&test_request(Method::GET, "/v1/jobs/job-1"), &state);
-        assert_status(&response, StatusCode::OK);
-        assert!(response.1.contains("\"state\":\"pending\""));
-        assert!(response.1.contains("\"result_ready\":false"));
+        let state = ready_state_with_job(
+            "job-1",
+            crate::serve::job_controller::AsyncJobRecord::pending(),
+        );
+        let response = response_for_request(
+            &test_request(tiny_http::Method::Get, "/v1/jobs/job-1"),
+            &state,
+        );
+        assert_status(&response, 200);
+        assert!(response.body.contains("\"state\":\"pending\""));
+        assert!(response.body.contains("\"result_ready\":false"));
     }
 
     #[test]
     fn pending_job_result_reports_not_ready() {
-        let state = ready_state_with_job("job-2", AsyncJobRecord::pending());
-        let response =
-            response_for_request(&test_request(Method::GET, "/v1/jobs/job-2/result"), &state);
-        assert_status(&response, StatusCode::CONFLICT);
-        assert!(response.1.contains("job_not_ready"));
+        let state = ready_state_with_job(
+            "job-2",
+            crate::serve::job_controller::AsyncJobRecord::pending(),
+        );
+        let response = response_for_request(
+            &test_request(tiny_http::Method::Get, "/v1/jobs/job-2/result"),
+            &state,
+        );
+        assert_status(&response, 409);
+        assert!(response.body.contains("job_not_ready"));
     }
 
     #[test]
     fn completed_job_result_returns_stored_body() {
         let state = ready_state_with_job(
             "job-3",
-            AsyncJobRecord {
-                state: AsyncJobState::Succeeded,
-                allocated_processors: Some(2),
-                result_body: Some("{\"status\":\"ok\"}".to_string()),
-                error_message: None,
-                error_status_code: None,
-            },
+            crate::serve::job_controller::AsyncJobRecord::succeeded(
+                "{\"status\":\"ok\"}".to_string(),
+                2,
+            ),
         );
-        let response =
-            response_for_request(&test_request(Method::GET, "/v1/jobs/job-3/result"), &state);
-        assert_status(&response, StatusCode::OK);
-        assert_eq!(response.1, "{\"status\":\"ok\"}");
+        let response = response_for_request(
+            &test_request(tiny_http::Method::Get, "/v1/jobs/job-3/result"),
+            &state,
+        );
+        assert_status(&response, 200);
+        assert_eq!(response.body, "{\"status\":\"ok\"}");
     }
 
     #[test]
     fn failed_job_result_returns_failure_contract() {
         let state = ready_state_with_job(
             "job-4",
-            AsyncJobRecord {
-                state: AsyncJobState::Failed,
-                allocated_processors: Some(1),
-                result_body: None,
-                error_message: Some("async scan job failed".to_string()),
-                error_status_code: Some(500),
-            },
+            crate::serve::job_controller::AsyncJobRecord::failed(
+                "async scan job failed".to_string(),
+                500,
+                1,
+            ),
         );
-        let response =
-            response_for_request(&test_request(Method::GET, "/v1/jobs/job-4/result"), &state);
-        assert_status(&response, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(response.1.contains("job_failed"));
-        assert!(response.1.contains("async scan job failed"));
-    }
-
-    #[test]
-    fn async_job_controller_rejects_submit_when_queue_is_full() {
-        let controller = AsyncJobController::with_limits(1, 1, 8);
-        {
-            let mut inner = controller
-                .inner
-                .lock()
-                .expect("test async job lock should not be poisoned");
-            for index in 0..controller.max_non_terminal_jobs() {
-                inner
-                    .jobs
-                    .insert(format!("job-{index}"), AsyncJobRecord::pending());
-            }
-        }
-
-        let result = controller.submit(dummy_async_request());
-        assert!(matches!(result, Err(AsyncSubmitError::QueueFull)));
-    }
-
-    #[test]
-    fn scheduler_leaves_extra_jobs_pending_when_budget_is_exhausted() {
-        let controller = AsyncJobController::with_limits(4, 2, 8);
-        let mut inner = AsyncJobControllerState {
-            active_processors: 0,
-            jobs: HashMap::new(),
-            pending: VecDeque::new(),
-            completed: VecDeque::new(),
-        };
-
-        for job_id in ["job-a", "job-b", "job-c"] {
-            inner
-                .jobs
-                .insert(job_id.to_string(), AsyncJobRecord::pending());
-            inner.pending.push_back(PendingAsyncJob {
-                job_id: job_id.to_string(),
-                request: dummy_async_request(),
-            });
-        }
-
-        let dispatches = controller.schedule_locked(&mut inner);
-        assert_eq!(dispatches.len(), 2);
-        assert_eq!(inner.active_processors, 4);
-        assert_eq!(inner.pending.len(), 1);
-        assert_eq!(inner.jobs["job-a"].state, AsyncJobState::Running);
-        assert_eq!(inner.jobs["job-b"].state, AsyncJobState::Running);
-        assert_eq!(inner.jobs["job-c"].state, AsyncJobState::Pending);
-    }
-
-    #[test]
-    fn completed_jobs_are_evicted_when_retention_limit_is_exceeded() {
-        let mut inner = AsyncJobControllerState {
-            active_processors: 0,
-            jobs: HashMap::from([
-                (
-                    "job-old".to_string(),
-                    AsyncJobRecord {
-                        state: AsyncJobState::Succeeded,
-                        allocated_processors: Some(1),
-                        result_body: Some("old".to_string()),
-                        error_message: None,
-                        error_status_code: None,
-                    },
-                ),
-                (
-                    "job-new".to_string(),
-                    AsyncJobRecord {
-                        state: AsyncJobState::Succeeded,
-                        allocated_processors: Some(1),
-                        result_body: Some("new".to_string()),
-                        error_message: None,
-                        error_status_code: None,
-                    },
-                ),
-            ]),
-            pending: VecDeque::new(),
-            completed: VecDeque::from(["job-old".to_string(), "job-new".to_string()]),
-        };
-
-        inner.evict_completed_jobs(1);
-
-        assert!(!inner.jobs.contains_key("job-old"));
-        assert!(inner.jobs.contains_key("job-new"));
-        assert_eq!(inner.completed.len(), 1);
+        let response = response_for_request(
+            &test_request(tiny_http::Method::Get, "/v1/jobs/job-4/result"),
+            &state,
+        );
+        assert_status(&response, 500);
+        assert!(response.body.contains("job_failed"));
+        assert!(response.body.contains("async scan job failed"));
     }
 
     #[test]
@@ -1170,34 +787,10 @@ mod tests {
 
     #[test]
     fn sync_scan_requires_json_content_type() {
-        let response = handle_sync_scan_request(&test_request(Method::POST, "/v1/scans"))
-            .unwrap_or_else(|e| e);
-        assert_status(&response, StatusCode::UNSUPPORTED_MEDIA_TYPE);
-        assert!(response.1.contains("unsupported_media_type"));
-    }
-
-    #[test]
-    fn parse_http_request_rejects_oversized_body() {
-        let request = format!(
-            "POST /v1/scans HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: {}\r\n\r\n",
-            MAX_REQUEST_BODY_BYTES + 1
-        );
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
-        let address = listener.local_addr().expect("listener address");
-
-        let handle = std::thread::spawn(move || {
-            let (stream, _) = listener.accept().expect("accept connection");
-            let mut stream = stream;
-            parse_http_request(&mut stream).expect_err("oversized request should fail")
-        });
-
-        let mut client = TcpStream::connect(address).expect("connect client");
-        client
-            .write_all(request.as_bytes())
-            .expect("write request bytes");
-        client.flush().expect("flush request bytes");
-
-        let error = handle.join().expect("join parser thread");
-        assert!(error.to_string().contains("request body exceeds max size"));
+        let response =
+            handle_sync_scan_request(&test_request(tiny_http::Method::Post, "/v1/scans"))
+                .unwrap_or_else(|e| e);
+        assert_status(&response, 415);
+        assert!(response.body.contains("unsupported_media_type"));
     }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -608,4 +608,35 @@ mod tests {
         assert_status(&response, 415);
         assert!(response.body.contains("unsupported_media_type"));
     }
+
+    #[test]
+    fn unknown_path_returns_not_found() {
+        let response =
+            response_for_request(&test_request(Method::Get, "/nonexistent"), &ready_state());
+        assert_status(&response, 404);
+        assert!(response.body.contains("not_found"));
+    }
+
+    #[test]
+    fn parse_job_route_rejects_empty_job_id() {
+        assert!(parse_job_route("/v1/jobs/").is_none());
+    }
+
+    #[test]
+    fn parse_job_route_rejects_embedded_slashes() {
+        assert!(parse_job_route("/v1/jobs/abc/def").is_none());
+        assert!(parse_job_route("/v1/jobs/abc/def/result").is_none());
+    }
+
+    #[test]
+    fn failed_job_result_with_invalid_status_code_falls_back_to_500() {
+        let state = ready_state_with_job(
+            "job-5",
+            crate::serve::job_controller::AsyncJobRecord::failed("bad status".to_string(), 999, 1),
+        );
+        let response =
+            response_for_request(&test_request(Method::Get, "/v1/jobs/job-5/result"), &state);
+        assert_status(&response, 500);
+        assert!(response.body.contains("job_failed"));
+    }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -16,9 +16,9 @@ use crate::cli::ServeArgs;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::serve::ingest::{IngestError, ScanError, SyncScanExecution};
 use crate::serve::job_controller::{
-    AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome,
+    AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome, JobResult,
 };
-use crate::serve_api::{API_VERSION, AsyncJobState, ServeScanRequest};
+use crate::serve_api::{API_VERSION, ServeScanRequest};
 use crate::version::BUILD_VERSION;
 use crate::workflow::WorkflowError;
 
@@ -362,7 +362,7 @@ fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
 }
 
 fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
-    let Some(snapshot) = state.jobs.result_snapshot(job_id) else {
+    let Some(result) = state.jobs.get_job_result(job_id) else {
         return HttpResponse::error(
             StatusCode::from(404),
             "job_not_found",
@@ -370,43 +370,38 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
         );
     };
 
-    match snapshot.state {
-        AsyncJobState::Succeeded => HttpResponse {
+    match result {
+        JobResult::Succeeded { result_body } => HttpResponse {
             status: StatusCode::from(200),
-            body: snapshot
-                .result_body
-                .expect("successful async job should retain result body"),
+            body: result_body,
         },
-        AsyncJobState::Pending | AsyncJobState::Running => HttpResponse::error(
+        JobResult::Pending => HttpResponse::error(
             StatusCode::from(409),
             "job_not_ready",
-            format!(
-                "async job {job_id} is currently {}",
-                match snapshot.state {
-                    AsyncJobState::Pending => "pending",
-                    AsyncJobState::Running => "running",
-                    _ => unreachable!(),
-                }
-            ),
+            format!("async job {job_id} is currently pending"),
         ),
-        AsyncJobState::Failed => {
-            let status_code = snapshot
-                .error_status_code
-                .and_then(|code| {
-                    let status = StatusCode::from(code);
-                    if status.0 >= 400 && status.0 < 600 {
-                        Some(status)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(StatusCode::from(500));
+        JobResult::Running => HttpResponse::error(
+            StatusCode::from(409),
+            "job_not_ready",
+            format!("async job {job_id} is currently running"),
+        ),
+        JobResult::Failed {
+            message,
+            status_code,
+        } => {
+            let status = if (400..600).contains(&status_code) {
+                StatusCode::from(status_code)
+            } else {
+                StatusCode::from(500)
+            };
             HttpResponse::error(
-                status_code,
+                status,
                 "job_failed",
-                snapshot
-                    .error_message
-                    .unwrap_or_else(|| format!("async job {job_id} failed")),
+                if message.is_empty() {
+                    format!("async job {job_id} failed")
+                } else {
+                    message
+                },
             )
         }
     }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -550,7 +550,6 @@ fn is_valid_job_id(job_id: &str) -> bool {
 mod tests {
     use super::*;
     use crate::serve::job_controller::AsyncJobController;
-    use crate::serve_api::{ServeScanInput, ServeScanOptions};
 
     fn test_request(method: Method, path: &str) -> ParsedRequest {
         ParsedRequest {
@@ -665,46 +664,6 @@ mod tests {
         assert_status(&response, 500);
         assert!(response.body.contains("job_failed"));
         assert!(response.body.contains("async scan job failed"));
-    }
-
-    #[test]
-    fn decode_sync_scan_request_rejects_empty_paths() {
-        let error = SyncScanExecution::new(ServeScanRequest {
-            input: ServeScanInput::Paths { paths: Vec::new() },
-            options: ServeScanOptions::default(),
-        })
-        .expect_err("empty paths should fail");
-
-        assert!(
-            error
-                .to_string()
-                .contains("input.paths must contain at least one path")
-        );
-    }
-
-    #[test]
-    fn url_input_requires_http_or_https() {
-        let error = SyncScanExecution::new(ServeScanRequest {
-            input: ServeScanInput::Url {
-                url: "file:///tmp/input.txt".to_string(),
-            },
-            options: ServeScanOptions::default(),
-        })
-        .expect_err("unsupported URL scheme should fail");
-
-        assert!(error.to_string().contains("http or https"));
-    }
-
-    #[test]
-    fn decode_sync_scan_request_requires_valid_json() {
-        let error =
-            ServeScanRequest::decode(br#"{"input": }"#).expect_err("malformed JSON should fail");
-
-        assert!(
-            error
-                .to_string()
-                .contains("request body must be valid JSON")
-        );
     }
 
     #[test]

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -342,17 +342,13 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 tool_version: BUILD_VERSION.to_string(),
             },
         ),
-        (m, "/v1/scans") if *m == Method::Post => {
-            handle_sync_scan_request(request).unwrap_or_else(|e| e)
-        }
+        (m, "/v1/scans") if *m == Method::Post => handle_sync_scan_request(request),
         (_, "/v1/scans") => HttpResponse::error(
             StatusCode::from(405),
             "method_not_allowed",
             "use POST /v1/scans for synchronous scan execution".to_string(),
         ),
-        (m, "/v1/scans:async") if *m == Method::Post => {
-            handle_async_scan_request(request, state).unwrap_or_else(|e| e)
-        }
+        (m, "/v1/scans:async") if *m == Method::Post => handle_async_scan_request(request, state),
         (_, "/v1/scans:async") => HttpResponse::error(
             StatusCode::from(405),
             "method_not_allowed",
@@ -365,8 +361,6 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
     }
 }
 
-type HandlerResult = Result<HttpResponse, HttpResponse>;
-
 impl From<ServeError> for HttpResponse {
     fn from(error: ServeError) -> HttpResponse {
         HttpResponse::error(
@@ -377,34 +371,41 @@ impl From<ServeError> for HttpResponse {
     }
 }
 
-fn handle_sync_scan_request(request: &ParsedRequest) -> HandlerResult {
-    let sync_request = decode_scan_request_from_http(request, "POST /v1/scans")?;
-    let execution = SyncScanExecution::new(sync_request)
-        .map_err(|e| HttpResponse::from(ServeError::from(e)))?;
+fn handle_sync_scan_request(request: &ParsedRequest) -> HttpResponse {
+    let sync_request = match decode_scan_request_from_http(request, "POST /v1/scans") {
+        Ok(req) => req,
+        Err(resp) => return resp,
+    };
+    let execution = match SyncScanExecution::new(sync_request) {
+        Ok(e) => e,
+        Err(e) => return HttpResponse::from(ServeError::from(e)),
+    };
     match execution.execute() {
-        Ok(body) => Ok(HttpResponse {
+        Ok(body) => HttpResponse {
             status: StatusCode::from(200),
             body,
-        }),
-        Err(error) => Err(ServeError::from(error).into()),
+        },
+        Err(error) => HttpResponse::from(ServeError::from(error)),
     }
 }
 
-fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> HandlerResult {
-    let sync_request = decode_scan_request_from_http(request, "POST /v1/scans:async")?;
-    let (response, dispatches) =
-        state
-            .jobs
-            .submit(sync_request)
-            .map_err(|AsyncSubmitError::QueueFull| {
-                HttpResponse::error(
-                    StatusCode::from(503),
-                    "server_busy",
-                    "async job queue is full; try again later".to_string(),
-                )
-            })?;
+fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> HttpResponse {
+    let sync_request = match decode_scan_request_from_http(request, "POST /v1/scans:async") {
+        Ok(req) => req,
+        Err(resp) => return resp,
+    };
+    let (response, dispatches) = match state.jobs.submit(sync_request) {
+        Ok(result) => result,
+        Err(AsyncSubmitError::QueueFull) => {
+            return HttpResponse::error(
+                StatusCode::from(503),
+                "server_busy",
+                "async job queue is full; try again later".to_string(),
+            );
+        }
+    };
     spawn_dispatches(state.jobs.clone(), dispatches);
-    Ok(HttpResponse::json(StatusCode::from(202), &response))
+    HttpResponse::json(StatusCode::from(202), &response)
 }
 
 fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
@@ -708,8 +709,7 @@ mod tests {
 
     #[test]
     fn sync_scan_requires_json_content_type() {
-        let response = handle_sync_scan_request(&test_request(Method::Post, "/v1/scans"))
-            .unwrap_or_else(|e| e);
+        let response = handle_sync_scan_request(&test_request(Method::Post, "/v1/scans"));
         assert_status(&response, 415);
         assert!(response.body.contains("unsupported_media_type"));
     }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use serde::Serialize;
 use serde_json::json;
 use tiny_http::{Header, Method, Response, Server, StatusCode};
@@ -113,39 +113,41 @@ struct HttpResponse {
     body: String,
 }
 
-fn json_response<T: Serialize>(status: StatusCode, body: &T) -> HttpResponse {
-    let serialized = serde_json::to_string(body).expect("response body should serialize");
-    HttpResponse {
-        status,
-        body: serialized,
+impl HttpResponse {
+    fn json<T: Serialize>(status: StatusCode, body: &T) -> Self {
+        let serialized = serde_json::to_string(body).expect("response body should serialize");
+        Self {
+            status,
+            body: serialized,
+        }
     }
-}
 
-fn error_response(status: StatusCode, status_str: &'static str, message: String) -> HttpResponse {
-    json_response(
-        status,
-        &crate::serve_api::ServeErrorResponse {
-            status: status_str.to_string(),
-            message,
-            api_version: API_VERSION.to_string(),
-        },
-    )
-}
+    fn error(status: StatusCode, status_str: &'static str, message: String) -> Self {
+        Self::json(
+            status,
+            &crate::serve_api::ServeErrorResponse {
+                status: status_str.to_string(),
+                message,
+                api_version: API_VERSION.to_string(),
+            },
+        )
+    }
 
-fn into_tiny_response(response: HttpResponse) -> Response<std::io::Cursor<Vec<u8>>> {
-    let content_type = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
-        .expect("Content-Type header should be valid ASCII");
+    fn into_tiny_response(self) -> Response<std::io::Cursor<Vec<u8>>> {
+        let content_type = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+            .expect("Content-Type header should be valid ASCII");
 
-    let body_bytes = response.body.into_bytes();
-    let len = body_bytes.len();
+        let body_bytes = self.body.into_bytes();
+        let len = body_bytes.len();
 
-    Response::new(
-        response.status,
-        vec![content_type],
-        std::io::Cursor::new(body_bytes),
-        Some(len),
-        None,
-    )
+        Response::new(
+            self.status,
+            vec![content_type],
+            std::io::Cursor::new(body_bytes),
+            Some(len),
+            None,
+        )
+    }
 }
 
 pub(crate) fn run(args: &ServeArgs) -> Result<()> {
@@ -202,24 +204,24 @@ fn handle_request(mut request: tiny_http::Request, state: &ServeState) -> Result
     let parsed = match parse_request(&mut request) {
         Ok(parsed) => parsed,
         Err(ServeError::Ingest(IngestError::PayloadTooLarge(_))) => {
-            let response = error_response(
+            let response = HttpResponse::error(
                 StatusCode::from(413),
                 "payload_too_large",
                 "request body exceeds max size".to_string(),
             );
-            request.respond(into_tiny_response(response))?;
+            request.respond(response.into_tiny_response())?;
             return Ok(());
         }
         Err(error) => {
             let response =
-                error_response(StatusCode::from(400), "invalid_request", error.to_string());
-            request.respond(into_tiny_response(response))?;
+                HttpResponse::error(StatusCode::from(400), "invalid_request", error.to_string());
+            request.respond(response.into_tiny_response())?;
             return Ok(());
         }
     };
 
     let response = response_for_request(&parsed, state);
-    request.respond(into_tiny_response(response))?;
+    request.respond(response.into_tiny_response())?;
     Ok(())
 }
 
@@ -273,7 +275,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 if request.method == Method::Get {
                     handle_job_status_request(job_id, state)
                 } else {
-                    error_response(
+                    HttpResponse::error(
                         StatusCode::from(405),
                         "method_not_allowed",
                         format!("use GET /v1/jobs/{job_id} to inspect async job state"),
@@ -284,7 +286,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 if request.method == Method::Get {
                     handle_job_result_request(job_id, state)
                 } else {
-                    error_response(
+                    HttpResponse::error(
                         StatusCode::from(405),
                         "method_not_allowed",
                         format!("use GET /v1/jobs/{job_id}/result to fetch async job output"),
@@ -295,14 +297,14 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
     }
 
     match (&request.method, request.path.as_str()) {
-        (m, "/livez") if *m == Method::Get => json_response(
+        (m, "/livez") if *m == Method::Get => HttpResponse::json(
             StatusCode::from(200),
             &crate::serve_api::ServeLivenessResponse {
                 status: "ok".to_string(),
             },
         ),
         (m, "/readyz") if *m == Method::Get => match readiness {
-            ReadinessState::Pending => json_response(
+            ReadinessState::Pending => HttpResponse::json(
                 StatusCode::from(503),
                 &crate::serve_api::ServeReadinessResponse {
                     status: "warming".to_string(),
@@ -313,7 +315,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
             ),
             ReadinessState::Ready {
                 spdx_license_list_version,
-            } => json_response(
+            } => HttpResponse::json(
                 StatusCode::from(200),
                 &crate::serve_api::ServeReadinessResponse {
                     status: "ready".to_string(),
@@ -322,7 +324,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                     message: None,
                 },
             ),
-            ReadinessState::Failed { message } => json_response(
+            ReadinessState::Failed { message } => HttpResponse::json(
                 StatusCode::from(503),
                 &crate::serve_api::ServeReadinessResponse {
                     status: "failed".to_string(),
@@ -332,7 +334,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 },
             ),
         },
-        (m, "/version") if *m == Method::Get => json_response(
+        (m, "/version") if *m == Method::Get => HttpResponse::json(
             StatusCode::from(200),
             &crate::serve_api::ServeVersionResponse {
                 service: "provenant-serve".to_string(),
@@ -343,7 +345,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
         (m, "/v1/scans") if *m == Method::Post => {
             handle_sync_scan_request(request).unwrap_or_else(|e| e)
         }
-        (_, "/v1/scans") => error_response(
+        (_, "/v1/scans") => HttpResponse::error(
             StatusCode::from(405),
             "method_not_allowed",
             "use POST /v1/scans for synchronous scan execution".to_string(),
@@ -351,7 +353,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
         (m, "/v1/scans:async") if *m == Method::Post => {
             handle_async_scan_request(request, state).unwrap_or_else(|e| e)
         }
-        (_, "/v1/scans:async") => error_response(
+        (_, "/v1/scans:async") => HttpResponse::error(
             StatusCode::from(405),
             "method_not_allowed",
             "use POST /v1/scans:async for asynchronous scan submission".to_string(),
@@ -367,7 +369,7 @@ type HandlerResult = Result<HttpResponse, HttpResponse>;
 
 impl From<ServeError> for HttpResponse {
     fn from(error: ServeError) -> HttpResponse {
-        error_response(
+        HttpResponse::error(
             error.http_status_code(),
             error.error_type(),
             error.to_string(),
@@ -395,20 +397,22 @@ fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> Han
             .jobs
             .submit(sync_request)
             .map_err(|AsyncSubmitError::QueueFull| {
-                error_response(
+                HttpResponse::error(
                     StatusCode::from(503),
                     "server_busy",
                     "async job queue is full; try again later".to_string(),
                 )
             })?;
     spawn_dispatches(state.jobs.clone(), dispatches);
-    Ok(json_response(StatusCode::from(202), &response))
+    Ok(HttpResponse::json(StatusCode::from(202), &response))
 }
 
 fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
     match state.jobs.status_snapshot(job_id) {
-        Some(snapshot) => json_response(StatusCode::from(200), &snapshot.into_status_response()),
-        None => error_response(
+        Some(snapshot) => {
+            HttpResponse::json(StatusCode::from(200), &snapshot.into_status_response())
+        }
+        None => HttpResponse::error(
             StatusCode::from(404),
             "job_not_found",
             format!("async job {job_id} was not found"),
@@ -418,7 +422,7 @@ fn handle_job_status_request(job_id: &str, state: &ServeState) -> HttpResponse {
 
 fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
     let Some(snapshot) = state.jobs.result_snapshot(job_id) else {
-        return error_response(
+        return HttpResponse::error(
             StatusCode::from(404),
             "job_not_found",
             format!("async job {job_id} was not found"),
@@ -432,7 +436,7 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
                 .result_body
                 .expect("successful async job should retain result body"),
         },
-        AsyncJobState::Pending | AsyncJobState::Running => error_response(
+        AsyncJobState::Pending | AsyncJobState::Running => HttpResponse::error(
             StatusCode::from(409),
             "job_not_ready",
             format!(
@@ -456,7 +460,7 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
                     }
                 })
                 .unwrap_or(StatusCode::from(500));
-            error_response(
+            HttpResponse::error(
                 status_code,
                 "job_failed",
                 snapshot
@@ -465,10 +469,6 @@ fn handle_job_result_request(job_id: &str, state: &ServeState) -> HttpResponse {
             )
         }
     }
-}
-
-fn decode_sync_scan_request(body: &[u8]) -> Result<SyncScanRequest> {
-    serde_json::from_slice(body).context("request body must be valid JSON")
 }
 
 fn decode_scan_request_from_http(
@@ -481,15 +481,15 @@ fn decode_scan_request_from_http(
         .any(|h| h.field.equiv("Content-Type") && h.value.as_str().starts_with("application/json"));
 
     if !has_json_content_type {
-        return Err(error_response(
+        return Err(HttpResponse::error(
             StatusCode::from(415),
             "unsupported_media_type",
             format!("{route_label} requires Content-Type: application/json"),
         ));
     }
 
-    decode_sync_scan_request(&request.body).map_err(|error| {
-        error_response(StatusCode::from(400), "invalid_request", error.to_string())
+    SyncScanRequest::decode(&request.body).map_err(|error| {
+        HttpResponse::error(StatusCode::from(400), "invalid_request", error.to_string())
     })
 }
 
@@ -697,7 +697,7 @@ mod tests {
     #[test]
     fn decode_sync_scan_request_requires_valid_json() {
         let error =
-            decode_sync_scan_request(br#"{"input": }"#).expect_err("malformed JSON should fail");
+            SyncScanRequest::decode(br#"{"input": }"#).expect_err("malformed JSON should fail");
 
         assert!(
             error

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -5,26 +5,23 @@ mod ingest;
 mod job_controller;
 
 use std::io::Read;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use serde_json::json;
-use tempfile::TempDir;
-use tiny_http::{Header, Response, Server, StatusCode};
+use tiny_http::{Header, Method, Response, Server, StatusCode};
 
-use crate::ProcessMode;
 use crate::cli::ServeArgs;
 use crate::license_detection::LicenseDetectionEngine;
-use crate::serve::ingest::{IngestError, prepare_sync_input};
+use crate::serve::ingest::{IngestError, ScanError, SyncScanExecution};
 use crate::serve::job_controller::{
     AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome,
 };
-use crate::serve_api::{API_VERSION, AsyncJobState, SyncLicenseSource, SyncScanRequest};
+use crate::serve_api::{API_VERSION, AsyncJobState, SyncScanRequest};
 use crate::version::BUILD_VERSION;
-use crate::workflow::{LicenseSource, ScanOptions, WorkflowError, scan_paths};
+use crate::workflow::WorkflowError;
 
 const MAX_REQUEST_BODY_BYTES: usize = 24 * 1024 * 1024;
 
@@ -33,9 +30,9 @@ pub(crate) enum ServeError {
     #[error(transparent)]
     Ingest(#[from] IngestError),
     #[error(transparent)]
+    Scan(#[from] ScanError),
+    #[error(transparent)]
     Workflow(#[from] WorkflowError),
-    #[error("{0}")]
-    Serialization(String),
 }
 
 impl ServeError {
@@ -45,9 +42,13 @@ impl ServeError {
             Self::Ingest(IngestError::PayloadTooLarge(_)) => StatusCode::from(413),
             Self::Ingest(IngestError::Upstream { .. }) => StatusCode::from(502),
             Self::Ingest(IngestError::Internal { .. }) => StatusCode::from(500),
+            Self::Scan(ScanError::Workflow(WorkflowError::InvalidOptions(_))) => {
+                StatusCode::from(422)
+            }
+            Self::Scan(ScanError::Workflow(WorkflowError::Pipeline(_))) => StatusCode::from(500),
+            Self::Scan(ScanError::Serialization(_)) => StatusCode::from(500),
             Self::Workflow(WorkflowError::InvalidOptions(_)) => StatusCode::from(422),
             Self::Workflow(WorkflowError::Pipeline(_)) => StatusCode::from(500),
-            Self::Serialization(_) => StatusCode::from(500),
         }
     }
 
@@ -57,9 +58,13 @@ impl ServeError {
             Self::Ingest(IngestError::PayloadTooLarge(_)) => "payload_too_large",
             Self::Ingest(IngestError::Upstream { .. }) => "upstream_error",
             Self::Ingest(IngestError::Internal { .. }) => "internal_error",
+            Self::Scan(ScanError::Workflow(WorkflowError::InvalidOptions(_))) => {
+                "invalid_scan_request"
+            }
+            Self::Scan(ScanError::Workflow(WorkflowError::Pipeline(_))) => "scan_failed",
+            Self::Scan(ScanError::Serialization(_)) => "scan_failed",
             Self::Workflow(WorkflowError::InvalidOptions(_)) => "invalid_scan_request",
             Self::Workflow(WorkflowError::Pipeline(_)) => "scan_failed",
-            Self::Serialization(_) => "scan_failed",
         }
     }
 }
@@ -96,15 +101,8 @@ struct ServeState {
     jobs: AsyncJobController,
 }
 
-#[derive(Debug)]
-struct SyncScanExecution {
-    paths: Vec<PathBuf>,
-    options: ScanOptions,
-    _staging_dir: Option<TempDir>,
-}
-
 struct ParsedRequest {
-    method: tiny_http::Method,
+    method: Method,
     path: String,
     headers: Vec<Header>,
     body: Vec<u8>,
@@ -272,7 +270,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
     if let Some(job_route) = parse_job_route(&request.path) {
         return match job_route {
             JobRoute::Status(job_id) => {
-                if request.method == tiny_http::Method::Get {
+                if request.method == Method::Get {
                     handle_job_status_request(job_id, state)
                 } else {
                     error_response(
@@ -283,7 +281,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 }
             }
             JobRoute::Result(job_id) => {
-                if request.method == tiny_http::Method::Get {
+                if request.method == Method::Get {
                     handle_job_result_request(job_id, state)
                 } else {
                     error_response(
@@ -297,13 +295,13 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
     }
 
     match (&request.method, request.path.as_str()) {
-        (m, "/livez") if *m == tiny_http::Method::Get => json_response(
+        (m, "/livez") if *m == Method::Get => json_response(
             StatusCode::from(200),
             &crate::serve_api::ServeLivenessResponse {
                 status: "ok".to_string(),
             },
         ),
-        (m, "/readyz") if *m == tiny_http::Method::Get => match readiness {
+        (m, "/readyz") if *m == Method::Get => match readiness {
             ReadinessState::Pending => json_response(
                 StatusCode::from(503),
                 &crate::serve_api::ServeReadinessResponse {
@@ -334,7 +332,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 },
             ),
         },
-        (m, "/version") if *m == tiny_http::Method::Get => json_response(
+        (m, "/version") if *m == Method::Get => json_response(
             StatusCode::from(200),
             &crate::serve_api::ServeVersionResponse {
                 service: "provenant-serve".to_string(),
@@ -342,7 +340,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 tool_version: BUILD_VERSION.to_string(),
             },
         ),
-        (m, "/v1/scans") if *m == tiny_http::Method::Post => {
+        (m, "/v1/scans") if *m == Method::Post => {
             handle_sync_scan_request(request).unwrap_or_else(|e| e)
         }
         (_, "/v1/scans") => error_response(
@@ -350,7 +348,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
             "method_not_allowed",
             "use POST /v1/scans for synchronous scan execution".to_string(),
         ),
-        (m, "/v1/scans:async") if *m == tiny_http::Method::Post => {
+        (m, "/v1/scans:async") if *m == Method::Post => {
             handle_async_scan_request(request, state).unwrap_or_else(|e| e)
         }
         (_, "/v1/scans:async") => error_response(
@@ -379,13 +377,14 @@ impl From<ServeError> for HttpResponse {
 
 fn handle_sync_scan_request(request: &ParsedRequest) -> HandlerResult {
     let sync_request = decode_scan_request_from_http(request, "POST /v1/scans")?;
-    let execution = build_sync_scan_execution(sync_request)?;
-    match execute_scan_execution(execution) {
+    let execution = SyncScanExecution::new(sync_request)
+        .map_err(|e| HttpResponse::from(ServeError::from(e)))?;
+    match execution.execute() {
         Ok(body) => Ok(HttpResponse {
             status: StatusCode::from(200),
             body,
         }),
-        Err(error) => Err(error.into()),
+        Err(error) => Err(ServeError::from(error).into()),
     }
 }
 
@@ -494,96 +493,30 @@ fn decode_scan_request_from_http(
     })
 }
 
-fn build_sync_scan_execution(request: SyncScanRequest) -> Result<SyncScanExecution, ServeError> {
-    let prepared_input = prepare_sync_input(request.input)?;
-
-    let mut options = ScanOptions::default();
-    options.collect_info = request.options.collect_info;
-    options.detect_license = match request.options.detect_license {
-        SyncLicenseSource::Disabled => LicenseSource::Disabled,
-        SyncLicenseSource::Embedded => LicenseSource::Embedded,
-        SyncLicenseSource::Directory { path } => LicenseSource::Directory(PathBuf::from(path)),
-    };
-    options.detect_packages = request.options.detect_packages;
-    options.detect_system_packages = request.options.detect_system_packages;
-    options.detect_packages_in_compiled = request.options.detect_packages_in_compiled;
-    options.detect_copyrights = request.options.detect_copyrights;
-    options.detect_emails = request.options.detect_emails;
-    options.detect_urls = request.options.detect_urls;
-    options.detect_generated = request.options.detect_generated;
-    options.include = request.options.include;
-    options.exclude = request.options.exclude;
-    if prepared_input.strip_staging_root {
-        options.strip_root = true;
-        options.full_root = false;
-    } else {
-        options.strip_root = request.options.strip_root;
-        options.full_root = request.options.full_root;
-    }
-    options.license_text = request.options.license_text;
-    options.license_text_diagnostics = request.options.license_text_diagnostics;
-    options.license_diagnostics = request.options.license_diagnostics;
-    options.unknown_licenses = request.options.unknown_licenses;
-    options.license_score = request.options.license_score;
-    options.only_findings = request.options.only_findings;
-    options.mark_source = request.options.mark_source;
-    options.classify = request.options.classify;
-    options.summary = request.options.summary;
-    options.license_clarity_score = request.options.license_clarity_score;
-    options.license_references = request.options.license_references;
-    options.tallies = request.options.tallies;
-    options.tallies_key_files = request.options.tallies_key_files;
-    options.tallies_with_details = request.options.tallies_with_details;
-    options.facets = request.options.facets;
-    options.tallies_by_facet = request.options.tallies_by_facet;
-
-    Ok(SyncScanExecution {
-        paths: prepared_input.paths,
-        options,
-        _staging_dir: prepared_input.staging_dir,
-    })
-}
-
-fn execute_scan_execution(execution: SyncScanExecution) -> Result<String, ServeError> {
-    let output = scan_paths(
-        execution.paths.iter().map(|path| path.as_path()),
-        &execution.options,
-    )?;
-    serde_json::to_string(&crate::output_schema::Output::from(&output))
-        .map_err(|e| ServeError::Serialization(format!("scan result should serialize: {e}")))
-}
-
-fn run_async_scan_request(
-    request: SyncScanRequest,
-    allocated_processors: usize,
-) -> Result<String, ServeError> {
-    let mut execution = build_sync_scan_execution(request)?;
-    execution.options.process_mode = if allocated_processors <= 1 {
-        ProcessMode::SequentialWithTimeouts
-    } else {
-        ProcessMode::Parallel(allocated_processors)
-    };
-    execute_scan_execution(execution)
-}
-
 fn spawn_dispatches(controller: AsyncJobController, dispatches: Vec<DispatchedAsyncJob>) {
     for dispatched in dispatches {
         let controller = controller.clone();
         thread::spawn(move || {
-            let outcome =
-                match run_async_scan_request(dispatched.request, dispatched.allocated_processors) {
-                    Ok(result_body) => {
-                        eprintln!("serve async job {} succeeded", dispatched.job_id);
-                        JobOutcome::Succeeded { result_body }
+            let result = SyncScanExecution::new(dispatched.request)
+                .map_err(ServeError::from)
+                .and_then(|e| {
+                    e.run_async(dispatched.allocated_processors)
+                        .map_err(ServeError::from)
+                });
+
+            let outcome = match result {
+                Ok(result_body) => {
+                    eprintln!("serve async job {} succeeded", dispatched.job_id);
+                    JobOutcome::Succeeded { result_body }
+                }
+                Err(error) => {
+                    eprintln!("serve async job {} failed: {error}", dispatched.job_id);
+                    JobOutcome::Failed {
+                        message: "async scan job failed".to_string(),
+                        status_code: error.http_status_code().0,
                     }
-                    Err(error) => {
-                        eprintln!("serve async job {} failed: {error}", dispatched.job_id);
-                        JobOutcome::Failed {
-                            message: "async scan job failed".to_string(),
-                            status_code: error.http_status_code().0,
-                        }
-                    }
-                };
+                }
+            };
             let follow_up_dispatches = controller.complete_job(
                 dispatched.job_id,
                 dispatched.allocated_processors,
@@ -618,7 +551,7 @@ mod tests {
     use crate::serve::job_controller::AsyncJobController;
     use crate::serve_api::{SyncScanInput, SyncScanOptions};
 
-    fn test_request(method: tiny_http::Method, path: &str) -> ParsedRequest {
+    fn test_request(method: Method, path: &str) -> ParsedRequest {
         ParsedRequest {
             method,
             path: path.to_string(),
@@ -661,10 +594,7 @@ mod tests {
 
     #[test]
     fn readyz_reports_ready_metadata() {
-        let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/readyz"),
-            &ready_state(),
-        );
+        let response = response_for_request(&test_request(Method::Get, "/readyz"), &ready_state());
         assert_status(&response, 200);
         assert!(response.body.contains("\"status\":\"ready\""));
         assert!(response.body.contains("\"api_version\":\"v1\""));
@@ -673,7 +603,7 @@ mod tests {
     #[test]
     fn async_scan_route_requires_post() {
         let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/v1/scans:async"),
+            &test_request(Method::Get, "/v1/scans:async"),
             &ready_state(),
         );
         assert_status(&response, 405);
@@ -686,10 +616,7 @@ mod tests {
             "job-1",
             crate::serve::job_controller::AsyncJobRecord::pending(),
         );
-        let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/v1/jobs/job-1"),
-            &state,
-        );
+        let response = response_for_request(&test_request(Method::Get, "/v1/jobs/job-1"), &state);
         assert_status(&response, 200);
         assert!(response.body.contains("\"state\":\"pending\""));
         assert!(response.body.contains("\"result_ready\":false"));
@@ -701,10 +628,8 @@ mod tests {
             "job-2",
             crate::serve::job_controller::AsyncJobRecord::pending(),
         );
-        let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/v1/jobs/job-2/result"),
-            &state,
-        );
+        let response =
+            response_for_request(&test_request(Method::Get, "/v1/jobs/job-2/result"), &state);
         assert_status(&response, 409);
         assert!(response.body.contains("job_not_ready"));
     }
@@ -718,10 +643,8 @@ mod tests {
                 2,
             ),
         );
-        let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/v1/jobs/job-3/result"),
-            &state,
-        );
+        let response =
+            response_for_request(&test_request(Method::Get, "/v1/jobs/job-3/result"), &state);
         assert_status(&response, 200);
         assert_eq!(response.body, "{\"status\":\"ok\"}");
     }
@@ -736,10 +659,8 @@ mod tests {
                 1,
             ),
         );
-        let response = response_for_request(
-            &test_request(tiny_http::Method::Get, "/v1/jobs/job-4/result"),
-            &state,
-        );
+        let response =
+            response_for_request(&test_request(Method::Get, "/v1/jobs/job-4/result"), &state);
         assert_status(&response, 500);
         assert!(response.body.contains("job_failed"));
         assert!(response.body.contains("async scan job failed"));
@@ -747,7 +668,7 @@ mod tests {
 
     #[test]
     fn decode_sync_scan_request_rejects_empty_paths() {
-        let error = build_sync_scan_execution(SyncScanRequest {
+        let error = SyncScanExecution::new(SyncScanRequest {
             input: SyncScanInput::Paths { paths: Vec::new() },
             options: SyncScanOptions::default(),
         })
@@ -762,7 +683,7 @@ mod tests {
 
     #[test]
     fn url_input_requires_http_or_https() {
-        let error = build_sync_scan_execution(SyncScanRequest {
+        let error = SyncScanExecution::new(SyncScanRequest {
             input: SyncScanInput::Url {
                 url: "file:///tmp/input.txt".to_string(),
             },
@@ -787,9 +708,8 @@ mod tests {
 
     #[test]
     fn sync_scan_requires_json_content_type() {
-        let response =
-            handle_sync_scan_request(&test_request(tiny_http::Method::Post, "/v1/scans"))
-                .unwrap_or_else(|e| e);
+        let response = handle_sync_scan_request(&test_request(Method::Post, "/v1/scans"))
+            .unwrap_or_else(|e| e);
         assert_status(&response, 415);
         assert!(response.body.contains("unsupported_media_type"));
     }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -5,7 +5,6 @@ mod ingest;
 mod job_controller;
 
 use std::io::Read;
-use std::sync::{Arc, Mutex};
 use std::thread;
 
 use anyhow::{Result, anyhow};
@@ -82,16 +81,9 @@ impl TryFrom<&ServeArgs> for ServeConfig {
     }
 }
 
-#[derive(Debug, Clone)]
-enum ReadinessState {
-    Pending,
-    Ready { spdx_license_list_version: String },
-    Failed { message: String },
-}
-
 #[derive(Debug)]
 struct ServeState {
-    readiness: Arc<Mutex<ReadinessState>>,
+    spdx_license_list_version: String,
     jobs: AsyncJobController,
 }
 
@@ -147,12 +139,12 @@ impl HttpResponse {
 pub(crate) fn run(args: &ServeArgs) -> Result<()> {
     let config = ServeConfig::try_from(args)?;
 
+    let spdx_license_list_version = LicenseDetectionEngine::embedded_spdx_license_list_version()
+        .map_err(|e| anyhow!("license detection engine failed to initialize: {e}"))?;
+
     let server = Server::http(&config.bind)
         .map_err(|e| anyhow!("Failed to bind provenant serve to {}: {e}", config.bind))?;
     let local_addr = server.server_addr();
-
-    let readiness = Arc::new(Mutex::new(ReadinessState::Pending));
-    start_warm_init(Arc::clone(&readiness));
 
     eprintln!(
         "Starting provenant serve on http://{} (api {API_VERSION})",
@@ -160,28 +152,10 @@ pub(crate) fn run(args: &ServeArgs) -> Result<()> {
     );
 
     let state = ServeState {
-        readiness,
+        spdx_license_list_version,
         jobs: AsyncJobController::new(),
     };
     serve_forever(server, state)
-}
-
-fn start_warm_init(readiness: Arc<Mutex<ReadinessState>>) {
-    thread::spawn(move || {
-        let next_state = match LicenseDetectionEngine::embedded_spdx_license_list_version() {
-            Ok(version) => ReadinessState::Ready {
-                spdx_license_list_version: version,
-            },
-            Err(error) => ReadinessState::Failed {
-                message: error.to_string(),
-            },
-        };
-
-        let mut current = readiness
-            .lock()
-            .expect("serve readiness lock should not be poisoned");
-        *current = next_state;
-    });
 }
 
 fn serve_forever(server: Server, state: ServeState) -> Result<()> {
@@ -257,12 +231,6 @@ fn parse_request(request: &mut tiny_http::Request) -> Result<ParsedRequest, Serv
 }
 
 fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResponse {
-    let readiness = state
-        .readiness
-        .lock()
-        .expect("serve readiness lock should not be poisoned")
-        .clone();
-
     if let Some(job_route) = parse_job_route(&request.path) {
         return match job_route {
             JobRoute::Status(job_id) => {
@@ -297,37 +265,15 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 status: "ok".to_string(),
             },
         ),
-        (m, "/readyz") if *m == Method::Get => match readiness {
-            ReadinessState::Pending => HttpResponse::json(
-                StatusCode::from(503),
-                &crate::serve_api::ServeReadinessResponse {
-                    status: "warming".to_string(),
-                    api_version: None,
-                    spdx_license_list_version: None,
-                    message: None,
-                },
-            ),
-            ReadinessState::Ready {
-                spdx_license_list_version,
-            } => HttpResponse::json(
-                StatusCode::from(200),
-                &crate::serve_api::ServeReadinessResponse {
-                    status: "ready".to_string(),
-                    api_version: Some(API_VERSION.to_string()),
-                    spdx_license_list_version: Some(spdx_license_list_version),
-                    message: None,
-                },
-            ),
-            ReadinessState::Failed { message } => HttpResponse::json(
-                StatusCode::from(503),
-                &crate::serve_api::ServeReadinessResponse {
-                    status: "failed".to_string(),
-                    api_version: None,
-                    spdx_license_list_version: None,
-                    message: Some(message),
-                },
-            ),
-        },
+        (m, "/readyz") if *m == Method::Get => HttpResponse::json(
+            StatusCode::from(200),
+            &crate::serve_api::ServeReadinessResponse {
+                status: "ready".to_string(),
+                api_version: Some(API_VERSION.to_string()),
+                spdx_license_list_version: Some(state.spdx_license_list_version.clone()),
+                message: None,
+            },
+        ),
         (m, "/version") if *m == Method::Get => HttpResponse::json(
             StatusCode::from(200),
             &crate::serve_api::ServeVersionResponse {
@@ -560,9 +506,7 @@ mod tests {
 
     fn ready_state() -> ServeState {
         ServeState {
-            readiness: Arc::new(Mutex::new(ReadinessState::Ready {
-                spdx_license_list_version: "3.28".to_string(),
-            })),
+            spdx_license_list_version: "3.28".to_string(),
             jobs: AsyncJobController::with_limits(2, 2, 8),
         }
     }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -31,8 +31,6 @@ pub(crate) enum ServeError {
     Ingest(#[from] IngestError),
     #[error(transparent)]
     Scan(#[from] ScanError),
-    #[error(transparent)]
-    Workflow(#[from] WorkflowError),
 }
 
 impl ServeError {
@@ -47,8 +45,6 @@ impl ServeError {
             }
             Self::Scan(ScanError::Workflow(WorkflowError::Pipeline(_))) => StatusCode::from(500),
             Self::Scan(ScanError::Serialization(_)) => StatusCode::from(500),
-            Self::Workflow(WorkflowError::InvalidOptions(_)) => StatusCode::from(422),
-            Self::Workflow(WorkflowError::Pipeline(_)) => StatusCode::from(500),
         }
     }
 
@@ -63,8 +59,6 @@ impl ServeError {
             }
             Self::Scan(ScanError::Workflow(WorkflowError::Pipeline(_))) => "scan_failed",
             Self::Scan(ScanError::Serialization(_)) => "scan_failed",
-            Self::Workflow(WorkflowError::InvalidOptions(_)) => "invalid_scan_request",
-            Self::Workflow(WorkflowError::Pipeline(_)) => "scan_failed",
         }
     }
 }

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -68,13 +68,13 @@ pub struct AsyncJobStatusResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct SyncScanRequest {
-    pub input: SyncScanInput,
+pub struct ServeScanRequest {
+    pub input: ServeScanInput,
     #[serde(default)]
-    pub options: SyncScanOptions,
+    pub options: ServeScanOptions,
 }
 
-impl SyncScanRequest {
+impl ServeScanRequest {
     pub fn decode(body: &[u8]) -> Result<Self> {
         serde_json::from_slice(body).context("request body must be valid JSON")
     }
@@ -82,7 +82,7 @@ impl SyncScanRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum SyncScanInput {
+pub enum ServeScanInput {
     Paths {
         paths: Vec<String>,
     },
@@ -102,7 +102,7 @@ pub enum SyncScanInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum SyncLicenseSource {
+pub enum ServeLicenseSource {
     Disabled,
     Embedded,
     Directory { path: String },
@@ -110,9 +110,9 @@ pub enum SyncLicenseSource {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
-pub struct SyncScanOptions {
+pub struct ServeScanOptions {
     pub collect_info: bool,
-    pub detect_license: SyncLicenseSource,
+    pub detect_license: ServeLicenseSource,
     pub detect_packages: bool,
     pub detect_system_packages: bool,
     pub detect_packages_in_compiled: bool,
@@ -142,11 +142,11 @@ pub struct SyncScanOptions {
     pub tallies_by_facet: bool,
 }
 
-impl Default for SyncScanOptions {
+impl Default for ServeScanOptions {
     fn default() -> Self {
         Self {
             collect_info: false,
-            detect_license: SyncLicenseSource::Disabled,
+            detect_license: ServeLicenseSource::Disabled,
             detect_packages: false,
             detect_system_packages: false,
             detect_packages_in_compiled: false,
@@ -251,7 +251,7 @@ pub fn openapi_document() -> Value {
                         "required": true,
                         "content": {
                             "application/json": {
-                                "schema": {"$ref": "#/components/schemas/SyncScanRequest"}
+                                "schema": {"$ref": "#/components/schemas/ServeScanRequest"}
                             }
                         }
                     },
@@ -302,7 +302,7 @@ pub fn openapi_document() -> Value {
                         "required": true,
                         "content": {
                             "application/json": {
-                                "schema": {"$ref": "#/components/schemas/SyncScanRequest"}
+                                "schema": {"$ref": "#/components/schemas/ServeScanRequest"}
                             }
                         }
                     },
@@ -435,10 +435,10 @@ pub fn openapi_document() -> Value {
                 "AsyncJobState": schema_json::<AsyncJobState>(),
                 "AsyncScanAcceptedResponse": schema_json::<AsyncScanAcceptedResponse>(),
                 "AsyncJobStatusResponse": schema_json::<AsyncJobStatusResponse>(),
-                "SyncScanRequest": schema_json::<SyncScanRequest>(),
-                "SyncScanInput": schema_json::<SyncScanInput>(),
-                "SyncLicenseSource": schema_json::<SyncLicenseSource>(),
-                "SyncScanOptions": schema_json::<SyncScanOptions>()
+                "ServeScanRequest": schema_json::<ServeScanRequest>(),
+                "ServeScanInput": schema_json::<ServeScanInput>(),
+                "ServeLicenseSource": schema_json::<ServeLicenseSource>(),
+                "ServeScanOptions": schema_json::<ServeScanOptions>()
             }
         }
     })

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -100,15 +100,18 @@ pub enum ServeScanInput {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServeLicenseSource {
+    #[default]
     Disabled,
     Embedded,
-    Directory { path: String },
+    Directory {
+        path: String,
+    },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct ServeScanOptions {
     pub collect_info: bool,
@@ -140,42 +143,6 @@ pub struct ServeScanOptions {
     pub tallies_with_details: bool,
     pub facets: Vec<String>,
     pub tallies_by_facet: bool,
-}
-
-impl Default for ServeScanOptions {
-    fn default() -> Self {
-        Self {
-            collect_info: false,
-            detect_license: ServeLicenseSource::Disabled,
-            detect_packages: false,
-            detect_system_packages: false,
-            detect_packages_in_compiled: false,
-            detect_copyrights: false,
-            detect_emails: false,
-            detect_urls: false,
-            detect_generated: false,
-            include: Vec::new(),
-            exclude: Vec::new(),
-            strip_root: false,
-            full_root: false,
-            license_text: false,
-            license_text_diagnostics: false,
-            license_diagnostics: false,
-            unknown_licenses: false,
-            license_score: 0,
-            only_findings: false,
-            mark_source: false,
-            classify: false,
-            summary: false,
-            license_clarity_score: false,
-            license_references: false,
-            tallies: false,
-            tallies_key_files: false,
-            tallies_with_details: false,
-            facets: Vec::new(),
-            tallies_by_facet: false,
-        }
-    }
 }
 
 pub fn openapi_document() -> Value {

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{Context, Result};
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -71,6 +72,12 @@ pub struct SyncScanRequest {
     pub input: SyncScanInput,
     #[serde(default)]
     pub options: SyncScanOptions,
+}
+
+impl SyncScanRequest {
+    pub fn decode(body: &[u8]) -> Result<Self> {
+        serde_json::from_slice(body).context("request body must be valid JSON")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -447,3 +447,20 @@ pub fn openapi_document() -> Value {
 fn schema_json<T: JsonSchema>() -> Value {
     serde_json::to_value(schema_for!(T)).expect("schema should serialize")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_rejects_invalid_json() {
+        let error =
+            ServeScanRequest::decode(br#"{"input": }"#).expect_err("malformed JSON should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("request body must be valid JSON")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the hand-rolled HTTP parser (`parse_http_request`) and raw TCP response writer (`write_http_response`) with `tiny_http`, a lightweight synchronous HTTP server crate that handles request parsing, response serialization, and server lifecycle.
- Extract `AsyncJobController` into `src/serve/job_controller.rs` with a cleaner contract: `submit()` returns `(response, dispatches)` and `complete_job()` accepts a `JobOutcome` enum, decoupling the controller from scan execution.
- Remove the explicit `http = "1"` dependency; `http::StatusCode` is replaced by `tiny_http::StatusCode` throughout. The `http` crate remains available as a transitive dependency via `reqwest`/`hyper`.
- Replace `http::StatusCode` named constants with `tiny_http::StatusCode::from(NNN)` since `tiny_http` only provides numeric constructors.
- Delete the `parse_http_request_rejects_oversized_body` test that was specific to the hand-rolled parser; body-size enforcement is now covered by `parse_request`'s content-length + take guard.

## Follow-up refactoring (new in this PR)

After the initial tiny_http migration, the following idiomatic improvements were implemented:

- **Remove unreachable `ServeError::Workflow`** — all `WorkflowError` values flow through `ScanError::Workflow`; the direct variant was dead code.
- **Replace `ReadinessState` with synchronous init** — eliminate `Arc<Mutex<ReadinessState>>` and background warm-init thread; `run()` now calls `LicenseDetectionEngine::embedded_spdx_license_list_version()` before binding, and `/readyz` always returns 200.
- **Replace `AsyncJobResultSnapshot` with `JobResult` enum** — state-carrying enum eliminates `unreachable!()` and `.expect()` on `result_body` in `handle_job_result_request`.
- **`ArchiveFormat` enum** — unify the implicit suffix-matching contract between `looks_like_supported_archive` and `extract_archive` into a single `detect_archive_format()` returning `Option<ArchiveFormat>`.
- **Single file open in `extract_archive`** — open the archive file once before the format match instead of 5 separate `File::open` calls.
- **Shared `extract_entry` helper** — DRY the duplicated directory-creation, limits-check, file-creation, `io::copy` logic between zip and tar extraction.
- **Derive `Default`** on `ServeScanOptions` and `ServeLicenseSource` — replace 33-line manual `Default` impl.
- **Move `SyncScanExecution` to `ingest.rs`** — with `new()`, `execute()`, `run_async()` methods; added `From<ServeLicenseSource> for LicenseSource` and `From<ServeScanOptions> for ScanOptions`; eliminated `PreparedSyncInput`.
- **Rename Sync\* → Serve\*** — `SyncScanOptions` → `ServeScanOptions`, etc., for API consistency.
- **Idiomatic method placement** — `HttpResponse::json/error/into_tiny_response`, `ServeScanRequest::decode`, `AsyncJobController::default_processor_budget`.
- **Remove `HandlerResult` alias** — handlers return `HttpResponse` directly with explicit control flow.
- **Fix `insert_job` test helper** — now adds terminal records to the `completed` deque, matching production behavior.
- **Drop redundant test** — `sync_scan_execution_rejects_non_http_url` duplicates `url_input_rejects_non_http_scheme`.
- **Add 5 missing tests** — 404 not-found, `parse_job_route` edge cases, out-of-range error status code fallback, `normalize_archive_path` with `CurDir`, unsupported archive format.

## Scope and exclusions

- Included: `src/serve/mod.rs`, `src/serve/ingest.rs`, `src/serve/job_controller.rs`, `src/serve_api.rs`, `Cargo.toml`, `Cargo.lock`
- Explicit exclusions: No changes to non-serve modules. No behavior changes to scan execution or API contracts.

## Intentional differences from Python

- None. The HTTP interface is Provenant-specific and has no Python ScanCode counterpart.

## Expected-output fixture changes

- None.