### PR TITLE
enhancement(license-detection): avoid full embedded-artifact decode on warm startup

### DIFF
--- a/src/license_detection/embedded/index.rs
+++ b/src/license_detection/embedded/index.rs
@@ -1,9 +1,37 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::Read;
+
+use serde::Deserialize;
+
 use super::schema::{EmbeddedArtifactMetadata, EmbeddedLoaderSnapshot, SCHEMA_VERSION};
 use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::index::build_index_from_loaded;
+
+/// Prefix of [`EmbeddedLoaderSnapshot`] covering only the leading fields needed
+/// to validate the cache and surface artifact metadata.
+///
+/// postcard serializes struct fields in declaration order with no whole-struct
+/// length framing, so deserializing this prefix from the start of the snapshot
+/// yields the same `schema_version` and `metadata` as the full snapshot without
+/// touching the (much larger) `rules` and `licenses` that follow. The field
+/// order here MUST stay in lockstep with the leading fields of
+/// [`EmbeddedLoaderSnapshot`].
+#[derive(Debug, Clone, Deserialize)]
+struct EmbeddedArtifactMetadataPrefix {
+    schema_version: u32,
+    metadata: EmbeddedArtifactMetadata,
+}
+
+/// Decompressed-prefix budget for the streaming metadata read. The metadata
+/// section is a few hundred bytes; this leaves generous headroom while keeping
+/// the read bounded so a malformed artifact cannot force decompressing the
+/// whole payload before failing.
+const METADATA_PREFIX_MAX_BYTES: usize = 64 * 1024;
+
+/// Bytes pulled from the streaming zstd decoder per growth step.
+const METADATA_PREFIX_CHUNK_BYTES: usize = 4 * 1024;
 
 // Loader handle: fields are consumed by maintainer/index-build paths, not every routine-scan path.
 #[derive(Debug, Clone)]
@@ -58,10 +86,73 @@ pub fn load_embedded_license_index_from_bytes(
     })
 }
 
+/// Read just the artifact metadata without materializing the full snapshot.
+///
+/// This streams the zstd payload and postcard-decodes only the
+/// `{schema_version, metadata}` prefix, so warm-cache startup no longer pays
+/// for decompressing and deserializing all rules and licenses just to validate
+/// the cache. The schema-version check matches
+/// [`load_loader_snapshot_from_bytes`] so a stale or mismatched artifact is
+/// still rejected here.
 pub fn load_embedded_artifact_metadata_from_bytes(
     bytes: &[u8],
 ) -> Result<EmbeddedArtifactMetadata, SerializationError> {
-    Ok(load_loader_snapshot_from_bytes(bytes)?.metadata)
+    if bytes.is_empty() {
+        return Err(SerializationError(
+            "Embedded license index artifact is empty".to_string(),
+        ));
+    }
+
+    let mut decoder =
+        zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes)).map_err(|e| {
+            SerializationError(format!("Failed to decompress embedded artifact: {}", e))
+        })?;
+
+    // Grow a decompressed prefix until the metadata prefix decodes, the decoder
+    // hits EOF, or we exceed the bounded budget. postcard reports a recoverable
+    // "ran out of bytes" error while the prefix is incomplete; any other error
+    // is a genuine deserialization failure and must propagate.
+    let mut prefix: Vec<u8> = Vec::with_capacity(METADATA_PREFIX_CHUNK_BYTES);
+    loop {
+        match postcard::take_from_bytes::<EmbeddedArtifactMetadataPrefix>(&prefix) {
+            Ok((decoded, _rest)) => {
+                if decoded.schema_version != SCHEMA_VERSION {
+                    return Err(SerializationError(format!(
+                        "Embedded artifact schema version mismatch: expected {}, got {}",
+                        SCHEMA_VERSION, decoded.schema_version
+                    )));
+                }
+                return Ok(decoded.metadata);
+            }
+            Err(postcard::Error::DeserializeUnexpectedEnd) => {}
+            Err(e) => {
+                return Err(SerializationError(format!(
+                    "Failed to deserialize embedded artifact metadata: {}",
+                    e
+                )));
+            }
+        }
+
+        if prefix.len() >= METADATA_PREFIX_MAX_BYTES {
+            return Err(SerializationError(format!(
+                "Embedded artifact metadata exceeds {} byte prefix budget",
+                METADATA_PREFIX_MAX_BYTES
+            )));
+        }
+
+        let mut chunk = [0u8; METADATA_PREFIX_CHUNK_BYTES];
+        let read = decoder.read(&mut chunk).map_err(|e| {
+            SerializationError(format!("Failed to decompress embedded artifact: {}", e))
+        })?;
+        if read == 0 {
+            // Decoder is exhausted but the prefix still did not decode.
+            return Err(SerializationError(
+                "Failed to deserialize embedded artifact metadata: artifact ended before metadata"
+                    .to_string(),
+            ));
+        }
+        prefix.extend_from_slice(&chunk[..read]);
+    }
 }
 
 #[cfg(test)]
@@ -216,5 +307,57 @@ mod tests {
     fn test_load_license_index_from_bytes_rejects_empty() {
         let error = load_embedded_license_index_from_bytes(&[]).unwrap_err();
         assert!(error.to_string().contains("artifact is empty"));
+    }
+
+    #[test]
+    fn test_metadata_prefix_matches_full_decode() {
+        // Use enough rules/licenses that the trailing sections clearly dwarf the
+        // metadata, so the prefix read cannot accidentally consume everything.
+        let rules: Vec<LoadedRule> = (0..256).map(|_| create_test_loaded_rule()).collect();
+        let licenses: Vec<LoadedLicense> = (0..256).map(|_| create_test_loaded_license()).collect();
+        let bytes = serialize_loader_snapshot_to_bytes(rules, licenses).expect("Should serialize");
+
+        let prefix_metadata =
+            load_embedded_artifact_metadata_from_bytes(&bytes).expect("prefix read should succeed");
+        let full_metadata = load_loader_snapshot_from_bytes(&bytes)
+            .expect("full decode should succeed")
+            .metadata;
+
+        assert_eq!(prefix_metadata, full_metadata);
+    }
+
+    #[test]
+    fn test_metadata_prefix_rejects_empty() {
+        let error = load_embedded_artifact_metadata_from_bytes(&[]).unwrap_err();
+        assert!(error.to_string().contains("artifact is empty"));
+    }
+
+    #[test]
+    fn test_metadata_prefix_rejects_schema_version_mismatch() {
+        let snapshot = EmbeddedLoaderSnapshot {
+            schema_version: SCHEMA_VERSION + 1,
+            metadata: create_test_metadata(),
+            rules: vec![create_test_loaded_rule()],
+            licenses: vec![create_test_loaded_license()],
+        };
+        let postcard_bytes = postcard::to_allocvec(&snapshot).expect("Should serialize");
+        let bytes = zstd::encode_all(&postcard_bytes[..], 0).expect("Should compress");
+
+        let error = load_embedded_artifact_metadata_from_bytes(&bytes).unwrap_err();
+        assert!(
+            error.to_string().contains("schema version mismatch"),
+            "expected schema mismatch, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_metadata_prefix_rejects_garbage() {
+        let bytes =
+            zstd::encode_all(&b"not a valid postcard snapshot"[..], 0).expect("Should compress");
+        let error = load_embedded_artifact_metadata_from_bytes(&bytes).unwrap_err();
+        assert!(
+            error.to_string().contains("deserialize"),
+            "expected deserialize failure, got: {error}"
+        );
     }
 }

--- a/src/license_detection/embedded/schema.rs
+++ b/src/license_detection/embedded/schema.rs
@@ -16,6 +16,13 @@ pub struct EmbeddedArtifactMetadata {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddedLoaderSnapshot {
+    // WARNING: `schema_version` and `metadata` MUST stay the first two fields,
+    // in this order. The warm-startup fast path in
+    // `embedded::index::load_embedded_artifact_metadata_from_bytes` postcard-
+    // decodes only this `{schema_version, metadata}` prefix (via
+    // `EmbeddedArtifactMetadataPrefix`) without reading `rules`/`licenses`.
+    // Inserting or reordering a field before/between these two silently breaks
+    // that prefix decode.
     pub schema_version: u32,
     pub metadata: EmbeddedArtifactMetadata,
     pub rules: Vec<LoadedRule>,

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -590,10 +590,10 @@ impl LicenseDetectionEngine {
         let provenance = Some(artifact_metadata.license_index_provenance.clone());
 
         if !cache_config.reindex {
+            let start = Instant::now();
             if let Some(cached) =
                 load_cached_index(cache_config, LicenseCacheNamespace::Embedded, &fingerprint)?
             {
-                let start = Instant::now();
                 eprintln!(
                     "License index loaded from rkyv cache in {:.2}s",
                     start.elapsed().as_secs_f64()


### PR DESCRIPTION
## Summary

- Warm-cache engine startup decompressed and postcard-deserialized the entire ~6.6 MB embedded artifact (all rules + licenses) just to read the tiny metadata used to validate the rkyv cache, adding fixed per-CLI-invocation latency.
- `load_embedded_artifact_metadata_from_bytes` now streams the zstd payload and postcard-decodes only the `{schema_version, metadata}` prefix via `take_from_bytes`, reading a few KB instead of the full payload. postcard serializes struct fields in declaration order with no whole-struct length framing, so the prefix decodes identically to the full snapshot.
- Cache safety is preserved: the schema-version check still runs (stale/mismatched artifact rejected), and the cache fingerprint is still computed over the full artifact bytes, so invalidation is unchanged. The full decode is kept only for the cache-miss rebuild path.
- Fixed the warm-hit timer, which was created after the load and always printed ~0; it now wraps the actual cache load.

## Issues

- Closes: #993

## Scope and exclusions

- Included: read-side prefix metadata decode, warm-hit timer fix, tests.
- Explicit exclusions: no change to the on-disk artifact format or the `xtask generate-index-artifact` generator (read-side-only change, no regeneration needed).

## How to verify

- `cargo test --lib license_detection::embedded` and `cargo test --lib license_detection::license_cache`.
- New tests assert the prefix read returns the same metadata as the full decode for a large snapshot, and that empty / schema-mismatch / garbage artifacts are still rejected.
- End-to-end: warm `provenant scan <dir> --license --json-pp - --cache-dir <dir>` still detects licenses and loads from the rkyv cache. Measured warm startup dropped from ~0.42s to ~0.36s per invocation (release build, single-file scan); the printed "loaded from rkyv cache" timer now shows a real duration (~0.29s) instead of 0.00s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)