### PR TITLE
fix(parsers): surface silent entry-drop truncation across all parsers

### DIFF
--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -35,7 +35,8 @@ use crate::models::{
     PartyType, Sha1Digest,
 };
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string,
+    split_name_email, truncate_field,
 };
 
 const MAX_ARCHIVE_SIZE: u64 = 1024 * 1024 * 1024; // 1GB uncompressed
@@ -133,7 +134,8 @@ fn parse_alpine_installed_db(content: &str) -> Vec<PackageData> {
 
     let mut all_packages = Vec::new();
 
-    for raw_text in raw_paragraphs.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(raw_paragraphs.len(), "alpine installed DB packages");
+    for raw_text in raw_paragraphs.iter().take(limit) {
         let headers = parse_alpine_headers(raw_text);
         let pkg = parse_alpine_package_paragraph(&headers, raw_text);
         if pkg.name.is_some() {
@@ -156,7 +158,7 @@ fn parse_alpine_installed_db(content: &str) -> Vec<PackageData> {
 fn parse_alpine_headers(content: &str) -> HashMap<String, Vec<String>> {
     let mut headers: HashMap<String, Vec<String>> = HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("alpine DB header lines") {
         if line.is_empty() {
             continue;
         }
@@ -1004,7 +1006,7 @@ fn extract_file_references(raw_text: &str) -> Vec<FileReference> {
     let mut current_dir = String::new();
     let mut current_file: Option<FileReference> = None;
 
-    for line in raw_text.lines().take(MAX_ITERATION_COUNT) {
+    for line in raw_text.lines().capped("alpine file-reference lines") {
         if line.is_empty() {
             continue;
         }
@@ -1082,7 +1084,7 @@ fn extract_file_references(raw_text: &str) -> Vec<FileReference> {
 fn extract_providers(raw_text: &str) -> Vec<String> {
     let mut providers = Vec::new();
 
-    for line in raw_text.lines().take(MAX_ITERATION_COUNT) {
+    for line in raw_text.lines().capped("alpine provider lines") {
         if line.is_empty() {
             continue;
         }
@@ -1274,7 +1276,7 @@ fn apk_pkginfo_content(path: &Path, archive_size: u64) -> Result<Option<String>,
 fn parse_pkginfo(content: &str) -> PackageData {
     let mut fields: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("alpine .PKGINFO lines") {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;

--- a/src/parsers/android.rs
+++ b/src/parsers/android.rs
@@ -15,7 +15,9 @@ use zip::ZipArchive;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field,
+};
 use crate::utils::magic;
 
 use super::PackageParser;
@@ -560,7 +562,11 @@ fn xml_attributes_to_map(
 ) -> Result<HashMap<String, String>, String> {
     let mut attributes = HashMap::new();
 
-    for attribute in event.attributes().flatten().take(MAX_ITERATION_COUNT) {
+    for attribute in event
+        .attributes()
+        .flatten()
+        .capped("AndroidManifest.xml attributes")
+    {
         let key = String::from_utf8_lossy(attribute.key.as_ref()).into_owned();
         let value = attribute
             .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())

--- a/src/parsers/arch.rs
+++ b/src/parsers/arch.rs
@@ -10,7 +10,7 @@ use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    CappedIterExt, capped_iteration_limit, read_file_to_string, split_name_email, truncate_field,
 };
 
 use super::PackageParser;
@@ -95,7 +95,7 @@ type MultiMap = HashMap<String, Vec<String>>;
 fn parse_key_value_lines(content: &str) -> MultiMap {
     let mut fields: MultiMap = HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("arch key=value lines") {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -121,7 +121,7 @@ fn parse_srcinfo_like(content: &str, datasource_id: DatasourceId) -> Vec<Package
     let mut packages: Vec<MultiMap> = Vec::new();
     let mut current_is_pkgbase = true;
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("arch .SRCINFO-like lines") {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -367,7 +367,8 @@ fn build_dependencies(fields: &MultiMap) -> Vec<Dependency> {
     let mut keys: Vec<_> = fields.keys().cloned().collect();
     keys.sort();
 
-    for key in keys.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(keys.len(), "arch dependency keys");
+    for key in keys.iter().take(limit) {
         let Some((scope, is_runtime, is_optional)) = dependency_semantics(key) else {
             continue;
         };
@@ -424,7 +425,15 @@ fn build_extra_data(
 
     let mut extra = HashMap::new();
 
-    for (key, values) in fields.iter().take(MAX_ITERATION_COUNT) {
+    // `fields` is an unordered HashMap, so sort the keys before applying the
+    // iteration cap to keep which entries survive truncation deterministic.
+    let mut field_keys: Vec<&String> = fields.keys().collect();
+    field_keys.sort();
+    let limit = capped_iteration_limit(field_keys.len(), "arch extra fields");
+    for key in field_keys.into_iter().take(limit) {
+        let Some(values) = fields.get(key) else {
+            continue;
+        };
         if consumed.contains(key.as_str()) {
             continue;
         }

--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -22,7 +22,7 @@
 //! Python implementation: `reference/scancode-toolkit/src/packagedcode/build.py` (BazelBuildHandler)
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
+use crate::parsers::utils::{RecursionGuard, capped_iteration_limit, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::path::Path;
@@ -84,10 +84,9 @@ fn parse_bazel_build(path: &Path) -> Result<Vec<PackageData>, String> {
 
     let mut packages = Vec::new();
 
-    for statement in top_level_statements(&module)
-        .iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let statements = top_level_statements(&module);
+    let limit = capped_iteration_limit(statements.len(), "bazel BUILD top-level statements");
+    for statement in statements.iter().take(limit) {
         if let Some(mut package_data) = extract_package_from_statement(statement) {
             set_scancode_simple_top_level(&mut package_data, scancode_simple_top_level);
             packages.push(package_data);
@@ -210,10 +209,9 @@ fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
     let mut dependencies = Vec::new();
     let mut overrides = Vec::new();
 
-    for statement in top_level_statements(&module)
-        .iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let statements = top_level_statements(&module);
+    let limit = capped_iteration_limit(statements.len(), "MODULE.bazel top-level statements");
+    for statement in statements.iter().take(limit) {
         let Some(call) = extract_call(statement) else {
             continue;
         };
@@ -334,9 +332,10 @@ fn extract_string_list_kwarg(call: &StarlarkCall<'_>, key: &str) -> Option<Vec<S
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
+    let limit = capped_iteration_limit(items.len(), "bazel string-list kwarg items");
     let values: Vec<_> = items
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(expr_as_string)
         .collect();
     (!values.is_empty()).then_some(values)
@@ -361,10 +360,9 @@ fn extract_bazel_dependency(call: &StarlarkCall<'_>) -> Option<Dependency> {
     let is_dev = extract_bool_kwarg(call, "dev_dependency").unwrap_or(false);
     let mut extra_data = JsonMap::new();
 
-    for field in ["repo_name", "max_compatibility_level", "registry"]
-        .iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let fields = ["repo_name", "max_compatibility_level", "registry"];
+    let limit = capped_iteration_limit(fields.len(), "bazel dependency extra fields");
+    for field in fields.iter().take(limit) {
         if let Some(value) = extract_kwarg_json(call, field) {
             extra_data.insert(field.to_string(), value);
         }
@@ -386,7 +384,8 @@ fn extract_bazel_dependency(call: &StarlarkCall<'_>) -> Option<Dependency> {
 fn extract_override(kind: &str, call: &StarlarkCall<'_>) -> JsonValue {
     let mut override_map = JsonMap::new();
     override_map.insert("kind".to_string(), JsonValue::String(kind.to_string()));
-    for argument in call.args.args.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(call.args.args.len(), "bazel override arguments");
+    for argument in call.args.args.iter().take(limit) {
         if let ast::ArgumentP::Named(name, value) = &argument.node
             && let Some(value) = expr_to_json(value, &mut RecursionGuard::depth_only())
         {
@@ -445,15 +444,19 @@ fn expr_to_json(expr: &ast::AstExpr, guard: &mut RecursionGuard<()>) -> Option<J
             "None" => Some(JsonValue::Null),
             _ => None,
         },
-        ast::ExprP::List(elts) | ast::ExprP::Tuple(elts) => Some(JsonValue::Array(
-            elts.iter()
-                .take(MAX_ITERATION_COUNT)
-                .filter_map(|e| expr_to_json(e, guard))
-                .collect(),
-        )),
+        ast::ExprP::List(elts) | ast::ExprP::Tuple(elts) => {
+            let limit = capped_iteration_limit(elts.len(), "bazel list/tuple elements");
+            Some(JsonValue::Array(
+                elts.iter()
+                    .take(limit)
+                    .filter_map(|e| expr_to_json(e, guard))
+                    .collect(),
+            ))
+        }
         ast::ExprP::Dict(items) => {
             let mut map = JsonMap::new();
-            for (key, value) in items.iter().take(MAX_ITERATION_COUNT) {
+            let limit = capped_iteration_limit(items.len(), "bazel dict entries");
+            for (key, value) in items.iter().take(limit) {
                 let Some(key) = expr_as_string(key) else {
                     continue;
                 };

--- a/src/parsers/bower.rs
+++ b/src/parsers/bower.rs
@@ -26,7 +26,7 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
 use std::path::Path;
@@ -191,9 +191,10 @@ fn extract_license_statement(json: &Value) -> Option<String> {
                 }
             }
             Value::Array(licenses) => {
+                let limit = capped_iteration_limit(licenses.len(), "bower license array");
                 let license_strings: Vec<String> = licenses
                     .iter()
-                    .take(MAX_ITERATION_COUNT)
+                    .take(limit)
                     .filter_map(|v| v.as_str())
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
@@ -220,9 +221,10 @@ fn normalize_bower_declared_license(
 ) {
     match json.get(FIELD_LICENSE) {
         Some(Value::Array(licenses)) => {
+            let limit = capped_iteration_limit(licenses.len(), "bower declared license array");
             let normalized = licenses
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|value| value.as_str().map(str::trim))
                 .filter(|value| !value.is_empty())
                 .map(normalize_declared_license_key)
@@ -250,8 +252,9 @@ fn extract_keywords(json: &Value) -> Vec<String> {
     json.get(FIELD_KEYWORDS)
         .and_then(|v| v.as_array())
         .map(|arr| {
+            let limit = capped_iteration_limit(arr.len(), "bower keywords");
             arr.iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|v| v.as_str())
                 .map(|s| truncate_field(s.to_string()))
                 .collect()
@@ -265,7 +268,8 @@ fn extract_parties(json: &Value) -> Vec<Party> {
     let mut parties = Vec::new();
 
     if let Some(authors) = json.get(FIELD_AUTHORS).and_then(|v| v.as_array()) {
-        for author in authors.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(authors.len(), "bower authors");
+        for author in authors.iter().take(limit) {
             if let Some(party) = extract_party_from_author(author) {
                 parties.push(party);
             }
@@ -391,8 +395,9 @@ fn extract_dependencies(
     json.get(field)
         .and_then(|deps| deps.as_object())
         .map_or_else(Vec::new, |deps| {
+            let limit = capped_iteration_limit(deps.len(), "bower dependencies");
             deps.iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|(name, requirement)| {
                     let requirement_str = requirement.as_str()?;
                     let package_url =

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use starlark_syntax::syntax::ast;
 use starlark_syntax::syntax::{AstModule, Dialect};
@@ -108,10 +108,9 @@ fn parse_buck_build(path: &Path) -> Result<Vec<PackageData>, String> {
 
     let mut packages = Vec::new();
 
-    for statement in top_level_statements(&module)
-        .iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let statements = top_level_statements(&module);
+    let limit = capped_iteration_limit(statements.len(), "BUCK top-level statements");
+    for statement in statements.iter().take(limit) {
         if let Some(package_data) = extract_build_package_from_statement(statement) {
             packages.push(package_data);
         }
@@ -125,10 +124,9 @@ fn parse_metadata_bzl(path: &Path) -> Result<PackageData, String> {
     let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
     let module = parse_starlark_module("<METADATA.bzl>", content)?;
 
-    for statement in top_level_statements(&module)
-        .iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let statements = top_level_statements(&module);
+    let limit = capped_iteration_limit(statements.len(), "METADATA.bzl top-level statements");
+    for statement in statements.iter().take(limit) {
         if let Some(dict) = extract_metadata_assignment_dict(statement) {
             return Ok(extract_metadata_dict(dict));
         }
@@ -219,7 +217,8 @@ fn extract_metadata_assignment_dict(
 fn extract_metadata_dict(dict: &[(ast::AstExpr, ast::AstExpr)]) -> PackageData {
     let mut fields: HashMap<String, MetadataValue> = HashMap::new();
 
-    for (key, value) in dict.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(dict.len(), "BUCK metadata dict entries");
+    for (key, value) in dict.iter().take(limit) {
         let Some(key_name) = expr_as_string(key) else {
             continue;
         };
@@ -493,9 +492,10 @@ fn metadata_value_from_expr(expr: &ast::AstExpr) -> Option<MetadataValue> {
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
+    let limit = capped_iteration_limit(items.len(), "BUCK metadata list items");
     let values: Vec<_> = items
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(expr_as_string)
         .collect();
     (!values.is_empty()).then_some(MetadataValue::List(values))
@@ -576,9 +576,10 @@ fn extract_named_kwarg_string_list(call: &StarlarkCall<'_>, key: &str) -> Option
         ast::ExprP::List(items) | ast::ExprP::Tuple(items) => items,
         _ => return None,
     };
+    let limit = capped_iteration_limit(items.len(), "BUCK kwarg string-list items");
     let values: Vec<_> = items
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(expr_as_string)
         .collect();
     (!values.is_empty()).then_some(values)

--- a/src/parsers/bun_lock.rs
+++ b/src/parsers/bun_lock.rs
@@ -11,7 +11,7 @@ use crate::models::{
     DatasourceId, Dependency, Md5Digest, PackageData, PackageType, ResolvedPackage, Sha1Digest,
     Sha256Digest, Sha512Digest,
 };
-use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, npm_purl, parse_sri, truncate_field};
 
 use super::PackageParser;
 
@@ -124,7 +124,8 @@ fn parse_bun_lockfile(root: &JsonValue) -> PackageData {
     };
 
     let mut dependencies = Vec::new();
-    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(packages.len(), "bun.lock packages");
+    for (key, value) in packages.iter().take(limit) {
         if let Some(dependency) = parse_package_entry(
             key,
             value,
@@ -165,7 +166,8 @@ fn extract_workspace_info(root: &JsonValue) -> WorkspaceContext {
         .map(|s| truncate_field(s.to_owned()));
 
     if let Some(workspaces) = workspaces {
-        for workspace in workspaces.values().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(workspaces.len(), "bun.lock workspace versions");
+        for workspace in workspaces.values().take(limit) {
             if let Some(name) = workspace.get("name").and_then(|value| value.as_str())
                 && let Some(version) = workspace.get("version").and_then(|value| value.as_str())
             {
@@ -181,7 +183,8 @@ fn extract_workspace_info(root: &JsonValue) -> WorkspaceContext {
     }
 
     if let Some(workspaces) = workspaces {
-        for workspace in workspaces.values().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(workspaces.len(), "bun.lock workspace manifests");
+        for workspace in workspaces.values().take(limit) {
             insert_manifest_dependency_info(
                 workspace.get("dependencies"),
                 "dependencies",
@@ -233,7 +236,8 @@ fn insert_manifest_dependency_info(
         return;
     };
 
-    for name in map.keys().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(map.len(), "bun.lock manifest dependency names");
+    for name in map.keys().take(limit) {
         out.insert(
             truncate_field(name.clone()),
             ManifestDependencyInfo {
@@ -491,8 +495,9 @@ fn build_nested_dependencies(
         return Vec::new();
     };
 
+    let limit = capped_iteration_limit(deps.len(), "bun.lock nested dependencies");
     deps.iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(name, value)| {
             let requirement = value.as_str()?;
             let version = if requirement.starts_with("workspace:") {

--- a/src/parsers/bun_lockb.rs
+++ b/src/parsers/bun_lockb.rs
@@ -12,7 +12,8 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha512Digest,
 };
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, npm_purl, parse_sri, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, npm_purl, parse_sri,
+    truncate_field,
 };
 
 use super::PackageParser;
@@ -368,7 +369,7 @@ fn parse_dependency_entries(
 
     bytes
         .chunks_exact(DEPENDENCY_ENTRY_SIZE)
-        .take(MAX_ITERATION_COUNT)
+        .capped("bun.lockb dependency entries")
         .map(|entry| {
             Ok(BunLockbDependencyEntry {
                 name: decode_bun_string(&entry[0..8], string_bytes)?,
@@ -386,7 +387,7 @@ fn parse_resolution_ids(bytes: &[u8]) -> Result<Vec<u32>, String> {
 
     bytes
         .chunks_exact(4)
-        .take(MAX_ITERATION_COUNT)
+        .capped("bun.lockb resolution ids")
         .map(|chunk| {
             let arr: [u8; 4] = chunk
                 .try_into()
@@ -423,7 +424,7 @@ fn build_dependencies_for_package(
     dep_slice
         .iter()
         .zip(res_slice.iter())
-        .take(MAX_ITERATION_COUNT)
+        .capped("bun.lockb package dependencies")
         .map(|(entry, package_id)| {
             let manifest = behavior_to_manifest(entry.behavior);
             let resolved_package = if (*package_id as usize) < packages.len() {

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -25,7 +25,7 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Sha256Digest};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::json;
 use std::collections::{HashMap, HashSet, hash_map::Entry};
@@ -257,14 +257,17 @@ fn extract_all_dependencies(
     let package_versions = build_package_versions(packages);
     let package_provenance = build_package_provenance(packages);
     let root_package_key = root_package.and_then(package_key_from_table);
-    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(packages.len(), "Cargo.lock packages");
+    for package in packages.iter().take(limit) {
         if let Some(pkg_table) = package.as_table() {
             let is_root_package = package_key_from_table(pkg_table)
                 .zip(root_package_key)
                 .is_some_and(|(package_key, root_key)| package_key == root_key);
 
             if let Some(deps) = pkg_table.get("dependencies").and_then(|v| v.as_array()) {
-                for dep in deps.iter().take(MAX_ITERATION_COUNT) {
+                let dep_limit =
+                    capped_iteration_limit(deps.len(), "Cargo.lock package dependencies");
+                for dep in deps.iter().take(dep_limit) {
                     if let Some(dep_str) = dep.as_str() {
                         let parsed_dependency = parse_dependency_string(dep_str);
                         let name = parsed_dependency.name;
@@ -330,9 +333,10 @@ fn extract_all_dependencies(
         }
     }
 
+    let provenance_limit = capped_iteration_limit(packages.len(), "Cargo.lock provenance packages");
     for package in packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(provenance_limit)
         .filter_map(|package| package.as_table())
     {
         let Some((name, version)) = package_key_from_table(package) else {

--- a/src/parsers/carthage.rs
+++ b/src/parsers/carthage.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use super::metadata::ParserMetadata;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 
 use super::PackageParser;
@@ -115,7 +115,7 @@ struct ParsedLine {
 fn parse_cartfile_lines(content: &str, is_resolved: bool) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("Cartfile lines") {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;

--- a/src/parsers/chef.rs
+++ b/src/parsers/chef.rs
@@ -40,7 +40,9 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, read_file_to_string, truncate_field};
+use super::utils::{
+    CappedIterExt, MAX_MANIFEST_SIZE, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 const FIELD_NAME: &str = "name";
 const FIELD_VERSION: &str = "version";
@@ -174,7 +176,8 @@ impl PackageParser for ChefMetadataJsonParser {
             .get(FIELD_DEPENDENCIES)
             .and_then(|v| v.as_object())
         {
-            for (dep_name, dep_version) in deps_obj.iter().take(MAX_ITERATION_COUNT) {
+            let limit = capped_iteration_limit(deps_obj.len(), "metadata.json dependencies");
+            for (dep_name, dep_version) in deps_obj.iter().take(limit) {
                 let version_constraint = dep_version
                     .as_str()
                     .map(|s| s.trim().to_string())
@@ -188,7 +191,8 @@ impl PackageParser for ChefMetadataJsonParser {
         }
 
         if let Some(depends_obj) = json_content.get(FIELD_DEPENDS).and_then(|v| v.as_object()) {
-            for (dep_name, dep_version) in depends_obj.iter().take(MAX_ITERATION_COUNT) {
+            let limit = capped_iteration_limit(depends_obj.len(), "metadata.json depends");
+            for (dep_name, dep_version) in depends_obj.iter().take(limit) {
                 let version_constraint = dep_version
                     .as_str()
                     .map(|s| s.trim().to_string())
@@ -280,7 +284,7 @@ impl PackageParser for ChefMetadataRbParser {
         let mut fields: HashMap<String, String> = HashMap::new();
         let mut deps: HashMap<String, Option<String>> = HashMap::new();
 
-        for line in reader.lines().take(MAX_ITERATION_COUNT) {
+        for line in reader.lines().capped("metadata.rb lines") {
             let line = match line {
                 Ok(l) => l,
                 Err(e) => {

--- a/src/parsers/citation.rs
+++ b/src/parsers/citation.rs
@@ -8,7 +8,7 @@ use crate::parser_warn as warn;
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 pub struct CitationCffParser;
 
@@ -108,7 +108,7 @@ fn extract_author_parties(value: Option<&yaml_serde::Value>) -> Vec<Party> {
         .and_then(yaml_serde::Value::as_sequence)
         .into_iter()
         .flatten()
-        .take(MAX_ITERATION_COUNT)
+        .capped("CITATION.cff authors")
         .filter_map(|entry| {
             let name = entry
                 .get("name")

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
@@ -546,9 +547,10 @@ fn extract_deps_map(
     scope: Option<&str>,
     runtime: bool,
 ) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(entries.len(), "deps.edn deps map");
     entries
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(lib, coord)| build_deps_edn_dependency(lib, coord, scope, runtime))
         .collect()
 }
@@ -605,9 +607,10 @@ fn build_deps_edn_dependency(
 }
 
 fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(entries.len(), "project.clj dependencies");
     entries
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|entry| {
             let Form::Vector(parts) = entry else {
                 return None;

--- a/src/parsers/compiled_binary.rs
+++ b/src/parsers/compiled_binary.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use super::metadata::ParserMetadata;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{CappedIterExt, capped_iteration_limit, truncate_field};
 
 use super::ParsePackagesResult;
 use super::go::create_golang_purl;
@@ -113,10 +113,11 @@ fn parse_rust_binary_bytes(bytes: &[u8]) -> Vec<PackageData> {
         return Vec::new();
     };
 
+    let limit = capped_iteration_limit(audit_data.packages.len(), "Rust binary audit packages");
     audit_data
         .packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .map(|package| build_rust_binary_package(package, &audit_data.packages))
         .collect()
 }
@@ -137,10 +138,12 @@ fn build_rust_binary_package(
     packages: &[RustBinaryAuditPackage],
 ) -> PackageData {
     let purl = create_cargo_purl(&package.name, &package.version);
+    let limit =
+        capped_iteration_limit(package.dependencies.len(), "Rust binary audit dependencies");
     let dependencies = package
         .dependencies
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|index| packages.get(*index))
         .filter_map(|dependency| {
             let purl = create_cargo_purl(&dependency.name, &dependency.version)?;
@@ -298,7 +301,7 @@ fn decode_uvarint(bytes: &[u8]) -> Option<(usize, usize)> {
 
 fn parse_go_modinfo_packages(modinfo: &str) -> Vec<PackageData> {
     let mut packages = Vec::new();
-    for line in modinfo.lines().take(MAX_ITERATION_COUNT) {
+    for line in modinfo.lines().capped("Go binary modinfo lines") {
         if let Some(rest) = line.strip_prefix("path\t") {
             packages.push(build_go_binary_package(rest, None, true));
             continue;

--- a/src/parsers/composer.rs
+++ b/src/parsers/composer.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
 
@@ -276,8 +276,9 @@ fn extract_dependencies(
         .get(field)
         .and_then(|value| value.as_object())
         .map_or_else(Vec::new, |deps| {
+            let limit = capped_iteration_limit(deps.len(), "composer.json dependencies");
             deps.iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|(name, requirement)| {
                     let requirement_str = requirement.as_str()?;
                     let (namespace, package_name) = split_namespace_name(name);
@@ -350,13 +351,16 @@ fn extract_lock_packages(json_content: &Value) -> Vec<PackageData> {
 
     let mut extracted = Vec::with_capacity(packages.len() + packages_dev.len());
 
-    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+    let packages_limit = capped_iteration_limit(packages.len(), "composer.lock packages");
+    for package in packages.iter().take(packages_limit) {
         if let Some(package_data) = build_lock_package_data(package, false) {
             extracted.push(package_data);
         }
     }
 
-    for package in packages_dev.iter().take(MAX_ITERATION_COUNT) {
+    let packages_dev_limit =
+        capped_iteration_limit(packages_dev.len(), "composer.lock packages-dev");
+    for package in packages_dev.iter().take(packages_dev_limit) {
         if let Some(package_data) = build_lock_package_data(package, true) {
             extracted.push(package_data);
         }
@@ -373,7 +377,8 @@ fn extract_lock_package_list(
 ) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(packages.len(), "composer.lock package list");
+    for package in packages.iter().take(limit) {
         if let Some(dependency) = build_lock_dependency(package, scope, is_runtime, is_optional) {
             dependencies.push(dependency);
         }
@@ -733,9 +738,10 @@ fn extract_keywords(json_content: &Value) -> Vec<String> {
         .get(FIELD_KEYWORDS)
         .and_then(|value| value.as_array())
         .map(|values| {
+            let limit = capped_iteration_limit(values.len(), "composer.json keywords");
             values
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|value| {
                     value
                         .as_str()
@@ -753,7 +759,8 @@ fn extract_parties(json_content: &Value, namespace: &Option<String>) -> Vec<Part
         .get(FIELD_AUTHORS)
         .and_then(|value| value.as_array())
     {
-        for author in authors.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(authors.len(), "composer.json authors");
+        for author in authors.iter().take(limit) {
             if let Some(author) = author.as_object() {
                 let name = author
                     .get("name")

--- a/src/parsers/conan.rs
+++ b/src/parsers/conan.rs
@@ -40,7 +40,7 @@ use super::PackageParser;
 use super::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_declared_license_key,
 };
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field};
 
 const MAX_AST_DEPTH: usize = 50;
 const MAX_AST_NODES: usize = 10_000;
@@ -124,7 +124,8 @@ fn extract_conanfile_data(class_def: &ast::StmtClassDef) -> PackageData {
     let mut requires_list = Vec::new();
     let mut tool_requires_list = Vec::new();
 
-    for stmt in class_def.body.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(class_def.body.len(), "conanfile.py class body");
+    for stmt in class_def.body.iter().take(limit) {
         match stmt {
             ast::Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
                 if let Some(target_name) = get_assignment_target(targets) {
@@ -506,7 +507,7 @@ fn parse_conanfile_txt(contents: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     let mut current_section = None;
 
-    for line in contents.lines().take(MAX_ITERATION_COUNT) {
+    for line in contents.lines().capped("conanfile.txt lines") {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -545,7 +546,8 @@ fn parse_conan_lock(json: &Value) -> Vec<Dependency> {
     if let Some(graph_lock) = json.get("graph_lock")
         && let Some(nodes) = graph_lock.get("nodes").and_then(|n| n.as_object())
     {
-        for (_node_id, node_data) in nodes.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(nodes.len(), "conan.lock graph_lock nodes");
+        for (_node_id, node_data) in nodes.iter().take(limit) {
             if let Some(ref_str) = node_data.get("ref").and_then(|r| r.as_str())
                 && !ref_str.is_empty()
                 && ref_str != "conanfile"
@@ -569,7 +571,8 @@ fn parse_conan_lock(json: &Value) -> Vec<Dependency> {
         ("python_requires", false, "python_requires"),
     ] {
         if let Some(refs) = json.get(key).and_then(|v| v.as_array()) {
-            for entry in refs.iter().take(MAX_ITERATION_COUNT) {
+            let limit = capped_iteration_limit(refs.len(), "conan.lock requires");
+            for entry in refs.iter().take(limit) {
                 if let Some(ref_str) = entry.as_str()
                     && !ref_str.is_empty()
                     && let Some(mut dep) = parse_conan_reference(ref_str)

--- a/src/parsers/conan_data.rs
+++ b/src/parsers/conan_data.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::models::PackageData;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -178,7 +178,13 @@ pub(crate) fn parse_conandata_yml(content: &str) -> Vec<PackageData> {
 
     let mut packages = Vec::new();
 
-    for (version, sources_value) in sources.into_iter().take(MAX_ITERATION_COUNT) {
+    // `sources` is an unordered HashMap; sort by version key so truncation at
+    // the cap drops a deterministic, reproducible set of entries.
+    let limit = capped_iteration_limit(sources.len(), "conandata.yml sources");
+    let mut sources: Vec<_> = sources.into_iter().collect();
+    sources.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    for (version, sources_value) in sources.into_iter().take(limit) {
         let source_infos = sources_to_infos(sources_value);
         let mut extra_data = HashMap::new();
 

--- a/src/parsers/conan_data_test.rs
+++ b/src/parsers/conan_data_test.rs
@@ -24,6 +24,40 @@ mod tests {
     }
 
     #[test]
+    fn test_versions_emitted_in_deterministic_sorted_order() {
+        // `sources` is deserialized into a std HashMap, so iteration order is
+        // nondeterministic. The parser sorts by version key before capping so
+        // emitted PackageData order (and truncation survivors) is reproducible.
+        let content = r#"
+sources:
+  "2.0.0":
+    url: "https://example.com/package-2.0.0.tar.gz"
+  "1.0.0":
+    url: "https://example.com/package-1.0.0.tar.gz"
+  "1.5.0":
+    url: "https://example.com/package-1.5.0.tar.gz"
+"#;
+        let run = || {
+            parse_conandata_yml(content)
+                .into_iter()
+                .filter_map(|p| p.version)
+                .collect::<Vec<_>>()
+        };
+        let first = run();
+        let second = run();
+        assert_eq!(first, second, "version order must be reproducible");
+        assert_eq!(
+            first,
+            vec![
+                "1.0.0".to_string(),
+                "1.5.0".to_string(),
+                "2.0.0".to_string()
+            ],
+            "versions must be emitted in sorted order"
+        );
+    }
+
+    #[test]
     fn test_parse_basic_conandata() {
         let content = r#"
 sources:

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -36,7 +36,9 @@ use std::path::Path;
 use packageurl::PackageUrl;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 use regex::Regex;
 use yaml_serde::Value;
 
@@ -258,7 +260,8 @@ impl PackageParser for CondaMetaYamlParser {
             for (scope_key, reqs_value) in requirements {
                 let scope = scope_key.as_str().unwrap_or("unknown");
                 if let Some(reqs) = reqs_value.as_sequence() {
-                    for req in reqs.iter().take(MAX_ITERATION_COUNT) {
+                    let limit = capped_iteration_limit(reqs.len(), "conda meta.yaml requirements");
+                    for req in reqs.iter().take(limit) {
                         if let Some(req_str) = req.as_str()
                             && let Some(dep) = parse_conda_requirement(req_str, scope)
                         {
@@ -554,7 +557,8 @@ fn collect_recipe_yaml_requirement_strings(
     }
 
     if let Some(items) = value.as_sequence() {
-        for item in items.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(items.len(), "recipe.yaml requirement items");
+        for item in items.iter().take(limit) {
             collect_recipe_yaml_requirement_strings(item, context, requirements);
         }
         return;
@@ -714,10 +718,13 @@ fn looks_like_conda_environment_yaml(yaml: &Value) -> bool {
 }
 
 fn looks_like_template_yaml(contents: &str) -> bool {
-    contents.lines().take(MAX_ITERATION_COUNT).any(|line| {
-        let trimmed = line.trim_start();
-        trimmed.starts_with("{{") || trimmed.starts_with("{%-") || trimmed.starts_with("{%")
-    })
+    contents
+        .lines()
+        .capped("conda template detection lines")
+        .any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("{{") || trimmed.starts_with("{%-") || trimmed.starts_with("{%")
+        })
 }
 
 /// Extract Jinja2-style variables from a Conda meta.yaml
@@ -727,7 +734,7 @@ fn looks_like_template_yaml(contents: &str) -> bool {
 pub fn extract_jinja2_variables(content: &str) -> HashMap<String, String> {
     let mut variables = HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("conda Jinja2 variable lines") {
         let trimmed = line.trim();
         if let Some(inner) = extract_jinja_statement(trimmed)
             && let Some(inner) = inner.strip_prefix("set").map(str::trim)
@@ -910,7 +917,8 @@ fn extract_environment_dependencies(yaml: &Value) -> Vec<Dependency> {
     };
 
     let mut deps = Vec::new();
-    for dep_value in dependencies.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(dependencies.len(), "conda environment dependencies");
+    for dep_value in dependencies.iter().take(limit) {
         if let Some(dep_str) = dep_value.as_str() {
             if let Some(dep) = parse_environment_string_dependency(dep_str) {
                 deps.push(dep);
@@ -1039,9 +1047,10 @@ fn create_conda_dependency(
 }
 
 fn extract_pip_dependencies(pip_deps: &[Value]) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(pip_deps.len(), "conda pip dependencies");
     pip_deps
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|pip_dep| {
             if let Some(pip_req_str) = pip_dep.as_str()
                 && let Some(parsed_req) =

--- a/src/parsers/conda_meta_json.rs
+++ b/src/parsers/conda_meta_json.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -226,7 +226,8 @@ fn build_conda_file_references(
     }
 
     if let Some(files) = files {
-        for file in files.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(files.len(), "conda meta files");
+        for file in files.iter().take(limit) {
             refs.push(FileReference {
                 path: truncate_field(file.clone()),
                 size: None,

--- a/src/parsers/cpan.rs
+++ b/src/parsers/cpan.rs
@@ -34,7 +34,9 @@ use yaml_serde::Value as YamlValue;
 use crate::models::{
     DatasourceId, Dependency, FileReference, PackageData, PackageType, Party, PartyType,
 };
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
 use super::license_normalization::{
@@ -247,7 +249,7 @@ impl PackageParser for CpanManifestParser {
 
         let file_references = content
             .lines()
-            .take(MAX_ITERATION_COUNT)
+            .capped("CPAN MANIFEST lines")
             .filter(|line| !line.trim().is_empty())
             .filter(|line| !line.trim().starts_with('#'))
             .map(|line| {
@@ -334,9 +336,10 @@ fn extract_license_from_json(json: &serde_json::Map<String, JsonValue>) -> Optio
     json.get(FIELD_LICENSE).and_then(|v| match v {
         JsonValue::String(s) => Some(truncate_field(s.clone())),
         JsonValue::Array(arr) => {
+            let limit = capped_iteration_limit(arr.len(), "CPAN JSON license array");
             let licenses: Vec<String> = arr
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                 .collect();
             if licenses.is_empty() {
@@ -354,9 +357,10 @@ fn extract_license_from_yaml(yaml: &yaml_serde::Mapping) -> Option<String> {
         .and_then(|v| match v {
             YamlValue::String(s) => Some(truncate_field(s.clone())),
             YamlValue::Sequence(arr) => {
+                let limit = capped_iteration_limit(arr.len(), "CPAN YAML license sequence");
                 let licenses: Vec<String> = arr
                     .iter()
-                    .take(MAX_ITERATION_COUNT)
+                    .take(limit)
                     .filter_map(|item| item.as_str().map(|s| truncate_field(s.to_string())))
                     .collect();
                 if licenses.is_empty() {
@@ -408,14 +412,17 @@ impl LicenseValueAdapter for JsonValue {
     fn license_values(&self) -> Vec<String> {
         match self {
             JsonValue::String(value) => vec![truncate_field(value.trim().to_string())],
-            JsonValue::Array(values) => values
-                .iter()
-                .take(MAX_ITERATION_COUNT)
-                .filter_map(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(|s| truncate_field(s.to_string()))
-                .collect(),
+            JsonValue::Array(values) => {
+                let limit = capped_iteration_limit(values.len(), "CPAN JSON license values");
+                values
+                    .iter()
+                    .take(limit)
+                    .filter_map(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|s| truncate_field(s.to_string()))
+                    .collect()
+            }
             _ => Vec::new(),
         }
     }
@@ -425,14 +432,17 @@ impl LicenseValueAdapter for YamlValue {
     fn license_values(&self) -> Vec<String> {
         match self {
             YamlValue::String(value) => vec![truncate_field(value.trim().to_string())],
-            YamlValue::Sequence(values) => values
-                .iter()
-                .take(MAX_ITERATION_COUNT)
-                .filter_map(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(|s| truncate_field(s.to_string()))
-                .collect(),
+            YamlValue::Sequence(values) => {
+                let limit = capped_iteration_limit(values.len(), "CPAN YAML license values");
+                values
+                    .iter()
+                    .take(limit)
+                    .filter_map(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|s| truncate_field(s.to_string()))
+                    .collect()
+            }
             _ => Vec::new(),
         }
     }
@@ -457,9 +467,10 @@ fn extract_parties_from_json(json: &serde_json::Map<String, JsonValue>) -> Vec<P
     json.get(FIELD_AUTHOR)
         .and_then(|v| v.as_array())
         .map_or_else(Vec::new, |authors| {
+            let limit = capped_iteration_limit(authors.len(), "CPAN JSON authors");
             authors
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|author| {
                     author.as_str().map(|s| {
                         let (name, email) = parse_author_string(s);
@@ -483,9 +494,10 @@ fn extract_parties_from_yaml(yaml: &yaml_serde::Mapping) -> Vec<Party> {
     yaml.get(YamlValue::String(FIELD_AUTHOR.to_string()))
         .and_then(|v| v.as_sequence())
         .map_or_else(Vec::new, |authors| {
+            let limit = capped_iteration_limit(authors.len(), "CPAN YAML authors");
             authors
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|author| {
                     author.as_str().map(|s| {
                         let (name, email) = parse_author_string(s);
@@ -715,8 +727,9 @@ fn extract_dependency_group(
     is_runtime: bool,
     is_optional: bool,
 ) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(deps.len(), "CPAN JSON dependency group");
     deps.iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(name, version)| {
             if name == "perl" {
                 return None;
@@ -754,8 +767,9 @@ fn extract_yaml_dependency_group(
     is_runtime: bool,
     is_optional: bool,
 ) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(deps.len(), "CPAN YAML dependency group");
     deps.iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(key, value)| {
             let name = key.as_str()?;
 

--- a/src/parsers/cpan_dist_ini.rs
+++ b/src/parsers/cpan_dist_ini.rs
@@ -20,7 +20,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 use serde_json::json;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
@@ -151,7 +153,7 @@ fn parse_ini_structure(
     let mut sections: HashMap<String, HashMap<String, String>> = HashMap::new();
     let mut current_section: Option<String> = None;
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("dist.ini lines") {
         let line = line.trim();
 
         if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
@@ -229,7 +231,8 @@ fn parse_dependencies(sections: &HashMap<String, HashMap<String, String>>) -> Ve
     let mut sorted_sections: Vec<_> = sections.iter().collect();
     sorted_sections.sort_by_key(|(left_name, _)| *left_name);
 
-    for (section_name, fields) in sorted_sections.iter().take(MAX_ITERATION_COUNT) {
+    let sections_limit = capped_iteration_limit(sorted_sections.len(), "dist.ini prereq sections");
+    for (section_name, fields) in sorted_sections.iter().take(sections_limit) {
         let Some(scope) = classify_prereq_scope(section_name) else {
             continue;
         };
@@ -237,7 +240,8 @@ fn parse_dependencies(sections: &HashMap<String, HashMap<String, String>>) -> Ve
         let mut sorted_fields: Vec<_> = fields.iter().collect();
         sorted_fields.sort_by_key(|(left_name, _)| *left_name);
 
-        for (module_name, version_req) in sorted_fields.iter().take(MAX_ITERATION_COUNT) {
+        let fields_limit = capped_iteration_limit(sorted_fields.len(), "dist.ini prereq modules");
+        for (module_name, version_req) in sorted_fields.iter().take(fields_limit) {
             let purl = truncate_field(format!(
                 "pkg:cpan/{}",
                 crate::parsers::cpan::cpan_distribution_name(module_name)

--- a/src/parsers/cpan_makefile_pl.rs
+++ b/src/parsers/cpan_makefile_pl.rs
@@ -20,7 +20,9 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, MAX_ITERATION_COUNT, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use regex::Regex;
 use serde_json::json;
@@ -370,6 +372,10 @@ fn extract_writemakefile_block(content: &str) -> String {
 
     for (i, &ch) in chars.iter().enumerate() {
         if i >= MAX_ITERATION_COUNT {
+            crate::parser_warn!(
+                "Truncated Makefile.PL WriteMakefile block scan at {} characters (MAX_ITERATION_COUNT); closing parenthesis not found within the cap",
+                MAX_ITERATION_COUNT
+            );
             break;
         }
         match ch {
@@ -397,7 +403,7 @@ fn parse_hash_fields(content: &str) -> HashMap<String, String> {
 
     for cap in RE_SIMPLE_KV
         .captures_iter(content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("Makefile.PL key/value fields")
     {
         let key = cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
         let value = cap
@@ -424,7 +430,7 @@ fn parse_hash_fields(content: &str) -> HashMap<String, String> {
 fn parse_hash_dependencies(content: &str, fields: &mut HashMap<String, String>) {
     for cap in RE_HASH_BLOCK
         .captures_iter(content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("Makefile.PL hash blocks")
     {
         let key = cap.get(1).map(|m| m.as_str()).unwrap_or("");
         let hash_content = cap.get(2).map(|m| m.as_str()).unwrap_or("");
@@ -446,7 +452,7 @@ fn parse_author_array(content: &str, fields: &mut HashMap<String, String>) {
 
         let authors: Vec<String> = RE_QUOTED_STRING
             .captures_iter(array_content)
-            .take(MAX_ITERATION_COUNT)
+            .capped("Makefile.PL author array")
             .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
             .collect();
 
@@ -540,7 +546,7 @@ fn extract_deps_from_hash(hash_content: &str, scope: &str, is_runtime: bool) -> 
 
     for cap in RE_DEP_PAIR
         .captures_iter(hash_content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("Makefile.PL dependency pairs")
     {
         let module_name = cap.get(1).map(|m| m.as_str()).unwrap_or("");
 

--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -34,7 +34,7 @@ use packageurl::PackageUrl;
 use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -189,7 +189,7 @@ fn parse_dcf(content: &str) -> HashMap<String, String> {
     let mut current_field: Option<String> = None;
     let mut current_value = String::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("DESCRIPTION DCF lines") {
         // Check if line is a continuation (starts with whitespace)
         if line.starts_with(' ') || line.starts_with('\t') {
             if current_field.is_some() {
@@ -228,7 +228,7 @@ fn parse_dcf(content: &str) -> HashMap<String, String> {
 fn parse_dependencies(deps_str: &str, scope: Option<&str>) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for dep in deps_str.split(',').take(MAX_ITERATION_COUNT) {
+    for dep in deps_str.split(',').capped("CRAN dependency list") {
         let dep = dep.trim();
         if dep.is_empty() {
             continue;
@@ -352,7 +352,7 @@ fn split_author_entries(author_str: &str) -> Vec<&str> {
     let mut bracket_depth: usize = 0;
     let mut paren_depth: usize = 0;
 
-    for (idx, ch) in author_str.char_indices().take(MAX_ITERATION_COUNT) {
+    for (idx, ch) in author_str.char_indices().capped("CRAN author string") {
         match ch {
             '[' => bracket_depth += 1,
             ']' => bracket_depth = bracket_depth.saturating_sub(1),

--- a/src/parsers/dart.rs
+++ b/src/parsers/dart.rs
@@ -30,7 +30,8 @@ use std::path::Path;
 
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 use packageurl::PackageUrl;
 use yaml_serde::{Mapping, Value};
@@ -294,7 +295,8 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
     if let Some(sdks) = lock_data.get(FIELD_SDKS).and_then(Value::as_mapping) {
-        for (name_value, version_value) in sdks.iter().take(MAX_ITERATION_COUNT) {
+        let sdks_limit = capped_iteration_limit(sdks.len(), "pubspec.lock SDKs");
+        for (name_value, version_value) in sdks.iter().take(sdks_limit) {
             if let (Some(name), Some(version_str)) = (name_value.as_str(), version_value.as_str()) {
                 let purl = build_dependency_purl(name, None).map(truncate_field);
                 dependencies.push(Dependency {
@@ -333,7 +335,8 @@ fn extract_lock_dependencies(lock_data: &Value) -> Vec<Dependency> {
         reachable_lock_packages(packages, &["direct main", "direct overridden"]);
     let dev_only_reachable = reachable_lock_packages(packages, &["direct dev"]);
 
-    for (name_value, details_value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    let packages_limit = capped_iteration_limit(packages.len(), "pubspec.lock packages");
+    for (name_value, details_value) in packages.iter().take(packages_limit) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
@@ -393,7 +396,8 @@ fn extract_lock_package_dependencies(details: &Mapping) -> Vec<Dependency> {
         return dependencies;
     };
 
-    for (name_value, requirement_value) in dep_map.iter().take(MAX_ITERATION_COUNT) {
+    let dep_limit = capped_iteration_limit(dep_map.len(), "pubspec.lock package dependencies");
+    for (name_value, requirement_value) in dep_map.iter().take(dep_limit) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
@@ -486,7 +490,8 @@ fn collect_dependencies(
         return dependencies;
     };
 
-    for (name_value, requirement_value) in dep_map.iter().take(MAX_ITERATION_COUNT) {
+    let dep_limit = capped_iteration_limit(dep_map.len(), "pubspec.yaml dependencies");
+    for (name_value, requirement_value) in dep_map.iter().take(dep_limit) {
         let name = match name_value.as_str() {
             Some(value) => value,
             None => continue,
@@ -549,7 +554,8 @@ fn format_dependency_mapping(map: &Mapping, guard: &mut RecursionGuard<()>) -> O
 
     let mut parts = Vec::new();
 
-    for (key, value) in map.iter().take(MAX_ITERATION_COUNT) {
+    let map_limit = capped_iteration_limit(map.len(), "pubspec dependency mapping");
+    for (key, value) in map.iter().take(map_limit) {
         let Some(key_str) = key.as_str() else {
             continue;
         };
@@ -683,7 +689,8 @@ fn extract_authors(yaml_content: &Value) -> Vec<crate::models::Party> {
     if let Some(authors_value) = yaml_content.get(FIELD_AUTHORS)
         && let Some(authors_array) = authors_value.as_sequence()
     {
-        for author_value in authors_array.iter().take(MAX_ITERATION_COUNT) {
+        let authors_limit = capped_iteration_limit(authors_array.len(), "pubspec.yaml authors");
+        for author_value in authors_array.iter().take(authors_limit) {
             if let Some(author_str) = author_value.as_str() {
                 parties.push(Party {
                     r#type: None,
@@ -814,7 +821,8 @@ fn reachable_lock_packages(packages: &Mapping, roots: &[&str]) -> HashSet<String
     let mut queue = VecDeque::new();
     let mut iterations = 0usize;
 
-    for (name_value, details_value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    let roots_limit = capped_iteration_limit(packages.len(), "pubspec.lock reachability roots");
+    for (name_value, details_value) in packages.iter().take(roots_limit) {
         let Some(name) = name_value.as_str() else {
             continue;
         };
@@ -849,10 +857,12 @@ fn reachable_lock_packages(packages: &Mapping, roots: &[&str]) -> HashSet<String
             continue;
         };
 
+        let dep_keys_limit =
+            capped_iteration_limit(dep_map.len(), "pubspec.lock reachability edges");
         for dep_name in dep_map
             .keys()
             .filter_map(Value::as_str)
-            .take(MAX_ITERATION_COUNT)
+            .take(dep_keys_limit)
         {
             queue.push_back(truncate_field(dep_name.to_string()));
         }

--- a/src/parsers/deno.rs
+++ b/src/parsers/deno.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{CappedIterExt, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value;
 use url::Url;
@@ -139,7 +139,7 @@ fn extract_import_dependencies(json: &Value) -> Vec<Dependency> {
         .and_then(Value::as_object)
         .into_iter()
         .flatten()
-        .take(MAX_ITERATION_COUNT)
+        .capped("deno.json imports")
         .filter_map(|(alias, value)| {
             value
                 .as_str()

--- a/src/parsers/deno_lock.rs
+++ b/src/parsers/deno_lock.rs
@@ -15,7 +15,9 @@ use crate::models::{
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, parse_sri, read_file_to_string, truncate_field};
+use super::utils::{
+    CappedIterExt, capped_iteration_limit, parse_sri, read_file_to_string, truncate_field,
+};
 
 const FIELD_VERSION: &str = "version";
 const FIELD_SPECIFIERS: &str = "specifiers";
@@ -129,7 +131,9 @@ fn extract_flat_dependencies(json: &Value) -> (Vec<Dependency>, Vec<String>) {
     let mut direct_jsr_keys = HashSet::new();
     let mut direct_npm_keys = HashSet::new();
 
-    for specifier in workspace_direct.iter().take(MAX_ITERATION_COUNT) {
+    let workspace_limit =
+        capped_iteration_limit(workspace_direct.len(), "deno.lock workspace specifiers");
+    for specifier in workspace_direct.iter().take(workspace_limit) {
         if let Some(resolved_key) = specifiers.get(specifier).and_then(Value::as_str) {
             if specifier.starts_with("jsr:") {
                 if let Some(full_key) = resolve_jsr_full_key(specifier, resolved_key)
@@ -151,7 +155,8 @@ fn extract_flat_dependencies(json: &Value) -> (Vec<Dependency>, Vec<String>) {
     }
 
     if let Some(jsr_map) = json.get(FIELD_JSR).and_then(Value::as_object) {
-        for key in jsr_map.keys().take(MAX_ITERATION_COUNT) {
+        let jsr_limit = capped_iteration_limit(jsr_map.len(), "deno.lock jsr packages");
+        for key in jsr_map.keys().take(jsr_limit) {
             if direct_jsr_keys.contains(key) {
                 continue;
             }
@@ -162,7 +167,8 @@ fn extract_flat_dependencies(json: &Value) -> (Vec<Dependency>, Vec<String>) {
     }
 
     if let Some(npm_map) = json.get(FIELD_NPM).and_then(Value::as_object) {
-        for key in npm_map.keys().take(MAX_ITERATION_COUNT) {
+        let npm_limit = capped_iteration_limit(npm_map.len(), "deno.lock npm packages");
+        for key in npm_map.keys().take(npm_limit) {
             if direct_npm_keys.contains(key) {
                 continue;
             }
@@ -212,7 +218,9 @@ fn extract_nested_npm_dependencies(json: &Value) -> Vec<Dependency> {
         .unwrap_or_default();
 
     let mut dependencies = Vec::new();
-    for key in packages_map.keys().take(MAX_ITERATION_COUNT) {
+    let packages_limit =
+        capped_iteration_limit(packages_map.len(), "deno.lock nested npm packages");
+    for key in packages_map.keys().take(packages_limit) {
         let requested = requested_by_resolved.get(key).map(String::as_str);
         if let Some(dep) = build_npm_dependency(key, requested.is_some(), packages, requested) {
             dependencies.push(dep);
@@ -226,7 +234,8 @@ fn extract_nested_npm_dependencies(json: &Value) -> Vec<Dependency> {
 fn extract_redirect_dependencies(json: &Value) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
     if let Some(redirects) = json.get(FIELD_REDIRECTS).and_then(Value::as_object) {
-        for (source, target) in redirects.iter().take(MAX_ITERATION_COUNT) {
+        let redirects_limit = capped_iteration_limit(redirects.len(), "deno.lock redirects");
+        for (source, target) in redirects.iter().take(redirects_limit) {
             let Some(target_url) = target.as_str() else {
                 continue;
             };
@@ -387,6 +396,12 @@ fn build_npm_dependency(
     let version_str = truncate_field(version.to_string());
     let purl = create_npm_purl(namespace.as_deref(), &name, Some(&version_str)).map(truncate_field);
 
+    let resolved_dependency_keys = npm_dependency_keys(npm_object.get(FIELD_DEPENDENCIES));
+    let resolved_dependency_limit = capped_iteration_limit(
+        resolved_dependency_keys.len(),
+        "deno.lock npm resolved dependencies",
+    );
+
     Some(Dependency {
         purl: purl.clone(),
         extracted_requirement: extracted_requirement.map(|value| truncate_field(value.to_string())),
@@ -416,9 +431,9 @@ fn build_npm_dependency(
             md5: None,
             is_virtual: true,
             extra_data: None,
-            dependencies: npm_dependency_keys(npm_object.get(FIELD_DEPENDENCIES))
+            dependencies: resolved_dependency_keys
                 .into_iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(resolved_dependency_limit)
                 .filter_map(|value| {
                     let (namespace, name, version) = parse_npm_key(&value)?;
                     Some(Dependency {
@@ -460,7 +475,7 @@ fn extract_jsr_resolved_dependencies(
         .into_iter()
         .flatten()
         .filter_map(Value::as_str)
-        .take(MAX_ITERATION_COUNT)
+        .capped("deno.lock jsr resolved dependencies")
         .filter_map(|value| {
             let (namespace, name, version) = parse_jsr_dependency_reference(value)?;
             Some(Dependency {

--- a/src/parsers/erlang_otp.rs
+++ b/src/parsers/erlang_otp.rs
@@ -12,7 +12,8 @@ use crate::models::{
 };
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 
 use super::PackageParser;
@@ -366,6 +367,10 @@ fn parse_dotted_terms(content: &str) -> Result<Vec<ErlTerm>, String> {
             continue;
         }
         if count >= MAX_ITERATION_COUNT {
+            warn!(
+                "Truncated Erlang term parsing at {} top-level terms (MAX_ITERATION_COUNT); remaining terms dropped",
+                MAX_ITERATION_COUNT
+            );
             break;
         }
         let term = parser.parse_term()?;
@@ -835,7 +840,8 @@ fn parse_rebar_config(content: &str) -> Result<PackageData, String> {
             match key.as_deref() {
                 Some("deps") => {
                     if let ErlTerm::List(deps) = &fields[1] {
-                        for dep in deps.iter().take(MAX_ITERATION_COUNT) {
+                        let deps_limit = capped_iteration_limit(deps.len(), "rebar.config deps");
+                        for dep in deps.iter().take(deps_limit) {
                             if let Some(d) = parse_rebar_dep(dep) {
                                 package.dependencies.push(d);
                             }
@@ -1038,7 +1044,8 @@ fn parse_profile_deps(term: &ErlTerm, dependencies: &mut Vec<Dependency>) {
         _ => return,
     };
 
-    for profile in profiles.iter().take(MAX_ITERATION_COUNT) {
+    let profiles_limit = capped_iteration_limit(profiles.len(), "rebar.config profiles");
+    for profile in profiles.iter().take(profiles_limit) {
         if let ErlTerm::Tuple(fields) = profile
             && fields.len() == 2
         {
@@ -1050,7 +1057,9 @@ fn parse_profile_deps(term: &ErlTerm, dependencies: &mut Vec<Dependency>) {
                         && term_to_str(&opt_fields[0]).as_deref() == Some("deps")
                         && let ErlTerm::List(deps) = &opt_fields[1]
                     {
-                        for dep in deps.iter().take(MAX_ITERATION_COUNT) {
+                        let profile_deps_limit =
+                            capped_iteration_limit(deps.len(), "rebar.config profile deps");
+                        for dep in deps.iter().take(profile_deps_limit) {
                             if let Some(mut d) = parse_rebar_dep(dep) {
                                 d.scope = Some(truncate_field(profile_name.clone()));
                                 dependencies.push(d);
@@ -1138,7 +1147,8 @@ fn parse_rebar_lock(content: &str) -> Result<PackageData, String> {
 
     let mut package = default_rebar_lock_package();
 
-    for dep_term in dep_list.iter().take(MAX_ITERATION_COUNT) {
+    let dep_list_limit = capped_iteration_limit(dep_list.len(), "rebar.lock deps");
+    for dep_term in dep_list.iter().take(dep_list_limit) {
         if let Some(dep) = parse_lock_dep(dep_term, &hash_map) {
             package.dependencies.push(dep);
         }
@@ -1252,7 +1262,9 @@ fn extract_pkg_hashes(term: &ErlTerm) -> HashMap<String, String> {
             && term_to_str(&fields[0]).as_deref() == Some("pkg_hash")
             && let ErlTerm::List(hash_list) = &fields[1]
         {
-            for entry in hash_list.iter().take(MAX_ITERATION_COUNT) {
+            let hash_list_limit =
+                capped_iteration_limit(hash_list.len(), "rebar.lock pkg_hash entries");
+            for entry in hash_list.iter().take(hash_list_limit) {
                 if let ErlTerm::Tuple(pair) = entry
                     && pair.len() == 2
                     && let (Some(name), Some(hash)) = (term_to_str(&pair[0]), term_to_str(&pair[1]))

--- a/src/parsers/gitmodules.rs
+++ b/src/parsers/gitmodules.rs
@@ -26,7 +26,9 @@ use std::path::Path;
 use crate::parser_warn as warn;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -74,9 +76,10 @@ impl PackageParser for GitmodulesParser {
             return vec![default_package_data()];
         }
 
+        let submodules_limit = capped_iteration_limit(submodules.len(), ".gitmodules submodules");
         let dependencies: Vec<Dependency> = submodules
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(submodules_limit)
             .map(|sub| Dependency {
                 purl: sub.purl.map(truncate_field),
                 extracted_requirement: Some(truncate_field(format!("{} at {}", sub.path, sub.url))),
@@ -110,7 +113,7 @@ fn parse_gitmodules(content: &str) -> Vec<Submodule> {
     let mut current_section: Option<HashMap<String, String>> = None;
     let mut current_name: Option<String> = None;
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped(".gitmodules lines") {
         let line = line.trim();
 
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -29,7 +29,9 @@
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 use packageurl::PackageUrl;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -95,7 +97,7 @@ pub fn parse_go_mod(content: &str) -> PackageData {
     let mut retracted_versions: Vec<String> = Vec::new();
     let mut block_state = BlockState::None;
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("go.mod lines") {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with("//") {
@@ -587,7 +589,7 @@ pub fn parse_go_sum(content: &str) -> PackageData {
     let mut dependencies = Vec::new();
     let mut seen = HashSet::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("go.sum lines") {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -710,7 +712,7 @@ pub fn parse_go_work(content: &str, work_path: &Path) -> PackageData {
     let mut unresolved_use_paths: Vec<String> = Vec::new();
     let mut block_state = BlockState::None;
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("go.work lines") {
         let trimmed = line.trim();
 
         if trimmed.is_empty() || trimmed.starts_with("//") {
@@ -876,7 +878,8 @@ fn resolve_workspace_use_dependencies(
     let mut dependencies = Vec::new();
     let mut unresolved = Vec::new();
 
-    for use_path in use_paths.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(use_paths.len(), "go.work use paths");
+    for use_path in use_paths.iter().take(limit) {
         let go_mod_path = base_dir.join(use_path).join("go.mod");
         let module_path = read_file_to_string(&go_mod_path, None)
             .ok()
@@ -920,7 +923,7 @@ fn resolve_workspace_use_dependencies(
 }
 
 fn extract_module_path_from_go_mod(content: &str) -> Option<String> {
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("go.mod module-path lines") {
         let trimmed = line.trim();
         if let Some(module_path) = trimmed.strip_prefix("module ") {
             let module_path = strip_comment(module_path).trim();
@@ -1123,7 +1126,8 @@ pub fn parse_godeps_json(content: &str) -> PackageData {
     let mut dependencies = Vec::new();
 
     if let Some(deps) = json.get("Deps").and_then(|v| v.as_array()) {
-        for dep in deps.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(deps.len(), "go list Deps");
+        for dep in deps.iter().take(limit) {
             let dep_import_path = dep.get("ImportPath").and_then(|v| v.as_str());
             let rev = dep.get("Rev").and_then(|v| v.as_str());
 

--- a/src/parsers/go_mod_graph.rs
+++ b/src/parsers/go_mod_graph.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::go::{create_golang_purl, split_module_path};
@@ -69,7 +69,7 @@ pub(crate) fn parse_go_mod_graph(content: &str) -> PackageData {
     let mut root_module: Option<String> = None;
     let mut dependency_map: BTreeMap<String, Dependency> = BTreeMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("go.mod graph lines") {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -31,7 +31,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 const MAX_RECURSION_DEPTH: usize = 50;
 use packageurl::PackageUrl;
@@ -430,7 +432,9 @@ fn extract_raw_dependencies(tokens: &[Tok]) -> Vec<RawDep> {
     let mut dependencies = Vec::new();
 
     for block in blocks {
-        for rd in parse_block(&block).into_iter().take(MAX_ITERATION_COUNT) {
+        let parsed = parse_block(&block);
+        let limit = capped_iteration_limit(parsed.len(), "gradle dependency block");
+        for rd in parsed.into_iter().take(limit) {
             dependencies.push(rd);
         }
     }
@@ -1121,7 +1125,10 @@ fn load_gradle_script_properties(path: &Path, content: &str) -> HashMap<String, 
     ];
 
     for pattern in literal_assignment_patterns {
-        for captures in pattern.captures_iter(content).take(MAX_ITERATION_COUNT) {
+        for captures in pattern
+            .captures_iter(content)
+            .capped("gradle literal assignments")
+        {
             let Some(name) = captures.get(1).map(|value| value.as_str().trim()) else {
                 continue;
             };
@@ -1140,7 +1147,7 @@ fn load_gradle_script_properties(path: &Path, content: &str) -> HashMap<String, 
 
     for captures in delegated_project_property_pattern
         .captures_iter(content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("gradle delegated project properties")
     {
         let Some(name) = captures.get(1).map(|value| value.as_str().trim()) else {
             continue;
@@ -1165,7 +1172,7 @@ fn load_gradle_properties(path: &Path) -> HashMap<String, String> {
         };
 
         let mut properties = HashMap::new();
-        for line in content.lines().take(MAX_ITERATION_COUNT) {
+        for line in content.lines().capped("gradle.properties lines") {
             let trimmed = line.split('#').next().unwrap_or("").trim();
             if trimmed.is_empty() {
                 continue;
@@ -1305,7 +1312,11 @@ fn find_build_src_dir(path: &Path) -> Option<PathBuf> {
 fn find_nearby_sibling_build_src_tiers(path: &Path) -> Vec<Vec<PathBuf>> {
     let mut tiers = Vec::new();
 
-    for ancestor in path.ancestors().skip(1).take(MAX_ITERATION_COUNT) {
+    for ancestor in path
+        .ancestors()
+        .skip(1)
+        .capped("gradle sibling buildSrc ancestors")
+    {
         let sibling_dirs = collect_sibling_build_src_dirs(ancestor, path);
         if !sibling_dirs.is_empty() {
             tiers.push(sibling_dirs);
@@ -1325,7 +1336,7 @@ fn collect_sibling_build_src_dirs(ancestor: &Path, current_path: &Path) -> Vec<P
     };
 
     let mut build_src_dirs = Vec::new();
-    for entry in entries.flatten().take(MAX_ITERATION_COUNT) {
+    for entry in entries.flatten().capped("gradle sibling directory entries") {
         let child_dir = entry.path();
         if !child_dir.is_dir() || current_path.starts_with(&child_dir) {
             continue;
@@ -1351,10 +1362,16 @@ fn resolve_nearby_sibling_build_src_value(
     symbolic_ref: &str,
     sibling_build_src_tiers: &[Vec<PathBuf>],
 ) -> Option<String> {
-    for sibling_build_src_dirs in sibling_build_src_tiers.iter().take(MAX_ITERATION_COUNT) {
+    let tier_limit = capped_iteration_limit(
+        sibling_build_src_tiers.len(),
+        "gradle sibling buildSrc tiers",
+    );
+    for sibling_build_src_dirs in sibling_build_src_tiers.iter().take(tier_limit) {
         let mut resolved_value: Option<String> = None;
 
-        for build_src_dir in sibling_build_src_dirs.iter().take(MAX_ITERATION_COUNT) {
+        let dir_limit =
+            capped_iteration_limit(sibling_build_src_dirs.len(), "gradle sibling buildSrc dirs");
+        for build_src_dir in sibling_build_src_dirs.iter().take(dir_limit) {
             let Some(constants) = load_build_src_constants(build_src_dir) else {
                 continue;
             };
@@ -1414,7 +1431,8 @@ fn parse_build_src_constants_dir(build_src_dir: &Path) -> Option<BuildSrcConstMa
     }
 
     let mut constants = HashMap::new();
-    for file in kotlin_files.into_iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(kotlin_files.len(), "gradle buildSrc kotlin files");
+    for file in kotlin_files.into_iter().take(limit) {
         let Ok(content) = read_file_to_string(&file, None) else {
             continue;
         };
@@ -1433,7 +1451,10 @@ fn collect_build_src_kotlin_files(dir: &Path, files: &mut Vec<PathBuf>) {
         return;
     };
 
-    for entry in entries.flatten().take(MAX_ITERATION_COUNT) {
+    for entry in entries
+        .flatten()
+        .capped("gradle buildSrc directory entries")
+    {
         if files.len() >= MAX_ITERATION_COUNT {
             break;
         }
@@ -1739,7 +1760,7 @@ fn parse_gradle_version_catalog(
     let mut versions = std::collections::HashMap::new();
     let mut libraries = std::collections::HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("gradle version catalog lines") {
         let trimmed = line.split('#').next().unwrap_or("").trim();
         if trimmed.is_empty() {
             continue;
@@ -1768,7 +1789,12 @@ fn parse_gradle_version_catalog(
     }
 
     let mut result = std::collections::HashMap::new();
-    for (alias, raw_value) in libraries.into_iter().take(MAX_ITERATION_COUNT) {
+    // `libraries` is a std HashMap; sort by alias so truncation drops a
+    // deterministic set of entries when the cap is exceeded.
+    let mut libraries: Vec<(String, String)> = libraries.into_iter().collect();
+    libraries.sort_by(|a, b| a.0.cmp(&b.0));
+    let limit = capped_iteration_limit(libraries.len(), "gradle version catalog libraries");
+    for (alias, raw_value) in libraries.into_iter().take(limit) {
         let Some(entry) = parse_gradle_catalog_entry(&raw_value, &versions) else {
             continue;
         };
@@ -1801,7 +1827,7 @@ fn parse_gradle_catalog_entry(
 
     let inner = &raw_value[1..raw_value.len() - 1];
     let mut fields = std::collections::HashMap::new();
-    for pair in inner.split(',').take(MAX_ITERATION_COUNT) {
+    for pair in inner.split(',').capped("gradle catalog entry fields") {
         let Some((key, value)) = pair.split_once('=') else {
             continue;
         };

--- a/src/parsers/gradle_lock.rs
+++ b/src/parsers/gradle_lock.rs
@@ -29,7 +29,7 @@ use std::path::Path;
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 /// Gradle gradle.lockfile parser.
 ///
@@ -119,7 +119,7 @@ impl PackageParser for GradleLockfileParser {
 fn extract_dependencies(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("gradle.lockfile lines") {
         let line = line.trim();
 
         // Skip empty lines and comments

--- a/src/parsers/gradle_module.rs
+++ b/src/parsers/gradle_module.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::{Map as JsonMap, Value};
 
@@ -267,7 +267,7 @@ fn extract_variant_data(
         .into_iter()
         .flatten()
         .filter_map(Value::as_object)
-        .take(MAX_ITERATION_COUNT)
+        .capped(".module variants")
     {
         let category = variant
             .get(FIELD_ATTRIBUTES)
@@ -311,7 +311,7 @@ fn extract_variant_data(
             for file in files
                 .iter()
                 .filter_map(Value::as_object)
-                .take(MAX_ITERATION_COUNT)
+                .capped(".module variant files")
             {
                 let artifact_score =
                     score_top_level_artifact(file, module_name, version, scope.as_deref());
@@ -362,7 +362,7 @@ fn extract_variant_data(
             .into_iter()
             .flatten()
             .filter_map(Value::as_object)
-            .take(MAX_ITERATION_COUNT)
+            .capped(".module variant dependencies")
         {
             let Some(group) = dependency.get("group").and_then(Value::as_str) else {
                 continue;

--- a/src/parsers/hackage.rs
+++ b/src/parsers/hackage.rs
@@ -11,7 +11,8 @@ use yaml_serde::{Mapping, Value as YamlValue};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string,
+    split_name_email, truncate_field,
 };
 
 use super::PackageParser;
@@ -320,7 +321,9 @@ fn parse_cabal_project(content: &str) -> PackageData {
         source_repo_entries.push(entry);
     }
 
-    for entry in source_repo_entries.into_iter().take(MAX_ITERATION_COUNT) {
+    let limit =
+        capped_iteration_limit(source_repo_entries.len(), "cabal source-repository entries");
+    for entry in source_repo_entries.into_iter().take(limit) {
         dependencies.push(build_source_repository_dependency(entry));
     }
 
@@ -358,7 +361,7 @@ fn parse_stack_yaml(yaml: &YamlValue) -> PackageData {
         dependencies.extend(parse_stack_extra_dep_entries(extra_deps));
     }
 
-    for (key, value) in mapping.iter().take(MAX_ITERATION_COUNT) {
+    for (key, value) in mapping.iter().capped("stack.yaml top-level keys") {
         let Some(key) = key.as_str() else {
             continue;
         };
@@ -533,7 +536,7 @@ fn parse_stack_package_entries(value: &YamlValue) -> Vec<Dependency> {
 
     sequence
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("stack.yaml packages")
         .filter_map(|entry| match entry {
             YamlValue::String(path) => {
                 let mut extra_data = HashMap::new();
@@ -585,7 +588,7 @@ fn parse_stack_extra_dep_entries(value: &YamlValue) -> Vec<Dependency> {
 
     sequence
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("stack.yaml extra-deps")
         .filter_map(|entry| match entry {
             YamlValue::String(spec) => parse_stack_extra_dep_string(spec),
             YamlValue::Mapping(map) => Some(parse_stack_extra_dep_mapping(map, entry)),
@@ -856,7 +859,7 @@ fn split_dependency_entries(value: &str) -> Vec<String> {
     let mut brace_depth = 0usize;
     let mut bracket_depth = 0usize;
 
-    for character in value.chars().take(MAX_ITERATION_COUNT) {
+    for character in value.chars().capped("cabal dependency entry characters") {
         match character {
             '(' => paren_depth += 1,
             ')' => paren_depth = paren_depth.saturating_sub(1),
@@ -889,7 +892,7 @@ fn split_dependency_entries(value: &str) -> Vec<String> {
 fn split_multiline_entries(value: &str) -> Vec<String> {
     value
         .lines()
-        .take(MAX_ITERATION_COUNT)
+        .capped("cabal multiline entries")
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(|line| line.strip_prefix("-").unwrap_or(line).trim().to_string())

--- a/src/parsers/haxe.rs
+++ b/src/parsers/haxe.rs
@@ -34,7 +34,7 @@ use super::license_normalization::{
     empty_declared_license_data,
 };
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field};
 
 /// Haxe package manifest (haxelib.json) parser.
 ///
@@ -93,16 +93,15 @@ impl PackageParser for HaxeParser {
                 (None, None, None)
             };
 
-        // Extract dependencies (maintain insertion order by sorting)
+        // Extract dependencies (maintain insertion order by sorting).
+        // `dependencies` is a std HashMap; sort before capping so truncation
+        // drops a deterministic set of entries when the cap is exceeded.
         let mut dependencies = Vec::new();
-        let mut deps_list: Vec<_> = json_content
-            .dependencies
-            .into_iter()
-            .take(MAX_ITERATION_COUNT)
-            .collect();
+        let mut deps_list: Vec<_> = json_content.dependencies.into_iter().collect();
         deps_list.sort_by(|a, b| a.0.cmp(&b.0));
+        let deps_limit = capped_iteration_limit(deps_list.len(), "haxelib.json dependencies");
 
-        for (dep_name, dep_version) in deps_list {
+        for (dep_name, dep_version) in deps_list.into_iter().take(deps_limit) {
             let is_pinned = !dep_version.is_empty();
             let dep_purl = create_dep_package_url(&dep_name, &dep_version, is_pinned);
 
@@ -124,7 +123,7 @@ impl PackageParser for HaxeParser {
         for contrib in json_content
             .contributors
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .capped("haxelib.json contributors")
         {
             parties.push(Party {
                 r#type: Some(PartyType::Person),
@@ -152,7 +151,7 @@ impl PackageParser for HaxeParser {
             keywords: json_content
                 .tags
                 .into_iter()
-                .take(MAX_ITERATION_COUNT)
+                .capped("haxelib.json tags")
                 .map(truncate_field)
                 .collect(),
             homepage_url: json_content.url.map(truncate_field),

--- a/src/parsers/haxe_test.rs
+++ b/src/parsers/haxe_test.rs
@@ -222,4 +222,50 @@ mod tests {
         assert_eq!(package_data.package_type, Some(PackageType::Haxe));
         assert!(package_data.name.is_none());
     }
+
+    #[test]
+    fn test_dependencies_emitted_in_deterministic_sorted_order() {
+        // `dependencies` is a std HashMap upstream, so iteration order is
+        // nondeterministic. The parser sorts by name before capping/emitting so
+        // output order (and which entries survive truncation) is reproducible.
+        let content = r#"{
+            "name": "ordered",
+            "version": "1.0.0",
+            "dependencies": {
+                "zeta": "",
+                "alpha": "1.0.0",
+                "mu": "",
+                "beta": "2.0.0"
+            }
+        }"#;
+
+        let (_temp_dir, haxelib_path) = create_temp_haxelib_json(content);
+
+        let purls_for_run = || {
+            HaxeParser::extract_first_package(&haxelib_path)
+                .dependencies
+                .into_iter()
+                .map(|dep| dep.purl)
+                .collect::<Vec<_>>()
+        };
+
+        let first = purls_for_run();
+        let second = purls_for_run();
+
+        // Reproducible across runs.
+        assert_eq!(first, second);
+        // And sorted by dependency name (alpha, beta, mu, zeta).
+        let names: Vec<String> = first
+            .iter()
+            .filter_map(|purl| purl.as_ref())
+            .map(|purl| {
+                purl.trim_start_matches("pkg:haxe/")
+                    .split(['@', '?'])
+                    .next()
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(names, vec!["alpha", "beta", "mu", "zeta"]);
+    }
 }

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 use yaml_serde::{Mapping, Value};
@@ -166,7 +166,7 @@ fn extract_chart_yaml_dependencies(yaml_content: &Value) -> Vec<Dependency> {
 
     entries
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("Chart.yaml dependencies")
         .filter_map(Value::as_mapping)
         .filter_map(parse_chart_yaml_dependency)
         .collect()
@@ -231,7 +231,7 @@ fn extract_chart_lock_dependencies(yaml_content: &Value) -> Vec<Dependency> {
 
     entries
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("Chart.lock dependencies")
         .filter_map(Value::as_mapping)
         .filter_map(parse_chart_lock_dependency)
         .collect()
@@ -292,7 +292,7 @@ fn extract_maintainers(yaml_content: &Value) -> Vec<Party> {
 
     maintainers
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("Chart.yaml maintainers")
         .filter_map(Value::as_mapping)
         .filter_map(|mapping| {
             let name = mapping_get(mapping, "name").and_then(yaml_value_to_string)?;
@@ -328,7 +328,7 @@ fn extract_string_values(value: &Value) -> Vec<String> {
         Value::String(value) => vec![truncate_field(value.clone())],
         Value::Sequence(values) => values
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .capped("Chart.yaml string list field")
             .filter_map(yaml_value_to_string)
             .collect(),
         _ => Vec::new(),

--- a/src/parsers/hex_lock.rs
+++ b/src/parsers/hex_lock.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
@@ -98,7 +99,8 @@ fn parse_mix_lock(content: &str) -> Result<PackageData, String> {
     };
 
     let mut dependencies = Vec::new();
-    for (key, value) in entries.into_iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(entries.len(), "mix.lock entries");
+    for (key, value) in entries.into_iter().take(limit) {
         if let Some(dep) = build_dependency_from_lock_entry(&key, &value)? {
             dependencies.push(dep);
         }
@@ -256,7 +258,8 @@ fn term_to_dependency_tuples(term: &Term) -> Result<Vec<DependencyTuple>, String
     };
 
     let mut result = Vec::new();
-    for item in items.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(items.len(), "mix.lock dependency tuples");
+    for item in items.iter().take(limit) {
         let tuple = match item {
             Term::Tuple(items) if items.len() == 3 => items,
             _ => continue,

--- a/src/parsers/huggingface.rs
+++ b/src/parsers/huggingface.rs
@@ -42,7 +42,7 @@ use crate::parser_warn as warn;
 
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 /// Parser for a Hugging Face model-card `README.md` (YAML frontmatter).
 pub struct HuggingfaceModelCardParser;
@@ -493,7 +493,7 @@ fn parse_config(json: &JsonValue, datasource_id: DatasourceId) -> PackageData {
     if let Some(architectures) = json.get("architectures").and_then(JsonValue::as_array) {
         let values: Vec<serde_json::Value> = architectures
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .capped("config.json architectures")
             .filter_map(|value| value.as_str())
             .map(|value| serde_json::Value::String(truncate_field(value.to_string())))
             .collect();
@@ -542,7 +542,7 @@ fn collect_string_seq(value: Option<&yaml_serde::Value>) -> Vec<String> {
             .as_sequence()
             .into_iter()
             .flatten()
-            .take(MAX_ITERATION_COUNT)
+            .capped("model card string sequence")
             .filter_map(yaml_serde::Value::as_str)
             .map(str::trim)
             .filter(|entry| !entry.is_empty())

--- a/src/parsers/julia.rs
+++ b/src/parsers/julia.rs
@@ -25,7 +25,7 @@
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    RecursionGuard, capped_iteration_limit, read_file_to_string, truncate_field,
 };
 use packageurl::PackageUrl;
 use std::path::Path;
@@ -269,7 +269,8 @@ fn extract_parties(toml_content: &Value) -> Vec<Party> {
     let mut seen = HashSet::new();
 
     if let Some(authors) = toml_content.get(FIELD_AUTHORS).and_then(|v| v.as_array()) {
-        for author in authors.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(authors.len(), "Julia authors field");
+        for author in authors.iter().take(limit) {
             push_author_party(author, &mut parties, &mut seen);
         }
     }
@@ -277,7 +278,8 @@ fn extract_parties(toml_content: &Value) -> Vec<Party> {
     if let Some(author_value) = toml_content.get(FIELD_AUTHOR) {
         match author_value {
             Value::Array(authors) => {
-                for author in authors.iter().take(MAX_ITERATION_COUNT) {
+                let limit = capped_iteration_limit(authors.len(), "Julia author field");
+                for author in authors.iter().take(limit) {
                     push_author_party(author, &mut parties, &mut seen);
                 }
             }
@@ -324,7 +326,8 @@ fn extract_project_dependencies(toml_content: &Value) -> Vec<Dependency> {
 
     let compat_table = toml_content.get(FIELD_COMPAT).and_then(|v| v.as_table());
 
-    for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(deps_table.len(), "Project.toml deps");
+    for (dep_name, dep_value) in deps_table.iter().take(limit) {
         let uuid = dep_value.as_str().map(String::from);
 
         let extracted_requirement = compat_table
@@ -381,13 +384,15 @@ fn extract_manifest_packages(toml_content: &Value) -> Vec<PackageData> {
         },
     };
 
-    for (dep_name, dep_value) in deps_table.iter().take(MAX_ITERATION_COUNT) {
+    let table_limit = capped_iteration_limit(deps_table.len(), "Manifest.toml deps");
+    for (dep_name, dep_value) in deps_table.iter().take(table_limit) {
         let dep_entries = match dep_value.as_array() {
             Some(entries) => entries,
             None => continue,
         };
 
-        for dep_entry in dep_entries.iter().take(MAX_ITERATION_COUNT) {
+        let entry_limit = capped_iteration_limit(dep_entries.len(), "Manifest.toml dep entries");
+        for dep_entry in dep_entries.iter().take(entry_limit) {
             let name = Some(truncate_field(dep_name.clone()));
 
             let uuid = dep_entry

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 
 use crate::parser_warn as warn;
 use crate::parsers::active_parser_license_engine;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard};
+use crate::parsers::utils::{RecursionGuard, capped_iteration_limit};
 
 use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::expression::{
@@ -846,7 +846,11 @@ fn collect_reference_strings(value: Option<&serde_json::Value>, references: &mut
         }
         serde_json::Value::String(_) => {}
         serde_json::Value::Array(values) => {
-            for value in values.iter().take(MAX_ITERATION_COUNT) {
+            let limit = capped_iteration_limit(
+                values.len(),
+                "license_normalization: declared license reference array",
+            );
+            for value in values.iter().take(limit) {
                 if let Some(value) = value.as_str().filter(|value| !value.trim().is_empty()) {
                     references.push(value.trim().to_string());
                 }

--- a/src/parsers/maven/manifest.rs
+++ b/src/parsers/maven/manifest.rs
@@ -7,7 +7,7 @@ use super::coordinates::{build_maven_purl, infer_meta_inf_maven_coordinates};
 use super::default_package_data;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -265,10 +265,12 @@ pub(crate) fn interpret_manifest_mf(content: &str, path: &Path) -> PackageData {
 pub(super) fn parse_osgi_package_list(package_list: &str, scope: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for package_entry in split_osgi_list(package_list)
-        .into_iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let package_entries = split_osgi_list(package_list);
+    let limit = capped_iteration_limit(
+        package_entries.len(),
+        "maven manifest: OSGi Import-Package entries",
+    );
+    for package_entry in package_entries.into_iter().take(limit) {
         let package_entry = package_entry.trim();
         if package_entry.is_empty() {
             continue;
@@ -307,10 +309,12 @@ pub(super) fn parse_osgi_package_list(package_list: &str, scope: &str) -> Vec<De
 pub(super) fn parse_osgi_bundle_list(bundle_list: &str, scope: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for bundle_entry in split_osgi_list(bundle_list)
-        .into_iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let bundle_entries = split_osgi_list(bundle_list);
+    let limit = capped_iteration_limit(
+        bundle_entries.len(),
+        "maven manifest: OSGi Require-Bundle entries",
+    );
+    for bundle_entry in bundle_entries.into_iter().take(limit) {
         let bundle_entry = bundle_entry.trim();
         if bundle_entry.is_empty() {
             continue;

--- a/src/parsers/meson.rs
+++ b/src/parsers/meson.rs
@@ -13,7 +13,10 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field};
+use super::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
+};
 
 pub struct MesonParser;
 
@@ -59,7 +62,8 @@ fn parse_meson_build(content: &str) -> Result<PackageData, String> {
     let mut dependencies = Vec::new();
     let mut control_flow_depth = 0usize;
 
-    for statement in statements.into_iter().take(MAX_ITERATION_COUNT) {
+    let statement_limit = capped_iteration_limit(statements.len(), "meson: top-level statements");
+    for statement in statements.into_iter().take(statement_limit) {
         let trimmed = statement.trim();
         if trimmed.is_empty() {
             continue;
@@ -210,9 +214,11 @@ fn extract_dependencies_from_call(call: &CallExpr) -> Vec<Dependency> {
     let required = call.keyword.get("required").and_then(expr_as_bool);
     let native = call.keyword.get("native").and_then(expr_as_bool);
 
+    let dependency_limit =
+        capped_iteration_limit(dependency_names.len(), "meson: dependency() names");
     dependency_names
         .into_iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(dependency_limit)
         .map(|name| {
             let mut extra_data = HashMap::new();
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -342,7 +342,7 @@ use crate::models::{DiagnosticSeverity, PackageData, PackageType, ScanDiagnostic
 use crate::parsers::license_normalization::{
     finalize_package_declared_license_references, populate_declared_license_and_holder,
 };
-use crate::parsers::utils::MAX_ITERATION_COUNT;
+use crate::parsers::utils::CappedIterExt;
 
 thread_local! {
     static PARSER_DIAGNOSTIC_STACK: RefCell<Vec<Vec<ScanDiagnostic>>> = const { RefCell::new(Vec::new()) };
@@ -390,7 +390,7 @@ where
                 finalize_package_declared_license_references(&mut package);
                 package
             })
-            .take(MAX_ITERATION_COUNT)
+            .capped("packages emitted by parser")
             .collect::<Vec<_>>()
     }));
     PARSER_LICENSE_ENGINE_STACK.with(|stack| {

--- a/src/parsers/nix.rs
+++ b/src/parsers/nix.rs
@@ -10,7 +10,8 @@ use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 
 use super::PackageParser;
@@ -924,9 +925,11 @@ fn parse_flake_lock(path: &Path, json: &JsonValue) -> Result<PackageData, String
     extra_data.insert("root".to_string(), JsonValue::String(root.to_string()));
     package.extra_data = Some(extra_data);
 
+    let root_inputs_limit =
+        capped_iteration_limit(root_inputs.len(), "nix: flake.lock root inputs");
     package.dependencies = root_inputs
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(root_inputs_limit)
         .filter_map(|(input_name, node_ref)| build_lock_dependency(input_name, node_ref, nodes))
         .collect();
     package
@@ -1194,9 +1197,10 @@ fn build_list_dependencies(
         return Vec::new();
     };
 
+    let items_limit = capped_iteration_limit(items.len(), "nix: dependency list items");
     items
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(items_limit)
         .flat_map(|expr| {
             expr_to_dependency_symbols_with_scopes(expr, scopes, &mut RecursionGuard::depth_only())
         })

--- a/src/parsers/npm.rs
+++ b/src/parsers/npm.rs
@@ -28,7 +28,9 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, npm_purl, parse_sri, truncate_field,
+};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
@@ -255,7 +257,11 @@ fn read_and_parse_json_with_lines(path: &Path) -> Result<(Value, HashMap<String,
 
     // Track line numbers for each field by iterating over lines
     let mut field_lines = HashMap::new();
-    for (line_num, line) in content.lines().enumerate().take(MAX_ITERATION_COUNT) {
+    for (line_num, line) in content
+        .lines()
+        .enumerate()
+        .capped("npm: package.json field line tracking")
+    {
         let trimmed = line.trim();
         if let Some(field_name) = extract_field_name(trimmed) {
             field_lines.insert(field_name, line_num + 1);
@@ -340,7 +346,8 @@ fn extract_license_statement(json: &Value) -> Option<String> {
     }
 
     if let Some(licenses) = json.get(FIELD_LICENSES).and_then(|v| v.as_array()) {
-        for license in licenses.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(licenses.len(), "npm: licenses array");
+        for license in licenses.iter().take(limit) {
             if let Some(license_obj) = license.as_object()
                 && let Some(type_val) = license_obj.get("type").and_then(|v| v.as_str())
             {
@@ -595,9 +602,10 @@ fn extract_party_from_field(field: &Value) -> Option<Party> {
 /// Extracts multiple parties from a JSON array.
 fn extract_parties_from_array(array: &Value) -> Option<Vec<Party>> {
     if let Value::Array(items) = array {
+        let limit = capped_iteration_limit(items.len(), "npm: parties array");
         let parties = items
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(limit)
             .filter_map(extract_party_from_field)
             .collect::<Vec<_>>();
         if !parties.is_empty() {
@@ -736,8 +744,9 @@ fn extract_dependency_group(
     json.get(field)
         .and_then(|deps| deps.as_object())
         .map_or_else(Vec::new, |deps| {
+            let limit = capped_iteration_limit(deps.len(), "npm: dependency group");
             deps.iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|(name, version)| {
                     let version_str = version.as_str()?;
 
@@ -847,9 +856,10 @@ fn extract_bundled_dependencies(json: &Value) -> Vec<Dependency> {
 
 /// Helper function to extract bundled dependencies from an array of package names.
 fn extract_bundled_list(bundled_array: &[Value]) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(bundled_array.len(), "npm: bundled dependencies");
     bundled_array
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|value| {
             let name = value.as_str()?;
             // Create PURL without version for bundled dependencies
@@ -889,9 +899,10 @@ fn extract_peer_dependencies_meta(json: &Value) -> HashMap<String, bool> {
     json.get(FIELD_PEER_DEPENDENCIES_META)
         .and_then(|meta| meta.as_object())
         .map_or_else(HashMap::new, |meta_obj| {
+            let limit = capped_iteration_limit(meta_obj.len(), "npm: peerDependenciesMeta");
             meta_obj
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|(package_name, meta_value)| {
                     meta_value.as_object().and_then(|obj| {
                         obj.get("optional")
@@ -949,9 +960,10 @@ fn extract_keywords_as_vec(json: &Value) -> Vec<String> {
             if let Some(str) = v.as_str() {
                 Some(vec![str.to_string()])
             } else if let Some(arr) = v.as_array() {
+                let limit = capped_iteration_limit(arr.len(), "npm: keywords array");
                 let keywords: Vec<String> = arr
                     .iter()
-                    .take(MAX_ITERATION_COUNT)
+                    .take(limit)
                     .filter_map(|kw| kw.as_str())
                     .map(|s| truncate_field(s.to_string()))
                     .collect();

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -29,7 +29,7 @@ use crate::models::{
 };
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, npm_purl, parse_sri,
+    MAX_RECURSION_DEPTH, RecursionGuard, capped_iteration_limit, npm_purl, parse_sri,
     read_file_to_string, truncate_field,
 };
 use serde_json::Value;
@@ -178,12 +178,15 @@ fn parse_lockfile_v2_plus(
 
     // Root dependencies are in top-level "dependencies" and "devDependencies"
     if let Some(root_deps_obj) = json.get(FIELD_DEPENDENCIES).and_then(|v| v.as_object()) {
-        for key in root_deps_obj.keys().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(root_deps_obj.len(), "npm lock: root dependencies");
+        for key in root_deps_obj.keys().take(limit) {
             root_deps.insert(key.clone());
         }
     }
     if let Some(root_dev_deps_obj) = json.get("devDependencies").and_then(|v| v.as_object()) {
-        for key in root_dev_deps_obj.keys().take(MAX_ITERATION_COUNT) {
+        let limit =
+            capped_iteration_limit(root_dev_deps_obj.len(), "npm lock: root devDependencies");
+        for key in root_dev_deps_obj.keys().take(limit) {
             root_deps.insert(key.clone());
         }
     }
@@ -195,7 +198,9 @@ fn parse_lockfile_v2_plus(
 
     let mut dependencies = Vec::new();
 
-    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    let packages_limit =
+        capped_iteration_limit(packages.len(), "npm lock: lockfile v2/v3 packages");
+    for (key, value) in packages.iter().take(packages_limit) {
         // Skip the root package (empty string key)
         if key.is_empty() {
             continue;
@@ -336,7 +341,9 @@ fn collect_linked_workspace_names(
 ) -> HashMap<String, String> {
     let mut linked_names = HashMap::new();
 
-    for (key, value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    let packages_limit =
+        capped_iteration_limit(packages.len(), "npm lock: linked workspace packages");
+    for (key, value) in packages.iter().take(packages_limit) {
         let is_link = value
             .get(FIELD_LINK)
             .and_then(|v| v.as_bool())
@@ -450,7 +457,8 @@ fn parse_dependencies_v1_with_depth(
 
     let mut dependencies = Vec::new();
 
-    for (package_name, dep_data) in dependencies_obj.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(dependencies_obj.len(), "npm lock: v1 dependencies");
+    for (package_name, dep_data) in dependencies_obj.iter().take(limit) {
         let version = match dep_data.get(FIELD_VERSION).and_then(|v| v.as_str()) {
             Some(v) => truncate_field(v.to_string()),
             None => continue,
@@ -646,9 +654,10 @@ fn extract_package_license(value: &Value) -> Option<String> {
     }
 
     if let Some(licenses) = value.get(FIELD_LICENSES).and_then(|v| v.as_array()) {
+        let limit = capped_iteration_limit(licenses.len(), "npm lock: package licenses array");
         let types: Vec<String> = licenses
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(limit)
             .filter_map(|entry| entry.get("type").and_then(|v| v.as_str()))
             .filter_map(non_empty_string)
             .collect();
@@ -680,7 +689,8 @@ fn collect_root_dependency_names(
     root_deps: &mut std::collections::HashSet<String>,
 ) {
     if let Some(entries) = value.and_then(|value| value.as_object()) {
-        for key in entries.keys().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(entries.len(), "npm lock: root dependency name section");
+        for key in entries.keys().take(limit) {
             root_deps.insert(key.clone());
         }
     }

--- a/src/parsers/npm_workspace.rs
+++ b/src/parsers/npm_workspace.rs
@@ -24,7 +24,7 @@
 use crate::models::PackageData;
 use crate::models::{DatasourceId, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use std::path::Path;
 use yaml_serde::Value;
 
@@ -93,9 +93,13 @@ fn parse_workspace_file(workspace_data: &Value) -> PackageData {
 
     match workspaces {
         Some(workspace_patterns) => {
+            let limit = capped_iteration_limit(
+                workspace_patterns.len(),
+                "pnpm workspace: packages patterns",
+            );
             let workspaces_vec: Vec<String> = workspace_patterns
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(|v| v.as_str())
                 .map(|s| truncate_field(s.to_string()))
                 .collect();

--- a/src/parsers/nuget/deps_json.rs
+++ b/src/parsers/nuget/deps_json.rs
@@ -7,7 +7,7 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
 
 use super::super::PackageParser;
-use super::super::utils::{MAX_ITERATION_COUNT, read_file_to_string};
+use super::super::utils::{capped_iteration_limit, read_file_to_string};
 use super::{build_nuget_purl, build_nuget_urls, default_package_data};
 
 pub struct DotNetDepsJsonParser;
@@ -73,16 +73,8 @@ fn parse_dotnet_deps_json(parsed: &serde_json::Value, path: &Path) -> PackageDat
         .unwrap_or_default();
 
     let mut dependencies = Vec::new();
-    let mut iteration_count: usize = 0;
-    for (library_key, target_entry) in selected_target.iter().take(MAX_ITERATION_COUNT) {
-        iteration_count += 1;
-        if iteration_count > MAX_ITERATION_COUNT {
-            warn!(
-                "Iteration limit exceeded in .deps.json at {:?}; stopping at {} dependencies",
-                path, MAX_ITERATION_COUNT
-            );
-            break;
-        }
+    let limit = capped_iteration_limit(selected_target.len(), "nuget .deps.json: target libraries");
+    for (library_key, target_entry) in selected_target.iter().take(limit) {
         if root_key.as_deref() == Some(library_key.as_str()) {
             continue;
         }

--- a/src/parsers/nuget/packages_lock.rs
+++ b/src/parsers/nuget/packages_lock.rs
@@ -10,7 +10,7 @@ use crate::parser_warn as warn;
 use packageurl::PackageUrl;
 
 use super::super::PackageParser;
-use super::super::utils::{MAX_ITERATION_COUNT, read_file_to_string};
+use super::super::utils::{capped_iteration_limit, read_file_to_string};
 use super::default_package_data;
 
 pub struct PackagesLockParser;
@@ -42,22 +42,19 @@ impl PackageParser for PackagesLockParser {
         };
 
         let mut dependencies = Vec::new();
-        let mut iteration_count: usize = 0;
 
         if let Some(deps_obj) = parsed.get("dependencies").and_then(|v| v.as_object()) {
-            for (target_framework, packages) in deps_obj.iter().take(MAX_ITERATION_COUNT) {
+            let framework_limit = capped_iteration_limit(
+                deps_obj.len(),
+                "nuget packages.lock.json: target frameworks",
+            );
+            for (target_framework, packages) in deps_obj.iter().take(framework_limit) {
                 if let Some(packages_obj) = packages.as_object() {
-                    for (package_name, package_info) in
-                        packages_obj.iter().take(MAX_ITERATION_COUNT)
-                    {
-                        iteration_count += 1;
-                        if iteration_count > MAX_ITERATION_COUNT {
-                            warn!(
-                                "Iteration limit exceeded in packages.lock.json at {:?}; stopping at {} dependencies",
-                                path, MAX_ITERATION_COUNT
-                            );
-                            break;
-                        }
+                    let package_limit = capped_iteration_limit(
+                        packages_obj.len(),
+                        "nuget packages.lock.json: framework packages",
+                    );
+                    for (package_name, package_info) in packages_obj.iter().take(package_limit) {
                         if let Some(info_obj) = package_info.as_object() {
                             let version = info_obj
                                 .get("resolved")

--- a/src/parsers/nuget/project_json.rs
+++ b/src/parsers/nuget/project_json.rs
@@ -8,7 +8,7 @@ use crate::parser_warn as warn;
 use crate::utils::text::strip_utf8_bom_str;
 
 use super::super::PackageParser;
-use super::super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use super::{
     build_nuget_party, build_nuget_purl, build_nuget_urls, default_package_data,
     insert_extra_string,
@@ -179,7 +179,9 @@ fn parse_project_json_manifest(parsed: &serde_json::Value) -> PackageData {
         .get("dependencies")
         .and_then(|value| value.as_object())
     {
-        for (dependency_name, dependency_spec) in root_dependencies.iter().take(MAX_ITERATION_COUNT)
+        for (dependency_name, dependency_spec) in root_dependencies
+            .iter()
+            .capped("project.json root dependencies")
         {
             if let Some(dependency) =
                 parse_project_json_dependency(dependency_name, dependency_spec, None)
@@ -190,7 +192,7 @@ fn parse_project_json_manifest(parsed: &serde_json::Value) -> PackageData {
     }
 
     if let Some(frameworks) = parsed.get("frameworks").and_then(|value| value.as_object()) {
-        for (framework, framework_value) in frameworks.iter().take(MAX_ITERATION_COUNT) {
+        for (framework, framework_value) in frameworks.iter().capped("project.json frameworks") {
             let Some(framework_dependencies) = framework_value
                 .get("dependencies")
                 .and_then(|value| value.as_object())
@@ -198,8 +200,9 @@ fn parse_project_json_manifest(parsed: &serde_json::Value) -> PackageData {
                 continue;
             };
 
-            for (dependency_name, dependency_spec) in
-                framework_dependencies.iter().take(MAX_ITERATION_COUNT)
+            for (dependency_name, dependency_spec) in framework_dependencies
+                .iter()
+                .capped("project.json framework dependencies")
             {
                 if let Some(dependency) = parse_project_json_dependency(
                     dependency_name,
@@ -316,14 +319,14 @@ fn parse_project_lock_manifest(parsed: &serde_json::Value) -> PackageData {
         .get("projectFileDependencyGroups")
         .and_then(|value| value.as_object())
     {
-        for (framework, entries) in groups.iter().take(MAX_ITERATION_COUNT) {
+        for (framework, entries) in groups.iter().capped("project.lock dependency groups") {
             let Some(entries) = entries.as_array() else {
                 continue;
             };
 
             for entry in entries
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .capped("project.lock group entries")
                 .filter_map(|value| value.as_str())
             {
                 if let Some(dependency) = parse_project_lock_dependency(

--- a/src/parsers/oci.rs
+++ b/src/parsers/oci.rs
@@ -31,7 +31,9 @@ use serde_json::json;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -217,7 +219,8 @@ fn collect_index_packages(
     depth: usize,
     packages: &mut Vec<PackageData>,
 ) {
-    for descriptor in index.manifests.into_iter().take(MAX_ITERATION_COUNT) {
+    let manifest_limit = capped_iteration_limit(index.manifests.len(), "OCI image index manifests");
+    for descriptor in index.manifests.into_iter().take(manifest_limit) {
         if packages.len() >= MAX_ITERATION_COUNT {
             break;
         }
@@ -453,9 +456,10 @@ fn parse_docker_save_manifest(content: &str) -> Vec<PackageData> {
         }
     };
 
+    let entry_limit = capped_iteration_limit(entries.len(), "docker save manifest entries");
     entries
         .into_iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(entry_limit)
         .filter_map(package_from_docker_save_entry)
         .collect()
 }

--- a/src/parsers/os_release.rs
+++ b/src/parsers/os_release.rs
@@ -35,7 +35,7 @@ use crate::models::PackageData;
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 const PACKAGE_TYPE: PackageType = PackageType::LinuxDistro;
 
@@ -149,7 +149,7 @@ fn determine_namespace_and_name<'a>(
 fn parse_key_value_pairs(content: &str) -> HashMap<String, String> {
     let mut fields = HashMap::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("os-release lines") {
         let line = line.trim();
 
         // Skip empty lines and comments

--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_FIELD_LENGTH, MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{CappedIterExt, MAX_FIELD_LENGTH, truncate_field};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Pep508Requirement {
@@ -92,7 +92,7 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
     }
 
     let mut name_end = trimmed.len();
-    for (idx, ch) in trimmed.char_indices().take(MAX_ITERATION_COUNT) {
+    for (idx, ch) in trimmed.char_indices().capped("pep508 name characters") {
         if ch == '[' || ch.is_whitespace() || matches!(ch, '<' | '>' | '=' | '!' | '~' | ';') {
             name_end = idx;
             break;
@@ -114,7 +114,7 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
         let extras_str = &rest_trimmed[1..close_idx];
         extras = extras_str
             .split(',')
-            .take(MAX_ITERATION_COUNT)
+            .capped("pep508 extras")
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
             .map(|value| truncate_field(value.to_string()))

--- a/src/parsers/pip_inspect_deplock.rs
+++ b/src/parsers/pip_inspect_deplock.rs
@@ -41,7 +41,7 @@ use super::python::PythonParser;
 #[cfg(test)]
 use super::python::extract_requires_dist_dependencies;
 #[cfg(test)]
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{CappedIterExt, truncate_field};
 
 const PACKAGE_TYPE: PackageType = PackageType::Pypi;
 
@@ -125,7 +125,7 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
     // Find the main package (has direct_url and is_requested)
     let main_package = installed_packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pip inspect installed packages")
         .find(|p| p.requested.unwrap_or(false) && p.direct_url.is_some());
 
     let metadata = if let Some(pkg) = main_package {
@@ -134,7 +134,7 @@ pub(crate) fn parse_pip_inspect_deplock(content: &str) -> PackageData {
         // If no main package found, try to find any requested package
         installed_packages
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .capped("pip inspect installed packages")
             .find(|p| p.requested.unwrap_or(false))
             .and_then(|p| p.metadata.as_ref())
     };

--- a/src/parsers/pipfile_lock.rs
+++ b/src/parsers/pipfile_lock.rs
@@ -35,7 +35,7 @@ use toml::map::Map as TomlMap;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Sha256Digest};
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -149,7 +149,7 @@ fn extract_lockfile_dependencies(
         .get(section)
         .and_then(|value| value.as_object())
     {
-        for (name, value) in section_map.iter().take(MAX_ITERATION_COUNT) {
+        for (name, value) in section_map.iter().capped("Pipfile.lock section packages") {
             if let Some(dependency) = build_lockfile_dependency(name, value, scope, is_runtime) {
                 dependencies.push(dependency);
             }
@@ -286,7 +286,7 @@ fn extract_pipfile_dependencies(
 ) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for (name, value) in packages.iter().take(MAX_ITERATION_COUNT) {
+    for (name, value) in packages.iter().capped("Pipfile packages") {
         if let Some(dependency) = build_pipfile_dependency(name, value, scope, is_runtime) {
             dependencies.push(dependency);
         }

--- a/src/parsers/pixi.rs
+++ b/src/parsers/pixi.rs
@@ -13,9 +13,7 @@ use toml::map::Map as TomlMap;
 use crate::models::{DatasourceId, Dependency, FileReference, PackageData, PackageType, Party};
 use crate::parsers::conda::build_purl as build_conda_purl;
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
-};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, split_name_email, truncate_field};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -213,7 +211,7 @@ fn extract_authors(identity: Option<&TomlMap<String, TomlValue>>) -> Vec<Party> 
         .and_then(TomlValue::as_array)
         .into_iter()
         .flatten()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pixi authors")
         .filter_map(TomlValue::as_str)
         .map(|author| {
             let (name, email) = split_name_email(author);
@@ -296,7 +294,7 @@ fn extract_manifest_dependencies(toml_content: &TomlValue) -> Vec<Dependency> {
         .get(FIELD_FEATURE)
         .and_then(TomlValue::as_table)
     {
-        for (feature_name, value) in feature_table.iter().take(MAX_ITERATION_COUNT) {
+        for (feature_name, value) in feature_table.iter().capped("pixi features") {
             let Some(feature) = value.as_table() else {
                 continue;
             };
@@ -325,7 +323,7 @@ fn extract_conda_dependencies(
 ) -> Vec<Dependency> {
     table
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pixi conda dependencies")
         .filter_map(|(name, value)| build_conda_dependency(name, value, scope, optional))
         .collect()
 }
@@ -406,7 +404,7 @@ fn extract_pypi_dependencies(
 ) -> Vec<Dependency> {
     table
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pixi pypi dependencies")
         .filter_map(|(name, value)| build_pypi_dependency(name, value, scope, optional))
         .collect()
 }
@@ -531,7 +529,7 @@ fn extract_v6_lock_dependencies(lock_content: &JsonValue) -> Vec<Dependency> {
 
     packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pixi v6 lock packages")
         .filter_map(JsonValue::as_object)
         .filter_map(|table| build_v6_lock_dependency(table, &environment_refs))
         .collect()
@@ -546,7 +544,7 @@ fn collect_v6_package_refs(lock_content: &JsonValue) -> HashMap<String, Vec<Json
         return refs;
     };
 
-    for (env_name, env_value) in environments.iter().take(MAX_ITERATION_COUNT) {
+    for (env_name, env_value) in environments.iter().capped("pixi v6 lock environments") {
         let Some(env_table) = env_value.as_object() else {
             continue;
         };
@@ -556,11 +554,11 @@ fn collect_v6_package_refs(lock_content: &JsonValue) -> HashMap<String, Vec<Json
         else {
             continue;
         };
-        for (platform, values) in package_platforms.iter().take(MAX_ITERATION_COUNT) {
+        for (platform, values) in package_platforms.iter().capped("pixi v6 lock platforms") {
             let Some(entries) = values.as_array() else {
                 continue;
             };
-            for entry in entries.iter().take(MAX_ITERATION_COUNT) {
+            for entry in entries.iter().capped("pixi v6 lock platform entries") {
                 let Some(table) = entry.as_object() else {
                     continue;
                 };
@@ -699,7 +697,7 @@ fn extract_v4_lock_dependencies(lock_content: &JsonValue) -> Vec<Dependency> {
 
     packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .capped("pixi v4 lock packages")
         .filter_map(JsonValue::as_object)
         .filter_map(build_v4_lock_dependency)
         .collect()

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -30,7 +30,8 @@ use crate::models::{
     Sha256Digest, Sha512Digest,
 };
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, npm_purl, parse_sri, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, capped_iteration_limit, npm_purl, parse_sri, read_file_to_string,
+    truncate_field,
 };
 use std::path::Path;
 use yaml_serde::Value;
@@ -110,12 +111,14 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
 
     // Step 1: Parse importers section to identify direct dependencies
     if let Some(importers) = lock_data.get("importers").and_then(|v| v.as_mapping()) {
-        for (_importer_path, importer_data) in importers.iter().take(MAX_ITERATION_COUNT) {
+        let importer_limit = capped_iteration_limit(importers.len(), "pnpm lockfile importers");
+        for (_importer_path, importer_data) in importers.iter().take(importer_limit) {
             if let Some(deps) = importer_data
                 .get("dependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (name, version_data) in deps.iter().take(MAX_ITERATION_COUNT) {
+                let limit = capped_iteration_limit(deps.len(), "pnpm importer dependencies");
+                for (name, version_data) in deps.iter().take(limit) {
                     if let Some(version) = version_data.get("version").and_then(|v| v.as_str()) {
                         let pkg_key = format_package_key_v9(name.as_str().unwrap_or(""), version);
                         prod_roots.insert(pkg_key);
@@ -127,7 +130,8 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
                 .get("devDependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (name, version_data) in dev_deps.iter().take(MAX_ITERATION_COUNT) {
+                let limit = capped_iteration_limit(dev_deps.len(), "pnpm importer devDependencies");
+                for (name, version_data) in dev_deps.iter().take(limit) {
                     if let Some(version) = version_data.get("version").and_then(|v| v.as_str()) {
                         let pkg_key = format_package_key_v9(name.as_str().unwrap_or(""), version);
                         dev_roots.insert(pkg_key);
@@ -141,12 +145,14 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
     let mut graph: HashMap<String, Vec<String>> = HashMap::new();
 
     if let Some(snapshots) = lock_data.get("snapshots").and_then(|v| v.as_mapping()) {
-        for (pkg_key, pkg_data) in snapshots.iter().take(MAX_ITERATION_COUNT) {
+        let snapshot_limit = capped_iteration_limit(snapshots.len(), "pnpm lockfile snapshots");
+        for (pkg_key, pkg_data) in snapshots.iter().take(snapshot_limit) {
             let pkg_key_str = pkg_key.as_str().unwrap_or("").to_string();
             let mut children = Vec::new();
 
             if let Some(deps) = pkg_data.get("dependencies").and_then(|v| v.as_mapping()) {
-                for (dep_name, dep_version) in deps.iter().take(MAX_ITERATION_COUNT) {
+                let limit = capped_iteration_limit(deps.len(), "pnpm snapshot dependencies");
+                for (dep_name, dep_version) in deps.iter().take(limit) {
                     let dep_name_str = dep_name.as_str().unwrap_or("");
                     let dep_version_str = dep_version.as_str().unwrap_or("");
                     let child_key = format!("{}@{}", dep_name_str, dep_version_str);
@@ -158,7 +164,9 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
                 .get("optionalDependencies")
                 .and_then(|v| v.as_mapping())
             {
-                for (dep_name, dep_version) in opt_deps.iter().take(MAX_ITERATION_COUNT) {
+                let limit =
+                    capped_iteration_limit(opt_deps.len(), "pnpm snapshot optionalDependencies");
+                for (dep_name, dep_version) in opt_deps.iter().take(limit) {
                     let dep_name_str = dep_name.as_str().unwrap_or("");
                     let dep_version_str = dep_version.as_str().unwrap_or("");
                     let child_key = format!("{}@{}", dep_name_str, dep_version_str);
@@ -183,6 +191,10 @@ fn compute_dev_only_packages_v9(lock_data: &Value) -> std::collections::HashSet<
     while let Some(current) = queue.pop_front() {
         bfs_iterations += 1;
         if bfs_iterations > MAX_ITERATION_COUNT {
+            crate::parser_warn!(
+                "Truncated pnpm dev/prod reachability traversal at {} iterations (MAX_ITERATION_COUNT); dev classification may be incomplete",
+                MAX_ITERATION_COUNT
+            );
             break;
         }
         if let Some(children) = graph.get(&current) {
@@ -211,6 +223,15 @@ fn format_package_key_v9(name: &str, version: &str) -> String {
     truncate_field(format!("{}@{}", name, clean_version))
 }
 
+/// Whether `parse_purl_fields` knows how to decode keys for this lockfile
+/// version. v5, v6, and v9 are the supported shapes; anything else makes every
+/// package key unparseable.
+fn is_supported_lockfile_version(lockfile_version: &str) -> bool {
+    lockfile_version.starts_with('5')
+        || lockfile_version.starts_with('6')
+        || lockfile_version.starts_with('9')
+}
+
 /// Parse pnpm lockfile and extract package data
 fn parse_pnpm_lockfile(lock_data: &Value) -> PackageData {
     let lockfile_version = detect_pnpm_version(lock_data);
@@ -228,7 +249,20 @@ fn parse_pnpm_lockfile(lock_data: &Value) -> PackageData {
 
     // Extract packages based on version
     if let Some(packages_map) = lock_data.get("packages").and_then(|v| v.as_mapping()) {
-        for (purl_fields, data) in packages_map.iter().take(MAX_ITERATION_COUNT) {
+        // An unrecognised lockfile version makes every key unparseable. Warn
+        // once here (with the entry count) instead of once per entry, which
+        // would otherwise be both a warning storm and misleading per key.
+        if !is_supported_lockfile_version(&lockfile_version) && !packages_map.is_empty() {
+            crate::parser_warn!(
+                "Skipping {} pnpm lockfile package entries: unsupported lockfileVersion {:?}",
+                packages_map.len(),
+                lockfile_version
+            );
+            return result;
+        }
+
+        let limit = capped_iteration_limit(packages_map.len(), "pnpm lockfile packages");
+        for (purl_fields, data) in packages_map.iter().take(limit) {
             let purl_fields_str = match purl_fields.as_str() {
                 Some(s) => s,
                 None => continue,
@@ -394,7 +428,8 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     let mut all_dependencies = Vec::new();
 
     if let Some(deps) = data.get("dependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in deps.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(deps.len(), "pnpm nested dependencies");
+        for (name, version) in deps.iter().take(limit) {
             if let Some(dep) = create_simple_dependency(name.as_str(), version.as_str(), None) {
                 all_dependencies.push(dep);
             }
@@ -402,7 +437,8 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     }
 
     if let Some(dev_deps) = data.get("devDependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in dev_deps.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(dev_deps.len(), "pnpm nested devDependencies");
+        for (name, version) in dev_deps.iter().take(limit) {
             if let Some(dep) =
                 create_simple_dependency(name.as_str(), version.as_str(), Some("dev".to_string()))
             {
@@ -412,7 +448,8 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
     }
 
     if let Some(peer_deps) = data.get("peerDependencies").and_then(|v| v.as_mapping()) {
-        for (name, version) in peer_deps.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(peer_deps.len(), "pnpm nested peerDependencies");
+        for (name, version) in peer_deps.iter().take(limit) {
             if let Some(dep) =
                 create_simple_dependency(name.as_str(), version.as_str(), Some("peer".to_string()))
             {
@@ -425,7 +462,8 @@ fn parse_nested_dependencies(data: &Value) -> Vec<Dependency> {
         .get("optionalDependencies")
         .and_then(|v| v.as_mapping())
     {
-        for (name, version) in opt_deps.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(opt_deps.len(), "pnpm nested optionalDependencies");
+        for (name, version) in opt_deps.iter().take(limit) {
             if let Some(dep) = create_simple_dependency(
                 name.as_str(),
                 version.as_str(),
@@ -480,7 +518,22 @@ pub fn extract_dependency(
     lockfile_version: &str,
     is_dev_only_v9: bool,
 ) -> Option<Dependency> {
-    let (namespace, name, version) = parse_purl_fields(clean_purl_fields, lockfile_version)?;
+    let (namespace, name, version) = match parse_purl_fields(clean_purl_fields, lockfile_version) {
+        Some(parsed) => parsed,
+        None => {
+            // Only warn per entry for a supported version, where a None means a
+            // genuinely malformed key. Unsupported versions are reported once
+            // (with the entry count) by the caller, not per entry here.
+            if is_supported_lockfile_version(lockfile_version) {
+                crate::parser_warn!(
+                    "Skipping pnpm lockfile entry with unparseable key {:?} (lockfileVersion {})",
+                    clean_purl_fields,
+                    lockfile_version
+                );
+            }
+            return None;
+        }
+    };
     let namespace = namespace.map(truncate_field);
     let name = truncate_field(name);
     let version = truncate_field(version);

--- a/src/parsers/pnpm_lock_test.rs
+++ b/src/parsers/pnpm_lock_test.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::pnpm_lock::*;
-use crate::models::PackageType;
-use crate::parsers::PackageParser;
+use crate::models::{DatasourceId, DiagnosticSeverity, PackageType};
+use crate::parsers::{PackageParser, capture_parser_diagnostics};
+use std::io::Write;
 use std::path::PathBuf;
 
 #[test]
@@ -409,4 +410,112 @@ fn test_parse_purl_fields_v6_scoped_with_underscore() {
     assert_eq!(namespace, Some("@babel".to_string()));
     assert_eq!(name, "helper_string_parser".to_string());
     assert_eq!(version, "7.24.8".to_string());
+}
+
+#[test]
+fn test_malformed_pnpm_entry_records_warning_and_keeps_valid_entries() {
+    // A v9 lockfile with one valid entry and one malformed key (a scoped name
+    // with an extra path segment) that parse_purl_fields cannot decode. The
+    // malformed entry must be skipped, but with a diagnostic naming the key,
+    // while the valid entry still parses.
+    let content = r#"lockfileVersion: '9.0'
+
+packages:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvKw==}
+  '@scope/extra/name@1.0.0':
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==}
+"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("pnpm-lock.yaml");
+    let mut file = std::fs::File::create(&lock_path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+
+    let result = capture_parser_diagnostics(
+        || PnpmLockParser::extract_packages(&lock_path),
+        "PnpmLockParser",
+        &lock_path,
+        None,
+    );
+
+    assert_eq!(result.packages.len(), 1);
+    assert_eq!(
+        result.packages[0].datasource_id,
+        Some(DatasourceId::PnpmLockYaml)
+    );
+
+    // The valid entry still parses.
+    assert!(
+        result.packages[0]
+            .dependencies
+            .iter()
+            .any(|dep| dep.purl.as_deref() == Some("pkg:npm/lodash@4.17.21")),
+        "expected the valid lodash entry to survive, got: {:?}",
+        result.packages[0].dependencies
+    );
+
+    // The malformed entry is skipped, with a diagnostic naming the offending key.
+    assert!(
+        result.scan_diagnostics.iter().any(|diagnostic| {
+            diagnostic.severity == DiagnosticSeverity::Warning
+                && diagnostic.message.contains("unparseable key")
+                && diagnostic.message.contains("@scope/extra/name@1.0.0")
+        }),
+        "expected a warning naming the unparseable key, got: {:?}",
+        result.scan_diagnostics
+    );
+}
+
+#[test]
+fn test_unsupported_lockfile_version_warns_once_not_per_entry() {
+    // An unsupported lockfileVersion makes every key unparseable. The parser
+    // must emit a single "unsupported lockfileVersion" warning naming the entry
+    // count, NOT one misleading per-entry "unparseable key" warning.
+    let content = r#"lockfileVersion: '4.0'
+
+packages:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvKw==}
+  react@18.0.0:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvKw==}
+"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let lock_path = dir.path().join("pnpm-lock.yaml");
+    let mut file = std::fs::File::create(&lock_path).unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+
+    let result = capture_parser_diagnostics(
+        || PnpmLockParser::extract_packages(&lock_path),
+        "PnpmLockParser",
+        &lock_path,
+        None,
+    );
+
+    // No entries are extractable, but datasource identity is preserved.
+    assert_eq!(result.packages.len(), 1);
+    assert!(result.packages[0].dependencies.is_empty());
+
+    // Exactly one warning, naming the version and the entry count; never the
+    // per-entry "unparseable key" message.
+    let warnings: Vec<&str> = result
+        .scan_diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Warning)
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected exactly one warning, got: {warnings:?}"
+    );
+    assert!(
+        warnings[0].contains("unsupported lockfileVersion") && warnings[0].contains("4.0"),
+        "expected a single unsupported-version warning, got: {warnings:?}"
+    );
+    assert!(
+        !warnings[0].contains("unparseable key"),
+        "must not emit the per-entry unparseable-key message for unsupported versions"
+    );
 }

--- a/src/parsers/podfile.rs
+++ b/src/parsers/podfile.rs
@@ -33,7 +33,7 @@ use regex::Regex;
 use super::metadata::ParserMetadata;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::PackageParser;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 /// Parses CocoaPods Podfile dependency files.
 ///
@@ -171,7 +171,7 @@ fn extract_dependencies_with_context(content: &str, base_dir: Option<&Path>) -> 
     let contexts = load_podfile_contexts(content, base_dir);
     let version_hashes = extract_podfile_hash_assignments(&contexts);
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("Podfile lines") {
         let cleaned_line = pre_process(line);
         if let Some(caps) = POD_PATTERN.captures(&cleaned_line) {
             let name = truncate_field(caps.get(1).map(|m| m.as_str()).unwrap_or("").to_string());
@@ -277,7 +277,7 @@ fn load_podfile_contexts(content: &str, base_dir: Option<&Path>) -> Vec<String> 
 
     for captures in REQUIRE_RELATIVE_PATTERN
         .captures_iter(content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("Podfile require_relative matches")
     {
         let Some(required) = captures.get(1).map(|value| value.as_str()) else {
             continue;
@@ -313,10 +313,10 @@ fn extract_podfile_hash_assignments(
 ) -> HashMap<String, HashMap<String, String>> {
     let mut hashes = HashMap::new();
 
-    for context in contexts.iter().take(MAX_ITERATION_COUNT) {
+    for context in contexts.iter().capped("Podfile hash-assignment contexts") {
         for captures in HASH_ASSIGNMENT_PATTERN
             .captures_iter(context)
-            .take(MAX_ITERATION_COUNT)
+            .capped("Podfile hash assignments")
         {
             let Some(hash_name) = captures.get(1).map(|value| value.as_str().to_string()) else {
                 continue;
@@ -328,7 +328,7 @@ fn extract_podfile_hash_assignments(
             let mut entries = HashMap::new();
             for entry in HASH_ENTRY_PATTERN
                 .captures_iter(body)
-                .take(MAX_ITERATION_COUNT)
+                .capped("Podfile hash entries")
             {
                 let Some(key) = entry.get(1).map(|value| value.as_str().to_string()) else {
                     continue;

--- a/src/parsers/podfile_lock.rs
+++ b/src/parsers/podfile_lock.rs
@@ -33,7 +33,7 @@ use yaml_serde::Value;
 use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha1Digest,
 };
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -120,7 +120,7 @@ impl DependencyDataByPurl {
         };
 
         if let Some(pods) = data.get("PODS").and_then(|v| v.as_sequence()) {
-            for pod in pods.iter().take(MAX_ITERATION_COUNT) {
+            for pod in pods.iter().capped("Podfile.lock PODS (collect)") {
                 let main_pod_str = match pod {
                     Value::String(s) => Some(s.as_str()),
                     Value::Mapping(m) => m.keys().next().and_then(|k| k.as_str()),
@@ -136,7 +136,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(deps) = data.get("DEPENDENCIES").and_then(|v| v.as_sequence()) {
-            for dep in deps.iter().take(MAX_ITERATION_COUNT) {
+            for dep in deps.iter().capped("Podfile.lock DEPENDENCIES") {
                 if let Some(dep_str) = dep.as_str() {
                     let (base_purl, _) = parse_dep_to_base_purl_and_version(dep_str);
                     dep_data.direct_dependency_purls.push(base_purl);
@@ -145,13 +145,13 @@ impl DependencyDataByPurl {
         }
 
         if let Some(spec_repos) = data.get("SPEC REPOS").and_then(|v| v.as_mapping()) {
-            for (repo_key, packages) in spec_repos.iter().take(MAX_ITERATION_COUNT) {
+            for (repo_key, packages) in spec_repos.iter().capped("Podfile.lock SPEC REPOS") {
                 let repo_name = match repo_key.as_str() {
                     Some(s) => truncate_field(s.to_string()),
                     None => continue,
                 };
                 if let Some(packages) = packages.as_sequence() {
-                    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+                    for package in packages.iter().capped("Podfile.lock SPEC REPOS packages") {
                         if let Some(pkg_str) = package.as_str() {
                             let (base_purl, _) = parse_dep_to_base_purl_and_version(pkg_str);
                             dep_data
@@ -164,7 +164,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(checksums) = data.get("SPEC CHECKSUMS").and_then(|v| v.as_mapping()) {
-            for (name_key, checksum_val) in checksums.iter().take(MAX_ITERATION_COUNT) {
+            for (name_key, checksum_val) in checksums.iter().capped("Podfile.lock SPEC CHECKSUMS") {
                 if let (Some(name), Some(checksum)) = (name_key.as_str(), checksum_val.as_str()) {
                     let (base_purl, _) = parse_dep_to_base_purl_and_version(name);
                     dep_data
@@ -175,7 +175,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(checkout_opts) = data.get("CHECKOUT OPTIONS").and_then(|v| v.as_mapping()) {
-            for (name_key, source) in checkout_opts.iter().take(MAX_ITERATION_COUNT) {
+            for (name_key, source) in checkout_opts.iter().capped("Podfile.lock CHECKOUT OPTIONS") {
                 if let (Some(name), Some(mapping)) = (name_key.as_str(), source.as_mapping()) {
                     let base_purl = make_base_purl(name);
                     let processed = truncate_field(process_external_source(mapping));
@@ -187,7 +187,7 @@ impl DependencyDataByPurl {
         }
 
         if let Some(ext_sources) = data.get("EXTERNAL SOURCES").and_then(|v| v.as_mapping()) {
-            for (name_key, source) in ext_sources.iter().take(MAX_ITERATION_COUNT) {
+            for (name_key, source) in ext_sources.iter().capped("Podfile.lock EXTERNAL SOURCES") {
                 if let (Some(name), Some(mapping)) = (name_key.as_str(), source.as_mapping()) {
                     let base_purl = make_base_purl(name);
                     if dep_data
@@ -213,10 +213,10 @@ fn parse_podfile_lock(data: &Value) -> PackageData {
     let mut dependencies = Vec::new();
 
     if let Some(pods) = data.get("PODS").and_then(|v| v.as_sequence()) {
-        for pod in pods.iter().take(MAX_ITERATION_COUNT) {
+        for pod in pods.iter().capped("Podfile.lock PODS") {
             match pod {
                 Value::Mapping(m) => {
-                    for (main_pod_key, dep_pods_val) in m.iter().take(MAX_ITERATION_COUNT) {
+                    for (main_pod_key, dep_pods_val) in m.iter().capped("Podfile.lock PODS entry") {
                         if let Some(main_pod_str) = main_pod_key.as_str() {
                             let dep_pods: Vec<&str> = dep_pods_val
                                 .as_sequence()

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -41,7 +41,9 @@ use crate::parsers::license_normalization::{
     DeclaredLicenseMatchMetadata, build_declared_license_data_from_pair,
     normalize_spdx_declared_license,
 };
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, capped_iteration_limit, read_file_to_string, truncate_field,
+};
 
 /// Parses CocoaPods specification files (.podspec).
 ///
@@ -387,7 +389,7 @@ fn extract_metadata_field(content: &str, pattern: &Regex) -> Option<String> {
 }
 
 fn extract_raw_field(content: &str, pattern: &Regex) -> Option<String> {
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("podspec extract_raw_field lines") {
         let cleaned_line = pre_process(line);
         if let Some(value) = pattern.captures(&cleaned_line).and_then(|caps| caps.get(1)) {
             return Some(value.as_str().trim().to_string());
@@ -398,7 +400,7 @@ fn extract_raw_field(content: &str, pattern: &Regex) -> Option<String> {
 
 /// Extract a single field using a regex pattern
 fn extract_field(content: &str, pattern: &Regex) -> Option<String> {
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("podspec extract_field lines") {
         let cleaned_line = pre_process(line);
         if let Some(value) = pattern.captures(&cleaned_line).and_then(|caps| caps.get(1)) {
             return Some(clean_string(value.as_str()));
@@ -409,7 +411,10 @@ fn extract_field(content: &str, pattern: &Regex) -> Option<String> {
 
 /// Extract description, handling multiline heredoc format
 fn extract_description(content: &str) -> Option<String> {
-    let lines: Vec<&str> = content.lines().take(MAX_ITERATION_COUNT).collect();
+    let lines: Vec<&str> = content
+        .lines()
+        .capped("podspec extract_description lines")
+        .collect();
 
     for (i, line) in lines.iter().enumerate() {
         let cleaned = pre_process(line);
@@ -458,7 +463,8 @@ fn extract_multiline_description(lines: &[&str], start_index: usize) -> Option<S
     let mut description_lines = Vec::new();
     let mut found_start = false;
 
-    for line in lines.iter().take(MAX_ITERATION_COUNT).skip(start_index) {
+    let limit = capped_iteration_limit(lines.len(), "podspec extract_multiline_description lines");
+    for line in lines.iter().take(limit).skip(start_index) {
         if !found_start && line.contains("<<-") {
             found_start = true;
             continue;
@@ -484,7 +490,7 @@ fn extract_multiline_description(lines: &[&str], start_index: usize) -> Option<S
 fn extract_authors(content: &str) -> Vec<(String, Option<String>)> {
     let mut authors = Vec::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("podspec extract_authors lines") {
         let cleaned_line = pre_process(line);
         if let Some(value) = AUTHOR_PATTERN
             .captures(&cleaned_line)
@@ -513,7 +519,7 @@ fn extract_authors(content: &str) -> Vec<(String, Option<String>)> {
 }
 
 fn extract_source_url(content: &str) -> Option<String> {
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("podspec extract_source_url lines") {
         let cleaned_line = pre_process(line);
         let Some(value) = SOURCE_PATTERN
             .captures(&cleaned_line)
@@ -584,7 +590,7 @@ fn parse_author_string(author: &str) -> (String, Option<String>) {
 fn extract_dependencies(content: &str) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("podspec extract_dependencies lines") {
         let cleaned_line = pre_process(line);
         if let Some(caps) = DEPENDENCY_PATTERN.captures(&cleaned_line) {
             let method = caps.get(0).map(|m| m.as_str()).unwrap_or("");

--- a/src/parsers/podspec_json.rs
+++ b/src/parsers/podspec_json.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use crate::parser_warn as warn;
 use crate::parsers::podfile_lock::build_cocoapods_purl;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use serde_json::Value;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
@@ -391,7 +391,7 @@ fn extract_parties(json: &Value) -> Vec<Party> {
     if let Some(authors) = json.get(FIELD_AUTHORS) {
         if let Some(authors_obj) = authors.as_object() {
             // Authors as dict: key=name, value=url
-            for (name, value) in authors_obj.iter().take(MAX_ITERATION_COUNT) {
+            for (name, value) in authors_obj.iter().capped("podspec.json authors") {
                 let name_str = truncate_field(name.trim().to_string());
                 if !name_str.is_empty() {
                     let url = value.as_str().and_then(|s| {
@@ -445,7 +445,7 @@ fn extract_dependencies(json: &Value) -> Vec<Dependency> {
     if let Some(deps) = json.get(FIELD_DEPENDENCIES)
         && let Some(deps_obj) = deps.as_object()
     {
-        for (name, requirement) in deps_obj.iter().take(MAX_ITERATION_COUNT) {
+        for (name, requirement) in deps_obj.iter().capped("podspec.json dependencies") {
             let name_str = name.trim();
             if name_str.is_empty() {
                 continue;

--- a/src/parsers/poetry_lock.rs
+++ b/src/parsers/poetry_lock.rs
@@ -36,7 +36,7 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha256Digest,
 };
 use crate::parsers::python::{build_pypi_urls, read_toml_file};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, truncate_field};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -102,7 +102,8 @@ fn parse_poetry_lock(toml_content: &TomlValue) -> PackageData {
         .and_then(|value| value.as_table());
 
     let mut dependencies = Vec::new();
-    for package in packages.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(packages.len(), "poetry.lock packages");
+    for package in packages.iter().take(limit) {
         if let Some(package_table) = package.as_table()
             && let Some(dependency) = build_dependency_from_package(package_table)
         {
@@ -284,7 +285,8 @@ fn extract_package_dependencies(package_table: &TomlMap<String, TomlValue>) -> V
         .get(FIELD_DEPENDENCIES)
         .and_then(|value| value.as_table())
     {
-        for (dep_name, dep_value) in dep_table.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(dep_table.len(), "poetry.lock package dependencies");
+        for (dep_name, dep_value) in dep_table.iter().take(limit) {
             if let Some(dependency) = build_dependency_from_table(dep_name, dep_value) {
                 dependencies.push(dependency);
             }
@@ -295,9 +297,12 @@ fn extract_package_dependencies(package_table: &TomlMap<String, TomlValue>) -> V
         .get(FIELD_EXTRAS)
         .and_then(|value| value.as_table())
     {
-        for (extra_name, extra_values) in extras_table.iter().take(MAX_ITERATION_COUNT) {
+        let extras_limit = capped_iteration_limit(extras_table.len(), "poetry.lock package extras");
+        for (extra_name, extra_values) in extras_table.iter().take(extras_limit) {
             if let Some(extra_list) = extra_values.as_array() {
-                for extra in extra_list.iter().take(MAX_ITERATION_COUNT) {
+                let extra_limit =
+                    capped_iteration_limit(extra_list.len(), "poetry.lock package extra list");
+                for extra in extra_list.iter().take(extra_limit) {
                     if let Some(spec) = extra.as_str()
                         && let Some(dependency) = build_dependency_from_extra(extra_name, spec)
                     {

--- a/src/parsers/publiccode.rs
+++ b/src/parsers/publiccode.rs
@@ -9,7 +9,7 @@ use crate::parser_warn as warn;
 use super::PackageParser;
 use super::license_normalization::normalize_spdx_declared_license;
 use super::metadata::ParserMetadata;
-use super::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use super::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 pub struct PubliccodeParser;
 
@@ -146,7 +146,7 @@ fn extract_contact_parties(maintenance: Option<&yaml_serde::Value>) -> Vec<Party
         .and_then(yaml_serde::Value::as_sequence)
         .into_iter()
         .flatten()
-        .take(MAX_ITERATION_COUNT)
+        .capped("publiccode contact parties")
         .filter_map(|contact| {
             let name = contact
                 .get("name")

--- a/src/parsers/pylock_toml.rs
+++ b/src/parsers/pylock_toml.rs
@@ -16,7 +16,9 @@ use crate::models::{
     Sha512Digest,
 };
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, truncate_field,
+};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
@@ -131,9 +133,10 @@ fn parse_pylock_toml(toml_content: &TomlValue) -> PackageData {
         return default_package_data();
     };
 
+    let package_limit = capped_iteration_limit(package_values.len(), "pylock.toml packages");
     let package_tables: Vec<&TomlMap<String, TomlValue>> = package_values
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(package_limit)
         .filter_map(TomlValue::as_table)
         .collect();
     if package_tables.is_empty() {
@@ -349,10 +352,14 @@ fn resolve_dependency_reference_indices(
     package_tables: &[&TomlMap<String, TomlValue>],
     reference: &TomlMap<String, TomlValue>,
 ) -> Vec<usize> {
+    let limit = capped_iteration_limit(
+        package_tables.len(),
+        "pylock.toml dependency reference indices",
+    );
     let matches: Vec<usize> = package_tables
         .iter()
         .enumerate()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(index, package_table)| {
             package_reference_matches(package_table, reference).then_some(index)
         })

--- a/src/parsers/python/archive.rs
+++ b/src/parsers/python/archive.rs
@@ -9,7 +9,9 @@ use super::utils::{
 use crate::models::{DatasourceId, FileReference, PackageData, Sha256Digest};
 use crate::parser_warn as warn;
 use crate::parsers::PackageParser;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{
+    CappedIterExt, MAX_ITERATION_COUNT, read_file_to_string, truncate_field,
+};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bzip2::read::BzDecoder;
@@ -1133,7 +1135,7 @@ pub(super) fn parse_record_csv(content: &str) -> Vec<FileReference> {
 pub(super) fn parse_file_list(content: &str) -> Vec<FileReference> {
     content
         .lines()
-        .take(MAX_ITERATION_COUNT)
+        .capped("python archive file list")
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(|path| FileReference::from_path(path.to_string()))

--- a/src/parsers/readme.rs
+++ b/src/parsers/readme.rs
@@ -29,7 +29,7 @@
 use crate::models::PackageData;
 use crate::models::{DatasourceId, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 use std::path::Path;
 
 use super::PackageParser;
@@ -88,7 +88,7 @@ impl PackageParser for ReadmeParser {
         let mut pkg = default_package_data();
 
         // Parse key:value pairs
-        for line in content.lines().take(MAX_ITERATION_COUNT) {
+        for line in content.lines().capped("readme key:value lines") {
             let line = line.trim();
             if line.is_empty() {
                 continue;

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -37,7 +37,8 @@ use serde_json::Value as JsonValue;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::pep508::{Pep508Requirement, parse_pep508_requirement};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard, read_file_to_string, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard,
+    capped_iteration_limit, read_file_to_string, truncate_field,
 };
 
 use super::PackageParser;
@@ -261,10 +262,9 @@ fn parse_requirements_with_includes(
         }
     };
 
-    for line in collect_logical_lines(&content)
-        .into_iter()
-        .take(MAX_ITERATION_COUNT)
-    {
+    let logical_lines = collect_logical_lines(&content);
+    let limit = capped_iteration_limit(logical_lines.len(), "requirements.txt logical lines");
+    for line in logical_lines.into_iter().take(limit) {
         let cleaned = strip_inline_comment(&line);
         let trimmed = cleaned.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -355,7 +355,7 @@ fn collect_logical_lines(content: &str) -> Vec<String> {
     let mut lines = Vec::new();
     let mut current = String::new();
 
-    for raw_line in content.lines().take(MAX_ITERATION_COUNT) {
+    for raw_line in content.lines().capped("requirements.txt raw lines") {
         let line = raw_line.trim_end_matches('\r');
         let trimmed = line.trim_end();
         let is_continuation = trimmed.ends_with('\\');

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -28,7 +28,7 @@ use crate::parser_warn as warn;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
 use crate::models::{Dependency, FileReference};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field};
+use crate::parsers::utils::{MAX_MANIFEST_SIZE, capped_iteration_limit, truncate_field};
 
 use super::PackageParser;
 use super::license_normalization::{
@@ -222,12 +222,15 @@ fn parse_rpm_database(
 
     let native_kind = native_kind_for_datasource(datasource_id)?;
     match read_installed_rpm_packages(path, native_kind) {
-        Ok(packages) => Ok(packages
-            .into_iter()
-            .take(MAX_ITERATION_COUNT)
-            .map(native_package_to_query_package)
-            .map(|pkg| build_package_data(pkg, datasource_id))
-            .collect()),
+        Ok(packages) => {
+            let limit = capped_iteration_limit(packages.len(), "rpm_db native packages");
+            Ok(packages
+                .into_iter()
+                .take(limit)
+                .map(native_package_to_query_package)
+                .map(|pkg| build_package_data(pkg, datasource_id))
+                .collect())
+        }
         Err(native_error) => Err(format!(
             "native installed RPM reader failed for {:?}: {}",
             path, native_error
@@ -257,6 +260,13 @@ fn native_kind_for_datasource(datasource_id: DatasourceId) -> Result<InstalledRp
 }
 
 fn native_package_to_query_package(package: InstalledRpmPackage) -> RpmQueryPackage {
+    let requires_limit = capped_iteration_limit(package.requires.len(), "rpm_db package requires");
+    let file_names_limit =
+        capped_iteration_limit(package.file_names.len(), "rpm_db package file_names");
+    let base_names_limit =
+        capped_iteration_limit(package.base_names.len(), "rpm_db package base_names");
+    let dir_names_limit =
+        capped_iteration_limit(package.dir_names.len(), "rpm_db package dir_names");
     RpmQueryPackage {
         name: truncate_optional_string(Some(package.name)),
         epoch: Some(package.epoch.to_string()),
@@ -272,26 +282,26 @@ fn native_package_to_query_package(package: InstalledRpmPackage) -> RpmQueryPack
         requires: package
             .requires
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(requires_limit)
             .map(truncate_field)
             .collect(),
         file_names: package
             .file_names
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(file_names_limit)
             .map(|s| Some(truncate_field(s)))
             .collect(),
         dir_indexes: package.dir_indexes,
         base_names: package
             .base_names
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(base_names_limit)
             .map(|s| Some(truncate_field(s)))
             .collect(),
         dir_names: package
             .dir_names
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(dir_names_limit)
             .map(truncate_field)
             .collect(),
     }
@@ -327,10 +337,14 @@ fn build_file_references(
         return Vec::new();
     }
 
+    let limit = capped_iteration_limit(
+        base_names.len().min(dir_indexes.len()),
+        "rpm_db file references",
+    );
     base_names
         .iter()
         .zip(dir_indexes.iter())
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|(basename, &dir_idx)| {
             let dirname = dir_names.get(dir_idx as usize)?;
             let basename = basename.as_deref().unwrap_or_default();
@@ -352,9 +366,10 @@ fn build_file_references(
 }
 
 fn build_file_references_from_paths(paths: &[Option<String>]) -> Vec<FileReference> {
+    let limit = capped_iteration_limit(paths.len(), "rpm_db file references from paths");
     paths
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|path| {
             let path = path.as_deref()?.trim();
             if path.is_empty() || path == "/" {
@@ -401,10 +416,11 @@ fn build_package_data(pkg: RpmQueryPackage, datasource_id: DatasourceId) -> Pack
     let architecture = normalize_optional_string(pkg.arch)
         .map(truncate_field)
         .or_else(|| infer_platform_architecture(pkg.platform.as_deref()));
+    let requires_limit = capped_iteration_limit(pkg.requires.len(), "rpm_db package dependencies");
     let dependencies = pkg
         .requires
         .into_iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(requires_limit)
         .filter_map(|require| build_dependency(&require))
         .collect();
     let extracted_license_statement = normalize_optional_string(pkg.license).map(truncate_field);

--- a/src/parsers/rpm_db_native/entry.rs
+++ b/src/parsers/rpm_db_native/entry.rs
@@ -8,7 +8,9 @@ use std::io::Cursor;
 use anyhow::{Context, Result, anyhow};
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, MAX_MANIFEST_SIZE, capped_iteration_limit, truncate_field,
+};
 
 use super::tags::{
     HEADER_I18NTABLE, RPMTAG_HEADERI18NTABLE, RPMTAG_HEADERIMAGE, RPMTAG_HEADERIMMUTABLE,
@@ -310,10 +312,9 @@ impl HeaderBlob {
     fn verify_entries(&self, data: &[u8]) -> Result<()> {
         let mut end: u32 = 0;
         let entry_offset = usize::from(self.region_tag != 0);
-        for entry in self.entry_infos[entry_offset..]
-            .iter()
-            .take(MAX_ITERATION_COUNT)
-        {
+        let entries = &self.entry_infos[entry_offset..];
+        let limit = capped_iteration_limit(entries.len(), "RPM native verify_entries");
+        for entry in entries.iter().take(limit) {
             let info = entry.to_native()?;
             let kind = info.kind;
             let offset_u32 = positive_offset(info.offset)
@@ -363,7 +364,8 @@ fn swab_region(
     data_end: u32,
 ) -> Result<(Vec<IndexEntry>, u32)> {
     let mut entries = Vec::new();
-    for (index, entry_info) in entry_infos.iter().enumerate().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(entry_infos.len(), "RPM native swab_region entries");
+    for (index, entry_info) in entry_infos.iter().enumerate().take(limit) {
         let info = entry_info.to_native()?;
         let kind = info.kind;
         let start = data_start + positive_offset(info.offset)?;

--- a/src/parsers/rpm_mariner_manifest.rs
+++ b/src/parsers/rpm_mariner_manifest.rs
@@ -26,7 +26,7 @@ use packageurl::PackageUrl;
 use std::path::Path;
 
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use crate::models::PackageData;
 
@@ -92,7 +92,7 @@ impl PackageParser for RpmMarinerManifestParser {
 pub(crate) fn parse_rpm_mariner_manifest(content: &str) -> Vec<PackageData> {
     let mut packages = Vec::new();
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("rpm mariner manifest lines") {
         // Only trim whitespace, not tabs
         let line = line.trim_matches(|c: char| c.is_whitespace() && c != '\t');
         if line.is_empty() {

--- a/src/parsers/rpm_specfile.rs
+++ b/src/parsers/rpm_specfile.rs
@@ -38,7 +38,8 @@ use regex::Regex;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string,
+    split_name_email, truncate_field,
 };
 
 use super::PackageParser;
@@ -151,7 +152,7 @@ fn parse_specfile(content: &str) -> PackageData {
 
             match tag.as_str() {
                 "buildrequires" => {
-                    for dep in value.split(',').take(MAX_ITERATION_COUNT) {
+                    for dep in value.split(',').capped("rpm specfile BuildRequires") {
                         let dep = dep.trim();
                         if !dep.is_empty() {
                             build_requires.push(dep.to_string());
@@ -170,7 +171,7 @@ fn parse_specfile(content: &str) -> PackageData {
                         Some("runtime".to_string())
                     };
 
-                    for dep in value.split(',').take(MAX_ITERATION_COUNT) {
+                    for dep in value.split(',').capped("rpm specfile Requires") {
                         let dep = dep.trim();
                         if !dep.is_empty() {
                             requires.push((dep.to_string(), scope.clone()));
@@ -178,7 +179,7 @@ fn parse_specfile(content: &str) -> PackageData {
                     }
                 }
                 "provides" => {
-                    for prov in value.split(',').take(MAX_ITERATION_COUNT) {
+                    for prov in value.split(',').capped("rpm specfile Provides") {
                         let prov = prov.trim();
                         if !prov.is_empty() {
                             provides.push(prov.to_string());
@@ -309,7 +310,9 @@ fn parse_specfile(content: &str) -> PackageData {
     // Create dependencies
     let mut dependencies = Vec::new();
 
-    for dep_str in build_requires.into_iter().take(MAX_ITERATION_COUNT) {
+    let build_requires_limit =
+        capped_iteration_limit(build_requires.len(), "rpm specfile build dependencies");
+    for dep_str in build_requires.into_iter().take(build_requires_limit) {
         let dep_str = truncate_field(expand_macros(&dep_str, &macros));
         let dep_name = extract_dep_name(&dep_str);
         let purl = build_rpm_purl(&dep_name, None).map(truncate_field);
@@ -327,7 +330,9 @@ fn parse_specfile(content: &str) -> PackageData {
         });
     }
 
-    for (dep_str, scope) in requires.into_iter().take(MAX_ITERATION_COUNT) {
+    let requires_limit =
+        capped_iteration_limit(requires.len(), "rpm specfile runtime dependencies");
+    for (dep_str, scope) in requires.into_iter().take(requires_limit) {
         let dep_str = truncate_field(expand_macros(&dep_str, &macros));
         let dep_name = extract_dep_name(&dep_str);
         let purl = build_rpm_purl(&dep_name, None).map(truncate_field);
@@ -363,9 +368,10 @@ fn parse_specfile(content: &str) -> PackageData {
         extra_data.insert("group".to_string(), serde_json::Value::String(g));
     }
     if !provides.is_empty() {
+        let provides_limit = capped_iteration_limit(provides.len(), "rpm specfile provides");
         let provides_json: Vec<serde_json::Value> = provides
             .into_iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(provides_limit)
             .map(|prov| serde_json::Value::String(truncate_field(expand_macros(&prov, &macros))))
             .collect();
         extra_data.insert(

--- a/src/parsers/rpm_yumdb.rs
+++ b/src/parsers/rpm_yumdb.rs
@@ -8,7 +8,7 @@ use crate::parser_warn as warn;
 use packageurl::PackageUrl;
 
 use crate::models::{DatasourceId, PackageData, PackageType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{CappedIterExt, read_file_to_string, truncate_field};
 
 use super::PackageParser;
 
@@ -100,7 +100,10 @@ impl PackageParser for RpmYumdbParser {
             }
         };
 
-        let entries: Vec<_> = entries.flatten().take(MAX_ITERATION_COUNT).collect();
+        let entries: Vec<_> = entries
+            .flatten()
+            .capped("rpm yumdb package directory entries")
+            .collect();
 
         for entry in entries {
             let key_path = entry.path();

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -32,7 +32,8 @@
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 use crate::parser_warn as warn;
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, read_file_to_string, split_name_email, truncate_field,
+    CappedIterExt, MAX_ITERATION_COUNT, capped_iteration_limit, read_file_to_string,
+    split_name_email, truncate_field,
 };
 use flate2::read::GzDecoder;
 use packageurl::PackageUrl;
@@ -178,7 +179,7 @@ fn parse_gemfile(content: &str) -> PackageData {
         }
     };
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("Gemfile lines") {
         let trimmed = line.trim();
 
         // Skip comments and empty lines
@@ -558,7 +559,7 @@ fn parse_gemfile_lock(content: &str) -> PackageData {
         }
     };
 
-    for line in content.lines().take(MAX_ITERATION_COUNT) {
+    for line in content.lines().capped("Gemfile.lock lines") {
         let trimmed = line.trim_end();
 
         // Empty line resets state
@@ -1343,7 +1344,7 @@ fn resolve_joined_constant_string(expression: &str, contexts: &[String]) -> Opti
     let separator = extract_first_ruby_value(separator_expr)?;
 
     let mut parts = Vec::new();
-    for item in body.split(',').take(MAX_ITERATION_COUNT) {
+    for item in body.split(',').capped("gemspec join expression parts") {
         let resolved = resolve_scalar_expression(item.trim(), None, contexts)?;
         parts.push(resolved);
     }
@@ -1535,7 +1536,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
     let mut dependencies: Vec<Dependency> = Vec::new();
 
     // Extract basic fields
-    for caps in field_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
+    for caps in field_re.captures_iter(content).capped("gemspec fields") {
         let field_name = match caps.get(1) {
             Some(m) => m.as_str(),
             None => continue,
@@ -1563,14 +1564,17 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
     }
 
     // Extract licenses (plural)
-    for caps in licenses_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
+    for caps in licenses_re
+        .captures_iter(content)
+        .capped("gemspec licenses")
+    {
         if let Some(raw) = caps.get(1) {
             licenses = extract_ruby_array(raw.as_str());
         }
     }
 
     // Extract authors
-    for caps in authors_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
+    for caps in authors_re.captures_iter(content).capped("gemspec authors") {
         if let Some(raw) = caps.get(1) {
             let raw_str = raw.as_str().trim();
             if raw_str.starts_with('[') {
@@ -1585,7 +1589,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
     }
 
     // Extract emails
-    for caps in email_re.captures_iter(content).take(MAX_ITERATION_COUNT) {
+    for caps in email_re.captures_iter(content).capped("gemspec emails") {
         if let Some(raw) = caps.get(1) {
             let raw_str = raw.as_str().trim();
             if raw_str.starts_with('[') {
@@ -1658,7 +1662,7 @@ fn parse_gemspec_with_context(content: &str, base_dir: Option<&Path>) -> Package
 
     for caps in dependency_call_re
         .captures_iter(content)
-        .take(MAX_ITERATION_COUNT)
+        .capped("gemspec dependency calls")
     {
         let method = match caps.get(1) {
             Some(m) => m.as_str(),
@@ -2111,7 +2115,8 @@ fn parse_gem_yaml_dependencies(yaml: &yaml_serde::Value) -> Vec<Dependency> {
         None => return dependencies,
     };
 
-    for dep_value in deps_seq.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(deps_seq.len(), "gem metadata YAML dependencies");
+    for dep_value in deps_seq.iter().take(limit) {
         let dep_name = match yaml_string(dep_value, "name").map(truncate_field) {
             Some(n) => n,
             None => continue,

--- a/src/parsers/sbt.rs
+++ b/src/parsers/sbt.rs
@@ -11,7 +11,10 @@ use serde_json::json;
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 
 use super::PackageParser;
-use super::utils::{MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field};
+use super::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
+};
 
 pub struct SbtParser;
 
@@ -412,7 +415,8 @@ fn matches_chars(chars: &[char], index: usize, expected: &[char]) -> bool {
 fn resolve_string_aliases(statements: &[String]) -> HashMap<String, String> {
     let mut raw_aliases = HashMap::new();
 
-    for statement in statements.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(statements.len(), "sbt alias statements");
+    for statement in statements.iter().take(limit) {
         let tokens = tokenize(statement);
         if let Some((name, expr)) = parse_alias_declaration(&tokens) {
             raw_aliases.insert(name, expr);
@@ -534,7 +538,8 @@ fn parse_statements(statements: &[String], aliases: &HashMap<String, String>) ->
     let bundle_aliases = resolve_seq_aliases(statements);
     let mut state = SbtParseAccumulator::default();
 
-    for statement in statements.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(statements.len(), "sbt statements");
+    for statement in statements.iter().take(limit) {
         let tokens = tokenize(statement);
         process_statement_tokens(&tokens, aliases, &bundle_aliases, &mut state);
     }
@@ -740,7 +745,8 @@ fn parse_dependency_seq(
     };
 
     let mut dependencies = Vec::new();
-    for item in items.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(items.len(), "sbt dependency seq items");
+    for item in items.iter().take(limit) {
         if let Some(dependency) = parse_dependency_expr(item, aliases, inherited_scope) {
             dependencies.push(dependency);
         }

--- a/src/parsers/swift_manifest_json.rs
+++ b/src/parsers/swift_manifest_json.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::utils::{MAX_ITERATION_COUNT, truncate_field};
+use super::utils::{capped_iteration_limit, truncate_field};
 
 use crate::parser_warn as warn;
 use packageurl::PackageUrl;
@@ -162,7 +162,8 @@ fn get_dependencies(dependencies: Option<&Value>) -> Vec<Dependency> {
 
     let mut dependent_packages = Vec::new();
 
-    for dependency in deps_array.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(deps_array.len(), "Swift manifest dependencies");
+    for dependency in deps_array.iter().take(limit) {
         if let Some(dep) = parse_manifest_dependency(dependency) {
             dependent_packages.push(dep);
         }

--- a/src/parsers/swift_resolved.rs
+++ b/src/parsers/swift_resolved.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::PackageParser;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, read_file_to_string, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 
 /// Parses Swift Package Manager lockfiles (Package.resolved).
 ///
@@ -184,15 +184,17 @@ fn parse_resolved(path: &Path) -> Result<PackageData, String> {
 }
 
 fn parse_v2_v3_pins(pins: &[PinV2]) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(pins.len(), "Package.resolved v2/v3 pins");
     pins.iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(pin_v2_to_dependency)
         .collect()
 }
 
 fn parse_v1_pins(pins: &[PinV1]) -> Vec<Dependency> {
+    let limit = capped_iteration_limit(pins.len(), "Package.resolved v1 pins");
     pins.iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(pin_v1_to_dependency)
         .collect()
 }

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -24,7 +24,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage};
 use crate::parsers::utils::{
-    MAX_ITERATION_COUNT, RecursionGuard, read_file_to_string, truncate_field,
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, read_file_to_string,
+    truncate_field,
 };
 
 use super::PackageParser;
@@ -193,10 +194,14 @@ fn build_dependency(
     let name = truncate_field(dep.name.as_ref()?.clone());
     let version = normalize_version(dep.version.clone());
     let purl = create_dependency_purl(dep, version.as_deref());
+    let nested_limit = capped_iteration_limit(
+        dep.dependencies.len(),
+        "swift show-dependencies nested dependencies",
+    );
     let nested_dependencies = dep
         .dependencies
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(nested_limit)
         .filter_map(|child| build_dependency(child, true, guard))
         .collect();
 

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -24,6 +24,101 @@ pub const MAX_FIELD_LENGTH: usize = 10 * 1024 * 1024;
 /// Default maximum iteration count for loops processing items (100,000).
 pub const MAX_ITERATION_COUNT: usize = 100_000;
 
+/// Returns the number of items to iterate for a collection of `total_len`,
+/// capped at [`MAX_ITERATION_COUNT`], and emits a [`crate::parser_warn!`]
+/// diagnostic when the cap actually truncates the input.
+///
+/// Use this in place of a bare `.take(MAX_ITERATION_COUNT)` when iterating a
+/// collection whose length is cheaply known, so silently-dropped entries
+/// become diagnosable in structured scan output. The warning fires only when
+/// `total_len` exceeds the cap, so normal (under-cap) files stay quiet.
+///
+/// `context` should name the file or section being truncated (for example
+/// `"pnpm lockfile packages"`) so the diagnostic identifies what was dropped.
+pub fn capped_iteration_limit(total_len: usize, context: &str) -> usize {
+    if total_len > MAX_ITERATION_COUNT {
+        crate::parser_warn!(
+            "Truncated {} from {} to {} entries (MAX_ITERATION_COUNT); {} entries dropped",
+            context,
+            total_len,
+            MAX_ITERATION_COUNT,
+            total_len - MAX_ITERATION_COUNT
+        );
+    }
+    total_len.min(MAX_ITERATION_COUNT)
+}
+
+/// Iterator adapter that yields at most [`MAX_ITERATION_COUNT`] items and emits
+/// a [`crate::parser_warn!`] diagnostic, naming `context`, if the underlying
+/// iterator actually had more items than the cap.
+///
+/// Created by [`CappedIterExt::capped`]. Use this for the lazy-iterator case
+/// where a collection length is not cheaply known, so truncation stays bounded
+/// and lazy yet becomes diagnosable. The warning fires once, when the cap is
+/// first exceeded; under-cap iterators stay quiet.
+pub struct CappedIter<I: Iterator> {
+    inner: I,
+    context: &'static str,
+    yielded: usize,
+    warned: bool,
+}
+
+impl<I: Iterator> Iterator for CappedIter<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.yielded >= MAX_ITERATION_COUNT {
+            // Probe a single item beyond the cap to detect (and report) real
+            // truncation without consuming the rest of the iterator.
+            if !self.warned && self.inner.next().is_some() {
+                self.warned = true;
+                crate::parser_warn!(
+                    "Truncated {} at {} entries (MAX_ITERATION_COUNT); additional entries dropped",
+                    self.context,
+                    MAX_ITERATION_COUNT
+                );
+            }
+            return None;
+        }
+        let item = self.inner.next();
+        if item.is_some() {
+            self.yielded += 1;
+        }
+        item
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // We yield at most the cap, minus what we've already yielded; clamp the
+        // inner hint so `collect()` callers don't over-allocate.
+        let remaining_cap = MAX_ITERATION_COUNT.saturating_sub(self.yielded);
+        let (lower, upper) = self.inner.size_hint();
+        let upper = match upper {
+            Some(upper) => upper.min(remaining_cap),
+            None => remaining_cap,
+        };
+        (lower.min(remaining_cap), Some(upper))
+    }
+}
+
+/// Extension trait providing [`capped`](CappedIterExt::capped) on any iterator.
+pub trait CappedIterExt: Iterator + Sized {
+    /// Caps iteration at [`MAX_ITERATION_COUNT`], warning (via
+    /// [`crate::parser_warn!`]) only if the source actually had more items.
+    ///
+    /// Prefer [`capped_iteration_limit`] when the collection length is cheaply
+    /// known; use this for lazy iterators where it is not.
+    fn capped(self, context: &'static str) -> CappedIter<Self> {
+        CappedIter {
+            inner: self,
+            context,
+            yielded: 0,
+            warned: false,
+        }
+    }
+}
+
+impl<I: Iterator> CappedIterExt for I {}
+
 /// Default maximum recursion depth for recursive parsing functions (50 levels).
 pub const MAX_RECURSION_DEPTH: usize = 50;
 
@@ -520,5 +615,119 @@ mod tests {
         let long = "x".repeat(MAX_FIELD_LENGTH + 100);
         let truncated = truncate_field(long);
         assert!(truncated.len() <= MAX_FIELD_LENGTH);
+    }
+
+    #[test]
+    fn test_capped_iteration_limit_under_cap() {
+        assert_eq!(capped_iteration_limit(0, "test"), 0);
+        assert_eq!(capped_iteration_limit(10, "test"), 10);
+        assert_eq!(
+            capped_iteration_limit(MAX_ITERATION_COUNT, "test"),
+            MAX_ITERATION_COUNT
+        );
+    }
+
+    #[test]
+    fn test_capped_iteration_limit_truncates() {
+        assert_eq!(
+            capped_iteration_limit(MAX_ITERATION_COUNT + 1, "test"),
+            MAX_ITERATION_COUNT
+        );
+        assert_eq!(
+            capped_iteration_limit(MAX_ITERATION_COUNT * 2, "test"),
+            MAX_ITERATION_COUNT
+        );
+    }
+
+    #[test]
+    fn test_capped_iteration_limit_warns_only_when_truncating() {
+        use crate::models::DiagnosticSeverity;
+        use crate::parsers::capture_parser_diagnostics;
+        use std::path::Path;
+
+        // Under the cap: no diagnostic.
+        let quiet = capture_parser_diagnostics(
+            || {
+                let _ = capped_iteration_limit(10, "under-cap context");
+                Vec::new()
+            },
+            "test",
+            Path::new("test"),
+            None,
+        );
+        assert!(
+            quiet.scan_diagnostics.is_empty(),
+            "expected no diagnostic under the cap, got: {:?}",
+            quiet.scan_diagnostics
+        );
+
+        // Over the cap: a warning naming the context and the cap.
+        let noisy = capture_parser_diagnostics(
+            || {
+                let _ = capped_iteration_limit(MAX_ITERATION_COUNT + 7, "over-cap context");
+                Vec::new()
+            },
+            "test",
+            Path::new("test"),
+            None,
+        );
+        assert!(
+            noisy.scan_diagnostics.iter().any(|diagnostic| {
+                diagnostic.severity == DiagnosticSeverity::Warning
+                    && diagnostic.message.contains("over-cap context")
+                    && diagnostic.message.contains("MAX_ITERATION_COUNT")
+            }),
+            "expected a truncation warning naming the context, got: {:?}",
+            noisy.scan_diagnostics
+        );
+    }
+
+    #[test]
+    fn test_capped_iter_under_cap_is_quiet_and_complete() {
+        use crate::parsers::capture_parser_diagnostics;
+        use std::path::Path;
+
+        let result = capture_parser_diagnostics(
+            || {
+                let collected: Vec<usize> = (0..10).capped("under-cap iter").collect();
+                assert_eq!(collected, (0..10).collect::<Vec<_>>());
+                Vec::new()
+            },
+            "test",
+            Path::new("test"),
+            None,
+        );
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "expected no diagnostic under the cap, got: {:?}",
+            result.scan_diagnostics
+        );
+    }
+
+    #[test]
+    fn test_capped_iter_truncates_and_warns() {
+        use crate::models::DiagnosticSeverity;
+        use crate::parsers::capture_parser_diagnostics;
+        use std::path::Path;
+
+        let result = capture_parser_diagnostics(
+            || {
+                let count = (0..MAX_ITERATION_COUNT + 5).capped("over-cap iter").count();
+                assert_eq!(count, MAX_ITERATION_COUNT);
+                Vec::new()
+            },
+            "test",
+            Path::new("test"),
+            None,
+        );
+        assert!(
+            result.scan_diagnostics.iter().any(|diagnostic| {
+                diagnostic.severity == DiagnosticSeverity::Warning
+                    && diagnostic.message.contains("over-cap iter")
+                    && diagnostic.message.contains("MAX_ITERATION_COUNT")
+            }),
+            "expected a truncation warning naming the context, got: {:?}",
+            result.scan_diagnostics
+        );
     }
 }

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -16,7 +16,9 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha256Digest,
 };
 use crate::parsers::python::read_toml_file;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, RecursionGuard, truncate_field};
+use crate::parsers::utils::{
+    MAX_ITERATION_COUNT, RecursionGuard, capped_iteration_limit, truncate_field,
+};
 
 use super::PackageParser;
 
@@ -105,9 +107,10 @@ fn parse_uv_lock(toml_content: &TomlValue) -> PackageData {
         return default_package_data();
     }
 
+    let packages_limit = capped_iteration_limit(packages.len(), "uv.lock package tables");
     let package_tables: Vec<&TomlMap<String, TomlValue>> = packages
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(packages_limit)
         .filter_map(TomlValue::as_table)
         .collect();
 
@@ -344,18 +347,22 @@ fn collect_root_direct_dependencies(
         .get(FIELD_OPTIONAL_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in optional_table.iter().take(MAX_ITERATION_COUNT) {
+        let optional_limit = capped_iteration_limit(
+            optional_table.len(),
+            "uv.lock root optional-dependency groups",
+        );
+        for (group, value) in optional_table.iter().take(optional_limit) {
             let requirement_map = optional_requirements.get(group);
-            for edge in collect_dependency_edges_from_array(
+            let edges = collect_dependency_edges_from_array(
                 value.as_array(),
                 Some(group.to_string()),
                 false,
                 true,
                 requirement_map,
-            )
-            .into_iter()
-            .take(MAX_ITERATION_COUNT)
-            {
+            );
+            let edges_limit =
+                capped_iteration_limit(edges.len(), "uv.lock root optional-dependency edges");
+            for edge in edges.into_iter().take(edges_limit) {
                 merge_direct_dependency_info(&mut infos, edge);
             }
         }
@@ -365,18 +372,20 @@ fn collect_root_direct_dependencies(
         .get(FIELD_DEV_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in dev_table.iter().take(MAX_ITERATION_COUNT) {
+        let dev_limit =
+            capped_iteration_limit(dev_table.len(), "uv.lock root dev-dependency groups");
+        for (group, value) in dev_table.iter().take(dev_limit) {
             let requirement_map = dev_requirements.get(group);
-            for edge in collect_dependency_edges_from_array(
+            let edges = collect_dependency_edges_from_array(
                 value.as_array(),
                 Some(group.to_string()),
                 false,
                 false,
                 requirement_map,
-            )
-            .into_iter()
-            .take(MAX_ITERATION_COUNT)
-            {
+            );
+            let edges_limit =
+                capped_iteration_limit(edges.len(), "uv.lock root dev-dependency edges");
+            for edge in edges.into_iter().take(edges_limit) {
                 merge_direct_dependency_info(&mut infos, edge);
             }
         }
@@ -467,18 +476,23 @@ fn collect_package_dependency_edges(
         .get(FIELD_OPTIONAL_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in optional_table.iter().take(MAX_ITERATION_COUNT) {
-            edges.extend(
-                collect_dependency_edges_from_array(
-                    value.as_array(),
-                    Some(group.to_string()),
-                    false,
-                    true,
-                    None,
-                )
-                .into_iter()
-                .take(MAX_ITERATION_COUNT),
+        let optional_limit = capped_iteration_limit(
+            optional_table.len(),
+            "uv.lock package optional-dependency groups",
+        );
+        for (group, value) in optional_table.iter().take(optional_limit) {
+            let group_edges = collect_dependency_edges_from_array(
+                value.as_array(),
+                Some(group.to_string()),
+                false,
+                true,
+                None,
             );
+            let edges_limit = capped_iteration_limit(
+                group_edges.len(),
+                "uv.lock package optional-dependency edges",
+            );
+            edges.extend(group_edges.into_iter().take(edges_limit));
         }
     }
 
@@ -486,18 +500,19 @@ fn collect_package_dependency_edges(
         .get(FIELD_DEV_DEPENDENCIES)
         .and_then(TomlValue::as_table)
     {
-        for (group, value) in dev_table.iter().take(MAX_ITERATION_COUNT) {
-            edges.extend(
-                collect_dependency_edges_from_array(
-                    value.as_array(),
-                    Some(group.to_string()),
-                    false,
-                    false,
-                    None,
-                )
-                .into_iter()
-                .take(MAX_ITERATION_COUNT),
+        let dev_limit =
+            capped_iteration_limit(dev_table.len(), "uv.lock package dev-dependency groups");
+        for (group, value) in dev_table.iter().take(dev_limit) {
+            let group_edges = collect_dependency_edges_from_array(
+                value.as_array(),
+                Some(group.to_string()),
+                false,
+                false,
+                None,
             );
+            let edges_limit =
+                capped_iteration_limit(group_edges.len(), "uv.lock package dev-dependency edges");
+            edges.extend(group_edges.into_iter().take(edges_limit));
         }
     }
 
@@ -607,9 +622,10 @@ fn parse_requirement_metadata_table(
 }
 
 fn parse_requirement_entries(values: &[TomlValue]) -> HashMap<String, String> {
+    let limit = capped_iteration_limit(values.len(), "uv.lock requirement entries");
     values
         .iter()
-        .take(MAX_ITERATION_COUNT)
+        .take(limit)
         .filter_map(|value| {
             let table = value.as_table()?;
             let name = table

--- a/src/parsers/vcpkg.rs
+++ b/src/parsers/vcpkg.rs
@@ -9,7 +9,7 @@ use packageurl::PackageUrl;
 use serde_json::Value;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
-use crate::parsers::utils::{MAX_ITERATION_COUNT, split_name_email, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, split_name_email, truncate_field};
 
 use super::PackageParser;
 
@@ -118,12 +118,15 @@ fn extract_maintainers(json: &Value) -> Vec<Party> {
 
     let maintainers: Vec<String> = match value {
         Value::String(s) => vec![s.clone()],
-        Value::Array(values) => values
-            .iter()
-            .take(MAX_ITERATION_COUNT)
-            .filter_map(Value::as_str)
-            .map(ToOwned::to_owned)
-            .collect(),
+        Value::Array(values) => {
+            let limit = capped_iteration_limit(values.len(), "vcpkg maintainers");
+            values
+                .iter()
+                .take(limit)
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        }
         _ => Vec::new(),
     };
 
@@ -150,24 +153,28 @@ fn extract_dependencies(json: &Value) -> Vec<Dependency> {
         .get("dependencies")
         .and_then(Value::as_array)
         .map(|deps| {
+            let limit = capped_iteration_limit(deps.len(), "vcpkg dependencies");
             deps.iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(limit)
                 .filter_map(parse_dependency_entry)
                 .collect()
         })
         .unwrap_or_default();
 
     if let Some(features) = json.get("features").and_then(Value::as_object) {
-        for (feature_name, feature_value) in features.iter().take(MAX_ITERATION_COUNT) {
+        let features_limit = capped_iteration_limit(features.len(), "vcpkg features");
+        for (feature_name, feature_value) in features.iter().take(features_limit) {
             let Some(feature_dependencies) =
                 feature_value.get("dependencies").and_then(Value::as_array)
             else {
                 continue;
             };
 
+            let feature_deps_limit =
+                capped_iteration_limit(feature_dependencies.len(), "vcpkg feature dependencies");
             for dependency in feature_dependencies
                 .iter()
-                .take(MAX_ITERATION_COUNT)
+                .take(feature_deps_limit)
                 .filter_map(parse_dependency_entry)
                 .map(|mut dependency| {
                     let mut extra_data = dependency.extra_data.take().unwrap_or_default();

--- a/src/parsers/yarn_lock.rs
+++ b/src/parsers/yarn_lock.rs
@@ -29,7 +29,7 @@ use crate::models::{
     DatasourceId, Dependency, PackageData, PackageType, ResolvedPackage, Sha512Digest,
 };
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, parse_sri, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, npm_purl, parse_sri, truncate_field};
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -118,7 +118,8 @@ fn parse_yarn_v2(
     let mut dependencies = Vec::new();
     let package_extra_data = extract_yarn_v2_package_extra_data(yaml_map);
 
-    for (spec, details) in yaml_map.iter().take(MAX_ITERATION_COUNT) {
+    let limit = capped_iteration_limit(yaml_map.len(), "yarn.lock v2 entries");
+    for (spec, details) in yaml_map.iter().take(limit) {
         if spec.as_str().map(|s| s == "__metadata").unwrap_or(false) {
             continue;
         }
@@ -270,7 +271,9 @@ fn parse_yarn_v1(
     let mut dependencies = Vec::new();
     let mut seen_purls = HashSet::new();
 
-    for block in content.split("\n\n").take(MAX_ITERATION_COUNT) {
+    let block_count = content.split("\n\n").count();
+    let limit = capped_iteration_limit(block_count, "yarn.lock v1 blocks");
+    for block in content.split("\n\n").take(limit) {
         if is_empty_or_comment_block(block) {
             continue;
         }
@@ -587,7 +590,9 @@ fn load_manifest_dependency_info(path: &Path) -> HashMap<String, ManifestDepende
         .get("peerDependencies")
         .and_then(|value| value.as_object())
     {
-        for name in peer_dependencies.keys().take(MAX_ITERATION_COUNT) {
+        let limit =
+            capped_iteration_limit(peer_dependencies.len(), "yarn manifest peerDependencies");
+        for name in peer_dependencies.keys().take(limit) {
             dependencies.insert(
                 name.clone(),
                 ManifestDependencyInfo {
@@ -609,7 +614,9 @@ fn insert_manifest_dependency_info(
     info: ManifestDependencyInfo,
 ) {
     if let Some(entries) = json.get(field).and_then(|value| value.as_object()) {
-        for name in entries.keys().take(MAX_ITERATION_COUNT) {
+        let context = format!("yarn manifest {field}");
+        let limit = capped_iteration_limit(entries.len(), &context);
+        for name in entries.keys().take(limit) {
             dependencies.insert(name.clone(), info.clone());
         }
     }
@@ -791,7 +798,8 @@ fn parse_yaml_dependencies(yaml_value: Option<&Value>) -> Vec<Dependency> {
     if let Some(deps_value) = yaml_value
         && let Some(mapping) = deps_value.as_mapping()
     {
-        for (key, value) in mapping.iter().take(MAX_ITERATION_COUNT) {
+        let limit = capped_iteration_limit(mapping.len(), "yarn.lock v2 nested dependencies");
+        for (key, value) in mapping.iter().take(limit) {
             let name = match key.as_str() {
                 Some(s) => s.to_string(),
                 None => continue,

--- a/src/parsers/yarn_pnp.rs
+++ b/src/parsers/yarn_pnp.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parser_warn as warn;
-use crate::parsers::utils::{MAX_ITERATION_COUNT, npm_purl, truncate_field};
+use crate::parsers::utils::{capped_iteration_limit, npm_purl, truncate_field};
 
 use super::PackageParser;
 
@@ -75,7 +75,8 @@ fn parse_yarn_pnp(content: &str) -> Result<PackageData, String> {
     let mut seen_locators = HashSet::new();
     let mut dependencies = Vec::new();
 
-    for entry in registry_entries.iter().take(MAX_ITERATION_COUNT) {
+    let entries_limit = capped_iteration_limit(registry_entries.len(), "yarn PnP registry entries");
+    for entry in registry_entries.iter().take(entries_limit) {
         let Some(locator) = entry.get(0).and_then(serde_json::Value::as_str) else {
             continue;
         };
@@ -132,9 +133,10 @@ fn parse_root_dependency_map(entry: &serde_json::Value) -> Option<HashMap<String
 
 fn parse_dependency_pairs(value: &serde_json::Value) -> HashMap<String, String> {
     if let Some(array) = value.as_array() {
+        let limit = capped_iteration_limit(array.len(), "yarn PnP dependency pairs");
         return array
             .iter()
-            .take(MAX_ITERATION_COUNT)
+            .take(limit)
             .filter_map(|pair| {
                 let pair = pair.as_array()?;
                 let name = pair.first()?.as_str()?;
@@ -147,11 +149,15 @@ fn parse_dependency_pairs(value: &serde_json::Value) -> HashMap<String, String> 
             .collect();
     }
 
+    let object_limit = capped_iteration_limit(
+        value.as_object().map_or(0, serde_json::Map::len),
+        "yarn PnP dependency object",
+    );
     value
         .as_object()
         .into_iter()
         .flatten()
-        .take(MAX_ITERATION_COUNT)
+        .take(object_limit)
         .filter_map(|(name, reference)| {
             reference.as_str().map(|reference| {
                 (


### PR DESCRIPTION
## Summary

- Many parser paths silently dropped package/dependency data when an iteration cap (`MAX_ITERATION_COUNT`) truncated input, and where the cap was applied to an unordered `HashMap` the dropped set was also nondeterministic run-to-run. Silently-incomplete output was indistinguishable from "not present". This PR makes every such truncation observable (and, where it was unordered, reproducible).
- Added two shared helpers in `src/parsers/utils.rs`:
  - `capped_iteration_limit(total_len, context) -> usize`: returns the capped length, emits `parser_warn!` only when the cap actually truncates. For collections with a cheap `.len()`.
  - `CappedIterExt::capped(context)`: iterator adapter that caps lazily and warns once if the source had more items. For lazy iterators with no cheap length (`regex.captures_iter`, `split`, `.lines()`, `read_dir().flatten()`, chained adapters). Preserves laziness/boundedness; never collects just to measure length.
- pnpm: `parser_warn!` (naming the offending key) when `parse_purl_fields` can't decode a package key; `parser_warn!` when the dev/prod reachability BFS hits the cap.
- Swept **every** silent `.take(MAX_ITERATION_COUNT)` across ~80 parser files through these helpers.

## Issues

- Closes: #1029

## Scope and exclusions

- Included: the shared util + the full cross-ecosystem sweep of silent `.take(MAX_ITERATION_COUNT)` sites, plus the pnpm key-parse and BFS diagnostics, plus the ruby.rs archive-cap audit. (The user explicitly requested the full sweep in one PR, overriding the usual one-ecosystem-per-PR discipline.)
- Left intentionally unchanged: 7 `.take(MAX_ITERATION_COUNT)` sites that already sit next to an explicit count-guard which emits a warning on truncation (`cargo.rs` x4, `rpm_parser.rs`, `rpm_db_native/entry.rs`, `rpm_db_native/mod.rs`). Converting them would double-warn. Pre-existing **silent** count-guards (`cpan_makefile_pl` WriteMakefile scan, `erlang_otp` term parsing) had a `parser_warn!` added instead.

## Deterministic-ordering fixes (the real correctness fixes)

Audit result: nearly every `.take(MAX_ITERATION_COUNT)` site iterates an already-ordered collection — `Vec`/slice, `serde_json::Map` and `yaml_serde::Mapping` (both `IndexMap`-backed; `serde_json` is built with `preserve_order`), `BTreeMap`/toml `Map`, or order-preserving lazy text iterators. Those only needed the **warning**.

Only **four** sites applied the cap to a genuinely unordered `std::collections::HashMap`, so which entries survived truncation was nondeterministic. These now impose a stable order before capping:

| Site | Ordering imposed |
|---|---|
| `arch.rs` `build_extra_data` | sort field keys |
| `conan_data.rs` `parse_conandata_yml` | sort by version key (observable: emitted `PackageData` order) |
| `gradle.rs` version-catalog `libraries` | sort by alias |
| `haxe.rs` `dependencies` | sort by name (also fixed a pre-existing take-before-sort) |

Spot determinism tests added for the two sites where the ordering is observable in output: `conan_data_test::test_versions_emitted_in_deterministic_sorted_order` and `haxe_test::test_dependencies_emitted_in_deterministic_sorted_order` (each asserts repeated runs are identical and sorted).

## ruby.rs archive-size caps

Audited `MAX_ARCHIVE_SIZE` (100MB), `MAX_FILE_SIZE` (50MB), `MAX_COMPRESSION_RATIO`, and the tar entry-count cap. Every one of these already surfaces when it triggers — either by returning `Err(...)` (warned at the caller's `Failed to extract .gem archive...`) or via a direct `warn!`/`parser_warn!`. None drop data silently, so no new diagnostics were added there (explained rather than changed).

## How to verify

- `cargo test --lib parsers::utils` — helper behavior: `capped_iteration_limit` and `CappedIterExt::capped` warn only on real truncation (verified via `capture_parser_diagnostics`), stay quiet under the cap.
- `cargo test --lib -- parsers::haxe parsers::conan_data` — the two deterministic-ordering spot tests.
- `cargo test --lib parsers::pnpm_lock` — `test_malformed_pnpm_entry_records_warning_and_keeps_valid_entries`.

## Follow-up work

- None deferred — this PR closes #1029 in full.

## Expected-output fixture changes

- Files changed: none. Parser `PackageData` is byte-identical for under-cap input; `parser_warn!` diagnostics live on a separate diagnostic channel, not in `PackageData`. The four ordering fixes either matched existing goldens or are not golden-captured. All 317 parser goldens pass unchanged and `generate-supported-formats --check` reports no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)