### PR TITLE
fix(serve): harden privileged ingest inputs

### DIFF
--- a/docs/SERVE_API_GUIDE.md
+++ b/docs/SERVE_API_GUIDE.md
@@ -16,6 +16,16 @@ For command-line scanning workflows, start with the [CLI Guide](CLI_GUIDE.md). F
 provenant serve --bind 127.0.0.1:8080
 ```
 
+By default, `provenant serve` is intended for same-host use and binds to loopback. On loopback binds, all input modes listed below are enabled.
+
+When the service is bound beyond localhost, requests may come from other machines. In that mode, local-path, remote-URL, and repository inputs are disabled unless the operator explicitly starts the service with `--allow-privileged-inputs`. Upload input remains available because the caller supplies the content to scan instead of asking the service host to read local paths, fetch URLs, or run `git fetch`.
+
+Use `--allow-privileged-inputs` only for trusted deployments with their own network access controls:
+
+```sh
+provenant serve --bind 0.0.0.0:8080 --allow-privileged-inputs
+```
+
 The current service surface includes:
 
 - `GET /livez`
@@ -74,7 +84,7 @@ That means the service can:
 - download a bounded remote HTTP(S) artifact or text resource into temporary local staging before scanning it
 - accept a bounded JSON upload payload and materialize it locally before scanning it
 
-Local-path input is best suited to same-host or operator-controlled deployments where the service already has filesystem access to the scan target.
+Local-path, repository, and remote URL inputs are privileged input modes: they use the service host's filesystem, network, or `git` client on behalf of the caller. They are best suited to same-host or operator-controlled deployments where callers are already trusted to make those host-side accesses.
 
 ### Local-path input
 

--- a/docs/openapi/provenant-serve.openapi.json
+++ b/docs/openapi/provenant-serve.openapi.json
@@ -174,6 +174,16 @@
               }
             }
           },
+          "422": {
+            "description": "Request is well-formed but cannot be executed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServeErrorResponse"
+                }
+              }
+            }
+          },
           "503": {
             "description": "Service has no remaining async admission capacity.",
             "content": {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -200,6 +200,10 @@ pub struct ServeArgs {
     /// Bind the service shell to HOST:PORT.
     #[arg(long = "bind", value_name = "ADDR", default_value = "127.0.0.1:8080")]
     pub bind: String,
+
+    /// Allow paths, URL, and repository inputs when bound beyond localhost.
+    #[arg(long = "allow-privileged-inputs")]
+    pub allow_privileged_inputs: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -76,7 +76,30 @@ fn test_parses_serve_subcommand() {
         .expect("serve subcommand should parse");
 
     match parsed.command {
-        Command::Serve(args) => assert_eq!(args.bind, "127.0.0.1:9090"),
+        Command::Serve(args) => {
+            assert_eq!(args.bind, "127.0.0.1:9090");
+            assert!(!args.allow_privileged_inputs);
+        }
+        other => panic!("expected serve subcommand, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parses_serve_privileged_inputs_flag() {
+    let parsed = Cli::try_parse_from([
+        "provenant",
+        "serve",
+        "--bind",
+        "0.0.0.0:9090",
+        "--allow-privileged-inputs",
+    ])
+    .expect("serve subcommand should parse privileged input flag");
+
+    match parsed.command {
+        Command::Serve(args) => {
+            assert_eq!(args.bind, "0.0.0.0:9090");
+            assert!(args.allow_privileged_inputs);
+        }
         other => panic!("expected serve subcommand, got {other:?}"),
     }
 }

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -81,6 +81,53 @@ const MAX_UPLOADED_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_ARCHIVE_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_COUNT: usize = 10_000;
+const ARCHIVE_LIMITS: ArchiveExtractionLimits = ArchiveExtractionLimits {
+    max_entry_bytes: MAX_ARCHIVE_ENTRY_BYTES,
+    max_total_bytes: MAX_ARCHIVE_TOTAL_BYTES,
+    max_entry_count: MAX_ARCHIVE_ENTRY_COUNT,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct IngestPolicy {
+    privileged_inputs: PrivilegedInputPolicy,
+}
+
+impl IngestPolicy {
+    pub(super) fn allow_privileged_inputs() -> Self {
+        Self {
+            privileged_inputs: PrivilegedInputPolicy::Allowed,
+        }
+    }
+
+    pub(super) fn upload_only() -> Self {
+        Self {
+            privileged_inputs: PrivilegedInputPolicy::UploadOnly,
+        }
+    }
+
+    pub(super) fn privileged_inputs_allowed(self) -> bool {
+        self.privileged_inputs == PrivilegedInputPolicy::Allowed
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivilegedInputPolicy {
+    Allowed,
+    UploadOnly,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ArchiveExtractionLimits {
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+    max_entry_count: usize,
+}
+
+#[derive(Debug, Default)]
+struct ArchiveExtractionState {
+    extracted_files: usize,
+    extracted_bytes: u64,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum IngestError {
@@ -136,7 +183,8 @@ impl IngestError {
 }
 
 impl ServeScanInput {
-    fn prepare(self) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
+    fn prepare(self, policy: IngestPolicy) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
+        validate_input_policy(&self, policy)?;
         match self {
             Self::Paths { paths } => prepare_paths_input(paths),
             Self::Repository { url, reference } => prepare_repository_input(&url, &reference),
@@ -147,6 +195,23 @@ impl ServeScanInput {
             } => prepare_upload_input(&filename, &content_base64),
         }
     }
+}
+
+pub(super) fn validate_input_policy(input: &ServeScanInput, policy: IngestPolicy) -> Result<()> {
+    if policy.privileged_inputs_allowed() {
+        return Ok(());
+    }
+
+    let input_type = match input {
+        ServeScanInput::Paths { .. } => "paths",
+        ServeScanInput::Repository { .. } => "repository",
+        ServeScanInput::Url { .. } => "url",
+        ServeScanInput::Upload { .. } => return Ok(()),
+    };
+
+    Err(IngestError::validation(format!(
+        "input.type = \"{input_type}\" requires --allow-privileged-inputs when provenant serve is bound beyond localhost"
+    )))
 }
 
 fn prepare_paths_input(paths: Vec<String>) -> Result<(Vec<PathBuf>, Option<TempDir>)> {
@@ -439,13 +504,13 @@ fn extract_archive(archive_path: &Path, output_dir: &Path, format: ArchiveFormat
 fn extract_entry(
     output_dir: &Path,
     relative_path: &Path,
-    entry_size: u64,
-    extracted_files: &mut usize,
-    extracted_bytes: &mut u64,
+    declared_entry_size: u64,
+    state: &mut ArchiveExtractionState,
     entry_reader: &mut dyn std::io::Read,
+    limits: ArchiveExtractionLimits,
     archive_context: &str,
 ) -> Result<()> {
-    enforce_archive_limits(extracted_files, extracted_bytes, entry_size)?;
+    enforce_archive_entry_start(state, declared_entry_size, limits)?;
 
     let destination = output_dir.join(relative_path);
     if let Some(parent) = destination.parent() {
@@ -456,16 +521,14 @@ fn extract_entry(
     let mut output = File::create(&destination).map_err(|e| {
         IngestError::internal_with_source(e, format!("failed to create {}", destination.display()))
     })?;
-    std::io::copy(entry_reader, &mut output).map_err(|e| {
-        IngestError::internal_with_source(
-            e,
-            format!(
-                "failed to extract {}{}",
-                archive_context,
-                relative_path.display()
-            ),
-        )
-    })?;
+    copy_archive_entry_with_limits(
+        entry_reader,
+        &mut output,
+        &mut state.extracted_bytes,
+        limits,
+        archive_context,
+        relative_path,
+    )?;
 
     Ok(())
 }
@@ -478,8 +541,7 @@ fn extract_zip_archive(archive_path: &Path, file: File, output_dir: &Path) -> Re
         )
     })?;
 
-    let mut extracted_files = 0usize;
-    let mut extracted_bytes = 0u64;
+    let mut state = ArchiveExtractionState::default();
     let archive_context = format!("{}/", archive_path.display());
 
     for index in 0..archive.len() {
@@ -506,14 +568,14 @@ fn extract_zip_archive(archive_path: &Path, file: File, output_dir: &Path) -> Re
             output_dir,
             &relative_path,
             entry.size(),
-            &mut extracted_files,
-            &mut extracted_bytes,
+            &mut state,
             &mut entry,
+            ARCHIVE_LIMITS,
             &archive_context,
         )?;
     }
 
-    if extracted_files == 0 {
+    if state.extracted_files == 0 {
         return Err(IngestError::validation(
             "archive did not contain any safe files to scan",
         ));
@@ -524,8 +586,7 @@ fn extract_zip_archive(archive_path: &Path, file: File, output_dir: &Path) -> Re
 
 fn extract_tar_archive<R: Read>(archive_path: &Path, reader: R, output_dir: &Path) -> Result<()> {
     let mut archive = Archive::new(reader);
-    let mut extracted_files = 0usize;
-    let mut extracted_bytes = 0u64;
+    let mut state = ArchiveExtractionState::default();
     let archive_context = format!("{}/", archive_path.display());
 
     for entry in archive.entries().map_err(|e| {
@@ -578,14 +639,14 @@ fn extract_tar_archive<R: Read>(archive_path: &Path, reader: R, output_dir: &Pat
             output_dir,
             &relative_path,
             entry_size,
-            &mut extracted_files,
-            &mut extracted_bytes,
+            &mut state,
             &mut entry,
+            ARCHIVE_LIMITS,
             &archive_context,
         )?;
     }
 
-    if extracted_files == 0 {
+    if state.extracted_files == 0 {
         return Err(IngestError::validation(
             "archive did not contain any safe files to scan",
         ));
@@ -594,35 +655,101 @@ fn extract_tar_archive<R: Read>(archive_path: &Path, reader: R, output_dir: &Pat
     Ok(())
 }
 
-fn enforce_archive_limits(
-    extracted_files: &mut usize,
-    extracted_bytes: &mut u64,
-    entry_size: u64,
+fn enforce_archive_entry_start(
+    state: &mut ArchiveExtractionState,
+    declared_entry_size: u64,
+    limits: ArchiveExtractionLimits,
 ) -> Result<()> {
-    if entry_size > MAX_ARCHIVE_ENTRY_BYTES {
+    if declared_entry_size > limits.max_entry_bytes {
         return Err(IngestError::PayloadTooLarge(format!(
             "archive entry exceeds max size of {} bytes",
-            MAX_ARCHIVE_ENTRY_BYTES
+            limits.max_entry_bytes
         )));
     }
 
-    *extracted_files += 1;
-    if *extracted_files > MAX_ARCHIVE_ENTRY_COUNT {
+    state.extracted_files += 1;
+    if state.extracted_files > limits.max_entry_count {
         return Err(IngestError::PayloadTooLarge(format!(
             "archive exceeds max entry count of {}",
-            MAX_ARCHIVE_ENTRY_COUNT
-        )));
-    }
-
-    *extracted_bytes += entry_size;
-    if *extracted_bytes > MAX_ARCHIVE_TOTAL_BYTES {
-        return Err(IngestError::PayloadTooLarge(format!(
-            "archive exceeds max extracted size of {} bytes",
-            MAX_ARCHIVE_TOTAL_BYTES
+            limits.max_entry_count
         )));
     }
 
     Ok(())
+}
+
+fn copy_archive_entry_with_limits(
+    entry_reader: &mut dyn std::io::Read,
+    output: &mut dyn Write,
+    extracted_bytes: &mut u64,
+    limits: ArchiveExtractionLimits,
+    archive_context: &str,
+    relative_path: &Path,
+) -> Result<u64> {
+    let mut entry_bytes = 0u64;
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let read_bytes = entry_reader.read(&mut buffer).map_err(|e| {
+            IngestError::internal_with_source(
+                e,
+                format!(
+                    "failed to extract {}{}",
+                    archive_context,
+                    relative_path.display()
+                ),
+            )
+        })?;
+        if read_bytes == 0 {
+            break;
+        }
+
+        let read_bytes = read_bytes as u64;
+        let next_entry_bytes = entry_bytes
+            .checked_add(read_bytes)
+            .ok_or_else(|| archive_entry_too_large(limits))?;
+        if next_entry_bytes > limits.max_entry_bytes {
+            return Err(archive_entry_too_large(limits));
+        }
+
+        let next_extracted_bytes = extracted_bytes
+            .checked_add(read_bytes)
+            .ok_or_else(|| archive_total_too_large(limits))?;
+        if next_extracted_bytes > limits.max_total_bytes {
+            return Err(archive_total_too_large(limits));
+        }
+
+        output
+            .write_all(&buffer[..read_bytes as usize])
+            .map_err(|e| {
+                IngestError::internal_with_source(
+                    e,
+                    format!(
+                        "failed to extract {}{}",
+                        archive_context,
+                        relative_path.display()
+                    ),
+                )
+            })?;
+        entry_bytes = next_entry_bytes;
+        *extracted_bytes = next_extracted_bytes;
+    }
+
+    Ok(entry_bytes)
+}
+
+fn archive_entry_too_large(limits: ArchiveExtractionLimits) -> IngestError {
+    IngestError::PayloadTooLarge(format!(
+        "archive entry exceeds max size of {} bytes",
+        limits.max_entry_bytes
+    ))
+}
+
+fn archive_total_too_large(limits: ArchiveExtractionLimits) -> IngestError {
+    IngestError::PayloadTooLarge(format!(
+        "archive exceeds max extracted size of {} bytes",
+        limits.max_total_bytes
+    ))
 }
 
 fn normalize_archive_path(path: &Path) -> Option<PathBuf> {
@@ -669,8 +796,8 @@ pub(super) struct SyncScanExecution {
 }
 
 impl SyncScanExecution {
-    pub(super) fn new(request: ServeScanRequest) -> Result<Self> {
-        let (paths, _staging_dir) = request.input.prepare()?;
+    pub(super) fn new(request: ServeScanRequest, policy: IngestPolicy) -> Result<Self> {
+        let (paths, _staging_dir) = request.input.prepare(policy)?;
 
         let mut options = ScanOptions::from(request.options);
         if _staging_dir.is_some() {
@@ -726,10 +853,13 @@ mod tests {
     fn sync_scan_execution_rejects_empty_paths() {
         use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
 
-        let error = SyncScanExecution::new(ServeScanRequest {
-            input: ServeScanInput::Paths { paths: Vec::new() },
-            options: ServeScanOptions::default(),
-        })
+        let error = SyncScanExecution::new(
+            ServeScanRequest {
+                input: ServeScanInput::Paths { paths: Vec::new() },
+                options: ServeScanOptions::default(),
+            },
+            IngestPolicy::allow_privileged_inputs(),
+        )
         .expect_err("empty paths should fail");
 
         assert!(
@@ -761,5 +891,89 @@ mod tests {
     fn detect_archive_format_returns_none_for_unsupported() {
         assert!(detect_archive_format("data.rar").is_none());
         assert!(detect_archive_format("readme.txt").is_none());
+    }
+
+    #[test]
+    fn restricted_policy_rejects_privileged_input_types() {
+        let policy = IngestPolicy::upload_only();
+        let paths = ServeScanInput::Paths {
+            paths: vec![".".to_string()],
+        };
+        let url = ServeScanInput::Url {
+            url: "https://example.com/archive.zip".to_string(),
+        };
+        let repository = ServeScanInput::Repository {
+            url: "https://example.com/repo.git".to_string(),
+            reference: "main".to_string(),
+        };
+
+        for input in [paths, url, repository] {
+            let error = validate_input_policy(&input, policy)
+                .expect_err("privileged input should require explicit opt-in");
+            assert!(error.to_string().contains("--allow-privileged-inputs"));
+        }
+    }
+
+    #[test]
+    fn restricted_policy_allows_upload_input() {
+        let upload = ServeScanInput::Upload {
+            filename: "archive.zip".to_string(),
+            content_base64: "Zm9v".to_string(),
+        };
+
+        validate_input_policy(&upload, IngestPolicy::upload_only())
+            .expect("upload input should not require privileged opt-in");
+    }
+
+    #[test]
+    fn copy_archive_entry_enforces_runtime_entry_bytes() {
+        let limits = ArchiveExtractionLimits {
+            max_entry_bytes: 4,
+            max_total_bytes: 100,
+            max_entry_count: 10,
+        };
+        let mut reader = std::io::Cursor::new(b"12345");
+        let mut output = Vec::new();
+        let mut extracted_bytes = 0;
+
+        let error = copy_archive_entry_with_limits(
+            &mut reader,
+            &mut output,
+            &mut extracted_bytes,
+            limits,
+            "archive.zip/",
+            Path::new("file.txt"),
+        )
+        .expect_err("runtime entry bytes should be capped");
+
+        assert!(error.to_string().contains("archive entry exceeds max size"));
+    }
+
+    #[test]
+    fn copy_archive_entry_enforces_runtime_total_bytes() {
+        let limits = ArchiveExtractionLimits {
+            max_entry_bytes: 100,
+            max_total_bytes: 6,
+            max_entry_count: 10,
+        };
+        let mut reader = std::io::Cursor::new(b"3456");
+        let mut output = Vec::new();
+        let mut extracted_bytes = 3;
+
+        let error = copy_archive_entry_with_limits(
+            &mut reader,
+            &mut output,
+            &mut extracted_bytes,
+            limits,
+            "archive.zip/",
+            Path::new("file.txt"),
+        )
+        .expect_err("runtime total bytes should be capped");
+
+        assert!(
+            error
+                .to_string()
+                .contains("archive exceeds max extracted size")
+        );
     }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -5,6 +5,7 @@ mod ingest;
 mod job_controller;
 
 use std::io::Read;
+use std::net::{IpAddr, SocketAddr};
 use std::thread;
 
 use anyhow::{Result, anyhow};
@@ -14,7 +15,9 @@ use tiny_http::{Header, Method, Response, Server, StatusCode};
 
 use crate::cli::ServeArgs;
 use crate::license_detection::LicenseDetectionEngine;
-use crate::serve::ingest::{IngestError, ScanError, SyncScanExecution};
+use crate::serve::ingest::{
+    IngestError, IngestPolicy, ScanError, SyncScanExecution, validate_input_policy,
+};
 use crate::serve::job_controller::{
     AsyncJobController, AsyncSubmitError, DispatchedAsyncJob, JobOutcome, JobResult,
 };
@@ -65,6 +68,7 @@ impl ServeError {
 #[derive(Debug, Clone)]
 pub(crate) struct ServeConfig {
     bind: String,
+    ingest_policy: IngestPolicy,
 }
 
 impl TryFrom<&ServeArgs> for ServeConfig {
@@ -75,16 +79,41 @@ impl TryFrom<&ServeArgs> for ServeConfig {
             return Err(anyhow!("--bind must not be empty"));
         }
 
+        let loopback_bind = bind_allows_privileged_inputs_by_default(&args.bind);
+        let ingest_policy = if loopback_bind || args.allow_privileged_inputs {
+            IngestPolicy::allow_privileged_inputs()
+        } else {
+            IngestPolicy::upload_only()
+        };
+
         Ok(Self {
             bind: args.bind.clone(),
+            ingest_policy,
         })
     }
+}
+
+fn bind_allows_privileged_inputs_by_default(bind: &str) -> bool {
+    if let Ok(addr) = bind.parse::<SocketAddr>() {
+        return addr.ip().is_loopback();
+    }
+
+    let Some((host, _port)) = bind.rsplit_once(':') else {
+        return false;
+    };
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 #[derive(Debug)]
 struct ServeState {
     spdx_license_list_version: String,
     jobs: AsyncJobController,
+    ingest_policy: IngestPolicy,
 }
 
 struct ParsedRequest {
@@ -150,10 +179,16 @@ pub(crate) fn run(args: &ServeArgs) -> Result<()> {
         "Starting provenant serve on http://{} (api {API_VERSION})",
         local_addr
     );
+    if !config.ingest_policy.privileged_inputs_allowed() {
+        eprintln!(
+            "Privileged serve inputs (paths, url, repository) are disabled for this non-loopback bind; use --allow-privileged-inputs only for trusted deployments."
+        );
+    }
 
     let state = ServeState {
         spdx_license_list_version,
         jobs: AsyncJobController::new(),
+        ingest_policy: config.ingest_policy,
     };
     serve_forever(server, state)
 }
@@ -285,7 +320,7 @@ fn response_for_request(request: &ParsedRequest, state: &ServeState) -> HttpResp
                 tool_version: BUILD_VERSION.to_string(),
             },
         ),
-        (m, "/v1/scans") if *m == Method::Post => handle_sync_scan_request(request),
+        (m, "/v1/scans") if *m == Method::Post => handle_sync_scan_request(request, state),
         (_, "/v1/scans") => HttpResponse::error(
             StatusCode::from(405),
             "method_not_allowed",
@@ -314,12 +349,12 @@ impl From<ServeError> for HttpResponse {
     }
 }
 
-fn handle_sync_scan_request(request: &ParsedRequest) -> HttpResponse {
+fn handle_sync_scan_request(request: &ParsedRequest, state: &ServeState) -> HttpResponse {
     let sync_request = match decode_scan_request_from_http(request, "POST /v1/scans") {
         Ok(req) => req,
         Err(resp) => return resp,
     };
-    let execution = match SyncScanExecution::new(sync_request) {
+    let execution = match SyncScanExecution::new(sync_request, state.ingest_policy) {
         Ok(e) => e,
         Err(e) => return HttpResponse::from(ServeError::from(e)),
     };
@@ -337,6 +372,9 @@ fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> Htt
         Ok(req) => req,
         Err(resp) => return resp,
     };
+    if let Err(error) = validate_input_policy(&sync_request.input, state.ingest_policy) {
+        return HttpResponse::from(ServeError::from(error));
+    }
     let (response, dispatches) = match state.jobs.submit(sync_request) {
         Ok(result) => result,
         Err(AsyncSubmitError::QueueFull) => {
@@ -347,7 +385,7 @@ fn handle_async_scan_request(request: &ParsedRequest, state: &ServeState) -> Htt
             );
         }
     };
-    spawn_dispatches(state.jobs.clone(), dispatches);
+    spawn_dispatches(state.jobs.clone(), dispatches, state.ingest_policy);
     HttpResponse::json(StatusCode::from(202), &response)
 }
 
@@ -432,11 +470,15 @@ fn decode_scan_request_from_http(
     })
 }
 
-fn spawn_dispatches(controller: AsyncJobController, dispatches: Vec<DispatchedAsyncJob>) {
+fn spawn_dispatches(
+    controller: AsyncJobController,
+    dispatches: Vec<DispatchedAsyncJob>,
+    ingest_policy: IngestPolicy,
+) {
     for dispatched in dispatches {
         let controller = controller.clone();
         thread::spawn(move || {
-            let result = SyncScanExecution::new(dispatched.request)
+            let result = SyncScanExecution::new(dispatched.request, ingest_policy)
                 .map_err(ServeError::from)
                 .and_then(|e| {
                     e.run_async(dispatched.allocated_processors)
@@ -461,7 +503,7 @@ fn spawn_dispatches(controller: AsyncJobController, dispatches: Vec<DispatchedAs
                 dispatched.allocated_processors,
                 outcome,
             );
-            spawn_dispatches(controller, follow_up_dispatches);
+            spawn_dispatches(controller, follow_up_dispatches, ingest_policy);
         });
     }
 }
@@ -506,6 +548,7 @@ mod tests {
         ServeState {
             spdx_license_list_version: "3.28".to_string(),
             jobs: AsyncJobController::with_limits(2, 2, 8),
+            ingest_policy: IngestPolicy::allow_privileged_inputs(),
         }
     }
 
@@ -522,10 +565,55 @@ mod tests {
     fn serve_config_requires_non_empty_bind() {
         let args = ServeArgs {
             bind: String::new(),
+            allow_privileged_inputs: false,
         };
 
         let error = ServeConfig::try_from(&args).expect_err("empty bind should fail");
         assert!(error.to_string().contains("--bind must not be empty"));
+    }
+
+    #[test]
+    fn serve_config_allows_privileged_inputs_for_loopback_bind() {
+        let args = ServeArgs {
+            bind: "127.0.0.1:8080".to_string(),
+            allow_privileged_inputs: false,
+        };
+
+        let config = ServeConfig::try_from(&args).expect("loopback bind should configure");
+        assert!(config.ingest_policy.privileged_inputs_allowed());
+    }
+
+    #[test]
+    fn serve_config_allows_privileged_inputs_for_localhost_hostname() {
+        let args = ServeArgs {
+            bind: "localhost:8080".to_string(),
+            allow_privileged_inputs: false,
+        };
+
+        let config = ServeConfig::try_from(&args).expect("localhost bind should configure");
+        assert!(config.ingest_policy.privileged_inputs_allowed());
+    }
+
+    #[test]
+    fn serve_config_restricts_privileged_inputs_for_non_loopback_bind() {
+        let args = ServeArgs {
+            bind: "0.0.0.0:8080".to_string(),
+            allow_privileged_inputs: false,
+        };
+
+        let config = ServeConfig::try_from(&args).expect("non-loopback bind should configure");
+        assert!(!config.ingest_policy.privileged_inputs_allowed());
+    }
+
+    #[test]
+    fn serve_config_explicitly_allows_privileged_inputs_for_non_loopback_bind() {
+        let args = ServeArgs {
+            bind: "0.0.0.0:8080".to_string(),
+            allow_privileged_inputs: true,
+        };
+
+        let config = ServeConfig::try_from(&args).expect("non-loopback bind should configure");
+        assert!(config.ingest_policy.privileged_inputs_allowed());
     }
 
     #[test]
@@ -604,7 +692,8 @@ mod tests {
 
     #[test]
     fn sync_scan_requires_json_content_type() {
-        let response = handle_sync_scan_request(&test_request(Method::Post, "/v1/scans"));
+        let state = ready_state();
+        let response = handle_sync_scan_request(&test_request(Method::Post, "/v1/scans"), &state);
         assert_status(&response, 415);
         assert!(response.body.contains("unsupported_media_type"));
     }

--- a/src/serve_api.rs
+++ b/src/serve_api.rs
@@ -300,6 +300,14 @@ pub fn openapi_document() -> Value {
                                 }
                             }
                         },
+                        "422": {
+                            "description": "Request is well-formed but cannot be executed.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ServeErrorResponse"}
+                                }
+                            }
+                        },
                         "503": {
                             "description": "Service has no remaining async admission capacity.",
                             "content": {


### PR DESCRIPTION
## Summary

- require an explicit `--allow-privileged-inputs` opt-in before `paths`, `url`, or `repository` scan inputs are accepted on non-loopback serve binds
- keep loopback/default serve behavior unchanged and leave upload input available on non-loopback binds
- enforce archive extracted byte limits while bytes are copied, not only from declared archive entry sizes
- document the serve trust boundary and regenerate the Serve OpenAPI contract for the new async 422 response

## Issues

- Covers: serve ingestion trust-boundary and archive runtime-limit hardening from the repo review

## Scope and exclusions

- Included: serve ingest policy validation, archive copy-limit enforcement, CLI flag parsing, Serve API guide, OpenAPI response contract, focused tests
- Explicit exclusions: auth, tenant isolation, URL allowlists, repository allowlists, and broader serve concurrency changes

## How to verify

- For a manual boundary check, run `provenant serve --bind 0.0.0.0:8080`, submit a `paths`, `url`, or `repository` scan request, and confirm it returns a 422 error mentioning `--allow-privileged-inputs`; repeat with `--allow-privileged-inputs` in a trusted local setup and confirm those input modes are accepted.
- For upload behavior, submit a small `upload` request to the non-loopback bind without the flag and confirm it is still accepted.

## Intentional differences from Python

- None. This only affects Provenant's HTTP serve ingestion boundary and extraction safety checks.

## Follow-up work

- Created or intentionally deferred: no follow-up created; auth/allowlist policy remains explicitly out of scope for this conservative hardening PR.

## Expected-output fixture changes

- Files changed: `docs/openapi/provenant-serve.openapi.json`
- Why the new expected output is correct: async scan submission can now reject well-formed requests during privileged-input validation, so the documented response contract includes 422.

Generated with [Claude Code](https://claude.ai/code)
