### PR TITLE
fix(scanner): include license dataset in incremental fingerprint

### DIFF
--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -31,7 +31,7 @@ pub mod seq_match;
 pub mod spdx_lid;
 pub mod spdx_mapping;
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;
 pub mod tokenize;
 pub mod unknown_match;
 
@@ -540,6 +540,15 @@ impl LicenseDetectionEngine {
     #[cfg(test)]
     pub(crate) fn from_test_index(index: index::LicenseIndex) -> Self {
         Self::from_index(index, None, None).expect("test index should build license engine")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_index_with_provenance(
+        index: index::LicenseIndex,
+        license_index_provenance: LicenseIndexProvenance,
+    ) -> Self {
+        Self::from_index(index, None, Some(license_index_provenance))
+            .expect("test index should build license engine")
     }
 
     /// Create a new license detection engine from the embedded license index.

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -75,27 +75,32 @@ pub fn scan_options_fingerprint(
     license_options: LicenseScanOptions,
     license_engine: Option<&LicenseDetectionEngine>,
 ) -> String {
-    let (license_enabled, rules_count, first_rule_id, last_rule_id) = match license_engine {
-        Some(engine) => {
-            let rules = &engine.index().rules_by_rid;
-            (
-                true,
-                rules.len(),
-                rules
-                    .first()
-                    .map(|rule| rule.identifier.as_str())
-                    .unwrap_or(""),
-                rules
-                    .last()
-                    .map(|rule| rule.identifier.as_str())
-                    .unwrap_or(""),
-            )
-        }
-        None => (false, 0, "", ""),
-    };
+    let (license_enabled, dataset_fingerprint, rules_count, first_rule_id, last_rule_id) =
+        match license_engine {
+            Some(engine) => {
+                let rules = &engine.index().rules_by_rid;
+                (
+                    true,
+                    engine
+                        .license_index_provenance()
+                        .map(|provenance| provenance.dataset_fingerprint.as_str())
+                        .unwrap_or(""),
+                    rules.len(),
+                    rules
+                        .first()
+                        .map(|rule| rule.identifier.as_str())
+                        .unwrap_or(""),
+                    rules
+                        .last()
+                        .map(|rule| rule.identifier.as_str())
+                        .unwrap_or(""),
+                )
+            }
+            None => (false, "", 0, "", ""),
+        };
 
     format!(
-        "tool_version={};info={};packages={};app_packages={};system_packages={};compiled_packages={};copyrights={};generated={};emails={};urls={};max_emails={};max_urls={};timeout={:.6};license_enabled={};rules_count={};first_rule_id={};last_rule_id={};license_text={};license_text_diagnostics={};license_diagnostics={};unknown_licenses={};sequence_matching={};license_score={}",
+        "tool_version={};info={};packages={};app_packages={};system_packages={};compiled_packages={};copyrights={};generated={};emails={};urls={};max_emails={};max_urls={};timeout={:.6};license_enabled={};license_dataset_fingerprint={};rules_count={};first_rule_id={};last_rule_id={};license_text={};license_text_diagnostics={};license_diagnostics={};unknown_licenses={};sequence_matching={};license_score={}",
         crate::version::BUILD_VERSION,
         text_options.collect_info,
         text_options.detect_packages,
@@ -110,6 +115,7 @@ pub fn scan_options_fingerprint(
         text_options.max_urls,
         text_options.timeout_seconds,
         license_enabled,
+        dataset_fingerprint,
         rules_count,
         first_rule_id,
         last_rule_id,

--- a/src/scanner/tests.rs
+++ b/src/scanner/tests.rs
@@ -9,8 +9,11 @@ use object::pe;
 use tempfile::TempDir;
 
 use crate::cache::build_collection_exclude_patterns;
+use crate::license_detection::test_utils::create_test_index_default;
 use crate::license_detection::{LicenseDetectionEngine, MatcherKind};
-use crate::models::{DatasourceId, FileType, PackageType as FilePackageType};
+use crate::models::{
+    DatasourceId, FileType, LicenseIndexProvenance, PackageType as FilePackageType,
+};
 use crate::progress::{ProgressMode, ScanProgress};
 
 use super::{
@@ -76,6 +79,47 @@ fn test_scan_options_fingerprint_changes_with_license_score() {
     );
 
     assert_ne!(default_fingerprint, filtered_fingerprint);
+}
+
+#[test]
+fn test_scan_options_fingerprint_changes_with_license_dataset_fingerprint() {
+    let text_options = TextDetectionOptions::default();
+    let first_engine = test_license_engine_with_dataset_fingerprint("dataset-fingerprint-one");
+    let second_engine = test_license_engine_with_dataset_fingerprint("dataset-fingerprint-two");
+
+    let first_fingerprint = scan_options_fingerprint(
+        &text_options,
+        LicenseScanOptions::default(),
+        Some(&first_engine),
+    );
+    let second_fingerprint = scan_options_fingerprint(
+        &text_options,
+        LicenseScanOptions::default(),
+        Some(&second_engine),
+    );
+
+    assert_ne!(first_fingerprint, second_fingerprint);
+    assert!(first_fingerprint.contains("license_dataset_fingerprint=dataset-fingerprint-one"));
+    assert!(second_fingerprint.contains("license_dataset_fingerprint=dataset-fingerprint-two"));
+}
+
+fn test_license_engine_with_dataset_fingerprint(
+    dataset_fingerprint: &str,
+) -> LicenseDetectionEngine {
+    LicenseDetectionEngine::from_test_index_with_provenance(
+        create_test_index_default(),
+        LicenseIndexProvenance {
+            source: "test-license-index".to_string(),
+            dataset_fingerprint: dataset_fingerprint.to_string(),
+            ignored_rules: vec![],
+            ignored_licenses: vec![],
+            ignored_rules_due_to_licenses: vec![],
+            added_rules: vec![],
+            replaced_rules: vec![],
+            added_licenses: vec![],
+            replaced_licenses: vec![],
+        },
+    )
 }
 
 fn scan_single_file(


### PR DESCRIPTION
## Summary

- Include the license index provenance dataset fingerprint in the scanner scan-options fingerprint used by incremental cache validation.
- Add focused regression coverage proving otherwise-identical license indexes produce different scan option fingerprints when dataset fingerprints differ.

## Issues

- Covers: incremental cache invalidation could reuse stale license scan results when rule/license content changed without changing rule count or first/last rule IDs.

## Scope and exclusions

- Included: scanner fingerprint integration and focused unit coverage.
- Explicit exclusions: broader cache storage changes, license dataset generation changes, and unrelated incremental cache behavior.

## How to verify

- No manual reviewer steps beyond CI are needed; the focused unit test covers the changed fingerprint contract.

## Follow-up work

- Created or intentionally deferred: none.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: no expected-output fixtures were changed.

Generated with [Claude Code](https://claude.ai/code)