### PR TITLE
test(license): pin refinement threshold boundaries and document provenance

### DIFF
--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -84,6 +84,9 @@ pub(super) fn is_false_positive(matches: &[LicenseMatch]) -> bool {
 
     let has_full_relevance = matches.iter().all(|m| m.rule_relevance == 100);
 
+    // ScanCode parity: any matched text containing a copyright marker exempts the group
+    // from false-positive classification (detection.py `is_false_positive`: `copyright_words`
+    // substring check). The `(c)` marker and case-insensitivity also follow upstream.
     let copyright_words = ["copyright", "(c)"];
     let has_copyrights = matches.iter().all(|m| {
         m.matched_text
@@ -113,6 +116,9 @@ pub(super) fn is_false_positive(matches: &[LicenseMatch]) -> bool {
             .any(|bare| m.rule_identifier.to_lowercase().contains(bare))
     });
 
+    // ScanCode keys this on bare `'gpl' in identifier` (detection.py `is_false_positive`).
+    // Provenant additionally excludes `lgpl` to avoid misclassifying LGPL references as GPL
+    // false positives.
     let is_gpl = matches.iter().all(|m| {
         let id = m.rule_identifier.to_lowercase();
         id.contains("gpl") && !id.contains("lgpl")

--- a/src/license_detection/detection/analysis_test.rs
+++ b/src/license_detection/detection/analysis_test.rs
@@ -525,6 +525,67 @@ fn test_is_false_positive_copyright_empty_string() {
     assert!(is_false_positive(&matches));
 }
 
+// Pins the `rule_length == 1` key for the GPL false-positive rule. A two-token GPL rule is
+// just outside the key, so the GPL FP path must not fire (rule_length below also pins the
+// boundary from the FP side).
+#[test]
+fn test_is_false_positive_gpl_rule_length_two_not_filtered() {
+    let m = create_test_match_full(
+        "gpl-2.0",
+        "2-aho",
+        1,
+        10,
+        MatchScore::from_percentage(50.0),
+        5,
+        2,
+        50.0,
+        50,
+        "gpl-2.0.LICENSE",
+    );
+    let matches = vec![m];
+    assert!(!is_false_positive(&matches));
+}
+
+// Companion to the above: rule_length == 1 GPL is exactly on the key and is a false positive.
+#[test]
+fn test_is_false_positive_gpl_rule_length_one_filtered() {
+    let m = create_test_match_full(
+        "gpl-2.0",
+        "2-aho",
+        1,
+        10,
+        MatchScore::from_percentage(50.0),
+        5,
+        1,
+        50.0,
+        50,
+        "gpl-2.0.LICENSE",
+    );
+    let matches = vec![m];
+    assert!(is_false_positive(&matches));
+}
+
+// Pins the copyright-substring exemption boundary: matched text whose only near-marker is
+// "copyrigh" (one char short of "copyright") does not exempt, so the GPL FP path still fires.
+#[test]
+fn test_is_false_positive_near_copyright_substring_not_exempt() {
+    let mut m = create_test_match_full(
+        "gpl-2.0",
+        "2-aho",
+        1,
+        10,
+        MatchScore::from_percentage(50.0),
+        5,
+        1,
+        50.0,
+        50,
+        "gpl-2.0.LICENSE",
+    );
+    m.matched_text = Some("copyrigh GPL".to_string());
+    let matches = vec![m];
+    assert!(is_false_positive(&matches));
+}
+
 #[test]
 fn test_is_low_quality_matches_low_coverage() {
     let matches = vec![create_test_match_full(

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -41,6 +41,8 @@ pub(crate) fn filter_spurious_matches(
             let mlen = m.matched_length;
             let hilen = m.hilen();
 
+            // ScanCode parity: the five density/length tiers below mirror upstream
+            // `filter_spurious_matches()` (match.py, Spurious1..Spurious5) verbatim.
             if mlen < 10 && (qdens < 0.1 || idens < 0.1) {
                 return false;
             }
@@ -862,6 +864,72 @@ mod tests {
         let matches: Vec<LicenseMatch> = vec![];
         let filtered = filter_spurious_matches(&matches, &query);
         assert_eq!(filtered.len(), 0);
+    }
+
+    // Build a seq match whose query span is dense and contiguous (qdensity == 1.0, well above
+    // every cascade threshold) so the idensity operand alone decides the outcome. The ispan is
+    // a contiguous block of `ispan_len` positions plus one far position at `ispan_max`, giving
+    // idensity == ispan_len / (ispan_max + 1).
+    fn spurious_test_match(
+        matched_length: usize,
+        ispan_len: usize,
+        ispan_max: usize,
+    ) -> LicenseMatch {
+        let mut positions: Vec<usize> = (0..ispan_len.saturating_sub(1)).collect();
+        positions.push(ispan_max);
+        let qspan = PositionSpan::range(0, 9);
+        let mut m = create_test_match("#1", 1, 10, MatchScore::MAX, 100.0, 100);
+        m.matcher = crate::license_detection::models::MatcherKind::Seq;
+        m.matched_length = matched_length;
+        m.coordinates = MatchCoordinates::rule_aligned(
+            qspan,
+            PositionSpan::from_positions(positions),
+            PositionSpan::range(0, 10),
+        );
+        m
+    }
+
+    // Pins the universal 0.4 density floor (the final cascade tier, ScanCode Spurious5). With a
+    // long match (no earlier tier applies) and qdensity == 1.0, idensity just below 0.4 is
+    // dropped while exactly 0.4 (and above) is kept.
+    #[test]
+    fn test_filter_spurious_matches_pins_final_density_floor_at_0_4() {
+        let index = LicenseIndex::with_legalese_count(10);
+        let query = Query::from_extracted_text("test text", &index, false).unwrap();
+
+        // idensity == 10 / 26 ≈ 0.385 (< 0.4) -> dropped.
+        let below = spurious_test_match(50, 10, 25);
+        assert_eq!(filter_spurious_matches(&[below], &query).len(), 0);
+
+        // idensity == 10 / 25 == 0.4 (not < 0.4) -> kept.
+        let at = spurious_test_match(50, 10, 24);
+        assert_eq!(filter_spurious_matches(&[at], &query).len(), 1);
+
+        // idensity == 10 / 24 ≈ 0.417 (> 0.4) -> kept.
+        let above = spurious_test_match(50, 10, 23);
+        assert_eq!(filter_spurious_matches(&[above], &query).len(), 1);
+    }
+
+    // Pins the cascade's monotonicity around the tier-1 length boundary, NOT the `mlen < 10`
+    // constant itself. Tier-1's drop condition (`mlen < 10 && density < 0.1`) is a strict subset
+    // of tier-2's (`mlen < 15 && density < 0.2`) and of the universal 0.4 floor, so no input can
+    // produce "dropped at mlen 9, kept at mlen 10": changing `< 10` to `< 9` or deleting tier-1
+    // would leave both assertions below unchanged. The constant is retained for ScanCode parity
+    // (Spurious1) and the universal 0.4 floor is what observably governs short low-density
+    // matches; that floor is pinned by the test above. This test guards the invariant that a
+    // short, very-low-density seq match drops on both sides of the boundary.
+    #[test]
+    fn test_filter_spurious_matches_short_low_density_drops_across_tier1_boundary() {
+        let index = LicenseIndex::with_legalese_count(10);
+        let query = Query::from_extracted_text("test text", &index, false).unwrap();
+
+        // idensity == 10 / 101 ≈ 0.099: length 9 (inside the tier-1 band) -> dropped.
+        let short = spurious_test_match(9, 10, 100);
+        assert_eq!(filter_spurious_matches(&[short], &query).len(), 0);
+
+        // Same low density at length 10 is still below the 0.4 floor -> also dropped.
+        let at_ten = spurious_test_match(10, 10, 100);
+        assert_eq!(filter_spurious_matches(&[at_ten], &query).len(), 0);
     }
 
     #[test]

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -288,6 +288,10 @@ fn is_redundant_low_coverage_composite_seq_wrapper(
     container: &LicenseMatch,
     candidate_contained_matches: &[LicenseMatch],
 ) -> bool {
+    // Provenant-specific tuning (no ScanCode equivalent): only very-low-coverage seq
+    // wrappers are eligible for redundant-composite dropping. A seq match at or above
+    // 30.0 coverage carries enough of its own signal to keep regardless of the contained
+    // exact matches it spans.
     if container.matcher != seq_match::MATCH_SEQ || container.coverage() >= 30.0 {
         return false;
     }

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -425,6 +425,10 @@ impl LicenseMatch {
         if self.matched_length < min_matched_len || self.hilen() < min_high_matched_len {
             return true;
         }
+        // ScanCode parity: the 80.0 small-rule coverage floor is a flat constant in
+        // upstream `LicenseMatch.is_small()` (match.py: `self.coverage() < 80`). It does
+        // not consult the rule's curated `minimum_coverage`; only the
+        // `min_matched_length` / `min_high_matched_length` checks above are rule-derived.
         if rule_is_small && self.coverage() < 80.0 {
             return true;
         }
@@ -621,5 +625,47 @@ impl LicenseMatch {
 
     pub fn has_unknown(&self) -> bool {
         self.license_expression.contains("unknown")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build a match that clears the first `is_small` branch (matched_length and hilen both
+    // above the mins below) so the test isolates the small-rule coverage floor.
+    fn match_with_coverage(coverage: f32) -> LicenseMatch {
+        LicenseMatch {
+            matched_length: 10,
+            rule_length: 10,
+            match_coverage: coverage,
+            coordinates: MatchCoordinates::rule_aligned(
+                PositionSpan::range(0, 10),
+                PositionSpan::range(0, 10),
+                PositionSpan::range(0, 10),
+            ),
+            ..Default::default()
+        }
+    }
+
+    // Pins the small-rule 80.0 coverage floor in `is_small` (ScanCode parity). min lengths
+    // are kept below the match so only the coverage branch can flip the result.
+    #[test]
+    fn is_small_pins_small_rule_coverage_floor_at_80() {
+        let min_matched_len = 1;
+        let min_high_matched_len = 1;
+
+        // Just below 80.0 -> small.
+        assert!(match_with_coverage(79.99).is_small(min_matched_len, min_high_matched_len, true));
+        // Exactly 80.0 -> not small (strict `< 80.0`).
+        assert!(!match_with_coverage(80.0).is_small(min_matched_len, min_high_matched_len, true));
+        // Just above 80.0 -> not small.
+        assert!(!match_with_coverage(80.01).is_small(min_matched_len, min_high_matched_len, true));
+    }
+
+    // The 80.0 floor only applies to small rules; a non-small rule below 80.0 is not small.
+    #[test]
+    fn is_small_coverage_floor_only_applies_to_small_rules() {
+        assert!(!match_with_coverage(79.99).is_small(1, 1, false));
     }
 }

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -1463,6 +1463,67 @@ fn test_filter_redundant_low_coverage_composite_seq_wrappers_drops_tiny_composit
     assert!(filtered.is_empty());
 }
 
+// Pins the 30.0 coverage exemption (Provenant-specific tuning) for the redundant
+// low-coverage composite seq-wrapper filter. The children are identical to the test above;
+// only the wrapper's coverage moves across the boundary. Below 30.0 the wrapper is dropped;
+// at or above 30.0 it is exempt and kept.
+#[test]
+fn test_filter_redundant_low_coverage_composite_seq_wrappers_pins_coverage_exemption_at_30() {
+    let make_container = |coverage: f32| {
+        let mut seq_container = make_test_match(
+            crate::license_detection::seq_match::MATCH_SEQ,
+            "composite-wrapper",
+            "epl-2.0_or_apache-2.0_or_gpl-2.0_with_openjdk-exception_and_others4.RULE",
+            55,
+            60,
+            Some(vec![55, 56, 57, 58, 59]),
+        );
+        seq_container.match_coverage = coverage;
+        seq_container
+    };
+    let make_children = || {
+        let aho_first = make_test_match(
+            crate::license_detection::aho_match::MATCH_AHO,
+            "gpl-3.0 WITH autoconf-simple-exception-2.0",
+            "gpl-3.0_with_autoconf-simple-exception-2.0_1.RULE",
+            55,
+            56,
+            None,
+        );
+        let aho_second = make_test_match(
+            crate::license_detection::aho_match::MATCH_AHO,
+            "epl-2.0 OR apache-2.0",
+            "epl-2.0_or_apache-2.0_3.RULE",
+            57,
+            60,
+            None,
+        );
+        [aho_first, aho_second]
+    };
+
+    // 29.99 (< 30.0) -> redundant -> dropped.
+    let below = make_children();
+    assert!(
+        filter_redundant_low_coverage_composite_seq_wrappers(vec![make_container(29.99)], &below)
+            .is_empty()
+    );
+
+    // Exactly 30.0 -> exempt (`>= 30.0`) -> kept.
+    let at = make_children();
+    assert_eq!(
+        filter_redundant_low_coverage_composite_seq_wrappers(vec![make_container(30.0)], &at).len(),
+        1
+    );
+
+    // 30.01 (> 30.0) -> exempt -> kept.
+    let above = make_children();
+    assert_eq!(
+        filter_redundant_low_coverage_composite_seq_wrappers(vec![make_container(30.01)], &above)
+            .len(),
+        1
+    );
+}
+
 #[test]
 fn test_hash_exact_mit() {
     let engine = get_engine();

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -22,8 +22,13 @@ use crate::models::MatchScore;
 
 pub const MATCH_UNKNOWN: MatcherKind = MatcherKind::Unknown;
 
+// ScanCode parity: 6-token ngram window, from upstream `UNKNOWN_NGRAM_LENGTH`
+// (match_unknown.py).
 const UNKNOWN_NGRAM_LENGTH: usize = 6;
 
+// Provenant-specific tuning: ScanCode runs unknown matching per query_run and has no
+// explicit ngram-count or region-length pre-gate. Provenant scans self-discovered
+// unmatched regions, so these two pre-gates bound that scan before attempting a match.
 const MIN_NGRAM_MATCHES: usize = 3;
 
 const MIN_REGION_LENGTH: usize = 5;
@@ -101,6 +106,9 @@ pub fn unknown_match(
             );
         }
 
+        // ScanCode parity: minimum qspan and hispan gates from upstream
+        // `match_unknowns()` (match_unknown.py: `len(qspan) < unknown_ngram_length * 4 or
+        // len(hispan) < 5`).
         if qspan_length < UNKNOWN_NGRAM_LENGTH * 4 {
             continue;
         }
@@ -1053,5 +1061,111 @@ mod tests {
 
         let matches = get_matched_ngrams(&tokens, 2, 1, &automaton);
         assert!(matches.is_empty(), "Invalid range should return empty");
+    }
+
+    // Build an index whose dictionary marks token ids `0..legalese_count` as legalese, plus an
+    // unknown automaton containing one 6-gram pattern per window start in `window_starts`. With
+    // all-distinct tokens each pattern matches exactly once, so the matched-ngram windows are
+    // deterministic. Returns (index, tokens) for driving `unknown_match` end to end.
+    fn unknown_index_with_windows(
+        token_count: usize,
+        legalese_count: u16,
+        window_starts: &[usize],
+    ) -> (LicenseIndex, Vec<u16>) {
+        use crate::license_detection::automaton::AutomatonBuilder;
+
+        let legalese_entries: Vec<(String, u16)> = (0u16..legalese_count)
+            .map(|i| (format!("legalese-{i}"), i))
+            .collect();
+        let mut index = LicenseIndex::with_legalese_count(0);
+        index.dictionary =
+            crate::license_detection::index::dictionary::TokenDictionary::new_with_legalese_pairs(
+                &legalese_entries
+                    .iter()
+                    .map(|(token, id)| (token.as_str(), *id))
+                    .collect::<Vec<_>>(),
+            );
+
+        let token_ids: Vec<TokenId> = (0..token_count as u16).map(TokenId::new).collect();
+
+        let mut builder = AutomatonBuilder::new();
+        for &start in window_starts {
+            let window = &token_ids[start..start + UNKNOWN_NGRAM_LENGTH];
+            let pattern: Vec<u8> = window.iter().flat_map(|tid| tid.to_le_bytes()).collect();
+            builder.add_pattern(&pattern);
+        }
+        index.unknown_automaton = builder.build();
+
+        let tokens: Vec<u16> = (0..token_count as u16).collect();
+        (index, tokens)
+    }
+
+    // Pins the minimum-qspan gate (`qspan_length < UNKNOWN_NGRAM_LENGTH * 4`, i.e. 24; ScanCode
+    // parity). Four non-overlapping 6-gram windows cover exactly 24 positions (kept); three
+    // cover only 18 (dropped). All tokens are legalese here so the hispan gate is satisfied.
+    #[test]
+    fn test_unknown_match_pins_min_qspan_at_24() {
+        use crate::license_detection::test_utils::create_mock_query_with_tokens;
+
+        // Three windows -> qspan == 18 (< 24) -> no match.
+        let (index, tokens) = unknown_index_with_windows(30, 30, &[0, 6, 12]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+        assert!(unknown_match(&index, &query, &[]).is_empty());
+
+        // Four windows -> qspan == 24 (== 24, not < 24) -> match produced.
+        let (index, tokens) = unknown_index_with_windows(30, 30, &[0, 6, 12, 18]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+        assert_eq!(unknown_match(&index, &query, &[]).len(), 1);
+    }
+
+    // Pins the minimum-hispan gate (`hispan < 5`; ScanCode parity). Four windows give a qspan of
+    // 24 positions; hispan counts how many of those are legalese. With 5 legalese tokens (ids
+    // 0..4) hispan == 5 and the match is kept; with 4 (ids 0..3) hispan == 4 and it is dropped.
+    #[test]
+    fn test_unknown_match_pins_min_hispan_at_5() {
+        use crate::license_detection::test_utils::create_mock_query_with_tokens;
+
+        // Only 4 legalese tokens within the qspan -> hispan == 4 (< 5) -> dropped.
+        let (index, tokens) = unknown_index_with_windows(30, 4, &[0, 6, 12, 18]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+        assert!(unknown_match(&index, &query, &[]).is_empty());
+
+        // 5 legalese tokens within the qspan -> hispan == 5 (not < 5) -> kept.
+        let (index, tokens) = unknown_index_with_windows(30, 5, &[0, 6, 12, 18]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+        assert_eq!(unknown_match(&index, &query, &[]).len(), 1);
+    }
+
+    // Pins the MIN_REGION_LENGTH=5 early-out. A region of length 4 (one shorter than the gate)
+    // yields no unknown match. The constant is a fast-path guard below the 6-token ngram window,
+    // so any region this short cannot contain an ngram regardless.
+    #[test]
+    fn test_unknown_match_pins_min_region_length_early_out() {
+        use crate::license_detection::test_utils::create_mock_query_with_tokens;
+
+        let (index, tokens) = unknown_index_with_windows(30, 30, &[0, 6, 12, 18]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+
+        // Cover everything except a 4-token region [0,4); below MIN_REGION_LENGTH so it is
+        // skipped before any ngram scan.
+        let known = vec![LicenseMatch {
+            matcher: MatcherKind::Aho,
+            coordinates: MatchCoordinates::query_region(PositionSpan::range(4, 30)),
+            ..Default::default()
+        }];
+        assert!(unknown_match(&index, &query, &known).is_empty());
+    }
+
+    // Pins the MIN_NGRAM_MATCHES=3 early-out. A region long enough to clear MIN_REGION_LENGTH but
+    // containing only two matched ngrams produces no unknown match. Like the region guard this is
+    // a cheap pre-gate: two 6-grams can cover at most 12 positions, below the 24-position qspan
+    // floor, so it cannot reach a match anyway.
+    #[test]
+    fn test_unknown_match_pins_min_ngram_matches_early_out() {
+        use crate::license_detection::test_utils::create_mock_query_with_tokens;
+
+        let (index, tokens) = unknown_index_with_windows(30, 30, &[0, 6]);
+        let query = create_mock_query_with_tokens(&tokens, &index);
+        assert!(unknown_match(&index, &query, &[]).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Pins the unvalidated magic-number thresholds in the license-detection refinement pipeline with boundary unit tests (value, value−ε, value+ε) so future refactors cannot silently shift kept/dropped behavior.
- Adds short provenance comments at each constant noting its origin: ScanCode parity (with a rough Python location) or Provenant-specific tuning.
- Purely additive: tests + comments only. No logic change; no golden output changes.

## Issues

- Covers: #1028
- Closes: <!-- intentionally left open: surfacing the is_small() design question below as a follow-up; the pinning itself is complete -->

## Scope and exclusions

- Included:
  - `is_small()` small-rule `coverage() < 80.0` floor (`models/license_match.rs`)
  - redundant low-coverage composite seq-wrapper `coverage() >= 30.0` exemption (`mod.rs`)
  - `filter_spurious_matches` five-level density/length cascade (`match_refine/filter_low_quality.rs`)
  - `unknown_match` gates: qspan `>= 24` (`UNKNOWN_NGRAM_LENGTH * 4`), hispan `>= 5`, and the `MIN_REGION_LENGTH=5` / `MIN_NGRAM_MATCHES=3` early-outs (`unknown_match.rs`)
  - `is_false_positive` copyright-substring exemption and GPL `rule_length == 1` keying (`detection/analysis.rs`)
- Explicit exclusions:
  - No threshold is retuned. The `is_small()` 80.0-vs-curated-`minimum_coverage` question (see Follow-up) is a behavior/design decision deferred out of this PR; current behavior is pinned as-is.

## How to verify

- CI covers it. Beyond CI, most boundary tests are designed to fail if a constant or comparison operator is changed: e.g. flipping `>= 30.0` to `> 30.0` breaks `test_filter_redundant_low_coverage_composite_seq_wrappers_pins_coverage_exemption_at_30`, and changing the `< 80.0` floor breaks `is_small_pins_small_rule_coverage_floor_at_80`. Exception: the spurious-cascade tier-1 `mlen < 10` constant is structurally subsumed by tier-2 and the universal 0.4 floor, so it cannot be pinned by a kept/dropped flip; that test instead guards the cascade's monotonicity and documents the subsumption, while the observable behavior is pinned by the 0.4-floor test.

## Intentional differences from Python

- `is_false_positive`'s `is_gpl` check additionally excludes `lgpl` (ScanCode keys on bare `'gpl' in identifier`); commented inline. Pinned by `test_is_false_positive_lgpl_short_not_filtered` (pre-existing).
- `unknown_match`'s `MIN_REGION_LENGTH=5` and `MIN_NGRAM_MATCHES=3` have no direct Python equivalent — ScanCode runs unknown matching per `query_run`, whereas Provenant scans self-discovered unmatched regions and needs these pre-gates. Both are fast-path guards that sit below the stricter qspan-derived floor (a region/ngram count this low cannot reach the 24-position qspan gate anyway), so they are documented and pinned as early-outs.

## Follow-up work

- **is_small() 80.0 vs curated minimum_coverage (open design question, #1028).** Investigated against the ScanCode reference: the 80.0 small-rule coverage floor is exact upstream parity (`match.py` `LicenseMatch.is_small()`: `self.rule.is_small and self.coverage() < 80`). Upstream does **not** consult the rule's curated `minimum_coverage` here either — only `min_matched_length` / `min_high_matched_length` are rule-derived. So the issue's concern (a curator lowering `minimum_coverage` on a small rule has no effect, because `is_small()` still discards below 80%) reflects a real interaction, but the current behavior is intended ScanCode parity, not a Provenant bug. Recommendation: treat "let curated `minimum_coverage` win for small rules" as a deliberate, parity-breaking enhancement decided separately (it would shift detection output); not done here. This PR pins the current behavior so any future change is explicit.

## Expected-output fixture changes

- Files changed: none. License detection golden suite (`license_detection_golden`, 21 cases) passes unchanged, confirming no behavior drift.