### PR TITLE
security(scanner): bound scans and stop following out-of-tree symlinks

### DIFF
--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -80,4 +80,19 @@ pub(crate) struct ScanRequest {
     pub(crate) max_email: usize,
     pub(crate) url: bool,
     pub(crate) max_url: usize,
+    /// Bounds applied to untrusted input trees (set by `provenant serve`).
+    /// Trusted CLI and library scans leave these unset for unchanged behavior.
+    pub(crate) scan_bounds: ScanBounds,
+}
+
+/// Optional collector ceilings for untrusted scans.
+///
+/// Defaults are fully permissive so trusted CLI and library scans behave
+/// exactly as before; `provenant serve` opts into finite values.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ScanBounds {
+    pub(crate) max_files: Option<usize>,
+    pub(crate) max_total_bytes: Option<u64>,
+    pub(crate) deadline_seconds: Option<f64>,
+    pub(crate) restrict_out_of_tree_symlinks: bool,
 }

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -43,8 +43,9 @@ use crate::scan_result_shaping::{
     prepare_filter_clue_rule_lookup, trim_preloaded_assembly_to_files,
 };
 use crate::scanner::{
-    ProcessResult, collect_paths, collect_selected_paths, process_collected_with_memory_limit,
-    process_collected_with_memory_limit_sequential, scan_options_fingerprint,
+    CollectionLimits, ProcessResult, collect_paths_with_limits, collect_selected_paths_with_limits,
+    process_collected_with_memory_limit, process_collected_with_memory_limit_sequential,
+    scan_options_fingerprint,
 };
 use crate::utils::hash::calculate_sha256;
 
@@ -475,6 +476,24 @@ pub(crate) fn compile_regex_patterns(option_name: &str, patterns: &[String]) -> 
         .collect()
 }
 
+/// Translates the request-level [`ScanBounds`](crate::app::request::ScanBounds)
+/// into collector limits, anchoring the wall-clock deadline at collection start
+/// and the symlink guard at the scan root.
+fn build_collection_limits(request: &ScanRequest, scan_root: &Path) -> CollectionLimits {
+    let bounds = &request.scan_bounds;
+    CollectionLimits {
+        max_file_count: bounds.max_files,
+        max_total_bytes: bounds.max_total_bytes,
+        deadline: bounds
+            .deadline_seconds
+            .filter(|seconds| seconds.is_finite() && *seconds > 0.0)
+            .map(|seconds| Instant::now() + std::time::Duration::from_secs_f64(seconds)),
+        symlink_root_guard: bounds
+            .restrict_out_of_tree_symlinks
+            .then(|| scan_root.to_path_buf()),
+    }
+}
+
 fn load_native_scan_session(
     request: &ScanRequest,
     scan_plan: &ScanPlan,
@@ -497,14 +516,21 @@ fn load_native_scan_session(
     let collection_exclude_patterns =
         build_collection_exclude_patterns(Path::new(&scan_path), cache_config.root_dir());
 
+    let collection_limits = build_collection_limits(request, Path::new(&scan_path));
     let mut collected = if request.paths_files.is_empty() {
-        collect_paths(&scan_path, request.max_depth, &collection_exclude_patterns)
+        collect_paths_with_limits(
+            &scan_path,
+            request.max_depth,
+            &collection_exclude_patterns,
+            &collection_limits,
+        )
     } else {
-        collect_selected_paths(
+        collect_selected_paths_with_limits(
             Path::new(&scan_path),
             &collection_frontier,
             request.max_depth,
             &collection_exclude_patterns,
+            &collection_limits,
         )
     };
     let user_excluded_count = apply_user_path_filters_to_collected(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -946,6 +946,7 @@ impl From<&ScanArgs> for ScanRequest {
             max_email: cli.max_email,
             url: cli.url,
             max_url: cli.max_url,
+            scan_bounds: crate::app::request::ScanBounds::default(),
         }
     }
 }

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -58,6 +58,7 @@ fn apply_user_path_filters_to_collected_filters_files_without_pruning_directorie
         excluded_count: 0,
         total_file_bytes: 0,
         collection_errors: Vec::new(),
+        limit_reached: false,
     };
 
     let removed = apply_user_path_filters_to_collected(
@@ -105,6 +106,7 @@ fn apply_user_path_filters_to_collected_keeps_single_file_root_input() {
         excluded_count: 0,
         total_file_bytes: 0,
         collection_errors: Vec::new(),
+        limit_reached: false,
     };
 
     let removed = apply_user_path_filters_to_collected(

--- a/src/scanner/collect.rs
+++ b/src/scanner/collect.rs
@@ -47,6 +47,26 @@ impl CollectionLimits {
         Self::default()
     }
 
+    /// Resolves the symlink guard once per walk so each encountered symlink only
+    /// canonicalizes its own target instead of re-canonicalizing the scan root.
+    ///
+    /// When a guard is requested but its root cannot be canonicalized, the root
+    /// path is left un-canonicalized so containment checks fail closed (no real
+    /// canonical target will be considered contained), matching the prior
+    /// per-symlink behavior.
+    fn resolved_for_walk(&self) -> Self {
+        let symlink_root_guard = self
+            .symlink_root_guard
+            .as_ref()
+            .map(|root| fs::canonicalize(root).unwrap_or_else(|_| root.clone()));
+        Self {
+            max_file_count: self.max_file_count,
+            max_total_bytes: self.max_total_bytes,
+            deadline: self.deadline,
+            symlink_root_guard,
+        }
+    }
+
     fn deadline_exceeded(&self) -> bool {
         self.deadline
             .is_some_and(|deadline| Instant::now() >= deadline)
@@ -135,6 +155,7 @@ pub fn collect_paths_with_limits<P: AsRef<Path>>(
     exclude_patterns: &[Pattern],
     limits: &CollectionLimits,
 ) -> CollectedPaths {
+    let limits = &limits.resolved_for_walk();
     let depth_limit = depth_limit_from_cli(max_depth);
     let root = root.as_ref();
 
@@ -219,6 +240,7 @@ pub fn collect_selected_paths_with_limits(
     exclude_patterns: &[Pattern],
     limits: &CollectionLimits,
 ) -> CollectedPaths {
+    let limits = &limits.resolved_for_walk();
     let depth_limit = depth_limit_from_cli(max_depth);
 
     if is_path_excluded(root, exclude_patterns) {
@@ -452,8 +474,8 @@ fn classify_for_traversal(
 ) -> io::Result<TraversalMetadata> {
     let link_metadata = fs::symlink_metadata(path)?;
     if link_metadata.file_type().is_symlink() {
-        if let Some(root) = &limits.symlink_root_guard
-            && symlink_target_escapes_root(path, root)
+        if let Some(canonical_root) = &limits.symlink_root_guard
+            && symlink_target_escapes_root(path, canonical_root)
         {
             // An untrusted input tree points a symlink at content outside the
             // scan root; refuse to dereference it so we never read or emit
@@ -470,16 +492,12 @@ fn classify_for_traversal(
     Ok(classify_resolved_metadata(link_metadata, true))
 }
 
-/// Returns `true` when the symlink at `path` resolves outside `root`, or when
-/// the target cannot be canonicalized (treated as an escape so we fail closed).
-fn symlink_target_escapes_root(path: &Path, root: &Path) -> bool {
-    let canonical_root = match fs::canonicalize(root) {
-        Ok(canonical_root) => canonical_root,
-        // Without a trustworthy root anchor we cannot prove containment.
-        Err(_) => return true,
-    };
+/// Returns `true` when the symlink at `path` resolves outside `canonical_root`,
+/// or when the target cannot be canonicalized (treated as an escape so we fail
+/// closed). `canonical_root` is canonicalized once per walk by the caller.
+fn symlink_target_escapes_root(path: &Path, canonical_root: &Path) -> bool {
     match fs::canonicalize(path) {
-        Ok(canonical_target) => !canonical_target.starts_with(&canonical_root),
+        Ok(canonical_target) => !canonical_target.starts_with(canonical_root),
         Err(_) => true,
     }
 }
@@ -601,11 +619,16 @@ fn merge_collected(
     accumulator
         .collection_errors
         .extend(collected.collection_errors);
-    accumulator.limit_reached |= collected.limit_reached;
 
+    // Insert the subtree's already-collected files before propagating its
+    // limit flag. `insert_file` early-returns once `limit_reached` is set, so
+    // flipping the flag first would silently drop valid files the subtree
+    // gathered within its own sub-budget.
     for (path, metadata) in collected.files {
         insert_file(accumulator, path, metadata, limits);
     }
+    accumulator.limit_reached |= collected.limit_reached;
+
     for (path, metadata) in collected.directories {
         if accumulator.dir_seen.insert(path.clone()) {
             accumulator.directories.push((path, metadata));
@@ -617,7 +640,7 @@ fn merge_collected(
 mod tests {
     use super::{
         CollectionFrontier, CollectionLimits, collect_paths, collect_paths_with_limits,
-        collect_selected_paths,
+        collect_selected_paths, collect_selected_paths_with_limits,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -896,5 +919,67 @@ mod tests {
 
         assert!(!collected.limit_reached);
         assert_eq!(collected.file_count(), 5);
+    }
+
+    #[test]
+    fn truncated_subtree_keeps_files_collected_within_its_budget() {
+        // Regression: when a recursing subtree collects valid files and then
+        // trips the file-count limit, those already-collected files must still
+        // appear in the merged result instead of being silently dropped.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+
+        let first = root.join("first");
+        fs::create_dir_all(&first).expect("create first dir");
+        for index in 0..3 {
+            fs::write(first.join(format!("f{index}.txt")), "x\n").expect("write file");
+        }
+
+        let second = root.join("second");
+        fs::create_dir_all(&second).expect("create second dir");
+        for index in 0..5 {
+            fs::write(second.join(format!("s{index}.txt")), "x\n").expect("write file");
+        }
+
+        let limits = CollectionLimits {
+            max_file_count: Some(5),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_selected_paths_with_limits(
+            root,
+            &[
+                CollectionFrontier {
+                    path: PathBuf::from("first"),
+                    recurse: true,
+                },
+                CollectionFrontier {
+                    path: PathBuf::from("second"),
+                    recurse: true,
+                },
+            ],
+            0,
+            &[],
+            &limits,
+        );
+
+        // 3 from `first` plus 2 collected from `second` before it tripped.
+        assert!(collected.limit_reached);
+        assert_eq!(collected.file_count(), 5);
+        assert_eq!(
+            collected
+                .files
+                .iter()
+                .filter(|(path, _)| path.starts_with(&first))
+                .count(),
+            3
+        );
+        assert_eq!(
+            collected
+                .files
+                .iter()
+                .filter(|(path, _)| path.starts_with(&second))
+                .count(),
+            2
+        );
     }
 }

--- a/src/scanner/collect.rs
+++ b/src/scanner/collect.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use crate::utils::file::is_path_excluded;
 
@@ -15,6 +16,57 @@ pub struct CollectedPaths {
     pub excluded_count: usize,
     pub total_file_bytes: u64,
     pub collection_errors: Vec<(PathBuf, String)>,
+    /// Set when a configured collection limit stopped the walk before it
+    /// finished. The reason is surfaced through `collection_errors`.
+    pub limit_reached: bool,
+}
+
+/// Bounds applied while walking the filesystem.
+///
+/// Defaults are fully permissive so ordinary CLI and library scans behave
+/// exactly as before. Untrusted callers (notably `provenant serve`) opt into
+/// finite ceilings and an out-of-tree symlink guard so a hostile input tree
+/// cannot exhaust memory, wall-clock time, or leak content from outside the
+/// scan root.
+#[derive(Debug, Clone, Default)]
+pub struct CollectionLimits {
+    /// Maximum number of regular files to collect, if any.
+    pub max_file_count: Option<usize>,
+    /// Maximum cumulative size of collected files in bytes, if any.
+    pub max_total_bytes: Option<u64>,
+    /// Wall-clock deadline for the whole collection pass, if any.
+    pub deadline: Option<Instant>,
+    /// When set, file symlinks whose canonicalized target escapes this root are
+    /// skipped instead of being dereferenced and scanned.
+    pub symlink_root_guard: Option<PathBuf>,
+}
+
+impl CollectionLimits {
+    /// Permissive limits used by trusted CLI and library scans.
+    pub fn unbounded() -> Self {
+        Self::default()
+    }
+
+    fn deadline_exceeded(&self) -> bool {
+        self.deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+    }
+
+    fn file_count_reached(&self, collected_files: usize) -> bool {
+        self.max_file_count
+            .is_some_and(|limit| collected_files >= limit)
+    }
+
+    fn total_bytes_exceeded(&self, collected_bytes: u64, next_file_bytes: u64) -> bool {
+        self.max_total_bytes
+            .is_some_and(|limit| collected_bytes.saturating_add(next_file_bytes) > limit)
+    }
+}
+
+/// Distinguishes a clean walk from one stopped by a configured limit.
+enum WalkBudget {
+    Continue,
+    Stop(&'static str),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +83,7 @@ struct CollectionAccumulator {
     excluded_count: usize,
     total_file_bytes: u64,
     collection_errors: Vec<(PathBuf, String)>,
+    limit_reached: bool,
 }
 
 enum TraversalMetadata {
@@ -68,6 +121,20 @@ pub fn collect_paths<P: AsRef<Path>>(
     max_depth: usize,
     exclude_patterns: &[Pattern],
 ) -> CollectedPaths {
+    collect_paths_with_limits(
+        root,
+        max_depth,
+        exclude_patterns,
+        &CollectionLimits::unbounded(),
+    )
+}
+
+pub fn collect_paths_with_limits<P: AsRef<Path>>(
+    root: P,
+    max_depth: usize,
+    exclude_patterns: &[Pattern],
+    limits: &CollectionLimits,
+) -> CollectedPaths {
     let depth_limit = depth_limit_from_cli(max_depth);
     let root = root.as_ref();
 
@@ -78,10 +145,11 @@ pub fn collect_paths<P: AsRef<Path>>(
             excluded_count: 1,
             total_file_bytes: 0,
             collection_errors: Vec::new(),
+            limit_reached: false,
         };
     }
 
-    let traversal_metadata = match classify_for_traversal(root, true) {
+    let traversal_metadata = match classify_for_traversal(root, true, limits) {
         Ok(traversal_metadata) => traversal_metadata,
         Err(error) => {
             return CollectedPaths {
@@ -90,6 +158,7 @@ pub fn collect_paths<P: AsRef<Path>>(
                 excluded_count: 0,
                 total_file_bytes: 0,
                 collection_errors: vec![(root.to_path_buf(), error.to_string())],
+                limit_reached: false,
             };
         }
     };
@@ -101,17 +170,21 @@ pub fn collect_paths<P: AsRef<Path>>(
             directories: Vec::new(),
             excluded_count: 0,
             collection_errors: Vec::new(),
+            limit_reached: false,
         },
         TraversalMetadata::Directory {
             metadata,
             can_recurse,
-        } if can_recurse => collect_all_paths(root, &metadata, depth_limit, exclude_patterns),
+        } if can_recurse => {
+            collect_all_paths(root, &metadata, depth_limit, exclude_patterns, limits)
+        }
         TraversalMetadata::Directory { metadata, .. } => CollectedPaths {
             files: Vec::new(),
             directories: vec![(root.to_path_buf(), metadata)],
             excluded_count: 0,
             total_file_bytes: 0,
             collection_errors: Vec::new(),
+            limit_reached: false,
         },
         TraversalMetadata::Other => CollectedPaths {
             files: Vec::new(),
@@ -119,6 +192,7 @@ pub fn collect_paths<P: AsRef<Path>>(
             excluded_count: 0,
             total_file_bytes: 0,
             collection_errors: Vec::new(),
+            limit_reached: false,
         },
     }
 }
@@ -129,6 +203,22 @@ pub fn collect_selected_paths(
     max_depth: usize,
     exclude_patterns: &[Pattern],
 ) -> CollectedPaths {
+    collect_selected_paths_with_limits(
+        root,
+        selected,
+        max_depth,
+        exclude_patterns,
+        &CollectionLimits::unbounded(),
+    )
+}
+
+pub fn collect_selected_paths_with_limits(
+    root: &Path,
+    selected: &[CollectionFrontier],
+    max_depth: usize,
+    exclude_patterns: &[Pattern],
+    limits: &CollectionLimits,
+) -> CollectedPaths {
     let depth_limit = depth_limit_from_cli(max_depth);
 
     if is_path_excluded(root, exclude_patterns) {
@@ -138,10 +228,11 @@ pub fn collect_selected_paths(
             excluded_count: 1,
             total_file_bytes: 0,
             collection_errors: Vec::new(),
+            limit_reached: false,
         };
     }
 
-    let root_metadata = match classify_for_traversal(root, true) {
+    let root_metadata = match classify_for_traversal(root, true, limits) {
         Ok(TraversalMetadata::Directory { metadata, .. }) => metadata,
         Ok(TraversalMetadata::File(metadata)) => metadata,
         Ok(TraversalMetadata::Other) => {
@@ -151,6 +242,7 @@ pub fn collect_selected_paths(
                 excluded_count: 0,
                 total_file_bytes: 0,
                 collection_errors: Vec::new(),
+                limit_reached: false,
             };
         }
         Err(error) => {
@@ -160,6 +252,7 @@ pub fn collect_selected_paths(
                 excluded_count: 0,
                 total_file_bytes: 0,
                 collection_errors: vec![(root.to_path_buf(), error.to_string())],
+                limit_reached: false,
             };
         }
     };
@@ -172,9 +265,13 @@ pub fn collect_selected_paths(
         excluded_count: 0,
         total_file_bytes: 0,
         collection_errors: Vec::new(),
+        limit_reached: false,
     };
 
     for frontier in minimize_frontier(selected) {
+        if accumulator.limit_reached {
+            break;
+        }
         let relative_depth = frontier.path.components().count();
         if depth_limit.is_some_and(|limit| relative_depth > limit) {
             continue;
@@ -186,7 +283,7 @@ pub fn collect_selected_paths(
             continue;
         }
 
-        let traversal_metadata = match classify_for_traversal(&absolute, false) {
+        let traversal_metadata = match classify_for_traversal(&absolute, false, limits) {
             Ok(traversal_metadata) => traversal_metadata,
             Err(error) => {
                 accumulator
@@ -196,11 +293,11 @@ pub fn collect_selected_paths(
             }
         };
 
-        add_ancestor_directories(root, &absolute, &mut accumulator);
+        add_ancestor_directories(root, &absolute, &mut accumulator, limits);
 
         let collected = match traversal_metadata {
             TraversalMetadata::File(metadata) => {
-                insert_file(&mut accumulator, absolute, metadata);
+                insert_file(&mut accumulator, absolute, metadata, limits);
                 continue;
             }
             TraversalMetadata::Directory {
@@ -209,7 +306,13 @@ pub fn collect_selected_paths(
             } if frontier.recurse && can_recurse => {
                 let subtree_depth_limit =
                     depth_limit.map(|limit| limit.saturating_sub(relative_depth));
-                collect_all_paths(&absolute, &metadata, subtree_depth_limit, exclude_patterns)
+                collect_all_paths(
+                    &absolute,
+                    &metadata,
+                    subtree_depth_limit,
+                    exclude_patterns,
+                    &subtree_limits(limits, &accumulator),
+                )
             }
             TraversalMetadata::Directory { metadata, .. } => CollectedPaths {
                 files: Vec::new(),
@@ -217,10 +320,11 @@ pub fn collect_selected_paths(
                 excluded_count: 0,
                 total_file_bytes: 0,
                 collection_errors: Vec::new(),
+                limit_reached: false,
             },
             TraversalMetadata::Other => continue,
         };
-        merge_collected(&mut accumulator, collected);
+        merge_collected(&mut accumulator, collected, limits);
     }
 
     CollectedPaths {
@@ -229,6 +333,25 @@ pub fn collect_selected_paths(
         excluded_count: accumulator.excluded_count,
         total_file_bytes: accumulator.total_file_bytes,
         collection_errors: accumulator.collection_errors,
+        limit_reached: accumulator.limit_reached,
+    }
+}
+
+/// Adjusts the file-count and total-bytes ceilings for a subtree walk so the
+/// nested walk accounts for what the parent walk has already collected.
+fn subtree_limits(
+    limits: &CollectionLimits,
+    accumulator: &CollectionAccumulator,
+) -> CollectionLimits {
+    CollectionLimits {
+        max_file_count: limits
+            .max_file_count
+            .map(|limit| limit.saturating_sub(accumulator.files.len())),
+        max_total_bytes: limits
+            .max_total_bytes
+            .map(|limit| limit.saturating_sub(accumulator.total_file_bytes)),
+        deadline: limits.deadline,
+        symlink_root_guard: limits.symlink_root_guard.clone(),
     }
 }
 
@@ -237,16 +360,18 @@ fn collect_all_paths(
     root_metadata: &fs::Metadata,
     depth_limit: Option<usize>,
     exclude_patterns: &[Pattern],
+    limits: &CollectionLimits,
 ) -> CollectedPaths {
     let mut files = Vec::new();
     let mut directories = vec![(root.to_path_buf(), root_metadata.clone())];
     let mut excluded_count = 0;
     let mut total_file_bytes = 0_u64;
     let mut collection_errors = Vec::new();
+    let mut limit_reached = false;
 
     let mut pending_dirs: Vec<(PathBuf, Option<usize>)> = vec![(root.to_path_buf(), depth_limit)];
 
-    while let Some((dir_path, current_depth)) = pending_dirs.pop() {
+    'walk: while let Some((dir_path, current_depth)) = pending_dirs.pop() {
         let entries: Vec<_> = match fs::read_dir(&dir_path) {
             Ok(entries) => entries.filter_map(Result::ok).collect(),
             Err(e) => {
@@ -263,8 +388,15 @@ fn collect_all_paths(
                 continue;
             }
 
-            match classify_for_traversal(&path, false) {
+            match classify_for_traversal(&path, false, limits) {
                 Ok(TraversalMetadata::File(metadata)) => {
+                    if let WalkBudget::Stop(reason) =
+                        enforce_file_budget(limits, files.len(), total_file_bytes, metadata.len())
+                    {
+                        collection_errors.push((path, reason.to_string()));
+                        limit_reached = true;
+                        break 'walk;
+                    }
                     total_file_bytes += metadata.len();
                     files.push((path, metadata));
                 }
@@ -290,15 +422,44 @@ fn collect_all_paths(
         excluded_count,
         total_file_bytes,
         collection_errors,
+        limit_reached,
     }
+}
+
+/// Decides whether the next file would breach a configured ceiling or deadline.
+fn enforce_file_budget(
+    limits: &CollectionLimits,
+    collected_files: usize,
+    collected_bytes: u64,
+    next_file_bytes: u64,
+) -> WalkBudget {
+    if limits.deadline_exceeded() {
+        return WalkBudget::Stop("scan exceeded its overall time budget");
+    }
+    if limits.file_count_reached(collected_files) {
+        return WalkBudget::Stop("scan exceeded its maximum file count");
+    }
+    if limits.total_bytes_exceeded(collected_bytes, next_file_bytes) {
+        return WalkBudget::Stop("scan exceeded its maximum total byte size");
+    }
+    WalkBudget::Continue
 }
 
 fn classify_for_traversal(
     path: &Path,
     recurse_into_symlinked_directories: bool,
+    limits: &CollectionLimits,
 ) -> io::Result<TraversalMetadata> {
     let link_metadata = fs::symlink_metadata(path)?;
     if link_metadata.file_type().is_symlink() {
+        if let Some(root) = &limits.symlink_root_guard
+            && symlink_target_escapes_root(path, root)
+        {
+            // An untrusted input tree points a symlink at content outside the
+            // scan root; refuse to dereference it so we never read or emit
+            // out-of-tree data.
+            return Ok(TraversalMetadata::Other);
+        }
         let target_metadata = fs::metadata(path)?;
         return Ok(classify_resolved_metadata(
             target_metadata,
@@ -307,6 +468,20 @@ fn classify_for_traversal(
     }
 
     Ok(classify_resolved_metadata(link_metadata, true))
+}
+
+/// Returns `true` when the symlink at `path` resolves outside `root`, or when
+/// the target cannot be canonicalized (treated as an escape so we fail closed).
+fn symlink_target_escapes_root(path: &Path, root: &Path) -> bool {
+    let canonical_root = match fs::canonicalize(root) {
+        Ok(canonical_root) => canonical_root,
+        // Without a trustworthy root anchor we cannot prove containment.
+        Err(_) => return true,
+    };
+    match fs::canonicalize(path) {
+        Ok(canonical_target) => !canonical_target.starts_with(&canonical_root),
+        Err(_) => true,
+    }
 }
 
 fn classify_resolved_metadata(metadata: fs::Metadata, can_recurse: bool) -> TraversalMetadata {
@@ -365,14 +540,19 @@ fn minimize_frontier(selected: &[CollectionFrontier]) -> Vec<CollectionFrontier>
     minimized
 }
 
-fn add_ancestor_directories(root: &Path, path: &Path, accumulator: &mut CollectionAccumulator) {
+fn add_ancestor_directories(
+    root: &Path,
+    path: &Path,
+    accumulator: &mut CollectionAccumulator,
+    limits: &CollectionLimits,
+) {
     let mut current = path.parent();
     while let Some(dir) = current {
         if dir == root {
             break;
         }
         if accumulator.dir_seen.insert(dir.to_path_buf()) {
-            match classify_for_traversal(dir, false) {
+            match classify_for_traversal(dir, false, limits) {
                 Ok(TraversalMetadata::Directory { metadata, .. }) => {
                     accumulator.directories.push((dir.to_path_buf(), metadata))
                 }
@@ -386,21 +566,45 @@ fn add_ancestor_directories(root: &Path, path: &Path, accumulator: &mut Collecti
     }
 }
 
-fn insert_file(accumulator: &mut CollectionAccumulator, path: PathBuf, metadata: fs::Metadata) {
-    if accumulator.file_seen.insert(path.clone()) {
-        accumulator.total_file_bytes += metadata.len();
-        accumulator.files.push((path, metadata));
+fn insert_file(
+    accumulator: &mut CollectionAccumulator,
+    path: PathBuf,
+    metadata: fs::Metadata,
+    limits: &CollectionLimits,
+) {
+    if accumulator.limit_reached || accumulator.file_seen.contains(&path) {
+        return;
     }
+    if let WalkBudget::Stop(reason) = enforce_file_budget(
+        limits,
+        accumulator.files.len(),
+        accumulator.total_file_bytes,
+        metadata.len(),
+    ) {
+        accumulator
+            .collection_errors
+            .push((path, reason.to_string()));
+        accumulator.limit_reached = true;
+        return;
+    }
+    accumulator.file_seen.insert(path.clone());
+    accumulator.total_file_bytes += metadata.len();
+    accumulator.files.push((path, metadata));
 }
 
-fn merge_collected(accumulator: &mut CollectionAccumulator, collected: CollectedPaths) {
+fn merge_collected(
+    accumulator: &mut CollectionAccumulator,
+    collected: CollectedPaths,
+    limits: &CollectionLimits,
+) {
     accumulator.excluded_count += collected.excluded_count;
     accumulator
         .collection_errors
         .extend(collected.collection_errors);
+    accumulator.limit_reached |= collected.limit_reached;
 
     for (path, metadata) in collected.files {
-        insert_file(accumulator, path, metadata);
+        insert_file(accumulator, path, metadata, limits);
     }
     for (path, metadata) in collected.directories {
         if accumulator.dir_seen.insert(path.clone()) {
@@ -411,9 +615,13 @@ fn merge_collected(accumulator: &mut CollectionAccumulator, collected: Collected
 
 #[cfg(test)]
 mod tests {
-    use super::{CollectionFrontier, collect_paths, collect_selected_paths};
+    use super::{
+        CollectionFrontier, CollectionLimits, collect_paths, collect_paths_with_limits,
+        collect_selected_paths,
+    };
     use std::fs;
     use std::path::PathBuf;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn file_scan_root_uses_parent_directory() {
@@ -544,5 +752,149 @@ mod tests {
                 .iter()
                 .any(|(path, _)| path == &root.join("link"))
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_root_guard_skips_file_symlink_pointing_outside_root() {
+        use std::os::unix::fs::symlink;
+
+        let outside_dir = tempfile::tempdir().expect("outside temp dir");
+        let secret = outside_dir.path().join("secret.txt");
+        fs::write(&secret, "TOP SECRET\n").expect("write out-of-tree secret");
+
+        let scan_dir = tempfile::tempdir().expect("scan temp dir");
+        let root = scan_dir.path();
+        fs::write(root.join("inside.txt"), "ordinary\n").expect("write inside file");
+        symlink(&secret, root.join("creds")).expect("create escaping symlink");
+
+        let limits = CollectionLimits {
+            symlink_root_guard: Some(root.to_path_buf()),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_paths_with_limits(root, 0, &[], &limits);
+
+        // The escaping symlink must never appear in the collected file set.
+        assert!(
+            collected
+                .files
+                .iter()
+                .all(|(path, _)| path != &root.join("creds"))
+        );
+        // The legitimate in-tree file is still collected.
+        assert!(
+            collected
+                .files
+                .iter()
+                .any(|(path, _)| path == &root.join("inside.txt"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_root_guard_keeps_in_tree_file_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let scan_dir = tempfile::tempdir().expect("scan temp dir");
+        let root = scan_dir.path();
+        let target = root.join("target.txt");
+        fs::write(&target, "content\n").expect("write target file");
+        symlink(&target, root.join("link.txt")).expect("create in-tree symlink");
+
+        let limits = CollectionLimits {
+            symlink_root_guard: Some(root.to_path_buf()),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_paths_with_limits(root, 0, &[], &limits);
+
+        assert!(
+            collected
+                .files
+                .iter()
+                .any(|(path, _)| path == &root.join("link.txt"))
+        );
+    }
+
+    #[test]
+    fn max_file_count_limit_stops_collection() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        for index in 0..5 {
+            fs::write(root.join(format!("file{index}.txt")), "x\n").expect("write file");
+        }
+
+        let limits = CollectionLimits {
+            max_file_count: Some(2),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_paths_with_limits(root, 0, &[], &limits);
+
+        assert!(collected.limit_reached);
+        assert!(collected.file_count() <= 2);
+        assert!(
+            collected
+                .collection_errors
+                .iter()
+                .any(|(_, reason)| reason.contains("maximum file count"))
+        );
+    }
+
+    #[test]
+    fn max_total_bytes_limit_stops_collection() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        for index in 0..5 {
+            fs::write(root.join(format!("file{index}.txt")), vec![b'x'; 100]).expect("write file");
+        }
+
+        let limits = CollectionLimits {
+            max_total_bytes: Some(150),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_paths_with_limits(root, 0, &[], &limits);
+
+        assert!(collected.limit_reached);
+        assert!(collected.total_file_bytes <= 150);
+        assert!(
+            collected
+                .collection_errors
+                .iter()
+                .any(|(_, reason)| reason.contains("maximum total byte size"))
+        );
+    }
+
+    #[test]
+    fn deadline_already_passed_stops_collection() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        fs::write(root.join("file.txt"), "x\n").expect("write file");
+
+        let limits = CollectionLimits {
+            deadline: Some(Instant::now() - Duration::from_secs(1)),
+            ..CollectionLimits::unbounded()
+        };
+        let collected = collect_paths_with_limits(root, 0, &[], &limits);
+
+        assert!(collected.limit_reached);
+        assert!(
+            collected
+                .collection_errors
+                .iter()
+                .any(|(_, reason)| reason.contains("overall time budget"))
+        );
+    }
+
+    #[test]
+    fn unbounded_limits_preserve_full_collection() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        for index in 0..5 {
+            fs::write(root.join(format!("file{index}.txt")), "x\n").expect("write file");
+        }
+
+        let collected = collect_paths_with_limits(root, 0, &[], &CollectionLimits::unbounded());
+
+        assert!(!collected.limit_reached);
+        assert_eq!(collected.file_count(), 5);
     }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -129,7 +129,8 @@ pub fn scan_options_fingerprint(
 }
 
 pub use self::collect::{
-    CollectedPaths, CollectionFrontier, collect_paths, collect_selected_paths,
+    CollectedPaths, CollectionFrontier, CollectionLimits, collect_paths, collect_paths_with_limits,
+    collect_selected_paths, collect_selected_paths_with_limits,
 };
 #[allow(unused_imports)]
 pub use self::process::{

--- a/src/serve/ingest.rs
+++ b/src/serve/ingest.rs
@@ -76,6 +76,15 @@ type Result<T> = std::result::Result<T, IngestError>;
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_REDIRECTS: usize = 5;
+
+// Overall per-scan ceilings for the untrusted serve lane. These are
+// intentionally generous so realistic projects scan unchanged, while still
+// bounding hostile inputs (e.g. a repository of millions of tiny files) that
+// would otherwise run effectively unbounded on the single sync-scan worker.
+const SERVE_MAX_SCAN_FILES: usize = 500_000;
+const SERVE_MAX_SCAN_TOTAL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const SERVE_SCAN_DEADLINE_SECONDS: f64 = 300.0;
+
 const MAX_REMOTE_INPUT_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_UPLOADED_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
@@ -805,6 +814,13 @@ impl SyncScanExecution {
             options.full_root = false;
         }
 
+        // Every serve request handles untrusted input, so bound the walk and
+        // refuse to dereference symlinks that escape the scan root.
+        options.max_files = Some(SERVE_MAX_SCAN_FILES);
+        options.max_total_bytes = Some(SERVE_MAX_SCAN_TOTAL_BYTES);
+        options.scan_deadline_seconds = Some(SERVE_SCAN_DEADLINE_SECONDS);
+        options.restrict_out_of_tree_symlinks = true;
+
         Ok(Self {
             paths,
             options,
@@ -866,6 +882,77 @@ mod tests {
             error
                 .to_string()
                 .contains("input.paths must contain at least one path")
+        );
+    }
+
+    #[test]
+    fn sync_scan_execution_applies_untrusted_scan_bounds() {
+        use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
+
+        let temp_dir = TempDir::new().expect("temp dir");
+        fs::write(temp_dir.path().join("file.txt"), "content\n").expect("write file");
+
+        let execution = SyncScanExecution::new(
+            ServeScanRequest {
+                input: ServeScanInput::Paths {
+                    paths: vec![temp_dir.path().to_string_lossy().to_string()],
+                },
+                options: ServeScanOptions::default(),
+            },
+            IngestPolicy::allow_privileged_inputs(),
+        )
+        .expect("scan execution should build");
+
+        assert_eq!(execution.options.max_files, Some(SERVE_MAX_SCAN_FILES));
+        assert_eq!(
+            execution.options.max_total_bytes,
+            Some(SERVE_MAX_SCAN_TOTAL_BYTES)
+        );
+        assert_eq!(
+            execution.options.scan_deadline_seconds,
+            Some(SERVE_SCAN_DEADLINE_SECONDS)
+        );
+        assert!(execution.options.restrict_out_of_tree_symlinks);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn serve_scan_does_not_emit_out_of_tree_symlink_target() {
+        use crate::serve_api::{ServeScanInput, ServeScanOptions, ServeScanRequest};
+        use std::os::unix::fs::symlink;
+
+        let outside_dir = TempDir::new().expect("outside temp dir");
+        let secret = outside_dir.path().join("secret.txt");
+        fs::write(&secret, "SERVE_SECRET_MARKER\n").expect("write out-of-tree secret");
+
+        let scan_dir = TempDir::new().expect("scan temp dir");
+        fs::write(scan_dir.path().join("inside.txt"), "ordinary\n").expect("write inside file");
+        symlink(&secret, scan_dir.path().join("creds")).expect("create escaping symlink");
+
+        let execution = SyncScanExecution::new(
+            ServeScanRequest {
+                input: ServeScanInput::Paths {
+                    paths: vec![scan_dir.path().to_string_lossy().to_string()],
+                },
+                options: ServeScanOptions {
+                    collect_info: true,
+                    ..ServeScanOptions::default()
+                },
+            },
+            IngestPolicy::allow_privileged_inputs(),
+        )
+        .expect("scan execution should build");
+
+        let body = execution.execute().expect("serve scan should succeed");
+
+        // The escaping symlink and the out-of-tree target name must not surface.
+        assert!(
+            !body.contains("creds"),
+            "escaping symlink should not be scanned"
+        );
+        assert!(
+            body.contains("inside.txt"),
+            "in-tree file should be scanned"
         );
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -88,6 +88,18 @@ pub struct ScanOptions {
     pub strip_root: bool,
     pub full_root: bool,
     pub header_options: JsonMap<String, JsonValue>,
+    /// Maximum number of files to collect before the walk stops, if any.
+    ///
+    /// Untrusted callers (such as `provenant serve`) set finite ceilings to
+    /// bound denial-of-service exposure; trusted scans leave these unset.
+    pub max_files: Option<usize>,
+    /// Maximum cumulative size of collected files in bytes, if any.
+    pub max_total_bytes: Option<u64>,
+    /// Overall wall-clock budget for the collection pass in seconds, if any.
+    pub scan_deadline_seconds: Option<f64>,
+    /// When `true`, file symlinks whose target escapes the scan root are skipped
+    /// instead of being dereferenced and scanned.
+    pub restrict_out_of_tree_symlinks: bool,
 }
 
 impl Default for ScanOptions {
@@ -144,6 +156,10 @@ impl Default for ScanOptions {
             strip_root: false,
             full_root: false,
             header_options: JsonMap::new(),
+            max_files: None,
+            max_total_bytes: None,
+            scan_deadline_seconds: None,
+            restrict_out_of_tree_symlinks: false,
         }
     }
 }
@@ -297,6 +313,12 @@ fn request_for_native_paths(input_paths: Vec<String>, options: &ScanOptions) -> 
         max_email: options.max_emails,
         url: options.detect_urls,
         max_url: options.max_urls,
+        scan_bounds: crate::app::request::ScanBounds {
+            max_files: options.max_files,
+            max_total_bytes: options.max_total_bytes,
+            deadline_seconds: options.scan_deadline_seconds,
+            restrict_out_of_tree_symlinks: options.restrict_out_of_tree_symlinks,
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- Stop the file walker from dereferencing out-of-tree file symlinks for untrusted scans, closing an information-disclosure primitive.
- Enforce configurable max-file-count, max-total-bytes, and an overall wall-clock deadline in the collector, closing an unbounded-scan DoS.
- Wire generous, non-breaking defaults for the `provenant serve` lane; trusted CLI and library scans are unchanged.

## Issues

- Closes: #988

## Scope and exclusions

- Included:
  - `CollectionLimits` on the collector with `max_file_count`, `max_total_bytes`, `deadline`, and an optional `symlink_root_guard`. When the guard is set, file symlinks whose canonicalized target escapes the scan root are skipped (fail-closed when the target cannot be canonicalized). Existing `collect_paths` / `collect_selected_paths` keep their signatures as unbounded wrappers over new `*_with_limits` entrypoints.
  - Limits thread `ScanOptions` -> `ScanRequest` -> collector; the deadline clock starts at collection time and the symlink guard is anchored at the scan root.
  - `provenant serve` applies the symlink guard and bounds to every request (untrusted input): 500k files, 4 GiB total, 300s deadline.
  - When a limit truncates a walk, a runtime error is recorded in scan output and `CollectedPaths.limit_reached` is set.
- Explicit exclusions:
  - Directory symlinks were already not recursed; unchanged.
  - The serve single-sync-worker count is unchanged; the per-scan deadline plus collector ceilings bound how long one request can hold that worker, which addresses the stall vector without changing the concurrency model.
  - A hard post-fetch disk cap on the git checkout is deferred (see Follow-up); the file-count, byte, and deadline ceilings already bound how much of a huge checkout is read and emitted.

## How to verify

- Symlink guard, end to end through serve: `cargo test --lib -- serve::ingest::tests::serve_scan_does_not_emit_out_of_tree_symlink_target` builds a scan dir with `creds -> <out-of-tree secret>` and asserts the secret is never emitted while the in-tree file still is.
- Collector unit coverage: `cargo test --lib -- scanner::collect` covers symlink-escape skip, in-tree symlink preserved, file-count cap, total-bytes cap, already-passed deadline, and the unbounded-default no-op.
- Manual: run `provenant serve --bind 127.0.0.1:8080`, POST a `paths` scan of a tree containing an escaping symlink, and confirm the target content is absent from the response.

## Follow-up work

- Created or intentionally deferred: a hard post-fetch size/disk cap on the `repository` git checkout (issue #988 suggested item) is deferred; the new collector ceilings bound read/emit cost, but a pre-read disk-usage check would additionally cap staging-disk consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
