### PR TITLE
docs(cli): clarify --max-in-memory bounds the in-scan working set, not peak RSS

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -610,6 +610,33 @@ These are worth learning early because they change what the output means:
 - `--reindex` only matters when the license engine is initialized (`--license` and some `--from-json` reference-recompute flows)
 - `--no-license-index-cache` only matters when the license engine is initialized
 
+## Memory Use and What `--max-in-memory` Actually Bounds
+
+`--max-in-memory <INT>` caps how many per-file/per-directory scan details
+(`FileInfo` records) Provenant keeps in memory during the in-scan
+file-processing window. Once that limit is reached, the remaining records spill
+to a temporary on-disk store instead of staying resident. `0` disables the cap
+(unlimited in-memory collection) and `-1` forces disk-only spill during the scan.
+
+Important: this flag bounds only the in-scan working set, not total or peak
+process memory (peak RSS). After file processing finishes, assembly, summary
+indexing, tallies, top-level license collection, and output all reconstitute the
+full result set (`load_all()` rebuilds the complete record vector before
+assembly) and operate over it as whole-set, random-access work. The peak RSS
+high-water mark is set in that post-scan span, not in the bounded in-scan window
+this flag controls.
+
+Concretely, on a 100k-file synthetic tree the spike in #1034 measured the
+default (`10000`, spills) at ~1124 MB peak RSS, `0` (no spill) at ~1023 MB, and
+`-1` (spill everything) at ~1032 MB — spilling does not lower peak RSS, and the
+default spilling mode is slightly higher because of chunk serialization overhead
+layered on top of the same full reconstitution. Use this flag to bound the
+in-scan retained set (for example, to keep the scan phase from growing without
+limit on very large trees); do not rely on it to bound the whole process's peak
+memory. Truly bounding peak RSS would require redesigning assembly and
+post-processing into a windowed/external-sort pipeline, which was explored and
+deferred as disproportionate in #1034.
+
 ## A Simple Decision Guide
 
 If you are not sure where to start, use this rule of thumb:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -350,8 +350,12 @@ pub struct ScanArgs {
     #[arg(long = "cache-trust-mtime", requires = "incremental")]
     pub cache_trust_mtime: bool,
 
-    /// Maximum number of file and directory scan details kept in memory.
+    /// Maximum number of file and directory scan details kept in memory during
+    /// the in-scan file-processing window before the rest spill to disk.
     /// Use 0 for unlimited memory or -1 for disk-only spill during the scan.
+    /// This bounds only the in-scan working set, NOT total or peak process
+    /// memory: assembly, summary, and output reconstitute the full result set
+    /// after the scan, so peak RSS is not bounded by this flag.
     #[arg(
         long = "max-in-memory",
         value_name = "INT",


### PR DESCRIPTION
## Summary

- Clarify that `--max-in-memory` bounds only the in-scan working set held during file processing before spilling to disk, NOT total or peak process memory (peak RSS).
- Update both the clap help text (`src/cli/mod.rs`) and `docs/CLI_GUIDE.md` with the honest contract.
- Documentation/help-text only: no change to the flag's behavior, the spill mechanism, or any default.

This is the resolution recommended in #1047. The #1034 feasibility spike proved the flag does not bound peak RSS: `process_collected_with_memory_limit` ends with `retained_files.extend(spill_store.load_all()?)`, rebuilding the full `Vec<FileInfo>` before assembly. Assembly, `SummaryIndex::build`, tallies, top-level license collection, and output are all whole-set random-access operations over that vec, so the peak RSS high-water mark is set in the `load_all()`->assembly->summary->output span, not the bounded in-scan window the flag controls.

Measured on a 100k-file synthetic tree (#1034):

| `--max-in-memory` | peak RSS | wall |
|---|---|---|
| `10000` (default, spills) | 1124.2 MB | 24.21 s |
| `0` (no spill) | 1023.1 MB | 23.68 s |
| `-1` (spill ALL) | 1031.8 MB | 24.12 s |

Spilling does not lower peak RSS; the default spilling mode is actually slightly higher (+10%) due to chunk serialization overhead layered on top of full reconstitution. Truly bounding peak RSS would require a windowed/external-sort assembly + post-processing rewrite, which was explored and deferred as disproportionate in #1034.

## Issues

- Closes: #1047

## Scope and exclusions

- Included: clap help string for `--max-in-memory`; a new "What `--max-in-memory` actually bounds" subsection in `docs/CLI_GUIDE.md`.
- Explicit exclusions: no behavior, spill-mechanism, or default changes; no windowed-assembly rewrite (deferred per #1034).

## How to verify

- `cargo run -- scan --help` and confirm the `--max-in-memory` help text states it bounds the in-scan working set, not peak RSS.
- Read the new subsection in `docs/CLI_GUIDE.md`. CI covers build, fmt, clippy, docs lint, and the existing `--max-in-memory` parse tests; nothing extra is needed beyond eyeballing the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)