### PR TITLE
perf(copyright): guard HTML-entity replace chain in prepare_text_line

### DIFF
--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -355,72 +355,80 @@ pub fn prepare_text_line(line: &str) -> String {
     s = REGISTERED_SIGN_AFTER_ASCII_RE
         .replace_all(&s, "${head} (r) ")
         .into_owned();
-    s = s
-        .replace("&reg;", " (r) ")
-        .replace("&reg", " (r) ")
-        .replace("&#174;", " (r) ");
 
-    // ── HTML entity decoding ──
-    // Must also happen BEFORE # and % removal for the same reason.
+    // HTML entity decoding (registered mark, copyright variants handled above,
+    // emdash, named/numeric entities). Every needle from here is either the
+    // emdash codepoint or begins with `&`, so skip the allocating chains when
+    // neither trigger is present (the common case for code lines).
+    let has_ampersand = s.contains('&');
+    if has_ampersand {
+        s = s
+            .replace("&reg;", " (r) ")
+            .replace("&reg", " (r) ")
+            .replace("&#174;", " (r) ");
 
-    if s.to_ascii_lowercase().contains("&lt;") && s.contains('@') {
-        s = ESCAPED_ANGLE_EMAIL_RE
-            .replace_all(&s, "<${email}>")
-            .into_owned();
+        // Must also happen BEFORE # and % removal for the same reason.
+        if s.to_ascii_lowercase().contains("&lt;") && s.contains('@') {
+            s = ESCAPED_ANGLE_EMAIL_RE
+                .replace_all(&s, "<${email}>")
+                .into_owned();
+        }
     }
 
-    s = s
-        // Emdash
-        .replace('\u{2013}', "-")
-        // CR/LF entities
-        .replace("&#13;&#10;", " ")
-        .replace("&#13;", " ")
-        .replace("&#10;", " ")
-        // Space entities
-        .replace("&nbsp;", " ")
-        .replace("&nbsp", " ")
-        .replace("&ensp;", " ")
-        .replace("&emsp;", " ")
-        .replace("&thinsp;", " ")
-        // Named entities
-        .replace("&quot;", "\"")
-        .replace("&#34;", "\"")
-        .replace("&auml;", "ä")
-        .replace("&auml", "ä")
-        .replace("&Auml;", "Ä")
-        .replace("&Auml", "Ä")
-        .replace("&ouml;", "ö")
-        .replace("&ouml", "ö")
-        .replace("&Ouml;", "Ö")
-        .replace("&Ouml", "Ö")
-        .replace("&uuml;", "ü")
-        .replace("&uuml", "ü")
-        .replace("&Uuml;", "Ü")
-        .replace("&Uuml", "Ü")
-        .replace("&szlig;", "ß")
-        .replace("&szlig", "ß")
-        .replace("&#196;", "Ä")
-        .replace("&#214;", "Ö")
-        .replace("&#220;", "Ü")
-        .replace("&#228;", "ä")
-        .replace("&#246;", "ö")
-        .replace("&#252;", "ü")
-        .replace("&#223;", "ß")
-        .replace("&#xC4;", "Ä")
-        .replace("&#xD6;", "Ö")
-        .replace("&#xDC;", "Ü")
-        .replace("&#xE4;", "ä")
-        .replace("&#xF6;", "ö")
-        .replace("&#xFC;", "ü")
-        .replace("&#xDF;", "ß")
-        .replace("&amp;", "&")
-        .replace("&#38;", "&")
-        .replace("&gt;", ">")
-        .replace("&gt", ">")
-        .replace("&#62;", ">")
-        .replace("&lt;", "<")
-        .replace("&lt", "<")
-        .replace("&#60;", "<");
+    if has_ampersand || s.contains('\u{2013}') {
+        s = s
+            // Emdash
+            .replace('\u{2013}', "-")
+            // CR/LF entities
+            .replace("&#13;&#10;", " ")
+            .replace("&#13;", " ")
+            .replace("&#10;", " ")
+            // Space entities
+            .replace("&nbsp;", " ")
+            .replace("&nbsp", " ")
+            .replace("&ensp;", " ")
+            .replace("&emsp;", " ")
+            .replace("&thinsp;", " ")
+            // Named entities
+            .replace("&quot;", "\"")
+            .replace("&#34;", "\"")
+            .replace("&auml;", "ä")
+            .replace("&auml", "ä")
+            .replace("&Auml;", "Ä")
+            .replace("&Auml", "Ä")
+            .replace("&ouml;", "ö")
+            .replace("&ouml", "ö")
+            .replace("&Ouml;", "Ö")
+            .replace("&Ouml", "Ö")
+            .replace("&uuml;", "ü")
+            .replace("&uuml", "ü")
+            .replace("&Uuml;", "Ü")
+            .replace("&Uuml", "Ü")
+            .replace("&szlig;", "ß")
+            .replace("&szlig", "ß")
+            .replace("&#196;", "Ä")
+            .replace("&#214;", "Ö")
+            .replace("&#220;", "Ü")
+            .replace("&#228;", "ä")
+            .replace("&#246;", "ö")
+            .replace("&#252;", "ü")
+            .replace("&#223;", "ß")
+            .replace("&#xC4;", "Ä")
+            .replace("&#xD6;", "Ö")
+            .replace("&#xDC;", "Ü")
+            .replace("&#xE4;", "ä")
+            .replace("&#xF6;", "ö")
+            .replace("&#xFC;", "ü")
+            .replace("&#xDF;", "ß")
+            .replace("&amp;", "&")
+            .replace("&#38;", "&")
+            .replace("&gt;", ">")
+            .replace("&gt", ">")
+            .replace("&#62;", ">")
+            .replace("&lt;", "<")
+            .replace("&lt", "<")
+            .replace("&#60;", "<");
+    }
 
     // Now remove remaining code comment markers (*, #, %) and strip edges.
     // HTML entities have already been decoded so # and % are safe to remove.


### PR DESCRIPTION
## Summary

- Profiling a single-thread copyright scan attributed ~41% of copyright time to `prepare_text_line` and ~0% to the `match_token` POS tagger, so this targets the real hotspot rather than #992's (independently-regressing) `RegexSet` idea.
- `prepare_text_line` runs a long chain of unconditional `String::replace()` calls; each scans the whole line and allocates a fresh `String` even when the needle is absent. The HTML-entity / registered-mark / emdash decoding chain (~53 replace ops) only matters when the line contains `&` or an emdash.
- This guards that chain behind a cheap `contains('&')` / `contains('\u{2013}')` precheck, skipping the allocating replaces for the large majority of source-code lines with no trigger char.

### Profile attribution (samply, release+debuginfo, `--copyright -n 1` on Vulkan-ValidationLayers @ d72c5f5)

Inclusive % of total samples:

| function | inclusive % |
|---|---|
| `detect_copyrights_from_text_with_deadline` | 97.3% |
| **`prepare_text_line`** | **40.9%** |
| `collect_candidate_lines` | 8.6% |
| `parse_with_deadline` | 5.3% |
| `is_junk_copyright` | 2.5% |
| `match_token` / POS tagger | 0% (absent) |

Top self-time: `alloc::str::replace` 12.5%, `StrSearcher::new` 8.3%.

### Before / after (single-thread `--copyright -n 1`, interleaved A/B, same machine, freshly rebuilt baseline)

Repo: `KhronosGroup/Vulkan-ValidationLayers` @ `d72c5f52886913598d4064fe8d03bf8ac471e215`.

| round | baseline (s) | optimized (s) |
|---|---|---|
| 1 | 14.05 | 13.77 |
| 2 | 13.95 | 13.72 |
| 3 | 13.71 | 13.59 |
| 4 | 13.74 | 13.62 |
| 5 | 13.84 | 13.62 |
| 6 | 13.81 | 13.59 |

Baseline median ~13.83s, optimized median ~13.62s. The optimized binary is faster in every interleaved round (~1.3–1.5% on total scan wall-time). Modest but consistent; correctness is the hard constraint and is preserved exactly.

## Issues

- Closes: #1013
- Context: supersedes #992 (RegexSet over the POS tagger — POS tagger is not a hotspot, and RegexSet regressed).

## Scope and exclusions

- Included: guard the HTML-entity/registered-mark/emdash `String::replace()` chain in `prepare_text_line`.
- Explicit exclusions: the `(c)`-symbol and quote-normalization blocks (their trigger chars are common in code, so a guard rarely skips), and any structural rewrite to remove per-`replace` allocation. Noted as follow-ups in #1013.

## How to verify

- Byte-for-byte output must be unchanged. Beyond CI's golden/lib suites, diff full-repo copyright output between this branch and `main` on a copyright-dense checkout:
  `provenant scan <repo> --copyright -n 1 --json out.json` for each build, compare `copyrights`/`holders`/`authors` per file. Verified 0 diffs across all 1038 files of the benchmark repo.

## Intentional differences from Python

- None. This is a pure performance guard; the decoded output is identical.

## Follow-up work

- Deferred (see #1013): guard remaining unconditional replace blocks and reduce per-`replace` allocations more structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)