### PR TITLE
feat(notice): reproduce upstream notices verbatim and add a drift check

### DIFF
--- a/.github/actions/verify-notice-attribution-sync/action.yml
+++ b/.github/actions/verify-notice-attribution-sync/action.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Verify NOTICE attribution sync
+description: Verify that retained upstream ScanCode NOTICE segments are reproduced verbatim in the root NOTICE
+runs:
+  using: composite
+  steps:
+    - name: Verify NOTICE attribution sync
+      shell: bash
+      run: ./scripts/check_notice_attribution_sync.sh --require-submodule

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Verify ScanCode output format version sync
         uses: ./.github/actions/verify-scancode-output-format-version
 
+      - name: Verify NOTICE attribution sync
+        uses: ./.github/actions/verify-notice-attribution-sync
+
   rust-quality:
     name: Code Quality
     runs-on: ubuntu-latest

--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,12 @@ a development-time reference and is excluded from Provenant distributions.
 Accordingly, upstream's "Third-party software licenses" notice is omitted as not
 pertaining to this work.
 
+The upstream attribution notices reproduced below are copied verbatim from the
+pinned `reference/scancode-toolkit/NOTICE`, and an automated check
+(`scripts/check_notice_attribution_sync.sh`) keeps them in sync. The upstream
+project is now hosted at https://github.com/aboutcode-org/scancode-toolkit; the
+github.com/nexB URLs preserved verbatim in the notices below redirect there.
+
 Provenant project code is licensed under the Apache License, Version 2.0.
 See `LICENSE` for the license text.
 
@@ -51,21 +57,21 @@ ScanCode data is licensed under CC-BY-4.0.
 See https://www.apache.org/licenses/LICENSE-2.0 for the Apache-2.0 license text.
 See https://creativecommons.org/licenses/by/4.0/legalcode for the CC-BY-4.0 license text.
 
-See https://github.com/aboutcode-org/scancode-toolkit for support or download.
+See https://github.com/nexB/scancode-toolkit for support or download.
 See https://aboutcode.org for more information about nexB OSS projects
 
 
 ScanCode data attribution
 =========================
 
-ScanCode includes datasets (for example, license-detection data) that are licensed under
-CC-BY-4.0.
+ScanCode includes datasets (e.g. for license detection) that are licensed under
+CC-BY-4.0
 
-The preferred attribution for use of ScanCode data is:
+The preferred attribution for use of ScanCode data is::
 
     Copyright (c) nexB Inc. and others. All rights reserved.
     ScanCode is a trademark of nexB Inc.
     SPDX-License-Identifier: CC-BY-4.0
     See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
-    See https://github.com/aboutcode-org/scancode-toolkit for support or download.
+    See https://github.com/nexB/scancode-toolkit for support or download.
     See https://aboutcode.org for more information about nexB OSS projects.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -61,6 +61,14 @@ pre-commit:
         - release.sh
       run: ./scripts/check_release_version_sync.sh
 
+    check-notice-attribution-sync:
+      glob:
+        - NOTICE
+        - scripts/notice_retained_segments.txt
+        - scripts/check_notice_attribution_sync.sh
+        - reference/scancode-toolkit
+      run: ./scripts/check_notice_attribution_sync.sh
+
     dependency-policy:
       glob:
         - Cargo.toml

--- a/release.sh
+++ b/release.sh
@@ -90,6 +90,8 @@ fi
 
 echo "🔎 Verifying ScanCode output format version sync..."
 ./scripts/check_scancode_output_format_sync.sh
+echo "🔎 Verifying NOTICE attribution sync (retained upstream notices verbatim)..."
+./scripts/check_notice_attribution_sync.sh --require-submodule
 echo "🔧 Regenerating embedded license index artifact..."
 cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,3 +115,27 @@ Example:
 ```bash
 ./scripts/check_scancode_output_format_sync.sh
 ```
+
+## `check_notice_attribution_sync.sh`
+
+Verify that the upstream ScanCode Toolkit attribution notices Provenant retains
+(Apache-2.0 section 4(d) / CC-BY-4.0) are reproduced verbatim in both the pinned
+`reference/scancode-toolkit/NOTICE` and the repository-root `NOTICE`. The
+canonical retained segments live in
+[`notice_retained_segments.txt`](notice_retained_segments.txt); the check is
+anchored on those segments only, so notices we intentionally omit (such as
+upstream's "Third-party software licenses" section) do not affect it.
+
+Pass `--require-submodule` to fail (instead of soft-skip) when the submodule
+NOTICE is missing; CI and `release.sh` use this so a submodule bump that changes
+a retained notice is caught before a release is tagged. If upstream _adds_ a new
+notice that pertains to the code or data Provenant distributes, add a matching
+segment and reproduce it in `NOTICE` — that case is a human judgment, not
+auto-detected.
+
+Example:
+
+```bash
+./scripts/check_notice_attribution_sync.sh
+./scripts/check_notice_attribution_sync.sh --require-submodule
+```

--- a/scripts/check_notice_attribution_sync.sh
+++ b/scripts/check_notice_attribution_sync.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify that the upstream ScanCode Toolkit attribution notices Provenant
+# retains are reproduced verbatim in BOTH the pinned submodule NOTICE and the
+# repository-root NOTICE. Anchored on the retained segments only, so notices we
+# intentionally omit (e.g. upstream's "Third-party software licenses" section)
+# never affect the result.
+#
+# Usage: ./scripts/check_notice_attribution_sync.sh [--require-submodule]
+#   --require-submodule: fail (instead of soft-skip) when the submodule NOTICE
+#                        is missing. Used by CI and release.sh.
+
+set -euo pipefail
+
+REQUIRE_SUBMODULE=""
+if [ "${1:-}" = "--require-submodule" ]; then
+    REQUIRE_SUBMODULE="1"
+fi
+
+UPSTREAM_NOTICE="reference/scancode-toolkit/NOTICE"
+LOCAL_NOTICE="NOTICE"
+SEGMENTS="scripts/notice_retained_segments.txt"
+
+if [ ! -f "$UPSTREAM_NOTICE" ]; then
+    if [ -n "$REQUIRE_SUBMODULE" ]; then
+        echo "Could not find upstream NOTICE at $UPSTREAM_NOTICE." >&2
+        echo "Initialize the reference/scancode-toolkit submodule first (npm run setup)." >&2
+        exit 1
+    fi
+    echo "ℹ️  Skipping NOTICE attribution check: $UPSTREAM_NOTICE not present (submodule not initialized)."
+    exit 0
+fi
+
+for required in "$LOCAL_NOTICE" "$SEGMENTS"; do
+    if [ ! -f "$required" ]; then
+        echo "Could not find required file: $required" >&2
+        exit 1
+    fi
+done
+
+python3 - "$UPSTREAM_NOTICE" "$LOCAL_NOTICE" "$SEGMENTS" <<'PY'
+import pathlib
+import sys
+
+upstream_path = pathlib.Path(sys.argv[1])
+local_path = pathlib.Path(sys.argv[2])
+segments_path = pathlib.Path(sys.argv[3])
+
+BEGIN = "@@BEGIN@@"
+END = "@@END@@"
+
+
+def normalize(text):
+    # Strip trailing whitespace per line (upstream NOTICE carries a few trailing
+    # spaces; our formatting tooling may not). Leading indentation is preserved
+    # because it is part of the reproduced notice.
+    return "\n".join(line.rstrip() for line in text.splitlines())
+
+
+def parse_segments(text):
+    segments = []
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == BEGIN:
+            if current is not None:
+                raise SystemExit(f"Nested {BEGIN} marker in {segments_path}")
+            current = []
+        elif stripped == END:
+            if current is None:
+                raise SystemExit(f"Unmatched {END} marker in {segments_path}")
+            # Drop blank lines (never content lines) immediately inside the
+            # markers, so the fragment can be authored with readable spacing.
+            # Blank-line context around a block is intentionally not asserted:
+            # the check guarantees the verbatim notice text, not surrounding
+            # whitespace, which carries no attribution meaning.
+            while current and not current[0].strip():
+                current.pop(0)
+            while current and not current[-1].strip():
+                current.pop()
+            segments.append("\n".join(current))
+            current = None
+        elif current is not None:
+            current.append(line)
+    if current is not None:
+        raise SystemExit(f"Unterminated {BEGIN} segment in {segments_path}")
+    return segments
+
+
+segments = parse_segments(segments_path.read_text(encoding="utf-8"))
+if not segments:
+    raise SystemExit(
+        f"No retained segments found in {segments_path}; expected at least one "
+        f"{BEGIN}/{END} block."
+    )
+
+upstream = normalize(upstream_path.read_text(encoding="utf-8"))
+local = normalize(local_path.read_text(encoding="utf-8"))
+
+problems = []
+for index, segment in enumerate(segments, start=1):
+    norm = normalize(segment)
+    preview = norm.splitlines()[0] if norm.splitlines() else "(empty)"
+    if norm not in upstream:
+        problems.append(
+            f"Segment {index} (\"{preview} ...\") is NOT a verbatim match in "
+            f"{upstream_path}.\n"
+            "  The pinned upstream NOTICE changed this retained notice. Re-sync "
+            f"both {segments_path} and {local_path} with the new upstream text."
+        )
+    if norm not in local:
+        problems.append(
+            f"Segment {index} (\"{preview} ...\") is NOT reproduced verbatim in "
+            f"{local_path}.\n"
+            f"  The root NOTICE drifted from {segments_path}. Restore the exact "
+            "upstream notice text in NOTICE."
+        )
+
+if problems:
+    raise SystemExit(
+        "NOTICE attribution sync check failed:\n\n"
+        + "\n\n".join(problems)
+        + "\n\nApache-2.0 section 4(d) requires a faithful copy of retained "
+        "attribution notices. See scripts/notice_retained_segments.txt for the "
+        "canonical segments."
+    )
+
+print(
+    f"✅ NOTICE attribution in sync: {len(segments)} retained upstream "
+    "segment(s) match both the submodule NOTICE and the root NOTICE."
+)
+PY

--- a/scripts/notice_retained_segments.txt
+++ b/scripts/notice_retained_segments.txt
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Canonical list of upstream ScanCode Toolkit NOTICE segments that Provenant
+# retains and reproduces verbatim (Apache-2.0 section 4(d) / CC-BY-4.0
+# attribution). Each segment between an @@BEGIN@@ / @@END@@ marker pair must
+# appear, verbatim (trailing whitespace ignored), in BOTH:
+#   - the pinned submodule NOTICE: reference/scancode-toolkit/NOTICE
+#   - the repository-root NOTICE
+# This is enforced by scripts/check_notice_attribution_sync.sh.
+#
+# Do NOT hand-edit a segment to "fix" wording. The segments are an exact copy
+# of upstream. If a bump of the reference/scancode-toolkit submodule changes a
+# retained notice, update these segments AND the root NOTICE together to match
+# the new upstream text. If upstream ADDS a new notice that pertains to the
+# code or data Provenant distributes, add a new segment here and reproduce it
+# in the root NOTICE (this is a human judgment, not auto-detected).
+#
+# Lines outside the @@BEGIN@@ / @@END@@ markers (such as this header) are
+# ignored by the check.
+
+@@BEGIN@@
+Copyright (c) nexB Inc. and others. All rights reserved.
+ScanCode is a trademark of nexB Inc.
+
+SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+
+ScanCode software is licensed under the Apache License version 2.0.
+ScanCode data is licensed under CC-BY-4.0.
+
+See https://www.apache.org/licenses/LICENSE-2.0 for the Apache-2.0 license text.
+See https://creativecommons.org/licenses/by/4.0/legalcode for the CC-BY-4.0 license text.
+
+See https://github.com/nexB/scancode-toolkit for support or download.
+See https://aboutcode.org for more information about nexB OSS projects
+@@END@@
+
+@@BEGIN@@
+ScanCode includes datasets (e.g. for license detection) that are licensed under
+CC-BY-4.0
+
+The preferred attribution for use of ScanCode data is::
+
+    Copyright (c) nexB Inc. and others. All rights reserved.
+    ScanCode is a trademark of nexB Inc.
+    SPDX-License-Identifier: CC-BY-4.0
+    See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
+    See https://github.com/nexB/scancode-toolkit for support or download.
+    See https://aboutcode.org for more information about nexB OSS projects.
+@@END@@


### PR DESCRIPTION
## Summary

- Restore the retained upstream ScanCode Toolkit attribution notices in `NOTICE` to a **verbatim** copy of the pinned `reference/scancode-toolkit/NOTICE` (including the original `github.com/nexB` URLs), matching the "readable copy of the attribution notices" standard in Apache-2.0 §4(d). The current `github.com/aboutcode-org` location is noted as a Provenant **addendum** rather than by editing the retained notice text.
- Add an automated **drift check** (`scripts/check_notice_attribution_sync.sh` + canonical `scripts/notice_retained_segments.txt`) and wire it into CI, the pre-commit hooks, and `release.sh`.

## Context

Follow-up to #984 (which added the data-modification indication and documented the third-party omission). That review raised the question of whether Apache-2.0 requires a verbatim NOTICE. §4(d) requires a *faithful copy of the attribution notices you retain* (it only authorizes excluding non-pertaining notices and adding your own) — so editing a retained notice's URL in place was technically off. This PR makes the retained notices an exact copy and adds tooling so they stay that way across submodule bumps.

## How the check works (and the omission question)

The check is anchored on the **retained segments only**, never a whole-file diff. Each segment in `notice_retained_segments.txt` must appear verbatim (trailing whitespace ignored) in **both** the submodule NOTICE and the root NOTICE.

- Notices we intentionally omit (upstream's "Third-party software licenses" section, which doesn't pertain to us) are simply not in the retained set, so upstream keeping or editing them never trips the check.
- It does **not** auto-detect upstream *adding* a brand-new notice that newly pertains to us — that is an inherent human judgment, documented as a manual step at submodule-bump time rather than fake-automated.

## Release safety

The check runs in `release.sh` right after the submodule bump and before any version bump, commit, tag, or push. If a bump changes a retained notice, the release aborts locally instead of pushing a release that then fails CI. CI enforces the same check (in the submodule-aware `license-index` job) as a backstop.

## Scope and exclusions

- Included: `NOTICE`, the check script + segments file, one CI composite action + a `check.yml` step, a `lefthook.yml` pre-commit entry, two lines in `release.sh`, and a `scripts/README.md` entry.
- Excluded: no code, data, or embedded-index changes.

## How to verify

```bash
# passes against the pinned submodule
./scripts/check_notice_attribution_sync.sh --require-submodule

# tamper with a retained URL in NOTICE -> fails on the local copy
# tamper with notice_retained_segments.txt -> fails on the upstream match
# remove/uninit the submodule, run without the flag -> soft-skips (exit 0);
#   with --require-submodule -> hard-fails (exit 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
