### PR TITLE
chore: remove stale allow attributes and justify the rest

### DIFF
--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 
 use super::super::seen_text::SeenTextSets;
 
+// Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_initial_detection_repairs(
     content: &str,
@@ -80,6 +81,7 @@ fn run_initial_detection_repairs(
     seen.dedup_new_holders(holders, h_before);
 }
 
+// Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_author_extraction_and_repairs(
     content: &str,
@@ -307,6 +309,7 @@ fn run_author_extraction_and_repairs(
     seen.rebuild_authors_from(authors);
 }
 
+// Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_mid_pipeline_repairs(
     content: &str,
@@ -400,6 +403,7 @@ fn run_mid_pipeline_repairs(
     seen.rebuild_holders_from(holders);
 }
 
+// Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_late_pattern_extractions(
     content: &str,
@@ -458,7 +462,6 @@ fn run_late_pattern_extractions(
     );
 }
 
-#[allow(clippy::too_many_arguments)]
 fn drop_placeholder_and_code_junk_by_raw_line(
     raw_lines: &[&str],
     copyrights: &mut Vec<CopyrightDetection>,
@@ -691,6 +694,7 @@ fn run_final_variant_and_cleanup_repairs(
     drop_placeholder_and_code_junk_by_raw_line(raw_lines, copyrights, holders);
 }
 
+// Copyright postprocess phase entry point; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 pub(in super::super) fn run_phase_postprocess(
     content: &str,

--- a/src/copyright/detector/phases/primary.rs
+++ b/src/copyright/detector/phases/primary.rs
@@ -6,6 +6,7 @@ use crate::copyright::types::{CopyrightDetection, HolderDetection};
 
 use super::super::seen_text::SeenTextSets;
 
+// Copyright primary-extraction phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_pre_pattern_repairs(
     content: &str,
@@ -186,6 +187,7 @@ fn run_pre_pattern_repairs(
     seen.dedup_new_copyrights(copyrights, c_before);
 }
 
+// Copyright primary-extraction phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_group_based_extractions(
     content: &str,
@@ -397,6 +399,7 @@ fn run_group_based_extractions(
     holders.extend(new_h);
 }
 
+// Copyright primary-extraction phase fn; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 fn run_content_and_markup_extractions(
     content: &str,
@@ -605,6 +608,7 @@ fn run_content_and_markup_extractions(
     holders.extend(new_h);
 }
 
+// Copyright primary-extraction phase entry point; the long argument list threads the shared detection-pipeline state.
 #[allow(clippy::too_many_arguments)]
 pub(in super::super) fn run_phase_primary_extractions(
     content: &str,

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -659,7 +659,7 @@ pub fn post_process_detections(
     // license_expression + rule_identifier + score + matched_text_tokens, which
     // would be identical for same-license texts at different locations.
     //
-    // TODO: Implement UniqueDetection with file_regions aggregation for output
+    // TODO(#926): Implement UniqueDetection with file_regions aggregation for output
     // formatting when we add full ScanCode output compatibility.
     let preferred = apply_detection_preferences(suppressed);
     let ranked = rank_detections(preferred);

--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -5,6 +5,7 @@ use super::schema::{EmbeddedArtifactMetadata, EmbeddedLoaderSnapshot, SCHEMA_VER
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::build_index_from_loaded;
 
+// Loader handle: fields are consumed by maintainer/index-build paths, not every routine-scan path.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct LoadedEmbeddedLicenseIndex {
@@ -43,6 +44,7 @@ pub fn load_loader_snapshot_from_bytes(
     Ok(snapshot)
 }
 
+// Used by maintainer/index-build entry points; not every binary links this path.
 #[allow(dead_code)]
 pub fn load_embedded_license_index_from_bytes(
     bytes: &[u8],

--- a/src/license_detection/expression/mod.rs
+++ b/src/license_detection/expression/mod.rs
@@ -23,6 +23,7 @@ pub use simplify::{
 };
 
 /// Error type for license expression parsing.
+// Variant names share the "Expression"/"Token" domain vocabulary; renaming for the lint would reduce clarity.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum ParseError {
@@ -73,7 +74,6 @@ pub enum LicenseExpression {
 
 impl LicenseExpression {
     /// Extract all license keys from the expression.
-    #[allow(dead_code)]
     pub fn license_keys(&self) -> Vec<String> {
         let mut keys = Vec::new();
         self.collect_keys(&mut keys);
@@ -82,7 +82,6 @@ impl LicenseExpression {
         keys
     }
 
-    #[allow(dead_code)]
     fn collect_keys(&self, keys: &mut Vec<String>) {
         match self {
             Self::License(key) => keys.push(key.clone()),

--- a/src/license_detection/expression/simplify.rs
+++ b/src/license_detection/expression/simplify.rs
@@ -574,7 +574,6 @@ pub fn combine_expressions_and_preserving_structure(
 ///
 /// This function parses each expression string, combines them with `OR`, and
 /// optionally deduplicates license keys.
-#[allow(dead_code)]
 pub fn combine_expressions_or(expressions: &[&str], unique: bool) -> Result<String, ParseError> {
     combine_expressions_with(
         expressions,

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -156,6 +156,7 @@ mod tests {
     use crate::models::LineNumber;
     use crate::models::MatchScore;
 
+    // Test helper that sets every match field explicitly; the long argument list is intentional.
     #[allow(clippy::too_many_arguments)]
     fn create_test_match_with_flags(
         rule_identifier: &str,

--- a/src/license_detection/rules/loader.rs
+++ b/src/license_detection/rules/loader.rs
@@ -73,6 +73,7 @@ impl ParseNumber for yaml_serde::Number {
     }
 }
 
+// Serde deserialization target: mirrors the full .LICENSE frontmatter; not every field is read.
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct LicenseFrontmatter {
@@ -227,6 +228,7 @@ fn parse_file_content(content: &str, path: &Path) -> Result<ParsedRuleFile> {
     })
 }
 
+// Serde deserialization target: mirrors the full .RULE frontmatter; not every field is read.
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct RuleFrontmatter {

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -48,6 +48,7 @@ struct MatchSearchContext<'a> {
 /// # Returns
 ///
 /// Tuple of (query_start, rule_start, match_length)
+// Index-based loop indexes parallel query/rule sequences in lockstep; an iterator rewrite would obscure the diagonal walk.
 #[allow(clippy::needless_range_loop)]
 fn find_longest_match_impl(
     context: &MatchSearchContext<'_>,

--- a/src/license_detection/tokenize.rs
+++ b/src/license_detection/tokenize.rs
@@ -488,7 +488,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(non_snake_case)]
     fn test_query_tokenizer_brace_case() {
         let result = tokenize("{{}some }}Text with   spAces! + _ -");
         assert_eq!(result, vec!["some", "text", "with", "spaces"]);

--- a/src/models/digest.rs
+++ b/src/models/digest.rs
@@ -15,10 +15,10 @@ macro_rules! define_digest {
         pub struct $name([u8; $byte_len]);
 
         impl $name {
+            // Macro-generated for every digest type; only some types use EMPTY, so allow per-type dead_code.
             #[allow(dead_code)]
             pub const EMPTY: Self = Self([0u8; $byte_len]);
 
-            #[allow(dead_code)]
             pub const fn from_bytes(bytes: [u8; $byte_len]) -> Self {
                 Self(bytes)
             }
@@ -31,6 +31,7 @@ macro_rules! define_digest {
                 Ok(Self(array))
             }
 
+            // Macro-generated accessor; not every digest type reads its raw bytes, so allow per-type dead_code.
             #[allow(dead_code)]
             pub fn as_bytes(&self) -> &[u8; $byte_len] {
                 &self.0

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -208,8 +208,9 @@ impl FileInfoBuilder {
 }
 
 impl FileInfo {
-    #[allow(clippy::too_many_arguments)]
     /// Construct a [`FileInfo`] from fully resolved scanner fields.
+    // Arguments mirror the resolved scanner fields that make up a [`FileInfo`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         base_name: String,

--- a/src/output_schema/serde_helpers.rs
+++ b/src/output_schema/serde_helpers.rs
@@ -20,7 +20,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 pub fn is_false(value: &bool) -> bool {
     !value
 }

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -753,6 +753,7 @@ fn non_version_download_url(version: &str, resolved: Option<&str>) -> Option<Str
         })
 }
 
+// Parameters map directly to the npm lockfile dependency fields this builder assembles.
 #[allow(clippy::too_many_arguments)]
 fn build_npm_dependency(
     package_name: &str,


### PR DESCRIPTION
## Summary

- Removes `#[allow(...)]` suppressions that masked code which is in fact used, after verifying each call site, and confirms `cargo clippy -p provenant-cli --lib -- -D warnings` stays clean.
- Adds concise one-line justification comments to the legitimate remaining suppressions so they comply with the AGENTS.md "rare, permanent, and justified" rule.
- Files a tracking issue for an existing TODO and references it from the code.

Removed (7 sites): `LicenseExpression::license_keys` and `collect_keys`, `combine_expressions_or`, `is_false` serde helper, `Digest::from_bytes`, a `non_snake_case` allow on an already-snake_case test fn, and a `clippy::too_many_arguments` allow on a 3-argument copyright fn (`drop_placeholder_and_code_junk_by_raw_line`) that the audit flagged as possibly unnecessary — confirmed unnecessary.

Justified (13 sites): digest `EMPTY`/`as_bytes` (macro-generated per-type), npm lockfile dependency builder, `FileInfo::new`, the seq-match diagonal range loop, the `.LICENSE`/`.RULE` serde frontmatter targets, the `ParseError` enum variant names, the embedded loader handle and load fn, a false-positive test helper, and the copyright primary/postprocess phase fns.

## Issues

- Covers: #926 (created as part of this work; not closed here)

## Scope and exclusions

- Included: suppression-attribute cleanup and justification across `src/license_detection/**`, `src/copyright/detector/phases/**`, `src/models/**`, `src/output_schema/serde_helpers.rs`, and `src/parsers/npm_lock.rs`; plus the TODO reference update.
- Explicit exclusions: no behavioral changes; no implementation of the UniqueDetection feature (deferred to #926). Files under parallel-refactor (utils/file, copyright refiner/tree_walk, output_schema/metadata, gradle parser, scanner/cli/analysis) were intentionally left untouched. Already-justified or KEEP-AS-IS suppressions (the `cast_sign_loss` truncation comment, documented `unsafe`, re-export `unused_imports`, commented dead_code) were left as-is.

## Follow-up work

- #926 — Implement `UniqueDetection` with `file_regions` aggregation for full ScanCode output compatibility. The bare `// TODO:` at `src/license_detection/detection/mod.rs` is now `// TODO(#926):`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)