### PR TITLE
fix(detection): scan Jupyter notebooks as decoded cell text

### DIFF
--- a/src/license_detection/golden_utils.rs
+++ b/src/license_detection/golden_utils.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 
 use crate::license_detection::{LicenseDetectionEngine, LicenseMatch};
 use crate::utils::file::{ExtractedTextKind, classify_file_info, extract_text_for_detection};
+use crate::utils::notebook::{extract_notebook_content, is_notebook};
 use crate::utils::sourcemap::{extract_sourcemap_content, is_sourcemap};
 use crate::utils::text::{
     remove_verbatim_escape_sequences, should_remove_verbatim_escape_sequences,
@@ -26,6 +27,11 @@ pub fn read_golden_input_content(test_file: &Path) -> Result<Option<(String, Ext
     if is_sourcemap(test_file) {
         Ok(Some((
             extract_sourcemap_content(&text).unwrap_or(text),
+            text_kind,
+        )))
+    } else if is_notebook(test_file) {
+        Ok(Some((
+            extract_notebook_content(&text).unwrap_or(text),
             text_kind,
         )))
     } else if should_remove_verbatim_escape_sequences(test_file, classification.is_source) {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -861,3 +861,87 @@ fn test_extract_copyright_information_ignores_pnpm_changelog_markdown_link_on_la
 
     assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
 }
+
+// A Jupyter notebook's code cell must not produce a copyright/holder false
+// positive from the JSON string-array punctuation around source lines.
+#[test]
+fn test_extract_copyright_information_ipynb_code_cell_no_false_positive() {
+    let notebook = r##"{
+      "cells": [
+        {"cell_type":"code","source":["@show typeof(C)\n","C[1:10,:]\n","# C.year #[!,:year]"],
+         "outputs":[]}
+      ],
+      "nbformat": 4
+    }"##;
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(
+        &mut builder,
+        Path::new("01. Data.ipynb"),
+        notebook,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("01. Data.ipynb".to_string())
+        .base_name("01. Data".to_string())
+        .extension(".ipynb".to_string())
+        .path("01. Data.ipynb".to_string())
+        .file_type(FileType::File)
+        .size(notebook.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(
+        file.copyrights.is_empty(),
+        "code cell should not yield a copyright: {:?}",
+        file.copyrights
+    );
+    assert!(
+        file.holders.is_empty(),
+        "code cell should not yield a holder: {:?}",
+        file.holders
+    );
+}
+
+// A genuine copyright notice that lives inside a notebook cell's output text must
+// be recovered (the raw JSON wrapping previously hid it from detection).
+#[test]
+fn test_extract_copyright_information_ipynb_detects_notice_in_output() {
+    let notebook = r#"{
+      "cells": [
+        {"cell_type":"code","source":"solve()",
+         "outputs":[{"output_type":"stream","name":"stdout",
+           "text":["\t(c) Brendan O'Donoghue, Stanford University, 2012\n"]}]}
+      ],
+      "nbformat": 4
+    }"#;
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(
+        &mut builder,
+        Path::new("09. Optimization.ipynb"),
+        notebook,
+        120.0,
+        false,
+    );
+
+    let file = builder
+        .name("09. Optimization.ipynb".to_string())
+        .base_name("09. Optimization".to_string())
+        .extension(".ipynb".to_string())
+        .path("09. Optimization.ipynb".to_string())
+        .file_type(FileType::File)
+        .size(notebook.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(
+        file.copyrights
+            .iter()
+            .any(|c| c.copyright.contains("Brendan O'Donoghue")),
+        "notice in output should be detected: {:?}",
+        file.copyrights
+    );
+}

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -366,7 +366,9 @@ fn prepare_license_detection_text(
     classification: &FileInfoClassification,
     text_content: String,
 ) -> String {
-    let text_content = if crate::utils::sourcemap::is_sourcemap(path) {
+    let text_content = if crate::utils::sourcemap::is_sourcemap(path)
+        || crate::utils::notebook::is_notebook(path)
+    {
         crate::utils::sourcemap::detection_text(path, &text_content).into_owned()
     } else if should_remove_verbatim_escape_sequences(path, classification.is_source) {
         remove_verbatim_escape_sequences(&text_content)
@@ -539,6 +541,7 @@ fn cap_non_source_json_license_text<'a>(
 ) -> Cow<'a, str> {
     if classification.is_source
         || crate::utils::sourcemap::is_sourcemap(path)
+        || crate::utils::notebook::is_notebook(path)
         || is_npm_lockfile(path)
         || !is_json_like_text(classification, path)
         || (has_line_rich_json_prefix(text) && !looks_like_generated_scan_result_json(text))

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod generated;
 pub mod hash;
 pub mod language;
 pub mod magic;
+pub mod notebook;
 pub mod path;
 pub mod sourcemap;
 pub mod spdx;

--- a/src/utils/notebook.rs
+++ b/src/utils/notebook.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Jupyter notebook (`.ipynb`) text extraction for scanner detection.
+//!
+//! A `.ipynb` file is a JSON document whose human-authored text (code, markdown)
+//! and program output live inside JSON string arrays. Scanning the raw JSON makes
+//! detection both miss real notices (e.g. a `(c) ...` line wrapped as
+//! `"\t(c) Foo, 2012\n",`) and emit false positives from JSON array punctuation
+//! around source lines. This module decodes the notebook into the plain cell text
+//! so license/copyright detection sees the same clean text a reader would.
+//!
+//! Like the source-map extractor, this trades exact line-number fidelity (offsets
+//! become relative to the extracted text) for correct detection content.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+/// Check whether a file is a Jupyter notebook based on its extension.
+pub fn is_notebook(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ipynb"))
+}
+
+/// Extract the human-readable text from a Jupyter notebook's cells.
+///
+/// Concatenates each cell's `source` (code and markdown) together with textual
+/// outputs (`stream` text and `text/plain` results). Non-text outputs such as
+/// `image/png` data are intentionally skipped to avoid scanning base64 noise.
+///
+/// Returns `Some(combined_text)` when the notebook parses and yields any text,
+/// otherwise `None` (the caller falls back to the raw content).
+pub fn extract_notebook_content(json_text: &str) -> Option<String> {
+    let json: Value = serde_json::from_str(json_text).ok()?;
+    let cells = json.get("cells")?.as_array()?;
+
+    let mut parts: Vec<String> = Vec::new();
+    for cell in cells {
+        if let Some(source) = cell.get("source").and_then(collect_text) {
+            parts.push(source);
+        }
+        if let Some(outputs) = cell.get("outputs").and_then(Value::as_array) {
+            for output in outputs {
+                // `stream` outputs (e.g. stdout) carry their text under `text`.
+                if let Some(text) = output.get("text").and_then(collect_text) {
+                    parts.push(text);
+                }
+                // `execute_result` / `display_data` carry a `text/plain` rendering.
+                if let Some(text) = output
+                    .get("data")
+                    .and_then(|data| data.get("text/plain"))
+                    .and_then(collect_text)
+                {
+                    parts.push(text);
+                }
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        // Separate cells with exactly one newline: trim each part's own trailing
+        // newlines first so a part that already ends with `\n` doesn't add a blank
+        // line, while a part that doesn't still stays on its own line.
+        Some(
+            parts
+                .iter()
+                .map(|part| part.trim_end_matches('\n'))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+}
+
+/// nbformat stores text either as a single string or as an array of line strings
+/// (each element already including its trailing newline). Reconstruct the original
+/// text by concatenating array elements verbatim.
+fn collect_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => (!s.is_empty()).then(|| s.clone()),
+        Value::Array(items) => {
+            let combined: String = items.iter().filter_map(Value::as_str).collect();
+            (!combined.is_empty()).then_some(combined)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_is_notebook() {
+        assert!(is_notebook(&PathBuf::from("Analysis.ipynb")));
+        assert!(is_notebook(&PathBuf::from("a/b/NOTEBOOK.IPYNB")));
+        assert!(!is_notebook(&PathBuf::from("script.py")));
+        assert!(!is_notebook(&PathBuf::from("data.json")));
+    }
+
+    #[test]
+    fn test_extract_source_array_and_stream_output() {
+        // `source` as a line array; a stream output carrying a copyright notice.
+        let json = r#"{
+          "cells": [
+            {"cell_type":"code","source":["@show typeof(C)\n","C[1:10,:]\n"],
+             "outputs":[{"output_type":"stream","name":"stdout",
+               "text":["\t(c) Brendan O'Donoghue, Stanford University, 2012\n"]}]}
+          ]
+        }"#;
+        let text = extract_notebook_content(json).expect("should extract");
+        // Cell source is reconstructed as clean code (no JSON punctuation).
+        assert!(text.contains("@show typeof(C)\nC[1:10,:]"));
+        // Output text is included so genuine notices are detectable.
+        assert!(text.contains("(c) Brendan O'Donoghue, Stanford University, 2012"));
+        // No JSON array punctuation leaks into the extracted text.
+        assert!(!text.contains("\", \""));
+    }
+
+    #[test]
+    fn test_extract_skips_binary_output_data() {
+        let json = r#"{
+          "cells": [
+            {"cell_type":"code","source":"print(1)",
+             "outputs":[{"output_type":"display_data",
+               "data":{"image/png":"iVBORw0KGgoAAAANSU","text/plain":"<Figure>"}}]}
+          ]
+        }"#;
+        let text = extract_notebook_content(json).expect("should extract");
+        assert!(text.contains("print(1)"));
+        assert!(text.contains("<Figure>"));
+        assert!(!text.contains("iVBORw0KGgoAAAANSU"));
+    }
+
+    #[test]
+    fn test_extract_source_string_form() {
+        let json = r##"{"cells":[{"cell_type":"markdown","source":"# Title\nSome prose"}]}"##;
+        let text = extract_notebook_content(json).expect("should extract");
+        assert_eq!(text, "# Title\nSome prose");
+    }
+
+    #[test]
+    fn test_extract_invalid_or_empty_returns_none() {
+        assert!(extract_notebook_content("not json").is_none());
+        assert!(extract_notebook_content(r#"{"nbformat":4}"#).is_none());
+        assert!(extract_notebook_content(r#"{"cells":[]}"#).is_none());
+    }
+
+    #[test]
+    fn test_extract_no_blank_line_between_parts() {
+        // A stream output whose lines each end with `\n`, followed by another cell.
+        let json = r#"{
+          "cells": [
+            {"cell_type":"code","source":"a()","outputs":[{"output_type":"stream","text":["one\n","two\n"]}]},
+            {"cell_type":"code","source":"b()"}
+          ]
+        }"#;
+        let text = extract_notebook_content(json).expect("should extract");
+        assert!(
+            !text.contains("\n\n"),
+            "no blank lines between parts: {text:?}"
+        );
+        assert!(text.contains("two\nb()"));
+    }
+}

--- a/src/utils/sourcemap.rs
+++ b/src/utils/sourcemap.rs
@@ -50,14 +50,24 @@ pub fn extract_sourcemap_content(json_text: &str) -> Option<String> {
 }
 
 /// Return the text scanners should inspect for this file.
+///
+/// Source maps and Jupyter notebooks embed the human-authored text inside a JSON
+/// wrapper; for those we hand scanners the extracted text instead of the raw JSON
+/// so detection sees what a reader would. All other files pass through unchanged.
 pub fn detection_text<'a>(path: &Path, text: &'a str) -> Cow<'a, str> {
-    if !is_sourcemap(path) {
-        return Cow::Borrowed(text);
+    if is_sourcemap(path) {
+        return extract_sourcemap_content(text)
+            .map(Cow::Owned)
+            .unwrap_or(Cow::Borrowed(text));
     }
 
-    extract_sourcemap_content(text)
-        .map(Cow::Owned)
-        .unwrap_or_else(|| Cow::Borrowed(text))
+    if crate::utils::notebook::is_notebook(path) {
+        return crate::utils::notebook::extract_notebook_content(text)
+            .map(Cow::Owned)
+            .unwrap_or(Cow::Borrowed(text));
+    }
+
+    Cow::Borrowed(text)
 }
 
 /// Replace verbatim escaped CR/LF characters with actual newlines.


### PR DESCRIPTION
## What

Jupyter notebooks (`.ipynb`) are JSON documents whose human-authored text (code, markdown) and program output live inside JSON string arrays. Scanning the raw JSON made copyright/license detection both **miss** real notices wrapped as escaped strings (e.g. `"\t(c) Foo, 2012\n",`) and emit **false positives** from the JSON array punctuation around source lines.

This adds a notebook extractor (`src/utils/notebook.rs`) that mirrors the existing source-map handling: it decodes a `.ipynb` into the plain cell text — each cell's `source` plus textual outputs (`stream` text and `text/plain` results), skipping binary outputs like `image/png` — and routes it through `detection_text`, so copyright **and** license detection see the same clean text a reader would. As with the source-map extractor, detection offsets become relative to the extracted text.

## Why / fixes #956

The two cases reported in #956 (from the `JuliaAcademy/DataScience` scan):
- **False positive** — `01. Data.ipynb`: a code cell (`C[1:10,:]` etc.) was misread as a copyright/holder from the surrounding JSON punctuation. Now yields nothing.
- **Missed notice** — `09. Numerical Optimization.ipynb`: a genuine `(c) Brendan O'Donoghue, Stanford University, 2012` inside cell output was hidden by the JSON wrapping. Now detected.

Confirmed against the real notebooks: notebook 01 produces no copyright; notebook 09's notice is recovered.

## Scope note

The recovered notice in notebook 09 still bleeds slightly (the holder over-extends past a `----` separator line into the next output line). That is a **pre-existing, general** copyright-refiner behavior — it reproduces identically on the same banner as a plain `.txt` file, with no notebook involved — so it is out of scope here and tracked separately in #973. This PR's job is to make `.ipynb` scan as clean text, which it does.

## How to verify

CI covers the unit/golden/integration suites. Beyond that:
- `cargo test --lib utils::notebook` and `cargo test --lib ipynb` cover extraction and the end-to-end copyright behavior (FP-gone + notice-detected).
- All changes are gated on `is_notebook(path)` (`.ipynb`); there are no `.ipynb` golden fixtures, so existing copyright/license goldens are unaffected.

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
