### PR TITLE
feat(xtask): add perf-ab A/B benchmarking helper and benchmark-perf-change skill

### DIFF
--- a/.agents/skills/benchmark-perf-change/SKILL.md
+++ b/.agents/skills/benchmark-perf-change/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: benchmark-perf-change
+description: Measure whether a Provenant code change actually improves performance — profile-first, before/after on the same code, regression-guarded, with a byte-identical correctness gate. Use for "is this optimization actually faster", "benchmark my change", "profile a copyright/license hotspot", "before/after perf", "did my refactor regress performance", or "prove this speedup".
+---
+
+# Benchmark a Performance Change
+
+This skill drives the disciplined workflow for proving that a Provenant **code change** makes the scanner faster (or for honestly reporting that it does not). It is profile-first, measures before/after on the same code paths, guards against regressions, and gates pure refactors on byte-identical output.
+
+This is **distinct** from [`verify-benchmark-target`](../verify-benchmark-target/SKILL.md). That skill compares **Provenant vs ScanCode** for parity and user-visible advantage and records durable entries in `docs/BENCHMARKS.md`. This skill compares **Provenant against itself** (one ref vs another) to attribute a wall-clock change to your edit. Keep the two lanes separate: a `perf-ab` self-comparison is not a ScanCode parity result and does not belong in `docs/BENCHMARKS.md`; a `compare-outputs`/`benchmark-target` ScanCode run does not prove that your specific edit moved the needle.
+
+## Best fit
+
+Use this skill when the task sounds like:
+
+- Is this optimization actually faster? Prove it.
+- Benchmark my change / before-and-after my refactor.
+- Profile the copyright (or license, or assembly) hotspot and speed it up.
+- Did my refactor regress performance?
+
+## Source documents
+
+- **xtask commands**: `xtask/README.md` — CLI reference for `perf-ab` (the A/B harness this skill drives) and `benchmark-target`.
+- **Benchmarks**: `docs/BENCHMARKS.md` — the ScanCode-comparison record. Read it to understand what lives there and why a self-comparison does **not**.
+- **PR template**: `.github/pull_request_template.md` — required structure for agent-authored PRs.
+- **AGENTS.md**: repo-level contributor guardrails (testing defaults, code-quality rules).
+
+## Tooling
+
+- **`xtask perf-ab`** is the harness for the A/B measurement step (step 4). It builds two git refs in release, interleaves timed rounds, reports per-side medians and the head-vs-base speedup, and can gate on byte-identical output with `--check-output`.
+- **`samply`** (macOS) or **`perf` / `cargo flamegraph`** (Linux) is the profiler for step 1. Build with the `profiling` Cargo profile (`cargo build --profile profiling`), which inherits `release` but keeps debug symbols.
+
+## Workflow
+
+### Step 1: Profile FIRST — never optimize on assumption
+
+Do not touch code until profiling proves where the time goes.
+
+1. Build release with debug symbols: `cargo build --profile profiling --bin provenant` (the `profiling` profile inherits `release` and keeps `debug = true`, `strip = false`). If that profile is ever removed, fall back to `--release` with symbols re-enabled.
+2. Profile a representative scan that actually exercises the suspected path:
+   - macOS: `samply record ./target/profiling/provenant scan --json /tmp/out.json -c -n 1 /path/to/repo`
+   - Linux: `perf record -g ./target/profiling/provenant scan ...` then `perf report`, or `cargo flamegraph`.
+3. Attribute cost to concrete functions. Confirm the hypothesized hotspot is genuinely hot **before** editing it.
+
+**Cautionary example (real):** a proposed optimization targeted an ~1100-regex tagger. Profiling showed that tagger was **0% of the profile** — the real cost was a string-replace chain in a different function. Optimizing the regex tagger would have cost effort and risk for zero gain. Profile first, then optimize the function profiling actually blames.
+
+### Step 2: Set a STOP CONDITION before implementing — and honor it
+
+Before writing the optimization, write down the threshold that makes it worth shipping (for example: ">= 10% median wall-clock reduction on a copyright-dense repo with `-c -n 1`, output byte-identical"). Then measure honestly against it:
+
+- If the change does not beat the threshold **while staying correct**, report the negative result and do **not** ship it.
+- A flat or slower result is a valid, valuable finding. Record it; do not quietly keep a change that does not pay for its complexity.
+
+**Cautionary examples (real):** a `RegexSet` rewrite measured a **2–3.5x regression** and was correctly rejected. A single-pass collapse of a multi-pass transform measured **flat** and was also correctly rejected. Both decisions were right because the stop condition was set up front.
+
+### Step 3: Byte-identical correctness gate (pure-refactor perf changes)
+
+A perf change that is supposed to preserve behavior must produce identical output. Prove it two ways:
+
+1. **Run the relevant golden INTEGRATION suite**, not `--lib`:
+
+   ```bash
+   cargo test --test <area>_golden --features golden-tests   # e.g. copyright_golden, parsers_golden, license_golden
+   ```
+
+   Golden suites are integration test targets (`tests/`). `cargo test --lib` does **not compile or run them**, so a passing `cargo test --lib` is **not sufficient** to prove behavior is unchanged. Pick the suite that owns the code you touched.
+
+2. **Diff full scan output of the before/after binaries on a real repo** and require **0 diffs**. `xtask perf-ab --check-output` does exactly this: it scans with both binaries to JSON and asserts byte-identical output after normalizing only the volatile header (version/timestamp/duration). Use it, or diff manually after normalizing the `headers` block.
+
+3. **Lock any order- or cascade-dependent behavior with a unit test.** If your change reorders passes, collapses a cascade, or changes iteration order, add a focused unit test that pins the observable result so a future refactor cannot silently drift.
+
+Any diff means a **bug in your change**. Fix the code — never edit the goldens to make a perf refactor "pass".
+
+### Step 4: A/B measurement hygiene
+
+Use `xtask perf-ab` and respect these rules (the harness already enforces most of them):
+
+- **Build BOTH refs in release.** Never compare a debug build to a release build, or two different cargo profiles.
+- **INTERLEAVE runs** (base, head, base, head, …) rather than all-base-then-all-head, so machine-wide thermal/scheduling drift is shared evenly. `perf-ab` does this automatically.
+- **Warm up and discard the cold run** per binary. `perf-ab` discards one warmup per side.
+- **Take the MEDIAN of >= 5 rounds.** `perf-ab` defaults to `--rounds 5` and reports the median.
+- **Run in a STABLE location, outside git worktrees.** Worktree churn and artifact deletion during a measurement corrupt timings. `perf-ab` builds each ref into its own stable checkout under `.provenant/` and times from there.
+- **Re-measure independently when numbers conflict.** A bad measurement once reported a bogus **1.5%** improvement that was actually **~16%** — caused by measuring in a churning location. If two runs disagree materially, repeat from a clean state before trusting either.
+
+Typical invocation:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
+  --base origin/main --head HEAD \
+  --target-path /path/to/representative/repo \
+  --rounds 7 --check-output -- -c -n 1
+```
+
+### Step 5: Isolate the component and pick a representative target
+
+Make the measurement attribute cost to the thing you changed:
+
+- **Isolate per-file CPU with `-n 1`** (single worker). Parallelism hides and reshuffles per-file cost; single-thread makes a detector's own work visible.
+- **Attribute one detector's cost as a delta vs a no-detection baseline.** Time the same scan with and without the detector flag (for example `-c` vs no `-c`) and compare the deltas before and after your change, rather than reading a whole-scan number that is dominated by unrelated work.
+- **Choose a target whose content actually exercises the path** — a copyright-dense repo for copyright work, a license-text-heavy tree for license work, a manifest-heavy repo for parser/assembly work — and **verify it does** (e.g. confirm the output actually contains many copyright findings) before trusting the numbers. A target that barely touches your code path will report flat regardless of whether the change helped.
+
+### Step 6: Decide, then report honestly
+
+- If the change beats the stop condition **and** the correctness gate is clean, keep it and write up the measured median reduction/factor, the target, the round count, and the `-n 1`/baseline-delta methodology.
+- If it does not, report the negative result plainly and drop the change.
+- Either way, attach the `perf-ab` run manifest path (`.provenant/perf-ab/<run-id>/run-manifest.json`) as evidence. Do **not** record self-comparison timings in `docs/BENCHMARKS.md`; that file is for Provenant-vs-ScanCode results.
+
+### Step 7: Open a PR
+
+1. Branch with a descriptive name (for example `perf/<area>-<what>`).
+2. Use a Conventional Commit type that matches the change (`perf` for a genuine speedup, `refactor` for a behavior-preserving cleanup that happens to be measured) with DCO sign-off (`git commit -s`).
+3. Use `.github/pull_request_template.md` for the body. In **How to verify**, give the exact `perf-ab` command, the representative target, and the measured median/factor — this is the extra-beyond-CI evidence reviewers cannot reproduce from the suite alone.
+4. State the stop condition and whether the change met it. If you rejected a tempting-but-flat/slower alternative, say so.
+5. List any golden or unit-test changes and why the new expectations are correct.
+
+## Common failure modes
+
+- Optimizing a function that profiling shows is cold (the 1100-regex-tagger trap). Profile first.
+- Trusting `cargo test --lib` to prove byte-identical behavior — it never compiles the golden integration suites. Run `cargo test --test <area>_golden --features golden-tests`.
+- Measuring base-debug vs head-release, or two different cargo profiles. Build both in release.
+- All-base-then-all-head timing instead of interleaving, so drift loads one side.
+- Reporting the single fastest (or a single cold) run instead of the median of >= 5 interleaved rounds.
+- Measuring inside a churning git worktree, producing a bogus number (the 1.5%-that-was-really-16% trap).
+- Using a target whose content does not exercise the changed path, then concluding "no change".
+- Keeping a change that misses its stop condition because it "feels" faster.
+- Editing goldens to absorb an output diff from a pure-refactor perf change instead of fixing the code.
+- Recording a self before/after `perf-ab` result in `docs/BENCHMARKS.md` (that file is the ScanCode-comparison record; see `verify-benchmark-target`).

--- a/.agents/skills/verify-benchmark-target/SKILL.md
+++ b/.agents/skills/verify-benchmark-target/SKILL.md
@@ -9,6 +9,8 @@ This skill drives the repeated compare-review-fix-rerun workflow used to verify 
 
 It covers the full scan pipeline: package and dependency extraction, license detection, copyright detection, author/holder cleanup, URL/email normalization, assembly behavior, and other common-profile output differences that show up during benchmark verification.
 
+This is the **parity-and-advantage vs ScanCode** lane. If instead you want to prove that a specific Provenant **code change** made the scanner faster (before/after on the same code, profile-first, regression-guarded), use [`benchmark-perf-change`](../benchmark-perf-change/SKILL.md) and its `xtask perf-ab` harness. Self before/after timings from that lane do **not** belong in `docs/BENCHMARKS.md`; this skill owns that file.
+
 ## Best fit
 
 Use this skill when the task sounds like:

--- a/.claude/skills/benchmark-perf-change/SKILL.md
+++ b/.claude/skills/benchmark-perf-change/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: benchmark-perf-change
+description: Measure whether a Provenant code change actually improves performance — profile-first, before/after on the same code, regression-guarded, with a byte-identical correctness gate. Use for "is this optimization actually faster", "benchmark my change", "profile a copyright/license hotspot", "before/after perf", "did my refactor regress performance", or "prove this speedup".
+---
+
+# Benchmark a Performance Change
+
+This skill drives the disciplined workflow for proving that a Provenant **code change** makes the scanner faster (or for honestly reporting that it does not). It is profile-first, measures before/after on the same code paths, guards against regressions, and gates pure refactors on byte-identical output.
+
+This is **distinct** from [`verify-benchmark-target`](../verify-benchmark-target/SKILL.md). That skill compares **Provenant vs ScanCode** for parity and user-visible advantage and records durable entries in `docs/BENCHMARKS.md`. This skill compares **Provenant against itself** (one ref vs another) to attribute a wall-clock change to your edit. Keep the two lanes separate: a `perf-ab` self-comparison is not a ScanCode parity result and does not belong in `docs/BENCHMARKS.md`; a `compare-outputs`/`benchmark-target` ScanCode run does not prove that your specific edit moved the needle.
+
+## Best fit
+
+Use this skill when the task sounds like:
+
+- Is this optimization actually faster? Prove it.
+- Benchmark my change / before-and-after my refactor.
+- Profile the copyright (or license, or assembly) hotspot and speed it up.
+- Did my refactor regress performance?
+
+## Source documents
+
+- **xtask commands**: `xtask/README.md` — CLI reference for `perf-ab` (the A/B harness this skill drives) and `benchmark-target`.
+- **Benchmarks**: `docs/BENCHMARKS.md` — the ScanCode-comparison record. Read it to understand what lives there and why a self-comparison does **not**.
+- **PR template**: `.github/pull_request_template.md` — required structure for agent-authored PRs.
+- **AGENTS.md**: repo-level contributor guardrails (testing defaults, code-quality rules).
+
+## Tooling
+
+- **`xtask perf-ab`** is the harness for the A/B measurement step (step 4). It builds two git refs in release, interleaves timed rounds, reports per-side medians and the head-vs-base speedup, and can gate on byte-identical output with `--check-output`.
+- **`samply`** (macOS) or **`perf` / `cargo flamegraph`** (Linux) is the profiler for step 1. Build with the `profiling` Cargo profile (`cargo build --profile profiling`), which inherits `release` but keeps debug symbols.
+
+## Workflow
+
+### Step 1: Profile FIRST — never optimize on assumption
+
+Do not touch code until profiling proves where the time goes.
+
+1. Build release with debug symbols: `cargo build --profile profiling --bin provenant` (the `profiling` profile inherits `release` and keeps `debug = true`, `strip = false`). If that profile is ever removed, fall back to `--release` with symbols re-enabled.
+2. Profile a representative scan that actually exercises the suspected path:
+   - macOS: `samply record ./target/profiling/provenant scan --json /tmp/out.json -c -n 1 /path/to/repo`
+   - Linux: `perf record -g ./target/profiling/provenant scan ...` then `perf report`, or `cargo flamegraph`.
+3. Attribute cost to concrete functions. Confirm the hypothesized hotspot is genuinely hot **before** editing it.
+
+**Cautionary example (real):** a proposed optimization targeted an ~1100-regex tagger. Profiling showed that tagger was **0% of the profile** — the real cost was a string-replace chain in a different function. Optimizing the regex tagger would have cost effort and risk for zero gain. Profile first, then optimize the function profiling actually blames.
+
+### Step 2: Set a STOP CONDITION before implementing — and honor it
+
+Before writing the optimization, write down the threshold that makes it worth shipping (for example: ">= 10% median wall-clock reduction on a copyright-dense repo with `-c -n 1`, output byte-identical"). Then measure honestly against it:
+
+- If the change does not beat the threshold **while staying correct**, report the negative result and do **not** ship it.
+- A flat or slower result is a valid, valuable finding. Record it; do not quietly keep a change that does not pay for its complexity.
+
+**Cautionary examples (real):** a `RegexSet` rewrite measured a **2–3.5x regression** and was correctly rejected. A single-pass collapse of a multi-pass transform measured **flat** and was also correctly rejected. Both decisions were right because the stop condition was set up front.
+
+### Step 3: Byte-identical correctness gate (pure-refactor perf changes)
+
+A perf change that is supposed to preserve behavior must produce identical output. Prove it two ways:
+
+1. **Run the relevant golden INTEGRATION suite**, not `--lib`:
+
+   ```bash
+   cargo test --test <area>_golden --features golden-tests   # e.g. copyright_golden, parsers_golden, license_golden
+   ```
+
+   Golden suites are integration test targets (`tests/`). `cargo test --lib` does **not compile or run them**, so a passing `cargo test --lib` is **not sufficient** to prove behavior is unchanged. Pick the suite that owns the code you touched.
+
+2. **Diff full scan output of the before/after binaries on a real repo** and require **0 diffs**. `xtask perf-ab --check-output` does exactly this: it scans with both binaries to JSON and asserts byte-identical output after normalizing only the volatile header (version/timestamp/duration). Use it, or diff manually after normalizing the `headers` block.
+
+3. **Lock any order- or cascade-dependent behavior with a unit test.** If your change reorders passes, collapses a cascade, or changes iteration order, add a focused unit test that pins the observable result so a future refactor cannot silently drift.
+
+Any diff means a **bug in your change**. Fix the code — never edit the goldens to make a perf refactor "pass".
+
+### Step 4: A/B measurement hygiene
+
+Use `xtask perf-ab` and respect these rules (the harness already enforces most of them):
+
+- **Build BOTH refs in release.** Never compare a debug build to a release build, or two different cargo profiles.
+- **INTERLEAVE runs** (base, head, base, head, …) rather than all-base-then-all-head, so machine-wide thermal/scheduling drift is shared evenly. `perf-ab` does this automatically.
+- **Warm up and discard the cold run** per binary. `perf-ab` discards one warmup per side.
+- **Take the MEDIAN of >= 5 rounds.** `perf-ab` defaults to `--rounds 5` and reports the median.
+- **Run in a STABLE location, outside git worktrees.** Worktree churn and artifact deletion during a measurement corrupt timings. `perf-ab` builds each ref into its own stable checkout under `.provenant/` and times from there.
+- **Re-measure independently when numbers conflict.** A bad measurement once reported a bogus **1.5%** improvement that was actually **~16%** — caused by measuring in a churning location. If two runs disagree materially, repeat from a clean state before trusting either.
+
+Typical invocation:
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
+  --base origin/main --head HEAD \
+  --target-path /path/to/representative/repo \
+  --rounds 7 --check-output -- -c -n 1
+```
+
+### Step 5: Isolate the component and pick a representative target
+
+Make the measurement attribute cost to the thing you changed:
+
+- **Isolate per-file CPU with `-n 1`** (single worker). Parallelism hides and reshuffles per-file cost; single-thread makes a detector's own work visible.
+- **Attribute one detector's cost as a delta vs a no-detection baseline.** Time the same scan with and without the detector flag (for example `-c` vs no `-c`) and compare the deltas before and after your change, rather than reading a whole-scan number that is dominated by unrelated work.
+- **Choose a target whose content actually exercises the path** — a copyright-dense repo for copyright work, a license-text-heavy tree for license work, a manifest-heavy repo for parser/assembly work — and **verify it does** (e.g. confirm the output actually contains many copyright findings) before trusting the numbers. A target that barely touches your code path will report flat regardless of whether the change helped.
+
+### Step 6: Decide, then report honestly
+
+- If the change beats the stop condition **and** the correctness gate is clean, keep it and write up the measured median reduction/factor, the target, the round count, and the `-n 1`/baseline-delta methodology.
+- If it does not, report the negative result plainly and drop the change.
+- Either way, attach the `perf-ab` run manifest path (`.provenant/perf-ab/<run-id>/run-manifest.json`) as evidence. Do **not** record self-comparison timings in `docs/BENCHMARKS.md`; that file is for Provenant-vs-ScanCode results.
+
+### Step 7: Open a PR
+
+1. Branch with a descriptive name (for example `perf/<area>-<what>`).
+2. Use a Conventional Commit type that matches the change (`perf` for a genuine speedup, `refactor` for a behavior-preserving cleanup that happens to be measured) with DCO sign-off (`git commit -s`).
+3. Use `.github/pull_request_template.md` for the body. In **How to verify**, give the exact `perf-ab` command, the representative target, and the measured median/factor — this is the extra-beyond-CI evidence reviewers cannot reproduce from the suite alone.
+4. State the stop condition and whether the change met it. If you rejected a tempting-but-flat/slower alternative, say so.
+5. List any golden or unit-test changes and why the new expectations are correct.
+
+## Common failure modes
+
+- Optimizing a function that profiling shows is cold (the 1100-regex-tagger trap). Profile first.
+- Trusting `cargo test --lib` to prove byte-identical behavior — it never compiles the golden integration suites. Run `cargo test --test <area>_golden --features golden-tests`.
+- Measuring base-debug vs head-release, or two different cargo profiles. Build both in release.
+- All-base-then-all-head timing instead of interleaving, so drift loads one side.
+- Reporting the single fastest (or a single cold) run instead of the median of >= 5 interleaved rounds.
+- Measuring inside a churning git worktree, producing a bogus number (the 1.5%-that-was-really-16% trap).
+- Using a target whose content does not exercise the changed path, then concluding "no change".
+- Keeping a change that misses its stop condition because it "feels" faster.
+- Editing goldens to absorb an output diff from a pure-refactor perf change instead of fixing the code.
+- Recording a self before/after `perf-ab` result in `docs/BENCHMARKS.md` (that file is the ScanCode-comparison record; see `verify-benchmark-target`).

--- a/.claude/skills/verify-benchmark-target/SKILL.md
+++ b/.claude/skills/verify-benchmark-target/SKILL.md
@@ -9,6 +9,8 @@ This skill drives the repeated compare-review-fix-rerun workflow used to verify 
 
 It covers the full scan pipeline: package and dependency extraction, license detection, copyright detection, author/holder cleanup, URL/email normalization, assembly behavior, and other common-profile output differences that show up during benchmark verification.
 
+This is the **parity-and-advantage vs ScanCode** lane. If instead you want to prove that a specific Provenant **code change** made the scanner faster (before/after on the same code, profile-first, regression-guarded), use [`benchmark-perf-change`](../benchmark-perf-change/SKILL.md) and its `xtask perf-ab` harness. Self before/after timings from that lane do **not** belong in `docs/BENCHMARKS.md`; this skill owns that file.
+
 ## Best fit
 
 Use this skill when the task sounds like:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -38,6 +38,10 @@ name = "compare-outputs"
 path = "src/bin/compare_outputs.rs"
 
 [[bin]]
+name = "perf-ab"
+path = "src/bin/perf_ab.rs"
+
+[[bin]]
 name = "generate-benchmark-chart"
 path = "src/bin/generate_benchmark_chart.rs"
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -18,6 +18,7 @@ cargo run --manifest-path xtask/Cargo.toml --bin <command> -- ...
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `benchmark-target`                | Measure Provenant against an explicit local or remote benchmark target.                                                                     |
 | `compare-outputs`                 | Compare Provenant and ScanCode raw outputs, either by running both scanners on one target or by comparing two existing JSON files directly. |
+| `perf-ab`                         | A/B-time a scan across two Provenant git refs (self before/after) and report the head-vs-base speedup.                                      |
 | `update-parser-golden`            | Regenerate parser `.expected.json` fixtures from current Rust parser output.                                                                |
 | `update-copyright-golden`         | Maintain copyright golden YAML fixtures with parity-gated or Rust-owned update modes.                                                       |
 | `update-license-golden`           | Maintain license golden YAML fixtures with parity-gated or Rust-owned update modes.                                                         |
@@ -240,6 +241,68 @@ Optional diagnostic logs when available:
 - `scancode-stdout.txt` and `provenant-stdout.txt` are best-effort diagnostic logs. The compare pipeline only requires the JSON outputs, so a log-write failure no longer makes the command fail.
 - Path-only buckets in `comparison/summary.json`, `comparison/summary.tsv`, and `comparison/samples/*.json` describe **final output membership**, not proven scan coverage. When the compared outputs used `--only-findings`, a path shown only on one side can simply mean the other side scanned it but filtered it away because no findings remained.
 - The command adds Git control-path ignore rules (`.git`, nested `.git`, and their contents) on the ScanCode side so repository metadata does not dominate the comparison artifacts without hiding package-adjacent files such as `.gitmodules`. Provenant already excludes `.git` directories during path collection by default, so xtask does not need to restate those ignores for Provenant. The harness no longer injects a blanket `target/*` ignore because some upstream repositories legitimately use `target/` as source content.
+
+## `perf-ab`
+
+### Purpose
+
+`perf-ab` answers "did my code change actually make Provenant faster?". It
+builds two Provenant git refs in release mode and **interleaved-A/B-times** a
+scan against the same target, reporting per-side medians and the head-vs-base
+speedup.
+
+This is a **self before/after** comparison and is intentionally different from
+`benchmark-target` and `compare-outputs`, which measure **Provenant against
+ScanCode**. `perf-ab` never runs ScanCode and its timings do not belong in
+`docs/BENCHMARKS.md`; it is for attributing a wall-clock change to your own
+edit. The companion `benchmark-perf-change` skill describes the full
+profile-first, regression-guarded workflow this command supports.
+
+### Usage
+
+```bash
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --help
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base origin/main --head HEAD --target-path /path/to/repo -- -c -n 1
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base origin/main --head HEAD --repo-url https://github.com/org/repo.git --repo-ref <sha> --rounds 7 --profile licenses
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base <ref> --head <ref> --target-path /path/to/repo --check-output -- -clupe -n 1
+cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base-bin ./base/provenant --head-bin ./head/provenant --target-path /path/to/repo -- -c -n 1
+```
+
+CLI arguments:
+
+- `--base REF`: base git ref to build and time (the "before" side). Default `origin/main`.
+- `--head REF`: head git ref to build and time (the "after" side). Default `HEAD`.
+- Choose exactly one target: either `--repo-url` (with `--repo-ref`) via the shared repo cache, or `--target-path PATH` for a local directory scanned in place.
+- `--repo-ref REF`: required with `--repo-url`; commit SHA, tag, or branch of the target repo.
+- `--rounds N`: number of interleaved timed rounds per side after the discarded warmup. Default `5`.
+- `--base-bin PATH` / `--head-bin PATH`: use a prebuilt binary for that side and skip building the ref.
+- `--check-output`: scan with both binaries to JSON and assert byte-identical output after normalizing the volatile header. The correctness gate for pure-refactor perf changes.
+- `--profile common|common-with-compiled|licenses|packages`: scan-flag shorthand shared by both sides. Mutually exclusive with explicit flags after `--`.
+- Pass either a supported `--profile` or explicit scan flags after `--` (for example `-- -c -n 1`). The same flags are forwarded to both binaries.
+
+### What It Does
+
+1. Resolves the scan target: either a local `--target-path` scanned in place, or `--repo-url` + `--repo-ref` materialized through the shared repo cache under `.provenant/repo-cache/` and removed after the run.
+2. Builds each ref in release (`cargo build --release --bin provenant`) into a stable per-ref worktree under `.provenant/perf-ab-build/`, backed by a dedicated bare clone of the current repo so the developer's working tree is untouched. `--base-bin` / `--head-bin` skip the build for that side.
+3. Optionally runs the `--check-output` correctness gate before timing.
+4. Runs one discarded warmup scan per binary, then `--rounds` interleaved timed scans (base, head, base, head, …) so machine-wide drift is shared evenly.
+5. Reports per-round real times, the per-side median, and the speedup as both a percent reduction and a factor (a factor below `1.0` is flagged as a regression).
+6. Writes a run manifest under `.provenant/perf-ab/<run-id>/run-manifest.json` recording both refs, their resolved build revisions, the binaries used, the per-round timings, and the computed speedup.
+
+### Output
+
+Each run writes artifacts under:
+
+- `.provenant/perf-ab/<run-id>/run-manifest.json`
+- `.provenant/perf-ab/<run-id>/<side>-<phase>-scan.json` (scratch scan outputs from timed runs)
+
+### Notes
+
+- Both sides always run with `--no-license-index-cache` so a warmed license index from one round does not skew the next, matching `benchmark-target` fairness.
+- The warmup run is discarded; only the `--rounds` interleaved timed runs feed the median.
+- Build each ref in release on a stable checkout; do not point `--base-bin`/`--head-bin` at debug or differently-profiled binaries, which would make the comparison meaningless.
+- `--check-output` normalizes only the volatile top-level `headers` block (version, timestamps, duration) before comparing; any remaining diff fails the run, because a behavior-preserving perf change must be byte-identical.
+- Building two release binaries is slow. Use `--base-bin`/`--head-bin` when you already have both binaries, or `--repo-ref`/refs that share most compiled artifacts.
 
 ## `update-parser-golden`
 

--- a/xtask/src/bin/perf_ab.rs
+++ b/xtask/src/bin/perf_ab.rs
@@ -275,19 +275,26 @@ fn build_side(
     prepare_self_worktree(project_root, &resolved, &worktree_dir)
         .with_context(|| format!("failed to materialize {label} worktree for {resolved}"))?;
 
-    build_release(&worktree_dir, label)?;
+    // Arm cleanup before building: once the worktree exists, the owning `Side`
+    // holds the cleanup handle so its `Drop` removes the worktree even if the
+    // build below fails or the binary is missing. Returning the error after
+    // constructing `side` lets that `Drop` fire, avoiding a build-artifact leak
+    // under `.provenant/perf-ab-build/`.
     let binary = worktree_dir.join("target/release/provenant");
-    if !binary.is_file() {
-        bail!("{label} binary not found at {}", binary.display());
-    }
-
-    Ok(Side {
+    let side = Side {
         label,
         git_ref: git_ref.to_string(),
         binary,
         build_revision: Some(resolved),
-        cleanup: Some((cache_dir, worktree_dir)),
-    })
+        cleanup: Some((cache_dir, worktree_dir.clone())),
+    };
+
+    build_release(&worktree_dir, label)?;
+    if !side.binary.is_file() {
+        bail!("{label} binary not found at {}", side.binary.display());
+    }
+
+    Ok(side)
 }
 
 fn self_repo_cache(project_root: &Path) -> PathBuf {
@@ -713,6 +720,75 @@ mod tests {
         assert_ne!(
             normalize_scan_json(a).unwrap(),
             normalize_scan_json(b).unwrap()
+        );
+    }
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// A `Side` armed with a `cleanup` handle removes its worktree on drop, so
+    /// the build path is leak-proof no matter which error fires after the
+    /// worktree is materialized (build failure, missing binary, etc.).
+    #[test]
+    fn side_drop_removes_armed_worktree() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        fs::create_dir_all(&source).unwrap();
+        git(&source, &["init"]);
+        git(&source, &["config", "user.name", "Test User"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "commit.gpgsign", "false"]);
+        fs::write(source.join("tracked.txt"), "hello\n").unwrap();
+        git(&source, &["add", "tracked.txt"]);
+        git(&source, &["commit", "-m", "init"]);
+
+        let cache_dir = temp.path().join("cache.git");
+        run_git(
+            Command::new("git")
+                .args(["clone", "--bare", "--local"])
+                .arg(&source)
+                .arg(&cache_dir),
+            "failed to create bare clone",
+        )
+        .unwrap();
+        let resolved = String::from_utf8_lossy(
+            &Command::new("git")
+                .arg(format!("--git-dir={}", cache_dir.display()))
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .trim()
+        .to_string();
+
+        let worktree_dir = temp.path().join("worktree");
+        prepare_repo_worktree(&cache_dir, &resolved, &worktree_dir).unwrap();
+        assert!(worktree_dir.exists());
+
+        let side = Side {
+            label: "base",
+            git_ref: "HEAD".to_string(),
+            binary: worktree_dir.join("target/release/provenant"),
+            build_revision: Some(resolved),
+            cleanup: Some((cache_dir, worktree_dir.clone())),
+        };
+        drop(side);
+
+        assert!(
+            !worktree_dir.exists(),
+            "armed Side drop should remove the worktree"
         );
     }
 }

--- a/xtask/src/bin/perf_ab.rs
+++ b/xtask/src/bin/perf_ab.rs
@@ -1,0 +1,718 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `perf-ab` builds two Provenant git refs in release mode and interleaved-A/B-times
+//! a scan against the same target, reporting per-side medians and the head-vs-base
+//! speedup. It is a self-comparison tool (does this code change make Provenant
+//! faster?), distinct from `compare-outputs`/`benchmark-target` which measure
+//! Provenant against ScanCode.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use provenant_xtask::common::{
+    ScanProfile, derive_repo_name_from_url, now_run_id, project_root, realpath, resolve_scan_args,
+    write_pretty_json,
+};
+use provenant_xtask::repo_cache::{
+    cleanup_repo_worktree, ensure_repo_mirror, prepare_repo_worktree, repo_cache_path,
+    resolve_repo_ref_to_sha,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+const WARMUP_LABEL: &str = "warmup";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "perf-ab",
+    trailing_var_arg = true,
+    about = "Interleaved A/B timing of a Provenant scan across two git refs"
+)]
+struct Args {
+    /// Base git ref to build and time (the "before" side).
+    #[arg(long, default_value = "origin/main")]
+    base: String,
+    /// Head git ref to build and time (the "after" side).
+    #[arg(long, default_value = "HEAD")]
+    head: String,
+    /// Benchmark a remote repository URL via the shared repo cache.
+    #[arg(long)]
+    repo_url: Option<String>,
+    /// Required with `--repo-url`; commit SHA, tag, or branch of the target repo.
+    #[arg(long)]
+    repo_ref: Option<String>,
+    /// Benchmark an existing local directory in place.
+    #[arg(long)]
+    target_path: Option<PathBuf>,
+    /// Number of interleaved timed rounds per side (after the discarded warmup).
+    #[arg(long, default_value_t = 5)]
+    rounds: usize,
+    /// Use this prebuilt base binary instead of building the base ref.
+    #[arg(long)]
+    base_bin: Option<PathBuf>,
+    /// Use this prebuilt head binary instead of building the head ref.
+    #[arg(long)]
+    head_bin: Option<PathBuf>,
+    /// Scan against this target with both binaries to JSON and require
+    /// byte-identical output after normalizing the volatile header.
+    #[arg(long)]
+    check_output: bool,
+    /// Scan profile shorthand. Mutually exclusive with explicit scan flags after `--`.
+    #[arg(long, value_enum)]
+    profile: Option<ScanProfile>,
+    /// Explicit scan flags forwarded to both binaries (after `--`).
+    scan_args: Vec<String>,
+}
+
+/// One built side of the A/B comparison.
+struct Side {
+    label: &'static str,
+    git_ref: String,
+    binary: PathBuf,
+    build_revision: Option<String>,
+    /// Set when this side owns a transient worktree that must be cleaned up.
+    cleanup: Option<(PathBuf, PathBuf)>,
+}
+
+impl Drop for Side {
+    fn drop(&mut self) {
+        if let Some((cache_dir, worktree_dir)) = &self.cleanup {
+            let _ = cleanup_repo_worktree(cache_dir, worktree_dir);
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SideManifest {
+    label: String,
+    git_ref: String,
+    build_revision: Option<String>,
+    binary: PathBuf,
+    median_seconds: f64,
+    round_seconds: Vec<f64>,
+}
+
+#[derive(Serialize)]
+struct RunManifest {
+    run_id: String,
+    target_label: String,
+    rounds: usize,
+    scan_profile: Option<String>,
+    scan_args: Vec<String>,
+    check_output: bool,
+    base: SideManifest,
+    head: SideManifest,
+    speedup_factor: Option<f64>,
+    reduction_percent: Option<f64>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.rounds == 0 {
+        bail!("--rounds must be at least 1");
+    }
+    let scan_args = resolve_scan_args(
+        args.profile,
+        args.scan_args.clone(),
+        "pass --profile <common|common-with-compiled|licenses|packages> or scan flags after --",
+    )?;
+    let project_root = project_root();
+
+    println!("==========================================");
+    println!("Provenant perf-ab (self before/after A/B)");
+    println!("==========================================\n");
+
+    let (target_dir, target_label, _target_guard) = prepare_target(&project_root, &args)?;
+
+    println!("[build] base ref: {}", args.base);
+    let base = build_side(&project_root, "base", &args.base, args.base_bin.as_deref())?;
+    println!("[build] head ref: {}", args.head);
+    let head = build_side(&project_root, "head", &args.head, args.head_bin.as_deref())?;
+
+    println!("\nConfiguration:");
+    println!("  Target:    {target_label}");
+    println!("  Work dir:  {}", target_dir.display());
+    if let Some(name) = args.profile.map(|p| p.display_name()) {
+        println!("  Profile:   {name}");
+    }
+    println!("  Scan args: {}", scan_args.join(" "));
+    println!("  Rounds:    {}", args.rounds);
+    println!("  base:      {} ({})", base.git_ref, describe_rev(&base));
+    println!("  head:      {} ({})", head.git_ref, describe_rev(&head));
+    println!();
+
+    if args.check_output {
+        run_correctness_gate(&base, &head, &target_dir, &scan_args)?;
+    }
+
+    let run_id = now_run_id("perf-ab");
+    let run_dir = project_root.join(".provenant/perf-ab").join(&run_id);
+    fs::create_dir_all(&run_dir)
+        .with_context(|| format!("failed to create {}", run_dir.display()))?;
+
+    let timings = run_interleaved(&base, &head, &target_dir, &scan_args, args.rounds, &run_dir)?;
+
+    let base_median = median(&timings.base).context("no base timings recorded")?;
+    let head_median = median(&timings.head).context("no head timings recorded")?;
+    let factor = speedup_factor(base_median, head_median);
+    let reduction = reduction_percent(base_median, head_median);
+
+    report(&timings, base_median, head_median, factor, reduction);
+
+    let manifest = RunManifest {
+        run_id: run_id.clone(),
+        target_label,
+        rounds: args.rounds,
+        scan_profile: args.profile.map(|p| p.display_name().to_string()),
+        scan_args,
+        check_output: args.check_output,
+        base: side_manifest(&base, base_median, &timings.base),
+        head: side_manifest(&head, head_median, &timings.head),
+        speedup_factor: factor,
+        reduction_percent: reduction,
+    };
+    let manifest_path = run_dir.join("run-manifest.json");
+    write_pretty_json(&manifest_path, &manifest)?;
+    println!("\nArtifacts:\n  {}", manifest_path.display());
+
+    Ok(())
+}
+
+fn describe_rev(side: &Side) -> String {
+    match &side.build_revision {
+        Some(rev) if rev.len() >= 8 => rev[..8].to_string(),
+        Some(rev) => rev.clone(),
+        None => "prebuilt".to_string(),
+    }
+}
+
+/// Resolve the scan target, returning its directory, a display label, and an
+/// optional cleanup guard for transient remote checkouts.
+fn prepare_target(
+    project_root: &Path,
+    args: &Args,
+) -> Result<(PathBuf, String, Option<TargetGuard>)> {
+    match (&args.target_path, &args.repo_url) {
+        (Some(_), Some(_)) => bail!("specify exactly one of --target-path or --repo-url"),
+        (None, None) => bail!("specify a target with --target-path or --repo-url"),
+        (Some(path), None) => {
+            if args.repo_ref.is_some() {
+                bail!("--repo-ref can only be used with --repo-url");
+            }
+            let resolved = realpath(path)?;
+            let label = resolved.display().to_string();
+            Ok((resolved, label, None))
+        }
+        (None, Some(repo_url)) => {
+            let repo_ref = args
+                .repo_ref
+                .as_deref()
+                .context("--repo-url requires --repo-ref (commit SHA, tag, or branch)")?;
+            let cache_dir = repo_cache_path(project_root, repo_url);
+            println!("[target] updating repo cache: {}", cache_dir.display());
+            ensure_repo_mirror(repo_url, repo_ref, &cache_dir)?;
+            let resolved_sha = resolve_repo_ref_to_sha(&cache_dir, repo_ref)?;
+            let worktree_dir = project_root
+                .join(".provenant/perf-ab-targets")
+                .join(derive_repo_name_from_url(repo_url, "perf-ab-target"));
+            println!("[target] checkout {repo_ref} -> {}", &resolved_sha[..8]);
+            prepare_repo_worktree(&cache_dir, &resolved_sha, &worktree_dir)?;
+            let label = format!("{repo_url}@{resolved_sha}");
+            let guard = TargetGuard {
+                cache_dir,
+                worktree_dir: worktree_dir.clone(),
+            };
+            Ok((worktree_dir, label, Some(guard)))
+        }
+    }
+}
+
+struct TargetGuard {
+    cache_dir: PathBuf,
+    worktree_dir: PathBuf,
+}
+
+impl Drop for TargetGuard {
+    fn drop(&mut self) {
+        let _ = cleanup_repo_worktree(&self.cache_dir, &self.worktree_dir);
+    }
+}
+
+/// Build (or reuse) a Provenant release binary for one git ref into a stable
+/// per-ref location and return its built revision.
+fn build_side(
+    project_root: &Path,
+    label: &'static str,
+    git_ref: &str,
+    prebuilt: Option<&Path>,
+) -> Result<Side> {
+    if let Some(prebuilt) = prebuilt {
+        let binary = realpath(prebuilt)?;
+        if !binary.is_file() {
+            bail!("{label} binary not found at {}", binary.display());
+        }
+        return Ok(Side {
+            label,
+            git_ref: git_ref.to_string(),
+            binary,
+            build_revision: None,
+            cleanup: None,
+        });
+    }
+
+    let cache_dir = self_repo_cache(project_root);
+    let resolved = resolve_self_ref(project_root, git_ref)
+        .with_context(|| format!("failed to resolve {label} ref '{git_ref}'"))?;
+    let worktree_dir = project_root
+        .join(".provenant/perf-ab-build")
+        .join(label)
+        .join(&resolved[..12.min(resolved.len())]);
+    prepare_self_worktree(project_root, &resolved, &worktree_dir)
+        .with_context(|| format!("failed to materialize {label} worktree for {resolved}"))?;
+
+    build_release(&worktree_dir, label)?;
+    let binary = worktree_dir.join("target/release/provenant");
+    if !binary.is_file() {
+        bail!("{label} binary not found at {}", binary.display());
+    }
+
+    Ok(Side {
+        label,
+        git_ref: git_ref.to_string(),
+        binary,
+        build_revision: Some(resolved),
+        cleanup: Some((cache_dir, worktree_dir)),
+    })
+}
+
+fn self_repo_cache(project_root: &Path) -> PathBuf {
+    // A bare repo whose object store lets us add detached worktrees for arbitrary
+    // local refs without disturbing the developer's checkout.
+    project_root.join(".provenant/perf-ab-self.git")
+}
+
+/// Resolve a ref against the current Provenant repository to a full commit SHA.
+fn resolve_self_ref(project_root: &Path, git_ref: &str) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(project_root)
+        .args(["rev-parse", "--verify", &format!("{git_ref}^{{commit}}")])
+        .output()
+        .context("failed to run git rev-parse")?;
+    if !output.status.success() {
+        bail!(
+            "git rev-parse failed for '{git_ref}': {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Materialize a detached worktree of the current repo at `resolved_sha` under
+/// `worktree_dir`, reusing a dedicated bare clone so the build is isolated from
+/// the developer's working tree (avoiding the worktree-churn timing corruption
+/// the skill warns about).
+fn prepare_self_worktree(
+    project_root: &Path,
+    resolved_sha: &str,
+    worktree_dir: &Path,
+) -> Result<()> {
+    let cache_dir = self_repo_cache(project_root);
+    if !cache_dir.exists() {
+        if let Some(parent) = cache_dir.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        run_git(
+            Command::new("git")
+                .args(["clone", "--bare", "--local"])
+                .arg(project_root)
+                .arg(&cache_dir),
+            "failed to create perf-ab self bare clone",
+        )?;
+    }
+    // Refresh objects so newly created local commits (e.g. HEAD) are present.
+    run_git(
+        Command::new("git")
+            .arg(format!("--git-dir={}", cache_dir.display()))
+            .args(["fetch", "--force", "--tags"])
+            .arg(project_root)
+            .arg("+refs/heads/*:refs/heads/*"),
+        "failed to refresh perf-ab self bare clone",
+    )?;
+    // Also fetch the exact commit in case it is not on any local branch.
+    let _ = run_git(
+        Command::new("git")
+            .arg(format!("--git-dir={}", cache_dir.display()))
+            .args(["fetch", "--force"])
+            .arg(project_root)
+            .arg(resolved_sha),
+        "failed to fetch target commit into perf-ab self bare clone",
+    );
+    prepare_repo_worktree(&cache_dir, resolved_sha, worktree_dir)
+}
+
+fn build_release(worktree_dir: &Path, label: &str) -> Result<()> {
+    println!("  building {label} in {} ...", worktree_dir.display());
+    let output = Command::new("cargo")
+        .current_dir(worktree_dir)
+        .args(["build", "--release", "--bin", "provenant"])
+        .output()
+        .with_context(|| format!("failed to build {label}"))?;
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for line in combined
+        .lines()
+        .filter(|line| line.contains("Compiling provenant") || line.contains("Finished"))
+    {
+        println!("    {line}");
+    }
+    if !output.status.success() {
+        bail!(
+            "cargo build --release failed for {label}:\n{}",
+            combined.trim()
+        );
+    }
+    Ok(())
+}
+
+struct Timings {
+    base: Vec<f64>,
+    head: Vec<f64>,
+}
+
+/// Warm up each binary once (discarded), then run `rounds` interleaved timed
+/// scans (base, head, base, head, ...). Interleaving spreads any machine-wide
+/// thermal/scheduling drift evenly across both sides.
+fn run_interleaved(
+    base: &Side,
+    head: &Side,
+    target_dir: &Path,
+    scan_args: &[String],
+    rounds: usize,
+    run_dir: &Path,
+) -> Result<Timings> {
+    println!("[warmup] discarding one cold run per side");
+    timed_scan(base, target_dir, scan_args, WARMUP_LABEL, run_dir)?;
+    timed_scan(head, target_dir, scan_args, WARMUP_LABEL, run_dir)?;
+
+    let mut timings = Timings {
+        base: Vec::with_capacity(rounds),
+        head: Vec::with_capacity(rounds),
+    };
+    println!("\n[timed] {rounds} interleaved rounds");
+    println!("  round | base (s) | head (s)");
+    println!("  ------+----------+---------");
+    for round in 1..=rounds {
+        let base_secs = timed_scan(base, target_dir, scan_args, "timed", run_dir)?;
+        let head_secs = timed_scan(head, target_dir, scan_args, "timed", run_dir)?;
+        timings.base.push(base_secs);
+        timings.head.push(head_secs);
+        println!("  {round:>5} | {base_secs:>8.3} | {head_secs:>7.3}");
+    }
+    Ok(timings)
+}
+
+/// Run one scan and return its wall-clock seconds. Output goes to a discarded
+/// per-side scratch file so the disk write is part of the measured work but the
+/// artifacts do not accumulate.
+fn timed_scan(
+    side: &Side,
+    target_dir: &Path,
+    scan_args: &[String],
+    phase: &str,
+    run_dir: &Path,
+) -> Result<f64> {
+    let out_file = run_dir.join(format!("{}-{}-scan.json", side.label, phase));
+    let mut command = Command::new(&side.binary);
+    command
+        .current_dir(target_dir)
+        .arg("--json")
+        .arg(&out_file)
+        .arg("--no-license-index-cache")
+        .args(scan_args)
+        .arg(".");
+    let start = Instant::now();
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run {} scan", side.label))?;
+    let elapsed = start.elapsed().as_secs_f64();
+    if !output.status.success() {
+        bail!(
+            "{} scan failed:\n{}",
+            side.label,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(elapsed)
+}
+
+/// Scan with both binaries to JSON and require byte-identical output after
+/// normalizing the volatile `headers` section (version, timestamps, duration).
+fn run_correctness_gate(
+    base: &Side,
+    head: &Side,
+    target_dir: &Path,
+    scan_args: &[String],
+) -> Result<()> {
+    println!("[check-output] verifying byte-identical output (normalized header)");
+    let tmp = std::env::temp_dir().join(now_run_id("perf-ab-check"));
+    fs::create_dir_all(&tmp).with_context(|| format!("failed to create {}", tmp.display()))?;
+    let base_json = scan_to_json(base, target_dir, scan_args, &tmp)?;
+    let head_json = scan_to_json(head, target_dir, scan_args, &tmp)?;
+    let base_norm = normalize_scan_json(&base_json)?;
+    let head_norm = normalize_scan_json(&head_json)?;
+    let _ = fs::remove_dir_all(&tmp);
+    if base_norm != head_norm {
+        bail!(
+            "check-output FAILED: base and head produced different scan output after header normalization.\n\
+             A pure-refactor perf change must be byte-identical. Fix the code, not the comparison."
+        );
+    }
+    println!("  check-output OK: outputs are byte-identical after header normalization");
+    Ok(())
+}
+
+fn scan_to_json(
+    side: &Side,
+    target_dir: &Path,
+    scan_args: &[String],
+    tmp: &Path,
+) -> Result<String> {
+    let out_file = tmp.join(format!("{}-check.json", side.label));
+    let output = Command::new(&side.binary)
+        .current_dir(target_dir)
+        .arg("--json")
+        .arg(&out_file)
+        .arg("--no-license-index-cache")
+        .args(scan_args)
+        .arg(".")
+        .output()
+        .with_context(|| format!("failed to run {} check scan", side.label))?;
+    if !output.status.success() {
+        bail!(
+            "{} check scan failed:\n{}",
+            side.label,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    fs::read_to_string(&out_file).with_context(|| format!("failed to read {}", out_file.display()))
+}
+
+/// Replace the volatile top-level `headers` array with a placeholder so that
+/// version, timestamp, and duration churn does not mask a real output diff.
+fn normalize_scan_json(raw: &str) -> Result<String> {
+    let mut value: Value = serde_json::from_str(raw).context("scan output was not valid JSON")?;
+    if let Some(object) = value.as_object_mut()
+        && object.contains_key("headers")
+    {
+        object.insert(
+            "headers".to_string(),
+            Value::String("<normalized>".to_string()),
+        );
+    }
+    serde_json::to_string(&value).context("failed to re-serialize normalized scan output")
+}
+
+fn side_manifest(side: &Side, median_seconds: f64, rounds: &[f64]) -> SideManifest {
+    SideManifest {
+        label: side.label.to_string(),
+        git_ref: side.git_ref.clone(),
+        build_revision: side.build_revision.clone(),
+        binary: side.binary.clone(),
+        median_seconds,
+        round_seconds: rounds.to_vec(),
+    }
+}
+
+fn report(
+    timings: &Timings,
+    base_median: f64,
+    head_median: f64,
+    factor: Option<f64>,
+    reduction: Option<f64>,
+) {
+    println!("\n==========================================");
+    println!("Results");
+    println!("==========================================");
+    println!(
+        "  base median: {base_median:.3}s  (rounds: {})",
+        fmt_rounds(&timings.base)
+    );
+    println!(
+        "  head median: {head_median:.3}s  (rounds: {})",
+        fmt_rounds(&timings.head)
+    );
+    match (factor, reduction) {
+        (Some(factor), Some(reduction)) => {
+            if reduction >= 0.0 {
+                println!("  head is {factor:.3}x the speed of base ({reduction:.2}% faster)");
+            } else {
+                println!(
+                    "  head is {factor:.3}x the speed of base ({:.2}% SLOWER \u{2014} regression)",
+                    reduction.abs()
+                );
+            }
+        }
+        _ => println!("  unable to compute speedup (zero or missing median)"),
+    }
+}
+
+fn fmt_rounds(rounds: &[f64]) -> String {
+    rounds
+        .iter()
+        .map(|value| format!("{value:.3}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn run_git(command: &mut Command, context_message: &str) -> Result<()> {
+    let output = command
+        .output()
+        .with_context(|| context_message.to_string())?;
+    if !output.status.success() {
+        bail!(
+            "{}: {}",
+            context_message,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Median of a sample. Returns `None` for an empty slice. For an even count it
+/// averages the two central values.
+fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        Some(sorted[mid])
+    } else {
+        Some((sorted[mid - 1] + sorted[mid]) / 2.0)
+    }
+}
+
+/// Speedup as a factor: how many times the head throughput is relative to base.
+/// `> 1.0` means head is faster. `None` when head median is zero.
+fn speedup_factor(base_median: f64, head_median: f64) -> Option<f64> {
+    (head_median != 0.0).then_some(base_median / head_median)
+}
+
+/// Percent reduction in time from base to head. Positive means head is faster.
+/// `None` when base median is zero.
+fn reduction_percent(base_median: f64, head_median: f64) -> Option<f64> {
+    (base_median != 0.0).then_some((base_median - head_median) / base_median * 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Order in which `run_interleaved` emits scans: base/head alternating per
+    /// round so machine-wide drift is shared evenly across both sides. This
+    /// mirrors the loop in `run_interleaved` and locks the contract that timed
+    /// rounds are interleaved rather than all-base-then-all-head.
+    fn interleave_order(rounds: usize) -> Vec<&'static str> {
+        let mut order = Vec::with_capacity(rounds * 2);
+        for _ in 0..rounds {
+            order.push("base");
+            order.push("head");
+        }
+        order
+    }
+
+    #[test]
+    fn median_of_odd_sample_is_middle_value() {
+        assert_eq!(median(&[3.0, 1.0, 2.0]), Some(2.0));
+    }
+
+    #[test]
+    fn median_of_even_sample_averages_central_pair() {
+        assert_eq!(median(&[4.0, 1.0, 3.0, 2.0]), Some(2.5));
+    }
+
+    #[test]
+    fn median_of_empty_sample_is_none() {
+        assert_eq!(median(&[]), None);
+    }
+
+    #[test]
+    fn median_ignores_input_order() {
+        let unsorted = [10.0, 2.0, 8.0, 4.0, 6.0];
+        assert_eq!(median(&unsorted), Some(6.0));
+    }
+
+    #[test]
+    fn speedup_factor_reports_head_relative_to_base() {
+        // base 2.0s, head 1.0s -> head runs at 2x the speed.
+        assert_eq!(speedup_factor(2.0, 1.0), Some(2.0));
+    }
+
+    #[test]
+    fn speedup_factor_below_one_signals_regression() {
+        // base 1.0s, head 2.0s -> head is half the speed.
+        assert_eq!(speedup_factor(1.0, 2.0), Some(0.5));
+    }
+
+    #[test]
+    fn speedup_factor_is_none_for_zero_head_median() {
+        assert_eq!(speedup_factor(1.0, 0.0), None);
+    }
+
+    #[test]
+    fn reduction_percent_is_positive_when_head_is_faster() {
+        // 4.0 -> 3.0 is a 25% reduction.
+        assert_eq!(reduction_percent(4.0, 3.0), Some(25.0));
+    }
+
+    #[test]
+    fn reduction_percent_is_negative_for_regression() {
+        // 2.0 -> 3.0 is a -50% reduction (slower).
+        assert_eq!(reduction_percent(2.0, 3.0), Some(-50.0));
+    }
+
+    #[test]
+    fn reduction_percent_is_none_for_zero_base_median() {
+        assert_eq!(reduction_percent(0.0, 1.0), None);
+    }
+
+    #[test]
+    fn interleave_order_alternates_base_then_head_per_round() {
+        assert_eq!(
+            interleave_order(3),
+            ["base", "head", "base", "head", "base", "head"]
+        );
+        assert!(interleave_order(0).is_empty());
+    }
+
+    #[test]
+    fn normalize_scan_json_replaces_header_block() {
+        let a = r#"{"headers":[{"tool_version":"1.0","duration":1.5}],"files":[{"path":"a"}]}"#;
+        let b = r#"{"headers":[{"tool_version":"2.0","duration":9.9}],"files":[{"path":"a"}]}"#;
+        assert_eq!(
+            normalize_scan_json(a).unwrap(),
+            normalize_scan_json(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn normalize_scan_json_detects_real_diffs() {
+        let a = r#"{"headers":[{"tool_version":"1.0"}],"files":[{"path":"a"}]}"#;
+        let b = r#"{"headers":[{"tool_version":"1.0"}],"files":[{"path":"b"}]}"#;
+        assert_ne!(
+            normalize_scan_json(a).unwrap(),
+            normalize_scan_json(b).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `perf-ab` xtask binary that builds two Provenant git refs in release mode and **interleaved-A/B-times** a scan against the same target, reporting per-round real times, per-side median, and the head-vs-base speedup (percent reduction + factor). It reuses `benchmark-target`'s shared repo-cache, worktree, and release-build infrastructure; supports `--base-bin`/`--head-bin` to skip building; writes a run manifest under `.provenant/perf-ab/`; and offers a `--check-output` byte-identical correctness gate that normalizes only the volatile scan header.
- Add a `benchmark-perf-change` skill encoding the profile-first, stop-condition, regression-guarded, byte-identical-gated workflow for proving a code change is faster (or honestly reporting it is not). Cross-linked both ways with `verify-benchmark-target` to keep the self-perf lane distinct from the ScanCode-parity lane.
- Document `perf-ab` in `xtask/README.md` (command-index row + `## perf-ab` section) and register the bin in `xtask/Cargo.toml`.

## Scope and exclusions

- Included: new `perf-ab` xtask bin + unit tests, new `benchmark-perf-change` skill (canonical `.agents/skills` + generated `.claude/skills` mirror), cross-link edit to `verify-benchmark-target`, README/Cargo.toml wiring.
- Explicit exclusions: no changes to the scanner itself; no new `docs/BENCHMARKS.md` entries (self before/after timings intentionally do not belong there).

## How to verify

Beyond CI (which covers build, clippy, fmt, and the xtask unit tests):

- `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --help` shows the full flag surface.
- Real smoke run (same binary on both sides, tiny target) exercises the warmup/interleave/median/`--check-output` path and should report ~0%:
  ```bash
  cargo build --release --bin provenant
  cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
    --base-bin target/release/provenant --head-bin target/release/provenant \
    --target-path /path/to/tiny/repo --rounds 5 --check-output -- -c -l -n 1
  ```
  Observed in development: `--check-output` reported byte-identical output, warmup discarded, 5 interleaved rounds timed, median computed, result `-0.03%` (within noise for identical binaries), and a complete `run-manifest.json` written under `.provenant/perf-ab/<run-id>/`.
- A full two-ref build run was not exercised end-to-end because building two release binaries is slow; the build path reuses the already-tested `repo_cache` worktree helpers plus `cargo build --release` and compiles cleanly.

## Follow-up work

- Created or intentionally deferred: none.