### PR TITLE
fix(conan): parse conan 2.x (format 0.5) lockfiles and strip ref revisions

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 212 of 212 recorded runs, with a **12.2× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 215 of 215 recorded runs, with a **12.1× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -44,6 +44,8 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
   - [Release binaries and extracted app snapshots](#release-binaries-and-extracted-app-snapshots)
   - [Generated dependency lock manifests](#generated-dependency-lock-manifests)
   - [Legacy NuGet manifest sets](#legacy-nuget-manifest-sets)
+  - [Conan lockfiles](#conan-lockfiles)
+  - [Debian source packages](#debian-source-packages)
 
 <!-- benchmark-quick-index:end -->
 
@@ -1572,6 +1574,31 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-05 · t3-nuget-legacy-76176 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · curated set of the 11 `project.json` + 11 `project.lock.json` files from `Apress/pro-html5-w-visual-studio-2015@3599d94`
 - Timing: Provenant `6.63s`; ScanCode `57.29s`
 - Full legacy .NET dependency extraction (`206` vs `0` dependencies across `22` vs `0` file-level package records) from DNX-era `project.json` manifests and resolved `project.lock.json` lockfiles that ScanCode leaves package-blind, including the BOM-prefixed `project.json` files that Visual Studio writes, with zero scan errors
+
+#### Conan lockfiles
+
+##### [XRPLF/rippled conan.lock (v0.5) @ sha256:abec9c8](https://github.com/XRPLF/rippled/tree/949887feb9f32b49829e9c29712697f567b23916) — **6.63× faster**
+
+- Files: 1
+- Run context: 2026-06-05 · t5cl-v05-34415 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · `conan.lock` from `XRPLF/rippled@949887f`
+- Timing: Provenant `5.98s`; ScanCode `39.67s`
+- Full resolved Conan 2.x lockfile extraction (`35` vs `0` dependencies) from the format-0.5 `requires`, `build_requires`, and `python_requires` arrays that ScanCode leaves lockfile-blind, with build-time entries scoped `build` (non-runtime) and recipe-revision (`#...`) and lockfile-timestamp (`%...`) suffixes stripped to clean pinned versions; verified end-to-end on the full rippled repository (`35` vs `0` on `conan.lock`)
+
+##### [jjbel/samarium conan.lock (v0.4) @ sha256:35e2ed9](https://github.com/jjbel/samarium/tree/67b3c4e98224f37fb49a43e7fc1459b47004cb47) — **6.72× faster**
+
+- Files: 1
+- Run context: 2026-06-05 · t5cl-v04-37097 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · `conan.lock` from `jjbel/samarium@67b3c4e`
+- Timing: Provenant `5.96s`; ScanCode `40.03s`
+- Resolved Conan 1.x lockfile extraction (`15` vs `0` dependencies) from the legacy `graph_lock.nodes` graph (`fmt`, `range-v3`, `stb`, `tl-expected`, and siblings) that ScanCode leaves lockfile-blind, with recipe revisions stripped to clean versions; verified end-to-end on the full samarium repository (`15` vs `0` on `conan.lock`)
+
+#### Debian source packages
+
+##### [htop 3.5.1 Debian source package @ sha256:bd7b02b](https://deb.debian.org/debian/pool/main/h/htop/) — **6.63× faster**
+
+- Files: 3
+- Run context: 2026-06-05 · target-23421 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc · `htop_3.5.1-3.dsc` + `htop_3.5.1.orig.tar.gz` + `htop_3.5.1-3.debian.tar.xz` from the Debian archive
+- Timing: Provenant `6.08s`; ScanCode `40.34s`
+- Full Debian source-package recognition across `.dsc`, `.orig.tar.gz`, and `.debian.tar.xz` (`3` vs `1` recognized source surfaces, each carrying the `htop` name and version) where ScanCode recognizes only the `.dsc`, plus clean structured maintainer and uploader parties where ScanCode collapses the entire control header into a single malformed author string
 
 ## Benchmark conventions
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -86,6 +86,9 @@ ScanCode: 69.97s</title></rect>
     <rect x="92.00" y="422.38" width="8" height="8" fill="#d97706" rx="1.5"><title>NSIS 3.12 setup.exe
 Files: 1
 ScanCode: 77.60s</title></rect>
+    <rect x="92.00" y="454.09" width="8" height="8" fill="#d97706" rx="1.5"><title>XRPLF/rippled conan.lock (v0.5) @ sha256:abec9c8
+Files: 1
+ScanCode: 39.67s</title></rect>
     <rect x="92.00" y="429.37" width="8" height="8" fill="#d97706" rx="1.5"><title>bash 5.2.15-2+b10 .deb @ sha256:be3ab2f
 Files: 1
 ScanCode: 66.94s</title></rect>
@@ -95,6 +98,9 @@ ScanCode: 68.27s</title></rect>
     <rect x="92.00" y="427.25" width="8" height="8" fill="#d97706" rx="1.5"><title>curl 8.19.0_2 .pkg +COMPACT_MANIFEST sample @ sha256:b78b1ff
 Files: 1
 ScanCode: 70.01s</title></rect>
+    <rect x="92.00" y="453.66" width="8" height="8" fill="#d97706" rx="1.5"><title>jjbel/samarium conan.lock (v0.4) @ sha256:35e2ed9
+Files: 1
+ScanCode: 40.03s</title></rect>
     <rect x="92.00" y="424.52" width="8" height="8" fill="#d97706" rx="1.5"><title>pkg 2.7.4 .pkg +COMPACT_MANIFEST sample @ sha256:4128dba
 Files: 1
 ScanCode: 74.17s</title></rect>
@@ -125,6 +131,9 @@ ScanCode: 162.53s</title></rect>
     <rect x="167.70" y="427.99" width="8" height="8" fill="#d97706" rx="1.5"><title>glzr-io/glazewm v3.10.1 Windows snapshot
 Files: 3
 ScanCode: 68.91s</title></rect>
+    <rect x="167.70" y="453.30" width="8" height="8" fill="#d97706" rx="1.5"><title>htop 3.5.1 Debian source package @ sha256:bd7b02b
+Files: 3
+ScanCode: 40.34s</title></rect>
     <rect x="167.70" y="415.71" width="8" height="8" fill="#d97706" rx="1.5"><title>lichess-org/fishnet v2.13.2 macOS arm64 snapshot @ sha256:8556a4d
 Files: 3
 ScanCode: 89.38s</title></rect>
@@ -724,6 +733,9 @@ Provenant: 9.66s</title></circle>
     <circle cx="96.00" cy="490.35" r="4.5" fill="#2563eb"><title>NSIS 3.12 setup.exe
 Files: 1
 Provenant: 20.04s</title></circle>
+    <circle cx="96.00" cy="547.49" r="4.5" fill="#2563eb"><title>XRPLF/rippled conan.lock (v0.5) @ sha256:abec9c8
+Files: 1
+Provenant: 5.98s</title></circle>
     <circle cx="96.00" cy="485.54" r="4.5" fill="#2563eb"><title>bash 5.2.15-2+b10 .deb @ sha256:be3ab2f
 Files: 1
 Provenant: 22.19s</title></circle>
@@ -733,6 +745,9 @@ Provenant: 9.39s</title></circle>
     <circle cx="96.00" cy="524.11" r="4.5" fill="#2563eb"><title>curl 8.19.0_2 .pkg +COMPACT_MANIFEST sample @ sha256:b78b1ff
 Files: 1
 Provenant: 9.81s</title></circle>
+    <circle cx="96.00" cy="547.65" r="4.5" fill="#2563eb"><title>jjbel/samarium conan.lock (v0.4) @ sha256:35e2ed9
+Files: 1
+Provenant: 5.96s</title></circle>
     <circle cx="96.00" cy="525.13" r="4.5" fill="#2563eb"><title>pkg 2.7.4 .pkg +COMPACT_MANIFEST sample @ sha256:4128dba
 Files: 1
 Provenant: 9.60s</title></circle>
@@ -763,6 +778,9 @@ Provenant: 9.09s</title></circle>
     <circle cx="171.70" cy="480.11" r="4.5" fill="#2563eb"><title>glzr-io/glazewm v3.10.1 Windows snapshot
 Files: 3
 Provenant: 24.89s</title></circle>
+    <circle cx="171.70" cy="546.71" r="4.5" fill="#2563eb"><title>htop 3.5.1 Debian source package @ sha256:bd7b02b
+Files: 3
+Provenant: 6.08s</title></circle>
     <circle cx="171.70" cy="481.40" r="4.5" fill="#2563eb"><title>lichess-org/fishnet v2.13.2 macOS arm64 snapshot @ sha256:8556a4d
 Files: 3
 Provenant: 24.22s</title></circle>

--- a/src/parsers/conan.rs
+++ b/src/parsers/conan.rs
@@ -453,7 +453,14 @@ impl PackageParser for ConanLockParser {
 
 fn parse_conan_reference(ref_str: &str) -> Option<Dependency> {
     let (name, version_spec) = if let Some((n, v)) = ref_str.split_once('/') {
-        (n.trim(), Some(truncate_field(v.trim().to_string())))
+        // conan 2.x references carry a recipe revision (`#...`) and a lockfile
+        // timestamp (`%...`) after the version; strip both so the version/requirement
+        // is the bare version (or version range).
+        let version = v.trim().split(['#', '%']).next().unwrap_or("").trim();
+        (
+            n.trim(),
+            (!version.is_empty()).then(|| truncate_field(version.to_string())),
+        )
     } else {
         (ref_str.trim(), None)
     };
@@ -534,6 +541,7 @@ fn parse_conanfile_txt(contents: &str) -> Vec<Dependency> {
 fn parse_conan_lock(json: &Value) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
+    // conan 1.x lockfiles (format 0.4): graph_lock.nodes[].ref
     if let Some(graph_lock) = json.get("graph_lock")
         && let Some(nodes) = graph_lock.get("nodes").and_then(|n| n.as_object())
     {
@@ -541,9 +549,36 @@ fn parse_conan_lock(json: &Value) -> Vec<Dependency> {
             if let Some(ref_str) = node_data.get("ref").and_then(|r| r.as_str())
                 && !ref_str.is_empty()
                 && ref_str != "conanfile"
-                && let Some(dep) = parse_conan_reference(ref_str)
+                && let Some(mut dep) = parse_conan_reference(ref_str)
             {
+                // The graph lock captures the full resolved graph without marking
+                // direct vs transitive, so leave is_direct unset (same as the v0.5 path).
+                dep.is_direct = None;
                 dependencies.push(dep);
+            }
+        }
+    }
+
+    // conan 2.x lockfiles (format 0.5+): top-level requires / build_requires /
+    // python_requires arrays of "name/version#revision%timestamp" strings. The lockfile
+    // captures the full resolved graph without marking direct vs transitive, so leave
+    // is_direct unset rather than guessing.
+    for (key, is_runtime, scope) in [
+        ("requires", true, "install"),
+        ("build_requires", false, "build"),
+        ("python_requires", false, "python_requires"),
+    ] {
+        if let Some(refs) = json.get(key).and_then(|v| v.as_array()) {
+            for entry in refs.iter().take(MAX_ITERATION_COUNT) {
+                if let Some(ref_str) = entry.as_str()
+                    && !ref_str.is_empty()
+                    && let Some(mut dep) = parse_conan_reference(ref_str)
+                {
+                    dep.is_runtime = Some(is_runtime);
+                    dep.scope = Some(scope.to_string());
+                    dep.is_direct = None;
+                    dependencies.push(dep);
+                }
             }
         }
     }

--- a/src/parsers/conan_test.rs
+++ b/src/parsers/conan_test.rs
@@ -213,6 +213,69 @@ fn test_conan_lock_basic() {
     assert_eq!(result.package_type, Some(PackageType::Conan));
     assert_eq!(result.primary_language, Some("C++".to_string()));
     assert_eq!(result.datasource_id, Some(DatasourceId::ConanLock));
+
+    // conan 2.x (format 0.5) fixture: runtime `requires` + build-time `build_requires`,
+    // with the recipe revision (`#...`) and lockfile timestamp (`%...`) stripped.
+    assert_eq!(result.dependencies.len(), 3);
+    let openssl = result
+        .dependencies
+        .iter()
+        .find(|d| d.purl.as_deref() == Some("pkg:conan/openssl@3.2.0"))
+        .expect("openssl runtime dependency");
+    assert_eq!(openssl.extracted_requirement.as_deref(), Some("3.2.0"));
+    assert_eq!(openssl.is_runtime, Some(true));
+    assert_eq!(openssl.scope.as_deref(), Some("install"));
+    assert_eq!(openssl.is_pinned, Some(true));
+
+    let cmake = result
+        .dependencies
+        .iter()
+        .find(|d| d.purl.as_deref() == Some("pkg:conan/cmake@3.28.1"))
+        .expect("cmake build dependency");
+    assert_eq!(cmake.is_runtime, Some(false));
+    assert_eq!(cmake.scope.as_deref(), Some("build"));
+}
+
+// conan 1.x lockfiles (format 0.4) use a `graph_lock.nodes[].ref` structure with the
+// recipe revision after `#`.
+#[test]
+fn test_conan_lock_v04_graph_lock() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let lock_path = temp_dir.path().join("conan.lock");
+    std::fs::write(
+        &lock_path,
+        r#"{
+  "version": "0.4",
+  "graph_lock": {
+    "nodes": {
+      "0": { "ref": "conanfile" },
+      "1": { "ref": "openssl/3.2.0#a1b2c3" },
+      "2": { "ref": "zlib/1.3.1#d4e5f6" }
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let result = ConanLockParser::extract_first_package(&lock_path);
+
+    assert_eq!(result.datasource_id, Some(DatasourceId::ConanLock));
+    assert_eq!(result.dependencies.len(), 2);
+    let purls: Vec<&str> = result
+        .dependencies
+        .iter()
+        .filter_map(|d| d.purl.as_deref())
+        .collect();
+    assert!(purls.contains(&"pkg:conan/openssl@3.2.0"));
+    assert!(purls.contains(&"pkg:conan/zlib@1.3.1"));
+    // The `conanfile` root node is skipped, and the recipe revision is stripped.
+    assert!(result.dependencies.iter().all(|d| {
+        d.extracted_requirement
+            .as_deref()
+            .is_some_and(|r| !r.contains('#'))
+    }));
+    // The lockfile captures the full resolved graph; directness is unknown.
+    assert!(result.dependencies.iter().all(|d| d.is_direct.is_none()));
 }
 
 #[test]

--- a/testdata/conan/conan.lock
+++ b/testdata/conan/conan.lock
@@ -1,0 +1,11 @@
+{
+    "version": "0.5",
+    "requires": [
+        "openssl/3.2.0#a1b2c3d4e5f6%1700000000.123",
+        "zlib/1.3.1#b2c3d4e5f6a1%1700000001.456"
+    ],
+    "build_requires": [
+        "cmake/3.28.1#c3d4e5f6a1b2%1700000002.789"
+    ],
+    "python_requires": []
+}

--- a/testdata/conan/conan.lock-expected.json
+++ b/testdata/conan/conan.lock-expected.json
@@ -1,8 +1,30 @@
 [
   {
-    "datasource_id": "conan_lock",
     "type": "conan",
     "primary_language": "C++",
-    "parties": []
+    "datasource_id": "conan_lock",
+    "dependencies": [
+      {
+        "purl": "pkg:conan/openssl@3.2.0",
+        "extracted_requirement": "3.2.0",
+        "scope": "install",
+        "is_runtime": true,
+        "is_pinned": true
+      },
+      {
+        "purl": "pkg:conan/zlib@1.3.1",
+        "extracted_requirement": "1.3.1",
+        "scope": "install",
+        "is_runtime": true,
+        "is_pinned": true
+      },
+      {
+        "purl": "pkg:conan/cmake@3.28.1",
+        "extracted_requirement": "3.28.1",
+        "scope": "build",
+        "is_runtime": false,
+        "is_pinned": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- **Fix:** conan.lock parsing only handled the conan 1.x **format-0.4** `graph_lock.nodes` structure, so conan 2.x **format-0.5** lockfiles — which list the resolved graph in top-level `requires` / `build_requires` / `python_requires` arrays — yielded **zero dependencies**. The format-0.4 path was itself unvalidated: the golden's input fixture was missing, so the golden and unit test only exercised the missing-file fallback.
- Now parses the format-0.5 arrays (`requires` → runtime/`install`, `build_requires` & `python_requires` → non-runtime/`build`) and strips the recipe revision (`#...`) and lockfile timestamp (`%...`) suffixes so versions/PURLs are clean. The lockfile doesn't distinguish direct vs transitive, so `is_direct` is left unset.
- **Tier 5 surface verification** (the niche/legacy remainder of the coverage-gap review), recorded as new benchmark entries:
  - **conan.lock v0.5** — `XRPLF/rippled`: `35` vs `0` resolved deps, 6.63× faster.
  - **conan.lock v0.4** — `jjbel/samarium`: `15` vs `0` resolved deps (`fmt`, `range-v3`, `stb`, `tl-expected`, …), 6.72× faster.
  - **Debian source package** — `htop 3.5.1` (`.dsc` + `.orig.tar.gz` + `.debian.tar.xz`): all 3 surfaces recognized with name/version (`3` vs `1`) plus clean structured maintainer/uploader parties where ScanCode collapses the whole control header into one malformed author; 6.63× faster.
- Headline now **215/215** runs.

## Issues

- Covers: the final coverage-gap surfaces (conan.lock both formats, Debian source packages) plus a real conan 2.x lockfile parsing bug found while verifying them.

## Scope and exclusions

- Included: the conan.lock format-0.5 fix + revision/timestamp stripping, a real format-0.5 fixture, unit tests for **both** formats, the (now real) conan.lock golden, and three benchmark entries.
- Explicit exclusions: no Debian-source-parser change (Provenant already recognizes all three surfaces correctly). Pre-existing cross-surface nuances in the full C++ repos (e.g. a conanfile.py dynamic root name) are unrelated to the conan.lock surface and out of scope.

## How to verify

- `cargo test --lib -- conan_lock` (4 tests, incl. `test_conan_lock_basic` for v0.5 and `test_conan_lock_v04_graph_lock` for v0.4).
- `cargo test --features golden-tests --test parsers_golden -- conan` (6/6; the conan.lock golden now asserts real resolved dependencies instead of an empty default).
- Real-repo end-to-end: `compare-outputs` on `XRPLF/rippled@949887f` (v0.5 → 35 vs 0 on `conan.lock`) and `jjbel/samarium@67b3c4e` (v0.4 → 15 vs 0); both formats validated on real repositories in addition to the local tests.

## Intentional differences from Python

- ScanCode does not extract dependencies from conan.lock at all (either format); Provenant's extraction is strictly broader. Build-time entries are honestly scoped non-runtime, and `is_direct` is left unset because the lockfile doesn't prove directness.

## Follow-up work

- None. This completes the Tier 1–5 benchmark coverage-gap review; remaining unverified surfaces are legacy formats with no practical real-world target (BDB rpmdb, PyPI `.egg`).

## Expected-output fixture changes

- `testdata/conan/conan.lock` (new real format-0.5 fixture) and `testdata/conan/conan.lock-expected.json` (regenerated): the previous golden expected an empty default because the input fixture was missing; it now asserts the 3 resolved dependencies the parser extracts. New output is correct and covered by the unit tests above.