### PR TITLE
test: add local code-coverage tooling and skill (cargo-llvm-cov)

### DIFF
--- a/.agents/skills/code-coverage/SKILL.md
+++ b/.agents/skills/code-coverage/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-coverage
+description: Measure and improve Provenant's Rust test coverage locally with cargo-llvm-cov. Use for code coverage, llvm-cov, finding untested code, test gaps, or "what isn't tested".
+---
+
+# Code Coverage (local signal)
+
+Coverage in Provenant is a **local tool for finding untested code**, not a CI gate
+or a number to maximize. See [`docs/TESTING_STRATEGY.md`](../../../docs/TESTING_STRATEGY.md)
+for the "confidence, not coverage" philosophy. Use this to locate genuinely
+untested paths, then write meaningful behavior tests for them — do not add tests
+just to move the number.
+
+## Prerequisites
+
+`cargo-llvm-cov` is installed by `npm run setup`. Otherwise:
+
+```bash
+cargo install --locked cargo-llvm-cov
+```
+
+## Commands
+
+```bash
+# Per-file summary table for the whole library (fast triage)
+npm run coverage            # = cargo llvm-cov --lib
+
+# Annotated line-by-line HTML report, opened in a browser
+npm run coverage:html       # = cargo llvm-cov --lib --open
+
+# Scope to one module while iterating (much faster)
+# The test-name filter must follow `--` so it is forwarded to the test binary.
+cargo llvm-cov --lib -- copyright::refiner
+
+# Show uncovered regions for a path as text
+cargo llvm-cov --lib --show-missing-lines -- <filter>
+```
+
+## How to read it
+
+- `--lib` covers **unit tests only**. Integration suites (`tests/*.rs`) and
+  golden suites (`--features golden-tests`) exercise far more code than this
+  credits, so treat the number as a **lower bound**. A file showing 0% may still
+  be well-covered by golden/integration tests.
+- Low coverage on pure data tables (e.g. `copyright/grammar/rules.rs`) or generated
+  code is expected and not worth "fixing".
+- Prioritize gaps in branching logic: error paths, parser fallbacks, edge cases
+  in detection/assembly — places where a wrong branch produces wrong output.
+
+## Workflow to close a real gap
+
+1. Run `npm run coverage` and pick a module with thin coverage on real logic.
+2. Re-run scoped (`cargo llvm-cov --lib --show-missing-lines -- <module>`) to see the
+   exact uncovered lines.
+3. Confirm the lines aren't already covered by a golden/integration suite before
+   assuming they're untested (grep the relevant `tests/` and `*_scan_test.rs`).
+4. Add behavior-focused tests per [`docs/TESTING_STRATEGY.md`](../../../docs/TESTING_STRATEGY.md)
+   (right layer: unit vs scan/assembly contract vs golden).
+5. Re-run scoped coverage to confirm the gap is closed.

--- a/.claude/skills/code-coverage/SKILL.md
+++ b/.claude/skills/code-coverage/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-coverage
+description: Measure and improve Provenant's Rust test coverage locally with cargo-llvm-cov. Use for code coverage, llvm-cov, finding untested code, test gaps, or "what isn't tested".
+---
+
+# Code Coverage (local signal)
+
+Coverage in Provenant is a **local tool for finding untested code**, not a CI gate
+or a number to maximize. See [`docs/TESTING_STRATEGY.md`](../../../docs/TESTING_STRATEGY.md)
+for the "confidence, not coverage" philosophy. Use this to locate genuinely
+untested paths, then write meaningful behavior tests for them — do not add tests
+just to move the number.
+
+## Prerequisites
+
+`cargo-llvm-cov` is installed by `npm run setup`. Otherwise:
+
+```bash
+cargo install --locked cargo-llvm-cov
+```
+
+## Commands
+
+```bash
+# Per-file summary table for the whole library (fast triage)
+npm run coverage            # = cargo llvm-cov --lib
+
+# Annotated line-by-line HTML report, opened in a browser
+npm run coverage:html       # = cargo llvm-cov --lib --open
+
+# Scope to one module while iterating (much faster)
+# The test-name filter must follow `--` so it is forwarded to the test binary.
+cargo llvm-cov --lib -- copyright::refiner
+
+# Show uncovered regions for a path as text
+cargo llvm-cov --lib --show-missing-lines -- <filter>
+```
+
+## How to read it
+
+- `--lib` covers **unit tests only**. Integration suites (`tests/*.rs`) and
+  golden suites (`--features golden-tests`) exercise far more code than this
+  credits, so treat the number as a **lower bound**. A file showing 0% may still
+  be well-covered by golden/integration tests.
+- Low coverage on pure data tables (e.g. `copyright/grammar/rules.rs`) or generated
+  code is expected and not worth "fixing".
+- Prioritize gaps in branching logic: error paths, parser fallbacks, edge cases
+  in detection/assembly — places where a wrong branch produces wrong output.
+
+## Workflow to close a real gap
+
+1. Run `npm run coverage` and pick a module with thin coverage on real logic.
+2. Re-run scoped (`cargo llvm-cov --lib --show-missing-lines -- <module>`) to see the
+   exact uncovered lines.
+3. Confirm the lines aren't already covered by a golden/integration suite before
+   assuming they're untested (grep the relevant `tests/` and `*_scan_test.rs`).
+4. Add behavior-focused tests per [`docs/TESTING_STRATEGY.md`](../../../docs/TESTING_STRATEGY.md)
+   (right layer: unit vs scan/assembly contract vs golden).
+5. Re-run scoped coverage to confirm the gap is closed.

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -435,6 +435,27 @@ Before marking a parser complete, verify:
 
 ---
 
+## Code coverage (local signal)
+
+Coverage is a **local signal for finding untested areas, not a target to maximize
+and not a CI gate** — it serves the "confidence, not coverage" goal below rather
+than replacing it. We deliberately do not track coverage in CI; chasing a number
+on every PR adds noise without changing the philosophy.
+
+When an engineer or agent wants to close a gap, run it locally:
+
+- `npm run coverage` prints a per-file summary so you can spot thinly-tested modules.
+- `npm run coverage:html` opens an annotated line-by-line report.
+- Both require `cargo-llvm-cov` (installed by `npm run setup`); scope to a module
+  with a test-name filter after `--`, e.g. `cargo llvm-cov --lib -- copyright::refiner`.
+- The `code-coverage` agent skill documents this workflow for automated use.
+
+Scope caveat: `--lib` measures unit tests only. Integration and golden suites
+exercise far more code than they credit, so read the report as a **lower bound**
+that points at genuinely untested paths, not a verdict on overall test quality.
+
+---
+
 ## Summary
 
 **Testing is about confidence, not coverage.**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Documentation tooling for Provenant",
   "scripts": {
     "prepare": "lefthook install",
-    "setup": "npm install && cargo install --locked cargo-sort cargo-machete cargo-deny && ./setup.sh",
+    "setup": "npm install && cargo install --locked cargo-sort cargo-machete cargo-deny cargo-llvm-cov && ./setup.sh",
     "hooks:install": "lefthook install",
     "hooks:run": "lefthook run pre-commit --all-files",
     "skills:sync": "./scripts/sync_agent_skills.sh",
@@ -21,7 +21,9 @@
     "validate:urls": "cargo run --quiet --manifest-path xtask/Cargo.toml --bin validate-urls -- --root .",
     "lint:docs": "npm run lint:md && npm run format:check",
     "fix:docs": "npm run lint:md:fix && npm run format",
-    "check:docs": "npm run lint:docs"
+    "check:docs": "npm run lint:docs",
+    "coverage": "cargo llvm-cov --lib",
+    "coverage:html": "cargo llvm-cov --lib --open"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

- Adds local code-coverage tooling using `cargo-llvm-cov`, positioned as a **local signal for finding untested code** — not a CI gate and not a number to maximize, consistent with the repo's "confidence, not coverage" philosophy.
- `npm run coverage` prints a per-file summary; `npm run coverage:html` opens an annotated report. `cargo-llvm-cov` is installed by `npm run setup`.
- New `code-coverage` agent skill documenting the local workflow (canonical `.agents/skills`, mirrored to `.claude/skills` via `npm run skills:sync`).
- `docs/TESTING_STRATEGY.md` gains a "Code coverage (local signal)" section.

## Scope and exclusions

- Included: npm scripts, `npm run setup` install, `code-coverage` agent skill, TESTING_STRATEGY note.
- Explicit exclusions: **no CI coverage job and no coverage gate** — intentionally local-only. A buried CI summary with no delta-reporting service adds noise without serving the actual use case (an engineer/agent finding untested code on demand).

## Follow-up work

- If coverage trend tracking is ever desired, revisit by wiring a service (e.g. Codecov) that comments per-PR deltas; only then would a CI job add value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)