### PR TITLE
fix(copyright): stop copyright/holder bleeding across a ruler line

### DIFF
--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -138,6 +138,76 @@ pub fn detect_copyrights_from_text(
     detect_copyrights_from_text_with_deadline(content, None)
 }
 
+/// A ruler / separator line made entirely of repeated punctuation (`----`,
+/// `====`, `****`) with no alphanumeric content.
+fn is_ruler_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.chars().count() >= 3
+        && !trimmed.chars().any(|c| c.is_alphanumeric())
+        && trimmed
+            .chars()
+            .filter(|c| matches!(c, '-' | '=' | '_' | '*' | '~' | '#' | '+'))
+            .count()
+            >= 3
+}
+
+/// Whether a group's lines, detected on their own, yield a copyright that names
+/// a holder. Runs the full detector on the reconstructed raw text rather than a
+/// single extraction pass, so the verdict matches what the main loop produces (a
+/// holder-less year-only result — as a junk line gives — returns false).
+fn segment_yields_copyright_with_holder(segment: &[(usize, String)], raw_lines: &[&str]) -> bool {
+    let text = segment
+        .iter()
+        .filter_map(|(ln, _)| raw_lines.get(*ln - 1).copied())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.trim().is_empty() {
+        return false;
+    }
+    let (copyrights, holders, _) = detect_copyrights_from_text(&text);
+    !copyrights.is_empty() && !holders.is_empty()
+}
+
+/// Split a candidate group at ruler lines, but only where the lines before a
+/// ruler already form a copyright with a holder. This stops a complete notice
+/// from bleeding across a divider into the following line, while leaving a junk
+/// line (which yields only a bare year when isolated) merged with its neighbours.
+fn split_groups_at_rulers(
+    groups: Vec<Vec<(usize, String)>>,
+    raw_lines: &[&str],
+) -> Vec<Vec<(usize, String)>> {
+    // The grouping look-ahead blanks a ruler's text but keeps its entry, so
+    // match it by raw line number rather than the (empty) group text.
+    let is_ruler_at = |ln: usize| {
+        raw_lines
+            .get(ln - 1)
+            .is_some_and(|line| is_ruler_line(line))
+    };
+    let mut out: Vec<Vec<(usize, String)>> = Vec::with_capacity(groups.len());
+    for group in groups {
+        // Cut at every qualifying ruler, not just the first: a group may hold
+        // more than one copyright/divider pair. A ruler whose preceding segment
+        // is not a copyright-with-holder is left in place (the segment keeps
+        // scanning), so junk lines stay merged with their neighbours.
+        let mut segment_start = 0;
+        for i in 0..group.len() {
+            if i > segment_start
+                && is_ruler_at(group[i].0)
+                && segment_yields_copyright_with_holder(&group[segment_start..i], raw_lines)
+            {
+                out.push(group[segment_start..i].to_vec());
+                segment_start = i + 1;
+            }
+        }
+        if segment_start == 0 {
+            out.push(group);
+        } else if segment_start < group.len() {
+            out.push(group[segment_start..].to_vec());
+        }
+    }
+    out
+}
+
 pub fn detect_copyrights_from_text_with_deadline(
     content: &str,
     max_runtime: Option<Duration>,
@@ -172,6 +242,7 @@ pub fn detect_copyrights_from_text_with_deadline(
 
     let groups =
         collect_candidate_lines(raw_lines.iter().enumerate().map(|(i, line)| (i + 1, *line)));
+    let groups = split_groups_at_rulers(groups, &raw_lines);
 
     let mut seen = seen_text::SeenTextSets::from_existing(&copyrights, &holders, &authors);
 

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -337,3 +337,51 @@ fn test_drop_code_and_cc0_prose_false_positive_copyrights() {
         "copyrights: {copyrights:?}"
     );
 }
+
+// A copyright followed by a ruler line and unrelated text must not bleed across
+// the divider into that text (issue #973).
+#[test]
+fn test_copyright_does_not_bleed_across_ruler_line() {
+    let input = "\t(c) Brendan O'Donoghue, Stanford University, 2012\n----------------------------------\nLin-sys: sparse-indirect, nnz in A = 24\n";
+    let (copyrights, holders, _a) = detect_copyrights_from_text(input);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| c.copyright.as_str())
+            .collect::<Vec<_>>(),
+        vec!["(c) Brendan O'Donoghue, Stanford University, 2012"],
+        "copyright should stop at the ruler"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Brendan O'Donoghue, Stanford University"],
+        "holder should not absorb the line after the ruler"
+    );
+}
+
+// Two copyright/ruler pairs in one group: both notices stay clean, neither
+// bleeds across its divider (issue #973, multi-ruler case).
+#[test]
+fn test_copyright_does_not_bleed_across_multiple_rulers() {
+    let input = "\t(c) Alice Example, Example Inc, 2010\n----------------------------------\nnoise line one\n----------------------------------\n\t(c) Bob Sample, Sample Corp, 2020\n----------------------------------\nnoise line two\n";
+    let (copyrights, _h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "(c) Alice Example, Example Inc, 2010"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "(c) Bob Sample, Sample Corp, 2020"),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        copyrights.iter().all(|c| !c.copyright.contains("noise")),
+        "no copyright should absorb a post-ruler line: {copyrights:?}"
+    );
+}


### PR DESCRIPTION
## What

When a copyright candidate is followed by a ruler/separator line (`----`, `====`, etc.) and then unrelated text, the candidate-grouping look-ahead pulls the post-ruler line into the copyright block. A clean notice then bleeds into the following line. Reported in #973 from the `JuliaAcademy/DataScience` scan (PR #972), where a solver banner produced:

- copyright: `(c) Brendan O'Donoghue, Stanford University, 2012 ----…---- Lin-sys: sparse-indirect, nnz in A = 24`
- holder: `Brendan O'Donoghue, Stanford University, Lin-sys`

After this change both are clean (`(c) Brendan O'Donoghue, Stanford University, 2012` / `Brendan O'Donoghue, Stanford University`), matching ScanCode.

## How

`split_groups_at_rulers` splits a candidate group before a ruler line, **but only when the lines before it already parse to a copyright with a holder**. The gate is what keeps this safe: a noisy line that only yields a bare year-only copyright when isolated (no holder) is left merged with its neighbours, so it stays suppressed exactly as before. The ruler is detected by raw line number, since grouping blanks the divider's text but keeps its entry.

## Why this approach

Earlier attempts confirmed simpler fixes were wrong: terminating the group at the ruler unconditionally resurfaced a holder-less `(c) 1985` from a junk line in `misco4/more-linux/misc-linux.txt`, and a blanket year-only junk filter broke 16 fixtures (Provenant intentionally keeps bare `(c) <year>` notices, incl. an `assembly_year_only_copyrights` suite). The holder-gated split fixes the bleed with no fixture changes.

## How to verify

CI runs the full suites. Beyond that:
- `cargo test --test copyright_golden --features golden-tests` — **all 1880 fixtures pass, zero changes**.
- `cargo test --lib copyright::detector::tests_multiline_repairs` covers the new behavior (`test_copyright_does_not_bleed_across_ruler_line`).

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)