### PR TITLE
fix(conda): recognize rattler-build recipe.yaml without schema_version

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 218 of 218 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 219 of 219 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -231,6 +231,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `23.57s`; ScanCode `332.23s`
 - Far broader Python/Conda/Pixi package and dependency extraction (`4` vs `1` packages, `1469` vs `78` dependencies) from `pixi.lock`'s large resolved Conda graph, `environment.yml`, `pixi.toml`, and the aggregated `requirements/*.txt` tree that ScanCode leaves at zero, with cleaner `pyproject.toml` requirement shaping for exact pins and environment markers
+
+##### [UCBoulder/tardigrade_micromorphic_tools @ d03a8ca](https://github.com/UCBoulder/tardigrade_micromorphic_tools/tree/d03a8cae9e0983040487d2ecf32da98d9b297b92) — **7.70× faster**
+
+- Files: 47
+- Run context: 2026-06-06 · tardigrade_micromorphic_tools-24660 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.06s`; ScanCode `46.66s`
+- Broader Conda dependency extraction (`17` vs `0` dependencies on `recipe/recipe.yaml`) by parsing the rattler-build `recipe.yaml` that ScanCode reads only as `recipe/meta.yaml`, with `${{ name|lower }}` context templating resolved into a real `pkg:conda/tardigrade_micromorphic_tools@0.0.0` identity and identical top-level license detection across the C++ source tree
 
 #### R / CRAN
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -173,6 +173,9 @@ ScanCode: 17.97s</title></rect>
     <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 74.96s</title></rect>
+    <rect x="357.31" y="446.42" width="8" height="8" fill="#d97706" rx="1.5"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
+Files: 47
+ScanCode: 46.66s</title></rect>
     <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 ScanCode: 235.99s</title></rect>
@@ -829,6 +832,9 @@ Provenant: 10.50s</title></circle>
     <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 10.05s</title></circle>
+    <circle cx="361.31" cy="546.87" r="4.5" fill="#2563eb"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
+Files: 47
+Provenant: 6.06s</title></circle>
     <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 Provenant: 27.50s</title></circle>

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -342,9 +342,15 @@ impl PackageParser for CondaMetaYamlParser {
 }
 
 fn looks_like_conda_recipe_yaml(yaml: &Value) -> bool {
-    yaml.get("schema_version")
-        .and_then(|value| value.as_u64())
-        .is_some_and(|value| value == 1)
+    // rattler-build treats schema_version as optional, defaulting to 1, so many real
+    // recipe.yaml files omit it. Accept an absent schema_version (default 1) and reject
+    // only an explicit version this parser does not understand.
+    let schema_version_ok = match yaml.get("schema_version").and_then(|value| value.as_u64()) {
+        Some(version) => version == 1,
+        None => true,
+    };
+
+    schema_version_ok
         && (yaml
             .get("package")
             .and_then(|value| value.as_mapping())
@@ -500,15 +506,28 @@ fn recipe_yaml_value_to_string(value: &Value, context: &HashMap<String, String>)
 }
 
 fn resolve_recipe_yaml_expressions(value: &str, context: &HashMap<String, String>) -> String {
-    let Some(re) = Regex::new(r#"\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}"#).ok() else {
+    // rattler-build recipe.yaml uses `${{ var }}` substitution from the `context:` block,
+    // optionally with a minijinja filter such as `${{ name|lower }}`. Capture the variable
+    // and an optional single filter so templated package names resolve to real identities
+    // instead of leaking the literal expression into PURLs.
+    let Some(re) = Regex::new(
+        r#"\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\|\s*([A-Za-z_][A-Za-z0-9_]*)\s*)?\}\}"#,
+    )
+    .ok() else {
         return truncate_field(value.to_string());
     };
 
     let resolved = re.replace_all(value, |caps: &regex::Captures| {
-        context
-            .get(&caps[1])
-            .cloned()
-            .unwrap_or_else(|| caps[0].to_string())
+        let Some(substituted) = context.get(&caps[1]) else {
+            // Unknown variable: leave the original expression untouched.
+            return caps[0].to_string();
+        };
+        match caps.get(2).map(|filter| filter.as_str()) {
+            Some("lower") => substituted.to_lowercase(),
+            Some("upper") => substituted.to_uppercase(),
+            // Unknown/no filter: use the substituted value as-is.
+            _ => substituted.clone(),
+        }
     });
     truncate_field(resolved.into_owned())
 }

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -986,4 +986,105 @@ about:
             Some(1)
         );
     }
+
+    // rattler-build treats schema_version as optional (default 1), so recipe.yaml files
+    // commonly omit it. The recipe must still be recognized and parsed.
+    #[test]
+    fn test_extract_recipe_yaml_without_schema_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+context:
+  version: "3.0.2"
+
+package:
+  name: pandas
+  version: ${{ version }}
+
+requirements:
+  run:
+    - python
+    - numpy >=1.26.0
+"#,
+        )
+        .unwrap();
+
+        let package_data = CondaMetaYamlParser::extract_first_package(&recipe_path);
+
+        assert_eq!(package_data.package_type, Some(PackageType::Conda));
+        assert_eq!(package_data.name.as_deref(), Some("pandas"));
+        assert_eq!(package_data.version.as_deref(), Some("3.0.2"));
+        let dependency_purls: Vec<&str> = package_data
+            .dependencies
+            .iter()
+            .filter_map(|dep| dep.purl.as_deref())
+            .collect();
+        assert!(dependency_purls.contains(&"pkg:conda/numpy"));
+    }
+
+    // An explicit, unrecognized schema_version is still rejected (no recipe extraction).
+    #[test]
+    fn test_recipe_yaml_explicit_unknown_schema_version_is_not_recognized() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+schema_version: 2
+
+package:
+  name: pandas
+  version: "3.0.2"
+"#,
+        )
+        .unwrap();
+
+        let packages = CondaMetaYamlParser::extract_packages(&recipe_path);
+        assert!(packages.is_empty());
+    }
+
+    // rattler-build recipes commonly template the package name with a filter, e.g.
+    // `name: ${{ name|lower }}`. The filter must be applied so the name resolves to a real
+    // identity instead of leaking the literal `${{ name|lower }}` expression into the PURL.
+    #[test]
+    fn test_extract_recipe_yaml_resolves_lower_filter_in_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+schema_version: 1
+
+context:
+  name: Tardigrade_Tools
+  version: 0.0.0
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+requirements:
+  host:
+    - cmake
+"#,
+        )
+        .unwrap();
+
+        let package_data = CondaMetaYamlParser::extract_first_package(&recipe_path);
+
+        assert_eq!(package_data.name.as_deref(), Some("tardigrade_tools"));
+        assert_eq!(package_data.version.as_deref(), Some("0.0.0"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:conda/tardigrade_tools@0.0.0")
+        );
+    }
 }


### PR DESCRIPTION
> Stacked on #953 → #952 → #951 → #950. Diff is against the helm branch.

## Summary

- **Fix:** `looks_like_conda_recipe_yaml` required `schema_version == 1`, so a `recipe.yaml` that omitted the field failed recognition and the parser returned **no packages** (`Vec::new()`). rattler-build treats `schema_version` as optional, defaulting to 1, so real recipe.yaml files commonly omit it.
- Now accepts an absent `schema_version` (default 1) while still rejecting an explicit unrecognized version.
- **Fix 5 of 6** from the parser version-coverage audit.

## How to verify

- `cargo test --lib -- conda` (new `test_extract_recipe_yaml_without_schema_version` extracts pandas + deps; `test_recipe_yaml_explicit_unknown_schema_version_is_not_recognized` confirms an explicit `schema_version: 2` is still rejected).
- Goldens unaffected: `cargo test --features golden-tests --test parsers_golden -- conda`.

## Intentional differences from Python

- None of concern — this widens recognition to match rattler-build's optional-schema_version default.

## Follow-up work

- Final stacked PR: hex mix.lock legacy tuples.

## Expected-output fixture changes

- None. New unit tests only.