### PR TITLE
docs(benchmarks): record harbor autoscaler trigger verification

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 204 of 204 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 207 of 207 recorded runs, with a **12.3× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -416,6 +416,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.57s`; ScanCode `146.24s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and cleaner package-author normalization in `package.json`
 
+##### [triggerdotdev/trigger.dev @ d1f4302](https://github.com/triggerdotdev/trigger.dev/tree/d1f430247e8a70a28e6c71a19fee5d0a7b5eccbf) — **28.86× faster**
+
+- Files: 4,169
+- Run context: 2026-06-03 · trigger.dev-89435 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `11.71s`; ScanCode `337.98s`
+- Broader pnpm/npm workspace and Helm coverage (`45` vs `39` packages, `6971` vs `6689` dependencies) from the root `pnpm-lock.yaml`, nested fixture lockfiles, workspace member manifests, `.gitmodules`, and `hosting/k8s/helm/Chart.yaml`, while private pnpm workspace root cleanup intentionally avoids a redundant root package row and remaining Yarn patch protocol deltas are representation differences rather than missing dependency evidence
+
 ##### [vercel/next.js @ 8e5a36f](https://github.com/vercel/next.js/tree/8e5a36f6347528d8968da97262f372f908897bac) — **20.68× faster**
 
 - Files: 28,044
@@ -707,6 +714,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `26.21s`; ScanCode `266.07s`
 - Broader package and dependency extraction (`3` vs `2` packages, `1943` vs `1917` dependencies) from `flake.nix`, `flake.lock`, `Dockerfile`, and `uv.lock`, plus a correct root Go module identity on `go.mod` where ScanCode emits the malformed `pkg:golang/%28` package row
 
+##### [goharbor/harbor @ eb944bb](https://github.com/goharbor/harbor/tree/eb944bb199211d6ac76fb207cd2ef1bf33ec0030) — **14.31× faster**
+
+- Files: 3,233
+- Run context: 2026-06-03 · harbor-57111 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `22.87s`; ScanCode `327.33s`
+- Broader package and dependency extraction (`5` vs `2` packages, `2972` vs `2407` dependencies) from committed Pipfile/Pipfile.lock, npm-family, Docker, and Go manifests, with local Go `replace` paths kept out of invalid PURLs, templated Conda YAML skipped instead of degraded into false metadata, and URL differences limited to normalization/truncation/canonicalization after review
+
 ##### [grpc/grpc @ f87c29f](https://github.com/grpc/grpc/tree/f87c29f069971d1356e5784005af499db52e7f31) — **14.43× faster**
 
 - Files: 10,361
@@ -720,6 +734,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `27.87s`; ScanCode `563.43s`
 - Broader Debian source-package and dependency extraction (`23` vs `19` packages, `18` vs `0` dependencies) from the root multi-binary `debian/control` file plus committed `.dsc` fixtures, with explicit package visibility for `dpkg-dev`, `libdpkg-dev`, and `libdpkg-perl` and one extra top-level Autotools package on `configure.ac`
+
+##### [kubernetes/autoscaler @ 9045d28](https://github.com/kubernetes/autoscaler/tree/9045d287a3458d6ea7440c3dcf921806bc994224) — **20.46× faster**
+
+- Files: 5,929
+- Run context: 2026-06-03 · autoscaler-75016 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `36.39s`; ScanCode `744.62s`
+- Broader Go and Helm package visibility (`11` vs `8` packages, `3127` vs `2892` dependencies), including 165 dependencies from `addon-resizer/Godeps/Godeps.json` where ScanCode reports none, direct chart packages for `cluster-autoscaler` and `vertical-pod-autoscaler`, cleaner rejection of ScanCode malformed Go-version package rows such as `pkg:golang/v2.4.0`, and generic author cleanup for Markdown `Authors:` lines with trailing bare handles
 
 ##### [kubernetes/kubernetes @ d3b9c54](https://github.com/kubernetes/kubernetes/tree/d3b9c54bd952117924fb0790f6989c0d30715b19) — **16.19× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -473,6 +473,9 @@ ScanCode: 332.23s</title></rect>
     <rect x="645.65" y="387.44" width="8" height="8" fill="#d97706" rx="1.5"><title>laravel/framework @ a3960e8
 Files: 3086
 ScanCode: 162.58s</title></rect>
+    <rect x="648.86" y="354.37" width="8" height="8" fill="#d97706" rx="1.5"><title>goharbor/harbor @ eb944bb
+Files: 3233
+ScanCode: 327.33s</title></rect>
     <rect x="649.58" y="327.73" width="8" height="8" fill="#d97706" rx="1.5"><title>debian:bookworm-slim @ sha256:f065376
 Files: 3267
 ScanCode: 575.28s</title></rect>
@@ -500,6 +503,9 @@ ScanCode: 429.19s</title></rect>
     <rect x="664.98" y="356.00" width="8" height="8" fill="#d97706" rx="1.5"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
 Files: 4085
 ScanCode: 316.25s</title></rect>
+    <rect x="666.38" y="352.86" width="8" height="8" fill="#d97706" rx="1.5"><title>triggerdotdev/trigger.dev @ d1f4302
+Files: 4169
+ScanCode: 337.98s</title></rect>
     <rect x="667.96" y="325.26" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
 Files: 4266
 ScanCode: 606.05s</title></rect>
@@ -527,6 +533,9 @@ ScanCode: 479.56s</title></rect>
     <rect x="687.04" y="292.14" width="8" height="8" fill="#d97706" rx="1.5"><title>python/cpython @ 7a468a1
 Files: 5627
 ScanCode: 1221.65s</title></rect>
+    <rect x="690.65" y="315.53" width="8" height="8" fill="#d97706" rx="1.5"><title>kubernetes/autoscaler @ 9045d28
+Files: 5929
+ScanCode: 744.62s</title></rect>
     <rect x="692.31" y="293.00" width="8" height="8" fill="#d97706" rx="1.5"><title>openssl/openssl @ 7fb28b9
 Files: 6074
 ScanCode: 1199.73s</title></rect>
@@ -1087,6 +1096,9 @@ Provenant: 23.57s</title></circle>
     <circle cx="649.65" cy="485.60" r="4.5" fill="#2563eb"><title>laravel/framework @ a3960e8
 Files: 3086
 Provenant: 22.16s</title></circle>
+    <circle cx="652.86" cy="484.11" r="4.5" fill="#2563eb"><title>goharbor/harbor @ eb944bb
+Files: 3233
+Provenant: 22.87s</title></circle>
     <circle cx="653.58" cy="426.73" r="4.5" fill="#2563eb"><title>debian:bookworm-slim @ sha256:f065376
 Files: 3267
 Provenant: 77.04s</title></circle>
@@ -1114,6 +1126,9 @@ Provenant: 21.96s</title></circle>
     <circle cx="668.98" cy="497.60" r="4.5" fill="#2563eb"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
 Files: 4085
 Provenant: 17.19s</title></circle>
+    <circle cx="670.38" cy="515.74" r="4.5" fill="#2563eb"><title>triggerdotdev/trigger.dev @ d1f4302
+Files: 4169
+Provenant: 11.71s</title></circle>
     <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
 Files: 4266
 Provenant: 40.75s</title></circle>
@@ -1141,6 +1156,9 @@ Provenant: 52.75s</title></circle>
     <circle cx="691.04" cy="475.47" r="4.5" fill="#2563eb"><title>python/cpython @ 7a468a1
 Files: 5627
 Provenant: 27.46s</title></circle>
+    <circle cx="694.65" cy="462.17" r="4.5" fill="#2563eb"><title>kubernetes/autoscaler @ 9045d28
+Files: 5929
+Provenant: 36.39s</title></circle>
     <circle cx="696.31" cy="439.39" r="4.5" fill="#2563eb"><title>openssl/openssl @ 7fb28b9
 Files: 6074
 Provenant: 58.93s</title></circle>

--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -39,6 +39,8 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
 ) -> Option<String> {
     static TRAILING_HANDLE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\s*\(@[A-Za-z0-9_.-]+\)\s*$").unwrap());
+    static TRAILING_BARE_HANDLE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?x)^(?P<base>.+?)\s+@[A-Za-z0-9_.-]+\s*$").unwrap());
     static TRAILING_COMMA_HANDLE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?x)
@@ -59,6 +61,17 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
     let without_handle = TRAILING_HANDLE_RE.replace(trimmed, "").trim().to_string();
     if without_handle != trimmed {
         return refine_author(&without_handle);
+    }
+
+    if let Some(captures) = TRAILING_BARE_HANDLE_RE.captures(trimmed) {
+        let base = captures
+            .name("base")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        if !base.is_empty() {
+            return refine_author(base);
+        }
     }
 
     if let Some(captures) = TRAILING_COMMA_HANDLE_RE.captures(trimmed) {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -314,6 +314,19 @@ fn test_extract_author_colon_inline_roster_with_handles() {
 }
 
 #[test]
+fn test_author_colon_markdown_block_strips_trailing_bare_handle() {
+    let input = "Authors:\nEvan Sheng (evan.sheng@airbnb.com) @evansheng\n\n";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.author == "Evan Sheng (evan.sheng@airbnb.com)"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_extract_markdown_heading_original_author_with_handle() {
     let input = "### Original author: Thomas Breloff (@tbreloff)\n";
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -106,6 +106,7 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^whoever named in\b",
         r"(?i)^as specified below\b",
         r"(?i)^as required\b",
+        r"(?i)^purposes(?:\.\s+the\s+master\s+list\s+of\s+authors\b.*)?$",
         r"(?i)^\((?:r|c|tm)\)\s*,\s*(?:&\s*\d{2,4}\s*,\s*){5,}.*$",
         r"(?i)^not used to limit\b",
         r"(?i)^the coordinator$",

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -305,6 +305,8 @@ static HOLDERS_JUNK: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "if",
         "grant",
         "notice",
+        "header",
+        "comment",
         "do the following",
         "does",
         "has",
@@ -665,7 +667,9 @@ fn contains_regex_or_template_marker(s: &str) -> bool {
         || trimmed.contains("{{")
         || trimmed.contains("}}")
         || trimmed.contains("${")
+        || trimmed.contains("0-9")
         || trimmed.contains("^ ")
+        || trimmed.ends_with('$')
         || trimmed.contains(" d+")
         || trimmed.contains(" ?")
 }

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -192,6 +192,17 @@ fn test_refine_holder_drops_document_form_reference_noise() {
     assert_eq!(refine_holder("Office FL-108"), None);
 }
 
+#[test]
+fn test_refine_holder_drops_go_authors_boilerplate_fragments() {
+    assert_eq!(refine_holder("purposes"), None);
+    assert_eq!(
+        refine_holder(
+            "purposes. The master list of authors in the main Go distribution, visible at"
+        ),
+        None
+    );
+}
+
 // ── strip_some_punct ─────────────────────────────────────────────
 
 #[test]
@@ -1121,6 +1132,13 @@ fn test_refine_holder_junk_template_placeholders() {
     assert_eq!(refine_holder("pkg.author"), None);
     assert_eq!(refine_holder("format YYYY-MM-DD, -04"), None);
     assert_eq!(refine_holder("< pkg.author >"), None);
+}
+
+#[test]
+fn test_refine_holder_junk_header_comment_and_regex_fragments() {
+    assert_eq!(refine_holder("header"), None);
+    assert_eq!(refine_holder("comment"), None);
+    assert_eq!(refine_holder("(c 0-9 4 The Harbor Authors$"), None);
 }
 
 #[test]

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -393,4 +393,57 @@ mod tests {
 
         assert!(urls.is_empty(), "urls: {urls:#?}");
     }
+
+    #[test]
+    fn test_find_urls_keeps_embedded_https_after_alphanumeric_prefix() {
+        let text = "issuer: tenant123https://sso.andrea.muellerpublic.de/auth/realms/harbor";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        let values: Vec<_> = urls.into_iter().map(|url| url.url).collect();
+        assert_eq!(
+            values,
+            vec!["https://sso.andrea.muellerpublic.de/auth/realms/harbor".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_find_urls_keeps_registry_host_templates() {
+        let text =
+            "https://registry.%s.aliyuncs.com/ https://api.ecr.%s.amazonaws.com/ https://%s/";
+        let config = DetectionConfig::default();
+        let urls = find_urls(text, &config);
+
+        let values: Vec<_> = urls.into_iter().map(|url| url.url).collect();
+        assert_eq!(
+            values,
+            vec![
+                "https://registry.%s.aliyuncs.com/".to_string(),
+                "https://api.ecr.%s.amazonaws.com/".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_urls_prefers_document_links_over_images_at_cap() {
+        let text = concat!(
+            "https://goharbor.io/logo.png\n",
+            "https://goharbor.io/banner.svg\n",
+            "https://goharbor.io/adopters\n",
+        );
+        let config = DetectionConfig {
+            max_urls: 2,
+            ..Default::default()
+        };
+        let urls = find_urls(text, &config);
+
+        let values: Vec<_> = urls.into_iter().map(|url| url.url).collect();
+        assert_eq!(
+            values,
+            vec![
+                "https://goharbor.io/adopters".to_string(),
+                "https://goharbor.io/logo.png".to_string(),
+            ]
+        );
+    }
 }

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -144,7 +144,7 @@ fn remove_user_password(url: &str) -> Option<String> {
         return Some(parsed.to_string());
     }
 
-    strip_manual_userinfo(url)
+    strip_manual_userinfo(url).or_else(|| Some(url.to_string()))
 }
 
 fn strip_manual_userinfo(url: &str) -> Option<String> {
@@ -167,7 +167,52 @@ fn canonical_url(url: &str) -> Option<String> {
     if !is_filterable(url) {
         return Some(url.to_string());
     }
-    Some(Url::parse(url).ok()?.to_string())
+    Url::parse(url)
+        .ok()
+        .map(|parsed| parsed.to_string())
+        .or_else(|| canonical_template_host_url(url))
+}
+
+fn canonical_template_host_url(url: &str) -> Option<String> {
+    let scheme_end = url.find("://")?;
+    let scheme = &url[..scheme_end];
+    if !matches!(scheme, "http" | "https") {
+        return None;
+    }
+
+    let after_scheme = &url[scheme_end + 3..];
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if !host.contains("%s") || !looks_like_template_host(host) {
+        return None;
+    }
+
+    let mut canonical = url.to_string();
+    if authority_end == after_scheme.len() {
+        canonical.push('/');
+    }
+    Some(canonical)
+}
+
+fn looks_like_template_host(host: &str) -> bool {
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 3 || labels[labels.len() - 2..].contains(&"%s") {
+        return false;
+    }
+    if !labels
+        .iter()
+        .any(|label| *label != "%s" && !label.is_empty())
+    {
+        return false;
+    }
+
+    let concrete = host.replace("%s", "template");
+    is_good_url_host_domain(&format!("http://{concrete}"))
 }
 
 pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
@@ -181,7 +226,10 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
             for matched in URLS_REGEX.find_iter(segment) {
                 if matched.start() > 0 {
                     let prev_byte = segment.as_bytes()[matched.start() - 1];
-                    if prev_byte.is_ascii_alphanumeric() {
+                    if prev_byte.is_ascii_alphanumeric()
+                        && !matched.as_str().starts_with("http://")
+                        && !matched.as_str().starts_with("https://")
+                    {
                         continue;
                     }
                 }
@@ -213,7 +261,11 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
                     continue;
                 };
 
-                if is_filterable(&candidate) && !is_good_url_host_domain(&candidate) {
+                if is_filterable(&candidate)
+                    && !is_good_url_host_domain(&candidate)
+                    && !canonical_template_host_url(&candidate)
+                        .is_some_and(|url| looks_like_template_url_host_domain(&url))
+                {
                     continue;
                 }
                 if !classify_url(&candidate.to_ascii_lowercase()) {
@@ -240,8 +292,36 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
     };
 
     if config.max_urls > 0 && detections.len() > config.max_urls {
+        detections.sort_by_key(|detection| is_low_priority_url(&detection.url));
         detections.truncate(config.max_urls);
     }
 
     detections
+}
+
+fn is_low_priority_url(url: &str) -> bool {
+    let Ok(parsed) = Url::parse(url) else {
+        return false;
+    };
+    let path = parsed.path().to_ascii_lowercase();
+    [
+        ".apng", ".avif", ".bmp", ".gif", ".ico", ".jpeg", ".jpg", ".png", ".svg", ".webp",
+    ]
+    .iter()
+    .any(|suffix| path.ends_with(suffix))
+}
+
+fn looks_like_template_url_host_domain(url: &str) -> bool {
+    let Some(scheme_end) = url.find("://") else {
+        return false;
+    };
+    let after_scheme = &url[scheme_end + 3..];
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    looks_like_template_host(host)
 }

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -626,6 +626,10 @@ impl PackageParser for CondaEnvironmentYmlParser {
             }
         };
 
+        if looks_like_template_yaml(&contents) {
+            return Vec::new();
+        }
+
         let yaml: Value = match yaml_serde::from_str(&contents) {
             Ok(y) => y,
             Err(e) => {
@@ -687,6 +691,13 @@ fn looks_like_conda_environment_yaml(yaml: &Value) -> bool {
         .is_some_and(|value| !value.trim().is_empty());
 
     has_dependencies || has_channels || has_prefix
+}
+
+fn looks_like_template_yaml(contents: &str) -> bool {
+    contents.lines().take(MAX_ITERATION_COUNT).any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("{{") || trimmed.starts_with("{%-") || trimmed.starts_with("{%")
+    })
 }
 
 /// Extract Jinja2-style variables from a Conda meta.yaml

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -390,6 +390,28 @@ spec:
         assert!(CondaEnvironmentYmlParser::extract_packages(&env_path).is_empty());
     }
 
+    #[test]
+    fn test_helm_template_environment_yaml_returns_no_packages() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_path = temp_dir.path().join("jobservice-cm-env.yaml");
+        fs::write(
+            &env_path,
+            r#"
+{{- if .Values.jobservice.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harbor.jobservice" . }}
+data:
+  CORE_URL: {{ template "harbor.coreURL" . }}
+{{- end }}
+"#,
+        )
+        .unwrap();
+
+        assert!(CondaEnvironmentYmlParser::extract_packages(&env_path).is_empty());
+    }
+
     // ==================== extract_first_package() Tests ====================
 
     #[test]

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -377,7 +377,12 @@ fn parse_replace_line(line: &str) -> Option<Dependency> {
     let new_module = new_parts[0];
     let new_version = new_parts.get(1).map(|s| truncate_field(s.to_string()));
 
-    let purl = create_golang_purl(new_module, new_version.as_deref());
+    let is_local_path = is_local_go_replace_path(new_module);
+    let purl = if is_local_path {
+        None
+    } else {
+        create_golang_purl(new_module, new_version.as_deref())
+    };
 
     let mut extra = std::collections::HashMap::new();
     extra.insert(
@@ -398,6 +403,12 @@ fn parse_replace_line(line: &str) -> Option<Dependency> {
         extra.insert(
             "replace_old_version".to_string(),
             serde_json::Value::String(truncate_field(ov.to_string())),
+        );
+    }
+    if is_local_path {
+        extra.insert(
+            "replace_local_path".to_string(),
+            serde_json::Value::Bool(true),
         );
     }
 
@@ -937,10 +948,7 @@ fn parse_workspace_replace_line(line: &str) -> Option<Dependency> {
     let old_version = old_parts.get(1).map(|s| s.as_str());
     let new_module = new_parts[0].as_str();
     let new_version = new_parts.get(1).map(|s| truncate_field(s.clone()));
-    let is_local_path = new_module.starts_with("./")
-        || new_module.starts_with("../")
-        || new_module.starts_with('/')
-        || new_module.starts_with('~');
+    let is_local_path = is_local_go_replace_path(new_module);
 
     let purl = if is_local_path {
         None
@@ -987,6 +995,13 @@ fn parse_workspace_replace_line(line: &str) -> Option<Dependency> {
         resolved_package: None,
         extra_data: Some(extra),
     })
+}
+
+fn is_local_go_replace_path(module: &str) -> bool {
+    module.starts_with("./")
+        || module.starts_with("../")
+        || module.starts_with('/')
+        || module.starts_with('~')
 }
 
 fn extract_single_go_token(value: &str) -> Option<String> {

--- a/src/parsers/go_test.rs
+++ b/src/parsers/go_test.rs
@@ -538,6 +538,11 @@ replace github.com/old/pkg => ../local/path
             extra.get("replace_new").and_then(|v| v.as_str()),
             Some("../local/path")
         );
+        assert_eq!(dep.purl, None, "local path should not produce a Go PURL");
+        assert_eq!(
+            extra.get("replace_local_path").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         // Local path replacements have no version
         assert_eq!(dep.extracted_requirement, None);
         assert!(


### PR DESCRIPTION
## Summary

- Records benchmark verification for goharbor/harbor, kubernetes/autoscaler, and triggerdotdev/trigger.dev.
- Adds generic parser, URL finder, copyright holder, and author-cleanup fixes surfaced during compare-output review.
- Regenerates docs/scan-duration-vs-files.svg and updates docs/BENCHMARKS.md headline metrics to 207 of 207 recorded runs, 12.3x median speedup, and 11.5x geometric-mean speedup.

## Scope and exclusions

- Included: benchmark rows and chart update for Harbor, autoscaler, and trigger.dev; generic fixes for local Go replace paths, Helm/Jinja YAML skipping in Conda environment parsing, URL extraction/capping, holder junk filtering, and trailing bare author handles.
- Explicit exclusions: no target-specific scanner hacks; no broad golden updates.

## Intentional differences from Python

- Provenant keeps local Go replace paths out of invalid PURLs where ScanCode can emit malformed Go package rows.
- Provenant intentionally skips templated Helm/Jinja YAML as package metadata instead of degrading templates into false Conda environment data.
- Provenant retains broader source-backed package and dependency coverage while treating remaining URL and Yarn patch protocol differences as normalization or representation differences after review.

## Follow-up work

- Created or intentionally deferred: none.

## Validation

- cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart -- --check
- npm run check:docs
- cargo test --lib parsers::go_test::tests::test_replace_local_path
- cargo test --lib parsers::conda_test::tests::test_helm_template_environment_yaml_returns_no_packages
- cargo test --lib copyright::refiner::tests::test_refine_holder_junk_header_comment_and_regex_fragments
- cargo test --lib copyright::refiner::tests::test_refine_holder_drops_go_authors_boilerplate_fragments
- cargo test --lib copyright::detector::author_heuristics::tests::test_author_colon_markdown_block_strips_trailing_bare_handle
- cargo test --lib finder::tests::test_find_urls
- git diff --check
- pre-commit hooks during git commit: clippy, generate-supported-formats, license-headers, markdown-lint, prettier, rustfmt, DCO signoff

Compare artifacts:

- .provenant/compare-runs/20260603T194522Z-harbor-57111
- .provenant/compare-runs/20260603T203107Z-autoscaler-75016
- .provenant/compare-runs/20260603T203639Z-trigger.dev-89435

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: no expected-output fixtures were updated.