### PR TITLE
enhancement(compare): add package declared-license/holder content comparison axis

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -634,6 +634,26 @@ pub(crate) fn write_comparison_artifacts(
         .filter(|entry| !entry.extra_in_provenant.is_empty())
         .map(|entry| entry.extra_in_provenant.len())
         .sum::<usize>();
+    let package_field_content_value_differences =
+        package_field_content_differences(&scancode, &provenant);
+    let mut package_field_content_missing = 0usize;
+    let mut package_field_content_extra = 0usize;
+    let mut package_field_content_by_field: BTreeMap<String, usize> = BTreeMap::new();
+    for entry in &package_field_content_value_differences {
+        *package_field_content_by_field
+            .entry(entry.field.clone())
+            .or_insert(0) += 1;
+        match (entry.scancode.is_some(), entry.provenant.is_some()) {
+            (true, false) => package_field_content_missing += 1,
+            (false, true) => package_field_content_extra += 1,
+            // Both sides carry a value but they differ: count it on each side so
+            // neither directional total hides a real content mismatch.
+            _ => {
+                package_field_content_missing += 1;
+                package_field_content_extra += 1;
+            }
+        }
+    }
     let raw_dependency_value_differences = raw_dependency_differences(&scancode, &provenant);
     let raw_dependency_missing = raw_dependency_value_differences
         .iter()
@@ -668,6 +688,22 @@ pub(crate) fn write_comparison_artifacts(
             "extra_in_provenant": raw_dependency_extra,
         }),
     );
+    file_metric_summary.insert(
+        "package_field_content".to_string(),
+        json!({
+            "missing_in_provenant": package_field_content_missing,
+            "extra_in_provenant": package_field_content_extra,
+            "by_field": package_field_content_by_field,
+        }),
+    );
+    let package_field_content_summary = json!({
+        "missing_in_provenant": package_field_content_missing,
+        "extra_in_provenant": package_field_content_extra,
+        "by_field": package_field_content_by_field,
+        "fields_compared": PACKAGE_CONTENT_FIELDS,
+    });
+    scancode_favored_signal_count += package_field_content_missing;
+    provenant_favored_signal_count += package_field_content_extra;
     if top_level_package_skip_reason.is_none() {
         scancode_favored_signal_count += top_level_package_missing;
         provenant_favored_signal_count += top_level_package_extra;
@@ -728,6 +764,20 @@ pub(crate) fn write_comparison_artifacts(
         raw_dependency_extra as i64,
         raw_dependency_extra as i64,
         "raw dependency identities present only in Provenant file-level package_data output",
+    ));
+    rows.push(tsv_row(
+        "package_field_content_missing_in_provenant",
+        package_field_content_missing as i64,
+        0,
+        -(package_field_content_missing as i64),
+        "identity-matched packages where declared-license/holder content is present only in ScanCode output",
+    ));
+    rows.push(tsv_row(
+        "package_field_content_extra_in_provenant",
+        0,
+        package_field_content_extra as i64,
+        package_field_content_extra as i64,
+        "identity-matched packages where declared-license/holder content is present only in Provenant output",
     ));
     rows.push(tsv_row(
         "top_level_license_expression_deltas",
@@ -809,6 +859,12 @@ pub(crate) fn write_comparison_artifacts(
             "row2_top_level_differences",
             layout.samples_dir.join("row2_top_level_differences.json"),
         ),
+        (
+            "package_field_content_value_differences",
+            layout
+                .samples_dir
+                .join("package_field_content_value_differences.json"),
+        ),
     ];
 
     write_pretty_json(&sample_paths[0].1, &scancode_only_output_paths)?;
@@ -824,6 +880,10 @@ pub(crate) fn write_comparison_artifacts(
     write_pretty_json(&sample_paths[10].1, &classify_value_differences)?;
     write_pretty_json(&sample_paths[11].1, &row2_value_differences)?;
     write_pretty_json(&sample_paths[12].1, &row2_top_level_differences)?;
+    write_pretty_json(
+        &sample_paths[13].1,
+        &package_field_content_value_differences,
+    )?;
 
     let summary = json!({
         "comparison_status": comparison_status,
@@ -852,6 +912,7 @@ pub(crate) fn write_comparison_artifacts(
         "top_level_package_summary": top_level_package_summary,
         "top_level_dependency_summary": top_level_dependency_summary,
         "raw_dependency_summary": raw_dependency_summary,
+        "package_field_content_summary": package_field_content_summary,
         "comparison_context": {
             "only_findings_active": only_findings_active,
             "path_presence_semantics": "final_output_membership",

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -636,24 +636,18 @@ pub(crate) fn write_comparison_artifacts(
         .sum::<usize>();
     let package_field_content_value_differences =
         package_field_content_differences(&scancode, &provenant);
-    let mut package_field_content_missing = 0usize;
-    let mut package_field_content_extra = 0usize;
-    let mut package_field_content_by_field: BTreeMap<String, usize> = BTreeMap::new();
-    for entry in &package_field_content_value_differences {
-        *package_field_content_by_field
-            .entry(entry.field.clone())
-            .or_insert(0) += 1;
-        match (entry.scancode.is_some(), entry.provenant.is_some()) {
-            (true, false) => package_field_content_missing += 1,
-            (false, true) => package_field_content_extra += 1,
-            // Both sides carry a value but they differ: count it on each side so
-            // neither directional total hides a real content mismatch.
-            _ => {
-                package_field_content_missing += 1;
-                package_field_content_extra += 1;
-            }
-        }
-    }
+    // Value-vs-value mismatches (both sides non-null but different) are tracked
+    // in their own bucket rather than being double-counted into both directional
+    // totals. This keeps the summary self-consistent: `missing + extra +
+    // value_vs_value_mismatch == sum(by_field.values()) == one entry per delta`,
+    // so a consumer can cross-check the totals against `by_field`.
+    let package_field_content_tally =
+        tally_package_field_content_differences(&package_field_content_value_differences);
+    let package_field_content_missing = package_field_content_tally.missing_in_provenant;
+    let package_field_content_extra = package_field_content_tally.extra_in_provenant;
+    let package_field_content_value_vs_value_mismatch =
+        package_field_content_tally.value_vs_value_mismatch;
+    let package_field_content_by_field = package_field_content_tally.by_field;
     let raw_dependency_value_differences = raw_dependency_differences(&scancode, &provenant);
     let raw_dependency_missing = raw_dependency_value_differences
         .iter()
@@ -693,17 +687,22 @@ pub(crate) fn write_comparison_artifacts(
         json!({
             "missing_in_provenant": package_field_content_missing,
             "extra_in_provenant": package_field_content_extra,
+            "value_vs_value_mismatch": package_field_content_value_vs_value_mismatch,
             "by_field": package_field_content_by_field,
         }),
     );
     let package_field_content_summary = json!({
         "missing_in_provenant": package_field_content_missing,
         "extra_in_provenant": package_field_content_extra,
+        "value_vs_value_mismatch": package_field_content_value_vs_value_mismatch,
         "by_field": package_field_content_by_field,
         "fields_compared": PACKAGE_CONTENT_FIELDS,
     });
     scancode_favored_signal_count += package_field_content_missing;
     provenant_favored_signal_count += package_field_content_extra;
+    // A value-vs-value mismatch favors neither side, so it is a non-directional
+    // review signal rather than a directional one.
+    non_directional_signal_count += package_field_content_value_vs_value_mismatch;
     if top_level_package_skip_reason.is_none() {
         scancode_favored_signal_count += top_level_package_missing;
         provenant_favored_signal_count += top_level_package_extra;
@@ -778,6 +777,13 @@ pub(crate) fn write_comparison_artifacts(
         package_field_content_extra as i64,
         package_field_content_extra as i64,
         "identity-matched packages where declared-license/holder content is present only in Provenant output",
+    ));
+    rows.push(tsv_row(
+        "package_field_content_value_vs_value_mismatch",
+        package_field_content_value_vs_value_mismatch as i64,
+        package_field_content_value_vs_value_mismatch as i64,
+        0,
+        "identity-matched packages where both outputs carry declared-license/holder content but the values differ",
     ));
     rows.push(tsv_row(
         "top_level_license_expression_deltas",

--- a/src/compare_driver_shared.rs
+++ b/src/compare_driver_shared.rs
@@ -502,6 +502,37 @@ pub fn package_field_content_differences(
     differences
 }
 
+/// Self-consistent tally of a [`package_field_content_differences`] result.
+///
+/// Each difference entry lands in exactly one of the three buckets, so the
+/// invariant `missing_in_provenant + extra_in_provenant + value_vs_value_mismatch
+/// == sum(by_field.values()) == total entries` always holds. Value-vs-value
+/// mismatches (both sides non-null but different) get their own bucket instead
+/// of being counted into both directional totals, which keeps the summary
+/// numbers reconcilable by any downstream consumer.
+#[derive(Debug, Default, Clone)]
+pub struct PackageFieldContentTally {
+    pub missing_in_provenant: usize,
+    pub extra_in_provenant: usize,
+    pub value_vs_value_mismatch: usize,
+    pub by_field: BTreeMap<String, usize>,
+}
+
+pub fn tally_package_field_content_differences(
+    differences: &[PackageFieldContentDifferenceEntry],
+) -> PackageFieldContentTally {
+    let mut tally = PackageFieldContentTally::default();
+    for entry in differences {
+        *tally.by_field.entry(entry.field.clone()).or_insert(0) += 1;
+        match (entry.scancode.is_some(), entry.provenant.is_some()) {
+            (true, false) => tally.missing_in_provenant += 1,
+            (false, true) => tally.extra_in_provenant += 1,
+            _ => tally.value_vs_value_mismatch += 1,
+        }
+    }
+    tally
+}
+
 pub fn difference_entries(
     left: &BTreeSet<String>,
     right: &BTreeSet<String>,
@@ -840,5 +871,108 @@ mod tests {
         assert_eq!(license.len(), 1);
         assert_eq!(license[0].scancode.as_deref(), Some("mit"));
         assert_eq!(license[0].provenant.as_deref(), Some("apache-2.0"));
+    }
+
+    /// Asserts the tally invariant: every entry lands in exactly one of the
+    /// three directional buckets, so they sum to both the total entry count and
+    /// the sum of `by_field`.
+    fn assert_tally_reconciles(tally: &PackageFieldContentTally, total_entries: usize) {
+        let bucket_total =
+            tally.missing_in_provenant + tally.extra_in_provenant + tally.value_vs_value_mismatch;
+        assert_eq!(
+            bucket_total, total_entries,
+            "directional buckets must sum to the number of difference entries"
+        );
+        let by_field_total: usize = tally.by_field.values().sum();
+        assert_eq!(
+            bucket_total, by_field_total,
+            "directional buckets must reconcile with by_field"
+        );
+    }
+
+    #[test]
+    fn tally_reconciles_for_one_sided_missing() {
+        // Content present only on the ScanCode side -> missing_in_provenant.
+        let scancode = json!({
+            "packages": [{ "purl": "pkg:npm/example@1.0.0", "holder": "Example Corp" }]
+        });
+        let provenant = json!({
+            "packages": [{ "purl": "pkg:npm/example@1.0.0" }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let tally = tally_package_field_content_differences(&differences);
+        assert_eq!(tally.missing_in_provenant, 1);
+        assert_eq!(tally.extra_in_provenant, 0);
+        assert_eq!(tally.value_vs_value_mismatch, 0);
+        assert_tally_reconciles(&tally, differences.len());
+    }
+
+    #[test]
+    fn tally_reconciles_for_one_sided_extra() {
+        // Content present only on the Provenant side -> extra_in_provenant.
+        let scancode = json!({
+            "packages": [{ "purl": "pkg:npm/example@1.0.0" }]
+        });
+        let provenant = json!({
+            "packages": [{ "purl": "pkg:npm/example@1.0.0", "holder": "Example Corp" }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let tally = tally_package_field_content_differences(&differences);
+        assert_eq!(tally.missing_in_provenant, 0);
+        assert_eq!(tally.extra_in_provenant, 1);
+        assert_eq!(tally.value_vs_value_mismatch, 0);
+        assert_tally_reconciles(&tally, differences.len());
+    }
+
+    #[test]
+    fn tally_reconciles_for_value_vs_value_mismatch() {
+        // Both sides non-null but different -> its own bucket, NOT double-counted
+        // into the directional totals.
+        let scancode = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "mit"
+            }]
+        });
+        let provenant = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "apache-2.0"
+            }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let tally = tally_package_field_content_differences(&differences);
+        assert_eq!(tally.missing_in_provenant, 0);
+        assert_eq!(tally.extra_in_provenant, 0);
+        assert_eq!(tally.value_vs_value_mismatch, 1);
+        assert_tally_reconciles(&tally, differences.len());
+    }
+
+    #[test]
+    fn tally_reconciles_for_mixed_entries() {
+        // A package gaining content (extra) plus a package with a value mismatch:
+        // the totals must still reconcile across all three buckets and by_field.
+        let scancode = json!({
+            "packages": [
+                { "purl": "pkg:npm/gains@1.0.0" },
+                { "purl": "pkg:npm/mismatch@1.0.0", "declared_license_expression": "mit" }
+            ]
+        });
+        let provenant = json!({
+            "packages": [
+                { "purl": "pkg:npm/gains@1.0.0", "holder": "Example Corp" },
+                { "purl": "pkg:npm/mismatch@1.0.0", "declared_license_expression": "apache-2.0" }
+            ]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let tally = tally_package_field_content_differences(&differences);
+        assert_eq!(tally.extra_in_provenant, 1);
+        assert_eq!(tally.value_vs_value_mismatch, 1);
+        assert_eq!(tally.missing_in_provenant, 0);
+        assert_tally_reconciles(&tally, differences.len());
     }
 }

--- a/src/compare_driver_shared.rs
+++ b/src/compare_driver_shared.rs
@@ -7,8 +7,24 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::compare_normalization::{
-    normalize_compare_path, normalize_text, package_fallback_identity, package_identity,
+    normalize_compare_path, normalize_license_expression, normalize_text,
+    package_fallback_identity, package_identity,
 };
+
+/// Package content fields whose values are compared by the
+/// package-field-content axis (see [`package_field_content_differences`]).
+///
+/// This axis is intentionally separate from the identity-only `package_data`
+/// metric: two outputs can agree on every package identity yet disagree on the
+/// declared-license/holder content those packages carry. The post-extraction
+/// declared-license/holder population hook fills exactly these fields, so a
+/// regression that drops or corrupts their content shows up here even though
+/// the identity bucket stays clean.
+pub const PACKAGE_CONTENT_FIELDS: &[&str] = &[
+    "declared_license_expression",
+    "declared_license_expression_spdx",
+    "holder",
+];
 
 pub const FILES_COUNT_SOURCE: &str = "files[]";
 pub const PACKAGES_COUNT_SOURCE: &str = "packages[]";
@@ -48,6 +64,15 @@ pub struct ValueDifferenceEntry {
 #[derive(Debug, Serialize, Clone)]
 pub struct ScalarDifferenceEntry {
     pub path: String,
+    pub scancode: Option<String>,
+    pub provenant: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PackageFieldContentDifferenceEntry {
+    pub path: String,
+    pub identity: String,
+    pub field: String,
     pub scancode: Option<String>,
     pub provenant: Option<String>,
 }
@@ -360,6 +385,123 @@ pub fn raw_dependency_identities_by_path(value: &Value) -> BTreeMap<String, BTre
     output
 }
 
+/// Normalizes one package content field for comparison.
+///
+/// License expressions go through [`normalize_license_expression`] so operand
+/// order and trivial parenthesization differences do not register as deltas;
+/// other fields (e.g. `holder`) are whitespace-normalized only. Returns `None`
+/// for absent, null, or whitespace-only values so a missing field and an empty
+/// string compare equal.
+pub fn normalize_package_content_field(item: &Value, field: &str) -> Option<String> {
+    let raw = item.get(field).and_then(Value::as_str)?;
+    let normalized = match field {
+        "declared_license_expression" | "declared_license_expression_spdx" => {
+            normalize_license_expression(raw)
+        }
+        _ => normalize_text(raw),
+    };
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+/// Collects every package row keyed by `(path, identity)` for the
+/// package-field-content axis, drawing from both top-level assembled
+/// `packages[]` and file-level `files[].package_data[]`.
+///
+/// Top-level packages are bucketed under the synthetic `<top-level>` path so
+/// they line up across the two compared outputs regardless of which file
+/// produced them; file-level rows keep their owning file path. Within a path,
+/// rows are keyed by package identity (purl, else the
+/// type|name|version|datasource_id fallback). When two rows in the same path
+/// share an identity, the first one wins, which is sufficient for the declared
+/// license/holder content this axis tracks.
+pub fn package_content_rows_by_key(value: &Value) -> BTreeMap<(String, String), Value> {
+    let mut output: BTreeMap<(String, String), Value> = BTreeMap::new();
+
+    for item in value
+        .get("packages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let identity = package_identity(item)
+            .map(str::to_string)
+            .or_else(|| package_fallback_identity(item))
+            .unwrap_or_else(|| "<unknown>".to_string());
+        output
+            .entry(("<top-level>".to_string(), identity))
+            .or_insert_with(|| item.clone());
+    }
+
+    for file in value
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let path = file
+            .get("path")
+            .and_then(Value::as_str)
+            .map(normalize_compare_path)
+            .unwrap_or_else(|| "<unknown>".to_string());
+        for item in file
+            .get("package_data")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let identity = package_identity(item)
+                .map(str::to_string)
+                .or_else(|| package_fallback_identity(item))
+                .unwrap_or_else(|| "<unknown>".to_string());
+            output
+                .entry((path.clone(), identity))
+                .or_insert_with(|| item.clone());
+        }
+    }
+
+    output
+}
+
+/// Diffs the content of [`PACKAGE_CONTENT_FIELDS`] for packages matched by
+/// `(path, identity)` across the two outputs.
+///
+/// Only identity-matched rows are compared: rows present on a single side are
+/// an identity-level signal already surfaced by the `package_data` and
+/// top-level package buckets, so they are skipped here to keep this axis
+/// focused on content drift for packages both outputs agree exist.
+///
+/// Enabling this axis can surface pre-existing ScanCode-vs-Provenant
+/// declared-license deltas that predate the post-extraction population hook.
+/// That is expected and valuable signal, not necessarily a regression to fix.
+pub fn package_field_content_differences(
+    scancode: &Value,
+    provenant: &Value,
+) -> Vec<PackageFieldContentDifferenceEntry> {
+    let sc_rows = package_content_rows_by_key(scancode);
+    let pr_rows = package_content_rows_by_key(provenant);
+
+    let mut differences = Vec::new();
+    for ((path, identity), sc_item) in &sc_rows {
+        let Some(pr_item) = pr_rows.get(&(path.clone(), identity.clone())) else {
+            continue;
+        };
+        for field in PACKAGE_CONTENT_FIELDS {
+            let sc_value = normalize_package_content_field(sc_item, field);
+            let pr_value = normalize_package_content_field(pr_item, field);
+            if sc_value != pr_value {
+                differences.push(PackageFieldContentDifferenceEntry {
+                    path: path.clone(),
+                    identity: identity.clone(),
+                    field: (*field).to_string(),
+                    scancode: sc_value,
+                    provenant: pr_value,
+                });
+            }
+        }
+    }
+    differences
+}
+
 pub fn difference_entries(
     left: &BTreeSet<String>,
     right: &BTreeSet<String>,
@@ -555,4 +697,148 @@ pub fn tsv_row(
         delta.to_string(),
         notes.to_string(),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entries_for(
+        differences: &[PackageFieldContentDifferenceEntry],
+        field: &str,
+    ) -> Vec<PackageFieldContentDifferenceEntry> {
+        differences
+            .iter()
+            .filter(|entry| entry.field == field)
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn normalize_package_content_field_treats_empty_and_absent_as_none() {
+        let item = json!({ "declared_license_expression": "", "holder": "   " });
+        assert_eq!(
+            normalize_package_content_field(&item, "declared_license_expression"),
+            None
+        );
+        assert_eq!(normalize_package_content_field(&item, "holder"), None);
+        assert_eq!(normalize_package_content_field(&item, "missing"), None);
+    }
+
+    #[test]
+    fn normalize_package_content_field_canonicalizes_license_expressions() {
+        let item = json!({ "declared_license_expression": "(MIT OR Apache-2.0)" });
+        assert_eq!(
+            normalize_package_content_field(&item, "declared_license_expression").as_deref(),
+            Some("Apache-2.0 OR MIT")
+        );
+    }
+
+    #[test]
+    fn package_field_content_reports_declared_license_gained() {
+        let scancode = json!({
+            "files": [{
+                "path": "metadata.rb",
+                "type": "file",
+                "package_data": [{
+                    "purl": "pkg:chef/example@1.0.0",
+                    "declared_license_expression": null
+                }]
+            }]
+        });
+        let provenant = json!({
+            "files": [{
+                "path": "metadata.rb",
+                "type": "file",
+                "package_data": [{
+                    "purl": "pkg:chef/example@1.0.0",
+                    "declared_license_expression": "apache-2.0",
+                    "declared_license_expression_spdx": "Apache-2.0"
+                }]
+            }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let license = entries_for(&differences, "declared_license_expression");
+        assert_eq!(license.len(), 1);
+        assert_eq!(license[0].scancode, None);
+        assert_eq!(license[0].provenant.as_deref(), Some("apache-2.0"));
+        assert_eq!(license[0].path, "metadata.rb");
+        assert_eq!(license[0].identity, "pkg:chef/example@1.0.0");
+        // The SPDX form gained content too.
+        assert_eq!(
+            entries_for(&differences, "declared_license_expression_spdx").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn package_field_content_matches_top_level_packages_by_identity() {
+        let scancode = json!({
+            "packages": [{ "purl": "pkg:chef/example@1.0.0" }]
+        });
+        let provenant = json!({
+            "packages": [{ "purl": "pkg:chef/example@1.0.0", "holder": "Example Corp" }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let holder = entries_for(&differences, "holder");
+        assert_eq!(holder.len(), 1);
+        assert_eq!(holder[0].path, "<top-level>");
+        assert_eq!(holder[0].provenant.as_deref(), Some("Example Corp"));
+    }
+
+    #[test]
+    fn package_field_content_ignores_operand_order_only_differences() {
+        let scancode = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "MIT OR Apache-2.0"
+            }]
+        });
+        let provenant = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "Apache-2.0 OR MIT"
+            }]
+        });
+
+        assert!(package_field_content_differences(&scancode, &provenant).is_empty());
+    }
+
+    #[test]
+    fn package_field_content_skips_identity_only_present_on_one_side() {
+        let scancode = json!({
+            "packages": [{ "purl": "pkg:npm/only-scancode@1.0.0", "holder": "A" }]
+        });
+        let provenant = json!({
+            "packages": [{ "purl": "pkg:npm/only-provenant@1.0.0", "holder": "B" }]
+        });
+
+        // Identity-only deltas are surfaced by the package_data buckets, not here.
+        assert!(package_field_content_differences(&scancode, &provenant).is_empty());
+    }
+
+    #[test]
+    fn package_field_content_reports_value_mismatch_on_both_sides() {
+        let scancode = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "mit"
+            }]
+        });
+        let provenant = json!({
+            "packages": [{
+                "purl": "pkg:npm/example@1.0.0",
+                "declared_license_expression": "apache-2.0"
+            }]
+        });
+
+        let differences = package_field_content_differences(&scancode, &provenant);
+        let license = entries_for(&differences, "declared_license_expression");
+        assert_eq!(license.len(), 1);
+        assert_eq!(license[0].scancode.as_deref(), Some("mit"));
+        assert_eq!(license[0].provenant.as_deref(), Some("apache-2.0"));
+    }
 }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -196,8 +196,13 @@ both outputs agree exist (matched by purl, else the
 and file-level `files[].package_data[]`), it diffs the **content** of
 `declared_license_expression`, `declared_license_expression_spdx`, and `holder`.
 This catches a change that drops or corrupts declared-license/holder content
-even when every package identity still matches. Because it compares content for
-the first time, enabling it can surface pre-existing ScanCode-vs-Provenant
+even when every package identity still matches. Each difference is counted in
+exactly one of three reconcilable buckets: `missing_in_provenant` (content only
+on the ScanCode side), `extra_in_provenant` (content only on the Provenant
+side), and `value_vs_value_mismatch` (both sides carry content but the values
+differ), so `missing + extra + value_vs_value_mismatch` always equals the total
+number of differences and `sum(by_field.values())`. Because it compares content
+for the first time, enabling it can surface pre-existing ScanCode-vs-Provenant
 declared-license deltas that have nothing to do with any recent change; that is
 expected, valuable parity signal to classify, not automatically a regression.
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -188,6 +188,19 @@ classification; it is not itself a regression verdict. The summary also exposes
 directional signal buckets under `comparison_signal_summary` plus top-level
 directional maps for the ScanCode-favored and Provenant-favored sides.
 
+Alongside the identity-only `package_data` bucket, the summary also reports a
+`package_field_content` axis (mirrored in `package_field_content_summary` and
+the `package_field_content_value_differences.json` sample). For packages that
+both outputs agree exist (matched by purl, else the
+`type|name|version|datasource_id` fallback, across both top-level `packages[]`
+and file-level `files[].package_data[]`), it diffs the **content** of
+`declared_license_expression`, `declared_license_expression_spdx`, and `holder`.
+This catches a change that drops or corrupts declared-license/holder content
+even when every package identity still matches. Because it compares content for
+the first time, enabling it can surface pre-existing ScanCode-vs-Provenant
+declared-license deltas that have nothing to do with any recent change; that is
+expected, valuable parity signal to classify, not automatically a regression.
+
 Optional diagnostic logs when available:
 
 - `raw/scancode-stdout.txt`


### PR DESCRIPTION
## Summary

- The compare harness matched `package_data` and top-level `packages` by **identity only** (purl, else `type|name|version|datasource_id`), so it never diffed the **content** of declared-license/holder fields. A change that drops or corrupts that content was invisible while every identity still matched.
- Adds a `package_field_content` comparison axis: for packages both outputs agree exist (matched by identity across top-level `packages[]` and file-level `files[].package_data[]`), it diffs the normalized content of `declared_license_expression`, `declared_license_expression_spdx`, and `holder`.
- License expressions reuse the existing `normalize_license_expression` so operand order and trivial parenthesization do not register as deltas; `holder` is whitespace-normalized. Absent/null/empty values compare equal.
- Additive only: a new `file_metric_summary.package_field_content` bucket, a top-level `package_field_content_summary` block, two `summary.tsv` rows, and a `package_field_content_value_differences.json` sample artifact. Signal counts feed the existing ScanCode-favored/Provenant-favored totals.

## Issues

- Covers: making the post-extraction declared-license/holder population effect observable in the compare harness so future content regressions are caught.

## Scope and exclusions

- Included: `src/compare_driver_shared.rs` (collection + diff + unit tests), `src/compare.rs` (wiring into summary/TSV/samples), `xtask/README.md` (axis documentation).
- Explicit exclusions: no change to the post-extraction population hook (`src/parsers/license_normalization.rs`) or any parser. No change to the identity-only `package_data` bucket.

## How to verify

Run the new axis over two Provenant scans of the same target (the harness accepts any two scan JSONs):

```
provenant compare --scancode-json before.json --provenant-json after.json --artifact-dir out
```

Then inspect `out/comparison/summary.json` `package_field_content_summary` and `out/comparison/samples/package_field_content_value_differences.json`. Validated against a pre-hook vs post-hook scan of chef/chef@0e353ff: the axis reported 94 field-level additions (47 `declared_license_expression` + 47 `declared_license_expression_spdx`, all `apache-2.0`, 0 `holder`), reproducing the measured per-package declared-license gain. The identity-deduped count (47 packages) is the identity-matched view of 63 positional rows; the gap is entirely top-level rpm/deb packages that share a purl.

## Intentional differences from Python

- N/A — this is a maintainer-facing compare/parity tool, not a scanner output surface.

## Follow-up work

- Enabling this axis on existing benchmark targets may surface pre-existing ScanCode-vs-Provenant declared-license deltas unrelated to any recent change; those are expected parity signal to classify, not necessarily regressions. Documented in `xtask/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)