### PR TITLE
docs(cli): simplify --max-in-memory section for a user audience

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -610,32 +610,22 @@ These are worth learning early because they change what the output means:
 - `--reindex` only matters when the license engine is initialized (`--license` and some `--from-json` reference-recompute flows)
 - `--no-license-index-cache` only matters when the license engine is initialized
 
-## Memory Use and What `--max-in-memory` Actually Bounds
+## Memory Use and What `--max-in-memory` Bounds
 
-`--max-in-memory <INT>` caps how many per-file/per-directory scan details
-(`FileInfo` records) Provenant keeps in memory during the in-scan
-file-processing window. Once that limit is reached, the remaining records spill
-to a temporary on-disk store instead of staying resident. `0` disables the cap
-(unlimited in-memory collection) and `-1` forces disk-only spill during the scan.
+`--max-in-memory <INT>` caps how many per-file scan results Provenant keeps in
+memory while it is processing files. Once the cap is reached, further results
+spill to a temporary on-disk store instead of staying resident. `0` disables the
+cap (everything stays in memory) and `-1` spills as aggressively as possible
+during the scan.
 
-Important: this flag bounds only the in-scan working set, not total or peak
-process memory (peak RSS). After file processing finishes, assembly, summary
-indexing, tallies, top-level license collection, and output all reconstitute the
-full result set (`load_all()` rebuilds the complete record vector before
-assembly) and operate over it as whole-set, random-access work. The peak RSS
-high-water mark is set in that post-scan span, not in the bounded in-scan window
-this flag controls.
+Important: this flag bounds only the working set held _during file scanning_, not
+the whole process's peak memory. The later phases — assembly, summaries, and
+output — need the complete result set in memory at once, and that is where peak
+memory use is highest. So spilling during the scan does not lower the overall
+peak, and very aggressive spilling can even raise it slightly.
 
-Concretely, on a 100k-file synthetic tree the spike in #1034 measured the
-default (`10000`, spills) at ~1124 MB peak RSS, `0` (no spill) at ~1023 MB, and
-`-1` (spill everything) at ~1032 MB — spilling does not lower peak RSS, and the
-default spilling mode is slightly higher because of chunk serialization overhead
-layered on top of the same full reconstitution. Use this flag to bound the
-in-scan retained set (for example, to keep the scan phase from growing without
-limit on very large trees); do not rely on it to bound the whole process's peak
-memory. Truly bounding peak RSS would require redesigning assembly and
-post-processing into a windowed/external-sort pipeline, which was explored and
-deferred as disproportionate in #1034.
+Use `--max-in-memory` to keep the scan phase from growing without bound on very
+large trees. Do not rely on it to cap the whole process's peak memory.
 
 ## A Simple Decision Guide
 


### PR DESCRIPTION
## Summary

The `## Memory Use and What --max-in-memory Bounds` section in the CLI guide (added in #1049) was too implementation-facing for user documentation. It referenced internal issue numbers, named internal implementation details, and dumped raw benchmark spike numbers.

This rewrites it for a user audience:

- **Removed**: issue-number references (`#1034` ×2), implementation internals (`load_all()`, "FileInfo record vector", "chunk serialization overhead", "windowed/external-sort pipeline"), and the raw spike measurements (`~1124 MB` / `~1023 MB` / `~1032 MB` on a "100k-file synthetic tree").
- **Kept**: the user-relevant contract — `--max-in-memory` bounds the working set held *during file scanning*, not the whole process's peak memory; the later phases (assembly, summaries, output) need the full result set in memory, so spilling does not lower peak RSS (and aggressive spilling can raise it slightly). Practical guidance retained: use it to bound the scan-phase working set on large trees; don't rely on it to cap total memory.

Documentation only — no behavior change. The clap `--help` text from #1049 is unchanged.

## Testing

- `npm run check:docs` — markdownlint 0 errors, prettier clean.

## Issues

Refines the section added in #1049 (no open issue; the user-facing wording was flagged in review after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)