### PR TITLE
docs(notice): indicate CC-BY-4.0 data modifications and third-party omission

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,6 +19,20 @@ Provenant copyright and a notice that the file was changed. The set of derived
 files is enumerated in the `derived` list of `.license-headers.toml` and is
 enforced by the license-header check.
 
+Provenant also ships a license-detection dataset derived from ScanCode Toolkit
+data (CC-BY-4.0). This dataset has been modified from upstream: certain rules
+are excluded and others are reclassified or tightened, and a small number of
+license/rule entries are added, as defined by
+`resources/license_detection/index_build_policy.toml` and the overlays under
+`resources/license_detection/overlay/`. Each scan also reports the applied
+modifications in its license-index provenance output.
+
+Provenant does not redistribute the third-party software packages that the
+upstream ScanCode Toolkit bundles; the `reference/scancode-toolkit` submodule is
+a development-time reference and is excluded from Provenant distributions.
+Accordingly, upstream's "Third-party software licenses" notice is omitted as not
+pertaining to this work.
+
 Provenant project code is licensed under the Apache License, Version 2.0.
 See `LICENSE` for the license text.
 


### PR DESCRIPTION
## Summary

- Update `NOTICE` to indicate that Provenant ships a **modified** derivative of upstream ScanCode Toolkit's CC-BY-4.0 license-detection data, satisfying CC-BY-4.0 §3(a)(1)(B)'s "indicate if you modified the material" obligation.
- Document that upstream's "Third-party software licenses" section is **intentionally omitted** because Provenant does not redistribute the third-party packages ScanCode bundles (the `reference/scancode-toolkit` submodule is dev-only and excluded from distributions), so that notice does not pertain to this work under Apache-2.0 §4(d).

## Why we do not repeat upstream's NOTICE verbatim

A verbatim copy would be both legally insufficient and misleading:

- **It would assert obligations that are false for us.** Upstream's NOTICE includes a third-party-source-code offer ("contact us at info@nexb.com / postal mail to nexB Inc. …") for packages *ScanCode* bundles. Provenant ships none of those packages, so copying that block would misdirect users to nexB for source we do not obtain from them. Apache-2.0 §4(d) explicitly permits excluding notices that "do not pertain to any part of the Derivative Works."
- **It would not satisfy CC-BY-4.0 anyway.** Upstream's NOTICE describes *their unmodified* data. Provenant ships a modified dataset (rules excluded/reclassified/tightened and entries added via `resources/license_detection/index_build_policy.toml` and `resources/license_detection/overlay/`). Verbatim copying would omit the modification indication CC-BY-4.0 requires of us.
- **Tailored attribution is what the licenses intend.** Both licenses are built for adaptation with accurate attribution, not transcription. Our NOTICE keeps the nexB copyright/trademark, the SPDX statements, and the CC-BY-4.0 "preferred attribution" block, uses current `aboutcode-org` URLs, disclaims affiliation, and now states our modifications — which is more accurate and respectful of upstream than a copy that misrepresents both projects.

## Scope and exclusions

- Included: `NOTICE` text only.
- Explicit exclusions: no code, data, or test changes; the embedded license index and overlays are unchanged (this PR documents existing behavior, it does not alter it).

## How to verify

Legal-text-only change with nothing for CI to exercise beyond the license-header check (which passes; `NOTICE` is not header-scoped). Reviewers should sanity-check the NOTICE wording against the actual modification machinery: `resources/license_detection/index_build_policy.toml`, `resources/license_detection/overlay/`, and the per-scan `LicenseIndexProvenance` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
