### PR TITLE
fix(julia): parse Manifest.toml format 1.0 (root-level packages)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 216 of 216 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 217 of 217 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1229,6 +1229,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `22.78s`; ScanCode `332.82s`
 - Broader mixed Hackage and Nix package extraction (`5` vs `0` packages, `197` vs `0` dependencies) from sibling `pandoc*.cabal` manifests, `stack.yaml`, and `flake.nix` / `flake.lock`, with explicit package identities across `pandoc`, `pandoc-cli`, `pandoc-lua-engine`, and `pandoc-server`
+
+##### [JuliaAcademy/DataScience @ 201f2e6](https://github.com/JuliaAcademy/DataScience/tree/201f2e66cf2067dacee2df02b546f75d77ed22e7) — **8.58× faster**
+
+- Files: 50
+- Run context: 2026-06-06 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `27.50s`; ScanCode `235.99s`
+- Direct Julia package visibility and broader dependency extraction (`1` vs `0` packages, `53` vs `0` dependencies) from the root legacy v1.0-format `Manifest.toml` and its `Project.toml`, with zero scan errors where ScanCode times out after 120s on `05. Clustering.ipynb` and no spurious low-confidence `GPL-3.0-only` detection bleeding from the binary `data/face_recog_qr.mat` blob
 
 ##### [JuliaLang/julia @ afc71c2](https://github.com/JuliaLang/julia/tree/afc71c255e327d8a64b69061c15994e80740974d) — **21.75× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -173,6 +173,9 @@ ScanCode: 17.97s</title></rect>
     <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 74.96s</title></rect>
+    <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
+Files: 50
+ScanCode: 235.99s</title></rect>
     <rect x="362.93" y="430.28" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 ScanCode: 65.66s</title></rect>
@@ -823,6 +826,9 @@ Provenant: 10.50s</title></circle>
     <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 10.05s</title></circle>
+    <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
+Files: 50
+Provenant: 27.50s</title></circle>
     <circle cx="366.93" cy="530.00" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 Provenant: 8.66s</title></circle>

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -358,9 +358,17 @@ fn extract_project_dependencies(toml_content: &Value) -> Vec<Dependency> {
 fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
     let mut packages = Vec::new();
 
+    // Manifest.toml format 2.0 (Julia 1.7+) nests packages under a [deps] table; format
+    // 1.0 (Julia 1.0-1.6) lists them as root-level [[PackageName]] array-of-tables. Prefer
+    // the [deps] table when present, otherwise fall back to the root table. Non-package
+    // metadata keys (manifest_format, julia_version, project_hash, ...) are scalars, so the
+    // as_array() check below skips them.
     let deps_table = match toml_content.get(FIELD_DEPS).and_then(|v| v.as_table()) {
         Some(table) => table,
-        None => return packages,
+        None => match toml_content.as_table() {
+            Some(table) => table,
+            None => return packages,
+        },
     };
 
     for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {

--- a/src/parsers/julia_test.rs
+++ b/src/parsers/julia_test.rs
@@ -144,3 +144,60 @@ author = ["Tom Breloff (@tbreloff)"]
 
     fs::remove_dir_all(&temp_dir).expect("remove temp test dir");
 }
+
+// Manifest.toml format 1.0 (Julia 1.0-1.6) lists packages as root-level [[PackageName]]
+// array-of-tables rather than nesting them under a [deps] table (format 2.0, Julia 1.7+).
+#[test]
+fn test_manifest_toml_format_1_root_level_packages() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "provenant-julia-manifest-v1-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&temp_dir).expect("create temp test dir");
+
+    let test_file = temp_dir.join("Manifest.toml");
+    fs::write(
+        &test_file,
+        r#"# This file is machine-generated - editing it directly is not advised
+julia_version = "1.6.7"
+manifest_format = "1.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3609a8aaa8c3a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "Sockets"]
+git-tree-sha1 = "60ed5f1643927479f845b0135bb369b031b541fa"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.17"
+"#,
+    )
+    .expect("write temp Manifest.toml");
+
+    let packages = JuliaManifestTomlParser::extract_packages(&test_file);
+
+    assert_eq!(packages.len(), 2);
+    assert!(
+        packages
+            .iter()
+            .all(|p| p.datasource_id == Some(DatasourceId::JuliaManifestToml))
+    );
+    let json = packages
+        .iter()
+        .find(|p| p.name.as_deref() == Some("JSON"))
+        .expect("JSON package");
+    assert_eq!(json.version.as_deref(), Some("0.21.4"));
+    assert!(
+        packages
+            .iter()
+            .any(|p| p.name.as_deref() == Some("HTTP") && p.version.as_deref() == Some("0.9.17"))
+    );
+
+    fs::remove_dir_all(&temp_dir).expect("remove temp test dir");
+}


### PR DESCRIPTION
> Stacked on #951 (pixi.lock) → #950 (deno.lock). This PR's diff is against the pixi branch.

## Summary

- **Fix:** `extract_manifest_packages` only read packages from a top-level `[deps]` table, which exists in **manifest_format 2.0** (Julia 1.7+). **Format 1.0** (Julia 1.0–1.6) lists packages as root-level `[[PackageName]]` array-of-tables with no `[deps]` wrapper, so those manifests yielded **zero packages**.
- Now prefers the `[deps]` table when present, otherwise falls back to the root table; non-package metadata keys (`manifest_format`, `julia_version`, …) are scalars and are skipped by the existing array check. Per-entry parsing is identical across both formats.
- **Fix 3 of 6** from the parser version-coverage audit.

## How to verify

- `cargo test --lib -- julia` (new `test_manifest_toml_format_1_root_level_packages` extracts JSON + HTTP from a real-shaped v1 manifest; existing v2 fixture test still passes).
- Goldens unaffected (v2 fixture; backward-compatible): `cargo test --features golden-tests --test parsers_golden -- julia`.
- ScanCode has no Julia parser, so this is purely broader coverage (no parity comparison applies); the unit test proves v1 extraction directly.

## Intentional differences from Python

- N/A — ScanCode does not parse Julia manifests.

## Follow-up work

- Remaining stacked PRs: Helm apiVersion v1, conda recipe.yaml, hex mix.lock.

## Expected-output fixture changes

- None. New unit test only.