### PR TITLE
perf(copyright): guard HTML-entity decode chains on '&' presence

### DIFF
--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -355,72 +355,84 @@ pub fn prepare_text_line(line: &str) -> String {
     s = REGISTERED_SIGN_AFTER_ASCII_RE
         .replace_all(&s, "${head} (r) ")
         .into_owned();
-    s = s
-        .replace("&reg;", " (r) ")
-        .replace("&reg", " (r) ")
-        .replace("&#174;", " (r) ");
+    // Registered-mark HTML entities only occur in strings containing `&`;
+    // skip the replacement chain for the common case where no `&` is present.
+    if s.contains('&') {
+        s = s
+            .replace("&reg;", " (r) ")
+            .replace("&reg", " (r) ")
+            .replace("&#174;", " (r) ");
+    }
 
     // ── HTML entity decoding ──
     // Must also happen BEFORE # and % removal for the same reason.
 
-    if s.to_ascii_lowercase().contains("&lt;") && s.contains('@') {
+    if s.contains('&') && s.contains('@') && s.to_ascii_lowercase().contains("&lt;") {
         s = ESCAPED_ANGLE_EMAIL_RE
             .replace_all(&s, "<${email}>")
             .into_owned();
     }
 
-    s = s
-        // Emdash
-        .replace('\u{2013}', "-")
-        // CR/LF entities
-        .replace("&#13;&#10;", " ")
-        .replace("&#13;", " ")
-        .replace("&#10;", " ")
-        // Space entities
-        .replace("&nbsp;", " ")
-        .replace("&nbsp", " ")
-        .replace("&ensp;", " ")
-        .replace("&emsp;", " ")
-        .replace("&thinsp;", " ")
-        // Named entities
-        .replace("&quot;", "\"")
-        .replace("&#34;", "\"")
-        .replace("&auml;", "ä")
-        .replace("&auml", "ä")
-        .replace("&Auml;", "Ä")
-        .replace("&Auml", "Ä")
-        .replace("&ouml;", "ö")
-        .replace("&ouml", "ö")
-        .replace("&Ouml;", "Ö")
-        .replace("&Ouml", "Ö")
-        .replace("&uuml;", "ü")
-        .replace("&uuml", "ü")
-        .replace("&Uuml;", "Ü")
-        .replace("&Uuml", "Ü")
-        .replace("&szlig;", "ß")
-        .replace("&szlig", "ß")
-        .replace("&#196;", "Ä")
-        .replace("&#214;", "Ö")
-        .replace("&#220;", "Ü")
-        .replace("&#228;", "ä")
-        .replace("&#246;", "ö")
-        .replace("&#252;", "ü")
-        .replace("&#223;", "ß")
-        .replace("&#xC4;", "Ä")
-        .replace("&#xD6;", "Ö")
-        .replace("&#xDC;", "Ü")
-        .replace("&#xE4;", "ä")
-        .replace("&#xF6;", "ö")
-        .replace("&#xFC;", "ü")
-        .replace("&#xDF;", "ß")
-        .replace("&amp;", "&")
-        .replace("&#38;", "&")
-        .replace("&gt;", ">")
-        .replace("&gt", ">")
-        .replace("&#62;", ">")
-        .replace("&lt;", "<")
-        .replace("&lt", "<")
-        .replace("&#60;", "<");
+    // Emdash normalization is independent of HTML entities and applies to any
+    // line, so it stays unconditional.
+    s = s.replace('\u{2013}', "-");
+
+    // Every remaining pattern in the HTML-entity decode chain begins with `&`,
+    // so the entire chain is a no-op when the line contains no `&`. Source code
+    // lines rarely contain `&`, so this guard skips ~50 full-string passes for
+    // the overwhelming majority of lines without changing output.
+    if s.contains('&') {
+        s = s
+            // CR/LF entities
+            .replace("&#13;&#10;", " ")
+            .replace("&#13;", " ")
+            .replace("&#10;", " ")
+            // Space entities
+            .replace("&nbsp;", " ")
+            .replace("&nbsp", " ")
+            .replace("&ensp;", " ")
+            .replace("&emsp;", " ")
+            .replace("&thinsp;", " ")
+            // Named entities
+            .replace("&quot;", "\"")
+            .replace("&#34;", "\"")
+            .replace("&auml;", "ä")
+            .replace("&auml", "ä")
+            .replace("&Auml;", "Ä")
+            .replace("&Auml", "Ä")
+            .replace("&ouml;", "ö")
+            .replace("&ouml", "ö")
+            .replace("&Ouml;", "Ö")
+            .replace("&Ouml", "Ö")
+            .replace("&uuml;", "ü")
+            .replace("&uuml", "ü")
+            .replace("&Uuml;", "Ü")
+            .replace("&Uuml", "Ü")
+            .replace("&szlig;", "ß")
+            .replace("&szlig", "ß")
+            .replace("&#196;", "Ä")
+            .replace("&#214;", "Ö")
+            .replace("&#220;", "Ü")
+            .replace("&#228;", "ä")
+            .replace("&#246;", "ö")
+            .replace("&#252;", "ü")
+            .replace("&#223;", "ß")
+            .replace("&#xC4;", "Ä")
+            .replace("&#xD6;", "Ö")
+            .replace("&#xDC;", "Ü")
+            .replace("&#xE4;", "ä")
+            .replace("&#xF6;", "ö")
+            .replace("&#xFC;", "ü")
+            .replace("&#xDF;", "ß")
+            .replace("&amp;", "&")
+            .replace("&#38;", "&")
+            .replace("&gt;", ">")
+            .replace("&gt", ">")
+            .replace("&#62;", ">")
+            .replace("&lt;", "<")
+            .replace("&lt", "<")
+            .replace("&#60;", "<");
+    }
 
     // Now remove remaining code comment markers (*, #, %) and strip edges.
     // HTML entities have already been decoded so # and % are safe to remove.
@@ -838,6 +850,26 @@ mod tests {
     #[test]
     fn test_emdash_normalization() {
         assert_eq!(prepare_text_line("2020\u{2013}2024"), "2020-2024");
+    }
+
+    #[test]
+    fn test_emdash_normalized_without_ampersand() {
+        // Emdash normalization must apply even when the line has no HTML
+        // entities, since the `&`-gated entity-decode chain is skipped then.
+        assert_eq!(
+            prepare_text_line("Copyright 2020\u{2013}2024 Acme"),
+            "Copyright 2020-2024 Acme"
+        );
+    }
+
+    #[test]
+    fn test_emdash_and_entity_decode_in_same_line() {
+        // Locks the cascade: emdash is normalized AND the `&`-entity chain runs
+        // when both appear together (the chain was split from the emdash step).
+        assert_eq!(
+            prepare_text_line("Foo 2020\u{2013}2024 &amp; Bar &nbsp;baz"),
+            "Foo 2020-2024 & Bar baz"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `prepare_text_line` is ~41% of single-thread copyright scan time. A precise within-function sub-step attribution (instrumented clone over the Vulkan-ValidationLayers @ `d72c5f5` corpus, ~917k lines, release build) shows the literal HTML-entity decode chain (~50 sequential `String::replace` passes) is the single biggest cost at **~37%** of the function, plus the registered-mark entity chain (`&reg;`/`&#174;`) at another **~2%** — yet only **~7%** of source lines contain `&`.
- Every pattern in those chains begins with `&`, so each chain is a guaranteed no-op when the line contains no `&`. This guards them on a cheap `s.contains('&')` byte check, skipping ~50 full-string scans + allocations per line for ~93% of lines. Emdash normalization (`–` → `-`) is split out and stays unconditional since it does not depend on `&`. The `&lt;`-escaped-email branch also gets the `&` short-circuit, avoiding its per-line `to_ascii_lowercase()` allocation for `&`-free lines.

### Sub-step attribution (top costs, ~917k corpus lines, release)

| share | sub-step |
|------:|----------|
| 36.7% | HTML-entity decode chain (`&...` literals) — **guarded** |
|  2.4% | registered-mark entity chain (`&reg;`/`&#174;`) — **guarded** |
| 23.5% | copyright-symbol chain (66.6% trigger rate — not cheaply guardable, left as-is) |
|  6.5% | quote-normalization chain |
|  2.7% | `normalize_replacement_chars` |
| <1% each | every regex `replace_all` pass (`PUNCTUATION_RE`, `HTML_TAG*`, etc.) |

This corrects the prior hypothesis that the regex passes dominated: they are each under ~1%. The reducible cost is the `&`-only literal entity chain run on every line regardless of whether `&` is present.

### Before / after

Single-thread `--copyright -n 1` on Vulkan-ValidationLayers @ `d72c5f5`, freshly rebuilt clean-`main` baseline vs this branch, 5 interleaved warm A/B rounds (binaries in a stable location outside the worktree):

- baseline median: **13.86s**
- this branch median: **11.73s**
- **~18% faster** (factor ~1.18x); reproduced across two independent A/B runs.

## Issues

- Closes: #1013

## Scope and exclusions

- Included: guard the two `&`-only HTML-entity literal `replace` chains (and the `&lt;` escaped-email branch's `to_ascii_lowercase` allocation) on a `s.contains('&')` precondition in `prepare_text_line`.
- Explicit exclusions: did not touch the copyright-symbol chain (66.6% trigger rate makes a coarse guard ineffective) or any regex pass (each <1%, no cheap reducible win). The POS tagger / `match_token` (#992) is not a hotspot and is untouched.

## How to verify

- Byte-identical: scan the corpus with a clean-`main` binary and this branch (`--copyright -n 1 <corpus> --json out.json`); the two JSONs are identical across all 1038 files except the `headers` version/timing block (verified: 0 file-level diffs).
- Two new unit tests lock the emdash/entity cascade after splitting emdash out of the chain: `test_emdash_normalized_without_ampersand` and `test_emdash_and_entity_decode_in_same_line`.

## Intentional differences from Python

- None. Output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
