### PR TITLE
enhancement(cache): add opt-in trust-mtime mode for incremental scans

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -485,6 +485,13 @@ than catching that rare same-tick, same-size edit (for example, fast local
 iteration on large trees). A genuinely changed size or mtime is still detected as
 changed in either mode.
 
+The miss does not become permanent: when a trust-mtime run reuses a stale result,
+the rewritten manifest keeps the hash of the bytes that produced that result rather
+than re-hashing the current file. A later run without `--cache-trust-mtime`
+therefore re-hashes, sees the hash no longer matches, and re-scans the file. In
+other words, switching back to the default paranoid mode recovers correct results
+on the next scan.
+
 ### 17. "I want policy-aware license review"
 
 ```sh

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -460,6 +460,31 @@ Important details:
 - if the previous manifest is missing, unreadable, or incompatible, Provenant falls back to a full rescan and rewrites it.
 - incremental reuse applies to native scans, not `--from-json` reshaping.
 
+#### Faster warm re-scans with `--cache-trust-mtime`
+
+By default, incremental reuse is paranoid: even when a file's size and nanosecond
+mtime still match the cached fingerprint, Provenant re-reads the file and re-hashes
+its content (SHA-256) before reusing the cached result. This makes default scans
+fully reproducible and byte-identical, but it still pays full read + hash I/O for
+the entire tree on every warm re-scan.
+
+`--cache-trust-mtime` (only valid together with `--incremental`) opts into trusting
+the size + mtime fingerprint: a matching fingerprint reuses the cached result
+without re-reading or re-hashing the file.
+
+Trade-off:
+
+- Faster: warm re-scans skip the read + SHA-256 of every unchanged file.
+- Slightly less safe: it can miss a file that was modified in place within the same
+  mtime tick at exactly the same size (rare, and typically only seen with very fast
+  programmatic edits or filesystems with coarse mtime resolution).
+
+The default stays paranoid (full re-hash) so reproducibility is never silently
+traded away. Reach for `--cache-trust-mtime` when warm-rescan speed matters more
+than catching that rare same-tick, same-size edit (for example, fast local
+iteration on large trees). A genuinely changed size or mtime is still detected as
+changed in either mode.
+
 ### 17. "I want policy-aware license review"
 
 ```sh

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -40,6 +40,7 @@ pub(crate) struct ScanRequest {
     pub(crate) cache_dir: Option<String>,
     pub(crate) cache_clear: bool,
     pub(crate) incremental: bool,
+    pub(crate) cache_trust_mtime: bool,
     pub(crate) max_depth: usize,
     pub(crate) max_in_memory: MemoryMode,
     pub(crate) info: bool,

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -602,6 +602,7 @@ fn load_native_scan_session(
             &mut collected.files,
             Path::new(&scan_path),
             previous_manifest.as_ref(),
+            cache_config.trust_mtime(),
         );
         progress.record_incremental_reused(reused_files.len());
     }
@@ -644,6 +645,7 @@ fn load_native_scan_session(
             &mut all_collected_files.clone(),
             Path::new(&scan_path),
             load_incremental_manifest(&manifest_path, &options_fingerprint)?.as_ref(),
+            cache_config.trust_mtime(),
         );
         result.files =
             merge_incremental_file_results(result.files, reused_files, &ordered_file_paths);
@@ -753,6 +755,7 @@ fn partition_incremental_files(
     collected_files: &mut Vec<(PathBuf, fs::Metadata)>,
     scan_root: &Path,
     manifest: Option<&IncrementalManifest>,
+    trust_mtime: bool,
 ) -> Vec<FileInfo> {
     let Some(manifest) = manifest else {
         return Vec::new();
@@ -768,7 +771,7 @@ fn partition_incremental_files(
             continue;
         };
 
-        match manifest_entry_matches_path(entry, &path, &metadata) {
+        match manifest_entry_matches_path(entry, &path, &metadata, trust_mtime) {
             Ok(true) => reused_files.push(entry.file_info.clone()),
             Ok(false) | Err(_) => files_to_scan.push((path, metadata)),
         }

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -28,7 +28,7 @@ use crate::cache::{
 use crate::cli::ProcessMode;
 use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::license_cache::LicenseCacheConfig;
-use crate::models::{FileInfo, FileType, Output, Sha256Digest};
+use crate::models::{FileInfo, FileType, Output};
 use crate::post_processing::{
     CreateOutputContext, CreateOutputOptions, DEFAULT_LICENSEDB_URL_TEMPLATE, FacetRule,
     apply_license_policy_from_file, apply_package_reference_following, build_facet_rules,
@@ -641,10 +641,11 @@ fn load_native_scan_session(
             cache_config.root_dir(),
             &incremental_manifest_key(Path::new(&scan_path), &options_fingerprint),
         );
+        let previous_manifest = load_incremental_manifest(&manifest_path, &options_fingerprint)?;
         let reused_files = partition_incremental_files(
             &mut all_collected_files.clone(),
             Path::new(&scan_path),
-            load_incremental_manifest(&manifest_path, &options_fingerprint)?.as_ref(),
+            previous_manifest.as_ref(),
             cache_config.trust_mtime(),
         );
         result.files =
@@ -655,6 +656,7 @@ fn load_native_scan_session(
             &all_collected_files,
             &result.files,
             &options_fingerprint,
+            previous_manifest.as_ref(),
         );
         write_incremental_manifest(cache_config.root_dir(), &manifest_path, &manifest)?;
     }
@@ -825,6 +827,7 @@ fn build_incremental_manifest(
     collected_files: &[(PathBuf, fs::Metadata)],
     files: &[FileInfo],
     options_fingerprint: &str,
+    previous_manifest: Option<&IncrementalManifest>,
 ) -> IncrementalManifest {
     let files_by_relative_path: std::collections::HashMap<_, _> = files
         .iter()
@@ -843,16 +846,28 @@ fn build_incremental_manifest(
             let relative_path = normalize_relative_scan_path(path, scan_root);
             let state = metadata_fingerprint(metadata)?;
             let file_info = files_by_relative_path.get(&relative_path)?.clone();
-            let content_sha256 = file_info.sha256.unwrap_or_else(|| {
-                fs::read(path)
-                    .map(|bytes| calculate_sha256(&bytes))
-                    .unwrap_or_else(|_| {
-                        Sha256Digest::from_hex(
-                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                        )
-                        .unwrap()
-                    })
-            });
+            // `content_sha256` must describe the bytes that produced `file_info`.
+            // For a reused entry under `--cache-trust-mtime`, `file_info` is the
+            // *previous* scan result, so re-reading the current file here would
+            // store a hash for bytes that do not match the stored result. That
+            // poisons the manifest: a later paranoid rescan would re-hash, match
+            // the freshly written hash, and reuse the stale result forever.
+            // Carry over the previous entry's hash when its fingerprint still
+            // matches; this is a no-op for paranoid reuse (same bytes, same hash)
+            // and lets paranoid mode self-heal after a trust-mtime miss.
+            let content_sha256 = file_info
+                .sha256
+                .or_else(|| {
+                    previous_manifest
+                        .and_then(|manifest| manifest.entry(&relative_path))
+                        .filter(|entry| entry.state == state)
+                        .map(|entry| entry.content_sha256)
+                })
+                .unwrap_or_else(|| {
+                    fs::read(path)
+                        .map(|bytes| calculate_sha256(&bytes))
+                        .unwrap_or_else(|_| calculate_sha256(&[]))
+                });
             Some((
                 relative_path,
                 IncrementalManifestEntry {
@@ -884,4 +899,168 @@ fn normalize_relative_scan_path(path: &Path, scan_root: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod incremental_manifest_tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::cache::FileStateFingerprint;
+    use crate::models::Sha256Digest;
+
+    fn file_info_without_hash(path: &Path, size: u64) -> FileInfo {
+        FileInfo::new(
+            "f.txt".to_string(),
+            "f".to_string(),
+            ".txt".to_string(),
+            path.to_string_lossy().to_string(),
+            FileType::File,
+            None,
+            None,
+            size,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    fn previous_manifest_with_hash(
+        relative_path: &str,
+        state: FileStateFingerprint,
+        content_sha256: Sha256Digest,
+        file_info: FileInfo,
+    ) -> IncrementalManifest {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            relative_path.to_string(),
+            IncrementalManifestEntry {
+                state,
+                content_sha256,
+                file_info,
+            },
+        );
+        IncrementalManifest::new("opts".to_string(), entries)
+    }
+
+    // A reused entry (no per-file sha256, e.g. when `--info` is off) must keep
+    // the previous manifest's content hash instead of re-reading the current
+    // file. Otherwise a `--cache-trust-mtime` miss would write the *current*
+    // hash next to the *stale* result, and a later paranoid rescan would see a
+    // matching hash and reuse the stale result forever.
+    #[test]
+    fn test_build_manifest_carries_over_previous_hash_for_reused_entry() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let scan_root = temp_dir.path();
+        let file_path = scan_root.join("f.txt");
+        fs::write(&file_path, b"current bytes").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+        let state = metadata_fingerprint(&metadata).expect("fingerprint");
+
+        let stale_hash = calculate_sha256(b"old bytes");
+        let current_hash = calculate_sha256(b"current bytes");
+        assert_ne!(stale_hash, current_hash);
+
+        let previous = previous_manifest_with_hash(
+            "f.txt",
+            state,
+            stale_hash,
+            file_info_without_hash(&file_path, metadata.len()),
+        );
+
+        let collected = vec![(file_path.clone(), metadata.clone())];
+        let files = vec![file_info_without_hash(&file_path, metadata.len())];
+
+        let manifest =
+            build_incremental_manifest(scan_root, &collected, &files, "opts", Some(&previous));
+
+        let entry = manifest.entry("f.txt").expect("entry");
+        assert_eq!(
+            entry.content_sha256, stale_hash,
+            "reused entry must keep the previous hash so paranoid mode can self-heal"
+        );
+    }
+
+    // When there is no usable previous hash (no matching fingerprint), the
+    // builder falls back to hashing the current file as before.
+    #[test]
+    fn test_build_manifest_hashes_current_file_without_previous_hash() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let scan_root = temp_dir.path();
+        let file_path = scan_root.join("f.txt");
+        fs::write(&file_path, b"current bytes").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+        let current_hash = calculate_sha256(b"current bytes");
+
+        let collected = vec![(file_path.clone(), metadata.clone())];
+        let files = vec![file_info_without_hash(&file_path, metadata.len())];
+
+        let manifest = build_incremental_manifest(scan_root, &collected, &files, "opts", None);
+
+        let entry = manifest.entry("f.txt").expect("entry");
+        assert_eq!(entry.content_sha256, current_hash);
+    }
+
+    // End-to-end: a trust-mtime miss must NOT permanently poison the cache. The
+    // previous scan recorded the old content hash for a fingerprint that a later
+    // silent same-size/same-mtime edit now also produces. A trust-mtime run
+    // reuses the stale result; the rewritten manifest must keep the *old* hash
+    // (carry-over), so a subsequent paranoid check re-hashes the *current* bytes
+    // and detects the mismatch instead of serving stale results forever.
+    #[test]
+    fn test_paranoid_rescan_detects_silent_change_after_trust_mtime_miss() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let scan_root = temp_dir.path();
+        let file_path = scan_root.join("f.txt");
+
+        // Current on-disk content after a silent same-fingerprint edit.
+        fs::write(&file_path, b"new bytes").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+        let state = metadata_fingerprint(&metadata).expect("fingerprint");
+        let old_hash = calculate_sha256(b"old bytes");
+        let current_hash = calculate_sha256(b"new bytes");
+        assert_ne!(old_hash, current_hash);
+
+        // The previous manifest recorded the old hash under this same fingerprint.
+        let previous = previous_manifest_with_hash(
+            "f.txt",
+            state.clone(),
+            old_hash,
+            file_info_without_hash(&file_path, metadata.len()),
+        );
+
+        // trust-mtime reuse keeps the old file_info; the rewritten manifest must
+        // keep the old hash rather than re-reading and storing the current hash.
+        let collected = vec![(file_path.clone(), metadata.clone())];
+        let reused = vec![file_info_without_hash(&file_path, metadata.len())];
+        let manifest =
+            build_incremental_manifest(scan_root, &collected, &reused, "opts", Some(&previous));
+        let entry = manifest.entry("f.txt").expect("entry");
+        assert_eq!(
+            entry.content_sha256, old_hash,
+            "rewritten manifest must keep the old hash so paranoid mode can self-heal"
+        );
+
+        // A later paranoid scan re-hashes the current bytes and detects the change.
+        assert!(
+            !manifest_entry_matches_path(entry, &file_path, &metadata, false)
+                .expect("paranoid compare"),
+            "paranoid rescan must detect the silent change instead of serving stale results"
+        );
+    }
 }

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -648,6 +648,15 @@ fn load_native_scan_session(
             previous_manifest.as_ref(),
             cache_config.trust_mtime(),
         );
+        // Only files that were actually reused may carry their stored hash
+        // forward; freshly re-scanned files must re-hash their current bytes so
+        // the manifest converges. A reused and a re-scanned file can share the
+        // same fingerprint after a silent same-size/same-mtime edit, so the
+        // fingerprint alone cannot tell them apart.
+        let reused_relative_paths: std::collections::HashSet<String> = reused_files
+            .iter()
+            .map(|file| normalize_relative_scan_path(Path::new(&file.path), Path::new(&scan_path)))
+            .collect();
         result.files =
             merge_incremental_file_results(result.files, reused_files, &ordered_file_paths);
 
@@ -657,6 +666,7 @@ fn load_native_scan_session(
             &result.files,
             &options_fingerprint,
             previous_manifest.as_ref(),
+            &reused_relative_paths,
         );
         write_incremental_manifest(cache_config.root_dir(), &manifest_path, &manifest)?;
     }
@@ -828,6 +838,7 @@ fn build_incremental_manifest(
     files: &[FileInfo],
     options_fingerprint: &str,
     previous_manifest: Option<&IncrementalManifest>,
+    reused_relative_paths: &std::collections::HashSet<String>,
 ) -> IncrementalManifest {
     let files_by_relative_path: std::collections::HashMap<_, _> = files
         .iter()
@@ -847,17 +858,24 @@ fn build_incremental_manifest(
             let state = metadata_fingerprint(metadata)?;
             let file_info = files_by_relative_path.get(&relative_path)?.clone();
             // `content_sha256` must describe the bytes that produced `file_info`.
-            // For a reused entry under `--cache-trust-mtime`, `file_info` is the
+            // For an entry reused via `--cache-trust-mtime`, `file_info` is the
             // *previous* scan result, so re-reading the current file here would
             // store a hash for bytes that do not match the stored result. That
             // poisons the manifest: a later paranoid rescan would re-hash, match
             // the freshly written hash, and reuse the stale result forever.
-            // Carry over the previous entry's hash when its fingerprint still
-            // matches; this is a no-op for paranoid reuse (same bytes, same hash)
-            // and lets paranoid mode self-heal after a trust-mtime miss.
+            // Carry over the previous entry's hash only for actually-reused
+            // paths; this is a no-op for paranoid reuse (same bytes, same hash)
+            // and lets paranoid mode self-heal after a trust-mtime miss. A
+            // freshly re-scanned file must NOT carry over: it can share the same
+            // fingerprint as a reused one, and carrying over the old hash would
+            // make every later paranoid run re-scan it forever without the
+            // manifest ever converging.
             let content_sha256 = file_info
                 .sha256
                 .or_else(|| {
+                    if !reused_relative_paths.contains(&relative_path) {
+                        return None;
+                    }
                     previous_manifest
                         .and_then(|manifest| manifest.entry(&relative_path))
                         .filter(|entry| entry.state == state)
@@ -910,6 +928,10 @@ mod incremental_manifest_tests {
     use super::*;
     use crate::cache::FileStateFingerprint;
     use crate::models::Sha256Digest;
+
+    fn reused_paths(paths: &[&str]) -> std::collections::HashSet<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
 
     fn file_info_without_hash(path: &Path, size: u64) -> FileInfo {
         FileInfo::new(
@@ -985,9 +1007,16 @@ mod incremental_manifest_tests {
 
         let collected = vec![(file_path.clone(), metadata.clone())];
         let files = vec![file_info_without_hash(&file_path, metadata.len())];
+        let reused = reused_paths(&["f.txt"]);
 
-        let manifest =
-            build_incremental_manifest(scan_root, &collected, &files, "opts", Some(&previous));
+        let manifest = build_incremental_manifest(
+            scan_root,
+            &collected,
+            &files,
+            "opts",
+            Some(&previous),
+            &reused,
+        );
 
         let entry = manifest.entry("f.txt").expect("entry");
         assert_eq!(
@@ -1010,7 +1039,14 @@ mod incremental_manifest_tests {
         let collected = vec![(file_path.clone(), metadata.clone())];
         let files = vec![file_info_without_hash(&file_path, metadata.len())];
 
-        let manifest = build_incremental_manifest(scan_root, &collected, &files, "opts", None);
+        let manifest = build_incremental_manifest(
+            scan_root,
+            &collected,
+            &files,
+            "opts",
+            None,
+            &reused_paths(&[]),
+        );
 
         let entry = manifest.entry("f.txt").expect("entry");
         assert_eq!(entry.content_sha256, current_hash);
@@ -1048,8 +1084,14 @@ mod incremental_manifest_tests {
         // keep the old hash rather than re-reading and storing the current hash.
         let collected = vec![(file_path.clone(), metadata.clone())];
         let reused = vec![file_info_without_hash(&file_path, metadata.len())];
-        let manifest =
-            build_incremental_manifest(scan_root, &collected, &reused, "opts", Some(&previous));
+        let manifest = build_incremental_manifest(
+            scan_root,
+            &collected,
+            &reused,
+            "opts",
+            Some(&previous),
+            &reused_paths(&["f.txt"]),
+        );
         let entry = manifest.entry("f.txt").expect("entry");
         assert_eq!(
             entry.content_sha256, old_hash,
@@ -1061,6 +1103,57 @@ mod incremental_manifest_tests {
             !manifest_entry_matches_path(entry, &file_path, &metadata, false)
                 .expect("paranoid compare"),
             "paranoid rescan must detect the silent change instead of serving stale results"
+        );
+    }
+
+    // A freshly re-scanned file (NOT in the reused set) must store its CURRENT
+    // hash even when a previous manifest entry shares the same fingerprint. If it
+    // carried over the old hash instead, every later paranoid run would re-hash,
+    // see a mismatch, re-scan, and re-write the old hash again -- the manifest
+    // would never converge for that file. This guards that the carry-over is
+    // gated on actual reuse, not on the fingerprint alone.
+    #[test]
+    fn test_build_manifest_uses_current_hash_for_freshly_scanned_file() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let scan_root = temp_dir.path();
+        let file_path = scan_root.join("f.txt");
+        fs::write(&file_path, b"new bytes").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+        let state = metadata_fingerprint(&metadata).expect("fingerprint");
+        let old_hash = calculate_sha256(b"old bytes");
+        let current_hash = calculate_sha256(b"new bytes");
+        assert_ne!(old_hash, current_hash);
+
+        // Previous entry shares the fingerprint but the file was re-scanned now.
+        let previous = previous_manifest_with_hash(
+            "f.txt",
+            state,
+            old_hash,
+            file_info_without_hash(&file_path, metadata.len()),
+        );
+
+        let collected = vec![(file_path.clone(), metadata.clone())];
+        let files = vec![file_info_without_hash(&file_path, metadata.len())];
+        // Empty reused set: this path was re-scanned, not reused.
+        let manifest = build_incremental_manifest(
+            scan_root,
+            &collected,
+            &files,
+            "opts",
+            Some(&previous),
+            &reused_paths(&[]),
+        );
+
+        let entry = manifest.entry("f.txt").expect("entry");
+        assert_eq!(
+            entry.content_sha256, current_hash,
+            "a re-scanned file must store its current hash so the manifest converges"
+        );
+        // The manifest is now self-consistent: a later paranoid check matches.
+        assert!(
+            manifest_entry_matches_path(entry, &file_path, &metadata, false)
+                .expect("paranoid compare"),
+            "after re-scan the manifest must stop flagging the unchanged file"
         );
     }
 }

--- a/src/app/scan_runtime.rs
+++ b/src/app/scan_runtime.rs
@@ -80,6 +80,7 @@ pub(crate) fn prepare_cache_config(
         request.cache_dir.as_deref().map(Path::new),
         env_cache_dir.as_deref(),
         request.incremental,
+        request.cache_trust_mtime,
     );
 
     if request.cache_clear {

--- a/src/cache/config.rs
+++ b/src/cache/config.rs
@@ -16,6 +16,7 @@ pub const CACHE_DIR_ENV_VAR: &str = "PROVENANT_CACHE";
 pub struct CacheConfig {
     root_dir: PathBuf,
     incremental: bool,
+    trust_mtime: bool,
 }
 
 impl CacheConfig {
@@ -24,13 +25,15 @@ impl CacheConfig {
         Self {
             root_dir,
             incremental: false,
+            trust_mtime: false,
         }
     }
 
-    pub fn with_options(root_dir: PathBuf, incremental: bool) -> Self {
+    pub fn with_options(root_dir: PathBuf, incremental: bool, trust_mtime: bool) -> Self {
         Self {
             root_dir,
             incremental,
+            trust_mtime,
         }
     }
 
@@ -76,10 +79,12 @@ impl CacheConfig {
         cli_cache_dir: Option<&Path>,
         env_cache_dir: Option<&Path>,
         incremental: bool,
+        trust_mtime: bool,
     ) -> Self {
         Self::with_options(
             Self::resolve_root_dir(scan_root, cli_cache_dir, env_cache_dir),
             incremental,
+            trust_mtime,
         )
     }
 
@@ -93,6 +98,12 @@ impl CacheConfig {
 
     pub const fn incremental_enabled(&self) -> bool {
         self.incremental
+    }
+
+    /// When `true`, warm incremental scans accept a cached entry on a size +
+    /// mtime fingerprint match without re-reading and re-hashing the file.
+    pub const fn trust_mtime(&self) -> bool {
+        self.trust_mtime
     }
 
     pub fn ensure_dirs(&self) -> io::Result<()> {
@@ -155,7 +166,8 @@ mod tests {
     #[test]
     fn test_ensure_dirs_creates_expected_tree() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let config = CacheConfig::with_options(temp_dir.path().join(DEFAULT_CACHE_DIR_NAME), true);
+        let config =
+            CacheConfig::with_options(temp_dir.path().join(DEFAULT_CACHE_DIR_NAME), true, false);
 
         config
             .ensure_dirs()
@@ -196,7 +208,7 @@ mod tests {
     #[test]
     fn test_clear_removes_cache_root_directory() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let config = CacheConfig::with_options(temp_dir.path().join("cache-root"), true);
+        let config = CacheConfig::with_options(temp_dir.path().join("cache-root"), true, false);
 
         config
             .ensure_dirs()

--- a/src/cache/incremental.rs
+++ b/src/cache/incremental.rs
@@ -78,13 +78,27 @@ pub fn metadata_fingerprint(metadata: &fs::Metadata) -> Option<FileStateFingerpr
     })
 }
 
+/// Decides whether a cached manifest entry can be reused for `path`.
+///
+/// Both modes first require the size + nanosecond-mtime fingerprint to match.
+///
+/// When `trust_mtime` is `false` (the default, paranoid mode) the file is
+/// re-read and SHA-256 hashed, so a content change that preserves both size and
+/// mtime is still detected. When `trust_mtime` is `true` the fingerprint match
+/// alone is accepted and the read + hash are skipped, trading the rare
+/// same-tick, same-size silent edit for warm-rescan speed.
 pub fn manifest_entry_matches_path(
     entry: &IncrementalManifestEntry,
     path: &Path,
     metadata: &fs::Metadata,
+    trust_mtime: bool,
 ) -> io::Result<bool> {
     if !metadata_fingerprint(metadata).is_some_and(|fingerprint| fingerprint == entry.state) {
         return Ok(false);
+    }
+
+    if trust_mtime {
+        return Ok(true);
     }
 
     let bytes = fs::read(path)?;
@@ -292,6 +306,105 @@ mod tests {
             ),
         };
 
-        assert!(!manifest_entry_matches_path(&entry, &file_path, &metadata).expect("compare path"));
+        assert!(
+            !manifest_entry_matches_path(&entry, &file_path, &metadata, false)
+                .expect("compare path")
+        );
+    }
+
+    /// Builds a manifest entry whose recorded SHA-256 deliberately does NOT
+    /// match the file's real contents, so any code path that re-hashes the file
+    /// returns `false` while a path that trusts the fingerprint returns `true`.
+    fn entry_with_wrong_hash(
+        file_path: &Path,
+        metadata: &fs::Metadata,
+    ) -> IncrementalManifestEntry {
+        IncrementalManifestEntry {
+            state: metadata_fingerprint(metadata).expect("fingerprint"),
+            content_sha256: Sha256Digest::EMPTY,
+            file_info: FileInfo::new(
+                "main.rs".to_string(),
+                "main".to_string(),
+                ".rs".to_string(),
+                file_path.to_string_lossy().to_string(),
+                FileType::File,
+                None,
+                None,
+                metadata.len(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Vec::new(),
+                None,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+        }
+    }
+
+    #[test]
+    fn test_trust_mtime_accepts_fingerprint_match_without_rehashing() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let file_path = temp_dir.path().join("src/main.rs");
+        fs::create_dir_all(file_path.parent().expect("parent")).expect("create parent");
+        fs::write(&file_path, "fn main() {}\n").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+
+        // The recorded hash is wrong, so the only way this returns `true` is by
+        // trusting the fingerprint and skipping the read + hash.
+        let entry = entry_with_wrong_hash(&file_path, &metadata);
+
+        assert!(
+            manifest_entry_matches_path(&entry, &file_path, &metadata, true).expect("compare path"),
+            "trust-mtime mode must accept a size+mtime match without re-hashing"
+        );
+    }
+
+    #[test]
+    fn test_default_mode_rehashes_on_fingerprint_match() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let file_path = temp_dir.path().join("src/main.rs");
+        fs::create_dir_all(file_path.parent().expect("parent")).expect("create parent");
+        fs::write(&file_path, "fn main() {}\n").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+
+        // Same wrong-hash entry: default (paranoid) mode must re-hash and reject.
+        let entry = entry_with_wrong_hash(&file_path, &metadata);
+
+        assert!(
+            !manifest_entry_matches_path(&entry, &file_path, &metadata, false)
+                .expect("compare path"),
+            "default mode must re-hash and reject a fingerprint match whose content differs"
+        );
+    }
+
+    #[test]
+    fn test_trust_mtime_still_detects_changed_fingerprint() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let file_path = temp_dir.path().join("src/main.rs");
+        fs::create_dir_all(file_path.parent().expect("parent")).expect("create parent");
+        fs::write(&file_path, "fn main() {}\n").expect("write file");
+        let metadata = fs::metadata(&file_path).expect("metadata");
+
+        // Record a fingerprint for a different size so the size check alone fails.
+        let mut state = metadata_fingerprint(&metadata).expect("fingerprint");
+        state.size += 1;
+        let mut entry = entry_with_wrong_hash(&file_path, &metadata);
+        entry.state = state;
+
+        assert!(
+            !manifest_entry_matches_path(&entry, &file_path, &metadata, true)
+                .expect("compare path"),
+            "trust-mtime mode must still treat a changed size/mtime fingerprint as changed"
+        );
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod locking;
 
 pub use config::{CACHE_DIR_ENV_VAR, CacheConfig, DEFAULT_CACHE_DIR_NAME};
 pub use incremental::{
-    IncrementalManifest, IncrementalManifestEntry, incremental_manifest_path,
+    FileStateFingerprint, IncrementalManifest, IncrementalManifestEntry, incremental_manifest_path,
     load_incremental_manifest, manifest_entry_matches_path, metadata_fingerprint,
     write_incremental_manifest,
 };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -342,6 +342,13 @@ pub struct ScanArgs {
     #[arg(long = "incremental")]
     pub incremental: bool,
 
+    /// Trust size + mtime for incremental reuse, skipping the content re-hash of
+    /// unchanged files. Speeds up warm incremental re-scans at the cost of
+    /// missing the rare edit that keeps the same size and mtime tick. Default
+    /// off keeps the paranoid full-hash check so scans stay reproducible.
+    #[arg(long = "cache-trust-mtime", requires = "incremental")]
+    pub cache_trust_mtime: bool,
+
     /// Maximum number of file and directory scan details kept in memory.
     /// Use 0 for unlimited memory or -1 for disk-only spill during the scan.
     #[arg(
@@ -724,6 +731,7 @@ impl ScanArgs {
 
         push_string_option(&mut flags, "--cache-dir", self.cache_dir.as_ref());
         push_bool_option(&mut flags, "--cache-clear", self.cache_clear);
+        push_bool_option(&mut flags, "--cache-trust-mtime", self.cache_trust_mtime);
         push_bool_option(&mut flags, "--classify", self.classify);
         push_string_option(&mut flags, "--custom-output", self.custom_output.as_ref());
         push_string_option(
@@ -906,6 +914,7 @@ impl From<&ScanArgs> for ScanRequest {
             cache_dir: cli.cache_dir.clone(),
             cache_clear: cli.cache_clear,
             incremental: cli.incremental,
+            cache_trust_mtime: cli.cache_trust_mtime,
             max_depth: cli.max_depth,
             max_in_memory: cli.max_in_memory,
             info: cli.info,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -344,8 +344,9 @@ pub struct ScanArgs {
 
     /// Trust size + mtime for incremental reuse, skipping the content re-hash of
     /// unchanged files. Speeds up warm incremental re-scans at the cost of
-    /// missing the rare edit that keeps the same size and mtime tick. Default
-    /// off keeps the paranoid full-hash check so scans stay reproducible.
+    /// missing the rare edit that keeps the same size and mtime tick. Such a miss
+    /// is not permanent: the next scan without this flag re-hashes and detects it.
+    /// Default off keeps the paranoid full-hash check so scans stay reproducible.
     #[arg(long = "cache-trust-mtime", requires = "incremental")]
     pub cache_trust_mtime: bool,
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1076,6 +1076,39 @@ fn test_parses_incremental_flag() {
     .expect("cli parse should accept incremental flag");
 
     assert!(parsed.incremental);
+    assert!(!parsed.cache_trust_mtime);
+}
+
+#[test]
+fn test_parses_cache_trust_mtime_flag_with_incremental() {
+    let parsed = Cli::try_parse_from([
+        "provenant",
+        "--json-pp",
+        "scan.json",
+        "--incremental",
+        "--cache-trust-mtime",
+        "samples",
+    ])
+    .expect("cli parse should accept cache-trust-mtime with incremental");
+
+    assert!(parsed.incremental);
+    assert!(parsed.cache_trust_mtime);
+}
+
+#[test]
+fn test_cache_trust_mtime_requires_incremental() {
+    let result = Cli::try_parse_from([
+        "provenant",
+        "--json-pp",
+        "scan.json",
+        "--cache-trust-mtime",
+        "samples",
+    ]);
+
+    assert!(
+        result.is_err(),
+        "--cache-trust-mtime must require --incremental"
+    );
 }
 
 #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -61,6 +61,12 @@ pub struct ScanOptions {
     pub cache_dir: Option<PathBuf>,
     pub cache_clear: bool,
     pub incremental: bool,
+    /// Opt-in trust-mtime mode for warm incremental scans.
+    ///
+    /// When `true`, a cached entry is reused on a size + mtime fingerprint match
+    /// without re-reading and re-hashing the file. Default `false` keeps the
+    /// paranoid full-hash behavior so default scans stay byte-identical.
+    pub cache_trust_mtime: bool,
     pub reindex: bool,
     pub no_license_index_cache: bool,
     pub license_text: bool,
@@ -129,6 +135,7 @@ impl Default for ScanOptions {
             cache_dir: None,
             cache_clear: false,
             incremental: false,
+            cache_trust_mtime: false,
             reindex: false,
             no_license_index_cache: false,
             license_text: false,
@@ -270,6 +277,7 @@ fn request_for_native_paths(input_paths: Vec<String>, options: &ScanOptions) -> 
             .map(|path| path.to_string_lossy().to_string()),
         cache_clear: options.cache_clear,
         incremental: options.incremental,
+        cache_trust_mtime: options.cache_trust_mtime,
         max_depth: options.max_depth,
         max_in_memory: options.max_in_memory,
         info: options.collect_info,


### PR DESCRIPTION
## Summary

- Warm incremental scans previously re-read and SHA-256 hashed every unchanged file even when the size + nanosecond-mtime fingerprint already matched (`manifest_entry_matches_path` did a full `fs::read` + hash), paying full read + hash I/O across the whole tree on every re-scan.
- Adds an opt-in `--cache-trust-mtime` flag (only valid together with `--incremental`). When set, a cached entry is reused on a size + mtime fingerprint match without re-reading or re-hashing the file.
- Default is unchanged: paranoid full re-hash. Default scans stay byte-identical and reproducible.
- The flag is threaded CLI -> `ScanRequest`/`ScanOptions` -> `CacheConfig::trust_mtime()` -> `partition_incremental_files` -> `manifest_entry_matches_path(.., trust_mtime)`. Thread-safety of the parallel scanner is preserved (the flag is read from the shared immutable `CacheConfig`).

### Measured warm-rescan win

Cold scan to populate the incremental cache, then interleaved warm re-scans (same release binary), 5 iterations each, median:

| mode | warm re-scan (median) |
| --- | --- |
| default (paranoid re-hash) | 3.28s |
| `--cache-trust-mtime` | 1.89s |

Target: ScanCode Toolkit `src/` tree (~39.5k files, 188 MB), scanned with `--license --copyright --info --incremental`. Net: ~1.39s saved per warm re-scan, ~42% faster (1.74x). The win is real and consistent, though it scales with tree size and I/O cost; small trees will see proportionally less.

## Issues

- Closes: #995

## Scope and exclusions

- Included: CLI flag + help, threading through scan options and cache config, the trust-mtime branch in `manifest_entry_matches_path`, unit tests, and CLI_GUIDE documentation of the trade-off.
- Explicit exclusions: no change to default behavior; no change to the manifest schema or the manifest options fingerprint (the flag does not invalidate caches across modes).

## How to verify

- `cargo test -p provenant-cli --lib cache` — covers the three trust-mtime contract tests plus the existing cache suite.
- Manual: build release, run `provenant scan --incremental --cache-dir <tmp> --json out.json <tree>` once (cold), then re-run with and without `--cache-trust-mtime` and compare wall-clock on a moderately large tree.
- Edge: `provenant scan --cache-trust-mtime <tree>` without `--incremental` is rejected by clap (`requires`).

## Expected-output fixture changes

- None. No golden/expected fixtures changed; default output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
