### PR TITLE
test(parsers): cover recognizer-surface dispatch through try_parse_file

### DIFF
--- a/src/parsers/misc_test.rs
+++ b/src/parsers/misc_test.rs
@@ -629,3 +629,64 @@ fn test_minimal_package_data_structure() {
     assert_eq!(pkg.dependencies.len(), 0);
     assert_eq!(pkg.parties.len(), 0);
 }
+
+// ============================================================================
+// Scanner-dispatch contract
+// ============================================================================
+
+// The per-recognizer tests above exercise each recognizer in isolation, but not that
+// it is registered and reachable through the scanner's `try_parse_file` dispatch. A
+// registration regression (a recognizer dropped from the dispatch list, or shadowed by
+// an earlier parser claiming the same path) would pass the unit tests yet break real
+// scans. This walks every extension/path-based recognizer surface end-to-end and
+// asserts the dispatched datasource id.
+//
+// Magic-byte recognizers (squashfs, NSIS, InstallShield) are excluded because their
+// dispatch depends on real binary signatures rather than the path alone.
+#[test]
+fn test_recognizer_surfaces_dispatch_through_try_parse_file() {
+    let temp = TempDir::new().expect("temp dir");
+    // Distinct parent dirs keep the lowercase `meta-inf` patterns from colliding with
+    // the uppercase `META-INF` ones on case-insensitive filesystems.
+    let cases: &[(&str, DatasourceId)] = &[
+        ("ear/app.ear", DatasourceId::JavaEarArchive),
+        (
+            "ear/META-INF/application.xml",
+            DatasourceId::JavaEarApplicationXml,
+        ),
+        ("war/app.war", DatasourceId::JavaWarArchive),
+        ("war/WEB-INF/web.xml", DatasourceId::JavaWarWebXml),
+        ("axis2/mod.mar", DatasourceId::Axis2Mar),
+        ("axis2/meta-inf/module.xml", DatasourceId::Axis2ModuleXml),
+        ("jboss/svc.sar", DatasourceId::JbossSar),
+        (
+            "jboss/meta-inf/jboss-service.xml",
+            DatasourceId::JbossServiceXml,
+        ),
+        ("android/lib.aar", DatasourceId::AndroidAarLibrary),
+        ("mozilla/ext.xpi", DatasourceId::MozillaXpi),
+        ("chrome/ext.crx", DatasourceId::ChromeCrx),
+        ("ios/app.ipa", DatasourceId::IosIpa),
+        ("cab/pkg.cab", DatasourceId::MicrosoftCabinet),
+        ("shar/pkg.shar", DatasourceId::SharShellArchive),
+        ("dmg/disk.dmg", DatasourceId::AppleDmg),
+        ("iso/disk.iso", DatasourceId::IsoDiskImage),
+        ("jar/lib.jar", DatasourceId::JavaJar),
+        ("ivy/ivy.xml", DatasourceId::AntIvyXml),
+        ("meteor/package.js", DatasourceId::MeteorPackage),
+    ];
+
+    for (rel, expected) in cases {
+        let path = temp.path().join(rel);
+        fs::create_dir_all(path.parent().unwrap()).expect("create parent dirs");
+        fs::write(&path, b"recognizer dispatch fixture").expect("write fixture");
+
+        let result = try_parse_file(&path)
+            .unwrap_or_else(|| panic!("try_parse_file returned None for {rel}"));
+        assert_eq!(
+            result.packages.first().and_then(|p| p.datasource_id),
+            Some(*expected),
+            "scanner dispatch for {rel} should yield {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Tier 4 of the benchmark coverage-gap review covers the misc **file-type recognizer** surfaces: `.ear`/`.war`/`.sar`/`.mar` and their `META-INF`/`meta-inf` XML manifests, `.aar`, `.xpi`, `.crx`, `.ipa`, `.cab`, `.shar`, disk images (`.dmg`/`.iso`/`.img`/`.udf`/`.sparseimage`), `.jar`, and `ivy.xml`.
- **Finding:** these are recognition-only in **both** Provenant and ScanCode (ScanCode implements them as `NonAssemblableDatafileHandler`; Provenant's recognizers emit just `{package_type, datasource_id}`). A `compare-outputs` run over real and constructed sample files confirmed **exact datasource parity with zero ScanCode-favored deltas** — so there is no extraction gap to fix and no meaningful benchmark entry to add (a "recognizes an empty `.iso` faster" row would be noise).
- **What was missing:** the recognizers were unit-tested in isolation (`Recognizer::is_match` / `extract_packages`) but had **no coverage that they are registered and reachable through the scanner's `try_parse_file` dispatch**. A registration regression — a recognizer dropped from the dispatch list or shadowed by an earlier parser claiming the same path — would pass the unit tests yet break real scans.
- This PR adds that missing scanner-dispatch contract test: it walks every extension/path-based recognizer surface end-to-end and asserts the dispatched `datasource_id`.

## Issues

- Covers: Tier 4 recognizer surfaces from the benchmark coverage review (verified parity; closes the dispatch-coverage gap).

## Scope and exclusions

- Included: one scanner-dispatch contract test in `src/parsers/misc_test.rs`.
- Explicit exclusions: no parser/recognizer behavior change and no `docs/BENCHMARKS.md` entry — the surfaces are recognizer-only parity with ScanCode, so neither is warranted. Magic-byte recognizers (squashfs, NSIS, InstallShield) are excluded from the test since their dispatch depends on real binary signatures, not the path.

## How to verify

- `cargo test --lib -- test_recognizer_surfaces_dispatch_through_try_parse_file` (asserts 18 recognizer surfaces dispatch to the expected datasource via `try_parse_file`).

## Intentional differences from Python

- None. Provenant and ScanCode both treat these as recognition-only datasources; the test asserts that parity-level wiring.

## Follow-up work

- None. This completes the Tier 1–4 benchmark coverage-gap review.

## Expected-output fixture changes

- None. One new contract test; no fixtures or goldens changed.