### PR TITLE
enhancement(benchmark): record copyright/email/url/info scan phase timings

### DIFF
--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -9,6 +9,15 @@ use crate::scanner::TextDetectionOptions;
 use crate::utils::font::is_supported_font_path;
 use std::collections::HashSet;
 use std::path::Path;
+use std::time::Instant;
+
+/// Per-detection durations so the caller can attribute them to the matching
+/// `scan:*` progress phases; `None` means the detection did not run.
+#[derive(Default)]
+pub(super) struct ContactDetectionTimings {
+    pub emails_seconds: Option<f64>,
+    pub urls_seconds: Option<f64>,
+}
 
 pub(super) fn extract_email_url_information(
     file_info_builder: &mut FileInfoBuilder,
@@ -16,9 +25,10 @@ pub(super) fn extract_email_url_information(
     text_content: &str,
     text_options: &TextDetectionOptions,
     from_binary_strings: bool,
-) {
+) -> ContactDetectionTimings {
+    let mut timings = ContactDetectionTimings::default();
     if !text_options.detect_emails && !text_options.detect_urls {
-        return;
+        return timings;
     }
 
     let applies_gettext_exception = is_gettext_mo_path(path);
@@ -29,6 +39,7 @@ pub(super) fn extract_email_url_information(
         is_font_metadata_path.then(|| text_content.lines().collect::<Vec<_>>());
 
     if text_options.detect_emails {
+        let started = Instant::now();
         let config = DetectionConfig {
             max_emails: text_options.max_emails,
             max_urls: text_options.max_urls,
@@ -54,9 +65,11 @@ pub(super) fn extract_email_url_information(
             })
             .collect::<Vec<_>>();
         file_info_builder.emails(emails);
+        timings.emails_seconds = Some(started.elapsed().as_secs_f64());
     }
 
     if text_options.detect_urls {
+        let started = Instant::now();
         let config = DetectionConfig {
             max_emails: text_options.max_emails,
             max_urls: if apply_binary_contact_filters {
@@ -90,7 +103,10 @@ pub(super) fn extract_email_url_information(
             }
         }
         file_info_builder.urls(urls);
+        timings.urls_seconds = Some(started.elapsed().as_secs_f64());
     }
+
+    timings
 }
 
 fn is_gettext_mo_path(path: &Path) -> bool {

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -187,6 +187,7 @@ fn extract_information_from_content(
     let classification = classify_file_info(&filesystem_path, &buffer);
 
     if text_options.collect_info {
+        let info_started = Instant::now();
         file_info_builder
             .sha1(Some(calculate_sha1(&buffer)))
             .md5(Some(calculate_md5(&buffer)))
@@ -204,6 +205,7 @@ fn extract_information_from_content(
             .files_count(Some(0))
             .dirs_count(Some(0))
             .size_count(Some(0));
+        progress.record_detail_timing("scan:info", info_started.elapsed().as_secs_f64());
     }
 
     if should_skip_text_detection(&filesystem_path, &buffer) {
@@ -284,6 +286,7 @@ fn extract_information_from_content(
     }
 
     if text_options.detect_copyrights {
+        let copyrights_started = Instant::now();
         extract_copyright_information(
             file_info_builder,
             path,
@@ -291,14 +294,24 @@ fn extract_information_from_content(
             text_options.timeout_seconds,
             from_binary_strings,
         );
+        progress.record_detail_timing(
+            "scan:copyrights",
+            copyrights_started.elapsed().as_secs_f64(),
+        );
     }
-    extract_email_url_information(
+    let contact_timings = extract_email_url_information(
         file_info_builder,
         path,
         &text_content,
         text_options,
         from_binary_strings,
     );
+    if let Some(seconds) = contact_timings.emails_seconds {
+        progress.record_detail_timing("scan:emails", seconds);
+    }
+    if let Some(seconds) = contact_timings.urls_seconds {
+        progress.record_detail_timing("scan:urls", seconds);
+    }
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
         return Err(FileScanError::Timeout(FileScanTimeout {

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -91,6 +91,12 @@ It also writes a tab-separated summary file at:
 
 - `results/summary.tsv`
 
+Besides wall, engine, scan, and total times, the summary table and
+`results/summary.tsv` record cumulative worker time for each per-detection
+scan phase reported by the Provenant progress summary: `scan:packages`,
+`scan:licenses`, `scan:copyrights`, `scan:emails`, `scan:urls`, and
+`scan:info`. Phases for detections the scan flags did not enable stay empty.
+
 ### Notes
 
 - The command uses an explicit per-scenario `--cache-dir` so incremental manifest results do not leak across scenarios.

--- a/xtask/src/bin/benchmark_target.rs
+++ b/xtask/src/bin/benchmark_target.rs
@@ -22,6 +22,17 @@ use provenant_xtask::repo_cache::{
 };
 use regex::Regex;
 
+/// Per-detection scan phases reported by the Provenant progress summary as
+/// cumulative worker time; phases for detections that did not run are empty.
+const SCAN_DETECTION_PHASES: [&str; 6] = [
+    "scan:packages",
+    "scan:licenses",
+    "scan:copyrights",
+    "scan:emails",
+    "scan:urls",
+    "scan:info",
+];
+
 #[derive(Parser, Debug)]
 #[command(name = "benchmark-target", trailing_var_arg = true)]
 struct Args {
@@ -84,6 +95,12 @@ fn main() -> Result<()> {
             "elapsed_seconds",
             "engine_seconds",
             "scan_seconds",
+            "scan_packages_seconds",
+            "scan_licenses_seconds",
+            "scan_copyrights_seconds",
+            "scan_emails_seconds",
+            "scan_urls_seconds",
+            "scan_info_seconds",
             "total_seconds",
             "peak_memory_kb",
             "files_scanned",
@@ -438,22 +455,27 @@ fn run_case(
         ],
     );
     let scan_seconds = extract_phase_seconds(&combined, "scan");
+    let scan_phase_seconds: Vec<(&str, String)> = SCAN_DETECTION_PHASES
+        .iter()
+        .map(|phase| (*phase, extract_phase_seconds(&combined, phase)))
+        .collect();
     let total_seconds = extract_phase_seconds(&combined, "total");
     let incremental_summary = extract_summary_line(&combined, "Incremental");
-    append_tsv_row(
-        &context.summary_file,
-        &[
-            scenario.to_string(),
-            format!("{elapsed_seconds:.3}"),
-            engine_seconds.clone(),
-            scan_seconds.clone(),
-            total_seconds.clone(),
-            peak_memory_kb.clone(),
-            files_scanned.clone(),
-            packages_detected.clone(),
-            incremental_summary.clone(),
-        ],
-    )?;
+    let mut row = vec![
+        scenario.to_string(),
+        format!("{elapsed_seconds:.3}"),
+        engine_seconds.clone(),
+        scan_seconds.clone(),
+    ];
+    row.extend(scan_phase_seconds.iter().map(|(_, value)| value.clone()));
+    row.extend([
+        total_seconds.clone(),
+        peak_memory_kb.clone(),
+        files_scanned.clone(),
+        packages_detected.clone(),
+        incremental_summary.clone(),
+    ]);
+    append_tsv_row(&context.summary_file, &row)?;
 
     println!();
     println!("  Wall clock time: {:.3} seconds", elapsed_seconds);
@@ -462,6 +484,11 @@ fn run_case(
     }
     if !scan_seconds.is_empty() {
         println!("  Scan time:       {scan_seconds} seconds");
+    }
+    for (phase, value) in &scan_phase_seconds {
+        if !value.is_empty() {
+            println!("    {phase}: {value} seconds (cumulative worker time)");
+        }
     }
     println!("  Files scanned:   {files_scanned}");
     println!("  Packages:        {packages_detected}");
@@ -565,6 +592,12 @@ fn print_summary_table(summary_file: &Path) -> Result<()> {
         "Seconds",
         "Engine s",
         "Scan s",
+        "Pkgs s",
+        "Lics s",
+        "Copyr s",
+        "Emails s",
+        "Urls s",
+        "Info s",
         "Total s",
         "Peak KB",
         "Files",
@@ -586,6 +619,12 @@ fn print_summary_table(summary_file: &Path) -> Result<()> {
                     "elapsed_seconds",
                     "engine_seconds",
                     "scan_seconds",
+                    "scan_packages_seconds",
+                    "scan_licenses_seconds",
+                    "scan_copyrights_seconds",
+                    "scan_emails_seconds",
+                    "scan_urls_seconds",
+                    "scan_info_seconds",
                     "total_seconds",
                     "peak_memory_kb",
                     "files_scanned",


### PR DESCRIPTION
## Summary

- Record per-detection scan phase timings for copyright, email, URL, and info collection in the per-file scanner pipeline, using the same `ScanProgress::record_detail_timing` aggregation already used for `scan:packages` and `scan:licenses` (mutex-accumulated cumulative worker time, safe under rayon).
- New phase keys follow the existing naming pattern: `scan:copyrights`, `scan:emails`, `scan:urls`, `scan:info`. Each is recorded only when the corresponding detection actually runs, mirroring how `scan:licenses` is gated.
- Teach the `benchmark-target` xtask to parse all six per-detection phases from the captured progress summary, record them as new `summary.tsv` columns (`scan_packages_seconds` through `scan_info_seconds`), print them per scenario, and include them in the final summary table.
- Document the recorded phases in `xtask/README.md`.

Timings continue to surface only in the stderr progress summary (`src/progress.rs`); nothing in `src/output_schema/` consumes them, so the ScanCode-compatible JSON output is unchanged (verified: scan output JSON contains zero timing keys).

Before (scan breakdown in the progress summary / recorded `provenant-stdout.txt`):

```text
  scan breakdown (cumulative worker time):
    scan:packages: 0.21s
    scan:licenses: 0.04s
```

After (same place; copyright detection cost from #1013/#1015 is now visible):

```text
  scan breakdown (cumulative worker time):
    scan:info: 0.00s
    scan:packages: 0.21s
    scan:copyrights: 0.20s
    scan:emails: 0.00s
    scan:urls: 0.00s
    scan:licenses: 0.04s
```

Before (benchmark-target summary table / `summary.tsv` columns):

```text
Scenario | Seconds | Engine s | Scan s | Total s | Peak KB | Files | Packages | Incremental summary
```

After (real run of `benchmark-target --target-path testdata/about --profile common`; `Info s` stays empty because the profile does not enable `--info`):

```text
Scenario           | Seconds | Engine s | Scan s | Pkgs s | Lics s | Copyr s | Emails s | Urls s | Info s | Total s | Peak KB | Files | Packages | Incremental summary
-------------------+---------+----------+--------+--------+--------+---------+----------+--------+--------+---------+---------+-------+----------+--------------------
uncached-cold      | 6.027   | 5.84     | 0.12   | 0.21   | 0.04   | 0.20    | 0.00     | 0.00   |        | 5.96    | 3036240 | 7     | 3        |
uncached-repeat    | 6.147   | 5.95     | 0.12   | 0.16   | 0.04   | 0.28    | 0.00     | 0.00   |        | 6.08    | 3359728 | 7     | 3        |
incremental-cold   | 6.041   | 5.84     | 0.13   | 0.16   | 0.04   | 0.28    | 0.00     | 0.00   |        | 5.97    | 3033600 | 7     | 3        |
incremental-repeat | 6.035   | 5.96     | 0.00   |        |        |         |          |        |        | 5.96    | 3032816 | 7     | 3        | Incremental: 7 unchanged file(s) reused
```

## Issues

- Covers: benchmark visibility follow-up for the copyright-detection cost center investigated in #1013 and #1015 — copyright phase time now appears in recorded benchmark data instead of being folded into wall time.

## Scope and exclusions

- Included: scanner per-file phase instrumentation (`scan:copyrights`, `scan:emails`, `scan:urls`, `scan:info`), benchmark-target parsing/recording/reporting, xtask README docs.
- Explicit exclusions: no changes to detection behavior, output schema, or the compare-outputs workflow; no new timing mechanism.

## How to verify

- Run a small scan with all detections and check the progress summary breakdown lists all six `scan:*` phases: `cargo run -- --license --copyright --email --url --info --package testdata/about --json /tmp/out.json`, then confirm `/tmp/out.json` contains no `"scan:` keys (output parity).
- Run a scan with only `--license` and confirm the breakdown contains only `scan:licenses` (gating).
- Run `cargo run --manifest-path xtask/Cargo.toml --bin benchmark-target -- --target-path testdata/about --profile common` and confirm the new columns appear in the printed table and in `.provenant/benchmarks/results/summary.tsv` (15 tab-separated fields per row, empty cells for disabled detections).

## Follow-up work

- Created or intentionally deferred: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
