### PR TITLE
perf(license): faster candidate selection via dense Vec maps + bitset high-gate

### DIFF
--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -358,9 +358,11 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     let mut rid_by_hash: HashMap<[u8; 20], RuleId> = HashMap::new();
     let mut rules_by_rid: Vec<Rule> = Vec::with_capacity(rules.len());
     let mut tids_by_rid: Vec<Vec<TokenId>> = Vec::with_capacity(rules.len());
-    let mut sets_by_rid: HashMap<RuleId, TokenSet> = HashMap::new();
-    let mut msets_by_rid: HashMap<RuleId, TokenMultiset> = HashMap::new();
-    let mut high_sets_by_rid: HashMap<RuleId, TokenSet> = HashMap::new();
+    // Dense, RuleId-indexed slots (mirroring Python's list layout). Sized to the
+    // total rule count below; `None` for rule IDs that hold no set.
+    let mut sets_by_rid: Vec<Option<TokenSet>> = Vec::new();
+    let mut msets_by_rid: Vec<Option<TokenMultiset>> = Vec::new();
+    let mut high_sets_by_rid: Vec<Option<TokenSet>> = Vec::new();
     let mut high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>> = HashMap::new();
     let mut rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>> = HashMap::new();
 
@@ -380,6 +382,13 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
 
     let mut all_rules: Vec<Rule> = license_rules.into_iter().chain(rules).collect();
     all_rules.sort();
+
+    // RuleId is dense (0..all_rules.len()); pre-size the per-rule slot vectors so
+    // each rule writes its own index. Slots stay `None` where no set is produced.
+    let rule_count = all_rules.len();
+    sets_by_rid.resize_with(rule_count, || None);
+    msets_by_rid.resize_with(rule_count, || None);
+    high_sets_by_rid.resize_with(rule_count, || None);
 
     let mut rid_by_spdx_key: HashMap<String, RuleId> = HashMap::new();
     let mut unknown_spdx_rid: Option<RuleId> = None;
@@ -462,14 +471,14 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         let tids_set = TokenSet::from_token_ids(rule_token_ids.iter().copied());
         let mset = TokenMultiset::from_token_ids(&rule_token_ids);
 
-        sets_by_rid.insert(rule_id, tids_set.clone());
-        msets_by_rid.insert(rule_id, mset.clone());
+        sets_by_rid[rid] = Some(tids_set.clone());
+        msets_by_rid[rid] = Some(mset.clone());
 
         let tids_set_high = tids_set.high_subset(&dictionary);
         let mset_high = mset.high_subset(&dictionary);
 
         if !tids_set_high.is_empty() {
-            high_sets_by_rid.insert(rule_id, tids_set_high.clone());
+            high_sets_by_rid[rid] = Some(tids_set_high.clone());
         }
 
         // Build inverted index: map high-value tokens to rules containing them

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -28,7 +28,7 @@ use crate::license_detection::spdx_mapping::build_spdx_mapping;
 use crate::license_detection::tokenize::{
     parse_required_phrase_spans, tokenize, tokenize_with_stopwords,
 };
-use crate::license_detection::{TokenMultiset, TokenSet};
+use crate::license_detection::{HighBitset, TokenMultiset, TokenSet};
 
 const UNKNOWN_NGRAM_LENGTH: usize = 6;
 const LICENSE_TOKEN_STRINGS: &[&str] = &["license", "licence", "licensed"];
@@ -363,6 +363,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     let mut sets_by_rid: Vec<Option<TokenSet>> = Vec::new();
     let mut msets_by_rid: Vec<Option<TokenMultiset>> = Vec::new();
     let mut high_sets_by_rid: Vec<Option<TokenSet>> = Vec::new();
+    let mut high_bitsets_by_rid: Vec<Option<HighBitset>> = Vec::new();
     let mut high_postings_by_rid: HashMap<RuleId, HashMap<TokenId, Vec<usize>>> = HashMap::new();
     let mut rids_by_high_tid: HashMap<TokenId, HashSet<RuleId>> = HashMap::new();
 
@@ -389,6 +390,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     sets_by_rid.resize_with(rule_count, || None);
     msets_by_rid.resize_with(rule_count, || None);
     high_sets_by_rid.resize_with(rule_count, || None);
+    high_bitsets_by_rid.resize_with(rule_count, || None);
 
     let mut rid_by_spdx_key: HashMap<String, RuleId> = HashMap::new();
     let mut unknown_spdx_rid: Option<RuleId> = None;
@@ -478,6 +480,8 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         let mset_high = mset.high_subset(&dictionary);
 
         if !tids_set_high.is_empty() {
+            high_bitsets_by_rid[rid] =
+                Some(HighBitset::from_token_set(&tids_set_high, len_legalese));
             high_sets_by_rid[rid] = Some(tids_set_high.clone());
         }
 
@@ -557,6 +561,7 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
         rule_metadata_by_identifier: HashMap::new(),
         msets_by_rid,
         high_sets_by_rid,
+        high_bitsets_by_rid,
         high_postings_by_rid,
         licenses_by_key,
         rid_by_spdx_key,

--- a/src/license_detection/index/builder/tests.rs
+++ b/src/license_detection/index/builder/tests.rs
@@ -211,9 +211,9 @@ mod test_cases {
         let index = build_index(rules, vec![]);
 
         let rid = find_rid_by_identifier(&index, "sets.RULE").expect("rule should exist");
-        assert!(index.sets_by_rid.contains_key(&rid));
-        assert!(index.msets_by_rid.contains_key(&rid));
-        assert!(!index.sets_by_rid[&rid].is_empty());
+        assert!(index.set_for_rid(rid).is_some());
+        assert!(index.mset_for_rid(rid).is_some());
+        assert!(!index.set_for_rid(rid).unwrap().is_empty());
     }
 
     #[test]
@@ -419,12 +419,12 @@ mod test_cases {
                 rules_with_empty_tokens += 1;
             }
             assert!(
-                index.sets_by_rid.contains_key(&rid),
+                index.set_for_rid(rid).is_some(),
                 "Rule {} should have token set",
                 rid
             );
             assert!(
-                index.msets_by_rid.contains_key(&rid),
+                index.mset_for_rid(rid).is_some(),
                 "Rule {} should have token multiset",
                 rid
             );
@@ -941,10 +941,7 @@ SOFTWARE."#;
             eprintln!("\nRule token count: {}", rule_tokens.len());
 
             // Use the indexed set from the index
-            let indexed_set = index
-                .sets_by_rid
-                .get(&rid)
-                .expect("Should have indexed set");
+            let indexed_set = index.set_for_rid(rid).expect("Should have indexed set");
             eprintln!(
                 "Rule unique tokens (from indexed set): {}",
                 indexed_set.len()

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -105,30 +105,27 @@ pub struct LicenseIndex {
 
     /// Token ID sets per rule for candidate selection.
     ///
-    /// Maps rule IDs to sets of unique token IDs present in that rule.
-    /// Used for efficient candidate selection based on token overlap.
-    ///
-    /// Corresponds to Python: `self.sets_by_rid = []` (line 212)
-    pub sets_by_rid: HashMap<RuleId, TokenSet>,
+    /// Indexed densely by `RuleId::raw()` (mirroring Python's `sets_by_rid = []`
+    /// list). Entries are `None` for rule IDs that hold no set (e.g. false-positive
+    /// rules), so the candidate-selection hot loop reads a `Vec` slot instead of a
+    /// hashed lookup. Use [`LicenseIndex::set_for_rid`] to access.
+    pub sets_by_rid: Vec<Option<TokenSet>>,
 
     pub rule_metadata_by_identifier: HashMap<String, IndexedRuleMetadata>,
 
     /// Token ID multisets per rule for candidate ranking.
     ///
-    /// Maps rule IDs to multisets (bags) of token IDs with their frequencies.
-    /// Used for ranking candidates by token frequency overlap.
-    ///
-    /// Corresponds to Python: `self.msets_by_rid = []` (line 213)
-    pub msets_by_rid: HashMap<RuleId, TokenMultiset>,
+    /// Indexed densely by `RuleId::raw()` (mirroring Python's `msets_by_rid = []`).
+    /// `None` where no multiset exists. Use [`LicenseIndex::mset_for_rid`].
+    pub msets_by_rid: Vec<Option<TokenMultiset>>,
 
     /// High-value token sets per rule for early candidate rejection.
     ///
-    /// Maps rule IDs to sets containing only high-value (legalese) token IDs.
-    /// This is a subset of `sets_by_rid` for faster intersection computation
-    /// and early rejection of candidates that won't pass the high-token threshold.
-    ///
-    /// Precomputed during index building to avoid redundant filtering at runtime.
-    pub high_sets_by_rid: HashMap<RuleId, TokenSet>,
+    /// Indexed densely by `RuleId::raw()`. A subset of `sets_by_rid` containing
+    /// only high-value (legalese) token IDs, for early rejection of candidates that
+    /// won't pass the high-token threshold. `None` where the rule has no high-value
+    /// tokens. Use [`LicenseIndex::high_set_for_rid`].
+    pub high_sets_by_rid: Vec<Option<TokenSet>>,
 
     /// Inverted index of high-value token positions per rule.
     ///
@@ -227,10 +224,10 @@ impl LicenseIndex {
             tids_by_rid: Vec::new(),
             rules_automaton: AutomatonBuilder::new().build(),
             unknown_automaton: AutomatonBuilder::new().build(),
-            sets_by_rid: HashMap::new(),
+            sets_by_rid: Vec::new(),
             rule_metadata_by_identifier: HashMap::new(),
-            msets_by_rid: HashMap::new(),
-            high_sets_by_rid: HashMap::new(),
+            msets_by_rid: Vec::new(),
+            high_sets_by_rid: Vec::new(),
             high_postings_by_rid: HashMap::new(),
             licenses_by_key: HashMap::new(),
             rid_by_spdx_key: HashMap::new(),
@@ -238,6 +235,29 @@ impl LicenseIndex {
             rids_by_high_tid: HashMap::new(),
             spdx_license_list_version: None,
         }
+    }
+
+    /// Unique-token set for a rule, or `None` if the rule holds no set
+    /// (e.g. a false-positive rule). Dense `Vec` lookup by `RuleId`.
+    #[inline]
+    pub fn set_for_rid(&self, rid: RuleId) -> Option<&TokenSet> {
+        self.sets_by_rid.get(rid.raw()).and_then(Option::as_ref)
+    }
+
+    /// High-value (legalese) token set for a rule, or `None` if the rule has no
+    /// high-value tokens. Dense `Vec` lookup by `RuleId`.
+    #[inline]
+    pub fn high_set_for_rid(&self, rid: RuleId) -> Option<&TokenSet> {
+        self.high_sets_by_rid
+            .get(rid.raw())
+            .and_then(Option::as_ref)
+    }
+
+    /// Token multiset for a rule, or `None` if the rule holds no multiset.
+    /// Dense `Vec` lookup by `RuleId`.
+    #[inline]
+    pub fn mset_for_rid(&self, rid: RuleId) -> Option<&TokenMultiset> {
+        self.msets_by_rid.get(rid.raw()).and_then(Option::as_ref)
     }
 
     /// Create a new empty license index with the specified legalese count.

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -16,7 +16,7 @@ pub use builder::{
 use crate::license_detection::automaton::{AsBytes, Automaton};
 use crate::license_detection::index::dictionary::{TokenDictionary, TokenId};
 use crate::license_detection::models::RuleId;
-use crate::license_detection::{TokenMultiset, TokenSet};
+use crate::license_detection::{HighBitset, TokenMultiset, TokenSet};
 use rkyv::Archive;
 use std::collections::{HashMap, HashSet};
 
@@ -127,6 +127,13 @@ pub struct LicenseIndex {
     /// tokens. Use [`LicenseIndex::high_set_for_rid`].
     pub high_sets_by_rid: Vec<Option<TokenSet>>,
 
+    /// High-value token sets as fixed-width bitsets (width = `len_legalese`),
+    /// densely indexed by `RuleId::raw()` and aligned with `high_sets_by_rid`
+    /// (`Some` exactly where that is `Some`). Used by the candidate-selection
+    /// high-token gate, where `AND`+`popcount` replaces the sorted-set merge
+    /// walk. Use [`LicenseIndex::high_bitset_for_rid`].
+    pub high_bitsets_by_rid: Vec<Option<HighBitset>>,
+
     /// Inverted index of high-value token positions per rule.
     ///
     /// Maps rule IDs to a mapping from high-value token IDs to their positions
@@ -228,6 +235,7 @@ impl LicenseIndex {
             rule_metadata_by_identifier: HashMap::new(),
             msets_by_rid: Vec::new(),
             high_sets_by_rid: Vec::new(),
+            high_bitsets_by_rid: Vec::new(),
             high_postings_by_rid: HashMap::new(),
             licenses_by_key: HashMap::new(),
             rid_by_spdx_key: HashMap::new(),
@@ -258,6 +266,15 @@ impl LicenseIndex {
     #[inline]
     pub fn mset_for_rid(&self, rid: RuleId) -> Option<&TokenMultiset> {
         self.msets_by_rid.get(rid.raw()).and_then(Option::as_ref)
+    }
+
+    /// High-value token bitset for a rule, or `None` if the rule has no
+    /// high-value tokens. Dense `Vec` lookup by `RuleId`.
+    #[inline]
+    pub fn high_bitset_for_rid(&self, rid: RuleId) -> Option<&HighBitset> {
+        self.high_bitsets_by_rid
+            .get(rid.raw())
+            .and_then(Option::as_ref)
     }
 
     /// Create a new empty license index with the specified legalese count.

--- a/src/license_detection/license_cache.rs
+++ b/src/license_detection/license_cache.rs
@@ -273,6 +273,7 @@ mod tests {
             rule_metadata_by_identifier: Default::default(),
             msets_by_rid: Default::default(),
             high_sets_by_rid: Default::default(),
+            high_bitsets_by_rid: Default::default(),
             high_postings_by_rid: Default::default(),
             licenses_by_key: Default::default(),
             rid_by_spdx_key: Default::default(),

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -106,7 +106,7 @@ pub use match_refine::{
 pub use position_set::PositionSet;
 pub use spdx_lid::spdx_lid_match;
 pub use token_multiset::TokenMultiset;
-pub use token_set::TokenSet;
+pub use token_set::{HighBitset, TokenSet};
 pub use unknown_match::unknown_match;
 
 use self::seq_match::{

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -390,10 +390,10 @@ fn find_set_candidates<'a>(
         let Some(rule) = index.rule(rid) else {
             continue;
         };
-        let Some(rule_set) = index.sets_by_rid.get(&rid) else {
+        let Some(rule_set) = index.set_for_rid(rid) else {
             continue;
         };
-        let Some(rule_high_set) = index.high_sets_by_rid.get(&rid) else {
+        let Some(rule_high_set) = index.high_set_for_rid(rid) else {
             continue;
         };
 
@@ -455,7 +455,7 @@ fn rescore_candidates_with_multisets<'a>(
             return candidates;
         }
 
-        let Some(rule_mset) = index.msets_by_rid.get(&candidate.rid) else {
+        let Some(rule_mset) = index.mset_for_rid(candidate.rid) else {
             continue;
         };
 

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -5,6 +5,7 @@
 
 //! Candidate selection using set and multiset similarity.
 
+use crate::license_detection::HighBitset;
 use crate::license_detection::LicenseDetectionError;
 use crate::license_detection::TokenMultiset;
 use crate::license_detection::TokenSet;
@@ -199,6 +200,7 @@ struct QueryData {
     query_set: TokenSet,
     query_mset: TokenMultiset,
     query_high_set: TokenSet,
+    query_high_bits: HighBitset,
     query_high_mset: TokenMultiset,
     query_set_len: usize,
     query_mset_len: usize,
@@ -230,6 +232,7 @@ impl QueryData {
             return None;
         }
 
+        let query_high_bits = HighBitset::from_token_set(&query_high_set, index.len_legalese);
         let query_high_mset = query_mset.high_subset(&index.dictionary);
         let query_set_len = query_set.len();
         let query_mset_len = query_mset.total_count();
@@ -238,6 +241,7 @@ impl QueryData {
             query_set,
             query_mset,
             query_high_set,
+            query_high_bits,
             query_high_mset,
             query_set_len,
             query_mset_len,
@@ -396,12 +400,20 @@ fn find_set_candidates<'a>(
         let Some(rule_high_set) = index.high_set_for_rid(rid) else {
             continue;
         };
+        let Some(rule_high_bits) = index.high_bitset_for_rid(rid) else {
+            continue;
+        };
 
-        let high_intersection_size = query_data.query_high_set.intersection_count(rule_high_set);
+        let high_intersection_size = query_data
+            .query_high_bits
+            .intersection_count(rule_high_bits);
         if high_intersection_size < rule.min_high_matched_length_unique {
             continue;
         }
-        // Require at least one shared high token.
+        // Defensive: require at least one shared high token. Every candidate rid
+        // comes from `rids_by_high_tid` (rules sharing a query high token), so
+        // `high_intersection_size >= 1` is currently guaranteed and this never
+        // fires; it guards correctness if candidate sourcing ever changes.
         if high_intersection_size == 0 {
             continue;
         }

--- a/src/license_detection/test_utils.rs
+++ b/src/license_detection/test_utils.rs
@@ -43,6 +43,16 @@ pub fn create_test_index_default() -> LicenseIndex {
     create_test_index(&[("mit", 0), ("license", 1), ("apache", 2), ("2.0", 3)], 2)
 }
 
+/// Grow a dense `RuleId`-indexed slot vector as needed and assign `value` at
+/// `rid`. Mirrors the builder's pre-sized layout for ad-hoc test rules.
+fn assign_rid_slot<T>(slots: &mut Vec<Option<T>>, rid: RuleId, value: T) {
+    let idx = rid.raw();
+    if slots.len() <= idx {
+        slots.resize_with(idx + 1, || None);
+    }
+    slots[idx] = Some(value);
+}
+
 /// Inserts a whitespace-tokenized rule into a test index and wires up the set,
 /// multiset, high-set, postings, and inverted-index structures needed by
 /// candidate selection and sequence matching.
@@ -62,15 +72,15 @@ pub fn add_text_rule(
 
     let set = TokenSet::from_token_ids(tokens.iter().copied());
     let mset = TokenMultiset::from_token_ids(&tokens);
-    let _ = index.sets_by_rid.insert(rid, set.clone());
-    let _ = index.msets_by_rid.insert(rid, mset);
+    assign_rid_slot(&mut index.sets_by_rid, rid, set.clone());
+    assign_rid_slot(&mut index.msets_by_rid, rid, mset);
 
     let high_set: TokenSet = TokenSet::from_u16_iter(
         set.iter()
             .filter(|&tid| index.dictionary.token_kind(TokenId::new(tid)) == TokenKind::Legalese),
     );
     if !high_set.is_empty() {
-        let _ = index.high_sets_by_rid.insert(rid, high_set);
+        assign_rid_slot(&mut index.high_sets_by_rid, rid, high_set);
     }
 
     let mut high_postings: HashMap<TokenId, Vec<usize>> = HashMap::new();

--- a/src/license_detection/test_utils.rs
+++ b/src/license_detection/test_utils.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 
+use crate::license_detection::HighBitset;
 use crate::license_detection::TokenMultiset;
 use crate::license_detection::TokenSet;
 use crate::license_detection::index::LicenseIndex;
@@ -80,6 +81,8 @@ pub fn add_text_rule(
             .filter(|&tid| index.dictionary.token_kind(TokenId::new(tid)) == TokenKind::Legalese),
     );
     if !high_set.is_empty() {
+        let high_bits = HighBitset::from_token_set(&high_set, index.len_legalese);
+        assign_rid_slot(&mut index.high_bitsets_by_rid, rid, high_bits);
         assign_rid_slot(&mut index.high_sets_by_rid, rid, high_set);
     }
 

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -899,12 +899,9 @@ fn test_engine_index_sets_by_rid() {
     let index = engine.index();
 
     for &rid in index.rid_by_hash.values().take(5) {
-        assert!(
-            index.sets_by_rid.contains_key(&rid),
-            "Rule {} should have token set",
-            rid
-        );
-        let set = &index.sets_by_rid[&rid];
+        let set = index.set_for_rid(rid).unwrap_or_else(|| {
+            panic!("Rule {} should have token set", rid);
+        });
         assert!(
             !set.is_empty(),
             "Rule {} token set should not be empty",
@@ -919,12 +916,9 @@ fn test_engine_index_msets_by_rid() {
     let index = engine.index();
 
     for &rid in index.rid_by_hash.values().take(5) {
-        assert!(
-            index.msets_by_rid.contains_key(&rid),
-            "Rule {} should have token multiset",
-            rid
-        );
-        let mset = &index.msets_by_rid[&rid];
+        let mset = index.mset_for_rid(rid).unwrap_or_else(|| {
+            panic!("Rule {} should have token multiset", rid);
+        });
         assert!(
             !mset.is_empty(),
             "Rule {} token multiset should not be empty",

--- a/src/license_detection/token_set.rs
+++ b/src/license_detection/token_set.rs
@@ -108,6 +108,55 @@ impl Deref for TokenSet {
     }
 }
 
+/// Fixed-width bitset over high-value (legalese) token IDs.
+///
+/// Legalese tokens occupy the reserved low ID range `0..len_legalese`, so a
+/// rule's (or query's) high-token set maps onto one bit per ID. Intersection
+/// count is then a word-wise `AND` + `popcount`, which replaces the sorted
+/// two-pointer merge walk in the candidate-selection high-token gate — a
+/// branch-free, allocation-free, constant-per-rule cost regardless of set size.
+///
+/// All bitsets compared together MUST share the same width (`len_legalese`).
+#[derive(Clone, Debug, PartialEq, Eq, Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct HighBitset(Box<[u64]>);
+
+impl HighBitset {
+    /// Build a bitset of `len_legalese` bits with the high tokens of `set` set.
+    ///
+    /// `set` is expected to contain only high token IDs (`< len_legalese`); any
+    /// out-of-range ID would be a builder invariant violation, so it is ignored
+    /// rather than panicking in the hot path.
+    pub fn from_token_set(set: &TokenSet, len_legalese: usize) -> Self {
+        let mut words = vec![0u64; len_legalese.div_ceil(64)].into_boxed_slice();
+        for tid in set.iter() {
+            let bit = tid as usize;
+            if let Some(word) = words.get_mut(bit / 64) {
+                *word |= 1u64 << (bit % 64);
+            }
+        }
+        Self(words)
+    }
+
+    /// Count of shared bits with `other`. Both bitsets must share a width
+    /// (built from the same `len_legalese`); `zip` would otherwise silently
+    /// truncate to the shorter operand and undercount.
+    #[inline]
+    pub fn intersection_count(&self, other: &HighBitset) -> usize {
+        debug_assert_eq!(
+            self.0.len(),
+            other.0.len(),
+            "HighBitset width mismatch: {} vs {} words",
+            self.0.len(),
+            other.0.len()
+        );
+        self.0
+            .iter()
+            .zip(other.0.iter())
+            .map(|(a, b)| (a & b).count_ones() as usize)
+            .sum()
+    }
+}
+
 impl Default for TokenSet {
     fn default() -> Self {
         Self::new()
@@ -143,5 +192,48 @@ mod tests {
         let high_set = set.high_subset(&dict);
 
         assert_eq!(high_set.iter().collect::<Vec<_>>(), vec![1, 2]);
+    }
+
+    #[test]
+    fn high_bitset_intersection_count_overlap_cases() {
+        let a = TokenSet::from_u16_iter([1, 5, 9, 63, 64, 200]);
+        let b = TokenSet::from_u16_iter([5, 9, 64, 201]);
+        // width 256 is not a multiple of 64's underlying word count boundary
+        // checks; use a width that leaves a partial trailing word (200 -> 4 words).
+        let width = 256;
+        let ba = HighBitset::from_token_set(&a, width);
+        let bb = HighBitset::from_token_set(&b, width);
+        // partial overlap: {5, 9, 64}
+        assert_eq!(ba.intersection_count(&bb), 3);
+        // full self-overlap
+        assert_eq!(ba.intersection_count(&ba), a.len());
+        // zero overlap
+        let c = HighBitset::from_token_set(&TokenSet::from_u16_iter([2, 3, 4]), width);
+        let d = HighBitset::from_token_set(&TokenSet::from_u16_iter([10, 11]), width);
+        assert_eq!(c.intersection_count(&d), 0);
+        // matches the TokenSet reference on the shared subset
+        assert_eq!(ba.intersection_count(&bb), a.intersection_count(&b));
+    }
+
+    #[test]
+    fn high_bitset_handles_non_multiple_of_64_width_and_boundary_bits() {
+        // width 65 -> 2 words; exercises a bit in the trailing partial word (64).
+        let width = 65;
+        let a = HighBitset::from_token_set(&TokenSet::from_u16_iter([0, 63, 64]), width);
+        let b = HighBitset::from_token_set(&TokenSet::from_u16_iter([63, 64]), width);
+        assert_eq!(a.intersection_count(&b), 2);
+    }
+
+    #[test]
+    fn high_bitset_skips_ids_beyond_allocated_words() {
+        // Width rounds up to whole u64 words, so `from_token_set` silently skips
+        // only IDs at/beyond words*64. In practice high token IDs are always
+        // < len_legalese, so this guard is defensive; here width 8 -> 1 word
+        // (64 bits), and id 100 (>= 64) is dropped from both sets.
+        let width = 8;
+        let a = HighBitset::from_token_set(&TokenSet::from_u16_iter([1, 7, 100]), width);
+        let b = HighBitset::from_token_set(&TokenSet::from_u16_iter([7, 100]), width);
+        // id 100 is skipped in both; only id 7 is shared and in range.
+        assert_eq!(a.intersection_count(&b), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Speeds up license candidate selection with two byte-identical, constant-factor changes in the hot loop (`find_set_candidates` / `rescore_candidates_with_multisets`), complementing the disproven volume-reduction approach of #1045 (its per-file prefilter regressed because the build cost only amortized on license-dense files; these changes have no per-file setup).
- **Vec-indexed rule maps:** `sets_by_rid` / `msets_by_rid` / `high_sets_by_rid` move from `HashMap<RuleId, _>` (SipHash) to `Vec<Option<_>>` indexed by `RuleId::raw()`. `RuleId` is dense (mirroring the upstream Python list layout), so each per-candidate access is a `Vec` slot read instead of a hash + probe + pointer-chase. `None` preserves the prior gaps (false-positive rules, empty high-sets).
- **Bitset high-token gate:** each rule's high (legalese) token set is also stored as a fixed-width bitset (`HighBitset`, width = `len_legalese` = 4506 bits ≈ 564 B/rule), and the query's high bitset is built once per query run. The per-candidate high-token gate then computes the shared-token count via word-wise `AND` + `popcount` instead of the sorted two-pointer merge walk — branch-free and constant-per-rule regardless of set size. Legalese tokens occupy the reserved ID range `0..len_legalese`, so token ID maps directly to bit index. The surviving-candidate materialization still uses the `TokenSet`.

### Measured (harbor @ eb944bb, M5 Pro, `perf-ab` interleaved A/B)

| Measurement | base (main) | head | speedup |
|---|---|---|---|
| Single-thread license-only (`-l -n 1`) | 43.33s | 29.27s | **~1.41× / ~29%** |
| — Vec-indexed maps alone | 43.33s | ~33.0s | 1.25× |
| — bitset high-gate alone | ~33.0s | 29.27s | 1.13× |
| End-to-end multicore (`-clupe -p 18`) | 10.09s | 9.52s | ~1.06× / ~5.7% |

The end-to-end figure is diluted by the fixed ~6s cold index build (~60% of harbor's wall under `--no-license-index-cache`), which this PR does not touch; the isolated single-thread number reflects the actual candidate-selection improvement. Bitset memory cost is ~21 MB (<1% of the ~3 GB working set).

## Issues

- Closes: #1052

## Scope and exclusions

- Included: the two constant-factor candidate-selection changes above, their dense-`Vec` accessors (`set_for_rid` / `high_set_for_rid` / `mset_for_rid` / `high_bitset_for_rid`), and the `HighBitset` type.
- Explicit exclusions: the full-set `intersection_count` at `mod.rs:415` is untouched (no cheap bitset over the full 16-bit token space); the algorithmic merge-walk *volume* reduction remains the deferred #1045-class lever.

## How to verify

- Byte-identical is the core claim, verified three ways beyond CI's golden suite: `-l -n 1` `--check-output` (identical ×3) and a full `-clupe --processes 18` base-vs-head diff that is identical once randomly-generated package UIDs are normalized out.
- To reproduce the speedup: `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base origin/main --head HEAD --repo-url https://github.com/goharbor/harbor.git --repo-ref eb944bb199211d6ac76fb207cd2ef1bf33ec0030 -- -l -n 1` (omit `--check-output` on `--package` profiles — see follow-up).

## Follow-up work

- The ~6s cold index build dominates small cold multicore scans and dilutes this gain end-to-end (#1053; profile evidence posted there).
- The third lever from #1052 — galloping the full-set `intersection_count` — was **investigated and parked**: it measured neutral (1.005×, within noise). A post-merge profile shows the dominant remaining cost is the *number* of full-set counts, not their per-call cost; reducing that (candidate-volume pruning) was already closed **not_planned** in #1045 because it regresses common corpora, so candidate selection has no clearly-actionable remaining lever. See #1052 for the full disposition and profile.
- `perf-ab --check-output` couldn't pass on `--package` profiles because package UIDs are random per run — **fixed in #1055** (normalizes UIDs).


