### PR TITLE
fix(helm): extract dependencies from Helm 2 sibling requirements.yaml

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 217 of 217 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 218 of 218 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -731,6 +731,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-03 · harbor-57111 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `22.87s`; ScanCode `327.33s`
 - Broader package and dependency extraction (`5` vs `2` packages, `2972` vs `2407` dependencies) from committed Pipfile/Pipfile.lock, npm-family, Docker, and Go manifests, with local Go `replace` paths kept out of invalid PURLs, templated Conda YAML skipped instead of degraded into false metadata, and URL differences limited to normalization/truncation/canonicalization after review
+
+##### [goharbor/harbor-helm @ 7233a81](https://github.com/goharbor/harbor-helm/tree/7233a81d24c891abc3fd83285ea8b91e2ab5522f) — **7.57× faster**
+
+- Files: 96
+- Run context: 2026-06-06 · harbor-helm-71676 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.36s`; ScanCode `48.15s`
+- Direct Helm chart package visibility (`1` vs `0` packages, `pkg:helm/harbor@1.4.0-dev` from the apiVersion-v1 `Chart.yaml`) plus a Dockerfile image package from `test/e2e/Dockerfile`, with identical top-level license detection and matching Go module coverage from the bundled `test/go.mod` / `test/go.sum` terratest harness
 
 ##### [grpc/grpc @ f87c29f](https://github.com/grpc/grpc/tree/f87c29f069971d1356e5784005af499db52e7f31) — **14.43× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -197,6 +197,9 @@ ScanCode: 65.75s</title></rect>
     <rect x="403.59" y="423.65" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 ScanCode: 75.55s</title></rect>
+    <rect x="406.52" y="444.93" width="8" height="8" fill="#d97706" rx="1.5"><title>goharbor/harbor-helm @ 7233a81
+Files: 96
+ScanCode: 48.15s</title></rect>
     <rect x="407.94" y="420.39" width="8" height="8" fill="#d97706" rx="1.5"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 ScanCode: 80.95s</title></rect>
@@ -850,6 +853,9 @@ Provenant: 8.84s</title></circle>
     <circle cx="407.59" cy="515.70" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 Provenant: 11.72s</title></circle>
+    <circle cx="410.52" cy="544.58" r="4.5" fill="#2563eb"><title>goharbor/harbor-helm @ 7233a81
+Files: 96
+Provenant: 6.36s</title></circle>
     <circle cx="411.94" cy="518.95" r="4.5" fill="#2563eb"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 Provenant: 10.94s</title></circle>

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -43,7 +43,25 @@ impl PackageParser for HelmChartYamlParser {
             }
         };
 
-        vec![parse_chart_yaml(&yaml_content)]
+        let mut package = parse_chart_yaml(&yaml_content);
+
+        // Helm 2 charts (apiVersion v1) declare dependencies in a sibling requirements.yaml
+        // rather than inline in Chart.yaml. When such a chart carries no dependencies, merge
+        // them from a neighbouring requirements.yaml (same `dependencies:` schema). Gate this
+        // on apiVersion v1 so a Helm 3 (v2) chart that legitimately has zero inline
+        // dependencies but shares a directory with an unrelated requirements.yaml (e.g. a
+        // monorepo with an Ansible/Python project alongside the chart) does not inherit them.
+        if extract_string_field(&yaml_content, "apiVersion").as_deref() == Some("v1")
+            && package.dependencies.is_empty()
+            && let Some(requirements_path) =
+                path.parent().map(|parent| parent.join("requirements.yaml"))
+            && requirements_path.is_file()
+            && let Ok(requirements_content) = read_yaml_file(&requirements_path)
+        {
+            package.dependencies = extract_chart_yaml_dependencies(&requirements_content);
+        }
+
+        vec![package]
     }
 }
 

--- a/src/parsers/helm_test.rs
+++ b/src/parsers/helm_test.rs
@@ -414,4 +414,115 @@ dependencies:
         assert_eq!(wildcard.purl.as_deref(), Some("pkg:helm/wildcard"));
         assert_eq!(wildcard.is_pinned, Some(false));
     }
+
+    // Helm 2 charts (apiVersion v1) declare dependencies in a sibling requirements.yaml,
+    // not inline in Chart.yaml. The Chart.yaml package should pick them up.
+    #[test]
+    fn test_chart_yaml_v1_merges_sibling_requirements_yaml_dependencies() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v1
+name: legacy-chart
+version: 1.2.3
+description: A Helm 2 chart
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            r#"dependencies:
+  - name: mariadb
+    version: 7.3.14
+    repository: https://kubernetes-charts.storage.googleapis.com/
+  - name: redis
+    version: 10.5.7
+    repository: https://kubernetes-charts.storage.googleapis.com/
+"#,
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.name.as_deref(), Some("legacy-chart"));
+        assert_eq!(package.datasource_id, Some(DatasourceId::HelmChartYaml));
+        assert_eq!(package.dependencies.len(), 2);
+        assert!(
+            package
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:helm/mariadb@7.3.14"))
+        );
+        assert!(
+            package
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:helm/redis@10.5.7"))
+        );
+    }
+
+    // A v2 Chart.yaml with inline dependencies must not be overridden by a sibling
+    // requirements.yaml (inline dependencies win).
+    #[test]
+    fn test_chart_yaml_v2_inline_dependencies_take_precedence() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v2
+name: modern-chart
+version: 2.0.0
+dependencies:
+  - name: postgresql
+    version: 12.1.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            "dependencies:\n  - name: should-be-ignored\n    version: 0.0.0\n",
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.dependencies.len(), 1);
+        assert_eq!(
+            package.dependencies[0].purl.as_deref(),
+            Some("pkg:helm/postgresql@12.1.0")
+        );
+    }
+
+    // A v2 (Helm 3) Chart.yaml that legitimately has zero dependencies must NOT inherit a
+    // co-located requirements.yaml: in a monorepo the neighbouring requirements.yaml may
+    // belong to an unrelated project (e.g. Ansible Galaxy / Python) rather than the chart.
+    // The sibling-merge is a Helm 2 (apiVersion v1) concern only.
+    #[test]
+    fn test_chart_yaml_v2_empty_deps_ignores_sibling_requirements_yaml() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v2
+name: modern-chart
+version: 2.0.0
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            "dependencies:\n  - name: unrelated-ansible-role\n    version: 1.0.0\n",
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.name.as_deref(), Some("modern-chart"));
+        assert!(
+            package.dependencies.is_empty(),
+            "v2 chart must not inherit an unrelated sibling requirements.yaml"
+        );
+    }
 }


### PR DESCRIPTION
> Stacked on #952 → #951 → #950. This PR's diff is against the julia branch.

## Summary

- **Fix:** Helm 2 charts (`apiVersion: v1`) declare dependencies in a sibling `requirements.yaml`, not inline in `Chart.yaml`, so v1 charts reported **zero dependencies**. When `Chart.yaml` carries no dependencies, the parser now merges them from a neighbouring `requirements.yaml` (same `dependencies:` schema, reusing the existing extractor).
- Requiring the sibling `Chart.yaml` distinguishes Helm's `requirements.yaml` from unrelated `requirements.yml` files (e.g. Ansible Galaxy), and v2 inline dependencies still take precedence. No new datasource — the deps attach to the `Chart.yaml` package.
- **Fix 4 of 6** from the parser version-coverage audit.

## How to verify

- `cargo test --lib -- helm` (new `test_chart_yaml_v1_merges_sibling_requirements_yaml_dependencies` and `test_chart_yaml_v2_inline_dependencies_take_precedence`; existing tests + scanner test still pass).
- Goldens unaffected: `cargo test --features golden-tests --test parsers_golden -- helm`.
- ScanCode has no Helm parser, so this is purely broader coverage; the unit tests prove v1 requirements.yaml extraction directly.

## Intentional differences from Python

- N/A — ScanCode does not parse Helm charts.

## Follow-up work

- Remaining stacked PRs: conda recipe.yaml, hex mix.lock.

## Expected-output fixture changes

- None. New unit tests only.