### PR TITLE
fix(python): extract dependencies from pip-inspect.deplock without a direct_url root

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 209 of 209 recorded runs, with a **12.3× median speedup** and **11.6× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 211 of 211 recorded runs, with a **12.3× median speedup** and **11.6× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -42,6 +42,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
   - [Package archives](#package-archives)
   - [Mobile app artifacts](#mobile-app-artifacts)
   - [Release binaries and extracted app snapshots](#release-binaries-and-extracted-app-snapshots)
+  - [Generated dependency lock manifests](#generated-dependency-lock-manifests)
 
 <!-- benchmark-quick-index:end -->
 
@@ -1545,6 +1546,22 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-24 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
 - Timing: Provenant `62.51s`; ScanCode `627.66s`
 - Equivalent package visibility on the outer offline-scan snapshot (`0` vs `0` packages), with far cleaner rejection of random CAB-byte email noise (`0` vs `9`) while scanning the signed index-plus-CAB bundle
+
+#### Generated dependency lock manifests
+
+##### [Flask 3.1.0 pip-inspect.deplock @ sha256:fd65296](https://pypi.org/project/flask/3.1.0/) — **6.87× faster**
+
+- Files: 1
+- Run context: 2026-06-05 · pip-target-45841 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · generated via `pip inspect` (pip 26.1.1) over a venv with `flask==3.1.0`
+- Timing: Provenant `6.35s`; ScanCode `43.65s`
+- Matched pip-inspect deplock dependency extraction (`8` vs `8` resolved dependencies) across the installed set, with PURL-identified `flask` and its transitive `werkzeug`, `jinja2`, `click`, `itsdangerous`, `markupsafe`, and `blinker` pins on a lockfile-style deplock package, structured author capture in the resolved package metadata, and cleaner `BSD-3-Clause` classification where ScanCode appends an unknown-license reference
+
+##### [swift-dependencies 1.9.4 swift-show-dependencies.deplock @ sha256:bed4a47](https://github.com/pointfreeco/swift-dependencies/tree/1.9.4) — **6.78× faster**
+
+- Files: 1
+- Run context: 2026-06-05 · swift-target-52067 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · generated via `swift package show-dependencies --format json` (Swift 6.3.2) on `swift-dependencies@1.9.4`
+- Timing: Provenant `6.08s`; ScanCode `41.20s`
+- Matched swift-show-dependencies deplock dependency extraction (`17` vs `17` resolved dependencies) across the full transitive graph spanning `combine-schedulers`, `swift-clocks`, `swift-concurrency-extras`, `swift-syntax`, and sibling Point-Free packages, with no detected output differences
 
 ## Benchmark conventions
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -77,6 +77,9 @@ ScanCode: 73.02s</title></rect>
     <rect x="92.00" y="424.52" width="8" height="8" fill="#d97706" rx="1.5"><title>Firefox langpack en-GB 141.0.2 .xpi
 Files: 1
 ScanCode: 74.17s</title></rect>
+    <rect x="92.00" y="449.57" width="8" height="8" fill="#d97706" rx="1.5"><title>Flask 3.1.0 pip-inspect.deplock @ sha256:fd65296
+Files: 1
+ScanCode: 43.65s</title></rect>
     <rect x="92.00" y="427.27" width="8" height="8" fill="#d97706" rx="1.5"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
 Files: 1
 ScanCode: 69.97s</title></rect>
@@ -104,6 +107,9 @@ ScanCode: 73.62s</title></rect>
     <rect x="92.00" y="428.71" width="8" height="8" fill="#d97706" rx="1.5"><title>sudo 1.9.15-7.p5.fc42 src.rpm @ sha256:96920ba
 Files: 1
 ScanCode: 67.87s</title></rect>
+    <rect x="92.00" y="452.30" width="8" height="8" fill="#d97706" rx="1.5"><title>swift-dependencies 1.9.4 swift-show-dependencies.deplock @ sha256:bed4a47
+Files: 1
+ScanCode: 41.20s</title></rect>
     <rect x="139.76" y="510.78" width="8" height="8" fill="#d97706" rx="1.5"><title>itchyny/gojq v0.12.19 darwin arm64 release snapshot @ sha256:40208d4
 Files: 2
 ScanCode: 11.95s</title></rect>
@@ -706,6 +712,9 @@ Provenant: 10.11s</title></circle>
     <circle cx="96.00" cy="521.94" r="4.5" fill="#2563eb"><title>Firefox langpack en-GB 141.0.2 .xpi
 Files: 1
 Provenant: 10.27s</title></circle>
+    <circle cx="96.00" cy="544.66" r="4.5" fill="#2563eb"><title>Flask 3.1.0 pip-inspect.deplock @ sha256:fd65296
+Files: 1
+Provenant: 6.35s</title></circle>
     <circle cx="96.00" cy="524.83" r="4.5" fill="#2563eb"><title>Humanizer.Core 3.0.10 .nupkg @ sha256:99f9521
 Files: 1
 Provenant: 9.66s</title></circle>
@@ -733,6 +742,9 @@ Provenant: 19.82s</title></circle>
     <circle cx="96.00" cy="525.97" r="4.5" fill="#2563eb"><title>sudo 1.9.15-7.p5.fc42 src.rpm @ sha256:96920ba
 Files: 1
 Provenant: 9.43s</title></circle>
+    <circle cx="96.00" cy="546.71" r="4.5" fill="#2563eb"><title>swift-dependencies 1.9.4 swift-show-dependencies.deplock @ sha256:bed4a47
+Files: 1
+Provenant: 6.08s</title></circle>
     <circle cx="143.76" cy="521.12" r="4.5" fill="#2563eb"><title>itchyny/gojq v0.12.19 darwin arm64 release snapshot @ sha256:40208d4
 Files: 2
 Provenant: 10.45s</title></circle>

--- a/src/parsers/python/pypi_json.rs
+++ b/src/parsers/python/pypi_json.rs
@@ -470,6 +470,38 @@ pub(super) fn extract_from_pip_inspect(path: &Path) -> Vec<PackageData> {
         main_pkg.dependencies = dependencies;
         main_pkg.dependencies.extend(unresolved_dependencies);
         vec![main_pkg]
+    } else if !dependencies.is_empty() {
+        // No requested package carried a `direct_url`, which is the common case for a
+        // `pip inspect` run over a PyPI-installed environment (a `direct_url` is only
+        // present for local-path, VCS, or URL installs). Emit the resolved installed
+        // packages as dependencies on a lockfile-style deplock package, matching
+        // ScanCode, instead of discarding them with an empty default package.
+        let mut extra_data = HashMap::new();
+        if let Some(pv) = &pip_version {
+            extra_data.insert(
+                "pip_version".to_string(),
+                serde_json::Value::String(pv.clone()),
+            );
+        }
+        if let Some(iv) = &inspect_version {
+            extra_data.insert(
+                "inspect_version".to_string(),
+                serde_json::Value::String(iv.clone()),
+            );
+        }
+
+        vec![PackageData {
+            package_type: Some(PythonParser::PACKAGE_TYPE),
+            primary_language: Some("Python".to_string()),
+            dependencies,
+            extra_data: if extra_data.is_empty() {
+                None
+            } else {
+                Some(extra_data)
+            },
+            datasource_id: Some(DatasourceId::PypiInspectDeplock),
+            ..Default::default()
+        }]
     } else {
         default_package_data(path)
     }

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -2460,6 +2460,58 @@ Test package description.
         );
     }
 
+    // Real `pip inspect` output over a PyPI-installed environment has no `direct_url`
+    // on any package (that field is only set for local-path, VCS, or URL installs), so
+    // there is no requested+direct_url root package. The installed packages must still
+    // be emitted as resolved dependencies on a lockfile-style deplock package rather
+    // than discarded.
+    #[test]
+    fn test_pip_inspect_no_direct_url_emits_resolved_dependencies() {
+        let content = r#"{
+  "version": "1",
+  "pip_version": "26.1.1",
+  "installed": [
+    {"metadata": {"name": "flask", "version": "3.1.0"}, "requested": true},
+    {"metadata": {"name": "werkzeug", "version": "3.1.8"}, "requested": false},
+    {"metadata": {"name": "jinja2", "version": "3.1.6"}, "requested": false}
+  ]
+}"#;
+        let (_temp_dir, file_path) = create_temp_file(content, "pip-inspect.deplock");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.package_type, Some(PackageType::Pypi));
+        assert_eq!(
+            package_data.datasource_id,
+            Some(DatasourceId::PypiInspectDeplock)
+        );
+        // Lockfile-style: no root identity, but every installed package is a dependency.
+        assert!(package_data.name.is_none());
+        assert_eq!(package_data.dependencies.len(), 3);
+
+        let dep_purls: Vec<&str> = package_data
+            .dependencies
+            .iter()
+            .filter_map(|d| d.purl.as_deref())
+            .collect();
+        assert!(dep_purls.contains(&"pkg:pypi/flask@3.1.0"));
+        assert!(dep_purls.contains(&"pkg:pypi/werkzeug@3.1.8"));
+        assert!(dep_purls.contains(&"pkg:pypi/jinja2@3.1.6"));
+
+        // The requested package is marked direct; transitive ones are not.
+        let flask = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:pypi/flask@3.1.0"))
+            .expect("flask dependency present");
+        assert_eq!(flask.is_direct, Some(true));
+        let werkzeug = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:pypi/werkzeug@3.1.8"))
+            .expect("werkzeug dependency present");
+        assert_eq!(werkzeug.is_direct, Some(false));
+    }
+
     #[test]
     fn test_pyproject_optional_dependencies_scopes() {
         let content = r#"


### PR DESCRIPTION
## Summary

- **Fix:** `extract_from_pip_inspect` only emitted dependencies when an installed package had **both** `requested: true` and a `direct_url`. A `direct_url` is present only for local-path/VCS/URL installs, so a `pip inspect` over an ordinary PyPI-installed environment has none — leaving no root package, returning an empty default package, and **discarding every resolved dependency**. It now emits the installed packages as resolved dependencies on a lockfile-style deplock package (no root identity), matching ScanCode.
- **Tier 2 surface verification** (the two generated-artifact deplock gaps from the benchmark coverage review), recorded in a new `docs/BENCHMARKS.md` "Generated dependency lock manifests" subsection:
  - **Flask 3.1.0 `pip-inspect.deplock`** (generated via `pip inspect`, pip 26.1.1): `8` vs `8` resolved dependencies — Provenant previously extracted **0**; **6.87× faster**.
  - **swift-dependencies 1.9.4 `swift-show-dependencies.deplock`** (generated via `swift package show-dependencies --format json`, Swift 6.3.2): `17` vs `17` resolved dependencies, **no detected differences**, **6.78× faster** — clean parity, no code change needed.
- Also confirmed **`pnpm-workspace.yaml`** parses at parity (`pnpm_workspace_yaml` datasource, `no_detected_differences`); it is already exercised by the existing pnpm monorepo benchmarks, so no separate entry is added.
- Regenerated the headline stats (now **211/211** runs) and the chart.

## Issues

- Covers: the deplock verified-surface gaps (`pip-inspect.deplock`, `swift-show-dependencies.deplock`) from the benchmark coverage review, plus a real pip-inspect dependency-extraction bug found while verifying them.

## Scope and exclusions

- Included: the pip-inspect parser fix + a regression test, and two `docs/BENCHMARKS.md` deplock entries with regenerated chart.
- Explicit exclusions: no swift parser change (already correct); no separate pnpm-workspace entry (already covered by existing pnpm benchmarks).

## How to verify

- `cargo test --lib -- pip_inspect` (15 tests incl. the new `test_pip_inspect_no_direct_url_emits_resolved_dependencies`).
- No parser-golden drift: `cargo test --features golden-tests --test parsers_golden -- python` (13/13). The in-repo pip-inspect fixtures carry a `direct_url`, so they exercise the unchanged root-package path.
- End-to-end: generate a real deplock (`python -m venv v && v/bin/pip install flask==3.1.0 && v/bin/pip inspect > pip-inspect.deplock`) and scan it — Provenant now reports 8 dependencies (flask + werkzeug/jinja2/click/itsdangerous/markupsafe/blinker) instead of 0.
- The two remaining pip deltas are justified Provenant-cleaner behavior: it captures the `blinker` author structurally in the dependency's resolved-package parties (ScanCode only text-detects it from the JSON), and drops a vague `unknown-license-reference` while keeping the concrete `BSD-3-Clause`.

## Intentional differences from Python

- Provenant captures dependency authors in structured package metadata rather than as loose file-level author clues, and omits unknown-license-reference noise from a resolved declared license. Both are cleaner-by-design and consistent with the project's scan-quality goal.

## Follow-up work

- None outstanding. With Tier 1 (`.fsproj`/`.vbproj`/`.nuspec`/`packages.lock.json`) merged and these deplock surfaces verified, the previously-unbenchmarked package surfaces are now covered.

## Expected-output fixture changes

- None. One new unit test added; no golden fixtures changed (python parser goldens pass unchanged).