### PR TITLE
chore: tidy parser/json-input dead code and surface Pipfile.lock hashes

### DIFF
--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -79,11 +79,6 @@ impl PackageParser for JuliaProjectTomlParser {
             .and_then(|v| v.as_str())
             .map(|s| truncate_field(s.to_string()));
 
-        let _uuid = toml_content
-            .get(FIELD_UUID)
-            .and_then(|v| v.as_str())
-            .map(String::from);
-
         let version = toml_content
             .get(FIELD_VERSION)
             .and_then(|v| v.as_str())

--- a/src/parsers/pipfile_lock.rs
+++ b/src/parsers/pipfile_lock.rs
@@ -12,7 +12,7 @@
 //! # Key Features
 //! - Dependency extraction from default and develop sections
 //! - Direct dependency tracking (top-level locks are direct)
-//! - Exact version resolution with hash verification
+//! - Exact version resolution with pinned artifact hashes surfaced as dependency `hash_options`
 //! - Package URL (purl) generation for PyPI packages
 //! - Markers and extras dependency handling
 //!
@@ -168,8 +168,6 @@ fn build_lockfile_dependency(
     let version = strip_pipfile_lock_version(&requirement);
     let purl = create_pypi_purl(&normalized_name, version.as_deref());
 
-    let _hashes = extract_lockfile_hashes(value);
-
     Some(Dependency {
         purl,
         extracted_requirement: Some(truncate_field(requirement)),
@@ -179,8 +177,43 @@ fn build_lockfile_dependency(
         is_pinned: Some(true),
         is_direct: Some(true),
         resolved_package: None,
-        extra_data: None,
+        extra_data: build_lockfile_dependency_extra_data(value),
     })
+}
+
+/// Surface the per-package pinned artifact hashes (the `hashes` array in each
+/// Pipfile.lock entry) as `hash_options`, mirroring the requirements.txt parser.
+///
+/// These are the expected hashes of the upstream wheels/sdists this lock pins,
+/// which is distinct from the scanned lockfile's own content hash. Returns
+/// `None` when no hashes are present so dependencies without pins stay clean.
+fn build_lockfile_dependency_extra_data(value: &JsonValue) -> Option<HashMap<String, JsonValue>> {
+    let hashes = extract_lockfile_hashes(value);
+    if hashes.is_empty() {
+        return None;
+    }
+    let mut extra_data = HashMap::new();
+    extra_data.insert(
+        "hash_options".to_string(),
+        JsonValue::Array(hashes.into_iter().map(JsonValue::String).collect()),
+    );
+    Some(extra_data)
+}
+
+/// Collect the raw pinned hash strings (e.g. `"sha256:..."`) from a Pipfile.lock
+/// entry's `hashes` array, preserving the algorithm prefix as requirements.txt does.
+fn extract_lockfile_hashes(value: &JsonValue) -> Vec<String> {
+    value
+        .get(FIELD_HASHES)
+        .and_then(|hashes_value| hashes_value.as_array())
+        .map(|hash_values| {
+            hash_values
+                .iter()
+                .filter_map(|hash_value| hash_value.as_str())
+                .map(|hash| truncate_field(hash.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn extract_lockfile_requirement(value: &JsonValue) -> Option<String> {
@@ -192,25 +225,6 @@ fn extract_lockfile_requirement(value: &JsonValue) -> Option<String> {
             .map(|version| truncate_field(version.to_string())),
         _ => None,
     }
-}
-
-fn extract_lockfile_hashes(value: &JsonValue) -> Vec<String> {
-    let mut hashes = Vec::new();
-    let hash_values = value
-        .get(FIELD_HASHES)
-        .and_then(|hashes_value| hashes_value.as_array());
-
-    if let Some(hash_values) = hash_values {
-        for hash_value in hash_values {
-            if let Some(hash) = hash_value.as_str()
-                && let Some(stripped) = hash.strip_prefix("sha256:")
-            {
-                hashes.push(truncate_field(stripped.to_string()));
-            }
-        }
-    }
-
-    hashes
 }
 
 fn strip_pipfile_lock_version(requirement: &str) -> Option<String> {

--- a/src/parsers/pipfile_lock_test.rs
+++ b/src/parsers/pipfile_lock_test.rs
@@ -60,4 +60,60 @@ mod tests {
             assert_eq!(dep.is_runtime, Some(false));
         }
     }
+
+    #[test]
+    fn test_pipfile_lock_surfaces_pinned_hashes_as_hash_options() {
+        use serde_json::json;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let content = r#"{
+    "_meta": {"hash": {"sha256": "test-hash"}, "pipfile-spec": 6},
+    "default": {
+        "requests": {
+            "hashes": ["sha256:abc123", "sha256:def456"],
+            "version": "==2.28.0"
+        },
+        "no-hash-pkg": {
+            "version": "==1.0.0"
+        }
+    }
+}"#;
+
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("Pipfile.lock");
+        fs::write(&file_path, content).unwrap();
+
+        let package_data = PipfileLockParser::extract_first_package(&file_path);
+
+        let requests = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some("pkg:pypi/requests@2.28.0"))
+            .expect("requests dependency");
+        let hash_options = requests
+            .extra_data
+            .as_ref()
+            .and_then(|extra| extra.get("hash_options"))
+            .expect("hash_options present");
+        assert_eq!(
+            hash_options,
+            &json!(["sha256:abc123", "sha256:def456"]),
+            "pinned artifact hashes should be surfaced as hash_options"
+        );
+
+        // A dependency without pinned hashes carries no hash_options noise.
+        let no_hash = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some("pkg:pypi/no-hash-pkg@1.0.0"))
+            .expect("no-hash-pkg dependency");
+        assert!(
+            no_hash
+                .extra_data
+                .as_ref()
+                .is_none_or(|extra| !extra.contains_key("hash_options")),
+            "dependencies without pinned hashes should not get hash_options"
+        );
+    }
 }

--- a/src/parsers/yarn_lock.rs
+++ b/src/parsers/yarn_lock.rs
@@ -131,7 +131,6 @@ fn parse_yarn_v2(
             None => continue,
         };
 
-        let _version = extract_yaml_string(details_map, "version").unwrap_or_default();
         let resolution = extract_yaml_string(details_map, "resolution").unwrap_or_default();
 
         let (namespace_opt, name, resolved_version) = parse_yarn_v2_resolution(&resolution);

--- a/src/scan_result_shaping/json_input.rs
+++ b/src/scan_result_shaping/json_input.rs
@@ -106,11 +106,6 @@ impl JsonScanInput {
             .iter()
             .flat_map(|header| header.errors.iter().cloned())
             .collect();
-        let _discarded_warning_count: usize = self
-            .headers
-            .iter()
-            .map(|header| header.warnings.len())
-            .sum();
         let mut files = self
             .files
             .iter()

--- a/testdata/python/golden/pipfile_lock/Pipfile.lock-expected.json
+++ b/testdata/python/golden/pipfile_lock/Pipfile.lock-expected.json
@@ -46,7 +46,12 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:679fc24b3e85bf5a07ca2f6d5c4cdf3d4477bbb02f43a6548335952cc75b5d23",
+            "sha256:3de62e71ce2cfbcdecb6e344cad04948506c8410ea5c6eab15c8f3b31b8ac1c0"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/feedparser@5.1.1",
@@ -57,7 +62,13 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:ae099763f4538aa08c5021d42ba6ce5b9b6218e71423c96031153f379955481a",
+            "sha256:52542106f55d044a404f00bf328bd29e81e49c38a130a05be66a8e4dc4f9ff57",
+            "sha256:172c23932965f91ef58e23e5abf93412333eecdc04d9e015cd09056d6b9301b3"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/pyasn1@0.4.2",
@@ -68,7 +79,22 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:f81c96761fca60d64b1c9b79ec2e40cf9495a745cf570613079ef324aeb9672b",
+            "sha256:7d626683e3d792cccc608da02498aff37ab4f3dafd8905d6bf755d11f9b26b43",
+            "sha256:e85895087905c65b5b594eb91f7522664c85545b147d5f4d4e7b1b07da8dcbdc",
+            "sha256:5a0db897b311d265cde49615cf783f1c78613138605cdd0f907ecfa5b2aba3ee",
+            "sha256:d5cd6ed995dba16fad0c521cfe31cd2d68400b53fcc2bce93326829be73ab6d1",
+            "sha256:a7efe807c4b83a859e2735c692b92ed7b567cfddc4163763412920041d876c2b",
+            "sha256:b5a9ca48055b9a20f6d1b3d68e38692e5431c86a0f99ea602e61294e891fee5b",
+            "sha256:c07d6e587b2f928366b1f67c09bda026a3e6fcc99e80a744dc67f8fca3895626",
+            "sha256:d84c2aea3cf43780e9e6a19f4e4dddee9f6976519020e64e47c57e5c7a8c3dd2",
+            "sha256:758cb50abddc03e4563fd9e7f03db56e3e87b58c0bd01247360326e5c0c7ffa5",
+            "sha256:0d7f6e959fe53f3960a23d73f35e1fce61348b30915b6664309ca756de7c1f89",
+            "sha256:d258b0a71994f7770599835249cece1caef3c70def868c4915e6e5ca49b67d15"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/pycrypto@2.4",
@@ -79,7 +105,11 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:f49d8aea2d7d65db9906c7d3b8b3a07fcae8387cf5cb06a7510383e211902d39"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/pyjwt@0.4.2",
@@ -90,7 +120,12 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:2d30be6375be006a6fec531ba15ec9a7cf3ac88fd6ea3caa2b6f86a84c372acc",
+            "sha256:a0019f8119cd9a31d9c29e7b47256b24642829c10941ee20f513487f466201d9"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/raven@1.9.4",
@@ -101,7 +136,11 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:7f14e651d321aedaf00635ab106b72520e4a6565d766b8fc64856e662c3acc8c"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/requests@2.2.1",
@@ -112,7 +151,12 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:b5bd2e1b78d28051108ebaa6248750221f9ccef52b4f054cb727de61b0406de0",
+            "sha256:1266921f1bed5fbf364cd83cf239b6d7b3ea5c32ccccbc93980d9ba12cdcfd02"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/rsa@3.4",
@@ -123,7 +167,12 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:0c7fde631f84f89e89ec671a9c58feb01ea25fab177dca08ba08650c548d48d5",
+            "sha256:9f1b6d4015cdf788273ff329d43004a7abf43971e9b06160765bad5227e4d70a"
+          ]
+        }
       },
       {
         "purl": "pkg:pypi/simplejson@2.4.0",
@@ -134,7 +183,11 @@
         "is_pinned": true,
         "is_direct": true,
         "resolved_package": {},
-        "extra_data": {}
+        "extra_data": {
+          "hash_options": [
+            "sha256:ac0f5122a213ef35c3af6464a2885aef5b56a4954f003eac767dd8e077949885"
+          ]
+        }
       }
     ],
     "repository_homepage_url": null,


### PR DESCRIPTION
## Summary

- **Enhancement** — `src/parsers/pipfile_lock.rs`: surface each entry's pinned artifact hashes (the `hashes` array) as the dependency's `extra_data.hash_options`, mirroring the `requirements_txt` parser. These were previously extracted and discarded. They are the expected hashes of the upstream wheels/sdists the lock pins (supply-chain provenance), distinct from the scanned lockfile's own content hash. Emitted only when present so unpinned deps stay clean. (This also makes the module doc accurate again, addressing Greptile's P2 on the stale "hash verification" line.)
- **Dead-computation removals** (computed-but-never-read):
  - `yarn_lock`: discarded `_version` (the version used downstream is `resolved_version`, parsed from the resolution string).
  - `julia`: discarded `_uuid` (the uuid that reaches `extra_data` is read independently in `extract_project_extra_data`).
  - `scan_result_shaping/json_input`: `_discarded_warning_count` sum that was never read.

## Issues

- Covers: dead-computation cleanup surfaced during the #926 investigation (license-detection dead code is handled separately in #932).

## Scope and exclusions

- Included: parser + json-input dead code, plus the Pipfile.lock `hash_options` enhancement.
- Explicit exclusions: license-detection dead code (#932).

## How to verify

- New unit test `test_pipfile_lock_surfaces_pinned_hashes_as_hash_options` asserts `hash_options` is populated when hashes are present and absent otherwise. Beyond CI: scan a project with a `Pipfile.lock` using `--package` and confirm each pinned dependency carries `extra_data.hash_options`.

## Intentional differences from Python

- `hash_options` on Pipfile.lock dependencies is a deliberate enhancement over ScanCode (whose `PipfileLockHandler` drops per-dependency hashes via dparse2). It mirrors the `hash_options` ScanCode already emits for requirements files, so the field name and shape stay consistent across pip-family formats.

## Follow-up work

- None.

## Expected-output fixture changes

- `testdata/python/golden/pipfile_lock/Pipfile.lock-expected.json`: dependency `extra_data` now carries `hash_options`. The new values are the pinned hashes copied verbatim from the input lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)