### PR TITLE
fix(license-detection): deterministic candidate iteration so deadline-truncated scans are reproducible

### DIFF
--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -366,12 +366,17 @@ fn find_set_candidates<'a>(
     high_resemblance: bool,
     deadline: Option<Instant>,
 ) -> Vec<Candidate<'a>> {
-    let candidate_rids: HashSet<RuleId> = query_data
+    let candidate_rid_set: HashSet<RuleId> = query_data
         .query_high_set
         .iter()
         .filter_map(|tid| index.rids_by_high_tid.get(&TokenId::new(tid)))
         .flat_map(|rids| rids.iter().copied())
         .collect();
+
+    // Sort so a deadline-truncated run returns a deterministic prefix rather
+    // than an arbitrary `HashSet`-ordered subset (issue #1017).
+    let mut candidate_rids: Vec<RuleId> = candidate_rid_set.into_iter().collect();
+    candidate_rids.sort_unstable();
 
     let mut candidates = Vec::new();
 
@@ -1061,6 +1066,95 @@ mod tests {
             sorted[0].rid,
             RuleId::new(2),
             "Python final candidate tuple ordering falls back to higher rid after equal scores"
+        );
+    }
+
+    /// Regression test for issue #1017: candidate selection must be
+    /// deterministic. `find_set_candidates` previously iterated a `HashSet`
+    /// (randomized order per process run), so a deadline-truncated run collected
+    /// a different arbitrary subset each run. The candidate rule IDs are now
+    /// sorted before the deadline-bounded loop, so the visited order is stable
+    /// and ascending by `RuleId`; any prefix the deadline truncates is therefore
+    /// itself deterministic.
+    #[test]
+    fn test_find_set_candidates_iterates_rids_in_deterministic_sorted_order() {
+        use crate::license_detection::query::Query;
+        use crate::license_detection::test_utils::{add_text_rule, create_test_index};
+
+        let mut index = create_test_index(
+            &[
+                ("license", 0),
+                ("copyright", 1),
+                ("permission", 2),
+                ("redistribute", 3),
+                ("granted", 4),
+            ],
+            5,
+        );
+
+        // Enough rules sharing the "license" high token that the deadline-bounded
+        // loop spans more than one checkpoint (checked at rid_index % 128 == 0),
+        // so a real mid-loop truncation would return a non-trivial prefix.
+        const RULE_COUNT: usize = 200;
+        for i in 0..RULE_COUNT {
+            let identifier = format!("lic.{i}.test");
+            add_text_rule(&mut index, &identifier, "license copyright", "lic");
+        }
+
+        let query = Query::from_extracted_text(
+            "license copyright permission redistribute granted",
+            &index,
+            false,
+        )
+        .expect("query construction should succeed");
+        let query_run = query.whole_query_run();
+        let query_data =
+            QueryData::new(&index, &query_run).expect("query data should be constructible");
+
+        let rid_sequence = |candidates: &[Candidate<'_>]| -> Vec<RuleId> {
+            candidates.iter().map(|c| c.rid).collect()
+        };
+
+        // The full (non-deadline) run must visit candidate rids in ascending
+        // RuleId order, and that order must be byte-identical across repeated
+        // calls within the same process. With the old HashSet iteration this
+        // ordering was randomized.
+        let baseline = rid_sequence(&find_set_candidates(&index, &query_data, false, None));
+        assert!(
+            baseline.len() > 128,
+            "expected enough candidates to span more than one deadline checkpoint, got {}",
+            baseline.len()
+        );
+
+        let mut sorted_baseline = baseline.clone();
+        sorted_baseline.sort_unstable();
+        assert_eq!(
+            baseline, sorted_baseline,
+            "candidate rids must be visited in ascending RuleId order"
+        );
+
+        for _ in 0..16 {
+            let again = rid_sequence(&find_set_candidates(&index, &query_data, false, None));
+            assert_eq!(
+                baseline, again,
+                "candidate iteration order must be deterministic across calls"
+            );
+        }
+
+        // The loop truncates the already-sorted sequence at a checkpoint, so any
+        // prefix it returns is a deterministic prefix of `baseline`. This is the
+        // invariant that makes a deadline-truncated run reproducible regardless of
+        // when the deadline fires; with the old HashSet ordering it would not hold.
+        let truncated = rid_sequence(&find_set_candidates(
+            &index,
+            &query_data,
+            false,
+            Some(Instant::now()),
+        ));
+        assert_eq!(
+            truncated,
+            baseline[..truncated.len()].to_vec(),
+            "a deadline-truncated run must return a deterministic prefix of the full ordering"
         );
     }
 }

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -47,14 +47,10 @@ mod tests {
     use super::*;
     use crate::license_detection::index::IndexedRuleMetadata;
     use crate::license_detection::index::LicenseIndex;
-    use crate::license_detection::index::dictionary::{TokenId, TokenKind};
-    use crate::license_detection::models::Rule;
     use crate::license_detection::models::RuleId;
     use crate::license_detection::query::Query;
     use crate::license_detection::test_utils::create_test_index;
-    use crate::license_detection::{TokenMultiset, TokenSet};
     use crate::models::LineNumber;
-    use std::collections::HashMap;
 
     pub(super) fn create_seq_match_test_index() -> LicenseIndex {
         create_test_index(
@@ -70,86 +66,8 @@ mod tests {
     }
 
     pub(super) fn add_test_rule(index: &mut LicenseIndex, text: &str, expression: &str) -> RuleId {
-        let rid = RuleId::new(index.rules_by_rid.len());
-        let tokens: Vec<TokenId> = text
-            .split_whitespace()
-            .filter_map(|word| index.dictionary.get(word))
-            .collect();
-
-        let set = TokenSet::from_token_ids(tokens.iter().copied());
-        let mset = TokenMultiset::from_token_ids(&tokens);
-        let _ = index.sets_by_rid.insert(rid, set.clone());
-        let _ = index.msets_by_rid.insert(rid, mset);
-
-        let high_set: TokenSet =
-            TokenSet::from_u16_iter(set.iter().filter(|&tid| {
-                index.dictionary.token_kind(TokenId::new(tid)) == TokenKind::Legalese
-            }));
-        if !high_set.is_empty() {
-            let _ = index.high_sets_by_rid.insert(rid, high_set);
-        }
-
-        let mut high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
-        for (pos, &tid) in tokens.iter().enumerate() {
-            if index.dictionary.token_kind(tid) == TokenKind::Legalese {
-                high_postings.entry(tid).or_default().push(pos);
-            }
-        }
-        let _ = index.high_postings_by_rid.insert(rid, high_postings);
-
-        let rule = Rule {
-            identifier: format!("{}.test", expression),
-            license_expression: expression.to_string(),
-            text: text.to_string(),
-            tokens: tokens.clone(),
-            rule_kind: crate::license_detection::models::RuleKind::Text,
-            is_false_positive: false,
-            is_required_phrase: false,
-            is_from_license: false,
-            relevance: 100,
-            minimum_coverage: None,
-            has_stored_minimum_coverage: false,
-            is_continuous: true,
-            referenced_filenames: None,
-            ignorable_urls: None,
-            ignorable_emails: None,
-            ignorable_copyrights: None,
-            ignorable_holders: None,
-            ignorable_authors: None,
-            language: None,
-            notes: None,
-            length_unique: tokens.len(),
-            high_length_unique: tokens
-                .iter()
-                .filter(|&&t| index.dictionary.token_kind(t) == TokenKind::Legalese)
-                .count(),
-            high_length: tokens.len(),
-            min_matched_length: 1,
-            min_high_matched_length: 1,
-            min_matched_length_unique: 1,
-            min_high_matched_length_unique: 1,
-            is_small: false,
-            is_tiny: false,
-            starts_with_license: false,
-            ends_with_license: false,
-            is_deprecated: false,
-            spdx_license_key: None,
-            other_spdx_license_keys: vec![],
-            required_phrase_spans: vec![],
-            stopwords_by_pos: std::collections::HashMap::new(),
-        };
-
-        index.rules_by_rid.push(rule.clone());
-        index.tids_by_rid.push(tokens.clone());
-
-        // Also populate inverted index for high-value tokens
-        for &tid in &tokens {
-            if index.dictionary.token_kind(tid) == TokenKind::Legalese {
-                index.rids_by_high_tid.entry(tid).or_default().insert(rid);
-            }
-        }
-
-        rid
+        let identifier = format!("{}.test", expression);
+        crate::license_detection::test_utils::add_text_rule(index, &identifier, text, expression)
     }
 
     #[test]

--- a/src/license_detection/test_utils.rs
+++ b/src/license_detection/test_utils.rs
@@ -8,9 +8,12 @@
 
 use std::collections::HashMap;
 
+use crate::license_detection::TokenMultiset;
+use crate::license_detection::TokenSet;
 use crate::license_detection::index::LicenseIndex;
-use crate::license_detection::index::dictionary::{TokenDictionary, TokenId};
+use crate::license_detection::index::dictionary::{TokenDictionary, TokenId, TokenKind};
 use crate::license_detection::models::Rule;
+use crate::license_detection::models::RuleId;
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
 
@@ -38,6 +41,101 @@ pub fn create_test_index(legalese: &[(&str, u16)], len_legalese: usize) -> Licen
 /// with len_legalese set to 2.
 pub fn create_test_index_default() -> LicenseIndex {
     create_test_index(&[("mit", 0), ("license", 1), ("apache", 2), ("2.0", 3)], 2)
+}
+
+/// Inserts a whitespace-tokenized rule into a test index and wires up the set,
+/// multiset, high-set, postings, and inverted-index structures needed by
+/// candidate selection and sequence matching.
+///
+/// `identifier` must be unique within the index. Returns the assigned `RuleId`.
+pub fn add_text_rule(
+    index: &mut LicenseIndex,
+    identifier: &str,
+    text: &str,
+    expression: &str,
+) -> RuleId {
+    let rid = RuleId::new(index.rules_by_rid.len());
+    let tokens: Vec<TokenId> = text
+        .split_whitespace()
+        .filter_map(|word| index.dictionary.get(word))
+        .collect();
+
+    let set = TokenSet::from_token_ids(tokens.iter().copied());
+    let mset = TokenMultiset::from_token_ids(&tokens);
+    let _ = index.sets_by_rid.insert(rid, set.clone());
+    let _ = index.msets_by_rid.insert(rid, mset);
+
+    let high_set: TokenSet = TokenSet::from_u16_iter(
+        set.iter()
+            .filter(|&tid| index.dictionary.token_kind(TokenId::new(tid)) == TokenKind::Legalese),
+    );
+    if !high_set.is_empty() {
+        let _ = index.high_sets_by_rid.insert(rid, high_set);
+    }
+
+    let mut high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();
+    for (pos, &tid) in tokens.iter().enumerate() {
+        if index.dictionary.token_kind(tid) == TokenKind::Legalese {
+            high_postings.entry(tid).or_default().push(pos);
+        }
+    }
+    let _ = index.high_postings_by_rid.insert(rid, high_postings);
+
+    let length_unique = set.len();
+    let high_length_unique = tokens
+        .iter()
+        .filter(|&&t| index.dictionary.token_kind(t) == TokenKind::Legalese)
+        .count();
+
+    let rule = Rule {
+        identifier: identifier.to_string(),
+        license_expression: expression.to_string(),
+        text: text.to_string(),
+        tokens: tokens.clone(),
+        rule_kind: crate::license_detection::models::RuleKind::Text,
+        is_false_positive: false,
+        is_required_phrase: false,
+        is_from_license: false,
+        relevance: 100,
+        minimum_coverage: None,
+        has_stored_minimum_coverage: false,
+        is_continuous: true,
+        referenced_filenames: None,
+        ignorable_urls: None,
+        ignorable_emails: None,
+        ignorable_copyrights: None,
+        ignorable_holders: None,
+        ignorable_authors: None,
+        language: None,
+        notes: None,
+        length_unique,
+        high_length_unique,
+        high_length: tokens.len(),
+        min_matched_length: 1,
+        min_high_matched_length: 1,
+        min_matched_length_unique: 1,
+        min_high_matched_length_unique: 1,
+        is_small: false,
+        is_tiny: false,
+        starts_with_license: false,
+        ends_with_license: false,
+        is_deprecated: false,
+        spdx_license_key: None,
+        other_spdx_license_keys: vec![],
+        required_phrase_spans: vec![],
+        stopwords_by_pos: HashMap::new(),
+    };
+
+    index.rules_by_rid.push(rule);
+    index.tids_by_rid.push(tokens.clone());
+
+    for &tid in &tokens {
+        if index.dictionary.token_kind(tid) == TokenKind::Legalese {
+            index.rids_by_high_tid.entry(tid).or_default().insert(rid);
+        }
+    }
+
+    rid
 }
 
 /// Creates a mock Rule for testing matchers.


### PR DESCRIPTION
## Summary

- `find_set_candidates` collected candidate rule IDs into a `HashSet<RuleId>`, whose SipHash iteration order is randomized per process run. When the per-file matching deadline fired, the function returned the partial subset collected so far. Because the iteration order was random, a deadline-truncated run collected a different arbitrary subset each run, producing non-deterministic (non-reproducible) license detections for inputs large enough to trip the deadline.
- Fix: collect the candidate rule IDs into a `Vec` and `sort_unstable()` by `RuleId` before the deadline-bounded loop, so a deadline-truncated run returns a deterministic prefix ordered by `RuleId`. The downstream sort/scoring is unchanged (it was already a total order via the `rid` tiebreak), and `rescore_candidates_with_multisets` already iterates an ordered `Vec`, so it needs no change.

## Issues

- Closes: #1017

## Scope and exclusions

- Included: deterministic candidate iteration in `find_set_candidates`; a regression test asserting deterministic full and deadline-truncated candidate selection.
- Explicit exclusions: no change to scoring, ranking, dedupe, or the downstream sorts. No golden fixtures regenerated (none shifted).

## How to verify

- `cargo test -p provenant-cli --lib license_detection::seq_match::candidates` exercises the new regression test, which asserts candidate iteration order is sorted by `RuleId` and byte-identical across repeated calls, including a run with an already-elapsed deadline that forces the early-exit branch.

## Expected-output fixture changes

- Files changed: none. The golden suite (`cargo test --test license_detection_golden --features golden-tests`) passes with 0 diffs because the golden fixtures are small and never trip the matching deadline.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)