### PR TITLE
perf(pipeline): skip unused per-file SHA-256 and fuse multi-hash under --info

### DIFF
--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -8,7 +8,7 @@ use super::license::{LicenseExtractionInput, extract_license_information};
 use super::special_cases::{is_go_non_production_source, should_skip_text_detection};
 use crate::license_detection::LicenseDetectionEngine;
 use crate::models::{
-    DatasourceId, FileInfo, FileInfoBuilder, FileType, PackageData, ScanDiagnostic, Sha256Digest,
+    DatasourceId, FileInfo, FileInfoBuilder, FileType, PackageData, ScanDiagnostic,
 };
 use crate::parsers::compiled_binary::{
     is_supported_compiled_binary_format, try_parse_compiled_bytes,
@@ -26,9 +26,7 @@ use crate::utils::file::{
     extract_text_for_detection_with_diagnostics, get_creation_date,
 };
 use crate::utils::generated::generated_code_hints_from_bytes;
-use crate::utils::hash::{
-    calculate_file_hashes, calculate_md5, calculate_sha1, calculate_sha1_git, calculate_sha256,
-};
+use crate::utils::hash::{calculate_buffer_hashes, calculate_file_hashes};
 use crate::utils::text::{
     remove_verbatim_escape_sequences, should_remove_verbatim_escape_sequences,
 };
@@ -66,10 +64,9 @@ pub(super) fn process_file(
         license_options,
         text_options,
     ) {
-        Ok((is_generated, sha256, is_source)) => {
+        Ok((is_generated, is_source)) => {
             generated_flag = is_generated;
             is_source_file = is_source;
-            let _ = sha256;
         }
         Err(FileScanError::Timeout(timeout)) => {
             scan_diagnostics.push(ScanDiagnostic::timeout(timeout.to_string()))
@@ -133,7 +130,7 @@ fn extract_information_from_content(
     license_engine: Option<Arc<LicenseDetectionEngine>>,
     license_options: LicenseScanOptions,
     text_options: &TextDetectionOptions,
-) -> Result<(Option<bool>, Sha256Digest, bool), FileScanError> {
+) -> Result<(Option<bool>, bool), FileScanError> {
     let started = Instant::now();
     let filesystem_path = absolute_filesystem_path(path);
     let license_enabled = license_engine.is_some();
@@ -167,7 +164,7 @@ fn extract_information_from_content(
                 populate_oversized_rpm_info(file_info_builder, &filesystem_path, text_options)?;
             }
             progress.record_detail_timing("scan:packages", rpm_fast_path_timing_seconds);
-            return Ok((None, Sha256Digest::EMPTY, false));
+            return Ok((None, false));
         }
     }
 
@@ -180,7 +177,6 @@ fn extract_information_from_content(
         }));
     }
 
-    let sha256 = calculate_sha256(&buffer);
     let is_generated = text_options
         .detect_generated
         .then(|| !generated_code_hints_from_bytes(&buffer).is_empty());
@@ -188,14 +184,15 @@ fn extract_information_from_content(
 
     if text_options.collect_info {
         let info_started = Instant::now();
+        let (sha1, md5, sha256, sha1_git) = calculate_buffer_hashes(&buffer);
         file_info_builder
-            .sha1(Some(calculate_sha1(&buffer)))
-            .md5(Some(calculate_md5(&buffer)))
+            .sha1(Some(sha1))
+            .md5(Some(md5))
             .sha256(Some(sha256))
             .programming_language(classification.programming_language.clone())
             .mime_type(Some(classification.mime_type.clone()))
             .file_type_label(Some(classification.file_type.clone()))
-            .sha1_git(Some(calculate_sha1_git(&buffer)))
+            .sha1_git(Some(sha1_git))
             .is_binary(Some(classification.is_binary))
             .is_text(Some(classification.is_text))
             .is_archive(Some(classification.is_archive))
@@ -209,7 +206,7 @@ fn extract_information_from_content(
     }
 
     if should_skip_text_detection(&filesystem_path, &buffer) {
-        return Ok((is_generated, sha256, classification.is_source));
+        return Ok((is_generated, classification.is_source));
     }
 
     if text_options.detect_packages {
@@ -282,7 +279,7 @@ fn extract_information_from_content(
     }
 
     if text_content.is_empty() {
-        return Ok((is_generated, sha256, classification.is_source));
+        return Ok((is_generated, classification.is_source));
     }
 
     if text_options.detect_copyrights {
@@ -371,7 +368,7 @@ fn extract_information_from_content(
         }));
     }
 
-    Ok((is_generated, sha256, classification.is_source))
+    Ok((is_generated, classification.is_source))
 }
 
 fn prepare_license_detection_text(

--- a/src/utils/hash.rs
+++ b/src/utils/hash.rs
@@ -33,6 +33,35 @@ pub fn calculate_sha1_git(content: &[u8]) -> GitSha1 {
     GitSha1::from_bytes(digest.into())
 }
 
+/// Computes sha1, md5, sha256 and git-sha1 for an in-memory buffer in a single
+/// chunked pass that updates every hasher per chunk, improving cache locality
+/// over four independent full passes over the same bytes.
+pub fn calculate_buffer_hashes(
+    content: &[u8],
+) -> (Sha1Digest, Md5DigestType, Sha256Digest, GitSha1) {
+    let mut sha1 = Sha1::new();
+    let mut md5 = Md5::new();
+    let mut sha256 = Sha256::new();
+    let mut git_sha1 = Sha1::new();
+
+    git_sha1.update(format!("blob {}\0", content.len()).as_bytes());
+
+    const CHUNK: usize = 64 * 1024;
+    for chunk in content.chunks(CHUNK) {
+        sha1.update(chunk);
+        md5.update(chunk);
+        sha256.update(chunk);
+        git_sha1.update(chunk);
+    }
+
+    (
+        Sha1Digest::from_bytes(sha1.finalize().into()),
+        Md5DigestType::from_bytes(md5.finalize().into()),
+        Sha256Digest::from_bytes(sha256.finalize().into()),
+        GitSha1::from_bytes(git_sha1.finalize().into()),
+    )
+}
+
 pub fn calculate_file_hashes(
     path: &Path,
     size: u64,
@@ -66,4 +95,26 @@ pub fn calculate_file_hashes(
         Sha256Digest::from_bytes(sha256.finalize().into()),
         GitSha1::from_bytes(git_sha1.finalize().into()),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the fused buffer pass to the individual single-hash helpers so a
+    /// future change to either path cannot silently diverge the `--info` output.
+    #[test]
+    fn fused_buffer_hashes_match_individual_helpers() {
+        for content in [
+            b"".as_slice(),
+            b"hello world\n".as_slice(),
+            &vec![0xABu8; 200 * 1024],
+        ] {
+            let (sha1, md5, sha256, sha1_git) = calculate_buffer_hashes(content);
+            assert_eq!(sha1, calculate_sha1(content));
+            assert_eq!(md5, calculate_md5(content));
+            assert_eq!(sha256, calculate_sha256(content));
+            assert_eq!(sha1_git, calculate_sha1_git(content));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- The per-file pipeline computed `calculate_sha256(&buffer)` for **every file on every scan** (`src/scanner/process/pipeline.rs`), but the returned digest was discarded by the caller (`let _ = sha256;`). The only real consumers of a file digest are the `--info` hash fields and the incremental manifest — and the manifest already re-reads + re-hashes the file itself when `file_info.sha256` is `None` (the default, non-info case). The unconditional pass was dead work on the hot path. It is now removed.
- Under `--info`, sha1/md5/sha256/sha1_git were four separate full passes over the buffer (and sha256 was computed twice). They are now fused into one chunked pass (`calculate_buffer_hashes`) that updates every hasher per 64 KiB chunk for better cache locality.

### Measured (perf-ab, this branch vs base, `-n 1`, byte-identical gate passing)

| Target | Mode | base median | head median | Result |
|---|---|---|---|---|
| 360 MB large-blob dir (42 files) | default (no `--info`) | 0.823s | 0.723s | **1.138x / 12.15% faster** |
| 360 MB large-blob dir | `--info` | 1.440s | 1.429s | 1.008x / 0.75% faster |
| 11 MB mixed source tree (`src/`, 682 files) | default | 0.054s | 0.051s | 1.059x / 5.59% faster |

7 interleaved rounds each; head was faster in **every** round on all three runs (no overlap in distributions). The win scales with corpus byte size, as predicted in the issue. The dominant, repeatable win is on the **default scan path** (the lazy-SHA256 removal). The fused-hash gain under `--info` is small and positive — hashing is memory-bandwidth-bound on this hardware (arm64 SHA acceleration), so fusing helps locality only modestly, but it never regresses and removes a redundant duplicate sha256 pass.

`--check-output` (byte-identical after header normalization) passed on **all three** runs.

## Issues

- Covers: #1032
- Closes: #1032

## Scope and exclusions

- Included: lazy/skipped unused per-file SHA-256 on the default path; fused multi-hash pass under `--info`.
- Explicit exclusions: no change to the incremental reuse algorithm, trust-mtime behavior (#995/#1024), or the manifest fingerprint format. Default-mode incremental still computes/compares sha256 via the manifest's own read+rehash fallback, unchanged.

## How to verify

Beyond CI, reproduce the A/B and correctness gates:

```
# default scan win + byte-identical gate (use a large-blob dir for the clearest signal)
cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
  --base origin/main --head HEAD --target-path /path/to/large-blob-dir \
  --rounds 7 --check-output -- -n 1
```

Functional correctness already verified locally:
- `--info` hashes match coreutils/git exactly (`sha256`, `sha1`, `md5`, `sha1_git` for `hello world\n`).
- Incremental warm re-scan with `--incremental`: a content-modified file is correctly re-scanned while an unchanged sibling is reused; a same-size content change in default (paranoid) mode is still detected (covered by `cache::incremental` and `scan_pipeline::incremental_manifest` unit tests, all green).

## Expected-output fixture changes

- None. This is a behavior-preserving perf change; scan output is byte-identical (verified by the `perf-ab --check-output` gate on all three targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
