### PR TITLE
fix(finder): filter FTP method URL false positives

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 201 of 201 recorded runs, with a **12.1× median speedup** and **11.3× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 202 of 202 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -206,6 +206,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-05-05 · pyodide-13754 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `10.77s`; ScanCode `135.33s`
 - Broader dependency extraction (`796` vs `718`) and slightly broader package visibility (`53` vs `52`) from `environment.yml`, `.gitmodules`, and committed wheel artifacts, with extension-qualified wheel PURLs, richer patch-header author recovery, and the fuller `Pyodide contributors and Mozilla` documentation notice
+
+##### [python/cpython @ 7a468a1](https://github.com/python/cpython/tree/7a468a101268d2b13105f94ae027df8b502d0c87) — **44.49× faster**
+
+- Files: 5,627
+- Run context: 2026-06-03 · cpython-8615 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `27.46s`; ScanCode `1221.65s`
+- Direct PEP 751 `Doc/pylock.toml` package visibility with 29 pinned PyPI documentation dependencies where ScanCode leaves the lockfile dependency-blind, plus cleaner FTP documentation URL extraction that keeps real FTP hosts while rejecting `ftp.*` method and member references
 
 ##### [python-poetry/poetry @ bfce511](https://github.com/python-poetry/poetry/tree/bfce5118814fa95445e823cb07a59bd77ffe1474) — **4.20× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -518,6 +518,9 @@ ScanCode: 379.55s</title></rect>
     <rect x="683.62" y="336.32" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/felix-dev @ 20aee77
 Files: 5354
 ScanCode: 479.56s</title></rect>
+    <rect x="687.04" y="292.14" width="8" height="8" fill="#d97706" rx="1.5"><title>python/cpython @ 7a468a1
+Files: 5627
+ScanCode: 1221.65s</title></rect>
     <rect x="692.31" y="293.00" width="8" height="8" fill="#d97706" rx="1.5"><title>openssl/openssl @ 7fb28b9
 Files: 6074
 ScanCode: 1199.73s</title></rect>
@@ -1123,6 +1126,9 @@ Provenant: 38.15s</title></circle>
     <circle cx="687.62" cy="444.62" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
 Files: 5354
 Provenant: 52.75s</title></circle>
+    <circle cx="691.04" cy="475.47" r="4.5" fill="#2563eb"><title>python/cpython @ 7a468a1
+Files: 5627
+Provenant: 27.46s</title></circle>
     <circle cx="696.31" cy="439.39" r="4.5" fill="#2563eb"><title>openssl/openssl @ 7fb28b9
 Files: 6074
 Provenant: 58.93s</title></circle>

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -342,6 +342,15 @@ mod tests {
     }
 
     #[test]
+    fn test_find_urls_ignores_bare_ftp_method_references() {
+        let text = "Use ftp.login(), ftp.cwd('/pub'), ftp.quit(), and ftp.passiveserver.";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        assert!(urls.is_empty(), "urls: {urls:#?}");
+    }
+
+    #[test]
     fn test_find_urls_keeps_ftp_hostname_after_punctuation() {
         let text = "Download: ftp.gnu.org/gnu/tar/ and also (ftp.mozilla.org/pub/)";
         let config = DetectionConfig::default();

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -112,6 +112,26 @@ fn add_fake_scheme(url: &str) -> String {
     }
 }
 
+fn is_bare_ftp_method_reference(candidate: &str) -> bool {
+    let candidate = candidate
+        .to_ascii_lowercase()
+        .trim_end_matches(|c: char| [',', '.', ':', ';', '!', '?'].contains(&c))
+        .to_string();
+    if !candidate.starts_with("ftp.") {
+        return false;
+    }
+
+    if !candidate.contains('/') && candidate.matches('.').count() == 1 {
+        return true;
+    }
+
+    let Some(paren_index) = candidate.find('(') else {
+        return false;
+    };
+
+    !candidate[..paren_index].contains('/')
+}
+
 fn remove_user_password(url: &str) -> Option<String> {
     if !is_filterable(url) {
         return Some(url.to_string());
@@ -167,6 +187,10 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
                 }
 
                 let mut candidate = matched.as_str().to_string();
+
+                if is_bare_ftp_method_reference(&candidate) {
+                    continue;
+                }
 
                 candidate = verbatim_crlf_url_cleaner(&candidate);
                 candidate = end_of_url_cleaner(&candidate);


### PR DESCRIPTION
## Summary

- Filters bare `ftp.*` method/member references out of URL detection while preserving real FTP hostnames.
- Records the verified `python/cpython` `Doc/pylock.toml` benchmark target and regenerates the benchmark chart.
- Verified target: `python/cpython @ 7a468a101268d2b13105f94ae027df8b502d0c87`, compare run `.provenant/compare-runs/20260603T153939Z-cpython-8615`.

## Scope and exclusions

- Included: generic URL false-positive reduction, focused finder regression coverage, CPython benchmark entry, regenerated `docs/scan-duration-vs-files.svg`.
- Explicit exclusions: later RPM Mariner and Go graph benchmark targets.

## Validation

- `cargo test --lib finder::tests::test_find_urls`
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart -- --check`
- `npm run check:docs`
- pre-commit hook: clippy, license headers, markdown lint, prettier, rustfmt

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: no golden or parser fixture output changed.