### PR TITLE
fix(license-detection): enforce required phrases for seq matches with referenced filenames

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 207 of 207 recorded runs, with a **12.3× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.1×** on 10k+ file targets.
+> Provenant is faster on 209 of 209 recorded runs, with a **12.3× median speedup** and **11.6× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1061,12 +1061,26 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `38.15s`; ScanCode `379.55s`
 - Broader .NET/NuGet package and dependency extraction (`105` vs `3` packages, `145` vs `33` dependencies) from many `*.csproj` files plus `Directory.Packages.props` and `Directory.Build.props` across samples, tooling, and test projects, with zero scan errors where ScanCode trips on `TwitterColorEmoji-SVGinOT.ttf`
 
+##### [bitwarden/server @ 051d0ef](https://github.com/bitwarden/server/tree/051d0ef35aefb91cf98d6180cdee4e6078894718) — **40.54× faster**
+
+- Files: 6,658
+- Run context: 2026-06-05 · server-53357 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `14.83s`; ScanCode `601.20s`
+- Far broader .NET/NuGet package and dependency extraction (`61` vs `4` packages, `9962` vs `933` dependencies) because 58 committed `packages.lock.json` lockfiles contribute fully resolved transitive NuGet graphs alongside 57 `*.csproj` and `Directory.Build.props` manifests plus sibling npm, Cargo, and Docker surfaces, with direct `AGPL-3.0-or-later` identity on the `bitwarden-server.slnx` solution and source-faithful copyright recovery that keeps `Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>` intact while rejecting Handlebars `CurrentYear` template placeholders, `(c)`-in-code fragments, and `package.json` field-jammed author noise
+
 ##### [dotnet/extensions @ 7171956](https://github.com/dotnet/extensions/tree/7171956b4fbafdd5e44ca8ca1ceed72c0d6bbb66) — **19.08× faster**
 
 - Files: 3,643
 - Run context: 2026-04-30 · extensions-9749 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `27.54s`; ScanCode `525.35s`
 - Broader .NET/NuGet package and dependency extraction (`162` vs `2` packages, `1161` vs `690` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and imported `eng/packages/*.props` / `Tests.props` / `Tools.props` central-version surfaces, with root and nested central package manifests carrying resolved package-version dependency metadata instead of empty imported-props placeholders
+
+##### [dotnet/fsharp @ f7be8d0](https://github.com/dotnet/fsharp/tree/f7be8d05a7e22ba1209e62363ee639d100df2488) — **26.48× faster**
+
+- Files: 10,138
+- Run context: 2026-06-05 · fsharp-59756 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `29.07s`; ScanCode `769.93s`
+- Broader .NET/NuGet package and dependency extraction (`111` vs `0` packages, `186` vs `0` dependencies) across `*.fsproj`, the `FSharp.ProjectSystem.PropertyPages.vbproj`, shipping `*.nuspec`, `*.csproj`, and `Directory.Build.props` surfaces that ScanCode leaves unassembled, plus matched dual `CC0-1.0 AND MIT` detection on the TaskBuilder-derived files where a public-domain dedication abuts the project-license reference, and cleaner rejection of F# quotation `(c)` code-fragment copyrights and holders, filename- and prose-shaped author noise, a placeholder email, and a malformed concatenated URL
 
 ##### [dotnet/runtime @ d1163e5](https://github.com/dotnet/runtime/tree/d1163e5a8f3f3aaa374993e8b5805911689aba28) — **31.49× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -545,6 +545,9 @@ ScanCode: 737.50s</title></rect>
     <rect x="695.18" y="331.26" width="8" height="8" fill="#d97706" rx="1.5"><title>containerd/containerd @ 83044a43
 Files: 6332
 ScanCode: 533.84s</title></rect>
+    <rect x="698.64" y="325.64" width="8" height="8" fill="#d97706" rx="1.5"><title>bitwarden/server @ 051d0ef
+Files: 6658
+ScanCode: 601.20s</title></rect>
     <rect x="699.05" y="244.10" width="8" height="8" fill="#d97706" rx="1.5"><title>npm/cli @ 05dbba5
 Files: 6698
 ScanCode: 3376.85s</title></rect>
@@ -590,6 +593,9 @@ ScanCode: 540.33s</title></rect>
     <rect x="725.29" y="288.71" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 ScanCode: 1313.69s</title></rect>
+    <rect x="727.61" y="313.95" width="8" height="8" fill="#d97706" rx="1.5"><title>dotnet/fsharp @ f7be8d0
+Files: 10138
+ScanCode: 769.93s</title></rect>
     <rect x="728.03" y="311.39" width="8" height="8" fill="#d97706" rx="1.5"><title>ffmpeg/ffmpeg @ 056562a
 Files: 10200
 ScanCode: 812.80s</title></rect>
@@ -1168,6 +1174,9 @@ Provenant: 47.33s</title></circle>
     <circle cx="699.18" cy="469.27" r="4.5" fill="#2563eb"><title>containerd/containerd @ 83044a43
 Files: 6332
 Provenant: 31.31s</title></circle>
+    <circle cx="702.64" cy="504.58" r="4.5" fill="#2563eb"><title>bitwarden/server @ 051d0ef
+Files: 6658
+Provenant: 14.83s</title></circle>
     <circle cx="703.05" cy="363.27" r="4.5" fill="#2563eb"><title>npm/cli @ 05dbba5
 Files: 6698
 Provenant: 295.10s</title></circle>
@@ -1213,6 +1222,9 @@ Provenant: 49.40s</title></circle>
     <circle cx="729.29" cy="442.66" r="4.5" fill="#2563eb"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 Provenant: 54.99s</title></circle>
+    <circle cx="731.61" cy="472.78" r="4.5" fill="#2563eb"><title>dotnet/fsharp @ f7be8d0
+Files: 10138
+Provenant: 29.07s</title></circle>
     <circle cx="732.03" cy="438.07" r="4.5" fill="#2563eb"><title>ffmpeg/ffmpeg @ 056562a
 Files: 10200
 Provenant: 60.60s</title></circle>

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -178,6 +178,14 @@ pub(crate) fn filter_matches_missing_required_phrases(
         let is_continuous = rule.is_continuous || rule.is_required_phrase;
         let ikey_spans = &rule.required_phrase_spans;
 
+        // The referenced-filename heuristic may only *discard* a match here; a
+        // satisfied (or bypassed) referenced-filename constraint must fall through to
+        // the required-phrase check below. Otherwise a rule that carries both a
+        // referenced filename and required key phrases would be kept on the strength of
+        // the filename alone, skipping required-phrase validation. ScanCode keeps these
+        // concerns independent (referenced filenames are not consulted in
+        // filter_matches_missing_required_phrases), so a match missing a required key
+        // phrase is discarded regardless of its referenced filename.
         if let Some(referenced_filenames) = &rule.referenced_filenames {
             let concrete_referenced_filenames: Vec<_> = referenced_filenames
                 .iter()
@@ -185,53 +193,54 @@ pub(crate) fn filter_matches_missing_required_phrases(
                     !filename.eq_ignore_ascii_case(INHERIT_LICENSE_FROM_PACKAGE_REFERENCE)
                 })
                 .collect();
-            if concrete_referenced_filenames.is_empty() {
-                kept.push(m.clone());
-                continue;
-            }
 
-            let all_references_are_simple_bare_names =
-                concrete_referenced_filenames.iter().all(|filename| {
-                    !filename.contains('/')
-                        && !filename.contains('\\')
-                        && !Path::new(filename)
-                            .file_name()
-                            .and_then(|name| name.to_str())
-                            .is_some_and(|basename| basename.contains('.'))
-                });
+            if !concrete_referenced_filenames.is_empty() {
+                let all_references_are_simple_bare_names =
+                    concrete_referenced_filenames.iter().all(|filename| {
+                        !filename.contains('/')
+                            && !filename.contains('\\')
+                            && !Path::new(filename)
+                                .file_name()
+                                .and_then(|name| name.to_str())
+                                .is_some_and(|basename| basename.contains('.'))
+                    });
 
-            if m.matcher == MatcherKind::Seq
-                && !all_references_are_simple_bare_names
-                && m.coverage() >= 50.0
-            {
-                kept.push(m.clone());
-                continue;
-            }
+                // Sequence matches against path-like referenced filenames are fuzzy and
+                // are not expected to quote the filename literally, so they skip the
+                // referenced-filename presence check (but not the required-phrase check).
+                let skip_referenced_filename_check = m.matcher == MatcherKind::Seq
+                    && !all_references_are_simple_bare_names
+                    && m.coverage() >= 50.0;
 
-            let matched_text = match &m.matched_text {
-                Some(text) => text.clone(),
-                None => query.matched_text(m.start_line.get(), m.end_line.get()),
-            };
-            let has_referenced_filename = concrete_referenced_filenames.iter().any(|filename| {
-                if matched_text.contains(filename.as_str()) {
-                    return true;
+                if !skip_referenced_filename_check {
+                    let matched_text = match &m.matched_text {
+                        Some(text) => text.clone(),
+                        None => query.matched_text(m.start_line.get(), m.end_line.get()),
+                    };
+                    let has_referenced_filename =
+                        concrete_referenced_filenames.iter().any(|filename| {
+                            if matched_text.contains(filename.as_str()) {
+                                return true;
+                            }
+
+                            let path = Path::new(filename);
+                            let is_path_like = filename.contains('/') || filename.contains('\\');
+                            let Some(basename) = path.file_name().and_then(|name| name.to_str())
+                            else {
+                                return false;
+                            };
+
+                            is_path_like
+                                && basename.contains('.')
+                                && matched_text
+                                    .to_ascii_lowercase()
+                                    .contains(&basename.to_ascii_lowercase())
+                        });
+                    if !has_referenced_filename {
+                        discarded.push(m.clone());
+                        continue;
+                    }
                 }
-
-                let path = Path::new(filename);
-                let is_path_like = filename.contains('/') || filename.contains('\\');
-                let Some(basename) = path.file_name().and_then(|name| name.to_str()) else {
-                    return false;
-                };
-
-                is_path_like
-                    && basename.contains('.')
-                    && matched_text
-                        .to_ascii_lowercase()
-                        .contains(&basename.to_ascii_lowercase())
-            });
-            if !has_referenced_filename {
-                discarded.push(m.clone());
-                continue;
             }
         }
 
@@ -1571,6 +1580,126 @@ mod tests {
         let (kept, discarded) = filter_matches_missing_required_phrases(&index, &[m], &query);
 
         assert_eq!(kept.len(), 1);
+        assert!(discarded.is_empty());
+    }
+
+    /// Build a rule that carries BOTH a path-like referenced filename and required
+    /// key phrases, like `cc0-1.0_161.RULE` (a CC0 dedication whose Debian tail adds a
+    /// second required phrase and a `/usr/share/common-licenses/CC0-1.0` reference).
+    fn rule_with_referenced_filename_and_required_phrases(
+        required_phrase_spans: Vec<std::ops::Range<usize>>,
+    ) -> Rule {
+        Rule {
+            identifier: "cc0-1.0_161".to_string(),
+            license_expression: "cc0-1.0".to_string(),
+            text: "to the extent possible under law".to_string(),
+            tokens: vec![],
+            rule_kind: crate::license_detection::models::RuleKind::Notice,
+            is_false_positive: false,
+            is_required_phrase: false,
+            is_from_license: false,
+            relevance: 100,
+            minimum_coverage: None,
+            has_stored_minimum_coverage: false,
+            is_continuous: false,
+            referenced_filenames: Some(vec!["/usr/share/common-licenses/CC0-1.0".to_string()]),
+            ignorable_urls: None,
+            ignorable_emails: None,
+            ignorable_copyrights: None,
+            ignorable_holders: None,
+            ignorable_authors: None,
+            language: None,
+            notes: None,
+            length_unique: 13,
+            high_length_unique: 0,
+            high_length: 0,
+            min_matched_length: 1,
+            min_high_matched_length: 0,
+            min_matched_length_unique: 0,
+            min_high_matched_length_unique: 0,
+            is_small: false,
+            is_tiny: false,
+            starts_with_license: false,
+            ends_with_license: false,
+            is_deprecated: false,
+            spdx_license_key: None,
+            other_spdx_license_keys: vec![],
+            required_phrase_spans,
+            stopwords_by_pos: std::collections::HashMap::new(),
+        }
+    }
+
+    /// A sequence match against a path-like referenced filename skips the
+    /// referenced-filename presence check, but it must NOT skip required-phrase
+    /// validation: a match missing a required key phrase is still discarded. This is
+    /// the `cc0-1.0_161` vs `cc0-1.0_27` case where keeping the longer partial CC0
+    /// match would let an adjacent resolved license reference drop the real CC0.
+    #[test]
+    fn test_seq_referenced_filename_match_missing_required_phrase_is_discarded() {
+        let mut index = LicenseIndex::with_legalese_count(10);
+        // First required phrase (0..3) is in the matched ispan; the second (10..13)
+        // lives in the unmatched Debian tail, so the match is missing a required phrase.
+        index
+            .rules_by_rid
+            .push(rule_with_referenced_filename_and_required_phrases(vec![
+                0..3,
+                10..13,
+            ]));
+
+        let query =
+            Query::from_extracted_text("to the extent possible under law", &index, false).unwrap();
+
+        let mut m = create_test_match("#0", 1, 9, MatchScore::MAX, 74.0, 100);
+        m.matcher = MatcherKind::Seq;
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(0, 9),
+            PositionSpan::range(0, 9),
+            PositionSpan::empty(),
+        );
+
+        let (kept, discarded) = filter_matches_missing_required_phrases(&index, &[m], &query);
+
+        assert!(
+            kept.is_empty(),
+            "match missing a required phrase must be discarded"
+        );
+        assert_eq!(discarded.len(), 1);
+    }
+
+    /// Companion to the above: when the matched ispan covers all required key phrases,
+    /// the same seq/referenced-filename match is kept.
+    #[test]
+    fn test_seq_referenced_filename_match_with_all_required_phrases_is_kept() {
+        let mut index = LicenseIndex::with_legalese_count(10);
+        index
+            .rules_by_rid
+            .push(rule_with_referenced_filename_and_required_phrases(vec![
+                0..3,
+                10..13,
+            ]));
+
+        let query = Query::from_extracted_text(
+            "to the extent possible under law dedicated rights public domain worldwide warranty notice",
+            &index,
+            false,
+        )
+        .unwrap();
+
+        let mut m = create_test_match("#0", 1, 13, MatchScore::MAX, 100.0, 100);
+        m.matcher = MatcherKind::Seq;
+        m.coordinates = MatchCoordinates::rule_aligned(
+            PositionSpan::range(0, 13),
+            PositionSpan::range(0, 13),
+            PositionSpan::empty(),
+        );
+
+        let (kept, discarded) = filter_matches_missing_required_phrases(&index, &[m], &query);
+
+        assert_eq!(
+            kept.len(),
+            1,
+            "match covering all required phrases must be kept"
+        );
         assert!(discarded.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **Fix:** `filter_matches_missing_required_phrases` merged referenced-filename handling with two early-keep paths that returned *before* the required-phrase check, so a `Seq` match against a path-like referenced filename (coverage ≥ 50) was kept without validating the rule's required key phrases. The referenced-filename block now only *discards* and otherwise falls through to required-phrase validation, matching ScanCode (which keeps the two concerns independent).
- **Impact:** `cc0-1.0_161` (a CC0-dedication superset whose Debian tail adds the required phrase "CC0 1.0 Universal license" + a `/usr/share/common-licenses/CC0-1.0` reference) was surviving on text containing only the dedication, displacing the exact `cc0-1.0_27` match. When the adjacent `// See License.txt` reference resolved to a project's MIT license, the grouped detection collapsed to `MIT` and dropped CC0. Files with a public-domain dedication beside a license reference now correctly report `CC0-1.0 AND MIT`.
- **Benchmarks:** also records two `compare-outputs` runs verifying previously-unbenchmarked NuGet surfaces (these are how the bug surfaced):
  - **dotnet/fsharp** `@ f7be8d0` — `nuget_fsproj` (72), `nuget_vbproj` (1), `nuget_nuspec` (4). **26.48× faster**; `111` vs `0` packages, `186` vs `0` dependencies; matched `CC0-1.0 AND MIT` on the TaskBuilder files.
  - **bitwarden/server** `@ 051d0ef` — `nuget_packages_lock` across 58 resolved lockfiles. **40.54× faster**; `61` vs `4` packages, `9962` vs `933` dependencies.
- Regenerated `docs/scan-duration-vs-files.svg` and the headline stats (now **209/209** runs).

## Issues

- Covers: NuGet verified-surface gaps (`.fsproj`, `.vbproj`, `.nuspec`, `packages.lock.json`) and a CC0/MIT detection-segmentation bug found while verifying them.

## Scope and exclusions

- Included: the required-phrase filter fix + 2 unit tests, and two `docs/BENCHMARKS.md` entries with regenerated chart.
- Explicit exclusions: none. The earlier-deferred CC0/MIT residual is now fixed.

## How to verify

- `cargo test --lib -- filter_matches_missing_required_phrases seq_referenced_filename` (7 tests: 5 existing + 2 new).
- Blast-radius gates (clean): `cargo test --features golden-tests --test license_detection_golden` (21/21) and `--test post_processing_golden` (20/20).
- End-to-end: a file with the CC0 public-domain dedication followed by `See License.txt in the project root...`, scanned beside a root MIT `License.txt`, now detects `CC0-1.0 AND MIT` via the exact `cc0-1.0_27.RULE` (the partial `cc0-1.0_161` is correctly discarded). Confirmed on dotnet/fsharp `Tasks.fs` / `TasksDynamic.fs`.
- All other ScanCode-favored deltas on both targets were triaged as ScanCode false positives Provenant correctly rejects (code-fragment `(c)` copyrights, transliterated `.xlf` tails, `CurrentYear` template placeholders, `package.json` author-field jamming, placeholder/test emails, malformed concatenated URLs) plus weak low-coverage clues and URL query-string normalization.

## Intentional differences from Python

- None. The fix moves Provenant *toward* ScanCode parity (ScanCode does not consult referenced filenames in `filter_matches_missing_required_phrases`).

## Follow-up work

- None outstanding.

## Expected-output fixture changes

- None. Two new unit tests added; no golden fixtures changed (license + post-processing goldens pass unchanged).