### PR TITLE
feat(docker): emit base-image PURLs from Dockerfile FROM directives

### DIFF
--- a/src/parsers/docker.rs
+++ b/src/parsers/docker.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use packageurl::PackageUrl;
 use serde_json::json;
 
-use crate::models::{DatasourceId, PackageData, PackageType};
+use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
 
 use super::PackageParser;
@@ -83,6 +85,8 @@ pub(crate) fn parse_dockerfile(content: &str) -> PackageData {
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         normalize_spdx_declared_license(extracted_license_statement.as_deref());
 
+    let dependencies = extract_base_image_dependencies(content);
+
     PackageData {
         package_type: Some(PACKAGE_TYPE),
         primary_language: Some("Dockerfile".to_string()),
@@ -107,7 +111,171 @@ pub(crate) fn parse_dockerfile(content: &str) -> PackageData {
         license_detections,
         extracted_license_statement: extracted_license_statement.map(truncate_field),
         extra_data,
+        dependencies,
         ..Default::default()
+    }
+}
+
+/// Parses `FROM` directives and emits each external base image as a `pkg:docker`
+/// dependency. Internal multi-stage references, `scratch`, and `ARG`-templated
+/// images are intentionally skipped.
+fn extract_base_image_dependencies(content: &str) -> Vec<Dependency> {
+    let mut stage_names: HashSet<String> = HashSet::new();
+    let mut dependencies = Vec::new();
+    let mut seen_purls: HashSet<String> = HashSet::new();
+
+    for instruction in logical_lines(content) {
+        let trimmed = instruction.trim_start();
+        if !starts_with_instruction(trimmed, "FROM") {
+            continue;
+        }
+
+        let Some((image, stage)) = parse_from_arguments(&trimmed[4..]) else {
+            continue;
+        };
+
+        // Skip references to an earlier build stage rather than an external image.
+        // The containment check must run before inserting the current alias so that
+        // `FROM image AS image` (alias equals the untagged image name) is not
+        // misclassified as an internal stage reference.
+        let is_internal = stage_names.contains(&image.to_ascii_lowercase());
+        if let Some(stage) = stage {
+            stage_names.insert(stage.to_ascii_lowercase());
+        }
+        if is_internal {
+            continue;
+        }
+
+        // `scratch` is the empty base, not a pullable image.
+        if image.eq_ignore_ascii_case("scratch") {
+            continue;
+        }
+
+        // Honest unknown: an unresolved build-arg template (`${BASE}` / `$BASE`).
+        if image.contains('$') {
+            continue;
+        }
+
+        let Some(purl) = build_docker_purl(image) else {
+            continue;
+        };
+
+        if seen_purls.insert(purl.clone()) {
+            // Only a `@sha256:…` digest is an immutable pin; a tag (or no tag)
+            // is mutable, so it is not considered pinned.
+            let is_pinned = image.contains('@');
+            dependencies.push(Dependency {
+                purl: Some(truncate_field(purl)),
+                extracted_requirement: None,
+                scope: None,
+                is_runtime: None,
+                is_optional: None,
+                is_pinned: Some(is_pinned),
+                is_direct: Some(true),
+                resolved_package: None,
+                extra_data: None,
+            });
+        }
+    }
+
+    dependencies
+}
+
+/// Extracts the image reference and optional `AS <stage>` name from a `FROM`
+/// directive body. Returns `None` when no image token is present. Leading
+/// `--platform=...` flags are ignored.
+fn parse_from_arguments(rest: &str) -> Option<(&str, Option<&str>)> {
+    let mut tokens = rest.split_whitespace().filter(|token| {
+        // Drop build flags such as `--platform=linux/amd64`.
+        !token.starts_with("--")
+    });
+
+    let image = tokens.next()?;
+
+    let mut stage = None;
+    if tokens
+        .next()
+        .is_some_and(|token| token.eq_ignore_ascii_case("AS"))
+    {
+        stage = tokens.next();
+    }
+
+    Some((image, stage))
+}
+
+/// Builds a `pkg:docker` PURL from a Docker image reference of the form
+/// `[registry/]repository[:tag|@digest]`. The registry, when present, is
+/// emitted as a `repository_url` qualifier; otherwise it is omitted.
+fn build_docker_purl(image: &str) -> Option<String> {
+    let (path, version) = split_image_version(image);
+    if path.is_empty() {
+        return None;
+    }
+
+    let (registry, repository) = split_registry(path);
+    let (namespace, name) = split_repository(repository)?;
+
+    let mut purl = PackageUrl::new("docker", name).ok()?;
+
+    if let Some(namespace) = namespace {
+        purl.with_namespace(namespace).ok()?;
+    }
+
+    if let Some(version) = version {
+        purl.with_version(version).ok()?;
+    }
+
+    if let Some(registry) = registry {
+        purl.add_qualifier("repository_url", registry).ok()?;
+    }
+
+    Some(purl.to_string())
+}
+
+/// Splits an image reference into its `[registry/]repository` path and the
+/// optional tag-or-digest version. A `@` digest takes precedence; otherwise a
+/// `:` after the final path segment is treated as a tag.
+fn split_image_version(image: &str) -> (&str, Option<&str>) {
+    if let Some((path, digest)) = image.split_once('@') {
+        return (path, (!digest.is_empty()).then_some(digest));
+    }
+
+    // A colon only marks a tag when it appears in the final path segment;
+    // a colon in an earlier segment denotes a registry port.
+    if let Some(colon) = image.rfind(':')
+        && !image[colon + 1..].contains('/')
+    {
+        let tag = &image[colon + 1..];
+        return (&image[..colon], (!tag.is_empty()).then_some(tag));
+    }
+
+    (image, None)
+}
+
+/// Separates a leading registry host from the repository path. The first
+/// segment is a registry when it contains a `.` or `:` (port) or equals
+/// `localhost`, matching Docker reference resolution.
+fn split_registry(path: &str) -> (Option<&str>, &str) {
+    if let Some((first, rest)) = path.split_once('/')
+        && (first.contains('.') || first.contains(':') || first == "localhost")
+    {
+        return (Some(first), rest);
+    }
+
+    (None, path)
+}
+
+/// Splits a repository path into an optional namespace and a name. The final
+/// path segment is the name; any preceding segments form the namespace.
+fn split_repository(repository: &str) -> Option<(Option<&str>, &str)> {
+    if repository.is_empty() {
+        return None;
+    }
+
+    match repository.rsplit_once('/') {
+        Some((namespace, name)) if !name.is_empty() => Some((Some(namespace), name)),
+        Some(_) => None,
+        None => Some((None, repository)),
     }
 }
 

--- a/src/parsers/docker_scan_test.rs
+++ b/src/parsers/docker_scan_test.rs
@@ -12,8 +12,8 @@ mod tests {
     fn test_containerfile_scan_keeps_package_data_unassembled() {
         let (files, result) = scan_and_assemble(Path::new("testdata/docker-golden/pulp"));
 
+        // The image being built has no PURL, so it is never hoisted to a top-level package.
         assert!(result.packages.is_empty());
-        assert!(result.dependencies.is_empty());
 
         let containerfile = files
             .iter()
@@ -27,5 +27,16 @@ mod tests {
         assert_eq!(package.package_type, Some(PackageType::Docker));
         assert_eq!(package.datasource_id, Some(DatasourceId::Dockerfile));
         assert_eq!(package.name.as_deref(), Some("Pulp OCI image"));
+
+        // The `FROM` base image is hoisted to a top-level dependency even though
+        // the Dockerfile datasource itself stays unassembled.
+        assert_eq!(result.dependencies.len(), 1);
+        let dependency = &result.dependencies[0];
+        assert_eq!(
+            dependency.purl.as_deref(),
+            Some("pkg:docker/pulp/pulp-base@latest?repository_url=quay.io")
+        );
+        assert_eq!(dependency.datasource_id, DatasourceId::Dockerfile);
+        assert!(dependency.datafile_path.ends_with("Containerfile"));
     }
 }

--- a/src/parsers/docker_test.rs
+++ b/src/parsers/docker_test.rs
@@ -142,4 +142,152 @@ LABEL org.opencontainers.image.title="Jitsi Broadcasting Infrastructure (jibri)"
         assert_eq!(package.datasource_id, Some(DatasourceId::Dockerfile));
         assert!(package.extra_data.is_none());
     }
+
+    fn purls(content: &str) -> Vec<String> {
+        parse_dockerfile(content)
+            .dependencies
+            .iter()
+            .filter_map(|dep| dep.purl.clone())
+            .collect()
+    }
+
+    #[test]
+    fn test_from_tag_emits_docker_purl() {
+        assert_eq!(
+            purls("FROM python:3.12-slim\n"),
+            vec!["pkg:docker/python@3.12-slim".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_registry_namespace_and_digest() {
+        assert_eq!(
+            purls("FROM ghcr.io/org/img@sha256:abc123\n"),
+            vec!["pkg:docker/org/img@sha256:abc123?repository_url=ghcr.io".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_registry_with_tag() {
+        assert_eq!(
+            purls("FROM quay.io/pulp/pulp-base:latest\n"),
+            vec!["pkg:docker/pulp/pulp-base@latest?repository_url=quay.io".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_docker_io_library_namespace() {
+        assert_eq!(
+            purls("FROM docker.io/library/debian:bookworm-slim\n"),
+            vec!["pkg:docker/library/debian@bookworm-slim?repository_url=docker.io".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_registry_with_port() {
+        assert_eq!(
+            purls("FROM registry.local:5000/team/app:1.0\n"),
+            vec!["pkg:docker/team/app@1.0?repository_url=registry.local:5000".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_without_tag_has_no_version() {
+        assert_eq!(
+            purls("FROM ubuntu\n"),
+            vec!["pkg:docker/ubuntu".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_is_pinned_only_for_digest_refs() {
+        // A `@sha256:…` digest is an immutable pin.
+        let digest = parse_dockerfile("FROM ghcr.io/org/img@sha256:abc123\n");
+        assert_eq!(digest.dependencies[0].is_pinned, Some(true));
+        // A tag is mutable, so not pinned.
+        let tag = parse_dockerfile("FROM python:3.12-slim\n");
+        assert_eq!(tag.dependencies[0].is_pinned, Some(false));
+        // No tag is also not pinned.
+        let untagged = parse_dockerfile("FROM ubuntu\n");
+        assert_eq!(untagged.dependencies[0].is_pinned, Some(false));
+    }
+
+    #[test]
+    fn test_scratch_emits_no_purl() {
+        assert!(purls("FROM scratch\nRUN echo hi\n").is_empty());
+    }
+
+    #[test]
+    fn test_arg_templated_image_is_skipped() {
+        assert!(purls("ARG BASE=python:3.12\nFROM ${BASE}\n").is_empty());
+        assert!(purls("FROM $BASE\n").is_empty());
+    }
+
+    #[test]
+    fn test_platform_flag_is_ignored() {
+        assert_eq!(
+            purls("FROM --platform=linux/amd64 alpine:3.20\n"),
+            vec!["pkg:docker/alpine@3.20".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_multistage_skips_internal_stage_reference() {
+        let content = "\
+FROM golang:1.22 AS build
+RUN go build
+FROM build
+COPY --from=build /app /app
+";
+        assert_eq!(purls(content), vec!["pkg:docker/golang@1.22".to_string()]);
+    }
+
+    #[test]
+    fn test_multistage_external_bases_both_emitted() {
+        let content = "\
+FROM node:20 AS frontend
+FROM nginx:1.27-alpine
+";
+        assert_eq!(
+            purls(content),
+            vec![
+                "pkg:docker/node@20".to_string(),
+                "pkg:docker/nginx@1.27-alpine".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_duplicate_base_images_are_deduplicated() {
+        let content = "FROM alpine:3.20\nFROM alpine:3.20\n";
+        assert_eq!(purls(content), vec!["pkg:docker/alpine@3.20".to_string()]);
+    }
+
+    #[test]
+    fn test_stage_name_matching_is_case_insensitive() {
+        let content = "FROM golang:1.22 AS Build\nFROM build\n";
+        assert_eq!(purls(content), vec!["pkg:docker/golang@1.22".to_string()]);
+    }
+
+    #[test]
+    fn test_base_image_dependency_is_direct() {
+        let package = parse_dockerfile("FROM python:3.12-slim\n");
+        assert_eq!(package.dependencies.len(), 1);
+        assert_eq!(package.dependencies[0].is_direct, Some(true));
+        assert_eq!(package.dependencies[0].extracted_requirement, None);
+    }
+
+    #[test]
+    fn test_stage_alias_same_as_image_name_emits_purl() {
+        // `FROM node AS node` -- the alias exactly equals the untagged image name.
+        // The image is external, so a PURL must be emitted. A previous bug inserted
+        // the alias before the internal-reference check, silently dropping this case.
+        assert_eq!(
+            purls(
+                "FROM node AS node
+"
+            ),
+            vec!["pkg:docker/node".to_string()]
+        );
+    }
 }

--- a/testdata/docker-golden/jibri/Dockerfile.expected.json
+++ b/testdata/docker-golden/jibri/Dockerfile.expected.json
@@ -59,7 +59,19 @@
         "org.opencontainers.image.version": "stable-8960-1"
       }
     },
-    "dependencies": [],
+    "dependencies": [
+      {
+        "purl": "pkg:docker/library/debian@bookworm-slim?repository_url=docker.io",
+        "extracted_requirement": null,
+        "scope": null,
+        "is_runtime": null,
+        "is_optional": null,
+        "is_pinned": null,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": {}
+      }
+    ],
     "repository_homepage_url": null,
     "repository_download_url": null,
     "api_data_url": null,

--- a/testdata/docker-golden/pulp/Containerfile.expected.json
+++ b/testdata/docker-golden/pulp/Containerfile.expected.json
@@ -43,7 +43,19 @@
         "org.opencontainers.image.version": "latest"
       }
     },
-    "dependencies": [],
+    "dependencies": [
+      {
+        "purl": "pkg:docker/pulp/pulp-base@latest?repository_url=quay.io",
+        "extracted_requirement": null,
+        "scope": null,
+        "is_runtime": null,
+        "is_optional": null,
+        "is_pinned": null,
+        "is_direct": true,
+        "resolved_package": null,
+        "extra_data": {}
+      }
+    ],
     "repository_homepage_url": null,
     "repository_download_url": null,
     "api_data_url": null,


### PR DESCRIPTION
## Summary

- Extends the existing Dockerfile/Containerfile parser to parse `FROM` directives and emit each external base image as a `pkg:docker` dependency.
- Registry (when present) becomes a `repository_url` qualifier; the final path segment is the name, preceding segments form the namespace, and the tag/digest becomes the version.
- Honors recipe semantics: internal multi-stage stage references are skipped, `scratch` emits no PURL, and `ARG`-templated images (`FROM ${BASE}`) are left as honest unknowns. The image being built still gets no PURL; only its base-image deps are new.
- The `Dockerfile` datasource stays unassembled, so these dependencies flow to the top-level result through the existing unassembled-dependency hoist (no new assembler wiring needed).

## Issues

- Covers: #978
- Closes: #978

## Scope and exclusions

- Included: `FROM` base-image dependency extraction, PURL building (registry/namespace/name/tag/digest), `--platform` flag handling, multi-stage stage detection, scratch/ARG handling, dedup; unit tests, a Layer-3 scanner/assembly test, and updated parser goldens.
- Explicit exclusions: scanning resolved image archives/manifests (OCI layout, `docker save` tarballs) → `pkg:oci` is tracked separately in #349.

## How to verify

Beyond the CI-covered suites, scan a real multi-stage Dockerfile and confirm only external base images are emitted:

```
provenant --package path/to/Dockerfile --json-pp -
```

Verified against grafana/grafana's 20+ `FROM`-line multi-stage Dockerfile. It yields exactly five external base-image dependencies and zero top-level packages:

- `pkg:docker/alpine@3.23.4`
- `pkg:docker/golang@1.26.4-alpine`
- `pkg:docker/node@24-alpine`
- `pkg:docker/ubuntu@24.04`
- `pkg:docker/distroless/static-debian13?repository_url=gcr.io`

It correctly skips every `${...}` ARG-templated `FROM`, all internal stage references (e.g. `alpine-base` reused repeatedly), and `--platform=` flags. ScanCode has no Dockerfile-`FROM` dependency support, so the ScanCode-parity lane is N/A for this change.

## Intentional differences from Python

- ScanCode's Dockerfile handler does not extract `FROM` base images as dependencies; Provenant does, as a strict improvement with no parity regression.

## Expected-output fixture changes

- Files changed: `testdata/docker-golden/jibri/Dockerfile.expected.json` and `testdata/docker-golden/pulp/Containerfile.expected.json`.
- Why the new expected output is correct: both fixtures contain a `FROM` base image (`docker.io/library/debian:bookworm-slim` and `quay.io/pulp/pulp-base:latest`) that is now correctly emitted as a `pkg:docker` dependency. The built image itself still has `purl: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
