### PR TITLE
fix(nuget): strip UTF-8 BOM before parsing legacy project.json/project.lock.json

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 211 of 211 recorded runs, with a **12.3× median speedup** and **11.6× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 212 of 212 recorded runs, with a **12.2× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -43,6 +43,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
   - [Mobile app artifacts](#mobile-app-artifacts)
   - [Release binaries and extracted app snapshots](#release-binaries-and-extracted-app-snapshots)
   - [Generated dependency lock manifests](#generated-dependency-lock-manifests)
+  - [Legacy NuGet manifest sets](#legacy-nuget-manifest-sets)
 
 <!-- benchmark-quick-index:end -->
 
@@ -1562,6 +1563,15 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-05 · swift-target-52067 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · generated via `swift package show-dependencies --format json` (Swift 6.3.2) on `swift-dependencies@1.9.4`
 - Timing: Provenant `6.08s`; ScanCode `41.20s`
 - Matched swift-show-dependencies deplock dependency extraction (`17` vs `17` resolved dependencies) across the full transitive graph spanning `combine-schedulers`, `swift-clocks`, `swift-concurrency-extras`, `swift-syntax`, and sibling Point-Free packages, with no detected output differences
+
+#### Legacy NuGet manifest sets
+
+##### [Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94](https://github.com/Apress/pro-html5-w-visual-studio-2015/tree/3599d94467454d39fd4fe62894e2920cb94942c9) — **8.64× faster**
+
+- Files: 22
+- Run context: 2026-06-05 · t3-nuget-legacy-76176 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · curated set of the 11 `project.json` + 11 `project.lock.json` files from `Apress/pro-html5-w-visual-studio-2015@3599d94`
+- Timing: Provenant `6.63s`; ScanCode `57.29s`
+- Full legacy .NET dependency extraction (`206` vs `0` dependencies across `22` vs `0` file-level package records) from DNX-era `project.json` manifests and resolved `project.lock.json` lockfiles that ScanCode leaves package-blind, including the BOM-prefixed `project.json` files that Visual Studio writes, with zero scan errors
 
 ## Benchmark conventions
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -149,6 +149,9 @@ ScanCode: 69.61s</title></rect>
     <rect x="294.90" y="411.70" width="8" height="8" fill="#d97706" rx="1.5"><title>ocetnik/react-native-background-timer @ 244ea3e
 Files: 19
 ScanCode: 97.28s</title></rect>
+    <rect x="305.00" y="436.72" width="8" height="8" fill="#d97706" rx="1.5"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
+Files: 22
+ScanCode: 57.29s</title></rect>
     <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 ScanCode: 73.99s</title></rect>
@@ -784,6 +787,9 @@ Provenant: 10.31s</title></circle>
     <circle cx="298.90" cy="526.07" r="4.5" fill="#2563eb"><title>ocetnik/react-native-background-timer @ 244ea3e
 Files: 19
 Provenant: 9.41s</title></circle>
+    <circle cx="309.00" cy="542.62" r="4.5" fill="#2563eb"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
+Files: 22
+Provenant: 6.63s</title></circle>
     <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 Provenant: 11.06s</title></circle>

--- a/src/parsers/nuget/nuget_test.rs
+++ b/src/parsers/nuget/nuget_test.rs
@@ -625,6 +625,56 @@ mod tests {
         );
     }
 
+    // Visual Studio writes project.json (and project.lock.json) with a leading UTF-8
+    // BOM. serde_json rejects the BOM, so without stripping it the parser fails with
+    // "expected value at line 1 column 1" and extracts nothing.
+    #[test]
+    fn test_project_json_parses_with_utf8_bom() {
+        let json = "\u{feff}{\n  \"name\": \"Bom.Project\",\n  \"version\": \"1.0.0\",\n  \"dependencies\": { \"Newtonsoft.Json\": \"13.0.1\" }\n}";
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let package_data = ProjectJsonParser::extract_first_package(temp_file.path());
+
+        assert_eq!(
+            package_data.datasource_id,
+            Some(DatasourceId::NugetProjectJson)
+        );
+        assert_eq!(package_data.name.as_deref(), Some("Bom.Project"));
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:nuget/Newtonsoft.Json")
+        );
+    }
+
+    #[test]
+    fn test_project_lock_json_parses_with_utf8_bom() {
+        let json = "\u{feff}{\n  \"locked\": false,\n  \"version\": 2,\n  \"projectFileDependencyGroups\": { \"\": [ \"Newtonsoft.Json >= 13.0.1\" ] },\n  \"libraries\": { \"Newtonsoft.Json/13.0.1\": { \"type\": \"package\" } }\n}";
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let package_data = ProjectLockJsonParser::extract_first_package(temp_file.path());
+
+        assert_eq!(
+            package_data.datasource_id,
+            Some(DatasourceId::NugetProjectLockJson)
+        );
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:nuget/Newtonsoft.Json")
+        );
+        assert_eq!(
+            package_data.dependencies[0]
+                .extracted_requirement
+                .as_deref(),
+            Some(">= 13.0.1")
+        );
+    }
+
     #[test]
     fn test_project_json_ignores_non_nuget_gitlab_style_metadata() {
         let json = r#"{

--- a/src/parsers/nuget/project_json.rs
+++ b/src/parsers/nuget/project_json.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
+use crate::utils::text::strip_utf8_bom_str;
 
 use super::super::PackageParser;
 use super::super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
@@ -40,19 +41,22 @@ impl PackageParser for ProjectJsonParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path, None) {
+        let raw = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read project.json at {:?}: {}", path, e);
                 return vec![default_package_data(Some(DatasourceId::NugetProjectJson))];
             }
         };
+        // Visual Studio writes project.json with a UTF-8 BOM, which serde_json
+        // rejects ("expected value at line 1 column 1"); strip it before parsing.
+        let content = strip_utf8_bom_str(&raw);
 
-        if !looks_like_probable_nuget_project_json_text(&content) {
+        if !looks_like_probable_nuget_project_json_text(content) {
             return Vec::new();
         }
 
-        let parsed: serde_json::Value = match serde_json::from_str(&content) {
+        let parsed: serde_json::Value = match serde_json::from_str(content) {
             Ok(value) => value,
             Err(e) => {
                 warn!("Failed to parse project.json at {:?}: {}", path, e);
@@ -90,7 +94,7 @@ impl PackageParser for ProjectLockJsonParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let content = match read_file_to_string(path, None) {
+        let raw = match read_file_to_string(path, None) {
             Ok(c) => c,
             Err(e) => {
                 warn!("Failed to read project.lock.json at {:?}: {}", path, e);
@@ -99,8 +103,11 @@ impl PackageParser for ProjectLockJsonParser {
                 ))];
             }
         };
+        // Strip a leading UTF-8 BOM (written by Visual Studio tooling) so serde_json
+        // does not fail on the first byte.
+        let content = strip_utf8_bom_str(&raw);
 
-        let parsed: serde_json::Value = match serde_json::from_str(&content) {
+        let parsed: serde_json::Value = match serde_json::from_str(content) {
             Ok(value) => value,
             Err(e) => {
                 warn!("Failed to parse project.lock.json at {:?}: {}", path, e);


### PR DESCRIPTION
## Summary

- **Fix:** Visual Studio writes legacy `project.json`/`project.lock.json` with a leading UTF-8 BOM. serde_json rejects the BOM (`expected value at line 1 column 1`), so the parser failed, emitted a scan error, and returned an empty default package — discarding all dependencies for every BOM-prefixed manifest. Both legacy parsers now strip the BOM (via the existing `strip_utf8_bom_str` helper) before parsing.
- **Tier 3 surface verification:** legacy DNX-era NuGet manifests (`project.json` + `project.lock.json`), recorded as a new `docs/BENCHMARKS.md` "Legacy NuGet manifest sets" entry. On a curated 22-file set from `Apress/pro-html5-w-visual-studio-2015@3599d94`, Provenant extracts **206 dependencies across 22 package records where ScanCode is package-blind (0/0)**, **8.64× faster**, with the BOM fix turning 10 scan errors into 0 and raising extracted dependencies from 106 to 206.
- Regenerated headline stats (now **212/212** runs) and chart.

## Issues

- Covers: the legacy NuGet verified-surface gaps (`project.json`, `project.lock.json`) from the benchmark coverage review, plus a real UTF-8 BOM parsing bug found while verifying them.

## Scope and exclusions

- Included: the BOM fix in `project_json.rs` (both parsers) + 2 regression tests, and one `docs/BENCHMARKS.md` entry.
- Explicit exclusions: the other Tier 3/4 surfaces (`ivy.xml`, `.aar`, `.ear`/`.war`/`.sar`/`.mar`, EAR/JBoss/Axis2 XML, `.dmg`/`.iso`/`.crx`/`.ipa`/`.cab`/`.xpi`/`.shar`) are recognition-only in **both** Provenant and ScanCode (`NonAssemblableDatafileHandler`); a compare confirms exact datasource parity (e.g. `ivy.xml`→`ant_ivy_xml`, `.aar`→`android_aar_library`) with zero ScanCode-favored deltas, so they need no code change or benchmark entry. (See the separate Tier 4 follow-up.)

## How to verify

- `cargo test --lib -- project_json project_lock` (9 tests incl. the new `test_project_json_parses_with_utf8_bom` and `test_project_lock_json_parses_with_utf8_bom`).
- No golden drift: `cargo test --features golden-tests --test parsers_golden -- nuget` (17/17).
- End-to-end: a `project.json` saved with a UTF-8 BOM (as Visual Studio writes it) now parses and yields its dependencies instead of a scan error; confirmed on the Apress curated set (206 deps, 0 errors).

## Intentional differences from Python

- None. ScanCode does not extract dependencies from these legacy manifests at all; Provenant's fuller extraction is strictly broader. The BOM handling matches ScanCode's tolerance of BOM-prefixed inputs.

## Follow-up work

- Tier 4 (recognizer-only surfaces) is verified parity with no committable change; will report separately.

## Expected-output fixture changes

- None. Two new unit tests; no golden fixtures changed (nuget parser goldens pass unchanged).