### PR TITLE
fix: parser version coverage across 6 ecosystems + license-front benchmarks

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 218 of 218 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 219 of 219 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -231,6 +231,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `23.57s`; ScanCode `332.23s`
 - Far broader Python/Conda/Pixi package and dependency extraction (`4` vs `1` packages, `1469` vs `78` dependencies) from `pixi.lock`'s large resolved Conda graph, `environment.yml`, `pixi.toml`, and the aggregated `requirements/*.txt` tree that ScanCode leaves at zero, with cleaner `pyproject.toml` requirement shaping for exact pins and environment markers
+
+##### [UCBoulder/tardigrade_micromorphic_tools @ d03a8ca](https://github.com/UCBoulder/tardigrade_micromorphic_tools/tree/d03a8cae9e0983040487d2ecf32da98d9b297b92) — **7.70× faster**
+
+- Files: 47
+- Run context: 2026-06-06 · tardigrade_micromorphic_tools-24660 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.06s`; ScanCode `46.66s`
+- Broader Conda dependency extraction (`17` vs `0` dependencies on `recipe/recipe.yaml`) by parsing the rattler-build `recipe.yaml` that ScanCode reads only as `recipe/meta.yaml`, with `${{ name|lower }}` context templating resolved into a real `pkg:conda/tardigrade_micromorphic_tools@0.0.0` identity and identical top-level license detection across the C++ source tree
 
 #### R / CRAN
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 217 of 217 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 218 of 218 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -731,6 +731,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-03 · harbor-57111 · macOS 26.5 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `22.87s`; ScanCode `327.33s`
 - Broader package and dependency extraction (`5` vs `2` packages, `2972` vs `2407` dependencies) from committed Pipfile/Pipfile.lock, npm-family, Docker, and Go manifests, with local Go `replace` paths kept out of invalid PURLs, templated Conda YAML skipped instead of degraded into false metadata, and URL differences limited to normalization/truncation/canonicalization after review
+
+##### [goharbor/harbor-helm @ 7233a81](https://github.com/goharbor/harbor-helm/tree/7233a81d24c891abc3fd83285ea8b91e2ab5522f) — **7.57× faster**
+
+- Files: 96
+- Run context: 2026-06-06 · harbor-helm-71676 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.36s`; ScanCode `48.15s`
+- Direct Helm chart package visibility (`1` vs `0` packages, `pkg:helm/harbor@1.4.0-dev` from the apiVersion-v1 `Chart.yaml`) plus a Dockerfile image package from `test/e2e/Dockerfile`, with identical top-level license detection and matching Go module coverage from the bundled `test/go.mod` / `test/go.sum` terratest harness
 
 ##### [grpc/grpc @ f87c29f](https://github.com/grpc/grpc/tree/f87c29f069971d1356e5784005af499db52e7f31) — **14.43× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 216 of 216 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 217 of 217 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1229,6 +1229,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `22.78s`; ScanCode `332.82s`
 - Broader mixed Hackage and Nix package extraction (`5` vs `0` packages, `197` vs `0` dependencies) from sibling `pandoc*.cabal` manifests, `stack.yaml`, and `flake.nix` / `flake.lock`, with explicit package identities across `pandoc`, `pandoc-cli`, `pandoc-lua-engine`, and `pandoc-server`
+
+##### [JuliaAcademy/DataScience @ 201f2e6](https://github.com/JuliaAcademy/DataScience/tree/201f2e66cf2067dacee2df02b546f75d77ed22e7) — **8.58× faster**
+
+- Files: 50
+- Run context: 2026-06-06 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `27.50s`; ScanCode `235.99s`
+- Direct Julia package visibility and broader dependency extraction (`1` vs `0` packages, `53` vs `0` dependencies) from the root legacy v1.0-format `Manifest.toml` and its `Project.toml`, with zero scan errors where ScanCode times out after 120s on `05. Clustering.ipynb` and no spurious low-confidence `GPL-3.0-only` detection bleeding from the binary `data/face_recog_qr.mat` blob
 
 ##### [JuliaLang/julia @ afc71c2](https://github.com/JuliaLang/julia/tree/afc71c255e327d8a64b69061c15994e80740974d) — **21.75× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 215 of 215 recorded runs, with a **12.1× median speedup** and **11.5× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 216 of 216 recorded runs, with a **12.1× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.0×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -314,6 +314,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
 - Timing: Provenant `23.76s`; ScanCode `761.82s`
 - Direct Helm package visibility on `deploy/helm/baserow/Chart.yaml` and `Chart.lock` (`2` file-level Helm surfaces vs `0`), with declared plus locked dependency extraction (`12` vs `0` on each chart file) covering sibling `baserow-common` aliases and the pinned Bitnami/Caddy chart inputs that ScanCode leaves at zero
+
+##### [catppuccin/gitea @ 6a78970](https://github.com/catppuccin/gitea/tree/6a789704686ec13178a13cd84bf1e30db191a437) — **6.76× faster**
+
+- Files: 23
+- Run context: 2026-06-06 · gitea-24220 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.02s`; ScanCode `40.69s`
+- Deno v4 lockfile dependency extraction (`37` vs `0` from `deno.lock`'s resolved `npm` and `jsr` graphs) where ScanCode is lockfile-blind, plus `deno.json` import-map package visibility and cleaner rejection of a bare-URL holder mistaken from README prose; the deno.lock parser now covers lockfile formats v1–v5 rather than v5 alone
 
 ##### [denoland/fresh @ 49c4be1](https://github.com/denoland/fresh/tree/49c4be1ac60603174bad1c6e3c13bd88602c51bb) — **11.69× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 219 of 219 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 220 of 220 recorded runs, with a **12.0× median speedup** and **11.4× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -263,6 +263,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Direct CRAN package visibility on the root `DESCRIPTION` plus declared dependency extraction (`41` vs `0`) across `Imports`, `Suggests`, and `Enhances`, with correct hyphenated CRAN version constraints such as `sf (>= 0.7-3)` and cleaner Rd or roxygen URL recovery
 
 #### Hex / Elixir / Erlang / OTP
+
+##### [bitwalker/distillery @ 3ab4d61](https://github.com/bitwalker/distillery/tree/3ab4d6146c7bc18139ed75d330e4fbb0fceb7591) — **8.76× faster**
+
+- Files: 305
+- Run context: 2026-06-06 · distillery-44866 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.53s`; ScanCode `57.19s`
+- Direct Hex dependency extraction (`367` vs `0` dependencies) from the root `mix.lock`'s legacy 7-element hex tuples that ScanCode does not parse, defaulting `hexpm` as the repository for tuples that omit it, with MIT license detection preserved across the Elixir source tree
 
 ##### [elixir-ecto/ecto @ 28d9282](https://github.com/elixir-ecto/ecto/tree/28d928267388018d5b0bb1f83e04368b7e8cae50) — **9.66× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -266,6 +266,9 @@ ScanCode: 117.64s</title></rect>
     <rect x="485.49" y="414.35" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
 Files: 302
 ScanCode: 91.99s</title></rect>
+    <rect x="486.18" y="436.80" width="8" height="8" fill="#d97706" rx="1.5"><title>bitwalker/distillery @ 3ab4d61
+Files: 305
+ScanCode: 57.19s</title></rect>
     <rect x="490.34" y="410.86" width="8" height="8" fill="#d97706" rx="1.5"><title>yesodweb/yesod @ 1b033c7
 Files: 324
 ScanCode: 99.03s</title></rect>
@@ -925,6 +928,9 @@ Provenant: 10.05s</title></circle>
     <circle cx="489.49" cy="521.62" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
 Files: 302
 Provenant: 10.34s</title></circle>
+    <circle cx="490.18" cy="543.34" r="4.5" fill="#2563eb"><title>bitwalker/distillery @ 3ab4d61
+Files: 305
+Provenant: 6.53s</title></circle>
     <circle cx="494.34" cy="520.36" r="4.5" fill="#2563eb"><title>yesodweb/yesod @ 1b033c7
 Files: 324
 Provenant: 10.62s</title></circle>

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -161,6 +161,9 @@ ScanCode: 97.28s</title></rect>
     <rect x="305.00" y="436.72" width="8" height="8" fill="#d97706" rx="1.5"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 ScanCode: 57.29s</title></rect>
+    <rect x="308.06" y="452.89" width="8" height="8" fill="#d97706" rx="1.5"><title>catppuccin/gitea @ 6a78970
+Files: 23
+ScanCode: 40.69s</title></rect>
     <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 ScanCode: 73.99s</title></rect>
@@ -808,6 +811,9 @@ Provenant: 9.41s</title></circle>
     <circle cx="309.00" cy="542.62" r="4.5" fill="#2563eb"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 Provenant: 6.63s</title></circle>
+    <circle cx="312.06" cy="547.18" r="4.5" fill="#2563eb"><title>catppuccin/gitea @ 6a78970
+Files: 23
+Provenant: 6.02s</title></circle>
     <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 Provenant: 11.06s</title></circle>

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -197,6 +197,9 @@ ScanCode: 65.75s</title></rect>
     <rect x="403.59" y="423.65" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 ScanCode: 75.55s</title></rect>
+    <rect x="406.52" y="444.93" width="8" height="8" fill="#d97706" rx="1.5"><title>goharbor/harbor-helm @ 7233a81
+Files: 96
+ScanCode: 48.15s</title></rect>
     <rect x="407.94" y="420.39" width="8" height="8" fill="#d97706" rx="1.5"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 ScanCode: 80.95s</title></rect>
@@ -850,6 +853,9 @@ Provenant: 8.84s</title></circle>
     <circle cx="407.59" cy="515.70" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 92
 Provenant: 11.72s</title></circle>
+    <circle cx="410.52" cy="544.58" r="4.5" fill="#2563eb"><title>goharbor/harbor-helm @ 7233a81
+Files: 96
+Provenant: 6.36s</title></circle>
     <circle cx="411.94" cy="518.95" r="4.5" fill="#2563eb"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 Provenant: 10.94s</title></circle>

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -173,6 +173,9 @@ ScanCode: 17.97s</title></rect>
     <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 74.96s</title></rect>
+    <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
+Files: 50
+ScanCode: 235.99s</title></rect>
     <rect x="362.93" y="430.28" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 ScanCode: 65.66s</title></rect>
@@ -823,6 +826,9 @@ Provenant: 10.50s</title></circle>
     <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 10.05s</title></circle>
+    <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
+Files: 50
+Provenant: 27.50s</title></circle>
     <circle cx="366.93" cy="530.00" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 Provenant: 8.66s</title></circle>

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -173,6 +173,9 @@ ScanCode: 17.97s</title></rect>
     <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 74.96s</title></rect>
+    <rect x="357.31" y="446.42" width="8" height="8" fill="#d97706" rx="1.5"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
+Files: 47
+ScanCode: 46.66s</title></rect>
     <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 ScanCode: 235.99s</title></rect>
@@ -829,6 +832,9 @@ Provenant: 10.50s</title></circle>
     <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 10.05s</title></circle>
+    <circle cx="361.31" cy="546.87" r="4.5" fill="#2563eb"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
+Files: 47
+Provenant: 6.06s</title></circle>
     <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 Provenant: 27.50s</title></circle>

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -342,9 +342,15 @@ impl PackageParser for CondaMetaYamlParser {
 }
 
 fn looks_like_conda_recipe_yaml(yaml: &Value) -> bool {
-    yaml.get("schema_version")
-        .and_then(|value| value.as_u64())
-        .is_some_and(|value| value == 1)
+    // rattler-build treats schema_version as optional, defaulting to 1, so many real
+    // recipe.yaml files omit it. Accept an absent schema_version (default 1) and reject
+    // only an explicit version this parser does not understand.
+    let schema_version_ok = match yaml.get("schema_version").and_then(|value| value.as_u64()) {
+        Some(version) => version == 1,
+        None => true,
+    };
+
+    schema_version_ok
         && (yaml
             .get("package")
             .and_then(|value| value.as_mapping())
@@ -500,15 +506,28 @@ fn recipe_yaml_value_to_string(value: &Value, context: &HashMap<String, String>)
 }
 
 fn resolve_recipe_yaml_expressions(value: &str, context: &HashMap<String, String>) -> String {
-    let Some(re) = Regex::new(r#"\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}"#).ok() else {
+    // rattler-build recipe.yaml uses `${{ var }}` substitution from the `context:` block,
+    // optionally with a minijinja filter such as `${{ name|lower }}`. Capture the variable
+    // and an optional single filter so templated package names resolve to real identities
+    // instead of leaking the literal expression into PURLs.
+    let Some(re) = Regex::new(
+        r#"\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\|\s*([A-Za-z_][A-Za-z0-9_]*)\s*)?\}\}"#,
+    )
+    .ok() else {
         return truncate_field(value.to_string());
     };
 
     let resolved = re.replace_all(value, |caps: &regex::Captures| {
-        context
-            .get(&caps[1])
-            .cloned()
-            .unwrap_or_else(|| caps[0].to_string())
+        let Some(substituted) = context.get(&caps[1]) else {
+            // Unknown variable: leave the original expression untouched.
+            return caps[0].to_string();
+        };
+        match caps.get(2).map(|filter| filter.as_str()) {
+            Some("lower") => substituted.to_lowercase(),
+            Some("upper") => substituted.to_uppercase(),
+            // Unknown/no filter: use the substituted value as-is.
+            _ => substituted.clone(),
+        }
     });
     truncate_field(resolved.into_owned())
 }

--- a/src/parsers/conda_test.rs
+++ b/src/parsers/conda_test.rs
@@ -986,4 +986,105 @@ about:
             Some(1)
         );
     }
+
+    // rattler-build treats schema_version as optional (default 1), so recipe.yaml files
+    // commonly omit it. The recipe must still be recognized and parsed.
+    #[test]
+    fn test_extract_recipe_yaml_without_schema_version() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+context:
+  version: "3.0.2"
+
+package:
+  name: pandas
+  version: ${{ version }}
+
+requirements:
+  run:
+    - python
+    - numpy >=1.26.0
+"#,
+        )
+        .unwrap();
+
+        let package_data = CondaMetaYamlParser::extract_first_package(&recipe_path);
+
+        assert_eq!(package_data.package_type, Some(PackageType::Conda));
+        assert_eq!(package_data.name.as_deref(), Some("pandas"));
+        assert_eq!(package_data.version.as_deref(), Some("3.0.2"));
+        let dependency_purls: Vec<&str> = package_data
+            .dependencies
+            .iter()
+            .filter_map(|dep| dep.purl.as_deref())
+            .collect();
+        assert!(dependency_purls.contains(&"pkg:conda/numpy"));
+    }
+
+    // An explicit, unrecognized schema_version is still rejected (no recipe extraction).
+    #[test]
+    fn test_recipe_yaml_explicit_unknown_schema_version_is_not_recognized() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+schema_version: 2
+
+package:
+  name: pandas
+  version: "3.0.2"
+"#,
+        )
+        .unwrap();
+
+        let packages = CondaMetaYamlParser::extract_packages(&recipe_path);
+        assert!(packages.is_empty());
+    }
+
+    // rattler-build recipes commonly template the package name with a filter, e.g.
+    // `name: ${{ name|lower }}`. The filter must be applied so the name resolves to a real
+    // identity instead of leaking the literal `${{ name|lower }}` expression into the PURL.
+    #[test]
+    fn test_extract_recipe_yaml_resolves_lower_filter_in_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe_dir = temp_dir.path().join("recipe");
+        fs::create_dir_all(&recipe_dir).unwrap();
+        let recipe_path = recipe_dir.join("recipe.yaml");
+        fs::write(
+            &recipe_path,
+            r#"
+schema_version: 1
+
+context:
+  name: Tardigrade_Tools
+  version: 0.0.0
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+requirements:
+  host:
+    - cmake
+"#,
+        )
+        .unwrap();
+
+        let package_data = CondaMetaYamlParser::extract_first_package(&recipe_path);
+
+        assert_eq!(package_data.name.as_deref(), Some("tardigrade_tools"));
+        assert_eq!(package_data.version.as_deref(), Some("0.0.0"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:conda/tardigrade_tools@0.0.0")
+        );
+    }
 }

--- a/src/parsers/deno_lock.rs
+++ b/src/parsers/deno_lock.rs
@@ -68,11 +68,56 @@ impl PackageParser for DenoLockParser {
 
 fn parse_deno_lock(json: &Value) -> PackageData {
     let lock_version = json.get(FIELD_VERSION).and_then(Value::as_str);
-    if lock_version != Some("5") {
-        warn!("Unsupported deno.lock version {:?}", lock_version);
-        return default_package_data();
+
+    // deno.lock has gone through several incompatible layouts; dispatch on the declared
+    // version so older lockfiles still in the wild are not silently dropped:
+    //   * v1 (Deno 1.0-1.17): remote ESM URL imports only, no registry dependencies.
+    //   * v2/v3 (Deno 1.18-1.40): npm dependencies nested under npm.{specifiers,packages};
+    //     no jsr or workspace sections.
+    //   * v4 (Deno 1.45+) and v5 (current): flat top-level specifiers/npm/jsr/workspace.
+    // Unknown/newer versions fall back to the latest (flat) layout rather than dropping.
+    let (mut dependencies, workspace_direct) = match lock_version {
+        Some("1") => (Vec::new(), Vec::new()),
+        Some("2") | Some("3") => (extract_nested_npm_dependencies(json), Vec::new()),
+        Some("4") | Some("5") => extract_flat_dependencies(json),
+        other => {
+            warn!(
+                "Unrecognized deno.lock version {:?}; parsing with the latest known layout",
+                other
+            );
+            extract_flat_dependencies(json)
+        }
+    };
+    dependencies.extend(extract_redirect_dependencies(json));
+
+    let mut extra_data = HashMap::new();
+    if let Some(version) = lock_version {
+        extra_data.insert(
+            FIELD_VERSION.to_string(),
+            Value::String(version.to_string()),
+        );
+    }
+    if !workspace_direct.is_empty() {
+        extra_data.insert(
+            "workspace_dependencies".to_string(),
+            Value::Array(workspace_direct.into_iter().map(Value::String).collect()),
+        );
     }
 
+    PackageData {
+        package_type: Some(DenoLockParser::PACKAGE_TYPE),
+        primary_language: Some("TypeScript".to_string()),
+        dependencies,
+        extra_data: (!extra_data.is_empty()).then_some(extra_data),
+        datasource_id: Some(DatasourceId::DenoLock),
+        ..Default::default()
+    }
+}
+
+/// Flat top-level layout used by deno.lock v4 and v5: `specifiers`, `npm`, `jsr`, and
+/// `workspace` sections. Returns the resolved dependencies plus the workspace's direct
+/// specifier list (recorded in extra_data by the caller).
+fn extract_flat_dependencies(json: &Value) -> (Vec<Dependency>, Vec<String>) {
     let specifiers = json
         .get(FIELD_SPECIFIERS)
         .and_then(Value::as_object)
@@ -127,6 +172,59 @@ fn parse_deno_lock(json: &Value) -> PackageData {
         }
     }
 
+    (dependencies, workspace_direct)
+}
+
+/// Nested layout used by deno.lock v2 and v3: npm dependencies live under `npm.packages`
+/// (the resolved graph), with `npm.specifiers` mapping requested ranges to resolved
+/// `name@version` keys. There are no jsr or workspace sections in these versions.
+fn extract_nested_npm_dependencies(json: &Value) -> Vec<Dependency> {
+    let Some(npm) = json.get(FIELD_NPM) else {
+        return Vec::new();
+    };
+    let Some(packages) = npm.get("packages") else {
+        return Vec::new();
+    };
+    let Some(packages_map) = packages.as_object() else {
+        return Vec::new();
+    };
+
+    // `npm.specifiers` maps each requested specifier (e.g. "chalk@5") to its resolved
+    // `name@version` key (e.g. "chalk@5.3.0"). Invert it so resolved packages referenced
+    // by a top-level specifier can be marked direct and keep their requested range; the
+    // remaining npm.packages entries are transitive.
+    let requested_by_resolved: HashMap<String, String> = npm
+        .get("specifiers")
+        .and_then(Value::as_object)
+        .map(|specifiers| {
+            specifiers
+                .iter()
+                .filter_map(|(specifier, resolved)| {
+                    resolved.as_str().map(|resolved| {
+                        (
+                            resolved.trim_start_matches("npm:").to_string(),
+                            specifier.clone(),
+                        )
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut dependencies = Vec::new();
+    for key in packages_map.keys().take(MAX_ITERATION_COUNT) {
+        let requested = requested_by_resolved.get(key).map(String::as_str);
+        if let Some(dep) = build_npm_dependency(key, requested.is_some(), packages, requested) {
+            dependencies.push(dep);
+        }
+    }
+    dependencies
+}
+
+/// Module redirects, shared across all lockfile versions: each redirect target is a
+/// remote module whose integrity hash lives in the `remote` section.
+fn extract_redirect_dependencies(json: &Value) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
     if let Some(redirects) = json.get(FIELD_REDIRECTS).and_then(Value::as_object) {
         for (source, target) in redirects.iter().take(MAX_ITERATION_COUNT) {
             let Some(target_url) = target.as_str() else {
@@ -181,30 +279,7 @@ fn parse_deno_lock(json: &Value) -> PackageData {
             });
         }
     }
-
-    let mut extra_data = HashMap::new();
-    extra_data.insert(FIELD_VERSION.to_string(), Value::String("5".to_string()));
-    if !workspace_direct.is_empty() {
-        extra_data.insert(
-            "workspace_dependencies".to_string(),
-            Value::Array(
-                workspace_direct
-                    .iter()
-                    .cloned()
-                    .map(Value::String)
-                    .collect(),
-            ),
-        );
-    }
-
-    PackageData {
-        package_type: Some(DenoLockParser::PACKAGE_TYPE),
-        primary_language: Some("TypeScript".to_string()),
-        dependencies,
-        extra_data: Some(extra_data),
-        datasource_id: Some(DatasourceId::DenoLock),
-        ..Default::default()
-    }
+    dependencies
 }
 
 fn extract_workspace_dependencies(json: &Value) -> Vec<String> {
@@ -277,6 +352,27 @@ fn build_jsr_dependency(
     })
 }
 
+/// A package's nested `dependencies` field is shaped differently across lockfile
+/// versions: v4/v5 `npm[key].dependencies` is an array of resolved `name@version`
+/// keys (`["ansi-styles@6.2.1"]`), while v2/v3 `npm.packages[key].dependencies` is an
+/// object mapping bare names to those resolved keys (`{"ansi-styles":"ansi-styles@6.2.1"}`).
+/// Both encode the same resolved keys, so collect them uniformly from either shape.
+fn npm_dependency_keys(value: Option<&Value>) -> Vec<String> {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        Some(Value::Object(map)) => map
+            .values()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 fn build_npm_dependency(
     resolved_key: &str,
     is_direct: bool,
@@ -320,19 +416,15 @@ fn build_npm_dependency(
             md5: None,
             is_virtual: true,
             extra_data: None,
-            dependencies: npm_object
-                .get(FIELD_DEPENDENCIES)
-                .and_then(Value::as_array)
+            dependencies: npm_dependency_keys(npm_object.get(FIELD_DEPENDENCIES))
                 .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
                 .take(MAX_ITERATION_COUNT)
                 .filter_map(|value| {
-                    let (namespace, name, version) = parse_npm_key(value)?;
+                    let (namespace, name, version) = parse_npm_key(&value)?;
                     Some(Dependency {
                         purl: create_npm_purl(namespace.as_deref(), &name, Some(version))
                             .map(truncate_field),
-                        extracted_requirement: Some(truncate_field(value.to_string())),
+                        extracted_requirement: Some(truncate_field(value.clone())),
                         scope: Some("dependencies".to_string()),
                         is_runtime: Some(true),
                         is_optional: Some(false),

--- a/src/parsers/deno_lock_test.rs
+++ b/src/parsers/deno_lock_test.rs
@@ -71,11 +71,127 @@ mod tests {
         assert!(remote.resolved_package.is_some());
     }
 
+    // deno.lock v2/v3 (Deno 1.18-1.40) nest npm deps under npm.{specifiers,packages}.
     #[test]
-    fn test_extract_from_deno_lock_unsupported_version() {
+    fn test_extract_from_deno_lock_v3_nested_npm() {
         let temp_dir = tempdir().unwrap();
         let file_path = temp_dir.path().join("deno.lock");
-        fs::write(&file_path, r#"{"version":"4"}"#).unwrap();
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "3",
+  "npm": {
+    "specifiers": { "chalk@5": "chalk@5.6.2" },
+    "packages": {
+      "chalk@5.6.2": { "integrity": "sha512-aaaa", "dependencies": { "ansi-styles": "ansi-styles@6.2.1" } },
+      "ansi-styles@6.2.1": { "integrity": "sha512-bbbb", "dependencies": {} }
+    }
+  },
+  "remote": {}
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 2);
+        let chalk = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:npm/chalk@5.6.2"))
+            .expect("chalk dependency");
+        assert_eq!(chalk.is_direct, Some(true));
+        // A directly-referenced package keeps its requested specifier as the requirement.
+        assert_eq!(chalk.extracted_requirement.as_deref(), Some("chalk@5"));
+        // v2/v3 encode nested dependencies as an object; the resolved key still surfaces.
+        let chalk_resolved = chalk
+            .resolved_package
+            .as_ref()
+            .expect("chalk resolved package");
+        assert!(
+            chalk_resolved
+                .dependencies
+                .iter()
+                .any(|d| d.purl.as_deref() == Some("pkg:npm/ansi-styles@6.2.1")),
+            "object-shaped nested dependencies should be parsed"
+        );
+        let ansi = package_data
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:npm/ansi-styles@6.2.1"))
+            .expect("transitive ansi-styles dependency");
+        assert_eq!(ansi.is_direct, Some(false));
+    }
+
+    // deno.lock v4 (Deno 1.45+) uses the same flat layout as v5.
+    #[test]
+    fn test_extract_from_deno_lock_v4_flat() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "4",
+  "specifiers": { "npm:chalk@5": "5.6.2" },
+  "npm": { "chalk@5.6.2": { "integrity": "sha512-aaaa" } },
+  "workspace": { "dependencies": ["npm:chalk@5"] }
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:npm/chalk@5.6.2")
+        );
+    }
+
+    // An unrecognized/newer version must not silently drop everything; it falls back to
+    // the latest known (flat) layout.
+    #[test]
+    fn test_extract_from_deno_lock_future_version_falls_back_to_flat() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "99",
+  "specifiers": { "npm:chalk@5": "5.6.2" },
+  "npm": { "chalk@5.6.2": { "integrity": "sha512-aaaa" } }
+}"#,
+        )
+        .unwrap();
+
+        let package_data = DenoLockParser::extract_first_package(&file_path);
+
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::DenoLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:npm/chalk@5.6.2")
+        );
+    }
+
+    // deno.lock v1 (Deno 1.0-1.17) predates npm/jsr support: remote ESM imports only, so
+    // no registry dependencies, but it must still be recognized (not error out).
+    #[test]
+    fn test_extract_from_deno_lock_v1_remote_only() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("deno.lock");
+        fs::write(
+            &file_path,
+            r#"{
+  "version": "1",
+  "remote": {
+    "https://deno.land/std@0.100.0/fmt/colors.ts": "abc0000000000000000000000000000000000000000000000000000000000abc"
+  }
+}"#,
+        )
+        .unwrap();
 
         let package_data = DenoLockParser::extract_first_package(&file_path);
 

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -43,7 +43,34 @@ impl PackageParser for HelmChartYamlParser {
             }
         };
 
-        vec![parse_chart_yaml(&yaml_content)]
+        let mut package = parse_chart_yaml(&yaml_content);
+
+        // Helm 2 charts (apiVersion v1) declare dependencies in a sibling requirements.yaml
+        // rather than inline in Chart.yaml. When such a chart carries no dependencies, merge
+        // them from a neighbouring requirements.yaml (same `dependencies:` schema). Gate this
+        // on apiVersion v1 so a Helm 3 (v2) chart that legitimately has zero inline
+        // dependencies but shares a directory with an unrelated requirements.yaml (e.g. a
+        // monorepo with an Ansible/Python project alongside the chart) does not inherit them.
+        if extract_string_field(&yaml_content, "apiVersion").as_deref() == Some("v1")
+            && package.dependencies.is_empty()
+            && let Some(requirements_path) =
+                path.parent().map(|parent| parent.join("requirements.yaml"))
+            && requirements_path.is_file()
+        {
+            match read_yaml_file(&requirements_path) {
+                Ok(requirements_content) => {
+                    package.dependencies = extract_chart_yaml_dependencies(&requirements_content);
+                }
+                Err(error) => {
+                    warn!(
+                        "Failed to read sibling requirements.yaml at {:?}: {}",
+                        requirements_path, error
+                    );
+                }
+            }
+        }
+
+        vec![package]
     }
 }
 

--- a/src/parsers/helm_test.rs
+++ b/src/parsers/helm_test.rs
@@ -414,4 +414,115 @@ dependencies:
         assert_eq!(wildcard.purl.as_deref(), Some("pkg:helm/wildcard"));
         assert_eq!(wildcard.is_pinned, Some(false));
     }
+
+    // Helm 2 charts (apiVersion v1) declare dependencies in a sibling requirements.yaml,
+    // not inline in Chart.yaml. The Chart.yaml package should pick them up.
+    #[test]
+    fn test_chart_yaml_v1_merges_sibling_requirements_yaml_dependencies() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v1
+name: legacy-chart
+version: 1.2.3
+description: A Helm 2 chart
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            r#"dependencies:
+  - name: mariadb
+    version: 7.3.14
+    repository: https://kubernetes-charts.storage.googleapis.com/
+  - name: redis
+    version: 10.5.7
+    repository: https://kubernetes-charts.storage.googleapis.com/
+"#,
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.name.as_deref(), Some("legacy-chart"));
+        assert_eq!(package.datasource_id, Some(DatasourceId::HelmChartYaml));
+        assert_eq!(package.dependencies.len(), 2);
+        assert!(
+            package
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:helm/mariadb@7.3.14"))
+        );
+        assert!(
+            package
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:helm/redis@10.5.7"))
+        );
+    }
+
+    // A v2 Chart.yaml with inline dependencies must not be overridden by a sibling
+    // requirements.yaml (inline dependencies win).
+    #[test]
+    fn test_chart_yaml_v2_inline_dependencies_take_precedence() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v2
+name: modern-chart
+version: 2.0.0
+dependencies:
+  - name: postgresql
+    version: 12.1.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            "dependencies:\n  - name: should-be-ignored\n    version: 0.0.0\n",
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.dependencies.len(), 1);
+        assert_eq!(
+            package.dependencies[0].purl.as_deref(),
+            Some("pkg:helm/postgresql@12.1.0")
+        );
+    }
+
+    // A v2 (Helm 3) Chart.yaml that legitimately has zero dependencies must NOT inherit a
+    // co-located requirements.yaml: in a monorepo the neighbouring requirements.yaml may
+    // belong to an unrelated project (e.g. Ansible Galaxy / Python) rather than the chart.
+    // The sibling-merge is a Helm 2 (apiVersion v1) concern only.
+    #[test]
+    fn test_chart_yaml_v2_empty_deps_ignores_sibling_requirements_yaml() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        fs::write(
+            temp_dir.path().join("Chart.yaml"),
+            r#"apiVersion: v2
+name: modern-chart
+version: 2.0.0
+"#,
+        )
+        .expect("write Chart.yaml");
+        fs::write(
+            temp_dir.path().join("requirements.yaml"),
+            "dependencies:\n  - name: unrelated-ansible-role\n    version: 1.0.0\n",
+        )
+        .expect("write requirements.yaml");
+
+        let package =
+            HelmChartYamlParser::extract_first_package(&temp_dir.path().join("Chart.yaml"));
+
+        assert_eq!(package.name.as_deref(), Some("modern-chart"));
+        assert!(
+            package.dependencies.is_empty(),
+            "v2 chart must not inherit an unrelated sibling requirements.yaml"
+        );
+    }
 }

--- a/src/parsers/hex_lock.rs
+++ b/src/parsers/hex_lock.rs
@@ -120,7 +120,12 @@ fn build_dependency_from_lock_entry(
         _ => return Ok(None),
     };
 
-    if tuple.len() < 8 {
+    // hex dependency tuples have grown over time; accept all historical shapes rather than
+    // dropping older lockfiles:
+    //   6 elements (legacy): {:hex, name, version, inner_checksum, managers, deps}
+    //   7 elements: + repo
+    //   8 elements (modern, Hex >= 0.20 / Elixir >= 1.7): + outer_checksum
+    if tuple.len() < 6 {
         return Ok(None);
     }
 
@@ -134,8 +139,16 @@ fn build_dependency_from_lock_entry(
     let inner_checksum = truncate_field(term_to_string(&tuple[3])?);
     let managers = term_to_atom_list(&tuple[4])?;
     let nested_dependencies = term_to_dependency_tuples(&tuple[5])?;
-    let repo = truncate_field(term_to_string(&tuple[6])?);
-    let outer_checksum = truncate_field(term_to_string(&tuple[7])?);
+    // repo (element 7) was added later; default to the public "hexpm" repository when absent.
+    let repo = match tuple.get(6) {
+        Some(term) => truncate_field(term_to_string(term)?),
+        None => "hexpm".to_string(),
+    };
+    // outer_checksum (element 8) is only present in modern lockfiles.
+    let outer_checksum = match tuple.get(7) {
+        Some(term) => Some(truncate_field(term_to_string(term)?)),
+        None => None,
+    };
 
     let purl = build_hex_purl(&package_name, Some(&version), Some(&repo));
     let resolved_package = ResolvedPackage {
@@ -146,25 +159,30 @@ fn build_dependency_from_lock_entry(
         sha512: None,
         md5: None,
         is_virtual: true,
-        extra_data: Some(HashMap::from([
-            (
-                "repo".to_string(),
-                JsonValue::String(truncate_field(repo.clone())),
-            ),
-            (
-                "outer_checksum".to_string(),
-                JsonValue::String(truncate_field(outer_checksum.clone())),
-            ),
-            (
-                "managers".to_string(),
-                JsonValue::Array(
-                    managers
-                        .into_iter()
-                        .map(|m| JsonValue::String(truncate_field(m)))
-                        .collect(),
+        extra_data: Some({
+            let mut extra = HashMap::from([
+                (
+                    "repo".to_string(),
+                    JsonValue::String(truncate_field(repo.clone())),
                 ),
-            ),
-        ])),
+                (
+                    "managers".to_string(),
+                    JsonValue::Array(
+                        managers
+                            .into_iter()
+                            .map(|m| JsonValue::String(truncate_field(m)))
+                            .collect(),
+                    ),
+                ),
+            ]);
+            if let Some(ref outer) = outer_checksum {
+                extra.insert(
+                    "outer_checksum".to_string(),
+                    JsonValue::String(truncate_field(outer.clone())),
+                );
+            }
+            extra
+        }),
         dependencies: nested_dependencies
             .into_iter()
             .map(build_nested_dependency)

--- a/src/parsers/hex_lock_test.rs
+++ b/src/parsers/hex_lock_test.rs
@@ -145,3 +145,62 @@ fn test_hex_mix_lock_malformed_returns_default() {
     assert_eq!(package_data.datasource_id, Some(DatasourceId::HexMixLock));
     assert!(package_data.dependencies.is_empty());
 }
+
+// Pre-2018 mix.lock entries use shorter hex tuples: 7 elements (no outer_checksum) or
+// 6 elements (no repo and no outer_checksum). They must still be extracted.
+#[test]
+fn test_hex_mix_lock_legacy_short_tuples() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("mix.lock");
+    std::fs::write(
+        &path,
+        concat!(
+            "%{\n",
+            // 7-tuple: repo present, no outer_checksum
+            "  \"plug\" => {:hex, :plug, \"1.5.0\", \"aaa111\", [:mix], [], \"hexpm\"},\n",
+            // 6-tuple: no repo, no outer_checksum
+            "  \"cowboy\" => {:hex, :cowboy, \"2.0.0\", \"bbb222\", [:rebar3], []}\n",
+            "}\n"
+        ),
+    )
+    .unwrap();
+
+    let package_data = HexLockParser::extract_first_package(&path);
+    assert_eq!(package_data.package_type, Some(PackageType::Hex));
+    assert_eq!(package_data.datasource_id, Some(DatasourceId::HexMixLock));
+    assert_eq!(package_data.dependencies.len(), 2);
+    let purls: Vec<&str> = package_data
+        .dependencies
+        .iter()
+        .filter_map(|dep| dep.purl.as_deref())
+        .collect();
+    assert!(purls.contains(&"pkg:hex/plug@1.5.0"));
+    assert!(purls.contains(&"pkg:hex/cowboy@2.0.0"));
+
+    // The 6-element cowboy tuple omits the repo field, so the parser must default it to
+    // "hexpm" rather than leaving it unset.
+    let cowboy_extra = package_data
+        .dependencies
+        .iter()
+        .find(|dep| dep.purl.as_deref() == Some("pkg:hex/cowboy@2.0.0"))
+        .and_then(|dep| dep.resolved_package.as_ref())
+        .and_then(|resolved| resolved.extra_data.as_ref())
+        .expect("cowboy resolved package extra_data");
+    assert_eq!(cowboy_extra.get("repo"), Some(&serde_json::json!("hexpm")));
+
+    // Neither legacy tuple carries an outer checksum (7th/8th element absent), so the key
+    // must not be present in extra_data.
+    for purl in ["pkg:hex/plug@1.5.0", "pkg:hex/cowboy@2.0.0"] {
+        let extra = package_data
+            .dependencies
+            .iter()
+            .find(|dep| dep.purl.as_deref() == Some(purl))
+            .and_then(|dep| dep.resolved_package.as_ref())
+            .and_then(|resolved| resolved.extra_data.as_ref())
+            .unwrap_or_else(|| panic!("{purl} resolved package extra_data"));
+        assert!(
+            !extra.contains_key("outer_checksum"),
+            "{purl} should not record an outer_checksum for a legacy short tuple"
+        );
+    }
+}

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -358,9 +358,17 @@ fn extract_project_dependencies(toml_content: &Value) -> Vec<Dependency> {
 fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
     let mut packages = Vec::new();
 
+    // Manifest.toml format 2.0 (Julia 1.7+) nests packages under a [deps] table; format
+    // 1.0 (Julia 1.0-1.6) lists them as root-level [[PackageName]] array-of-tables. Prefer
+    // the [deps] table when present, otherwise fall back to the root table. Non-package
+    // metadata keys (manifest_format, julia_version, project_hash, ...) are scalars, so the
+    // as_array() check below skips them.
     let deps_table = match toml_content.get(FIELD_DEPS).and_then(|v| v.as_table()) {
         Some(table) => table,
-        None => return packages,
+        None => match toml_content.as_table() {
+            Some(table) => table,
+            None => return packages,
+        },
     };
 
     for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {

--- a/src/parsers/julia_test.rs
+++ b/src/parsers/julia_test.rs
@@ -144,3 +144,60 @@ author = ["Tom Breloff (@tbreloff)"]
 
     fs::remove_dir_all(&temp_dir).expect("remove temp test dir");
 }
+
+// Manifest.toml format 1.0 (Julia 1.0-1.6) lists packages as root-level [[PackageName]]
+// array-of-tables rather than nesting them under a [deps] table (format 2.0, Julia 1.7+).
+#[test]
+fn test_manifest_toml_format_1_root_level_packages() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "provenant-julia-manifest-v1-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&temp_dir).expect("create temp test dir");
+
+    let test_file = temp_dir.join("Manifest.toml");
+    fs::write(
+        &test_file,
+        r#"# This file is machine-generated - editing it directly is not advised
+julia_version = "1.6.7"
+manifest_format = "1.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3609a8aaa8c3a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "Sockets"]
+git-tree-sha1 = "60ed5f1643927479f845b0135bb369b031b541fa"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.17"
+"#,
+    )
+    .expect("write temp Manifest.toml");
+
+    let packages = JuliaManifestTomlParser::extract_packages(&test_file);
+
+    assert_eq!(packages.len(), 2);
+    assert!(
+        packages
+            .iter()
+            .all(|p| p.datasource_id == Some(DatasourceId::JuliaManifestToml))
+    );
+    let json = packages
+        .iter()
+        .find(|p| p.name.as_deref() == Some("JSON"))
+        .expect("JSON package");
+    assert_eq!(json.version.as_deref(), Some("0.21.4"));
+    assert!(
+        packages
+            .iter()
+            .any(|p| p.name.as_deref() == Some("HTTP") && p.version.as_deref() == Some("0.9.17"))
+    );
+
+    fs::remove_dir_all(&temp_dir).expect("remove temp test dir");
+}

--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -188,10 +188,20 @@ fn parse_pixi_lock(lock_content: &JsonValue, primary_language: &str) -> PackageD
     }
     package.extra_data = (!extra_data.is_empty()).then_some(extra_data);
 
+    // pixi.lock formats 4 and 5 share the `kind`-tagged package layout; format 6 switched
+    // to `conda:`/`pypi:` discriminated entries. Unknown/newer versions evolve from the v6
+    // layout, so fall back to the v6 extractor rather than dropping all dependencies.
     match lock_version {
+        Some(4) | Some(5) => package.dependencies = extract_v4_lock_dependencies(lock_content),
         Some(6) => package.dependencies = extract_v6_lock_dependencies(lock_content),
-        Some(4) => package.dependencies = extract_v4_lock_dependencies(lock_content),
-        Some(_) | None => {}
+        Some(other) => {
+            warn!("Unrecognized pixi.lock version {other}; parsing with the v6 layout");
+            package.dependencies = extract_v6_lock_dependencies(lock_content);
+        }
+        None => {
+            warn!("pixi.lock is missing a version field; parsing with the v6 layout");
+            package.dependencies = extract_v6_lock_dependencies(lock_content);
+        }
     }
 
     package

--- a/src/parsers/pixi_test.rs
+++ b/src/parsers/pixi_test.rs
@@ -493,8 +493,86 @@ sha256 = "pypi-v4-hash"
         );
     }
 
+    // pixi.lock format 5 shares the `kind`-tagged package layout of format 4.
     #[test]
-    fn test_extract_from_pixi_lock_unsupported_version_returns_default_lock_package() {
+    fn test_extract_from_pixi_lock_v5() {
+        let content = r#"
+version = 5
+
+[environments.default]
+channels = [{ url = "https://conda.anaconda.org/conda-forge/" }]
+
+[environments.default.packages]
+win-64 = [
+  { conda = "https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda" },
+  { pypi = "./foo" },
+]
+
+[[packages]]
+kind = "conda"
+name = "python"
+version = "3.12.3"
+url = "https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda"
+sha256 = "conda-v5-hash"
+
+[[packages]]
+kind = "pypi"
+name = "foo"
+version = "0.1.0"
+path = "./foo"
+editable = true
+sha256 = "pypi-v5-hash"
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("pixi.lock", content);
+        let package_data = PixiLockParser::extract_first_package(&path);
+
+        assert_eq!(package_data.dependencies.len(), 2);
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:conda/python@3.12.3"))
+        );
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:pypi/foo@0.1.0"))
+        );
+    }
+
+    // An unrecognized/newer pixi.lock version must not silently drop everything; it falls
+    // back to the latest known (v6) layout.
+    #[test]
+    fn test_extract_from_pixi_lock_future_version_falls_back_to_v6() {
+        let content = r#"
+version = 99
+
+[environments.default]
+channels = [{ url = "https://conda.anaconda.org/conda-forge/" }]
+
+[environments.default.packages]
+linux-64 = [
+  { conda = "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-h2628c8c_0_cpython.conda" },
+]
+
+[[packages]]
+conda = "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-h2628c8c_0_cpython.conda"
+version = "3.12.7"
+sha256 = "conda-hash"
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("pixi.lock", content);
+        let package_data = PixiLockParser::extract_first_package(&path);
+
+        assert_eq!(package_data.package_type, Some(PackageType::Pixi));
+        assert_eq!(package_data.datasource_id, Some(DatasourceId::PixiLock));
+        assert_eq!(package_data.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_from_pixi_lock_missing_packages_returns_default_lock_package() {
         let content = r#"
 version = 99
 


### PR DESCRIPTION
Consolidates the previously-stacked PRs #950–#954 into a single merge to `main` (one CI run instead of six). The branch contains all twelve commits (six parser fixes + six benchmark entries), each already reviewed on its original PR with Greptile threads addressed.

## What's included (6 parser version-coverage fixes)

- **deno** (`deno.lock`): parse formats v1–v4, not just v5 (nested v2/v3 npm layout incl. object-shaped `dependencies`; direct-dep `extracted_requirement` from `npm.specifiers`).
- **pixi** (`pixi.lock`): parse format 5 (kind-style v4 layout), not just 4 and 6; warn on missing version.
- **julia** (`Manifest.toml`): parse legacy format 1.0 (root-level packages).
- **helm** (`Chart.yaml`): merge Helm 2 sibling `requirements.yaml`, gated on `apiVersion: v1`; warn instead of silently dropping an unreadable `requirements.yaml`.
- **conda** (`recipe.yaml`): recognize rattler-build recipes without `schema_version`; resolve `${{ var|lower }}`/`|upper` context templating.
- **hex** (`mix.lock`): parse legacy 6- and 7-element hex tuples (default `hexpm` repo, absent outer checksum).

## Benchmarks added (real-repo license-front compares vs ScanCode)

deno (catppuccin/gitea), Julia (JuliaAcademy/DataScience, v1.0 manifest), Helm (goharbor/harbor-helm), conda (UCBoulder/tardigrade_micromorphic_tools, rattler-build), hex (bitwalker/distillery, legacy tuples). Each documents broader package/dependency extraction with license-front parity or advantage; chart + headline stats regenerated.

## How to verify

CI covers build/clippy/fmt and the unit, golden, and integration suites. Beyond CI, each ecosystem fix has focused parser tests (`cargo test --lib parsers::<eco>`); the benchmark entries were produced via `compare-outputs --profile common` against the pinned SHAs listed in `docs/BENCHMARKS.md`.

Supersedes #950, #951, #952, #953, #954 (closed in favor of this consolidated merge). Out-of-scope PURL spec-compliance findings surfaced during this work are tracked in #971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)