### PR TITLE
fix(rpm): improve Mariner rootfs package assembly

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 202 of 202 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 203 of 203 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1278,6 +1278,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-05 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `19.47s`; ScanCode `23.84s`
 - Equal top-level Alpine package count with Alpine-native installed-db dependency requirements and virtual providers preserved, plus cleaner BusyBox/OpenSSL binary-text normalization and richer `os-release` package identity
+
+##### [Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9](https://mcr.microsoft.com/product/azurelinux/distroless/minimal/about) — **8.62× faster**
+
+- Files: 1,844
+- Run context: 2026-06-03 · rootfs-74993 · macOS 26.5.0 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.26s`; ScanCode `62.57s`
+- Matched Azure Linux and Mariner RPM manifest package coverage (`5` vs `5`) from `var/lib/rpmmanifest/container-manifest-2`, with RPM package-license sidecar metadata merged from `/usr/share/licenses/*` and direct Linux distro PURL identity on `usr/lib/os-release`
 
 ##### [lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11](https://hub.docker.com/r/lambci/lambda) — **18.40× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -404,6 +404,9 @@ ScanCode: 563.43s</title></rect>
     <rect x="607.89" y="346.71" width="8" height="8" fill="#d97706" rx="1.5"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 ScanCode: 384.96s</title></rect>
+    <rect x="610.17" y="432.56" width="8" height="8" fill="#d97706" rx="1.5"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
+Files: 1844
+ScanCode: 62.57s</title></rect>
     <rect x="613.31" y="384.18" width="8" height="8" fill="#d97706" rx="1.5"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 ScanCode: 174.19s</title></rect>
@@ -1012,6 +1015,9 @@ Provenant: 27.87s</title></circle>
     <circle cx="611.89" cy="491.89" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 Provenant: 19.40s</title></circle>
+    <circle cx="614.17" cy="538.33" r="4.5" fill="#2563eb"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
+Files: 1844
+Provenant: 7.26s</title></circle>
     <circle cx="617.31" cy="514.08" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
 Provenant: 12.13s</title></circle>

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -729,12 +729,6 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["opam", "*.opam"],
         mode: AssemblyMode::SiblingMerge,
     },
-    // RPM Mariner manifest
-    AssemblerConfig {
-        datasource_ids: &[DatasourceId::RpmMarinerManifest],
-        sibling_file_patterns: &["*.rpm.manifest"],
-        mode: AssemblyMode::SiblingMerge,
-    },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::RpmYumdb],
         sibling_file_patterns: &["**/var/lib/yum/yumdb/*/*/from_repo"],
@@ -800,8 +794,14 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             DatasourceId::RpmInstalledDatabaseBdb,
             DatasourceId::RpmInstalledDatabaseNdb,
             DatasourceId::RpmInstalledDatabaseSqlite,
+            DatasourceId::RpmMarinerManifest,
         ],
-        sibling_file_patterns: &["Packages", "Packages.db", "rpmdb.sqlite"],
+        sibling_file_patterns: &[
+            "Packages",
+            "Packages.db",
+            "rpmdb.sqlite",
+            "container-manifest-2",
+        ],
         mode: AssemblyMode::OnePerPackageData,
     },
     AssemblerConfig {

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::str::FromStr;
 
-use crate::models::{DatasourceId, FileInfo, Package, TopLevelDependency};
+use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
 use packageurl::PackageUrl;
 use strum::EnumIter;
 
@@ -60,6 +60,10 @@ const DB_PATH_CONFIGS: &[DbPathConfig] = &[
         path_suffix: "var/lib/rpm/rpmdb.sqlite",
     },
     DbPathConfig {
+        datasource_ids: &[DatasourceId::RpmMarinerManifest],
+        path_suffix: "var/lib/rpmmanifest/container-manifest-2",
+    },
+    DbPathConfig {
         datasource_ids: &[DatasourceId::DebianInstalledStatusDb],
         path_suffix: "var/lib/dpkg/status",
     },
@@ -73,6 +77,7 @@ const RPM_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::RpmInstalledDatabaseBdb,
     DatasourceId::RpmInstalledDatabaseNdb,
     DatasourceId::RpmInstalledDatabaseSqlite,
+    DatasourceId::RpmMarinerManifest,
 ];
 const RPM_YUMDB_PATH_SUFFIX: &str = "var/lib/yum/yumdb/";
 const CONDA_META_PATH_SEGMENT: &str = "conda-meta/";
@@ -87,12 +92,15 @@ const DEBIAN_INSTALLED_SUPPLEMENTAL_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::DebianInstalledFilesList,
     DatasourceId::DebianInstalledMd5Sums,
 ];
+const RPM_INSTALLED_SUPPLEMENTAL_DATASOURCE_IDS: &[DatasourceId] =
+    &[DatasourceId::RpmPackageLicenses];
 
 const INSTALLED_DB_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::AlpineInstalledDb,
     DatasourceId::RpmInstalledDatabaseBdb,
     DatasourceId::RpmInstalledDatabaseNdb,
     DatasourceId::RpmInstalledDatabaseSqlite,
+    DatasourceId::RpmMarinerManifest,
     DatasourceId::DebianInstalledStatusDb,
     DatasourceId::DebianDistrolessInstalledDb,
 ];
@@ -361,6 +369,10 @@ fn resolve_installed_db_file_references(
             &mut file_references,
             collect_debian_installed_file_references(files, package),
         );
+    }
+
+    if is_rpm_package(package) {
+        merge_rpm_installed_supplemental_package_data(files, package, dependencies, &root);
     }
 
     let mut missing_refs = Vec::new();
@@ -868,6 +880,89 @@ fn collect_debian_installed_file_references(
     refs
 }
 
+fn merge_rpm_installed_supplemental_package_data(
+    files: &mut [FileInfo],
+    package: &mut Package,
+    dependencies: &mut [TopLevelDependency],
+    root: &str,
+) {
+    let mut supplemental_package_data: Vec<(usize, PackageData, String)> = Vec::new();
+    for (file_idx, file) in files.iter().enumerate() {
+        for pkg_data in &file.package_data {
+            let Some(dsid) = pkg_data.datasource_id else {
+                continue;
+            };
+            if !RPM_INSTALLED_SUPPLEMENTAL_DATASOURCE_IDS.contains(&dsid) {
+                continue;
+            }
+            if !rpm_installed_license_file_in_root(&file.path, root) {
+                continue;
+            }
+            if pkg_data.name != package.name {
+                continue;
+            }
+            if !rpm_installed_namespace_matches(&pkg_data.namespace, &package.namespace) {
+                continue;
+            }
+
+            supplemental_package_data.push((file_idx, pkg_data.clone(), file.path.clone()));
+        }
+    }
+
+    for (file_idx, pkg_data, datafile_path) in supplemental_package_data {
+        let old_package_uid = package.package_uid.clone();
+        package.update(&pkg_data, datafile_path);
+        if package.package_uid != old_package_uid {
+            replace_package_uid(files, dependencies, &old_package_uid, &package.package_uid);
+        }
+
+        if !files[file_idx].for_packages.contains(&package.package_uid) {
+            files[file_idx]
+                .for_packages
+                .push(package.package_uid.clone());
+        }
+    }
+}
+
+fn rpm_installed_license_file_in_root(path: &str, root: &str) -> bool {
+    let expected_prefix = format!("{}usr/share/licenses/", root);
+    path.starts_with(&expected_prefix)
+}
+
+fn rpm_installed_namespace_matches(
+    supplemental_namespace: &Option<String>,
+    package_namespace: &Option<String>,
+) -> bool {
+    match (
+        supplemental_namespace.as_deref(),
+        package_namespace.as_deref(),
+    ) {
+        (Some(left), Some(right)) => left == right,
+        _ => true,
+    }
+}
+
+fn replace_package_uid(
+    files: &mut [FileInfo],
+    dependencies: &mut [TopLevelDependency],
+    old_package_uid: &crate::models::PackageUid,
+    new_package_uid: &crate::models::PackageUid,
+) {
+    for file in files.iter_mut() {
+        for package_uid in &mut file.for_packages {
+            if package_uid == old_package_uid {
+                *package_uid = new_package_uid.clone();
+            }
+        }
+    }
+
+    for dep in dependencies.iter_mut() {
+        if dep.for_package_uid.as_ref() == Some(old_package_uid) {
+            dep.for_package_uid = Some(new_package_uid.clone());
+        }
+    }
+}
+
 fn find_attached_manifest_file_references<'a>(
     files: &'a [FileInfo],
     package: &Package,
@@ -1009,6 +1104,10 @@ fn apply_rpm_namespace(
     dependencies: &mut [TopLevelDependency],
     namespace: &str,
 ) {
+    if package.namespace.is_some() {
+        return;
+    }
+
     let old_package_uid = package.package_uid.clone();
 
     package.namespace = Some(namespace.to_string());
@@ -1020,19 +1119,9 @@ fn apply_rpm_namespace(
         package.package_uid = old_package_uid.replace_base(&updated_purl);
     }
 
-    for file in files.iter_mut() {
-        for package_uid in &mut file.for_packages {
-            if *package_uid == old_package_uid {
-                *package_uid = package.package_uid.clone();
-            }
-        }
-    }
+    replace_package_uid(files, dependencies, &old_package_uid, &package.package_uid);
 
     for dep in dependencies.iter_mut() {
-        if dep.for_package_uid.as_ref() == Some(&old_package_uid) {
-            dep.for_package_uid = Some(package.package_uid.clone());
-        }
-
         if dep.for_package_uid.as_ref() == Some(&package.package_uid) {
             dep.namespace = Some(namespace.to_string());
 

--- a/src/parsers/os_release.rs
+++ b/src/parsers/os_release.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use packageurl::PackageUrl;
 
 use crate::models::PackageData;
 
@@ -93,6 +94,7 @@ pub(crate) fn parse_os_release(content: &str) -> PackageData {
     let homepage_url = fields.get("HOME_URL").cloned().map(truncate_field);
     let bug_tracking_url = fields.get("BUG_REPORT_URL").cloned().map(truncate_field);
     let code_view_url = fields.get("SUPPORT_URL").cloned().map(truncate_field);
+    let purl = build_purl(namespace, name, version_id.as_deref());
 
     PackageData {
         package_type: Some(PACKAGE_TYPE),
@@ -103,8 +105,17 @@ pub(crate) fn parse_os_release(content: &str) -> PackageData {
         bug_tracking_url,
         code_view_url,
         datasource_id: Some(DatasourceId::EtcOsRelease),
+        purl,
         ..Default::default()
     }
+}
+
+fn build_purl(namespace: &str, name: &str, version: Option<&str>) -> Option<String> {
+    let mut purl = PackageUrl::new(PACKAGE_TYPE.as_str(), name).ok()?;
+    purl.with_namespace(namespace).ok()?;
+    let version = version?;
+    purl.with_version(version).ok()?;
+    Some(truncate_field(purl.to_string()))
 }
 
 fn determine_namespace_and_name<'a>(

--- a/src/parsers/os_release_test.rs
+++ b/src/parsers/os_release_test.rs
@@ -57,6 +57,10 @@ BUG_REPORT_URL="https://bugs.debian.org/"
         assert_eq!(result.namespace, Some("debian".to_string()));
         assert_eq!(result.name, Some("debian".to_string()));
         assert_eq!(result.version, Some("11".to_string()));
+        assert_eq!(
+            result.purl,
+            Some("pkg:linux-distro/debian/debian@11".to_string())
+        );
         assert_eq!(result.datasource_id, Some(DatasourceId::EtcOsRelease));
 
         assert_eq!(
@@ -111,6 +115,26 @@ PRETTY_NAME="Fedora Linux 37 (Workstation Edition)"
         assert_eq!(result.namespace, Some("fedora".to_string()));
         assert_eq!(result.name, Some("fedora".to_string()));
         assert_eq!(result.version, Some("37".to_string()));
+    }
+
+    #[test]
+    fn test_parse_azure_linux_purl() {
+        let content = r#"
+NAME="Azure Linux"
+VERSION_ID="3.0"
+PRETTY_NAME="Azure Linux 3.0"
+ID=azurelinux
+"#;
+
+        let result = super::super::os_release::parse_os_release(content);
+
+        assert_eq!(result.namespace, Some("azurelinux".to_string()));
+        assert_eq!(result.name, Some("azurelinux".to_string()));
+        assert_eq!(result.version, Some("3.0".to_string()));
+        assert_eq!(
+            result.purl,
+            Some("pkg:linux-distro/azurelinux/azurelinux@3.0".to_string())
+        );
     }
 
     #[test]

--- a/src/parsers/rpm_mariner_manifest.rs
+++ b/src/parsers/rpm_mariner_manifest.rs
@@ -19,7 +19,8 @@
 //! - One package per line
 //! - Spec: https://github.com/microsoft/marinara/
 
-use crate::models::{DatasourceId, PackageType};
+use crate::models::{DatasourceId, PackageType, Party, PartyType};
+use packageurl::PackageUrl;
 use std::path::Path;
 
 use crate::parser_warn as warn;
@@ -38,6 +39,18 @@ fn default_package_data() -> PackageData {
         datasource_id: Some(DatasourceId::RpmMarinerManifest),
         ..Default::default()
     }
+}
+
+fn build_mariner_purl(name: &str, version: Option<&str>, arch: Option<&str>) -> Option<String> {
+    let mut purl = PackageUrl::new(PACKAGE_TYPE.as_str(), name).ok()?;
+    purl.with_namespace("mariner").ok()?;
+    if let Some(version) = version {
+        purl.with_version(version).ok()?;
+    }
+    if let Some(arch) = arch {
+        purl.add_qualifier("arch", arch).ok()?;
+    }
+    Some(truncate_field(purl.to_string()))
 }
 
 /// Parser for RPM Mariner container manifest files
@@ -101,16 +114,44 @@ pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
 
         let name = truncate_field(parts[0].to_string());
         let version = truncate_field(parts[1].to_string());
+        let party = truncate_field(parts[4].to_string());
         let arch = truncate_field(parts[7].to_string());
         let filename = truncate_field(parts[9].to_string());
 
-        let qualifiers = if arch.is_empty() {
+        let name_opt = if name.is_empty() { None } else { Some(name) };
+        let version_opt = if version.is_empty() {
             None
         } else {
+            Some(version)
+        };
+        let arch_opt = if arch.is_empty() { None } else { Some(arch) };
+
+        let qualifiers = if let Some(arch) = &arch_opt {
             let mut quals = std::collections::HashMap::new();
             quals.insert("arch".to_string(), arch.clone());
             Some(quals)
+        } else {
+            None
         };
+
+        let parties = if party.is_empty() {
+            Vec::new()
+        } else {
+            vec![Party {
+                r#type: Some(PartyType::Organization),
+                role: Some("owner".to_string()),
+                name: Some(party),
+                email: None,
+                url: None,
+                organization: None,
+                organization_url: None,
+                timezone: None,
+            }]
+        };
+
+        let purl = name_opt
+            .as_deref()
+            .and_then(|name| build_mariner_purl(name, version_opt.as_deref(), arch_opt.as_deref()));
 
         let extra_data = if filename.is_empty() {
             None
@@ -126,15 +167,13 @@ pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
         packages.push(PackageData {
             package_type: Some(PACKAGE_TYPE),
             namespace: Some(truncate_field("mariner".to_string())),
-            name: if name.is_empty() { None } else { Some(name) },
-            version: if version.is_empty() {
-                None
-            } else {
-                Some(version)
-            },
+            name: name_opt,
+            version: version_opt,
             qualifiers,
+            parties,
             datasource_id: Some(DatasourceId::RpmMarinerManifest),
             extra_data,
+            purl,
             ..Default::default()
         });
     }

--- a/src/parsers/rpm_mariner_manifest_test.rs
+++ b/src/parsers/rpm_mariner_manifest_test.rs
@@ -7,6 +7,7 @@ mod tests {
     use super::super::rpm_mariner_manifest::*;
     use crate::models::DatasourceId;
     use crate::models::PackageType;
+    use crate::models::PartyType;
     use std::path::PathBuf;
 
     #[test]
@@ -43,6 +44,14 @@ mod tests {
         let quals = pkg1.qualifiers.as_ref().unwrap();
         assert_eq!(quals.get("arch"), Some(&"x86_64".to_string()));
         assert_eq!(pkg1.datasource_id, Some(DatasourceId::RpmMarinerManifest));
+        assert_eq!(
+            pkg1.purl.as_deref(),
+            Some("pkg:rpm/mariner/bash@5.0.17?arch=x86_64")
+        );
+        assert_eq!(pkg1.parties.len(), 1);
+        assert_eq!(pkg1.parties[0].r#type, Some(PartyType::Organization));
+        assert_eq!(pkg1.parties[0].role.as_deref(), Some("owner"));
+        assert_eq!(pkg1.parties[0].name.as_deref(), Some("Microsoft"));
 
         // Check extra_data contains filename
         assert!(pkg1.extra_data.is_some());

--- a/src/parsers/rpm_scan_test.rs
+++ b/src/parsers/rpm_scan_test.rs
@@ -139,4 +139,145 @@ mod tests {
         assert!(package.datafile_paths[0].ends_with("/demo-1.0-1.x86_64.rpm"));
         assert_eq!(rpm_file.for_packages, vec![package.package_uid.clone()]);
     }
+
+    #[test]
+    fn test_rpm_mariner_manifest_scan_assembles_each_manifest_row() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let manifest_dir = temp_dir.path().join("var/lib/rpmmanifest");
+        fs::create_dir_all(&manifest_dir).expect("create rpmmanifest dir");
+        fs::copy(
+            "testdata/rpm/var/lib/rpmmanifest/container-manifest-2",
+            manifest_dir.join("container-manifest-2"),
+        )
+        .expect("copy RPM Mariner manifest fixture");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_eq!(result.packages.len(), 2, "packages: {:#?}", result.packages);
+        let bash = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("bash"))
+            .expect("bash package should be assembled");
+        assert_eq!(bash.package_type, Some(PackageType::Rpm));
+        assert_eq!(bash.version.as_deref(), Some("5.0.17"));
+        assert_eq!(
+            bash.purl.as_deref(),
+            Some("pkg:rpm/mariner/bash@5.0.17?arch=x86_64")
+        );
+        assert!(
+            bash.datasource_ids
+                .contains(&DatasourceId::RpmMarinerManifest)
+        );
+        assert_eq!(bash.datafile_paths.len(), 1);
+        assert!(bash.datafile_paths[0].ends_with("/var/lib/rpmmanifest/container-manifest-2"));
+
+        let manifest = files
+            .iter()
+            .find(|file| {
+                file.path
+                    .ends_with("/var/lib/rpmmanifest/container-manifest-2")
+            })
+            .expect("manifest should be scanned");
+        assert_eq!(manifest.for_packages.len(), 2);
+        assert!(manifest.for_packages.contains(&bash.package_uid));
+    }
+
+    #[test]
+    fn test_rpm_mariner_manifest_keeps_explicit_namespace_over_os_release() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let manifest_dir = temp_dir.path().join("var/lib/rpmmanifest");
+        let os_release_dir = temp_dir.path().join("usr/lib");
+        fs::create_dir_all(&manifest_dir).expect("create rpmmanifest dir");
+        fs::create_dir_all(&os_release_dir).expect("create os-release dir");
+
+        fs::copy(
+            "testdata/rpm/var/lib/rpmmanifest/container-manifest-2",
+            manifest_dir.join("container-manifest-2"),
+        )
+        .expect("copy RPM Mariner manifest fixture");
+        fs::write(
+            os_release_dir.join("os-release"),
+            r#"NAME="Azure Linux"
+ID=azurelinux
+VERSION_ID="3"
+PRETTY_NAME="Azure Linux 3.0"
+"#,
+        )
+        .expect("write Azure Linux os-release fixture");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        let os_release = files
+            .iter()
+            .find(|file| file.path.ends_with("/usr/lib/os-release"))
+            .expect("os-release should be scanned");
+        assert!(os_release.package_data.iter().any(|pkg_data| {
+            pkg_data.datasource_id == Some(DatasourceId::EtcOsRelease)
+                && pkg_data.namespace.as_deref() == Some("azurelinux")
+        }));
+
+        let bash = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("bash"))
+            .expect("bash package should be assembled");
+
+        assert_eq!(bash.namespace.as_deref(), Some("mariner"));
+        assert_eq!(
+            bash.purl.as_deref(),
+            Some("pkg:rpm/mariner/bash@5.0.17?arch=x86_64")
+        );
+    }
+
+    #[test]
+    fn test_rpm_mariner_manifest_scan_merges_package_license_file() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let manifest_dir = temp_dir.path().join("var/lib/rpmmanifest");
+        let license_dir = temp_dir.path().join("usr/share/licenses/bash");
+        fs::create_dir_all(&manifest_dir).expect("create rpmmanifest dir");
+        fs::create_dir_all(&license_dir).expect("create license dir");
+
+        let manifest_path = manifest_dir.join("container-manifest-2");
+        let license_path = license_dir.join("LICENSE");
+        fs::write(
+            &manifest_path,
+            "bash\t5.0.17\t1\t2\tMicrosoft\t3\t4\tx86_64\tsha256\tbash-5.0.17-1.cm2.x86_64.rpm\n",
+        )
+        .expect("write RPM Mariner manifest fixture");
+        fs::write(&license_path, "GPL-3.0-or-later\n").expect("write license fixture");
+
+        let (files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_eq!(result.packages.len(), 1, "packages: {:#?}", result.packages);
+        let bash = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("bash"))
+            .expect("bash package should be assembled");
+
+        assert_eq!(bash.package_type, Some(PackageType::Rpm));
+        assert!(
+            bash.datasource_ids
+                .contains(&DatasourceId::RpmMarinerManifest)
+        );
+        assert!(
+            bash.datasource_ids
+                .contains(&DatasourceId::RpmPackageLicenses)
+        );
+        let mut actual_datafile_paths = bash.datafile_paths.clone();
+        actual_datafile_paths.sort();
+        let mut expected_datafile_paths = vec![
+            manifest_path.to_string_lossy().to_string(),
+            license_path.to_string_lossy().to_string(),
+        ];
+        expected_datafile_paths.sort();
+        assert_eq!(actual_datafile_paths, expected_datafile_paths);
+
+        let license_file = files
+            .iter()
+            .find(|file| file.path == license_path.to_string_lossy())
+            .expect("license file should be scanned");
+        assert_eq!(license_file.for_packages, vec![bash.package_uid.clone()]);
+    }
 }

--- a/testdata/os-release/etc/os-release.expected.json
+++ b/testdata/os-release/etc/os-release.expected.json
@@ -8,6 +8,7 @@
     "homepage_url": "https://www.debian.org/",
     "bug_tracking_url": "https://bugs.debian.org/",
     "code_view_url": "https://www.debian.org/support",
-    "datasource_id": "etc_os_release"
+    "datasource_id": "etc_os_release",
+    "purl": "pkg:linux-distro/debian/debian@11"
   }
 ]

--- a/testdata/rpm/var/lib/rpmmanifest/container-manifest-2.expected.json
+++ b/testdata/rpm/var/lib/rpmmanifest/container-manifest-2.expected.json
@@ -7,10 +7,17 @@
     "qualifiers": {
       "arch": "x86_64"
     },
-    "parties": [],
+    "parties": [
+      {
+        "type": "organization",
+        "role": "owner",
+        "name": "Microsoft"
+      }
+    ],
     "extra_data": {
       "filename": "bash-5.0.17-1.cm2.x86_64.rpm"
     },
-    "datasource_id": "rpm_mariner_manifest"
+    "datasource_id": "rpm_mariner_manifest",
+    "purl": "pkg:rpm/mariner/bash@5.0.17?arch=x86_64"
   }
 ]


### PR DESCRIPTION
## Summary

- Improves Azure Linux/Mariner rootfs package assembly from `var/lib/rpmmanifest/container-manifest-2` by assembling each manifest row as an installed RPM package.
- Adds Mariner RPM PURLs and publisher owner metadata, preserves explicit Mariner namespaces over `os-release`, and merges `/usr/share/licenses/*` RPM license sidecars onto matching installed packages.
- Adds generic `os-release` Linux distro PURLs and records the Azure Linux distroless/minimal 3.0 benchmark result in `docs/BENCHMARKS.md` plus the generated chart.

## Issues

- Covers: Azure Linux distroless/minimal 3.0 rootfs benchmark verification

## Scope and exclusions

- Included: generic RPM Mariner manifest parsing/assembly, RPM installed license sidecar merge, explicit RPM namespace preservation, Linux distro PURL generation, focused regression coverage, parser expected-output fixture updates, benchmark docs/chart update.
- Explicit exclusions: target-specific scanner hacks and further non-package text-extraction changes. The final residual differences are triaged certificate/profile text extraction samples rather than package, dependency, or license-detection regressions.

## Intentional differences from Python

- Provenant keeps explicit Mariner RPM package identity (`pkg:rpm/mariner/...`) instead of rewriting installed RPM packages to the distro namespace from `usr/lib/os-release`.
- Provenant records Linux distro identity as `pkg:linux-distro/<namespace>/<name>@<version>` for `os-release` package data.

## Follow-up work

- Created or intentionally deferred: no benchmark-blocking follow-up. Additional text-extraction tuning for certificate binary samples or the `etc/profile` ROT13-looking email can be considered separately if it proves broadly useful.

## Expected-output fixture changes

- Files changed: `testdata/os-release/etc/os-release.expected.json`, `testdata/rpm/var/lib/rpmmanifest/container-manifest-2.expected.json`.
- Why the new expected output is correct: `os-release` now emits a Linux distro PURL, and Mariner manifest package data now includes its RPM PURL plus publisher owner metadata from the manifest row.

## Benchmark evidence

- Target: `mcr.microsoft.com/azurelinux/distroless/minimal:3.0`, `linux/amd64`, digest `sha256:0c64ab9cfc44d4f100c0590bd59ead9afedda6cc54f14bb7465b5f9c35ddc037`.
- Final compare run: `.provenant/compare-runs/20260603T164032Z-rootfs-74993`.
- Profile: `common`.
- Timing: Provenant `7.26s`; ScanCode `62.57s`; speedup `8.62×`.
- Counts: files `1844` vs `1844`, packages `5` vs `5`, dependencies `0` vs `0`, license detections `5` vs `5`, package data deltas `0`.

## Validation

- LSP diagnostics on all changed Rust files: clean.
- `cargo test --lib rpm_mariner_manifest`
- `cargo test --lib os_release`
- `cargo test --features golden-tests test_golden_os_release`
- `cargo test --lib assembly::assemblers::tests::test_every_datasource_id_is_accounted_for`
- `cargo test --lib assembly::file_ref_resolve::tests::test_resolve_rpm_namespace`
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart -- --check`
- `npm run check:docs`
- Pre-commit hooks: clippy, generated supported formats, license headers, markdown lint, prettier, rustfmt.