### PR TITLE
fix(purl): add central per-type PURL normalization layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ For parser work, Layer 3 scanner/assembly contract tests are the default expecta
 
 - Avoid `.unwrap()` in library code unless a panic is genuinely intended.
 - Do not use `#[allow(dead_code)]` or clippy suppressions as a shortcut. Suppressions should be rare, permanent, and justified in comments.
-- Use comments to explain non-obvious intent or tradeoffs, not to restate the code.
+- Use comments to explain non-obvious intent or tradeoffs, not to restate the code. Keep them sparse and short; do not add unnecessary or verbose comments, and never narrate what the code plainly already says.
 - Use `Path` and `PathBuf` for filesystem paths instead of string concatenation, and watch for `\n` vs `\r\n` sensitivity in tests.
 - When touching scanner concurrency or shared-state code, preserve thread safety and parallel-processing assumptions.
 

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1133,6 +1133,10 @@ impl Package {
         let Some(next_purl) = self.build_current_purl() else {
             return;
         };
+        // Canonicalize via the central per-type normalizer so the identity and
+        // its derived `package_uid` (the dedup key) are spec-compliant
+        // regardless of which parser produced the PURL.
+        let next_purl = crate::models::normalize_purl(&next_purl);
 
         if self.purl.as_deref() != Some(next_purl.as_str()) || self.package_uid.is_empty() {
             self.package_uid = PackageUid::new(&next_purl);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -12,6 +12,7 @@ mod match_score;
 mod output;
 mod package_type;
 mod package_uid;
+mod purl;
 
 pub use datasource_id::DatasourceId;
 pub use dependency_uid::DependencyUid;
@@ -29,6 +30,7 @@ pub use line_number::LineNumber;
 pub use match_score::MatchScore;
 pub use package_type::PackageType;
 pub use package_uid::PackageUid;
+pub use purl::normalize_purl;
 
 pub use output::{
     ExtraData, FacetTallies, HEADER_NOTICE, Header, LicenseClarityScore, LicenseIndexProvenance,

--- a/src/models/purl.rs
+++ b/src/models/purl.rs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Central, per-type Package-URL (PURL) normalization.
+//!
+//! The `packageurl` crate percent-encodes components and lowercases a few
+//! hard-coded names, but does not apply the full per-type case/canonicalization
+//! rules from the [purl-spec](https://github.com/package-url/purl-spec), and
+//! never touches the namespace. Without a central layer each parser would have
+//! to reimplement these rules, so the same package could get different PURLs
+//! from different datasources (e.g. `typing_extensions` vs `typing-extensions`),
+//! breaking dedup and registry/vuln-database lookups.
+//!
+//! Every emitted PURL passes through [`normalize_purl`]: in-memory before a
+//! [`crate::models::Package`] derives its `package_uid` (the dedup key), and at
+//! the `src/output_schema` boundary for package, package-data, dependency, and
+//! resolved-package PURLs.
+//!
+//! This layer covers the case/name-canonicalization rules. Structural per-type
+//! fixes that need parser knowledge (type remapping, moving a value between
+//! namespace/qualifier/subpath, synthesizing a required qualifier) stay with the
+//! owning parser. Unlisted types are returned unchanged, preserving the
+//! case-sensitive types (npm, maven, cargo, gem, …).
+
+use std::str::FromStr;
+
+use packageurl::PackageUrl;
+
+/// Normalize a PURL string according to its type's spec rules.
+///
+/// Per-type case/canonicalization rules are applied to the namespace and name;
+/// version, qualifiers, and subpath are preserved. Unparsable input and types
+/// with no rule are returned unchanged, so already-canonical PURLs never churn.
+pub fn normalize_purl(purl: &str) -> String {
+    let Ok(parsed) = PackageUrl::from_str(purl) else {
+        return purl.to_string();
+    };
+
+    let (new_namespace, new_name): (Option<String>, String) = match parsed.ty() {
+        // PEP 503: lowercase, then collapse runs of `-_.` to a single `-` (the
+        // crate only handles `_`). Namespace is prohibited for pypi.
+        "pypi" => (None, normalize_pypi_name(parsed.name())),
+
+        // Lowercase namespace + name. The crate lowercases some of these names
+        // but never the namespace.
+        "composer" | "hex" | "github" | "gitlab" | "bitbucket" => (
+            parsed.namespace().map(str::to_ascii_lowercase),
+            parsed.name().to_ascii_lowercase(),
+        ),
+
+        // golang's spec is self-contradictory and acknowledged-broken; the
+        // decided direction (purl-spec#308) is to lowercase only the host
+        // segment and preserve path-part case (e.g. keep `github.com/Azure/…`).
+        // The crate force-lowercases the whole golang namespace at parse time,
+        // so `parsed` has already lost the case — edit the raw string instead.
+        "golang" => return lowercase_first_path_segment(purl, "pkg:golang/"),
+
+        _ => return purl.to_string(),
+    };
+
+    rebuild(purl, &parsed, new_namespace, new_name)
+}
+
+/// Re-emit `parsed` with a replaced namespace/name, preserving the rest.
+///
+/// Falls back to the original string if the rebuilt PURL cannot be constructed.
+fn rebuild(
+    original: &str,
+    parsed: &PackageUrl<'_>,
+    namespace: Option<String>,
+    name: String,
+) -> String {
+    let Ok(mut rebuilt) = PackageUrl::new(parsed.ty().to_string(), name) else {
+        return original.to_string();
+    };
+
+    if let Some(namespace) = namespace.filter(|value| !value.is_empty())
+        && rebuilt.with_namespace(namespace).is_err()
+    {
+        return original.to_string();
+    }
+
+    if let Some(version) = parsed.version()
+        && rebuilt.with_version(version.to_string()).is_err()
+    {
+        return original.to_string();
+    }
+
+    for (key, value) in parsed.qualifiers() {
+        if rebuilt
+            .add_qualifier(key.to_string(), value.to_string())
+            .is_err()
+        {
+            return original.to_string();
+        }
+    }
+
+    if let Some(subpath) = parsed.subpath()
+        && rebuilt.with_subpath(subpath.to_string()).is_err()
+    {
+        return original.to_string();
+    }
+
+    rebuilt.to_string()
+}
+
+/// Apply the PEP 503 normalized distribution name rule: lowercase, then collapse
+/// every run of `-`, `_`, or `.` into a single `-`.
+fn normalize_pypi_name(name: &str) -> String {
+    let lower = name.to_ascii_lowercase();
+    let mut normalized = String::with_capacity(lower.len());
+    let mut last_was_separator = false;
+
+    for ch in lower.chars() {
+        if matches!(ch, '-' | '_' | '.') {
+            if !last_was_separator {
+                normalized.push('-');
+                last_was_separator = true;
+            }
+        } else {
+            normalized.push(ch);
+            last_was_separator = false;
+        }
+    }
+
+    normalized
+}
+
+/// Lowercase the first path segment that follows `prefix` in a PURL string,
+/// stopping at the next path separator or component delimiter (`/ @ ? #`).
+///
+/// Used for golang's host-only lowercasing: it edits the raw string so the
+/// remaining path parts, version, qualifiers, and subpath survive untouched.
+/// Returns the input unchanged if it does not start with `prefix`.
+fn lowercase_first_path_segment(purl: &str, prefix: &str) -> String {
+    let Some(rest) = purl.strip_prefix(prefix) else {
+        return purl.to_string();
+    };
+    let end = rest.find(['/', '@', '?', '#']).unwrap_or(rest.len());
+    format!(
+        "{prefix}{}{}",
+        rest[..end].to_ascii_lowercase(),
+        &rest[end..]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spec-rule matrix: representative PURL per type asserted against the
+    /// canonical form. Guards every parser against drift.
+    #[test]
+    fn normalize_purl_matrix() {
+        let cases = [
+            // pypi: full PEP 503 (lowercase + collapse `-_.` runs).
+            (
+                "pkg:pypi/typing_extensions@4.0.0",
+                "pkg:pypi/typing-extensions@4.0.0",
+            ),
+            ("pkg:pypi/Django@4.2", "pkg:pypi/django@4.2"),
+            ("pkg:pypi/zope.interface@5.0", "pkg:pypi/zope-interface@5.0"),
+            ("pkg:pypi/foo__bar@1.0", "pkg:pypi/foo-bar@1.0"),
+            // composer: lowercase vendor namespace + name.
+            (
+                "pkg:composer/Monolog/Monolog@2.0",
+                "pkg:composer/monolog/monolog@2.0",
+            ),
+            // hex: lowercase namespace + name.
+            ("pkg:hex/Phoenix@1.7.0", "pkg:hex/phoenix@1.7.0"),
+            // github / gitlab / bitbucket: lowercase namespace + name.
+            (
+                "pkg:github/Package-Url/purl-Spec@1.0",
+                "pkg:github/package-url/purl-spec@1.0",
+            ),
+            ("pkg:gitlab/FooBar/Baz@2.0", "pkg:gitlab/foobar/baz@2.0"),
+            (
+                "pkg:bitbucket/Birkenfeld/Pygments@2.0",
+                "pkg:bitbucket/birkenfeld/pygments@2.0",
+            ),
+            // golang: lowercase host only, preserve path-part case.
+            (
+                "pkg:golang/github.com/Azure/azure-sdk-for-go@1.0",
+                "pkg:golang/github.com/Azure/azure-sdk-for-go@1.0",
+            ),
+            (
+                "pkg:golang/GitHub.com/Azure/azure-sdk-for-go@1.0",
+                "pkg:golang/github.com/Azure/azure-sdk-for-go@1.0",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(normalize_purl(input), expected, "input: {input}");
+        }
+    }
+
+    /// Case-sensitive and custom types must be returned byte-for-byte unchanged.
+    #[test]
+    fn normalize_purl_preserves_case_sensitive_types() {
+        let untouched = [
+            // npm grandfathers mixed-case names.
+            "pkg:npm/%40angular/Core@13.0.0",
+            "pkg:maven/com.Example/MyLib@1.0",
+            "pkg:cargo/Serde@1.0",
+            "pkg:gem/RSpec@3.0",
+            // Unknown / custom type with no registered spec.
+            "pkg:bower/SomeLib@1.0",
+        ];
+
+        for purl in untouched {
+            assert_eq!(normalize_purl(purl), purl, "input: {purl}");
+        }
+    }
+
+    #[test]
+    fn normalize_purl_is_idempotent() {
+        let inputs = [
+            "pkg:pypi/typing_extensions@4.0.0",
+            "pkg:composer/Monolog/Monolog@2.0",
+            "pkg:golang/GitHub.com/Azure/azure-sdk-for-go@1.0",
+            "pkg:github/Foo/Bar",
+        ];
+
+        for input in inputs {
+            let once = normalize_purl(input);
+            let twice = normalize_purl(&once);
+            assert_eq!(once, twice, "not idempotent for {input}");
+        }
+    }
+
+    #[test]
+    fn normalize_purl_preserves_qualifiers_and_subpath() {
+        // pypi name changes, but qualifiers and subpath survive the round-trip.
+        assert_eq!(
+            normalize_purl("pkg:pypi/typing_extensions@4.0?arch=any#sub/path"),
+            "pkg:pypi/typing-extensions@4.0?arch=any#sub/path",
+        );
+    }
+
+    #[test]
+    fn normalize_purl_returns_unparsable_input_unchanged() {
+        assert_eq!(normalize_purl("not-a-purl"), "not-a-purl");
+        assert_eq!(normalize_purl(""), "");
+    }
+
+    #[test]
+    fn normalize_purl_handles_pypi_without_version() {
+        assert_eq!(
+            normalize_purl("pkg:pypi/typing_extensions"),
+            "pkg:pypi/typing-extensions",
+        );
+    }
+
+    /// A golang PURL with no namespace (single-segment module path): the whole
+    /// `rest` slice is lowercased, which is the correct host-only rule when the
+    /// module name itself is the host (e.g. the standard library placeholder).
+    #[test]
+    fn normalize_purl_golang_no_namespace() {
+        assert_eq!(
+            normalize_purl("pkg:golang/Std@go1.21"),
+            "pkg:golang/std@go1.21",
+        );
+        // Already lowercase — unchanged.
+        assert_eq!(
+            normalize_purl("pkg:golang/std@go1.21"),
+            "pkg:golang/std@go1.21",
+        );
+    }
+
+    /// Qualifiers and subpath on a golang PURL must survive the raw-string edit.
+    #[test]
+    fn normalize_purl_golang_preserves_qualifiers_and_subpath() {
+        assert_eq!(
+            normalize_purl(
+                "pkg:golang/GITHUB.COM/Azure/pkg@1.0?vcs_url=https://github.com/Azure/pkg#sub/path"
+            ),
+            "pkg:golang/github.com/Azure/pkg@1.0?vcs_url=https://github.com/Azure/pkg#sub/path",
+        );
+    }
+
+    /// A golang PURL whose type prefix is not all-lowercase is returned unchanged
+    /// because `lowercase_first_path_segment` relies on the crate serializer
+    /// always emitting a lowercase type; all PURL-generating paths in this code
+    /// base go through that serializer so this edge is never triggered in practice.
+    #[test]
+    fn normalize_purl_golang_mixed_case_type_unchanged() {
+        // The crate's serializer always lowercases the type, so "pkg:Golang/"
+        // never appears in practice. The function documents this no-op contract.
+        assert_eq!(
+            normalize_purl("pkg:Golang/GITHUB.COM/Azure/pkg@1.0"),
+            "pkg:Golang/GITHUB.COM/Azure/pkg@1.0",
+        );
+    }
+}

--- a/src/output_schema/dependency.rs
+++ b/src/output_schema/dependency.rs
@@ -24,7 +24,7 @@ pub struct OutputDependency {
 impl From<&crate::models::Dependency> for OutputDependency {
     fn from(value: &crate::models::Dependency) -> Self {
         Self {
-            purl: value.purl.clone(),
+            purl: value.purl.as_deref().map(crate::models::normalize_purl),
             extracted_requirement: value.extracted_requirement.clone(),
             scope: value.scope.clone(),
             is_runtime: value.is_runtime,

--- a/src/output_schema/package.rs
+++ b/src/output_schema/package.rs
@@ -115,7 +115,7 @@ impl From<&crate::models::Package> for OutputPackage {
             repository_homepage_url: value.repository_homepage_url.clone(),
             repository_download_url: value.repository_download_url.clone(),
             api_data_url: value.api_data_url.clone(),
-            purl: value.purl.clone(),
+            purl: value.purl.as_deref().map(crate::models::normalize_purl),
             package_uid: value.package_uid.to_string(),
             datafile_paths: value.datafile_paths.clone(),
             datasource_ids: value

--- a/src/output_schema/package_data.rs
+++ b/src/output_schema/package_data.rs
@@ -130,7 +130,7 @@ impl From<&crate::models::PackageData> for OutputPackageData {
             repository_download_url: value.repository_download_url.clone(),
             api_data_url: value.api_data_url.clone(),
             datasource_id: value.datasource_id.map(OutputDatasourceId::from),
-            purl: value.purl.clone(),
+            purl: value.purl.as_deref().map(crate::models::normalize_purl),
         }
     }
 }

--- a/src/output_schema/resolved_package.rs
+++ b/src/output_schema/resolved_package.rs
@@ -130,7 +130,7 @@ impl From<&crate::models::ResolvedPackage> for OutputResolvedPackage {
             repository_download_url: value.repository_download_url.clone(),
             api_data_url: value.api_data_url.clone(),
             datasource_id: value.datasource_id.map(OutputDatasourceId::from),
-            purl: value.purl.clone(),
+            purl: value.purl.as_deref().map(crate::models::normalize_purl),
         }
     }
 }

--- a/src/output_schema/top_level_dependency.rs
+++ b/src/output_schema/top_level_dependency.rs
@@ -30,7 +30,7 @@ pub struct OutputTopLevelDependency {
 impl From<&crate::models::TopLevelDependency> for OutputTopLevelDependency {
     fn from(value: &crate::models::TopLevelDependency) -> Self {
         Self {
-            purl: value.purl.clone(),
+            purl: value.purl.as_deref().map(crate::models::normalize_purl),
             extracted_requirement: value.extracted_requirement.clone(),
             scope: value.scope.clone(),
             is_runtime: value.is_runtime,

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -488,16 +488,6 @@ pub(crate) fn create_golang_purl(module_path: &str, version: Option<&str>) -> Op
         }
     };
 
-    if let Some(ns) = &namespace
-        && let Err(e) = purl.with_namespace(ns)
-    {
-        warn!(
-            "Failed to set namespace '{}' for golang module '{}': {}",
-            ns, module_path, e
-        );
-        return None;
-    }
-
     if let Some(v) = version
         && let Err(e) = purl.with_version(v)
     {
@@ -508,7 +498,16 @@ pub(crate) fn create_golang_purl(module_path: &str, version: Option<&str>) -> Op
         return None;
     }
 
-    Some(purl.to_string())
+    // Splice the namespace in manually instead of via `with_namespace`, which
+    // force-lowercases the whole golang namespace; `normalize_purl` then applies
+    // the host-only lowercasing the spec direction (purl-spec#308) calls for.
+    let built = purl.to_string();
+    let built = match &namespace {
+        Some(ns) => built.replacen("pkg:golang/", &format!("pkg:golang/{ns}/"), 1),
+        None => built,
+    };
+
+    Some(crate::models::normalize_purl(&built))
 }
 
 /// Returns a default empty PackageData for Go modules.

--- a/testdata/go-golden/godeps-comments/Godeps.json.expected.json
+++ b/testdata/go-golden/godeps-comments/Godeps.json.expected.json
@@ -51,7 +51,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:golang/github.com/sirupsen/logrus",
+        "purl": "pkg:golang/github.com/Sirupsen/logrus",
         "extracted_requirement": "5568a01db73b24230945a9ccd6813fac482e226f",
         "scope": "Deps",
         "is_runtime": true,

--- a/testdata/python/golden/poetry_lock/poetry.lock-expected.json
+++ b/testdata/python/golden/poetry_lock/poetry.lock-expected.json
@@ -98,7 +98,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/coverage%5btoml%5d",
+              "purl": "pkg:pypi/coverage%5Btoml%5D",
               "extracted_requirement": ">=5.0.2",
               "scope": "dev",
               "is_runtime": null,
@@ -219,7 +219,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/zope.interface",
+              "purl": "pkg:pypi/zope-interface",
               "extracted_requirement": null,
               "scope": "dev",
               "is_runtime": null,
@@ -263,7 +263,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/zope.interface",
+              "purl": "pkg:pypi/zope-interface",
               "extracted_requirement": null,
               "scope": "docs",
               "is_runtime": null,
@@ -285,7 +285,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/coverage%5btoml%5d",
+              "purl": "pkg:pypi/coverage%5Btoml%5D",
               "extracted_requirement": ">=5.0.2",
               "scope": "tests",
               "is_runtime": null,
@@ -362,7 +362,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/zope.interface",
+              "purl": "pkg:pypi/zope-interface",
               "extracted_requirement": null,
               "scope": "tests",
               "is_runtime": null,
@@ -384,7 +384,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/coverage%5btoml%5d",
+              "purl": "pkg:pypi/coverage%5Btoml%5D",
               "extracted_requirement": ">=5.0.2",
               "scope": "tests-no-zope",
               "is_runtime": null,
@@ -764,7 +764,7 @@
               "extra_data": null
             },
             {
-              "purl": "pkg:pypi/zest.releaser%5brecommended%5d",
+              "purl": "pkg:pypi/zest-releaser%5Brecommended%5D",
               "extracted_requirement": null,
               "scope": "dev",
               "is_runtime": null,


### PR DESCRIPTION
## Summary

- There was no central per-type PURL normalization in Provenant. The `packageurl` crate percent-encodes components and lowercases a few hard-coded **names**, but it never normalizes the namespace and skips most per-type spec rules — so the same package could get different PURLs from different datasources (e.g. `typing_extensions` vs `typing-extensions`), breaking dedup and registry/vuln-database lookups.
- Adds `models::purl::normalize_purl`, a single layer keyed on PURL type that applies each type's spec case/name rules at the point identities are finalized, so individual parsers can't drift.
- Wired in at two points: `Package::refresh_identity` (before deriving `package_uid`, so dedup keys are canonical) and the `output_schema` domain→output conversions (package, package-data, dependency, resolved-package), so every emitted PURL is canonical regardless of source parser.

Case-fix coverage:

- **pypi** — full PEP 503 (lowercase + collapse `-_.` runs); the crate only handled `_`, so lockfile parsers emitted `typing_extensions` / `zope.interface`.
- **composer / hex / github / gitlab / bitbucket** — lowercase namespace + name.
- **golang** — lowercase only the host segment, preserving path-part case (e.g. keep `github.com/Azure/…`), the documented purl-spec#308 deviation. `create_golang_purl` now splices the namespace manually instead of via the crate's `with_namespace`, which force-lowercases the whole golang namespace before the normalizer could see it.

Case-sensitive and custom types (npm, maven, cargo, gem, …) are returned byte-for-byte unchanged, so already-canonical PURLs never churn. A spec-rule test matrix asserts representative PURLs per type.

## Issues

- Covers: #971 (umbrella normalization layer; the pypi-lockfile, golang, github/gitlab, composer, and hex case-fix findings)

## Scope and exclusions

- Included: central normalization layer + spec test matrix; the case/name-canonicalization findings from #971; golang construction fix in `go.rs`.
- Explicit exclusions: structural per-type fixes that need parser-level restructuring rather than central normalization — dart→`pub`, alpine→`apk`, conda channel placement, julia `uuid`, cpan name/namespace, cocoapods subspec→subpath, deb/rpm `epoch`. These remain tracked in #971. Component fields (`namespace`/`name`) are not yet re-normalized to match the canonical PURL string; out of scope here.

## How to verify

- The change is fully covered by the spec-rule matrix in `src/models/purl.rs` and the existing golden suites; CI is the source of truth.
- Beyond CI, to see the layer end-to-end: scan a Go project whose module path has a mixed-case owner and confirm the host lowercases while the path keeps its case, e.g. `cargo run -- scan testdata/go-golden/godeps-comments --package --json-pp -` and look for `pkg:golang/github.com/Sirupsen/logrus` (host `github.com` lower, `Sirupsen` preserved).

## Follow-up work

- Created or intentionally deferred: the structural per-type findings listed under exclusions stay tracked in #971; the hex "non-`hexpm` repo: namespace vs `repository_url` qualifier" review question is unaddressed.

## Expected-output fixture changes

- Files changed: `testdata/go-golden/godeps-comments/Godeps.json.expected.json`, `testdata/python/golden/poetry_lock/poetry.lock-expected.json`.
- Why the new expected output is correct: golang now preserves path-part case (`pkg:golang/github.com/Sirupsen/logrus`) per the purl-spec#308 direction; pypi names get the full PEP 503 collapse (`zope.interface`→`zope-interface`) and canonical RFC-3986 uppercase percent-encoding (`%5b`→`%5B`) now that the names round-trip through the normalizer. Edited by hand rather than via `update-parser-golden`, which emits the internal/domain schema instead of the public output schema these goldens use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
