### PR TITLE
fix(deno): parse deno.lock formats v1-v4, not just v5

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 215 of 215 recorded runs, with a **12.1× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 216 of 216 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -314,6 +314,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `23.76s`; ScanCode `761.82s`
 - Direct Helm package visibility on `deploy/helm/baserow/Chart.yaml` and `Chart.lock` (`2` file-level Helm surfaces vs `0`), with declared plus locked dependency extraction (`12` vs `0` on each chart file) covering sibling `baserow-common` aliases and the pinned Bitnami/Caddy chart inputs that ScanCode leaves at zero
+
+##### [catppuccin/gitea @ 6a78970](https://github.com/catppuccin/gitea/tree/6a789704686ec13178a13cd84bf1e30db191a437) — **6.76× faster**
+
+- Files: 23
+- Run context: 2026-06-06 · gitea-24220 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.02s`; ScanCode `40.69s`
+- Deno v4 lockfile dependency extraction (`37` vs `0` from `deno.lock`'s resolved `npm` and `jsr` graphs) where ScanCode is lockfile-blind, plus `deno.json` import-map package visibility and cleaner rejection of a bare-URL holder mistaken from README prose; the deno.lock parser now covers lockfile formats v1–v5 rather than v5 alone
 
 ##### [denoland/fresh @ 49c4be1](https://github.com/denoland/fresh/tree/49c4be1ac60603174bad1c6e3c13bd88602c51bb) — **11.69× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -161,6 +161,9 @@ ScanCode: 97.28s</title></rect>
     <rect x="305.00" y="436.72" width="8" height="8" fill="#d97706" rx="1.5"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 ScanCode: 57.29s</title></rect>
+    <rect x="308.06" y="452.89" width="8" height="8" fill="#d97706" rx="1.5"><title>catppuccin/gitea @ 6a78970
+Files: 23
+ScanCode: 40.69s</title></rect>
     <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 ScanCode: 73.99s</title></rect>
@@ -808,6 +811,9 @@ Provenant: 9.41s</title></circle>
     <circle cx="309.00" cy="542.62" r="4.5" fill="#2563eb"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 Provenant: 6.63s</title></circle>
+    <circle cx="312.06" cy="547.18" r="4.5" fill="#2563eb"><title>catppuccin/gitea @ 6a78970
+Files: 23
+Provenant: 6.02s</title></circle>
     <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 Provenant: 11.06s</title></circle>

--- a/src/parsers/deno_lock.rs
+++ b/src/parsers/deno_lock.rs
@@ -68,11 +68,56 @@ impl PackageParser for DenoLockParser {
 
 fn parse_deno_lock(json: &Value) -> PackageData {
     let lock_version = json.get(FIELD_VERSION).and_then(Value::as_str);
-    if lock_version != Some("5") {
-        warn!("Unsupported deno.lock version {:?}", lock_version);
-        return default_package_data();
+
+    // deno.lock has gone through several incompatible layouts; dispatch on the declared
+    // version so older lockfiles still in the wild are not silently dropped:
+    //   * v1 (Deno 1.0-1.17): remote ESM URL imports only, no registry dependencies.
+    //   * v2/v3 (Deno 1.18-1.40): npm dependencies nested under npm.{specifiers,packages};
+    //     no jsr or workspace sections.
+    //   * v4 (Deno 1.45+) and v5 (current): flat top-level specifiers/npm/jsr/workspace.
+    // Unknown/newer versions fall back to the latest (flat) layout rather than dropping.
+    let (mut dependencies, workspace_direct) = match lock_version {
+        Some("1") => (Vec::new(), Vec::new()),
+        Some("2") | Some("3") => (extract_nested_npm_dependencies(json), Vec::new()),
+        Some("4") | Some("5") => extract_flat_dependencies(json),
+        other => {
+            warn!(
+                "Unrecognized deno.lock version {:?}; parsing with the latest known layout",
+                other
+            );
+            extract_flat_dependencies(json)
+        }
+    };
+    dependencies.extend(extract_redirect_dependencies(json));
+
+    let mut extra_data = HashMap::new();
+    if let Some(version) = lock_version {
+        extra_data.insert(
+            FIELD_VERSION.to_string(),
+            Value::String(version.to_string()),
+        );
+    }
+    if !workspace_direct.is_empty() {
+        extra_data.insert(
+            "workspace_dependencies".to_string(),
+            Value::Array(workspace_direct.into_iter().map(Value::String).collect()),
+        );
     }
 
+    PackageData {
+        package_type: Some(DenoLockParser::PACKAGE_TYPE),
+        primary_language: Some("TypeScript".to_string()),
+        dependencies,
+        extra_data: (!extra_data.is_empty()).then_some(extra_data),
+        datasource_id: Some(DatasourceId::DenoLock),
+        ..Default::default()
+    }
+}
+
+/// Flat top-level layout used by deno.lock v4 and v5: `specifiers`, `npm`, `jsr`, and
+/// `workspace` sections. Returns the resolved dependencies plus the workspace's direct
+/// specifier list (recorded in extra_data by the caller).
+fn extract_flat_dependencies(json: &Value) -> (Vec<Dependency>, Vec<String>) {
     let specifiers = json
         .get(FIELD_SPECIFIERS)
         .and_then(Value::as_object)
@@ -127,6 +172,59 @@ fn parse_deno_lock(json: &Value) -> PackageData {
         }
     }
 
+    (dependencies, workspace_direct)
+}
+
+/// Nested layout used by deno.lock v2 and v3: npm dependencies live under `npm.packages`
+/// (the resolved graph), with `npm.specifiers` mapping requested ranges to resolved
+/// `name@version` keys. There are no jsr or workspace sections in these versions.
+fn extract_nested_npm_dependencies(json: &Value) -> Vec<Dependency> {
+    let Some(npm) = json.get(FIELD_NPM) else {
+        return Vec::new();
+    };
+    let Some(packages) = npm.get("packages") else {
+        return Vec::new();
+    };
+    let Some(packages_map) = packages.as_object() else {
+        return Vec::new();
+    };
+
+    // `npm.specifiers` maps each requested specifier (e.g. "chalk@5") to its resolved
+    // `name@version` key (e.g. "chalk@5.3.0"). Invert it so resolved packages referenced
+    // by a top-level specifier can be marked direct and keep their requested range; the
+    // remaining npm.packages entries are transitive.
+    let requested_by_resolved: HashMap<String, String> = npm
+        .get("specifiers")
+        .and_then(Value::as_object)
+        .map(|specifiers| {
+            specifiers
+                .iter()
+                .filter_map(|(specifier, resolved)| {
+                    resolved.as_str().map(|resolved| {
+                        (
+                            resolved.trim_start_matches("npm:").to_string(),
+                            specifier.clone(),
+                        )
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut dependencies = Vec::new();
+    for key in packages_map.keys().take(MAX_ITERATION_COUNT) {
+        let requested = requested_by_resolved.get(key).map(String::as_str);
+        if let Some(dep) = build_npm_dependency(key, requested.is_some(), packages, requested) {
+            dependencies.push(dep);
+        }
+    }
+    dependencies
+}
+
+/// Module redirects, shared across all lockfile versions: each redirect target is a
+/// remote module whose integrity hash lives in the `remote` section.
+fn extract_redirect_dependencies(json: &Value) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
     if let Some(redirects) = json.get(FIELD_REDIRECTS).and_then(Value::as_object) {
         for (source, target) in redirects.iter().take(MAX_ITERATION_COUNT) {
             let Some(target_url) = target.as_str() else {
@@ -181,30 +279,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
             });
         }
     }
-
-    let mut extra_data = HashMap::new();
-    extra_data.insert(FIELD_VERSION.to_string(), Value::String("5".to_string()));
-    if !workspace_direct.is_empty() {
-        extra_data.insert(
-            "workspace_dependencies".to_string(),
-            Value::Array(
-                workspace_direct
-                    .iter()
-                    .cloned()
-                    .map(Value::String)
-                    .collect(),
-            ),
-        );
-    }
-
-    PackageData {
-        package_type: Some(DenoLockParser::PACKAGE_TYPE),
-        primary_language: Some("TypeScript".to_string()),
-        dependencies,
-        extra_data: Some(extra_data),
-        datasource_id: Some(DatasourceId::DenoLock),
-        ..Default::default()
-    }
+    dependencies
 }
 
 fn extract_workspace_dependencies(json: &Value) -> Vec<String> {
@@ -277,6 +352,27 @@ fn build_jsr_dependency(
     })
 }
 
+/// A package's nested `dependencies` field is shaped differently across lockfile
+/// versions: v4/v5 `npm[key].dependencies` is an array of resolved `name@version`
+/// keys (`["ansi-styles@6.2.1"]`), while v2/v3 `npm.packages[key].dependencies` is an
+/// object mapping bare names to those resolved keys (`{"ansi-styles":"ansi-styles@6.2.1"}`).
+/// Both encode the same resolved keys, so collect them uniformly from either shape.
+fn npm_dependency_keys(value: Option<&Value>) -> Vec<String> {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        Some(Value::Object(map)) => map
+            .values()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 fn build_npm_dependency(
     resolved_key: &str,
     is_direct: bool,
@@ -320,19 +416,15 @@ fn build_npm_dependency(
             md5: None,
             is_virtual: true,
             extra_data: None,
-            dependencies: npm_object
-                .get(FIELD_DEPENDENCIES)
-                .and_then(Value::as_array)
+            dependencies: npm_dependency_keys(npm_object.get(FIELD_DEPENDENCIES))
                 .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
                 .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| {
-                    let (namespace, name, version) = parse_npm_key(value)?;
+                    let (namespace, name, version) = parse_npm_key(&value)?;
                     Some(Dependency {
                         purl: create_npm_purl(namespace.as_deref(), &name, Some(version))
                             .map(truncate_field),
-                        extracted_requirement: Some(truncate_field(value.to_string())),
+                        extracted_requirement: Some(truncate_field(value.clone())),
                         scope: Some("dependencies".to_string()),
                         is_runtime: Some(true),
                         is_optional: Some(false),

--- a/src/parsers/deno_lock_test.rs
+++ b/src/parsers/deno_lock_test.rs
@@ -71,11 +71,127 @@ mod tests {
         assert!(remote.resolved_package.is_some());
     }
 
+    // deno.lock v2/v3 (Deno 1.18-1.40) nest npm deps under npm.{specifiers,packages}.
     #[test]
-    fn test_extract_from_deno_lock_unsupported_version() {
+    fn test_extract_from_deno_lock_v3_nested_npm() {
         let temp_dir = tempdir().unwrap();
         let file_path = temp_dir.path().join("deno.lock");
-        fs::write(&file_path, r#"{"version":"4"}"#).unwrap();
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "3",
+  "npm": {
+    "specifiers": { "chalk@5": "chalk@5.6.2" },
+    "packages": {
+      "chalk@5.6.2": { "integrity": "sha512-aaaa", "dependencies": { "ansi-styles": "ansi-styles@6.2.1" } },
+      "ansi-styles@6.2.1": { "integrity": "sha512-bbbb", "dependencies": {} }
+    }
+  },
+  "remote": {}
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 2);
+        let chalk = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:npm/chalk@5.6.2"))
+            .expect("chalk dependency");
+        assert_eq!(chalk.is_direct, Some(true));
+        // A directly-referenced package keeps its requested specifier as the requirement.
+        assert_eq!(chalk.extracted_requirement.as_deref(), Some("chalk@5"));
+        // v2/v3 encode nested dependencies as an object; the resolved key still surfaces.
+        let chalk_resolved = chalk
+            .resolved_package
+            .as_ref()
+            .expect("chalk resolved package");
+        assert!(
+            chalk_resolved
+                .dependencies
+                .iter()
+                .any(|d| d.purl.as_deref() == Some("pkg:npm/ansi-styles@6.2.1")),
+            "object-shaped nested dependencies should be parsed"
+        );
+        let ansi = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:npm/ansi-styles@6.2.1"))
+            .expect("transitive ansi-styles dependency");
+        assert_eq!(ansi.is_direct, Some(false));
+    }
+
+    // deno.lock v4 (Deno 1.45+) uses the same flat layout as v5.
+    #[test]
+    fn test_extract_from_deno_lock_v4_flat() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "4",
+  "specifiers": { "npm:chalk@5": "5.6.2" },
+  "npm": { "chalk@5.6.2": { "integrity": "sha512-aaaa" } },
+  "workspace": { "dependencies": ["npm:chalk@5"] }
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:npm/chalk@5.6.2")
+        );
+    }
+
+    // An unrecognized/newer version must not silently drop everything; it falls back to
+    // the latest known (flat) layout.
+    #[test]
+    fn test_extract_from_deno_lock_future_version_falls_back_to_flat() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "99",
+  "specifiers": { "npm:chalk@5": "5.6.2" },
+  "npm": { "chalk@5.6.2": { "integrity": "sha512-aaaa" } }
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:npm/chalk@5.6.2")
+        );
+    }
+
+    // deno.lock v1 (Deno 1.0-1.17) predates npm/jsr support: remote ESM imports only, so
+    // no registry dependencies, but it must still be recognized (not error out).
+    #[test]
+    fn test_extract_from_deno_lock_v1_remote_only() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "1",
+  "remote": {
+    "https://deno.land/std@0.100.0/fmt/colors.ts": "abc0000000000000000000000000000000000000000000000000000000000abc"
+  }
+}"#,
+        )
+        .unwrap();
 
         let package_data = DenoLockParser::extract_first_package(&file_path);
 


### PR DESCRIPTION
## Summary

- **Fix:** `parse_deno_lock` rejected any `deno.lock` whose `version` wasn't `"5"`, returning an empty package and **dropping every dependency** — the same bug class as the recent conan.lock fix. deno.lock has shipped several incompatible layouts still common in the wild:
  - **v1** (Deno 1.0–1.17): remote ESM URL imports only, no registry deps.
  - **v2/v3** (Deno 1.18–1.40): npm deps nested under `npm.{specifiers,packages}`; no jsr/workspace.
  - **v4** (Deno 1.45+) / **v5** (current): flat top-level `specifiers`/`npm`/`jsr`/`workspace`.
- Now dispatches on the declared version: v4/v5 share the flat extractor, v2/v3 use a nested-npm extractor, v1 is recognized with no registry deps, and **unknown/newer versions fall back to the latest (flat) layout** instead of dropping. Module redirects are extracted for all versions.
- This is **fix 1 of 6** from the parser version-coverage audit (deno → pixi → julia → helm → conda recipe.yaml → hex). PRs are stacked.

## Issues

- Covers: deno.lock version-coverage gap (only v5 handled) found in the audit.

## Scope and exclusions

- Included: the version-dispatch fix + unit tests for v1, v3 (nested npm), v4 (flat), and the future-version fallback; one benchmark entry.
- Excludes: other ecosystems' version gaps (separate stacked PRs).

## How to verify

- `cargo test --lib -- deno_lock` (v1/v3/v4/v5 + future-fallback).
- Goldens unaffected (existing fixtures are v5; backward-compatible): `cargo test --features golden-tests --test parsers_golden -- deno`.
- Real repos: `catppuccin/gitea@6a78970` (v4) extracts **37 deps from deno.lock** (npm + jsr) where it previously extracted 0; `hattipjs/hattip@15aa5ae` (v3) extracts its redirects (was 0). ScanCode is lockfile-blind to deno.lock in all versions.

## Intentional differences from Python

- ScanCode does not parse deno.lock; Provenant's extraction is strictly broader across all versions.

## Follow-up work

- Stacked PRs for the remaining five audited gaps (pixi.lock v5, Julia Manifest.toml v1, Helm apiVersion v1, conda recipe.yaml, hex mix.lock).

## Expected-output fixture changes

- None. New unit tests only; existing v5 goldens pass unchanged.