### PR TITLE
refactor: switch internal cache/spill serialization from serde_json to postcard

### DIFF
--- a/src/cache/incremental.rs
+++ b/src/cache/incremental.rs
@@ -14,8 +14,8 @@ use super::locking::with_exclusive_cache_lock;
 use crate::models::{FileInfo, Sha256Digest};
 use crate::utils::hash::calculate_sha256;
 
-const INCREMENTAL_MANIFEST_VERSION: u32 = 4;
-const MANIFEST_FILE_NAME: &str = "manifest.json";
+const INCREMENTAL_MANIFEST_VERSION: u32 = 5;
+const MANIFEST_FILE_NAME: &str = "manifest.postcard";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileStateFingerprint {
@@ -101,7 +101,7 @@ pub fn load_incremental_manifest(
         Err(err) => return Err(err),
     };
 
-    let manifest: IncrementalManifest = match serde_json::from_slice(&bytes) {
+    let manifest: IncrementalManifest = match postcard::from_bytes(&bytes) {
         Ok(manifest) => manifest,
         Err(_) => return Ok(None),
     };
@@ -118,7 +118,7 @@ pub fn write_incremental_manifest(
     manifest_path: &Path,
     manifest: &IncrementalManifest,
 ) -> io::Result<()> {
-    let bytes = serde_json::to_vec_pretty(manifest)
+    let bytes = postcard::to_allocvec(manifest)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
     with_exclusive_cache_lock(cache_root, || write_bytes_atomically(manifest_path, &bytes))

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -1193,7 +1193,9 @@ fn build_collection_exclude_patterns_skips_explicit_in_tree_cache_dir() {
     fs::create_dir_all(explicit_cache_dir.join("incremental")).unwrap();
     fs::write(scan_root.join("docs").join("README.md"), "hello").unwrap();
     fs::write(
-        explicit_cache_dir.join("incremental").join("manifest.json"),
+        explicit_cache_dir
+            .join("incremental")
+            .join("manifest.postcard"),
         "cached",
     )
     .unwrap();

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -512,7 +512,7 @@ pub struct PackageData {
     pub is_private: bool,
     #[serde(default)]
     pub is_virtual: bool,
-    #[serde(default)]
+    #[serde(default, with = "super::json_value_map")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     pub dependencies: Vec<Dependency>,
@@ -623,7 +623,7 @@ pub struct Dependency {
     pub is_pinned: Option<bool>,
     pub is_direct: Option<bool>,
     pub resolved_package: Option<Box<ResolvedPackage>>,
-    #[serde(default)]
+    #[serde(default, with = "super::json_value_map")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
 }
 
@@ -673,7 +673,7 @@ pub struct ResolvedPackage {
     pub is_private: bool,
     #[serde(default)]
     pub is_virtual: bool,
-    #[serde(default)]
+    #[serde(default, with = "super::json_value_map")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     pub dependencies: Vec<Dependency>,
@@ -852,6 +852,7 @@ pub struct FileReference {
     pub md5: Option<Md5Digest>,
     pub sha256: Option<Sha256Digest>,
     pub sha512: Option<Sha512Digest>,
+    #[serde(with = "super::json_value_map")]
     pub extra_data: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
@@ -922,7 +923,7 @@ pub struct Package {
     pub is_private: bool,
     #[serde(default)]
     pub is_virtual: bool,
-    #[serde(default)]
+    #[serde(default, with = "super::json_value_map")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
     pub repository_homepage_url: Option<String>,
     pub repository_download_url: Option<String>,
@@ -1390,7 +1391,7 @@ pub struct TopLevelDependency {
     pub is_pinned: Option<bool>,
     pub is_direct: Option<bool>,
     pub resolved_package: Option<Box<ResolvedPackage>>,
-    #[serde(default)]
+    #[serde(default, with = "super::json_value_map")]
     pub extra_data: Option<HashMap<String, serde_json::Value>>,
     /// Unique identifier for this dependency instance (PURL with UUID qualifier).
     pub dependency_uid: DependencyUid,

--- a/src/models/json_value_map.rs
+++ b/src/models/json_value_map.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub fn serialize<S: Serializer>(
+    value: &Option<HashMap<String, Value>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        None => Option::<HashMap<String, String>>::None.serialize(serializer),
+        Some(map) => {
+            let string_map: HashMap<String, String> = map
+                .iter()
+                .map(|(k, v)| {
+                    serde_json::to_string(v)
+                        .map(|s| (k.clone(), s))
+                        .map_err(serde::ser::Error::custom)
+                })
+                .collect::<Result<_, _>>()?;
+            Some(string_map).serialize(serializer)
+        }
+    }
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, Value>>, D::Error> {
+    let string_map: Option<HashMap<String, String>> = Option::deserialize(deserializer)?;
+    match string_map {
+        None => Ok(None),
+        Some(map) => {
+            let value_map: HashMap<String, Value> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    serde_json::from_str(&v)
+                        .map(|val| (k, val))
+                        .map_err(serde::de::Error::custom)
+                })
+                .collect::<Result<_, _>>()?;
+            Ok(Some(value_map))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_postcard() {
+        let mut map: HashMap<String, Value> = HashMap::new();
+        map.insert("string_val".to_string(), serde_json::json!("hello"));
+        map.insert("number_val".to_string(), serde_json::json!(42));
+        map.insert("float_val".to_string(), serde_json::json!(2.5));
+        map.insert("bool_val".to_string(), serde_json::json!(true));
+        map.insert("null_val".to_string(), serde_json::json!(null));
+        map.insert(
+            "object_val".to_string(),
+            serde_json::json!({"nested": "data"}),
+        );
+        map.insert("array_val".to_string(), serde_json::json!([1, "two", true]));
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Wrapper {
+            #[serde(with = "super")]
+            data: Option<HashMap<String, Value>>,
+        }
+
+        let original = Wrapper { data: Some(map) };
+        let bytes = postcard::to_allocvec(&original).expect("serialize");
+        let restored: Wrapper = postcard::from_bytes(&bytes).expect("deserialize");
+
+        assert_eq!(
+            restored.data.as_ref().unwrap()["string_val"],
+            serde_json::json!("hello")
+        );
+        assert_eq!(
+            restored.data.as_ref().unwrap()["number_val"],
+            serde_json::json!(42)
+        );
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ mod dependency_uid;
 mod diagnostic;
 mod digest;
 pub(crate) mod file_info;
+mod json_value_map;
 mod line_number;
 mod match_score;
 mod output;

--- a/src/scanner/process/spill.rs
+++ b/src/scanner/process/spill.rs
@@ -69,10 +69,10 @@ impl FileInfoSpillStore {
         let path = self
             .temp_dir
             .path()
-            .join(format!("batch-{:06}.json.zst", self.batch_index));
+            .join(format!("batch-{:06}.postcard.zst", self.batch_index));
         self.batch_index += 1;
 
-        let payload = serde_json::to_vec(&files).expect("encode spilled file batch");
+        let payload = postcard::to_allocvec(&files).expect("encode spilled file batch");
         let file = File::create(path).expect("create spill batch file");
         let mut encoder = zstd::Encoder::new(file, 3).expect("create spill encoder");
         encoder
@@ -96,7 +96,7 @@ impl FileInfoSpillStore {
             let mut payload = Vec::new();
             decoder.read_to_end(&mut payload).expect("read spill batch");
             let mut batch: Vec<FileInfo> =
-                serde_json::from_slice(&payload).expect("decode spilled file batch");
+                postcard::from_bytes(&payload).expect("decode spilled file batch");
             files.append(&mut batch);
         }
         files


### PR DESCRIPTION
## Summary

- Replace `serde_json` with `postcard` for the spill store (`src/scanner/process/spill.rs`) and incremental cache manifest (`src/cache/incremental.rs`)
- Add `json_value_map` serde adapter module (`src/models/json_value_map.rs`) that converts `HashMap<String, serde_json::Value>` to/from `HashMap<String, String>` for postcard compatibility (postcard returns `WontImplement` for `serde_json::Value` since it does not support self-describing deserialization)
- Apply `#[serde(with = "super::json_value_map")]` to all 6 `extra_data` fields across `PackageData`, `Dependency`, `ResolvedPackage`, `FileReference`, `Package`, `TopLevelDependency`
- Bump incremental manifest version 4 → 5 (old manifests gracefully invalidated)

## Issues

- Related to: #906

## Scope and exclusions

- Included: spill store format switch, incremental manifest format switch, json_value_map adapter, manifest version bump, test updates
- Explicit exclusions: license dataset manifest (`dataset.rs`) stays JSON (user-facing file); no rkyv changes; no new dependencies

## Intentional differences from Python

- N/A (internal serialization format, no output behavior change)

## Follow-up work

- The redundant second manifest load in `scan_pipeline.rs:608-617` could be eliminated to avoid deserializing the manifest twice per incremental scan

## Expected-output fixture changes

- None (internal format change only, no output behavior change)