### PR TITLE
perf(license): prune and defer set-intersection work in candidate selection

### DIFF
--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -399,21 +399,27 @@ fn find_set_candidates<'a>(
         if high_intersection_size < rule.min_high_matched_length_unique {
             continue;
         }
-
-        let high_set_intersection = query_data.query_high_set.intersection(rule_high_set);
-        if high_set_intersection.is_empty() {
+        // Require at least one shared high token.
+        if high_intersection_size == 0 {
             continue;
         }
 
-        let intersection = query_data.query_set.intersection(rule_set);
-        if intersection.is_empty() {
+        // A rule needing more unique tokens than the query holds in total can never
+        // pass the match-length gate below, so skip its O(n+m) merge walk.
+        if query_data.query_set_len < rule.min_matched_length_unique {
             continue;
         }
 
-        let matched_length = intersection.len();
+        let matched_length = query_data.query_set.intersection_count(rule_set);
+        if matched_length == 0 {
+            continue;
+        }
         if matched_length < rule.min_matched_length_unique {
             continue;
         }
+
+        // Allocate the high-token intersection only for surviving candidates.
+        let high_set_intersection = query_data.query_high_set.intersection(rule_high_set);
 
         let Some(candidate) = build_ranked_candidate(
             rid,


### PR DESCRIPTION
## Summary

- Reduce allocation and merge-walk work in the per-query-run set-candidate selection loop (`find_set_candidates`), the dominant license-detection hotspot, without changing any detection output.
- A fresh single-thread `samply` profile of a license-only scan on apache/airflow @ 47ce5f3 shows candidate selection is **not** diffuse (contrary to #994's earlier inclusive-figure reading): `select_seq_candidates_with_deadline` is **~36%** self-time and `TokenSet::intersection` (called from inside it) is **~33%** — together ~70% of single-thread CPU, concentrated in this one loop.

## Issues

- Covers: #1031
- Closes: #1031

## Scope and exclusions

- Included: three behavior-preserving changes in `find_set_candidates`:
  1. Replace the full-set `TokenSet::intersection` (previously allocated only to read `.len()`/`.is_empty()`) with the allocation-free `intersection_count`; len and emptiness are derivable from the count.
  2. Add a scalar pre-gate: skip the full-set merge walk when the query's unique-token count is already below the rule's `min_matched_length_unique` (the match count can never exceed the query token count).
  3. Materialize the high-token intersection only after every count-based gate passes, so the surviving-candidate allocation is the only heap allocation in the hot loop.
- Explicit exclusions: no change to the multiset rescore phase, ordering, deadline behavior, or any threshold. No tiered rule-set / cross-query-run caching (considered but not pursued — see Follow-up).

## How to verify

Beyond CI (which runs the golden suite), the load-bearing extra evidence is the self-A/B with the byte-identical gate, which a reviewer cannot reproduce from the suite alone:

```
cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
  --base 197316c0 --head 085926fd \
  --target-path /path/to/apache-airflow@47ce5f3 \
  --rounds 5 --check-output -- --license -n 1
```

Measured (apache/airflow @ 47ce5f3, single-thread, 5 interleaved warm rounds):

- base median **188.843s** -> head median **184.174s** = **2.47% faster** (1.025x), every head round faster than every base round.
- `perf-ab --check-output`: **outputs byte-identical** after header normalization.
- Independent full-corpus diff: **0** `license_detections` and **0** `license_clues` diffs across all 15,111 files.

Stop condition: real, repeatable perf-ab win on a real license scan AND provably byte-identical output. Met. The win is modest because the dominant cost is the sorted-set merge walk itself (still O(n+m)); this PR removes the per-candidate allocation and defers the high-set allocation behind the gates, which is the safe, semantics-preserving slice. The scalar pre-gate adds little on this corpus (most surviving rules have small `min_matched_length_unique`) but is free and helps token-poor query runs.

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: a larger algorithmic prune (tiered rule sets keyed on cheap file signals, or per-file hoisting of query-run-invariant exclusions) could attack the merge-walk volume itself rather than the per-candidate constant factor. Deferred — higher risk to byte-identical output (the #1017 class) and warrants its own measured cycle.

## Expected-output fixture changes

- Files changed: none. Output is byte-identical; no golden/expected fixtures were modified.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)