### PR TITLE
refactor(license-detection): remove dead aggregation, score, and candidate metrics

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -199,8 +199,6 @@ pub(crate) fn aho_match_with_extra_matchables(
             is_from_license: rule.is_from_license,
             rule_start_token: 0,
             coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         };
 
         matches.push(license_match);

--- a/src/license_detection/detection/analysis_test.rs
+++ b/src/license_detection/detection/analysis_test.rs
@@ -30,8 +30,6 @@ fn create_test_match(coverage: f32, rule_identifier: &str) -> LicenseMatch {
         rule_length: 100,
         rule_start_token: 0,
         coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 11)),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
 }
 
@@ -76,8 +74,6 @@ fn create_test_match_full(
             start_line.get(),
             end_line.get() + 1,
         )),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
 }
 

--- a/src/license_detection/detection/analysis_test.rs
+++ b/src/license_detection/detection/analysis_test.rs
@@ -1085,7 +1085,6 @@ fn test_classify_detection_valid_perfect() {
         matches: vec![m],
         detection_log: vec!["perfect-detection".to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(classify_detection(&detection, 0.0));
 }
@@ -1110,7 +1109,6 @@ fn test_classify_detection_invalid_low_score() {
         matches: vec![m],
         detection_log: vec![],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(!classify_detection(&detection, 50.0));
 }
@@ -1135,7 +1133,6 @@ fn test_classify_detection_invalid_false_positive() {
         matches: vec![m],
         detection_log: vec![],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(!classify_detection(&detection, 0.0));
 }
@@ -1162,7 +1159,6 @@ fn test_classify_detection_keeps_true_license_clue_even_if_false_positive_heuris
         matches: vec![m],
         detection_log: vec![DETECTION_LOG_LICENSE_CLUES.to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
 
     assert!(classify_detection(&detection, 0.0));
@@ -1176,7 +1172,6 @@ fn test_classify_detection_invalid_empty() {
         matches: vec![],
         detection_log: vec![],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(!classify_detection(&detection, 0.0));
 }
@@ -1201,7 +1196,6 @@ fn test_classify_detection_score_threshold() {
         matches: vec![m],
         detection_log: vec![],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(classify_detection(&detection, 45.0));
     assert!(!classify_detection(&detection, 50.0));
@@ -1227,7 +1221,6 @@ fn test_classify_detection_perfect_matches() {
         matches: vec![m],
         detection_log: vec!["perfect-detection".to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
     assert!(classify_detection(&detection, 0.0));
 }

--- a/src/license_detection/detection/grouping.rs
+++ b/src/license_detection/detection/grouping.rs
@@ -248,8 +248,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -287,8 +285,6 @@ mod tests {
                 start_token,
                 end_token,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/detection/identifier.rs
+++ b/src/license_detection/detection/identifier.rs
@@ -192,8 +192,6 @@ mod tests {
             rule_length: 100,
             rule_start_token: 0,
             coordinates: MatchCoordinates::query_region(PositionSpan::range(1, 11)),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -12,11 +12,10 @@ pub mod identifier;
 mod types;
 
 pub use grouping::{group_matches_by_region, sort_matches_by_line};
-pub(crate) use types::{DetectionGroup, FileRegion, LicenseDetection, UniqueDetection};
+pub(crate) use types::{DetectionGroup, LicenseDetection};
 
-use crate::license_detection::models::LicenseMatch;
 use crate::license_detection::spdx_mapping::SpdxMapping;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::license_detection::expression::licensing_contains;
 use crate::license_detection::expression::parse_expression;
@@ -84,7 +83,6 @@ pub(crate) fn populate_detection_from_group(
     let matches_for_expression = select_matches_for_expression(&group.matches, log_category, false);
 
     detection.matches = group.matches.clone();
-    detection.file_regions = collect_file_regions_from_matches(&detection.matches);
 
     let _score = compute_detection_score(&detection.matches);
 
@@ -178,7 +176,6 @@ fn create_detection_from_group(group: &DetectionGroup) -> LicenseDetection {
         matches: Vec::new(),
         detection_log: Vec::new(),
         identifier: None,
-        file_regions: Vec::new(),
     };
 
     if group.matches.is_empty() {
@@ -197,7 +194,6 @@ pub(crate) fn empty_detection() -> LicenseDetection {
         matches: Vec::new(),
         detection_log: Vec::new(),
         identifier: None,
-        file_regions: Vec::new(),
     }
 }
 
@@ -317,84 +313,6 @@ pub(crate) fn attach_source_path_to_detections(
             if match_item.from_file.is_none() {
                 match_item.from_file = Some(source_path.to_string());
             }
-        }
-        detection.file_regions = collect_file_regions_from_matches(&detection.matches);
-    }
-}
-
-type SeenRegionKey = (String, usize, usize);
-type UniqueDetectionEntry = (UniqueDetection, HashSet<SeenRegionKey>);
-
-pub(crate) fn get_unique_detections(detections: &[LicenseDetection]) -> Vec<UniqueDetection> {
-    let mut detections_by_identifier: BTreeMap<String, UniqueDetectionEntry> = BTreeMap::new();
-
-    for detection in detections {
-        let Some(identifier) = detection.identifier.as_ref() else {
-            continue;
-        };
-
-        let (entry, seen_regions) = detections_by_identifier
-            .entry(identifier.clone())
-            .or_insert_with(|| {
-                (
-                    UniqueDetection {
-                        identifier: identifier.clone(),
-                        file_regions: Vec::new(),
-                    },
-                    HashSet::new(),
-                )
-            });
-
-        for region in &detection.file_regions {
-            let key = (
-                region.path.clone(),
-                region.start_line.get(),
-                region.end_line.get(),
-            );
-            if seen_regions.insert(key) {
-                entry.file_regions.push(region.clone());
-            }
-        }
-    }
-
-    detections_by_identifier
-        .into_values()
-        .map(|(unique_detection, _)| unique_detection)
-        .collect()
-}
-
-fn collect_file_regions_from_matches(matches: &[LicenseMatch]) -> Vec<FileRegion> {
-    let Some(first_path) = matches
-        .iter()
-        .find_map(|match_item| match_item.from_file.clone())
-    else {
-        return Vec::new();
-    };
-
-    let start_line = matches.iter().map(|match_item| match_item.start_line).min();
-    let end_line = matches.iter().map(|match_item| match_item.end_line).max();
-
-    match (start_line, end_line) {
-        (Some(start_line), Some(end_line)) => vec![FileRegion {
-            path: first_path,
-            start_line,
-            end_line,
-        }],
-        _ => Vec::new(),
-    }
-}
-
-fn attach_aggregated_file_regions(detections: &mut [LicenseDetection]) {
-    let unique_regions: HashMap<_, _> = get_unique_detections(detections)
-        .into_iter()
-        .map(|unique| (unique.identifier, unique.file_regions))
-        .collect();
-
-    for detection in detections {
-        if let Some(identifier) = detection.identifier.as_ref()
-            && let Some(file_regions) = unique_regions.get(identifier)
-        {
-            detection.file_regions = file_regions.clone();
         }
     }
 }
@@ -646,26 +564,26 @@ pub fn post_process_detections(
     let filtered = filter_detections_by_score(detections, min_score);
     let promoted = promote_non_clue_no_expression_detections(filtered);
     let suppressed = suppress_weaker_gpl_family_detections(promoted);
-    // NOTE: We do NOT call remove_duplicate_detections here.
+    // NOTE: We intentionally do NOT call remove_duplicate_detections here.
     //
-    // Python's get_unique_detections() groups detections by identifier and creates
-    // UniqueDetection objects with aggregated file_regions, but it does NOT remove
-    // detections. The Python test infrastructure uses idx.match() which returns
-    // raw matches without any deduplication.
+    // ScanCode's get_unique_detections() groups detections by identifier into
+    // UniqueDetection objects for the codebase-level `license_detections` summary,
+    // but it never removes the underlying per-location detections. Deduplicating
+    // here would incorrectly merge detections that share an identifier at different
+    // locations (e.g. two bsd-new blocks in different parts of one file), because the
+    // identifier is derived from license_expression + rule_identifier + score +
+    // matched_text_tokens and is identical for the same license text wherever it
+    // appears.
     //
-    // Calling remove_duplicate_detections would incorrectly merge detections that
-    // have the same license expression at different locations (e.g., two bsd-new
-    // licenses in different parts of a file). The identifier is computed from
-    // license_expression + rule_identifier + score + matched_text_tokens, which
-    // would be identical for same-license texts at different locations.
-    //
-    // TODO(#926): Implement UniqueDetection with file_regions aggregation for output
-    // formatting when we add full ScanCode output compatibility.
+    // The UniqueDetection-style aggregation ScanCode exposes in output lives in
+    // post_processing::reference_following::collect_top_level_license_detections,
+    // which derives detection_count from the distinct file regions. ScanCode does not
+    // serialize file_regions in its JSON (they are filtered out of both
+    // LicenseDetection.to_dict and UniqueDetection.to_dict), so there is no
+    // output-schema work to do here.
     let preferred = apply_detection_preferences(suppressed);
     let ranked = rank_detections(preferred);
-    let mut sorted = sort_detections_by_line(ranked);
-    attach_aggregated_file_regions(&mut sorted);
-    sorted
+    sort_detections_by_line(ranked)
 }
 
 fn suppress_weaker_gpl_family_detections(
@@ -1182,7 +1100,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group(&mut detection, &group, None);
         assert_eq!(detection.matches.len(), 1);
@@ -1202,7 +1119,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group(&mut detection, &group, None);
         assert!(detection.matches.is_empty());
@@ -1223,7 +1139,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group(&mut detection, &group, None);
         assert!(
@@ -1246,7 +1161,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
 
         populate_detection_from_group(&mut detection, &group, None);
@@ -1273,7 +1187,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
 
         populate_detection_from_group(&mut detection, &group, None);
@@ -1302,7 +1215,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
         assert!(detection.license_expression_spdx.is_some());
@@ -1319,7 +1231,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
         assert!(detection.matches.is_empty());
@@ -1333,7 +1244,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec!["perfect-detection".to_string()],
             identifier: None,
-            file_regions: Vec::new(),
         };
         detection.identifier = Some(compute_detection_identifier(&detection));
         let filtered = filter_detections_by_score(vec![detection], 0.0);
@@ -1356,7 +1266,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![weak_match],
             detection_log: vec![],
             identifier: Some("weak-gpl1".to_string()),
-            file_regions: Vec::new(),
         };
 
         let mut strong_match = create_test_match(15, 15, "2-aho", "gpl-2.0-plus_544.RULE");
@@ -1373,7 +1282,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![strong_match],
             detection_log: vec![],
             identifier: Some("strong-gpl2plus".to_string()),
-            file_regions: Vec::new(),
         };
 
         let processed = post_process_detections(vec![weak_detection, strong_detection], 0.0);
@@ -1393,7 +1301,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec!["perfect-detection".to_string()],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d1.identifier = Some(compute_detection_identifier(&d1));
 
@@ -1407,7 +1314,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d2.identifier = Some(compute_detection_identifier(&d2));
 
@@ -1427,7 +1333,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         detection.identifier = Some(compute_detection_identifier(&detection));
         let filtered = filter_detections_by_score(vec![detection], 50.0);
@@ -1448,7 +1353,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: Some("mit-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("apache-2.0".to_string()),
@@ -1456,7 +1360,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(20, 30)],
             detection_log: vec![],
             identifier: Some("apache-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let result = remove_duplicate_detections(vec![d1, d2]);
         assert_eq!(result.len(), 2);
@@ -1470,7 +1373,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: Some("mit-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("mit".to_string()),
@@ -1478,7 +1380,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(20, 30)],
             detection_log: vec![],
             identifier: Some("mit-def456".to_string()),
-            file_regions: Vec::new(),
         };
         let result = remove_duplicate_detections(vec![d1, d2]);
         assert_eq!(
@@ -1502,7 +1403,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let mut d2 = LicenseDetection {
             license_expression: Some("apache-2.0".to_string()),
@@ -1514,7 +1414,6 @@ MySQL FLOSS License Exception body starts here.
             }],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d1.identifier = Some(compute_detection_identifier(&d1));
         d2.identifier = Some(compute_detection_identifier(&d2));
@@ -1533,7 +1432,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m1],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let mut m2 = create_test_match(20, 30, "1-hash", "apache.LICENSE");
         m2.score = MatchScore::from_percentage(90.0);
@@ -1544,7 +1442,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m2],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d1.identifier = Some(compute_detection_identifier(&d1));
         d2.identifier = Some(compute_detection_identifier(&d2));
@@ -1571,7 +1468,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m.clone()],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("mit".to_string()),
@@ -1579,7 +1475,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let id1 = compute_detection_identifier(&d1);
         let id2 = compute_detection_identifier(&d2);
@@ -1596,7 +1491,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m1],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("apache-2.0".to_string()),
@@ -1604,7 +1498,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m2],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         let id1 = compute_detection_identifier(&d1);
         let id2 = compute_detection_identifier(&d2);
@@ -1622,7 +1515,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: Some("mit-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("mit".to_string()),
@@ -1630,7 +1522,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(20, 30)],
             detection_log: vec![],
             identifier: Some("mit-def456".to_string()),
-            file_regions: Vec::new(),
         };
         let result = apply_detection_preferences(vec![d1, d2]);
         assert_eq!(
@@ -1648,7 +1539,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: Some("mit-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("apache-2.0".to_string()),
@@ -1656,7 +1546,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(20, 30)],
             detection_log: vec![],
             identifier: Some("apache-abc123".to_string()),
-            file_regions: Vec::new(),
         };
         let result = apply_detection_preferences(vec![d1, d2]);
         assert_eq!(result.len(), 2);
@@ -1677,7 +1566,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m],
             detection_log: vec!["perfect-detection".to_string()],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d.identifier = Some(compute_detection_identifier(&d));
         let result = post_process_detections(vec![d], 0.0);
@@ -1696,7 +1584,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![m],
             detection_log: vec![],
             identifier: None,
-            file_regions: Vec::new(),
         };
         d.identifier = Some(compute_detection_identifier(&d));
         let result = post_process_detections(vec![d], 50.0);
@@ -1727,7 +1614,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![proper_match],
             detection_log: vec![],
             identifier: Some("bsd_new-proper".to_string()),
-            file_regions: Vec::new(),
         };
         let low_quality = LicenseDetection {
             license_expression: None,
@@ -1735,7 +1621,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![low_quality_match],
             detection_log: vec![DETECTION_LOG_LOW_QUALITY_MATCH_FRAGMENTS.to_string()],
             identifier: None,
-            file_regions: Vec::new(),
         };
 
         let result = post_process_detections(vec![proper, low_quality], 0.0);
@@ -1771,7 +1656,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![proper_match],
             detection_log: vec![],
             identifier: Some("mit-proper".to_string()),
-            file_regions: Vec::new(),
         };
         let clue = LicenseDetection {
             license_expression: None,
@@ -1779,7 +1663,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![clue_match],
             detection_log: vec![DETECTION_LOG_LICENSE_CLUES.to_string()],
             identifier: None,
-            file_regions: Vec::new(),
         };
 
         let result = post_process_detections(vec![proper, clue], 0.0);
@@ -1809,7 +1692,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(20, 30)],
             detection_log: vec![],
             identifier: Some("mit-1".to_string()),
-            file_regions: Vec::new(),
         };
         let d2 = LicenseDetection {
             license_expression: Some("apache-2.0".to_string()),
@@ -1817,7 +1699,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![create_perfect_match(1, 10)],
             detection_log: vec![],
             identifier: Some("apache-1".to_string()),
-            file_regions: Vec::new(),
         };
         let sorted = sort_detections_by_line(vec![d1, d2]);
         assert_eq!(sorted[0].matches[0].start_line, LineNumber::ONE);
@@ -1874,7 +1755,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
         assert!(detection.license_expression_spdx.is_some());
@@ -1896,7 +1776,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
         assert!(detection.license_expression.is_some());
@@ -1921,7 +1800,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
 
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
@@ -1946,7 +1824,6 @@ MySQL FLOSS License Exception body starts here.
             matches: Vec::new(),
             detection_log: Vec::new(),
             identifier: None,
-            file_regions: Vec::new(),
         };
         populate_detection_from_group_with_spdx(&mut detection, &group, &spdx_mapping, None);
         assert!(detection.license_expression.is_some());
@@ -1978,7 +1855,7 @@ MySQL FLOSS License Exception body starts here.
     }
 
     #[test]
-    fn test_attach_source_path_to_detections_populates_file_regions() {
+    fn test_attach_source_path_to_detections_sets_from_file() {
         let mut match_item = create_perfect_match(4, 8);
         match_item.from_file = None;
         let mut detections = vec![LicenseDetection {
@@ -1987,7 +1864,6 @@ MySQL FLOSS License Exception body starts here.
             matches: vec![match_item],
             detection_log: vec![],
             identifier: Some("mit-1".to_string()),
-            file_regions: Vec::new(),
         }];
 
         attach_source_path_to_detections(&mut detections, "src/lib.rs");
@@ -1996,144 +1872,5 @@ MySQL FLOSS License Exception body starts here.
             detections[0].matches[0].from_file.as_deref(),
             Some("src/lib.rs")
         );
-        assert_eq!(detections[0].file_regions.len(), 1);
-        assert_eq!(detections[0].file_regions[0].path, "src/lib.rs");
-        assert_eq!(
-            detections[0].file_regions[0].start_line,
-            LineNumber::new(4).expect("valid")
-        );
-        assert_eq!(
-            detections[0].file_regions[0].end_line,
-            LineNumber::new(8).expect("valid")
-        );
-    }
-
-    #[test]
-    fn test_attach_source_path_to_detections_uses_single_detection_region_span() {
-        let mut first = create_perfect_match(4, 8);
-        first.from_file = None;
-        let mut second = create_perfect_match(20, 25);
-        second.from_file = None;
-        let mut detections = vec![LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![first, second],
-            detection_log: vec![],
-            identifier: Some("mit-1".to_string()),
-            file_regions: Vec::new(),
-        }];
-
-        attach_source_path_to_detections(&mut detections, "src/lib.rs");
-
-        assert_eq!(detections[0].file_regions.len(), 1);
-        assert_eq!(detections[0].file_regions[0].path, "src/lib.rs");
-        assert_eq!(
-            detections[0].file_regions[0].start_line,
-            LineNumber::new(4).expect("valid")
-        );
-        assert_eq!(
-            detections[0].file_regions[0].end_line,
-            LineNumber::new(25).expect("valid")
-        );
-    }
-
-    #[test]
-    fn test_get_unique_detections_aggregates_distinct_regions() {
-        let first = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(1, 10)],
-            detection_log: vec![],
-            identifier: Some("mit-shared".to_string()),
-            file_regions: vec![FileRegion {
-                path: "src/one.rs".to_string(),
-                start_line: LineNumber::ONE,
-                end_line: LineNumber::new(10).expect("valid"),
-            }],
-        };
-        let second = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(20, 30)],
-            detection_log: vec![],
-            identifier: Some("mit-shared".to_string()),
-            file_regions: vec![FileRegion {
-                path: "src/two.rs".to_string(),
-                start_line: LineNumber::new(20).expect("valid"),
-                end_line: LineNumber::new(30).expect("valid"),
-            }],
-        };
-        let third = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(20, 30)],
-            detection_log: vec![],
-            identifier: Some("mit-shared".to_string()),
-            file_regions: vec![FileRegion {
-                path: "src/two.rs".to_string(),
-                start_line: LineNumber::new(20).expect("valid"),
-                end_line: LineNumber::new(30).expect("valid"),
-            }],
-        };
-
-        let unique = get_unique_detections(&[first, second, third]);
-
-        assert_eq!(unique.len(), 1);
-        assert_eq!(unique[0].identifier, "mit-shared");
-        assert_eq!(unique[0].file_regions.len(), 2);
-    }
-
-    #[test]
-    fn test_get_unique_detections_skips_detections_without_identifier() {
-        let detection = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(1, 10)],
-            detection_log: vec![],
-            identifier: None,
-            file_regions: vec![FileRegion {
-                path: "src/one.rs".to_string(),
-                start_line: LineNumber::ONE,
-                end_line: LineNumber::new(10).expect("valid"),
-            }],
-        };
-
-        let unique = get_unique_detections(&[detection]);
-
-        assert!(unique.is_empty());
-    }
-
-    #[test]
-    fn test_post_process_detections_attaches_aggregated_file_regions() {
-        let first = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(1, 10)],
-            detection_log: vec![],
-            identifier: Some("mit-shared".to_string()),
-            file_regions: vec![FileRegion {
-                path: "src/one.rs".to_string(),
-                start_line: LineNumber::ONE,
-                end_line: LineNumber::new(10).expect("valid"),
-            }],
-        };
-        let second = LicenseDetection {
-            license_expression: Some("mit".to_string()),
-            license_expression_spdx: Some("MIT".to_string()),
-            matches: vec![create_perfect_match(20, 30)],
-            detection_log: vec![],
-            identifier: Some("mit-shared".to_string()),
-            file_regions: vec![FileRegion {
-                path: "src/two.rs".to_string(),
-                start_line: LineNumber::new(20).expect("valid"),
-                end_line: LineNumber::new(30).expect("valid"),
-            }],
-        };
-
-        let processed = post_process_detections(vec![first, second], 0.0);
-
-        assert_eq!(processed.len(), 2);
-        assert_eq!(processed[0].file_regions.len(), 2);
-        assert_eq!(processed[1].file_regions.len(), 2);
     }
 }

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -84,8 +84,6 @@ pub(crate) fn populate_detection_from_group(
 
     detection.matches = group.matches.clone();
 
-    let _score = compute_detection_score(&detection.matches);
-
     if should_compute_public_expression(log_category)
         && let Ok(expr) = determine_license_expression(&matches_for_expression, source_text)
     {
@@ -720,8 +718,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -74,8 +74,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -4,20 +4,6 @@
 //! Core detection data structures.
 
 use crate::license_detection::models::LicenseMatch;
-use crate::models::LineNumber;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct FileRegion {
-    pub(crate) path: String,
-    pub(crate) start_line: LineNumber,
-    pub(crate) end_line: LineNumber,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct UniqueDetection {
-    pub(crate) identifier: String,
-    pub(crate) file_regions: Vec<FileRegion>,
-}
 
 pub struct DetectionGroup {
     /// The matches in this group
@@ -50,8 +36,6 @@ pub struct LicenseDetection {
     /// An identifier unique for a license detection, containing the license
     /// expression and a UUID crafted from the match contents.
     pub identifier: Option<String>,
-
-    pub(crate) file_regions: Vec<FileRegion>,
 }
 
 #[cfg(test)]

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -118,8 +118,6 @@ pub fn hash_match(index: &LicenseIndex, query_run: &QueryRun) -> Vec<LicenseMatc
             is_from_license: rule.is_from_license,
             rule_start_token: 0,
             coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         };
 
         matches.push(license_match);

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -204,8 +204,6 @@ mod tests {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::query_region(PositionSpan::range(0, matched_length)),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -708,8 +708,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -750,8 +748,6 @@ mod tests {
                 start_token,
                 end_token,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -241,13 +241,6 @@ pub fn filter_overlapping_matches(
                 break;
             }
 
-            // Note: We do NOT use candidate_resemblance for tie-breaking here.
-            // candidate_resemblance is a GLOBAL measure based on multiset intersection
-            // over the entire query and rule, not the actual matched region.
-            // Using it for LOCAL overlap decisions produces wrong results.
-            // See: CC-BY-SA-2.0 vs CC-BY-NC-SA-2.0 where NC-SA has higher
-            // candidate_resemblance but lower actual coverage.
-
             // When overlap is >= 90%, prefer higher coverage when lengths are equal.
             // This ensures that for matches with identical qspan, the one with better
             // coverage is kept. See: gfdl-1.1 vs gfdl-1.1-plus where both match the
@@ -553,8 +546,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -596,8 +587,6 @@ mod tests {
                 PositionSpan::range(0, matched_length),
                 PositionSpan::range(0, matched_length / 2),
             ),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -422,8 +422,6 @@ mod tests {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -462,8 +460,6 @@ mod tests {
                 PositionSpan::empty(),
                 PositionSpan::empty(),
             ),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -500,8 +496,6 @@ mod tests {
                 start_token,
                 end_token,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -432,8 +432,6 @@ mod tests {
                 start_line,
                 end_line + 1,
             )),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -234,16 +234,6 @@ pub struct LicenseMatch {
 
     /// Coordinate data distinguishing rule-aligned from query-region matches.
     pub coordinates: MatchCoordinates,
-
-    /// Candidate resemblance score from set similarity.
-    /// Used for cross-license tie-breaking when matches overlap.
-    /// Higher resemblance means better candidate quality.
-    pub candidate_resemblance: f32,
-
-    /// Candidate containment score from set similarity.
-    /// Used for cross-license tie-breaking when matches overlap.
-    /// Higher containment means more of the rule is matched.
-    pub candidate_containment: f32,
 }
 
 #[derive(Serialize)]
@@ -275,8 +265,6 @@ struct SerializableLicenseMatch<'a> {
     is_from_license: bool,
     hilen: usize,
     rule_start_token: usize,
-    candidate_resemblance: f32,
-    candidate_containment: f32,
 }
 
 impl Serialize for LicenseMatch {
@@ -311,8 +299,6 @@ impl Serialize for LicenseMatch {
             is_from_license: self.is_from_license,
             hilen: self.hilen(),
             rule_start_token: self.rule_start_token,
-            candidate_resemblance: self.candidate_resemblance,
-            candidate_containment: self.candidate_containment,
         }
         .serialize(serializer)
     }
@@ -343,8 +329,6 @@ impl Default for LicenseMatch {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::default(),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 }

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -122,8 +122,6 @@ mod tests {
                 PositionSpan::range(0, 100),
                 PositionSpan::range(0, 50),
             ),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }
     }
 
@@ -537,8 +535,6 @@ mod tests {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         };
 
         assert!(match_result.from_file.is_none());
@@ -691,8 +687,6 @@ mod tests {
                 PositionSpan::range(0, 100),
                 PositionSpan::range(0, 50),
             ),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         };
 
         assert_eq!(

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -102,16 +102,6 @@ impl CandidateMetrics {
         u128::from(matched) * 10 >= u128::from(union) * u128::from(threshold_tenths)
     }
 
-    pub(super) fn containment_f32(&self) -> f32 {
-        self.matched_length as f32 / self.rule_len as f32
-    }
-
-    pub(super) fn amplified_resemblance_f32(&self) -> f32 {
-        let union_len = self.union_len() as f32;
-        let resemblance = self.matched_length as f32 / union_len;
-        resemblance * resemblance
-    }
-
     fn rounded_containment_tenths(&self) -> u32 {
         quantize_ratio_tenths(self.matched_length as u64, self.rule_len as u64)
     }

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -367,8 +367,6 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
                         is_from_license: candidate.rule.is_from_license,
                         rule_start_token: ipos,
                         coordinates: MatchCoordinates::rule_aligned(qspan, ispan, hispan),
-                        candidate_resemblance: candidate.metrics.amplified_resemblance_f32(),
-                        candidate_containment: candidate.metrics.containment_f32(),
                     };
 
                     matches.push(license_match);

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -391,8 +391,6 @@ pub fn spdx_lid_match(index: &LicenseIndex, query: &Query) -> Vec<LicenseMatch> 
                 is_from_license: false,
                 rule_start_token: 0,
                 coordinates: MatchCoordinates::query_region(qspan),
-                candidate_resemblance: 0.0,
-                candidate_containment: 0.0,
             };
 
             matches.push(license_match);

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -290,8 +290,6 @@ fn create_unknown_match_from_qspan(query: &Query, qspan: &PositionSet) -> Option
         is_from_license: false,
         rule_start_token: 0,
         coordinates: MatchCoordinates::query_region(qspan_span),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
     .into()
 }
@@ -835,8 +833,6 @@ mod tests {
             coordinates: MatchCoordinates::query_region(PositionSpan::from_positions(vec![
                 0, 1, 2, 7, 8, 9,
             ])),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }];
 
         let covered = compute_covered_positions(&query, &known_matches);
@@ -882,8 +878,6 @@ mod tests {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::query_region(PositionSpan::range(5, 10)),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }];
 
         let covered = compute_covered_positions(&query, &known_matches);
@@ -932,8 +926,6 @@ mod tests {
             coordinates: MatchCoordinates::query_region(PositionSpan::from_positions(vec![
                 0, 1, 2, 3, 11, 12, 13, 14,
             ])),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }];
 
         let covered = compute_covered_positions(&query, &known_matches);
@@ -1013,8 +1005,6 @@ mod tests {
             is_from_license: false,
             rule_start_token: 0,
             coordinates: MatchCoordinates::query_region(PositionSpan::range(0, 5)),
-            candidate_resemblance: 0.0,
-            candidate_containment: 0.0,
         }];
 
         let matches = unknown_match(&index, &query, &known_matches);

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1447,8 +1447,6 @@ fn public_match_to_internal(
         coordinates: crate::license_detection::models::MatchCoordinates::query_region(
             crate::license_detection::models::PositionSpan::empty(),
         ),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
 }
 

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -6,8 +6,7 @@ use std::path::Path;
 
 use super::font_policy::{is_font_asset_path, is_font_license_file_name};
 use crate::license_detection::detection::{
-    FileRegion as InternalFileRegion, determine_license_expression, determine_spdx_expression,
-    select_matches_for_expression,
+    determine_license_expression, determine_spdx_expression, select_matches_for_expression,
 };
 use crate::license_detection::expression::parse_expression;
 use crate::license_detection::models::RuleId;
@@ -879,7 +878,7 @@ fn apply_resolved_reference_targets(
         detection.license_expression.as_str(),
         "unknown-license-reference" | "free-unknown"
     );
-    let mut internal_detection = public_detection_to_internal(detection, current_path);
+    let mut internal_detection = public_detection_to_internal(detection);
     let mut source_matches = Vec::new();
     if strip_source_matches_for_expression {
         source_matches = internal_detection.matches.clone();
@@ -887,7 +886,7 @@ fn apply_resolved_reference_targets(
     }
     for target in &referenced_targets {
         for referenced_detection in &target.detections {
-            let mut internal = public_detection_to_internal(referenced_detection, &target.path);
+            let mut internal = public_detection_to_internal(referenced_detection);
             for match_item in &mut internal.matches {
                 if target.preserve_match_from_file {
                     match_item
@@ -1382,27 +1381,12 @@ pub(super) fn use_referenced_license_expression(
 
 fn public_detection_to_internal(
     detection: &LicenseDetection,
-    owning_path: &str,
 ) -> crate::license_detection::LicenseDetection {
     let matches: Vec<_> = detection
         .matches
         .iter()
         .map(public_match_to_internal)
         .collect();
-    let file_regions = if matches.is_empty() {
-        Vec::new()
-    } else {
-        let start_line = matches.iter().map(|match_item| match_item.start_line).min();
-        let end_line = matches.iter().map(|match_item| match_item.end_line).max();
-        match (start_line, end_line) {
-            (Some(start_line), Some(end_line)) => vec![InternalFileRegion {
-                path: owning_path.to_string(),
-                start_line,
-                end_line,
-            }],
-            _ => Vec::new(),
-        }
-    };
     crate::license_detection::LicenseDetection {
         license_expression: (!detection.license_expression.is_empty())
             .then(|| detection.license_expression.clone()),
@@ -1411,7 +1395,6 @@ fn public_detection_to_internal(
         matches: matches.clone(),
         detection_log: detection.detection_log.clone(),
         identifier: (!detection.identifier.is_empty()).then(|| detection.identifier.clone()),
-        file_regions,
     }
 }
 

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -74,7 +74,6 @@ fn make_detection(rule_url: &str) -> InternalLicenseDetection {
         matches: vec![make_internal_match(rule_url)],
         detection_log: vec![],
         identifier: Some("mit-test".to_string()),
-        file_regions: Vec::new(),
     }
 }
 
@@ -378,7 +377,6 @@ fn test_convert_detection_to_model_promotes_exact_reference_url_clue() {
         matches: vec![weaker_match, stronger_match],
         detection_log: vec![],
         identifier: None,
-        file_regions: Vec::new(),
     };
 
     let (converted, clues) = convert_detection_to_model(
@@ -445,7 +443,6 @@ fn test_promote_legal_notice_low_quality_detections_promotes_apache_notice_fragm
         matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
         detection_log: Vec::new(),
         identifier: None,
-        file_regions: Vec::new(),
     };
     let low_quality = InternalLicenseDetection {
         license_expression: None,
@@ -453,7 +450,6 @@ fn test_promote_legal_notice_low_quality_detections_promotes_apache_notice_fragm
         matches: vec![make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8)],
         detection_log: vec!["low-quality-match-fragments".to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
     let mut detections = vec![concrete, low_quality];
 
@@ -482,7 +478,6 @@ fn test_promote_legal_notice_low_quality_detections_ignores_non_legal_path() {
         matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
         detection_log: Vec::new(),
         identifier: None,
-        file_regions: Vec::new(),
     };
     let low_quality = InternalLicenseDetection {
         license_expression: None,
@@ -490,7 +485,6 @@ fn test_promote_legal_notice_low_quality_detections_ignores_non_legal_path() {
         matches: vec![make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8)],
         detection_log: vec!["low-quality-match-fragments".to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
     let mut detections = vec![concrete, low_quality];
 
@@ -507,7 +501,6 @@ fn test_promote_legal_notice_low_quality_detections_ignores_true_clue_rules() {
         matches: vec![make_internal_notice_match("cve-tou", "cve-tou", 39, 42)],
         detection_log: Vec::new(),
         identifier: None,
-        file_regions: Vec::new(),
     };
     let mut clue_match = make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8);
     clue_match.rule_kind = RuleKind::Clue;
@@ -517,7 +510,6 @@ fn test_promote_legal_notice_low_quality_detections_ignores_true_clue_rules() {
         matches: vec![clue_match],
         detection_log: vec!["low-quality-match-fragments".to_string()],
         identifier: None,
-        file_regions: Vec::new(),
     };
     let mut detections = vec![concrete, low_quality];
 

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -62,8 +62,6 @@ fn make_internal_match(rule_url: &str) -> LicenseMatch {
         is_from_license: true,
         rule_start_token: 0,
         coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
 }
 
@@ -113,8 +111,6 @@ fn make_internal_notice_match(
         is_from_license: false,
         rule_start_token: 0,
         coordinates: MatchCoordinates::query_region(PositionSpan::empty()),
-        candidate_resemblance: 0.0,
-        candidate_containment: 0.0,
     }
 }
 


### PR DESCRIPTION
## Summary

Removes several pieces of license-detection code that compute values which never reach output. All are dead/internal; no behavior change (verified by unit + golden suites).

1. **`file_regions` aggregation** — the in-module `file_regions` field on `LicenseDetection`, the `FileRegion` / `UniqueDetection` types, and `collect_file_regions_from_matches` / `get_unique_detections` / `attach_aggregated_file_regions`. `LicenseDetection.file_regions` is not `Serialize`, and the codebase-level `UniqueDetection` summary ScanCode emits is produced independently by `post_processing::reference_following::collect_top_level_license_detections` (which derives `detection_count` from distinct file regions). ScanCode also filters `file_regions` out of both `LicenseDetection.to_dict` and `UniqueDetection.to_dict`. Replaces the stale `TODO(#926)` with an accurate NOTE.
2. **`_score`** — `populate_detection_from_group` computed `compute_detection_score(...)` into a discarded `_score`; `LicenseDetection` has no score field. Scores are still computed where actually used (`rank_detections`, analysis).
3. **`candidate_resemblance` / `candidate_containment`** — `LicenseMatch` fields written only in `seq_match` and never read in production (not serialized; the internal `LicenseMatch` `Serialize` impl is not on any output/golden path). Removing them makes `CandidateMetrics::amplified_resemblance_f32` / `containment_f32` dead, so those go too.

## Issues

- Closes: #926

## Scope and exclusions

- Included: dead-code removal within the `license_detection` module (+ the `reference_following` / `scanner` match-construction sites that set the removed fields).
- Explicit exclusions: dead computations outside this module (parsers, json-input shaping) are handled separately in #933.

## How to verify

- No behavior change; CI unit + golden suites cover it. Beyond CI, to confirm the parity behavior the original TODO worried about: scan a file with two well-separated `bsd-new` blocks (`--license`) and observe two location-preserving file-level detections sharing one identifier plus one top-level `license_detections` entry with `detection_count: 2`.

## Intentional differences from Python

- None. Aligns with ScanCode, which does not serialize `file_regions` and has no per-detection score / candidate-metric output.

## Follow-up work

- None.

## Expected-output fixture changes

- None. No golden/`.expected` output changed (the tallies golden with `zlib` ×7 / `lgpl-2.1-plus` ×3 still matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)