### PR TITLE
perf(license): use FxHash for candidate-selection per-run set/map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "rkyv",
  "rpm",
  "rusqlite",
+ "rustc-hash",
  "rustpython-ruff_python_ast",
  "rustpython-ruff_python_parser",
  "rusty-axml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ rpm = { version = "0.25.0", default-features = false, features = [
 ruff_python_ast = { version = "0.15.8", package = "rustpython-ruff_python_ast" }
 ruff_python_parser = { version = "0.15.8", package = "rustpython-ruff_python_parser" }
 rusqlite = { version = "0.39.0", features = ["bundled"], optional = true }
+rustc-hash = "2.1.2"
 rusty-axml = "0.2.1"
 schemars = { version = "1.2.1", features = ["derive"] }
 serde = { workspace = true }

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -13,7 +13,7 @@ use crate::license_detection::index::dictionary::TokenId;
 use crate::license_detection::models::Rule;
 use crate::license_detection::models::RuleId;
 use crate::license_detection::query::QueryRun;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
 
 use super::HIGH_RESEMBLANCE_THRESHOLD_TENTHS;
@@ -366,7 +366,7 @@ fn find_set_candidates<'a>(
     high_resemblance: bool,
     deadline: Option<Instant>,
 ) -> Vec<Candidate<'a>> {
-    let candidate_rid_set: HashSet<RuleId> = query_data
+    let candidate_rid_set: FxHashSet<RuleId> = query_data
         .query_high_set
         .iter()
         .filter_map(|tid| index.rids_by_high_tid.get(&TokenId::new(tid)))
@@ -374,7 +374,9 @@ fn find_set_candidates<'a>(
         .collect();
 
     // Sort so a deadline-truncated run returns a deterministic prefix rather
-    // than an arbitrary `HashSet`-ordered subset (issue #1017).
+    // than an arbitrary hash-ordered subset (issue #1017). The hasher only
+    // affects intermediate slot placement; this total sort fully determines
+    // the visited order, so swapping SipHash for FxHash cannot change output.
     let mut candidate_rids: Vec<RuleId> = candidate_rid_set.into_iter().collect();
     candidate_rids.sort_unstable();
 
@@ -532,7 +534,7 @@ impl DupeGroupKey {
 ///
 /// Corresponds to Python: `filter_dupes()` in match_set.py (line 461-498)
 pub(super) fn filter_dupes(candidates: Vec<Candidate<'_>>) -> Vec<Candidate<'_>> {
-    let mut groups: HashMap<DupeGroupKey, Vec<Candidate>> = HashMap::new();
+    let mut groups: FxHashMap<DupeGroupKey, Vec<Candidate>> = FxHashMap::default();
 
     for candidate in candidates {
         let key = DupeGroupKey::from_candidate(&candidate);


### PR DESCRIPTION
## Summary

- Replace the default-SipHash collections in the license candidate-selection hot path with `rustc-hash` FxHash equivalents:
  - the per-query-run `candidate_rid_set` (`HashSet<RuleId>` -> `FxHashSet<RuleId>`) in `find_set_candidates`
  - the `filter_dupes` grouping map (`HashMap<DupeGroupKey, _>` -> `FxHashMap`)
- Adds `rustc-hash = "2.1.2"` (tiny, well-maintained; `cargo deny` clean).

This is the constant-factor lever surfaced by #1045's profiling. Re-measured on real scans per #1046's caveat (the #994 `FxHashMap` bundle measured ~0%); unlike #994 this is a real, repeatable, multi-target win because candidate selection was reworked in #1044 and the per-run hashing is now a measurable slice.

### Fresh profile (current main @ 72faf6a5, post-#1044; rippled, `--license -n 1`, samply self-time)

- `TokenSet::intersection_count` — 53.95% (the merge walk; deferred lever from #1045, untouched here)
- **SipHash / hashing combined — 10.83%**: `BuildHasher::hash_one` 4.31% + `sip::Hasher::write` 4.17% + `RawTable::reserve_rehash` 2.00% + `HashMap::insert` 0.21%

This confirms #1046's ~9.8% figure is still present on the current build. The hashing in this hot path is exclusively the candidate-selection set build and per-candidate map lookups.

### Ordering-safety analysis (why the hasher swap cannot change output — #1017)

The hazard #1017 documented is that a hasher change reorders `HashSet`/`HashMap` iteration, and a deadline-truncated candidate loop could then return a different subset. Both touched collections are provably immune:

1. `candidate_rid_set`: built, then immediately `.into_iter().collect()` into a `Vec<RuleId>` and `sort_unstable()`-ed before the deadline-bounded loop. `RuleId` sort is a **total order** (no ties), so the visited sequence — and therefore any deadline-truncated prefix — is fully determined by the sort, not the hasher. The HashSet iteration order is discarded entirely. The existing #1017 regression test `test_find_set_candidates_iterates_rids_in_deterministic_sorted_order` asserts this invariant and passes.
2. `filter_dupes` groups: each group's winner is chosen by a total order (`score_vec_full` then `rule.identifier`, which is unique), and the resulting candidate `Vec` is re-sorted downstream in `select_seq_candidates_with_deadline` by the total `Candidate` `Ord` (ending in `rid.cmp`). HashMap iteration order does not reach output.

Verified empirically by `perf-ab --check-output` (byte-identical after header normalization) on three diverse targets, plus the full license golden suite green with zero drift.

## Issues

- Covers: #1046
- Closes: #1046

## Scope and exclusions

- Included: FxHash swap for the two non-archived, per-run hot collections in `find_set_candidates` / `filter_dupes`.
- Explicit exclusions: the archived `LicenseIndex` lookup maps (`sets_by_rid`, `high_sets_by_rid`, `msets_by_rid`, `rids_by_high_tid`, ...) are left as `std::HashMap`. They deserialize from the embedded rkyv artifact, so converting their hasher would change the archive layout and force artifact regeneration for a marginal additional gain; deliberately out of scope. No change to thresholds, deadline behavior, ordering, or the merge-walk algorithm.

## How to verify

Beyond CI (which runs the golden suite), the load-bearing extra evidence is the self-A/B with the byte-identical gate, which a reviewer cannot reproduce from the suite alone:

```
cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
  --base origin/main --head HEAD \
  --repo-url https://github.com/curl/curl \
  --repo-ref bb837dda23ed4df77a9bbeaefd69c8cd9b6e4915 \
  --rounds 7 --check-output -- --license -n 1
```

Measured (`--license -n 1`, 7 interleaved warm rounds, one warmup discarded per side), all `check-output OK: byte-identical`:

| Target | shape | base median | head median | speedup | rounds |
|---|---|---|---|---|---|
| curl @ bb837dda | license-dense C | 35.402s | 33.620s | **5.03% faster** | non-overlapping |
| rippled @ 949887fe | license-dense C++ | 11.364s | 11.023s | **3.00% faster** | non-overlapping |
| flask @ 36e4a824 | sparse Python (small) | 7.887s | 7.822s | 0.81% faster | thermally noisy, byte-identical |

The win scales with how much candidate selection runs (largest on license-dense trees, near-flat on small/sparse ones), which is the expected shape for a per-run constant-factor hashing fix.

## Follow-up work

- Created or intentionally deferred: the `TokenSet::intersection_count` merge walk (53.95% self-time) remains the dominant license-detection cost; it is the algorithmic lever tracked separately (#1045) and untouched here.

## Expected-output fixture changes

- Files changed: none. Output is byte-identical; the license golden suite (21 tests) passes unchanged.

Fixes #1046