### PR TITLE
fix(parsers): do not rewrite version-range idiom when other license operands follow

### DIFF
--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -585,11 +585,21 @@ fn counts_multiple_license_entries(statement: &str) -> bool {
 /// applies. A bare major version is expanded to its canonical point release
 /// (e.g. `2` -> `2.0`), while an explicit minor version is preserved
 /// (e.g. `2.1`). Both `>= N.M` and `>= N-M` separators are accepted.
+///
+/// The idiom must span the WHOLE statement. A compound CRAN declaration such as
+/// `LGPL (>= 2.1) | GPL-2` carries additional license operands after the range;
+/// rewriting only the leading operand would silently drop the rest and bypass
+/// the multi-license composite guard. When anything follows the closing paren,
+/// this returns `None` so the statement falls through to that guard (which
+/// leaves the declared expression an honest `null`).
 fn rewrite_version_range_or_later_idiom(statement: &str) -> Option<String> {
     let trimmed = statement.trim();
     let open = trimmed.find('(')?;
     let close = trimmed.rfind(')')?;
     if close <= open {
+        return None;
+    }
+    if !trimmed[close + 1..].trim().is_empty() {
         return None;
     }
 
@@ -1658,6 +1668,43 @@ mod tests {
         assert!(rewrite_version_range_or_later_idiom("GPL (== 2)").is_none());
         assert!(rewrite_version_range_or_later_idiom("GPL (>= 2.0.1)").is_none());
         assert!(rewrite_version_range_or_later_idiom("GPL").is_none());
+    }
+
+    #[test]
+    fn test_rewrite_version_range_or_later_idiom_rejects_trailing_operands() {
+        // A compound CRAN declaration carries more license operands after the
+        // range. Rewriting only the leading operand would silently drop the rest
+        // and bypass the composite guard, so the idiom must not fire.
+        assert!(rewrite_version_range_or_later_idiom("LGPL (>= 2.1) | GPL-2").is_none());
+        assert!(rewrite_version_range_or_later_idiom("GPL (>= 2), MIT").is_none());
+        assert!(rewrite_version_range_or_later_idiom("GPL (>= 2) | file LICENSE").is_none());
+        // The whole-statement idiom still rewrites.
+        assert_eq!(
+            rewrite_version_range_or_later_idiom("GPL (>= 2)").as_deref(),
+            Some("GPL-2.0+")
+        );
+        assert_eq!(
+            rewrite_version_range_or_later_idiom("GPL (>= 3)").as_deref(),
+            Some("GPL-3.0+")
+        );
+    }
+
+    #[test]
+    fn test_compound_version_range_statement_is_null() {
+        // Hook-level guard: a compound statement must yield an honest null, not a
+        // partial `lgpl-2.1-plus` that drops the trailing operand.
+        for statement in [
+            "LGPL (>= 2.1) | GPL-2",
+            "GPL (>= 2), MIT",
+            "GPL (>= 2) | file LICENSE",
+        ] {
+            let (declared, declared_spdx) = declared_for(statement);
+            assert!(declared.is_none(), "{statement:?} -> {declared:?}");
+            assert!(
+                declared_spdx.is_none(),
+                "{statement:?} -> {declared_spdx:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes the post-merge Greptile P1 raised on #1011 (comment 3387689802): `rewrite_version_range_or_later_idiom` located the closing paren with `rfind(')')` but never checked for content after it.
- For a compound CRAN declaration such as `LGPL (>= 2.1) | GPL-2` the function returned `Some("LGPL-2.1+")`, silently dropping the `| GPL-2` operand. Because the rewrite runs *before* `looks_like_multi_license_composite` and produces a clean single expression that normalizes successfully, it bypassed the composite guard entirely — turning a statement that should be an honest `null` into a confident, incomplete `lgpl-2.1-plus`. This is exactly the silently-dropped-operand failure mode the composite guard exists to prevent (CRAN's `|` separator means "or").
- Fix: require the idiom to span the WHOLE statement. After computing `close`, if `trimmed[close + 1..].trim()` is non-empty, return `None` so the statement falls through to the composite guard (→ `null`). The leading side was already safe because `family_raw` must exactly match `GPL`/`LGPL`/`AGPL`, so `MIT | LGPL (>= 2.1)` already returned `None`.

## Scope and exclusions

- Included: `src/parsers/license_normalization.rs` — the one-line guard in `rewrite_version_range_or_later_idiom` plus unit and hook-level tests.
- Explicit exclusions: no detection-engine, license-rule, overlay, or embedded-index changes; no golden fixture edits.

## How to verify

Beyond CI, the compound-statement behavior is covered by new tests:
- `test_rewrite_version_range_or_later_idiom_rejects_trailing_operands`: the rewrite returns `None` for `LGPL (>= 2.1) | GPL-2`, `GPL (>= 2), MIT`, and `GPL (>= 2) | file LICENSE`, while `GPL (>= 2)`/`GPL (>= 3)` alone still rewrite to `GPL-2.0+`/`GPL-3.0+`.
- `test_compound_version_range_statement_is_null`: the full hook leaves `declared_license_expression` null (not a partial expression) for those compound statements.

Local validation run:
- `cargo test --test parsers_golden --features golden-tests` → **313 passed, 0 failed** (CRAN goldens, incl. the `GPL (>= 3)` geometry case, still correct).
- `cargo test -p provenant-cli --lib` license_normalization tests → **38 passed, 0 failed**.
- `cargo clippy --all-targets` → clean.

## Intentional differences from Python

- None new. The whole-statement single-operand cases (`GPL (>= N)`) keep the intentional Provenant `-or-later` derivation introduced in #1011.

## Expected-output fixture changes

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
