### PR TITLE
fix(assembly): deterministic assembler order and scoped nested-merge dedup

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::super::assemble;
     use crate::models::{
         DatasourceId, Dependency, FileInfo, FileType, Package, PackageData, PackageType,
-        Sha256Digest,
+        PackageUid, Sha256Digest,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -3921,5 +3921,176 @@ mod tests {
             2,
             "Expected database file to reference both packages"
         );
+    }
+
+    /// Builds a fingerprint of an assembly run that is independent of the
+    /// random UUID suffix baked into every `PackageUid`, but still sensitive to
+    /// assembler-order-dependent decisions such as which package claims a file.
+    ///
+    /// Each `PackageUid` is resolved to its owning package's stable identity
+    /// (purl + name + version + datafile_paths + datasource_ids) so that two runs
+    /// producing the same logical assignment compare equal, while a run that
+    /// assigns a file to a different package (the symptom of nondeterministic
+    /// assembler order) compares unequal.
+    fn assembly_fingerprint(files: &mut [FileInfo]) -> String {
+        use std::collections::HashMap;
+
+        let result = assemble(files);
+
+        let mut uid_to_identity: HashMap<String, String> = HashMap::new();
+        for package in &result.packages {
+            let identity = format!(
+                "purl={:?}|name={:?}|version={:?}|datafiles={:?}|datasources={:?}",
+                package.purl,
+                package.name,
+                package.version,
+                package.datafile_paths,
+                package
+                    .datasource_ids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+            );
+            uid_to_identity.insert(package.package_uid.to_string(), identity);
+        }
+
+        let resolve = |uid: &PackageUid| -> String {
+            uid_to_identity
+                .get(uid.as_ref())
+                .cloned()
+                .unwrap_or_else(|| format!("<unknown:{uid}>"))
+        };
+
+        let mut fingerprint = String::new();
+
+        let mut package_lines: Vec<String> = uid_to_identity.values().cloned().collect();
+        package_lines.sort();
+        fingerprint.push_str("PACKAGES\n");
+        for line in package_lines {
+            fingerprint.push_str(&line);
+            fingerprint.push('\n');
+        }
+
+        fingerprint.push_str("DEPENDENCIES\n");
+        let mut dep_lines: Vec<String> = result
+            .dependencies
+            .iter()
+            .map(|dep| {
+                format!(
+                    "purl={:?}|req={:?}|scope={:?}|datafile={}|datasource={}|for={}",
+                    dep.purl,
+                    dep.extracted_requirement,
+                    dep.scope,
+                    dep.datafile_path,
+                    dep.datasource_id,
+                    dep.for_package_uid
+                        .as_ref()
+                        .map(&resolve)
+                        .unwrap_or_else(|| "<none>".to_string()),
+                )
+            })
+            .collect();
+        dep_lines.sort();
+        for line in dep_lines {
+            fingerprint.push_str(&line);
+            fingerprint.push('\n');
+        }
+
+        fingerprint.push_str("FILE_OWNERSHIP\n");
+        let mut file_lines: Vec<String> = files
+            .iter()
+            .map(|file| {
+                let mut owners: Vec<String> = file.for_packages.iter().map(&resolve).collect();
+                owners.sort();
+                format!("{} -> {:?}", file.path, owners)
+            })
+            .collect();
+        file_lines.sort();
+        for line in file_lines {
+            fingerprint.push_str(&line);
+            fingerprint.push('\n');
+        }
+
+        fingerprint
+    }
+
+    /// Regression guard for nondeterministic per-directory assembler order
+    /// (issue #1026, bug 1). A polyglot directory contains manifests from
+    /// multiple ecosystems, so the set of active assembler configs has more than
+    /// one member. Iterating that set in `HashSet` order made file ownership
+    /// nondeterministic run-to-run; this asserts the resolved assignment is
+    /// stable across many repeated runs.
+    #[test]
+    fn test_assemble_polyglot_directory_is_deterministic() {
+        let build_files = || {
+            let mut npm = create_test_file_info(
+                "repo/package.json",
+                DatasourceId::NpmPackageJson,
+                Some("pkg:npm/poly@1.0.0"),
+                Some("poly"),
+                Some("1.0.0"),
+                vec![create_test_dependency(
+                    "pkg:npm/left-pad",
+                    Some("^1.0.0"),
+                    None,
+                )],
+            );
+            npm.package_data[0].package_type = Some(PackageType::Npm);
+
+            let mut cargo = create_test_file_info(
+                "repo/Cargo.toml",
+                DatasourceId::CargoToml,
+                Some("pkg:cargo/poly-rs@2.0.0"),
+                Some("poly-rs"),
+                Some("2.0.0"),
+                vec![create_test_dependency("pkg:cargo/serde", Some("1"), None)],
+            );
+            cargo.package_data[0].package_type = Some(PackageType::Cargo);
+
+            let mut composer = create_test_file_info(
+                "repo/composer.json",
+                DatasourceId::PhpComposerJson,
+                Some("pkg:composer/poly-php@3.0.0"),
+                Some("poly-php"),
+                Some("3.0.0"),
+                vec![],
+            );
+            composer.package_data[0].package_type = Some(PackageType::Composer);
+
+            vec![npm, cargo, composer]
+        };
+
+        // The active config keys must be visited in a stable, sorted order. A
+        // `HashSet` here would order keys by hash seeding, breaking this.
+        let files = build_files();
+        let file_indices: Vec<usize> = (0..files.len()).collect();
+        let keys = super::super::active_config_keys(
+            &files,
+            &file_indices,
+            &super::super::ASSEMBLER_LOOKUP,
+        );
+        let collected: Vec<DatasourceId> = keys.iter().copied().collect();
+        let mut sorted = collected.clone();
+        sorted.sort();
+        assert!(
+            collected.len() >= 2,
+            "polyglot fixture should activate multiple assemblers, got {collected:?}"
+        );
+        assert_eq!(
+            collected, sorted,
+            "active assembler config keys must be visited in deterministic sorted order"
+        );
+
+        let mut baseline_files = build_files();
+        let baseline = assembly_fingerprint(&mut baseline_files);
+
+        for run in 0..50 {
+            let mut files = build_files();
+            let fingerprint = assembly_fingerprint(&mut files);
+            assert_eq!(
+                fingerprint, baseline,
+                "assembly output diverged on run {run}; per-directory assembler order is not deterministic"
+            );
+        }
     }
 }

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -28,7 +28,7 @@ mod swift_merge;
 mod topology;
 mod windows_update_merge;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
@@ -105,17 +105,7 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
     let topology_plan = topology::TopologyPlan::build(files, &dir_files);
 
     for file_indices in dir_files.values() {
-        let mut groups: HashSet<DatasourceId> = HashSet::new();
-
-        for &idx in file_indices {
-            for pkg_data in &files[idx].package_data {
-                if let Some(dsid) = pkg_data.datasource_id
-                    && let Some(&config_key) = assembler_lookup.get(&dsid)
-                {
-                    groups.insert(config_key);
-                }
-            }
-        }
+        let groups = active_config_keys(files, file_indices, assembler_lookup);
 
         for &config_key in &groups {
             let config = assembler_config_lookup
@@ -159,19 +149,23 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
             nested_merge::assemble_nested_patterns(files, config)
         {
             let package_uid = pkg.package_uid.clone();
-            let purl = pkg.purl.clone();
-            let removed_package_uids: Vec<PackageUid> = packages
+
+            // The nested merge subsumes exactly the per-directory packages that were
+            // previously created for the files it consumed. Those packages are recorded
+            // on the affected files' `for_packages`, so key dedup off those specific UIDs
+            // rather than a blanket purl match (which would also delete unrelated packages,
+            // including every purl-less package scan-wide when the merged purl is `None`).
+            let removed_package_uids: HashSet<PackageUid> = affected_indices
                 .iter()
-                .filter(|p| p.purl == purl)
-                .map(|p| p.package_uid.clone())
+                .flat_map(|idx| files[*idx].for_packages.iter().cloned())
+                .filter(|uid| *uid != package_uid)
                 .collect();
 
-            packages.retain(|p| p.purl != purl);
+            packages.retain(|p| !removed_package_uids.contains(&p.package_uid));
             dependencies.retain(|d| {
-                d.for_package_uid.as_ref() != Some(&package_uid)
-                    && !removed_package_uids
-                        .iter()
-                        .any(|old_uid| d.for_package_uid.as_ref() == Some(old_uid))
+                d.for_package_uid
+                    .as_ref()
+                    .is_none_or(|old_uid| !removed_package_uids.contains(old_uid))
             });
 
             for idx in &affected_indices {
@@ -364,6 +358,31 @@ pub(super) fn should_skip_placeholder_only_cocoapods_podspec(
             .and_then(|data| data.get("dynamic_identity_placeholders"))
             .and_then(|value| value.as_bool())
             == Some(true)
+}
+
+/// Collect the assembler config keys active in a directory in a deterministic
+/// order.
+///
+/// The keys are gathered into a `BTreeSet` so iteration order is stable across
+/// runs and processes. A `HashSet` here made per-directory assembler execution
+/// order depend on hash seeding, which produced run-to-run nondeterministic
+/// output in polyglot directories (issue #1026).
+fn active_config_keys(
+    files: &[FileInfo],
+    file_indices: &[usize],
+    assembler_lookup: &HashMap<DatasourceId, DatasourceId>,
+) -> BTreeSet<DatasourceId> {
+    let mut groups: BTreeSet<DatasourceId> = BTreeSet::new();
+    for &idx in file_indices {
+        for pkg_data in &files[idx].package_data {
+            if let Some(dsid) = pkg_data.datasource_id
+                && let Some(&config_key) = assembler_lookup.get(&dsid)
+            {
+                groups.insert(config_key);
+            }
+        }
+    }
+    groups
 }
 
 /// Group file indices by their parent directory path.

--- a/src/models/datasource_id.rs
+++ b/src/models/datasource_id.rs
@@ -25,7 +25,27 @@ use strum::{EnumCount, EnumIter};
 /// Variants serialize as PascalCase in the cache/spill format (e.g., `NpmPackageJson`).
 /// For JSON output, use `as_str()` / `Display` which returns snake_case strings
 /// matching the Python ScanCode Toolkit values (e.g., `npm_package_json`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, EnumCount, EnumIter)]
+///
+/// # Ordering
+///
+/// `PartialOrd`/`Ord` are derived and therefore follow **declaration order**. The assembly
+/// stage iterates active assembler configs via a `BTreeSet<DatasourceId>`, so adding or
+/// reordering variants changes the per-directory assembler execution sequence in polyglot
+/// directories.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    EnumCount,
+    EnumIter,
+)]
 pub enum DatasourceId {
     // ── About/README/OS ──
     AboutFile,


### PR DESCRIPTION
## Summary

- Fixes two related correctness bugs in the assembly stage (`src/assembly/mod.rs`).
- **Bug 1 (nondeterministic assembler order):** per-directory active assembler config keys were collected into a `HashSet<DatasourceId>` and iterated, so in polyglot directories (e.g. `package.json` + `Cargo.toml`) the order in which sibling/special mergers ran varied with hash seeding. Now collected into a `BTreeSet` via a new `active_config_keys` helper so iteration is stable across runs and processes. `DatasourceId` now derives `PartialOrd`/`Ord`.
- **Bug 2 (over-broad purl-keyed nested-merge dedup):** after `assemble_nested_patterns`, the code ran `packages.retain(|p| p.purl != purl)`, removing every package sharing the merged purl — and when the merged purl was `None`, deleting all purl-less packages scan-wide. Dedup is now scoped to the specific prior packages the merge actually subsumed: the package UIDs recorded on the consumed files' `for_packages` (the files in the `affected_indices` the merge reports). Dependency pruning keys off those same exact UIDs and preserves any dependency with no owning package.

## Issues

- Closes: #1026

## Scope and exclusions

- Included: the two assembly bugs above and a determinism regression test.
- Explicit exclusions: no parser, output-schema, or golden-fixture changes. Assembly goldens are intentionally left unchanged (and verified unchanged).

## How to verify

- The determinism test `test_assemble_polyglot_directory_is_deterministic` (in `src/assembly/assembly_test.rs`) asserts the active config keys are visited in sorted order and that a UID-normalized assembly fingerprint is stable across repeated runs. It fails if `active_config_keys` is reverted to a `HashSet` (verified locally: `HashSet` yields `[CargoToml, PhpComposerJson, BunLock]` vs sorted `[BunLock, CargoToml, PhpComposerJson]`).
- The full assembly golden suite (`cargo test --test assembly_golden --features golden-tests`) passes with no diff, including the nested-merge fixtures (`maven_meta_inf`, `npm_nested_packages`, `ruby_extracted`), confirming the dedup fix removes exactly the consumed packages.

## Expected-output fixture changes

- Files changed: none. Goldens are unchanged; the dedup narrowing removes exactly the packages the merge previously consumed via the purl match in the covered single-package cases, so output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)