### PR TITLE
docs(security): document serve API no-auth posture and deployment guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,3 +20,28 @@ When reporting, include as much of the following as you can:
 - impact assessment if known
 
 We will triage reports as quickly as practical and coordinate on disclosure timing for confirmed vulnerabilities.
+
+## Serve Mode Security Posture
+
+`provenant serve` exposes the scanner over HTTP. It has **no built-in authentication or authorization** by design: any client that can reach the listening port can submit scans and read results. The current service has no concept of users, API keys, or per-request credentials.
+
+Access control is delegated entirely to where and how you bind the service:
+
+- **Default loopback bind.** `provenant serve` binds to `127.0.0.1:8080` by default. On a loopback bind the service is only reachable from the same host, which is the intended deployment for same-host use.
+- **Privileged-input gate.** Local-path, remote-URL, and repository inputs are _privileged inputs_: they make the service host read local files, fetch URLs, or run `git fetch` on behalf of the caller. On a loopback bind these are enabled. When the service is bound beyond loopback, they are **disabled** unless the operator explicitly passes `--allow-privileged-inputs`. Upload input always remains available because the caller supplies the content to scan rather than directing the host to access something.
+
+Because there is no request-level authn/authz, the bind address and the privileged-input gate are the _only_ protections the service provides on its own.
+
+### Operator guidance
+
+- Treat any non-loopback `provenant serve` deployment as unauthenticated and place it behind your own access controls: a reverse proxy that enforces authentication, a network policy, a firewall, or an equivalent perimeter control.
+- Use `--allow-privileged-inputs` only for trusted deployments that already have their own network access controls. Enabling it on an exposed bind lets any reachable caller make the host read local paths, fetch arbitrary HTTP(S) URLs, and clone arbitrary repositories. Treat repository and URL ingestion as sensitive, server-side-effecting operations.
+- Do not expose the privileged-input modes to untrusted callers. If callers are not already trusted to perform host-side filesystem, network, and `git` access, prefer upload input on a restricted bind.
+
+The service does enforce bounded request, upload, remote-download, and archive-extraction sizes, but these are denial-of-service mitigations, not access control.
+
+### Future work
+
+An optional bearer-token (or similar request-credential) gate for deployments that expose the port has been considered but is intentionally **not implemented** today. Until such a feature exists, operators must rely on the bind address, the privileged-input gate, and an external perimeter as described above.
+
+See the [Serve API Guide](docs/SERVE_API_GUIDE.md#security-posture) for the concrete bind, input-mode, and `--allow-privileged-inputs` behavior this posture is built on.

--- a/docs/SERVE_API_GUIDE.md
+++ b/docs/SERVE_API_GUIDE.md
@@ -26,6 +26,19 @@ Use `--allow-privileged-inputs` only for trusted deployments with their own netw
 provenant serve --bind 0.0.0.0:8080 --allow-privileged-inputs
 ```
 
+## Security posture
+
+`provenant serve` has **no built-in authentication or authorization**. Any client that can reach the listening port can submit scans and read results; there are no users, API keys, or per-request credentials. The service's only built-in protections are the bind address and the privileged-input gate described above:
+
+- The default `127.0.0.1:8080` bind keeps the service reachable only from the same host.
+- Privileged inputs (local paths, remote URLs, repositories) make the host read files, fetch URLs, or run `git fetch` on behalf of the caller. They are enabled on a loopback bind and disabled on a non-loopback bind unless you pass `--allow-privileged-inputs`.
+
+If you bind beyond loopback, treat the deployment as unauthenticated and put it behind your own access controls — a reverse proxy that enforces authentication, a network policy, or a firewall. Enable `--allow-privileged-inputs` only for trusted deployments with their own network access controls, since it lets any reachable caller drive sensitive server-side filesystem, network, and `git` access. The bounded request, upload, remote-download, and archive-extraction sizes the service enforces are denial-of-service mitigations, not access control.
+
+An optional request-credential (for example bearer-token) gate for exposed deployments is possible future work but is intentionally not implemented today.
+
+For the full security-posture statement and operator guidance, see [SECURITY.md](../SECURITY.md#serve-mode-security-posture).
+
 The current service surface includes:
 
 - `GET /livez`
@@ -301,7 +314,7 @@ The current API surface is intentionally narrow:
 - async jobs run under bounded background execution and may wait in `pending` before starting
 - upload input is JSON-only and bounded; multipart upload is not implemented
 - remote URL input currently supports only `http` and `https`
-- auth is not implemented
+- authentication and authorization are not implemented; see [Security posture](#security-posture)
 - async job state and result retention are bounded in-memory service state, not durable external persistence
 
 ## Machine-readable contract


### PR DESCRIPTION
## Summary

- Document that `provenant serve` has **no built-in authentication or authorization** by design, and that protection relies solely on the bind address plus the privileged-input gate.
- Add a "Serve Mode Security Posture" section to `SECURITY.md` covering the default loopback bind (`127.0.0.1:8080`), the `--allow-privileged-inputs` gate, the sensitivity of repository/URL ingestion, and operator guidance to front any non-loopback deployment with a reverse proxy / network policy / firewall.
- Add a cross-referenced "Security posture" section to `docs/SERVE_API_GUIDE.md` and link the two documents together; tighten the existing "auth is not implemented" limit bullet to point at it.
- Note an optional bearer-token (request-credential) gate as future work — intentionally **not** implemented here.

## Issues

- Closes: #990

## Scope and exclusions

- Included: documentation only — `SECURITY.md` and `docs/SERVE_API_GUIDE.md`.
- Explicit exclusions: no code changes; the optional token gate is described as future work but not built.

## How to verify

- `npm run check:docs` passes (markdownlint: 0 errors; prettier: all files formatted).
- Confirm the documented behavior matches the implementation: default bind `127.0.0.1:8080` and the loopback/`--allow-privileged-inputs` gate in `src/cli/mod.rs` (`ServeArgs`) and `src/serve/mod.rs` (`ServeConfig::try_from` / `bind_allows_privileged_inputs_by_default`).
- Check the in-doc anchors resolve: `SECURITY.md` → `SERVE_API_GUIDE.md#security-posture` and `SERVE_API_GUIDE.md` → `SECURITY.md#serve-mode-security-posture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)