### PR TITLE
fix(parsers): correct post-extraction fallback referenced-filenames, CRLF holders, and slash guard

### DIFF
--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -135,9 +135,16 @@ pub(crate) fn normalize_spdx_declared_license(
     )
 }
 
+/// Runs free-text license detection over `text` and shapes the result into
+/// declared-license data.
+///
+/// `referenced_filename` records the file the statement was read from when the
+/// license came from a *referenced* file (so the detection carries that
+/// provenance). Pass `None` when the statement is the manifest's own declared
+/// value, since there is no separate referenced file in that case.
 pub(crate) fn detect_declared_license_from_text(
     text: &str,
-    referenced_filename: &str,
+    referenced_filename: Option<&str>,
 ) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
     let text = text.trim();
     if text.is_empty() {
@@ -170,7 +177,7 @@ pub(crate) fn detect_declared_license_from_text(
         declared_license_expression_spdx,
     ) {
         (Some(declared), Some(declared_spdx)) => {
-            let references = [referenced_filename];
+            let references: Vec<&str> = referenced_filename.into_iter().collect();
             build_declared_license_data_from_pair(
                 declared,
                 declared_spdx,
@@ -420,7 +427,10 @@ fn populate_declared_license_fields(package_data: &mut PackageData) {
         } else if looks_like_multi_license_composite(statement) {
             empty_declared_license_data()
         } else {
-            detect_declared_license_from_text(statement, statement)
+            // The statement is the manifest's own declared value, not a
+            // referenced file, so it must not be recorded as a referenced
+            // filename in the resulting detection.
+            detect_declared_license_from_text(statement, None)
         }
     };
 
@@ -465,7 +475,7 @@ fn derive_holder_from_copyright(copyright: &str) -> String {
     }
 
     let prefixed = copyright
-        .split('\n')
+        .lines()
         .map(|line| format!("Copyright {line}"))
         .collect::<Vec<_>>()
         .join("\n");
@@ -496,12 +506,18 @@ fn looks_like_multi_license_composite(statement: &str) -> bool {
         return true;
     }
     // Separators that commonly join distinct license names (e.g. "MIT/BSD",
-    // "GPL | LGPL", "MIT, Apache-2.0"). A "/" inside a URL is excluded by the
-    // surrounding scheme check.
+    // "GPL | LGPL", "MIT, Apache-2.0").
     if statement.contains('|') || statement.contains(';') || statement.contains(',') {
         return true;
     }
-    statement.contains('/') && !statement.contains("://")
+    // A bare "/" separates license names, but a "/" inside a URL (e.g.
+    // "http://x") must not count. Inspect each whitespace token and ignore the
+    // ones that look like URLs, so "MIT/BSD see http://x" is still composite
+    // while "https://example.com/LICENSE" is not.
+    statement
+        .split_whitespace()
+        .filter(|token| !token.contains("://"))
+        .any(|token| token.contains('/'))
 }
 
 /// Estimates whether a multi-line statement carries more than one license.
@@ -1143,6 +1159,97 @@ mod tests {
         assert!(package.declared_license_expression.is_none());
         assert!(package.declared_license_expression_spdx.is_none());
         assert!(package.license_detections.is_empty());
+    }
+
+    #[test]
+    fn test_populate_declared_license_via_engine_fallback_has_no_referenced_filenames() {
+        // A declared license derived from the manifest's own statement (here via
+        // the free-text engine fallback) has no separate referenced file, so the
+        // detection must not record the statement text as a referenced filename.
+        let mut package = package_with(Some("Apache 2.0"), None, None);
+        populate_declared_license_and_holder(&mut package);
+
+        assert!(!package.license_detections.is_empty());
+        for detection in &package.license_detections {
+            for detection_match in &detection.matches {
+                assert!(
+                    detection_match
+                        .referenced_filenames
+                        .as_ref()
+                        .is_none_or(|filenames| filenames.is_empty()),
+                    "engine-fallback declared license must not record referenced filenames, got {:?}",
+                    detection_match.referenced_filenames
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_detect_declared_license_from_text_without_referenced_filename() {
+        let (declared, _declared_spdx, detections) =
+            detect_declared_license_from_text("Apache 2.0", None);
+
+        assert_eq!(declared.as_deref(), Some("apache-2.0"));
+        assert_eq!(detections.len(), 1);
+        assert!(
+            detections[0].matches[0]
+                .referenced_filenames
+                .as_ref()
+                .is_none_or(|filenames| filenames.is_empty())
+        );
+    }
+
+    #[test]
+    fn test_detect_declared_license_from_text_with_referenced_filename() {
+        let (declared, _declared_spdx, detections) =
+            detect_declared_license_from_text("Apache 2.0", Some("LICENSE"));
+
+        assert_eq!(declared.as_deref(), Some("apache-2.0"));
+        assert_eq!(detections.len(), 1);
+        assert_eq!(
+            detections[0].matches[0].referenced_filenames.as_deref(),
+            Some(["LICENSE".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn test_populate_holder_handles_crlf_like_lf() {
+        let crlf = package_with(
+            None,
+            Some("Copyright (c) 2024 Foo Corp\r\nCopyright (c) 2024 Bar Inc"),
+            None,
+        );
+        let lf = package_with(
+            None,
+            Some("Copyright (c) 2024 Foo Corp\nCopyright (c) 2024 Bar Inc"),
+            None,
+        );
+
+        let mut crlf_package = crlf;
+        let mut lf_package = lf;
+        populate_declared_license_and_holder(&mut crlf_package);
+        populate_declared_license_and_holder(&mut lf_package);
+
+        assert_eq!(crlf_package.holder, lf_package.holder);
+        assert!(
+            !crlf_package
+                .holder
+                .as_deref()
+                .unwrap_or_default()
+                .contains('\r'),
+            "CRLF copyright must not leak a trailing carriage return into the holder"
+        );
+    }
+
+    #[test]
+    fn test_looks_like_multi_license_composite_slash_with_url() {
+        // A bare slash separating license names is composite even when a URL is
+        // also present.
+        assert!(looks_like_multi_license_composite("MIT/BSD see http://x"));
+        // A slash that only appears inside a URL is not a separator.
+        assert!(!looks_like_multi_license_composite(
+            "Apache 2.0 http://www.apache.org/licenses/LICENSE-2.0"
+        ));
     }
 
     #[test]

--- a/src/parsers/windows_executable.rs
+++ b/src/parsers/windows_executable.rs
@@ -964,7 +964,7 @@ fn merge_sibling_license_text(path: &Path, package: &mut PackageData) {
     };
 
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-        detect_declared_license_from_text(&license_text, &license_path);
+        detect_declared_license_from_text(&license_text, Some(license_path.as_str()));
 
     if declared_license_expression_spdx.is_some() {
         package.declared_license_expression = declared_license_expression;

--- a/testdata/assembly-golden/maven-basic/expected.json
+++ b/testdata/assembly-golden/maven-basic/expected.json
@@ -53,9 +53,7 @@
               "rule_identifier": "apache-2.0_771.RULE",
               "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_771.RULE",
               "matched_text": "- license:\n    name: Apache License 2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0",
-              "referenced_filenames": [
-                "- license:\n    name: Apache License 2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0"
-              ]
+              "referenced_filenames": []
             }
           ],
           "identifier": "apache_2_0-c6b77120-5aec-1811-2b12-f22e7b75b1bd"

--- a/testdata/clojure-golden/basic-project/project.clj.expected.json
+++ b/testdata/clojure-golden/basic-project/project.clj.expected.json
@@ -92,9 +92,7 @@
             "rule_identifier": "epl-1.0_30.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/epl-1.0_30.RULE",
             "matched_text": "- license:\n    name: Eclipse Public License\n    url: https://www.eclipse.org/legal/epl-v10.html",
-            "referenced_filenames": [
-              "- license:\n    name: Eclipse Public License\n    url: https://www.eclipse.org/legal/epl-v10.html"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/cran/geometry/expected.json
+++ b/testdata/cran/geometry/expected.json
@@ -101,7 +101,7 @@
             "rule_identifier": "gpl-3.0_25.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0_25.RULE",
             "matched_text": "GPL (>= 3)",
-            "referenced_filenames": ["GPL (>= 3)"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/erlang-otp-golden/lager.app.src.expected
+++ b/testdata/erlang-otp-golden/lager.app.src.expected
@@ -44,9 +44,7 @@
             "rule_identifier": "apache-2.0_217.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_217.RULE",
             "matched_text": "Apache 2",
-            "referenced_filenames": [
-              "Apache 2"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/maven-golden/jrecordbind/pom.xml.expected
+++ b/testdata/maven-golden/jrecordbind/pom.xml.expected
@@ -106,9 +106,7 @@
             "rule_identifier": "lgpl_bare_single_word.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl_bare_single_word.RULE",
             "matched_text": "- license:\n    name: LGPL\n    url: http://www.gnu.org/copyleft/lesser.html",
-            "referenced_filenames": [
-              "- license:\n    name: LGPL\n    url: http://www.gnu.org/copyleft/lesser.html"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/maven-golden/logback-access/pom.xml.expected
+++ b/testdata/maven-golden/logback-access/pom.xml.expected
@@ -85,9 +85,7 @@
             "rule_identifier": "lgpl-2.1-plus_515.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_515.RULE",
             "matched_text": "- license:\n    name: GNU Lesser General Public License\n    url: http://www.gnu.org/licenses/lgpl.html",
-            "referenced_filenames": [
-              "- license:\n    name: GNU Lesser General Public License\n    url: http://www.gnu.org/licenses/lgpl.html"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/maven-golden/spring/pom.xml.expected
+++ b/testdata/maven-golden/spring/pom.xml.expected
@@ -598,9 +598,7 @@
             "rule_identifier": "apache-2.0_1309.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1309.RULE",
             "matched_text": "- license:\n    name: The Apache Software License, Version 2.0\n    url: http://www.apache.org/licenses/LICENSE-2.0.txt",
-            "referenced_filenames": [
-              "- license:\n    name: The Apache Software License, Version 2.0\n    url: http://www.apache.org/licenses/LICENSE-2.0.txt"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nix-golden/default-demo/default.nix.expected.json
+++ b/testdata/nix-golden/default-demo/default.nix.expected.json
@@ -57,7 +57,7 @@
             "rule_identifier": "mit_30.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE",
             "matched_text": "licenses.mit",
-            "referenced_filenames": ["licenses.mit"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/npm-golden/authors_list_dicts/package.json.expected
+++ b/testdata/npm-golden/authors_list_dicts/package.json.expected
@@ -72,9 +72,7 @@
             "rule_identifier": "mit_30.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE",
             "matched_text": "- type: MIT\n  url: https://github.com/csscomb/grunt-csscomb/blob/master/LICENSE-MIT",
-            "referenced_filenames": [
-              "- type: MIT\n  url: https://github.com/csscomb/grunt-csscomb/blob/master/LICENSE-MIT"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/npm-golden/express-jwt-3.4.0/package.json.expected
+++ b/testdata/npm-golden/express-jwt-3.4.0/package.json.expected
@@ -63,9 +63,7 @@
             "rule_identifier": "mit_13.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_13.RULE",
             "matched_text": "- type: MIT\n  url: http://www.opensource.org/licenses/MIT",
-            "referenced_filenames": [
-              "- type: MIT\n  url: http://www.opensource.org/licenses/MIT"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/aspnet-mvc/Microsoft.AspNet.Mvc.nuspec.expected
+++ b/testdata/nuget-golden/aspnet-mvc/Microsoft.AspNet.Mvc.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "ms-net-library_1.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/ms-net-library_1.RULE",
             "matched_text": "http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
-            "referenced_filenames": [
-              "http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/bootstrap/bootstrap.nuspec.expected
+++ b/testdata/nuget-golden/bootstrap/bootstrap.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "mit_180.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_180.RULE",
             "matched_text": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
-            "referenced_filenames": [
-              "https://github.com/twbs/bootstrap/blob/master/LICENSE"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/castle-core/Castle.Core.nuspec.expected
+++ b/testdata/nuget-golden/castle-core/Castle.Core.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "apache-2.0_20.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_20.RULE",
             "matched_text": "http://www.apache.org/licenses/LICENSE-2.0.html",
-            "referenced_filenames": [
-              "http://www.apache.org/licenses/LICENSE-2.0.html"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/entity-framework/EntityFramework.nuspec.expected
+++ b/testdata/nuget-golden/entity-framework/EntityFramework.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "ms-net-library_6.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/ms-net-library_6.RULE",
             "matched_text": "http://go.microsoft.com/fwlink/?LinkID=320539",
-            "referenced_filenames": [
-              "http://go.microsoft.com/fwlink/?LinkID=320539"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/jquery-ui/jQuery.UI.Combined.nuspec.expected
+++ b/testdata/nuget-golden/jquery-ui/jQuery.UI.Combined.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "mit_jquery_url.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_jquery_url.RULE",
             "matched_text": "http://jquery.org/license",
-            "referenced_filenames": [
-              "http://jquery.org/license"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/nuget-golden/net-http/Microsoft.Net.Http.nuspec.expected
+++ b/testdata/nuget-golden/net-http/Microsoft.Net.Http.nuspec.expected
@@ -59,9 +59,7 @@
             "rule_identifier": "ms-net-library-2018-11_3.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/ms-net-library-2018-11_3.RULE",
             "matched_text": "http://go.microsoft.com/fwlink/?LinkId=329770",
-            "referenced_filenames": [
-              "http://go.microsoft.com/fwlink/?LinkId=329770"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/pip-inspect-deplock/basic/pip-inspect.deplock.expected.json
+++ b/testdata/pip-inspect-deplock/basic/pip-inspect.deplock.expected.json
@@ -43,7 +43,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/python/golden/anonapi-sdist-pkginfo-expected.json
+++ b/testdata/python/golden/anonapi-sdist-pkginfo-expected.json
@@ -61,9 +61,7 @@
             "rule_identifier": "mit_31.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_31.RULE",
             "matched_text": "license: MIT license\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'",
-            "referenced_filenames": [
-              "license: MIT license\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/python/golden/anonapi-wheel-metadata-expected.json
+++ b/testdata/python/golden/anonapi-wheel-metadata-expected.json
@@ -125,9 +125,7 @@
             "rule_identifier": "mit_31.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_31.RULE",
             "matched_text": "license: MIT license\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'",
-            "referenced_filenames": [
-              "license: MIT license\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/python/golden/metadata/METADATA-expected.json
+++ b/testdata/python/golden/metadata/METADATA-expected.json
@@ -58,9 +58,7 @@
             "rule_identifier": "mit_30.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_30.RULE",
             "matched_text": "license: MIT\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'",
-            "referenced_filenames": [
-              "license: MIT\nclassifiers:\n  - 'License :: OSI Approved :: MIT License'"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/download-link-as-download_url/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/download-link-as-download_url/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/downloaded-from-as-download_url/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/downloaded-from-as-download_url/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/project-as-name/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/project-as-name/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/repo-as-homepage_url/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/repo-as-homepage_url/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/source-as-homepage_url/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/source-as-homepage_url/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/readme-golden/facebook/website-as-homepage_url/README.facebook.expected.json
+++ b/testdata/readme-golden/facebook/website-as-homepage_url/README.facebook.expected.json
@@ -44,7 +44,7 @@
             "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
             "matched_text": "Apache 2.0",
-            "referenced_filenames": ["Apache 2.0"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/rpm/specfile/cpio.spec.expected.json
+++ b/testdata/rpm/specfile/cpio.spec.expected.json
@@ -77,7 +77,7 @@
             "rule_identifier": "gpl-3.0-plus_28.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gpl-3.0-plus_28.RULE",
             "matched_text": "GPLv3+",
-            "referenced_filenames": ["GPLv3+"]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/sbt-golden/literal-root/build.sbt-expected.json
+++ b/testdata/sbt-golden/literal-root/build.sbt-expected.json
@@ -44,9 +44,7 @@
             "rule_identifier": "apache-2.0_required_phrase_11.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_required_phrase_11.RULE",
             "matched_text": "- license:\n    name: Apache-2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0.txt",
-            "referenced_filenames": [
-              "- license:\n    name: Apache-2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0.txt"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/sbt-golden/settings-and-shared-bundles/build.sbt-expected.json
+++ b/testdata/sbt-golden/settings-and-shared-bundles/build.sbt-expected.json
@@ -82,9 +82,7 @@
             "rule_identifier": "apache-2.0_required_phrase_11.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_required_phrase_11.RULE",
             "matched_text": "- license:\n    name: Apache-2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0.txt",
-            "referenced_filenames": [
-              "- license:\n    name: Apache-2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0.txt"
-            ]
+            "referenced_filenames": []
           }
         ],
         "identifier": null

--- a/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
+++ b/testdata/summarycode-golden/reference_following/file_to_package_inheritance/expected.json
@@ -200,7 +200,7 @@
               "license_expression": "bsd-new",
               "license_expression_spdx": "BSD-3-Clause",
               "rule_identifier": "bsd-new_195.RULE",
-              "referenced_filenames": ["license: BSD-3-Clause"]
+              "referenced_filenames": []
             }
           ]
         }
@@ -257,7 +257,7 @@
                   "license_expression": "bsd-new",
                   "license_expression_spdx": "BSD-3-Clause",
                   "rule_identifier": "bsd-new_195.RULE",
-                  "referenced_filenames": ["license: BSD-3-Clause"]
+                  "referenced_filenames": []
                 }
               ]
             }
@@ -295,7 +295,7 @@
               "license_expression": "bsd-new",
               "license_expression_spdx": "BSD-3-Clause",
               "rule_identifier": "bsd-new_195.RULE",
-              "referenced_filenames": ["license: BSD-3-Clause"]
+              "referenced_filenames": []
             }
           ]
         }


### PR DESCRIPTION
## Summary

- Follows up #1007 by fixing four Greptile review findings in `src/parsers/license_normalization.rs` that merged unresolved.
- F4 (output bug): `detect_declared_license_from_text` no longer records the license *statement* text as a `referenced_filename`. The post-extraction hook now passes `None`, since a license derived from the manifest's own declared statement has no separate referenced file. The parameter is now `Option<&str>`, and the genuine referenced-file caller (`windows_executable` sibling-license detection) keeps passing its real file path via `Some(..)`.
- F1 (CRLF): `derive_holder_from_copyright` uses `str::lines()` instead of `split('\n')`, so CRLF copyright input no longer leaves a trailing `\r` on each derived holder.
- F2 (slash guard): `looks_like_multi_license_composite` now detects bare separator slashes per whitespace token while ignoring URL tokens, so `"MIT/BSD see http://x"` is still composite while a slash that only appears in a URL is not.
- F3 (`Some("")` holder): judged benign and intentionally left unchanged (see Intentional differences).

## Issues

- Covers: unresolved Greptile findings on #1007 (comment ids 3384694345, 3384421464, 3384421508, 3384421546).

## Scope and exclusions

- Included: the four findings above, their unit tests, the `Option<&str>` signature change plus its two callers, and golden fixtures whose declared license came from a manifest statement.
- Explicit exclusions: no behavior change for genuine referenced-file detections; no change to the composite-expression or detection-clobber guards #1007 added.

## How to verify

- CI covers the full matrix. Beyond that: `cargo test -p provenant-cli --lib license_normalization` exercises the new F4/F1/F2 unit tests directly.

## Intentional differences from Python

- F3: the early-return guard fires only when `holder` is `Some` and non-empty after trimming, so a parser-set `Some("")` falls through and is replaced by a derived holder. This is intentional: an empty-string holder carries no information, and replacing it with a real derived holder is strictly more useful than preserving a meaningless empty value. No honest parser-set value is overwritten.

## Expected-output fixture changes

- Files changed: 1 assembly golden, 1 post-processing golden, and 28 parser goldens (nuget/maven/npm/python/readme/sbt/clojure/cran/erlang/nix/rpm/pip-inspect).
- Why the new expected output is correct: in each case the declared license was derived from the manifest's own statement (not a resolved referenced file), so the previously recorded `referenced_filenames` entry was the raw statement text leaking through the F4 bug. The corrected output is an empty `referenced_filenames`. Genuine referenced-file fixtures (e.g. nuget `fizzler`, buck) were verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)