### PR TITLE
fix(copyright): reduce refiner boilerplate noise

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 203 of 203 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 204 of 204 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -601,6 +601,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-05-07 · asio-38900 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `18.97s`; ScanCode `333.52s`
 - More correct root Autotools package identity on `configure.ac` instead of ScanCode's generic input placeholder, plus cleaner holder normalization on `include/asio.hpp` and the Oliver Kowalke C++ notice set; the remaining ScanCode edge is limited to two multiline continuation headers and a small Perl author/copyright-email-tail set
+
+##### [chuckha/crispy-tribble @ 20479cf](https://github.com/chuckha/crispy-tribble/tree/20479cfe45a694ee4fababd635f1bd8ebcb44ed3) — **13.28× faster**
+
+- Files: 471
+- Run context: 2026-06-03 · crispy-tribble-96153 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.32s`; ScanCode `123.76s`
+- Broader Go module graph dependency visibility (`117` vs `61` dependencies) from committed `go.mod.graph` while preserving matched package coverage (`10` vs `10`) across `go.mod`, `go.sum`, and vendored manifests, plus cleaner rejection of Go AUTHORS boilerplate and code-comment author/copyright fragments
 
 ##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **23.90× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -266,6 +266,9 @@ ScanCode: 135.43s</title></rect>
     <rect x="514.79" y="385.13" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
 ScanCode: 170.71s</title></rect>
+    <rect x="516.12" y="400.33" width="8" height="8" fill="#d97706" rx="1.5"><title>chuckha/crispy-tribble @ 20479cf
+Files: 471
+ScanCode: 123.76s</title></rect>
     <rect x="516.85" y="391.50" width="8" height="8" fill="#d97706" rx="1.5"><title>phoenixframework/phoenix @ e7b8081
 Files: 476
 ScanCode: 149.17s</title></rect>
@@ -877,6 +880,9 @@ Provenant: 10.70s</title></circle>
     <circle cx="518.79" cy="507.78" r="4.5" fill="#2563eb"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
 Provenant: 13.86s</title></circle>
+    <circle cx="520.12" cy="526.53" r="4.5" fill="#2563eb"><title>chuckha/crispy-tribble @ 20479cf
+Files: 471
+Provenant: 9.32s</title></circle>
     <circle cx="520.85" cy="511.54" r="4.5" fill="#2563eb"><title>phoenixframework/phoenix @ e7b8081
 Files: 476
 Provenant: 12.80s</title></circle>

--- a/src/copyright/refiner/authors_junk_patterns.rs
+++ b/src/copyright/refiner/authors_junk_patterns.rs
@@ -88,6 +88,7 @@ pub(super) static AUTHORS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^with the mode of \d{3,4}$",
         r"(?i)^kernel afs\.\s+skip afs metadata and acls$",
         r"(?i)^with a (?:fsf|dco)$",
+        r"(?i)^optional\s+spec$",
         r"(?i)^gives unlimited$",
         r"(?i)^word assigns past and future changes\b",
         r"(?i)^maintainers\s*<[^>]+>\s+from\s+https?://\S+$",

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -191,6 +191,7 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright and other proprietary\b",
         r"(?i)^copyright in the\b",
         r"(?i)^copyright in and\b",
+        r"(?i)^copyright\s+purposes(?:\.|\b).*$",
         r"(?i)^copyright the software\b",
         r"(?i)^copyright info for\b",
         r"(?i)^copyright grant\b",

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -1395,17 +1395,20 @@ pub fn refine_copyright(s: &str) -> Option<String> {
 }
 
 fn is_explicit_junk_copyright_phrase(s: &str) -> bool {
+    let lower = s.trim().to_ascii_lowercase();
     matches!(
-        s.trim().to_ascii_lowercase().as_str(),
+        lower.as_str(),
         "copyright exclude"
             | "copyright doctrines of fair use, fair dealing, or other equivalents"
             | "copyright doctrines of fair use, fair dealing, or other equivalents."
             | "copyright licenses specified in the"
             | "copyright in its"
+            | "copyright purposes"
             | "copyright sections were added"
             | "copyright c- core core"
             | "copyright applying to the plugin. if"
-    ) || is_placeholder_or_code_junk_copyright(s, &s.trim().to_ascii_lowercase())
+    ) || lower.starts_with("copyright purposes.")
+        || is_placeholder_or_code_junk_copyright(s, &lower)
 }
 
 fn strip_known_copyright_wrappers(s: &str) -> String {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1600,6 +1600,13 @@ fn test_refine_copyright_drops_prose_fragments_from_license_boilerplate() {
         None
     );
     assert_eq!(refine_copyright("copyright in its"), None);
+    assert_eq!(refine_copyright("copyright purposes"), None);
+    assert_eq!(
+        refine_copyright(
+            "copyright purposes. The master list of authors is in the main Go distribution, visible at http://tip.golang.org/AUTHORS"
+        ),
+        None
+    );
 }
 
 #[test]
@@ -2208,6 +2215,7 @@ fn test_refine_author_drops_code_call_and_graphql_fragments() {
         None
     );
     assert_eq!(refine_author("UserWithType ...UserAvailability"), None);
+    assert_eq!(refine_author("optional Spec"), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reject two generic copyright/author boilerplate fragments exposed while verifying `chuckha/crispy-tribble`.
- Record the pinned crispy-tribble benchmark run and regenerate the scan-duration chart.

## Scope and exclusions

- Included: generic copyright refiner cleanup for `optional Spec` author noise and `copyright purposes...` prose fragments; benchmark documentation for `chuckha/crispy-tribble @ 20479cfe45a694ee4fababd635f1bd8ebcb44ed3`.
- Explicit exclusions: no target-specific scanner behavior and no committed compare-run artifacts.

## Intentional differences from Python

- Final compare run: `.provenant/compare-runs/20260603T172611Z-crispy-tribble-96153`.
- Provenant preserves matched package coverage (`10` vs `10`) and broader Go module graph dependency visibility (`117` vs `61`) from committed `go.mod.graph`.
- Reviewed ScanCode-favored author/copyright samples are false positives such as Go AUTHORS boilerplate and code/comment fragments, so the branch tightens generic junk rejection instead of matching that noise.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: no golden fixtures changed; focused unit tests cover the new generic refiner cleanup.

## Validation

- `cargo test --lib copyright::refiner::tests`
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart -- --check`
- `npm run check:docs`
- LSP diagnostics clean for changed refiner files
- `git diff --check main..HEAD`