### PR TITLE
fix(copyright): skip overlong words instead of truncating the holder tail

### DIFF
--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -79,8 +79,11 @@ const ENCODED_CHAR_RATIO: f64 = 0.90;
 /// Check whether a long line contains copyright-relevant content.
 ///
 /// Returns `true` if the line has strong copyright indicators anywhere in it.
-/// Strong indicators are: "opyr"/"opyl"/"auth" (case-insensitive), or "(c)"
-/// followed by a digit (distinguishes copyright `(c)2024` from code `(c){var`).
+/// Strong indicators are: "opyr"/"opyl"/"auth" (case-insensitive), the `©`
+/// copyright sign (U+00A9), or "(c)" followed by a digit (distinguishes
+/// copyright `(c)2024` from code `(c){var`). `©` mirrors ScanCode's
+/// `statement_markers`, so a minified line carrying only a `©` notice past the
+/// length cap is still treated as copyright-relevant.
 ///
 /// Uses byte-level search to avoid allocating a lowercase copy of potentially
 /// huge (100KB+) lines.
@@ -89,7 +92,21 @@ fn has_copyright_indicators(line: &str) -> bool {
     contains_ascii_ci(bytes, b"opyr")
         || contains_ascii_ci(bytes, b"opyl")
         || contains_ascii_ci(bytes, b"auth")
+        || contains_bytes(bytes, COPYRIGHT_SIGN_UTF8)
         || has_c_sign_before_year(bytes)
+}
+
+/// UTF-8 encoding of `©` (U+00A9 COPYRIGHT SIGN).
+const COPYRIGHT_SIGN_UTF8: &[u8] = &[0xC2, 0xA9];
+
+/// Exact (case-sensitive) byte-substring search without allocation.
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return needle.is_empty();
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 /// Check whether a long or obvious-code line should still be treated as copyright-relevant.
@@ -102,6 +119,7 @@ fn has_long_line_copyright_indicators(line: &str) -> bool {
     contains_ascii_ci(bytes, b"opyr")
         || contains_ascii_ci(bytes, b"opyl")
         || has_explicit_author_marker(bytes)
+        || contains_bytes(bytes, COPYRIGHT_SIGN_UTF8)
         || has_c_sign_before_year(bytes)
 }
 
@@ -1347,6 +1365,22 @@ mod tests {
         assert!(!has_copyright_indicators(
             "just some random @ text with right margin"
         ));
+    }
+
+    #[test]
+    fn test_indicators_copyright_sign() {
+        assert!(has_copyright_indicators("\u{a9} 2024 Acme Inc."));
+        assert!(has_long_line_copyright_indicators("\u{a9} 2024 Acme Inc."));
+    }
+
+    #[test]
+    fn test_long_line_with_only_copyright_sign_is_not_skipped() {
+        // A minified line past MAX_LINE_LENGTH whose only copyright signal is `©`
+        // must still be collected as a candidate.
+        let filler = "a;b=c+d;".repeat(400); // > MAX_LINE_LENGTH bytes
+        let line = format!("{filler}/*\u{a9} 2024 Acme Inc.*/{filler}");
+        assert!(line.len() > MAX_LINE_LENGTH);
+        assert!(has_long_line_copyright_indicators(&line));
     }
 
     #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2466,3 +2466,54 @@ fn test_refine_copyright_and_holder_trim_contact_and_ladspa_junk() {
         Some("Nokia Corporation".to_string())
     );
 }
+
+// ── truncate_long_words ─────────────────────────────────────────
+
+#[test]
+fn test_truncate_long_words_skips_long_url_keeps_trailing_holders() {
+    // A long URL token between real holders is skipped, not treated as the end
+    // of the string: the trailing holders survive.
+    let long_url =
+        "https://docs.aws.amazon.com/config/latest/developerguide/securityhub-enabled.html";
+    assert!(long_url.len() > 80);
+    assert_eq!(
+        truncate_long_words(&format!("Acme Corp ({long_url}) Other Real Holder")),
+        "Acme Corp Other Real Holder"
+    );
+}
+
+#[test]
+fn test_truncate_long_words_stops_at_binary_garbage() {
+    // A long non-URL token is the onset of garbled/binary data, so it and the
+    // trailing junk fragments are dropped.
+    let garbage = "x".repeat(120);
+    assert_eq!(
+        truncate_long_words(&format!("Acme Corp {garbage} more junk")),
+        "Acme Corp"
+    );
+}
+
+#[test]
+fn test_truncate_long_words_length_boundary() {
+    // Words up to 80 bytes are kept; 81+ (non-URL) stop the scan.
+    let exactly_80 = "y".repeat(80);
+    let just_over_80 = "z".repeat(81);
+    assert_eq!(
+        truncate_long_words(&format!("{exactly_80} {just_over_80} tail")),
+        exactly_80
+    );
+    // Strings with no long words are returned unchanged (whitespace normalized).
+    assert_eq!(truncate_long_words("Acme Corp"), "Acme Corp");
+}
+
+#[test]
+fn test_refine_holder_keeps_holders_after_long_url() {
+    // Mirrors the junk-copyright-251 fixture: a long URL between the leading and
+    // trailing holders is dropped while both holders survive.
+    let long_url =
+        "https://docs.aws.amazon.com/config/latest/developerguide/securityhub-enabled.html";
+    assert_eq!(
+        refine_holder(&format!("securityhub-enabled {long_url} The AWS Account")),
+        Some("securityhub-enabled The AWS Account".to_string())
+    );
+}

--- a/src/copyright/refiner/utils.rs
+++ b/src/copyright/refiner/utils.rs
@@ -381,15 +381,34 @@ pub(super) fn strip_repeated_leading_holder_prefix(h: &str) -> String {
     h.to_string()
 }
 
-/// Drop trailing words longer than 80 characters (garbled/binary data).
+/// Truncate a string at the first garbled/binary word.
+///
+/// A word longer than 80 bytes is treated as the onset of garbled or binary
+/// data (minified JS, base64 blobs, raw bytes adjacent to copyright text), so
+/// the word and everything after it is dropped. This is a Provenant-specific
+/// guard; ScanCode has no equivalent.
+///
+/// The exception is a long *URL* token sitting between real holders, e.g.
+/// `Acme Corp <long url> Other Holder`: the URL is skipped but the trailing
+/// holders are preserved. Binary garbage does not look like a URL, so it still
+/// stops the scan and the trailing junk fragments are discarded.
 pub(super) fn truncate_long_words(s: &str) -> String {
-    let words: Vec<&str> = s.split_whitespace().collect();
     let mut result: Vec<&str> = Vec::new();
-    for w in &words {
+    for w in s.split_whitespace() {
         if w.len() > 80 {
+            if is_url_like_word(w) {
+                continue;
+            }
             break;
         }
         result.push(w);
     }
     result.join(" ")
+}
+
+/// A long word is URL-like when it carries a `://` scheme separator (covering
+/// wrapped forms such as `(https://...)`). Used to decide whether an overlong
+/// token is a skippable URL or the onset of binary garbage.
+fn is_url_like_word(w: &str) -> bool {
+    w.contains("://")
 }

--- a/testdata/copyright-golden/copyrights/misco4/to_improve/junk-copyright-251.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco4/to_improve/junk-copyright-251.txt.yml
@@ -3,7 +3,7 @@ what:
   - holders
   - authors
 copyrights:
-  - (c) securityhub-enabled
+  - (c) securityhub-enabled The AWS Account
 holders:
   - securityhub-enabled The AWS Account
 authors: []


### PR DESCRIPTION
## Summary

- Fix `truncate_long_words` so a long URL token between real holders no longer truncates the tail. When the overlong token is URL-like it is skipped and the trailing holders are preserved; for genuine garbled/binary data (minified JS, base64, raw bytes) the function still stops at the first overlong token, preserving the existing junk-suppression behavior.
- Add the `©` copyright sign (U+00A9) to the long-line candidate escape hatch so a minified line past `MAX_LINE_LENGTH` whose only copyright signal is `©` is still collected.

### Bug detail

`truncate_long_words` used `break` on the first `>80`-byte word, dropping all subsequent words. For "(c) securityhub-enabled (https://.../securityhub-enabled.html) The AWS Account" the real holder "The AWS Account" was dropped after the URL. Holders feed tallies/summaries, so this was real data loss. The fix distinguishes a skippable long URL from the onset of binary garbage.

## Issues

- Covers: #1027 (items 1 and 2; item 3, the year-regex ceiling, is already documented in `hints.rs` as an intentional improvement over Python and left as-is)
- Closes: #1027

## Scope and exclusions

- Included: URL-aware `truncate_long_words` fix; `©` long-line indicator; unit tests; one regenerated `to_improve` golden.
- Explicit exclusions: No change to the 1960–2099 year regex (item 3). I also evaluated and rejected adding a blanket `is_junk_copyright` gate to the final refine pass — it regressed 50+ legitimate goldens (ChangeLog, debian copyright, kernel headers), so it is out of scope as too broad for this fix.

## How to verify

- `cargo test --lib copyright::refiner::tests::test_truncate_long_words_skips_long_url_keeps_trailing_holders`
- `cargo test --lib copyright::refiner::tests::test_truncate_long_words_stops_at_binary_garbage`
- `cargo test --lib copyright::refiner::tests::test_refine_holder_keeps_holders_after_long_url`
- `cargo test --features golden-tests --test copyright_golden` — exercises the regenerated junk-copyright-251 fixture and confirms the binary-garbage fixtures (junk-copyright-5, should_not_detect/*) are unaffected.

## Intentional differences from Python

- None introduced. ScanCode's `refine_copyright`/`refine_holder` have no word-length truncation, so there is no parity contract on the tail-discard behavior; `truncate_long_words` is a Provenant-specific guard and the fix corrects its own documented intent. The `©` indicator brings the long-line escape hatch closer to ScanCode's `statement_markers`.

## Follow-up work

- None.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco4/to_improve/junk-copyright-251.txt.yml` (copyright field).
- Why the new expected output is correct: input is `(c) securityhub-enabled (https://.../securityhub-enabled.html) The AWS Account`. The copyright now reads `(c) securityhub-enabled The AWS Account`, consistent with the holder which was already `securityhub-enabled The AWS Account` — the URL token is dropped and the real trailing holder is retained. The fixture lives in `to_improve/`, marking its prior golden as known-suboptimal. Regenerated with `update-copyright-golden --sync-actual --filter junk-copyright-251 --write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)