### PR TITLE
docs(pr-lifecycle): clarify PR-return loop and out-of-scope findings

### DIFF
--- a/.agents/skills/pr-lifecycle/SKILL.md
+++ b/.agents/skills/pr-lifecycle/SKILL.md
@@ -31,6 +31,8 @@ gh pr create --base main --head <branch> --title "<conventional title>" --body "
 
 ## 2. Wait for Signals
 
+Opening a PR does **not** obligate you to block on CI or review — it is fine to open one and move on rather than sit through a ~12-minute CI run. What matters is that a PR is not "done" at opened: **any time you return to a PR — later this turn or in a future session — resume the loop from Step 3 against the current head**, fetching fresh CI and review signals and addressing them. Treat an opened-but-unreviewed PR as unfinished work to come back to, not a finished task.
+
 - CI: `gh pr checks <num> --watch` (or `gh run watch`). Map any failure to the `ci-failure-triage` skill.
 - Review: Greptile posts a summary as an issue comment plus inline review comments; humans may comment too.
 
@@ -65,6 +67,7 @@ git push --force-with-lease origin <branch>
 ```
 
 - Re-run the narrowest validation that proves the fix (focused `cargo build`/`clippy`/targeted tests, or docs/lint checks per `CONTRIBUTING.md`) before pushing.
+- **Out-of-scope findings.** If a finding is valid but outside this PR's scope — an enhancement, an unrelated refactor, or work that belongs to another ecosystem/module per `AGENTS.md` scope discipline — do **not** silently expand the PR. Reply on the thread acknowledging it and say where it will live: a follow-up issue/PR, or an explicit "out of scope, declining" with the reason. Then open the follow-up if warranted. Decide explicitly rather than defaulting to fix-in-place; a finding being correct is not by itself a reason to widen this PR.
 
 ## 5. Reply and Resolve Threads
 

--- a/.claude/skills/pr-lifecycle/SKILL.md
+++ b/.claude/skills/pr-lifecycle/SKILL.md
@@ -31,6 +31,8 @@ gh pr create --base main --head <branch> --title "<conventional title>" --body "
 
 ## 2. Wait for Signals
 
+Opening a PR does **not** obligate you to block on CI or review — it is fine to open one and move on rather than sit through a ~12-minute CI run. What matters is that a PR is not "done" at opened: **any time you return to a PR — later this turn or in a future session — resume the loop from Step 3 against the current head**, fetching fresh CI and review signals and addressing them. Treat an opened-but-unreviewed PR as unfinished work to come back to, not a finished task.
+
 - CI: `gh pr checks <num> --watch` (or `gh run watch`). Map any failure to the `ci-failure-triage` skill.
 - Review: Greptile posts a summary as an issue comment plus inline review comments; humans may comment too.
 
@@ -65,6 +67,7 @@ git push --force-with-lease origin <branch>
 ```
 
 - Re-run the narrowest validation that proves the fix (focused `cargo build`/`clippy`/targeted tests, or docs/lint checks per `CONTRIBUTING.md`) before pushing.
+- **Out-of-scope findings.** If a finding is valid but outside this PR's scope — an enhancement, an unrelated refactor, or work that belongs to another ecosystem/module per `AGENTS.md` scope discipline — do **not** silently expand the PR. Reply on the thread acknowledging it and say where it will live: a follow-up issue/PR, or an explicit "out of scope, declining" with the reason. Then open the follow-up if warranted. Decide explicitly rather than defaulting to fix-in-place; a finding being correct is not by itself a reason to widen this PR.
 
 ## 5. Reply and Resolve Threads
 


### PR DESCRIPTION
## Summary

Two clarifications to the `pr-lifecycle` skill, surfaced while using it:

- **Step 2** — make explicit that opening a PR does **not** obligate blocking on CI/review (no sitting through a ~12-minute run). The review loop just isn't finished at "opened": whenever an agent returns to a PR (same turn or a later session), it resumes from Step 3 against the current head and addresses fresh signals. This closes the gap where an opened-but-unreviewed PR was implicitly treated as done.
- **Step 4** — add guidance for findings that are valid but outside the PR's scope: acknowledge on the thread and route to a follow-up issue/PR (or decline explicitly with a reason) instead of silently expanding the PR.

Canonical `.agents` copy edited; `.claude` mirror regenerated via `scripts/sync_agent_skills.sh`.

## Issues

- Covers: process gaps noticed during the #932 / #933 work.

## Scope and exclusions

- Included: `pr-lifecycle/SKILL.md` wording only (both synced copies).
- Explicit exclusions: no behavior/code changes.

## How to verify

- Docs-only. The `agent-skills-sync` pre-commit hook confirms the two copies are identical; no runtime behavior to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)