### PR TITLE
docs(benchmarks): record lambda al2 yumdb target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 200 of 200 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 201 of 201 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1271,6 +1271,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-05 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `19.47s`; ScanCode `23.84s`
 - Equal top-level Alpine package count with Alpine-native installed-db dependency requirements and virtual providers preserved, plus cleaner BusyBox/OpenSSL binary-text normalization and richer `os-release` package identity
+
+##### [lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11](https://hub.docker.com/r/lambci/lambda) — **18.40× faster**
+
+- Files: 4,085
+- Run context: 2026-06-03 · lambci-lambda-provided-al2-amd64-rootfs-50088 · macOS 26.5.0 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `17.19s`; ScanCode `316.25s`
+- Broader Amazon Linux 2 RPM rootfs inventory (`45` vs `0` packages, `590` vs `0` dependencies) from the real Berkeley rpmdb, with YumDB sidecar provenance merged onto matching installed RPM packages under `extra_data.yumdb` for repository, checksum, origin, and install-reason metadata while ScanCode reports one rpmdb assembly error and leaves top-level package/dependency output empty
 
 ##### [debian:bookworm-slim @ sha256:f065376](https://hub.docker.com/layers/library/debian/bookworm-slim/images/sha256-f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a) — **7.47× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -491,6 +491,9 @@ ScanCode: 446.79s</title></rect>
     <rect x="664.50" y="341.57" width="8" height="8" fill="#d97706" rx="1.5"><title>yairm210/Unciv @ d54f33c
 Files: 4057
 ScanCode: 429.19s</title></rect>
+    <rect x="664.98" y="356.00" width="8" height="8" fill="#d97706" rx="1.5"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
+Files: 4085
+ScanCode: 316.25s</title></rect>
     <rect x="667.96" y="325.26" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
 Files: 4266
 ScanCode: 606.05s</title></rect>
@@ -1093,6 +1096,9 @@ Provenant: 23.74s</title></circle>
     <circle cx="668.50" cy="486.03" r="4.5" fill="#2563eb"><title>yairm210/Unciv @ d54f33c
 Files: 4057
 Provenant: 21.96s</title></circle>
+    <circle cx="668.98" cy="497.60" r="4.5" fill="#2563eb"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
+Files: 4085
+Provenant: 17.19s</title></circle>
     <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
 Files: 4266
 Provenant: 40.75s</title></circle>

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -657,7 +657,7 @@ pub fn merge_rpm_yumdb_metadata(files: &mut [FileInfo], packages: &mut Vec<Packa
 
             (target_root == yumdb_root
                 && package.name == yumdb_package.name
-                && package.version == yumdb_package.version
+                && rpm_yumdb_versions_match(&package.version, &yumdb_package.version)
                 && target_arch == yumdb_arch)
                 .then_some(idx)
         }) else {
@@ -704,6 +704,22 @@ pub fn merge_rpm_yumdb_metadata(files: &mut [FileInfo], packages: &mut Vec<Packa
     removal_indices.dedup();
     for idx in removal_indices.into_iter().rev() {
         packages.remove(idx);
+    }
+}
+
+fn rpm_yumdb_versions_match(
+    rpmdb_version: &Option<String>,
+    yumdb_version: &Option<String>,
+) -> bool {
+    match (rpmdb_version.as_deref(), yumdb_version.as_deref()) {
+        (Some(rpmdb), Some(yumdb)) => {
+            rpmdb == yumdb
+                || rpmdb
+                    .split_once(':')
+                    .is_some_and(|(_, version)| version == yumdb)
+        }
+        (None, None) => true,
+        _ => false,
     }
 }
 

--- a/src/assembly/file_ref_resolve_test.rs
+++ b/src/assembly/file_ref_resolve_test.rs
@@ -853,6 +853,22 @@ fn test_resolve_rpm_namespace() {
 }
 
 #[test]
+fn test_rpm_yumdb_versions_match_ignores_rpmdb_epoch() {
+    assert!(rpm_yumdb_versions_match(
+        &Some("1:6.0.0-15.amzn2.0.2".to_string()),
+        &Some("6.0.0-15.amzn2.0.2".to_string()),
+    ));
+    assert!(rpm_yumdb_versions_match(
+        &Some("6.0.0-15.amzn2.0.2".to_string()),
+        &Some("6.0.0-15.amzn2.0.2".to_string()),
+    ));
+    assert!(!rpm_yumdb_versions_match(
+        &Some("2:6.0.0-15.amzn2.0.2".to_string()),
+        &Some("6.0.0-15.amzn2.0.3".to_string()),
+    ));
+}
+
+#[test]
 fn test_merge_rpm_yumdb_metadata() {
     let mut files = vec![
         FileInfo {

--- a/src/parsers/rpm_yumdb.rs
+++ b/src/parsers/rpm_yumdb.rs
@@ -24,7 +24,8 @@ fn default_package_data() -> PackageData {
 
 fn parse_yumdb_dir_name(dir_name: &str) -> Option<(String, String, String)> {
     let (_, package_part) = dir_name.split_once('-')?;
-    let (name_version_release, arch) = package_part.rsplit_once('.')?;
+
+    let (name_version_release, arch) = split_yumdb_arch(package_part)?;
 
     let mut parts = name_version_release.rsplitn(3, '-');
     let release = parts.next()?;
@@ -36,6 +37,21 @@ fn parse_yumdb_dir_name(dir_name: &str) -> Option<(String, String, String)> {
         truncate_field(format!("{}-{}", version, release)),
         truncate_field(arch.to_string()),
     ))
+}
+
+fn split_yumdb_arch(package_part: &str) -> Option<(&str, &str)> {
+    if let Some((name_version_release, arch)) = package_part.rsplit_once('-')
+        && is_plausible_rpm_arch(arch)
+    {
+        return Some((name_version_release, arch));
+    }
+
+    package_part.rsplit_once('.')
+}
+
+fn is_plausible_rpm_arch(arch: &str) -> bool {
+    arch.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && arch.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 fn build_yumdb_purl(name: &str, version: &str, arch: &str) -> Option<String> {
@@ -150,6 +166,14 @@ mod tests {
         let parsed = parse_yumdb_dir_name("abc123-bash-5.0-1.el8.x86_64").unwrap();
         assert_eq!(parsed.0, "bash");
         assert_eq!(parsed.1, "5.0-1.el8");
+        assert_eq!(parsed.2, "x86_64");
+
+        let parsed = parse_yumdb_dir_name(
+            "f5d239a7a36834cca0361050b89f9dcf6675df03-bash-4.2.46-34.amzn2-x86_64",
+        )
+        .unwrap();
+        assert_eq!(parsed.0, "bash");
+        assert_eq!(parsed.1, "4.2.46-34.amzn2");
         assert_eq!(parsed.2, "x86_64");
     }
 


### PR DESCRIPTION
## Summary

- Fix YumDB parsing for Amazon Linux 2 directory names that encode arch after the final hyphen.
- Merge YumDB metadata into matching rpmdb packages when rpmdb versions include an epoch and YumDB versions omit it.
- Record the verified lambci/lambda:provided.al2 linux/amd64 YumDB benchmark and refresh the benchmark chart.

## Scope and exclusions

- Included: RPM YumDB parser/assembly fixes, focused regression coverage, docs/BENCHMARKS.md row, regenerated scan-duration chart.
- Explicit exclusions: no broad RPM parser refactor, no synthetic YumDB fixture benchmark, no generated compare artifacts committed.

## Intentional differences from Python

- Provenant statically extracts installed RPM packages and dependencies from the AL2 rpmdb and merges YumDB sidecar provenance onto matching packages. The verified ScanCode run reports one rpmdb assembly error and leaves top-level package/dependency output empty on this target.

## Follow-up work

- Created or intentionally deferred: none.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: no golden expected files changed; new focused tests cover AL2 YumDB directory parsing and epoch-insensitive YumDB/rpmdb matching.

## Verification

- Compare run: .provenant/compare-runs/20260603T140934Z-lambci-lambda-provided-al2-amd64-rootfs-50088
- Target: lambci/lambda:provided.al2 linux/amd64, digest lambci/lambda@sha256:7765ec11e11603d4123630148e115f980812c33f7ab6943c5cbfafccca0f2f17
- Result: Provenant 17.19s; ScanCode 316.25s; 18.40x faster; Provenant 45 packages / 590 dependencies vs ScanCode 0 / 0
- cargo fmt --check
- cargo test --lib test_parse_yumdb_dir_name
- cargo test --lib test_rpm_yumdb_versions_match_ignores_rpmdb_epoch
- cargo test --lib test_merge_rpm_yumdb_metadata
- cargo test --lib test_rpm_yumdb_scan_assembles_virtual_package_and_preserves_metadata
- cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart -- --check
- npm run check:docs
- git diff --check