### PR TITLE
enhancement(parsers): npm lockfile per-package licenses

### DIFF
--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -631,7 +631,10 @@ fn extract_root_package_identity(
 ///
 /// npm lockfile `license` values are SPDX-by-convention strings (e.g. `"MIT"`,
 /// `"(MIT OR Apache-2.0)"`). The deprecated object form `{ "type": ... }` and
-/// the legacy `licenses` array are also tolerated by reading the `type` field.
+/// the legacy plural `licenses` array are also tolerated by reading the `type`
+/// field. Per the npm spec, multiple entries in the `licenses` array express
+/// dual-licensing where a user may comply with any one of them, so they are
+/// combined with SPDX `OR` (not `AND`).
 fn extract_package_license(value: &Value) -> Option<String> {
     if let Some(license) = value.get(FIELD_LICENSE) {
         if let Some(text) = license.as_str() {
@@ -650,7 +653,13 @@ fn extract_package_license(value: &Value) -> Option<String> {
             .filter_map(non_empty_string)
             .collect();
         if !types.is_empty() {
-            return Some(truncate_field(types.join(" AND ")));
+            let joined = types.join(" OR ");
+            let statement = if types.len() > 1 {
+                format!("({})", joined)
+            } else {
+                joined
+            };
+            return Some(truncate_field(statement));
         }
     }
 

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::PackageParser;
+use super::license_normalization::normalize_spdx_declared_license;
 use super::metadata::ParserMetadata;
 
 // Field name constants
@@ -51,6 +52,8 @@ const FIELD_DEV: &str = "dev";
 const FIELD_OPTIONAL: &str = "optional";
 const FIELD_DEV_OPTIONAL: &str = "devOptional";
 const FIELD_LINK: &str = "link";
+const FIELD_LICENSE: &str = "license";
+const FIELD_LICENSES: &str = "licenses";
 
 /// npm lockfile parser supporting package-lock.json v1, v2, and v3 formats.
 ///
@@ -162,6 +165,14 @@ fn parse_lockfile_v2_plus(
         normalize_root_package_metadata(&root_name, &root_version);
     let linked_workspace_names = collect_linked_workspace_names(packages);
 
+    // v2/v3 lockfiles carry the root project's license on the `packages[""]` entry.
+    let root_license_statement = packages.get("").and_then(extract_package_license);
+    let (
+        root_declared_license_expression,
+        root_declared_license_expression_spdx,
+        root_license_detections,
+    ) = normalize_spdx_declared_license(root_license_statement.as_deref());
+
     // Collect root-level dependencies from top-level sections
     let mut root_deps = std::collections::HashSet::new();
 
@@ -238,6 +249,7 @@ fn parse_lockfile_v2_plus(
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         let is_direct = root_deps.contains(&install_name) && is_direct_dependency_path(key);
+        let license_statement = extract_package_license(value);
 
         let dependency = match version {
             Some(version) => build_npm_dependency(
@@ -252,6 +264,7 @@ fn parse_lockfile_v2_plus(
                 from,
                 in_bundle,
                 Vec::new(),
+                license_statement,
             ),
             None if is_link => build_link_dependency(
                 &package_name,
@@ -296,13 +309,13 @@ fn parse_lockfile_v2_plus(
         vcs_url: None,
         copyright: None,
         holder: None,
-        declared_license_expression: None,
-        declared_license_expression_spdx: None,
-        license_detections: Vec::new(),
+        declared_license_expression: root_declared_license_expression,
+        declared_license_expression_spdx: root_declared_license_expression_spdx,
+        license_detections: root_license_detections,
         other_license_expression: None,
         other_license_expression_spdx: None,
         other_license_detections: Vec::new(),
-        extracted_license_statement: None,
+        extracted_license_statement: root_license_statement,
         notice_text: None,
         source_packages: Vec::new(),
         file_references: Vec::new(),
@@ -483,6 +496,7 @@ fn parse_dependencies_v1_with_depth(
             from,
             in_bundle,
             nested_deps,
+            None,
         );
 
         dependencies.push(dependency);
@@ -611,6 +625,36 @@ fn extract_root_package_identity(
     });
 
     (name.unwrap_or_default(), version.unwrap_or_default())
+}
+
+/// Extract a declared-license candidate from a v2/v3 `packages[*]` entry.
+///
+/// npm lockfile `license` values are SPDX-by-convention strings (e.g. `"MIT"`,
+/// `"(MIT OR Apache-2.0)"`). The deprecated object form `{ "type": ... }` and
+/// the legacy `licenses` array are also tolerated by reading the `type` field.
+fn extract_package_license(value: &Value) -> Option<String> {
+    if let Some(license) = value.get(FIELD_LICENSE) {
+        if let Some(text) = license.as_str() {
+            return non_empty_string(text).map(truncate_field);
+        }
+        if let Some(type_val) = license.get("type").and_then(|v| v.as_str()) {
+            return non_empty_string(type_val).map(truncate_field);
+        }
+    }
+
+    if let Some(licenses) = value.get(FIELD_LICENSES).and_then(|v| v.as_array()) {
+        let types: Vec<String> = licenses
+            .iter()
+            .take(MAX_ITERATION_COUNT)
+            .filter_map(|entry| entry.get("type").and_then(|v| v.as_str()))
+            .filter_map(non_empty_string)
+            .collect();
+        if !types.is_empty() {
+            return Some(truncate_field(types.join(" AND ")));
+        }
+    }
+
+    None
 }
 
 fn non_empty_string(value: &str) -> Option<String> {
@@ -769,6 +813,7 @@ fn build_npm_dependency(
     from: Option<&str>,
     in_bundle: bool,
     nested_deps: Vec<Dependency>,
+    license_statement: Option<String>,
 ) -> Dependency {
     let (dep_namespace, dep_name) = extract_namespace_and_name(package_name);
     let dep_namespace = truncate_field(dep_namespace);
@@ -821,6 +866,9 @@ fn build_npm_dependency(
     let sha1_from_url = resolved.as_deref().and_then(parse_resolved_url);
     let sha1 = sha1_from_integrity.or(sha1_from_url);
 
+    let (declared_license_expression, declared_license_expression_spdx, license_detections) =
+        normalize_spdx_declared_license(license_statement.as_deref());
+
     let mut dep_extra_data = HashMap::new();
     if let Some(from) = from {
         dep_extra_data.insert("from".to_string(), Value::String(from.to_string()));
@@ -836,6 +884,10 @@ fn build_npm_dependency(
         sha256: None,
         sha512: sha512_from_integrity.and_then(|h| Sha512Digest::from_hex(&h).ok()),
         md5: None,
+        declared_license_expression,
+        declared_license_expression_spdx,
+        license_detections,
+        extracted_license_statement: license_statement,
         is_virtual: true,
         extra_data: None,
         dependencies: nested_deps,

--- a/src/parsers/npm_lock_test.rs
+++ b/src/parsers/npm_lock_test.rs
@@ -217,6 +217,64 @@ mod tests {
     }
 
     #[test]
+    fn test_v3_resolved_package_legacy_licenses_array_is_dual_license_or() {
+        // The deprecated plural `licenses` array expresses dual-licensing: the
+        // user may comply with any one entry, so the entries combine with OR.
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0" },
+                "node_modules/dual-array": {
+                    "version": "1.0.0",
+                    "licenses": [
+                        { "type": "MIT", "url": "http://example.com/mit" },
+                        { "type": "Apache-2.0", "url": "http://example.com/apache" }
+                    ]
+                }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        let dual = resolved_for(&package_data, "dual-array");
+        assert_eq!(
+            dual.extracted_license_statement,
+            Some("(MIT OR Apache-2.0)".to_string())
+        );
+        assert_eq!(
+            dual.declared_license_expression_spdx,
+            Some("Apache-2.0 OR MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_v3_resolved_package_single_entry_licenses_array() {
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0" },
+                "node_modules/single-array": {
+                    "version": "1.0.0",
+                    "licenses": [ { "type": "MIT", "url": "http://example.com/mit" } ]
+                }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        let single = resolved_for(&package_data, "single-array");
+        assert_eq!(single.extracted_license_statement, Some("MIT".to_string()));
+        assert_eq!(
+            single.declared_license_expression_spdx,
+            Some("MIT".to_string())
+        );
+    }
+
+    #[test]
     fn test_v3_resolved_package_without_license_stays_unset() {
         let content = r#"{
             "name": "demo",

--- a/src/parsers/npm_lock_test.rs
+++ b/src/parsers/npm_lock_test.rs
@@ -117,6 +117,126 @@ mod tests {
         }
     }
 
+    // ===== Per-package license tests (v2/v3 `packages[*].license`) =====
+
+    fn resolved_for<'a>(
+        package_data: &'a crate::models::PackageData,
+        name: &str,
+    ) -> &'a crate::models::ResolvedPackage {
+        package_data
+            .dependencies
+            .iter()
+            .filter_map(|dep| dep.resolved_package.as_deref())
+            .find(|resolved| resolved.name == name)
+            .unwrap_or_else(|| panic!("expected resolved package for {name}"))
+    }
+
+    #[test]
+    fn test_v2_root_license_normalized() {
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0", "license": "Apache-2.0" }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        assert_eq!(
+            package_data.extracted_license_statement,
+            Some("Apache-2.0".to_string())
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx,
+            Some("Apache-2.0".to_string())
+        );
+        assert!(!package_data.license_detections.is_empty());
+    }
+
+    #[test]
+    fn test_v3_resolved_package_license_string_and_expression() {
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0" },
+                "node_modules/plain": { "version": "1.2.3", "license": "MIT" },
+                "node_modules/dual": { "version": "4.5.6", "license": "(MIT OR Apache-2.0)" }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        let plain = resolved_for(&package_data, "plain");
+        assert_eq!(plain.extracted_license_statement, Some("MIT".to_string()));
+        assert_eq!(
+            plain.declared_license_expression_spdx,
+            Some("MIT".to_string())
+        );
+
+        let dual = resolved_for(&package_data, "dual");
+        assert_eq!(
+            dual.extracted_license_statement,
+            Some("(MIT OR Apache-2.0)".to_string())
+        );
+        assert_eq!(
+            dual.declared_license_expression_spdx,
+            Some("Apache-2.0 OR MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_v3_resolved_package_license_object_form() {
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0" },
+                "node_modules/legacy": {
+                    "version": "1.0.0",
+                    "license": { "type": "BSD-3-Clause", "url": "http://example.com" }
+                }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        let legacy = resolved_for(&package_data, "legacy");
+        assert_eq!(
+            legacy.extracted_license_statement,
+            Some("BSD-3-Clause".to_string())
+        );
+        assert_eq!(
+            legacy.declared_license_expression_spdx,
+            Some("BSD-3-Clause".to_string())
+        );
+    }
+
+    #[test]
+    fn test_v3_resolved_package_without_license_stays_unset() {
+        let content = r#"{
+            "name": "demo",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "demo", "version": "1.0.0" },
+                "node_modules/nolicense": { "version": "1.0.0" }
+            }
+        }"#;
+        let (_tmp, path) = create_temp_lock_file(content);
+        let package_data = NpmLockParser::extract_first_package(&path);
+
+        let resolved = resolved_for(&package_data, "nolicense");
+        assert!(resolved.extracted_license_statement.is_none());
+        assert!(resolved.declared_license_expression.is_none());
+        assert!(resolved.declared_license_expression_spdx.is_none());
+        assert!(resolved.license_detections.is_empty());
+    }
+
     #[test]
     fn test_parse_scoped_packages() {
         let lock_path = load_testdata_file("package-lock-scoped.json");

--- a/testdata/npm/package-lock-v2.json
+++ b/testdata/npm/package-lock-v2.json
@@ -18,6 +18,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -26,13 +27,15 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "(MIT OR Apache-2.0)",
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -41,7 +44,10 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "dev": true,
+      "license": {
+        "type": "BSD-2-Clause"
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/testdata/npm/package-lock-v2.json.expected.json
+++ b/testdata/npm/package-lock-v2.json.expected.json
@@ -5,6 +5,33 @@
     "name": "megak",
     "version": "1.0.0",
     "parties": [],
+    "declared_license_expression": "isc",
+    "declared_license_expression_spdx": "ISC",
+    "license_detections": [
+      {
+        "license_expression": "isc",
+        "license_expression_spdx": "ISC",
+        "matches": [
+          {
+            "license_expression": "isc",
+            "license_expression_spdx": "ISC",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "ISC"
+          }
+        ],
+        "identifier": null
+      }
+    ],
+    "extracted_license_statement": "ISC",
     "extra_data": {
       "lockfileVersion": 2
     },
@@ -25,6 +52,33 @@
           "primary_language": "JavaScript",
           "download_url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
           "sha512": "f4d113f75d0335a20f9e06272cb3de83e3a0ceab22f6e3389926e8539cbaa7c4b90f3313544b0966b6b08be0680cd51505ad83849a9061416f3037e0534eb62d",
+          "declared_license_expression": "mit",
+          "declared_license_expression_spdx": "MIT",
+          "license_detections": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "matches": [
+                {
+                  "license_expression": "mit",
+                  "license_expression_spdx": "MIT",
+                  "from_file": null,
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "parser-declared-license",
+                  "score": 100.0,
+                  "matched_length": 1,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "parser-declared-license",
+                  "rule_url": null,
+                  "matched_text": "MIT"
+                }
+              ],
+              "identifier": null
+            }
+          ],
+          "extracted_license_statement": "MIT",
           "is_virtual": true,
           "dependencies": [],
           "datasource_id": "npm_package_lock_json"
@@ -45,6 +99,33 @@
           "primary_language": "JavaScript",
           "download_url": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
           "sha512": "88aa51a573fe0ab3f68f2af1be0d64314a570f24541435aeaf16e7553d6f40fc7e5b3f6e098b0c22a62e4812d5f8f01a646fddee444b29115cf680ccb07fa615",
+          "declared_license_expression": "isc",
+          "declared_license_expression_spdx": "ISC",
+          "license_detections": [
+            {
+              "license_expression": "isc",
+              "license_expression_spdx": "ISC",
+              "matches": [
+                {
+                  "license_expression": "isc",
+                  "license_expression_spdx": "ISC",
+                  "from_file": null,
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "parser-declared-license",
+                  "score": 100.0,
+                  "matched_length": 1,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "parser-declared-license",
+                  "rule_url": null,
+                  "matched_text": "ISC"
+                }
+              ],
+              "identifier": null
+            }
+          ],
+          "extracted_license_statement": "ISC",
           "is_virtual": true,
           "dependencies": [],
           "datasource_id": "npm_package_lock_json"
@@ -65,6 +146,33 @@
           "primary_language": "JavaScript",
           "download_url": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
           "sha512": "64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f",
+          "declared_license_expression": "apache-2.0 OR mit",
+          "declared_license_expression_spdx": "Apache-2.0 OR MIT",
+          "license_detections": [
+            {
+              "license_expression": "apache-2.0 OR mit",
+              "license_expression_spdx": "Apache-2.0 OR MIT",
+              "matches": [
+                {
+                  "license_expression": "apache-2.0 OR mit",
+                  "license_expression_spdx": "Apache-2.0 OR MIT",
+                  "from_file": null,
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "parser-declared-license",
+                  "score": 100.0,
+                  "matched_length": 3,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "mit_or_apache-2.0_15.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
+                  "matched_text": "(MIT OR Apache-2.0)"
+                }
+              ],
+              "identifier": null
+            }
+          ],
+          "extracted_license_statement": "(MIT OR Apache-2.0)",
           "is_virtual": true,
           "dependencies": [],
           "datasource_id": "npm_package_lock_json"
@@ -85,6 +193,33 @@
           "primary_language": "JavaScript",
           "download_url": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
           "sha512": "2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011",
+          "declared_license_expression": "bsd-2-clause",
+          "declared_license_expression_spdx": "BSD-2-Clause",
+          "license_detections": [
+            {
+              "license_expression": "bsd-2-clause",
+              "license_expression_spdx": "BSD-2-Clause",
+              "matches": [
+                {
+                  "license_expression": "bsd-2-clause",
+                  "license_expression_spdx": "BSD-2-Clause",
+                  "from_file": null,
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "parser-declared-license",
+                  "score": 100.0,
+                  "matched_length": 1,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "spdx_license_id_bsd-2-clause_for_bsd-simplified.RULE",
+                  "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_bsd-2-clause_for_bsd-simplified.RULE",
+                  "matched_text": "BSD-2-Clause"
+                }
+              ],
+              "identifier": null
+            }
+          ],
+          "extracted_license_statement": "BSD-2-Clause",
           "is_virtual": true,
           "dependencies": [],
           "datasource_id": "npm_package_lock_json"


### PR DESCRIPTION
## Summary

- Read the SPDX-by-convention `license` key from npm `package-lock.json` v2/v3 `packages[*]` entries and surface it as real license metadata instead of dropping it.
- The root project's license (`packages[""].license`) is attached to the top-level `PackageData`; every resolved dependency's license is attached to its `ResolvedPackage`.
- Values go through `normalize_spdx_declared_license`, populating `declared_license_expression`, `declared_license_expression_spdx`, `license_detections`, and `extracted_license_statement`. Free-text fallbacks are still handled by the central post-extraction hook.
- Supports the plain string form (`"MIT"`), SPDX expressions (`"(MIT OR Apache-2.0)"`), the legacy object form (`{ "type": ... }`), and the deprecated plural `licenses[]` array. The `licenses[]` array is dual-licensing (a user may comply with any one entry), so its entries combine with SPDX `OR`, matching ScanCode's npm handler.

## Issues

- Closes #999

The npm-lockfile portion of #999 is fully implemented here. The archive-introspection half is tracked separately in #1022.

## Scope and exclusions

- Included: npm `package-lock.json` / `npm-shrinkwrap.json` v2/v3 per-package and root license extraction.
- Explicit exclusions: The recognizer-only archive-introspection half (bounded zip reads for `.jar`/`.war`/`.aar` MANIFEST.MF + Maven `pom.properties`, plus a real `ivy.xml` parser, and the associated new-datasource assembly classification) is **not** in this PR. That half is substantially larger (new bounded-zip introspection, OSGi/Maven interpretation reuse, a new XML parser, datasource classification, assembly wiring, and goldens for multiple formats) and is tracked separately in #1022. v1 lockfiles are untouched because they carry no per-package licenses.

## How to verify

- `cargo test -p provenant-cli --lib parsers::npm_lock_test` exercises root + per-package string/expression/object/no-license cases plus the single-entry and multi-entry `licenses[]` array forms on synthetic lockfiles.
- The `package-lock-v2.json` golden now shows MIT / ISC / `Apache-2.0 OR MIT` / BSD-2-Clause on resolved packages and ISC on the root; inspect `testdata/npm/package-lock-v2.json.expected.json`.

## Intentional differences from Python

- ScanCode drops the lockfile `license` key entirely; this surfaces it as normalized declared-license data — a beat-upstream enrichment in the largest JS workflow. The deprecated `licenses[]` array's OR (dual-license) semantics match ScanCode's npm `licenses_mapper`.

## Follow-up work

- Created or intentionally deferred: archive-metadata introspection half (JAR/WAR/EAR/AAR + `ivy.xml`) is tracked in #1022.

## Expected-output fixture changes

- Files changed: `testdata/npm/package-lock-v2.json` (added per-package `license` keys covering string, SPDX-expression, and object forms) and `testdata/npm/package-lock-v2.json.expected.json` (now carries the normalized declared-license fields + `extracted_license_statement` on root and resolved packages).
- Why the new expected output is correct: the `license` values are valid SPDX identifiers/expressions; the recorded `declared_license_expression(_spdx)` and `license_detections` are exactly what `normalize_spdx_declared_license` produces, matching how the npm `package.json` parser already normalizes declared licenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
