### PR TITLE
fix(pixi): parse pixi.lock format 5, not just 4 and 6

### DIFF
--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -188,10 +188,20 @@ fn parse_pixi_lock(lock_content: &JsonValue, primary_language: &str) -> PackageD
     }
     package.extra_data = (!extra_data.is_empty()).then_some(extra_data);
 
+    // pixi.lock formats 4 and 5 share the `kind`-tagged package layout; format 6 switched
+    // to `conda:`/`pypi:` discriminated entries. Unknown/newer versions evolve from the v6
+    // layout, so fall back to the v6 extractor rather than dropping all dependencies.
     match lock_version {
+        Some(4) | Some(5) => package.dependencies = extract_v4_lock_dependencies(lock_content),
         Some(6) => package.dependencies = extract_v6_lock_dependencies(lock_content),
-        Some(4) => package.dependencies = extract_v4_lock_dependencies(lock_content),
-        Some(_) | None => {}
+        Some(other) => {
+            warn!("Unrecognized pixi.lock version {other}; parsing with the v6 layout");
+            package.dependencies = extract_v6_lock_dependencies(lock_content);
+        }
+        None => {
+            warn!("pixi.lock is missing a version field; parsing with the v6 layout");
+            package.dependencies = extract_v6_lock_dependencies(lock_content);
+        }
     }
 
     package

--- a/src/parsers/pixi_test.rs
+++ b/src/parsers/pixi_test.rs
@@ -493,8 +493,86 @@ sha256 = "pypi-v4-hash"
         );
     }
 
+    // pixi.lock format 5 shares the `kind`-tagged package layout of format 4.
     #[test]
-    fn test_extract_from_pixi_lock_unsupported_version_returns_default_lock_package() {
+    fn test_extract_from_pixi_lock_v5() {
+        let content = r#"
+version = 5
+
+[environments.default]
+channels = [{ url = "https://conda.anaconda.org/conda-forge/" }]
+
+[environments.default.packages]
+win-64 = [
+  { conda = "https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda" },
+  { pypi = "./foo" },
+]
+
+[[packages]]
+kind = "conda"
+name = "python"
+version = "3.12.3"
+url = "https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda"
+sha256 = "conda-v5-hash"
+
+[[packages]]
+kind = "pypi"
+name = "foo"
+version = "0.1.0"
+path = "./foo"
+editable = true
+sha256 = "pypi-v5-hash"
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("pixi.lock", content);
+        let package_data = PixiLockParser::extract_first_package(&path);
+
+        assert_eq!(package_data.dependencies.len(), 2);
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:conda/python@3.12.3"))
+        );
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:pypi/foo@0.1.0"))
+        );
+    }
+
+    // An unrecognized/newer pixi.lock version must not silently drop everything; it falls
+    // back to the latest known (v6) layout.
+    #[test]
+    fn test_extract_from_pixi_lock_future_version_falls_back_to_v6() {
+        let content = r#"
+version = 99
+
+[environments.default]
+channels = [{ url = "https://conda.anaconda.org/conda-forge/" }]
+
+[environments.default.packages]
+linux-64 = [
+  { conda = "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-h2628c8c_0_cpython.conda" },
+]
+
+[[packages]]
+conda = "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-h2628c8c_0_cpython.conda"
+version = "3.12.7"
+sha256 = "conda-hash"
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("pixi.lock", content);
+        let package_data = PixiLockParser::extract_first_package(&path);
+
+        assert_eq!(package_data.package_type, Some(PackageType::Pixi));
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::PixiLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_from_pixi_lock_missing_packages_returns_default_lock_package() {
         let content = r#"
 version = 99
 


### PR DESCRIPTION
> Stacked on #950 (deno.lock). Review/merge that first; this PR's diff is against the deno branch.

## Summary

- **Fix:** the pixi.lock version dispatch handled only formats **4** and **6**; format **5** fell into an empty `match` arm and yielded **zero dependencies** — same bug class as conan.lock/deno.lock. Format 5 shares format 4's `kind`-tagged package layout (verified against real v5 lockfiles, e.g. openMVG's), so it now routes to the v4 extractor. Unknown/newer versions fall back to the v6 extractor instead of dropping.
- **Fix 2 of 6** from the parser version-coverage audit.

## How to verify

- `cargo test --lib -- pixi` (v4/v5/v6 + future-version fallback).
- Goldens unaffected (v6 fixtures; backward-compatible): `cargo test --features golden-tests --test parsers_golden -- pixi`.
- Real repo: `openMVG/openMVG@c76d872` (pixi.lock v5) extracts **396 conda/pypi dependencies** (was 0); ScanCode is lockfile-blind. (No benchmark entry added — the full repo is C++-source-noise-heavy and the focused lockfile carries a pre-existing GPL-1.0-or-later license-expression policy residual unrelated to this fix.)

## Intentional differences from Python

- ScanCode does not extract dependencies from pixi.lock; Provenant's extraction is broader across all formats.

## Follow-up work

- Remaining stacked PRs: Julia Manifest.toml v1, Helm apiVersion v1, conda recipe.yaml, hex mix.lock.

## Expected-output fixture changes

- None. New unit tests only.