### PR TITLE
fix(xtask): normalize random package UIDs in perf-ab --check-output

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -283,7 +283,7 @@ CLI arguments:
 - `--repo-ref REF`: required with `--repo-url`; commit SHA, tag, or branch of the target repo.
 - `--rounds N`: number of interleaved timed rounds per side after the discarded warmup. Default `5`.
 - `--base-bin PATH` / `--head-bin PATH`: use a prebuilt binary for that side and skip building the ref.
-- `--check-output`: scan with both binaries to JSON and assert byte-identical output after normalizing the volatile header. The correctness gate for pure-refactor perf changes.
+- `--check-output`: scan with both binaries to JSON and assert byte-identical output after normalizing the volatile header and randomly-generated package UIDs. The correctness gate for pure-refactor perf changes.
 - `--profile common|common-with-compiled|licenses|packages`: scan-flag shorthand shared by both sides. Mutually exclusive with explicit flags after `--`.
 - Pass either a supported `--profile` or explicit scan flags after `--` (for example `-- -c -n 1`). The same flags are forwarded to both binaries.
 
@@ -308,7 +308,7 @@ Each run writes artifacts under:
 - Both sides always run with `--no-license-index-cache` so a warmed license index from one round does not skew the next, matching `benchmark-target` fairness.
 - The warmup run is discarded; only the `--rounds` interleaved timed runs feed the median.
 - Build each ref in release on a stable checkout; do not point `--base-bin`/`--head-bin` at debug or differently-profiled binaries, which would make the comparison meaningless.
-- `--check-output` normalizes only the volatile top-level `headers` block (version, timestamps, duration) before comparing; any remaining diff fails the run, because a behavior-preserving perf change must be byte-identical.
+- `--check-output` normalizes the volatile top-level `headers` block (version, timestamps, duration) and randomly-generated package `uuid=` UIDs (which differ on every run, so without this `--package`/`-clupe` profiles could never pass) before comparing; any remaining diff fails the run, because a behavior-preserving perf change must be byte-identical.
 - Building two release binaries is slow. Use `--base-bin`/`--head-bin` when you already have both binaries, or `--repo-ref`/refs that share most compiled artifacts.
 
 ## `update-parser-golden`

--- a/xtask/src/bin/perf_ab.rs
+++ b/xtask/src/bin/perf_ab.rs
@@ -22,6 +22,7 @@ use provenant_xtask::repo_cache::{
     cleanup_repo_worktree, ensure_repo_mirror, prepare_repo_worktree, repo_cache_path,
     resolve_repo_ref_to_sha,
 };
+use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -59,7 +60,8 @@ struct Args {
     #[arg(long)]
     head_bin: Option<PathBuf>,
     /// Scan against this target with both binaries to JSON and require
-    /// byte-identical output after normalizing the volatile header.
+    /// byte-identical output after normalizing the volatile header and
+    /// randomly-generated package UIDs.
     #[arg(long)]
     check_output: bool,
     /// Scan profile shorthand. Mutually exclusive with explicit scan flags after `--`.
@@ -513,8 +515,14 @@ fn scan_to_json(
     fs::read_to_string(&out_file).with_context(|| format!("failed to read {}", out_file.display()))
 }
 
-/// Replace the volatile top-level `headers` array with a placeholder so that
-/// version, timestamp, and duration churn does not mask a real output diff.
+/// Normalize the volatile parts of scan output so that only behavioral diffs
+/// remain:
+///
+/// - the top-level `headers` array (version, timestamps, duration), and
+/// - randomly-generated package UIDs (`uuid=<uuid>` in `package_uid`,
+///   `dependency_uid`, `for_package_uid`, and the PURLs that reference them),
+///   which differ on every scan run and would otherwise make `--check-output`
+///   fail on any `--package` profile regardless of the code change.
 fn normalize_scan_json(raw: &str) -> Result<String> {
     let mut value: Value = serde_json::from_str(raw).context("scan output was not valid JSON")?;
     if let Some(object) = value.as_object_mut()
@@ -525,7 +533,23 @@ fn normalize_scan_json(raw: &str) -> Result<String> {
             Value::String("<normalized>".to_string()),
         );
     }
-    serde_json::to_string(&value).context("failed to re-serialize normalized scan output")
+    let serialized =
+        serde_json::to_string(&value).context("failed to re-serialize normalized scan output")?;
+    Ok(normalize_package_uids(&serialized))
+}
+
+/// Replace each random `uuid=<uuid>` (as emitted in package UID fields and the
+/// PURLs that reference them) with a stable placeholder. Matches the canonical
+/// 8-4-4-4-12 hex UUID form so non-UID content is left untouched.
+fn normalize_package_uids(input: &str) -> String {
+    static UID_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = UID_RE.get_or_init(|| {
+        // Case-insensitive so uppercase-hex UUIDs (some `Display` impls) are also
+        // normalized rather than slipping through and causing spurious failures.
+        Regex::new(r"(?i)uuid=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+            .expect("static UID regex is valid")
+    });
+    re.replace_all(input, "uuid=<normalized>").into_owned()
 }
 
 fn side_manifest(side: &Side, median_seconds: f64, rounds: &[f64]) -> SideManifest {
@@ -717,6 +741,40 @@ mod tests {
     fn normalize_scan_json_detects_real_diffs() {
         let a = r#"{"headers":[{"tool_version":"1.0"}],"files":[{"path":"a"}]}"#;
         let b = r#"{"headers":[{"tool_version":"1.0"}],"files":[{"path":"b"}]}"#;
+        assert_ne!(
+            normalize_scan_json(a).unwrap(),
+            normalize_scan_json(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn normalize_scan_json_ignores_random_package_uids() {
+        // Two runs of the same code differ only by randomly-generated package UIDs.
+        let a = r#"{"headers":[],"packages":[{"package_uid":"pkg:golang/x@1?uuid=7d2f562e-87fa-4423-9951-aac2ca7f521f"}]}"#;
+        let b = r#"{"headers":[],"packages":[{"package_uid":"pkg:golang/x@1?uuid=6ce89029-256e-4642-8bbd-8a45b15a771d"}]}"#;
+        assert_eq!(
+            normalize_scan_json(a).unwrap(),
+            normalize_scan_json(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn normalize_scan_json_normalizes_uppercase_uuids() {
+        // Lowercase vs uppercase hex for the same logical (random) UID must both
+        // normalize to the placeholder, so case never causes a spurious failure.
+        let a = r#"{"headers":[],"packages":[{"package_uid":"pkg:x@1?uuid=7d2f562e-87fa-4423-9951-aac2ca7f521f"}]}"#;
+        let b = r#"{"headers":[],"packages":[{"package_uid":"pkg:x@1?uuid=6CE89029-256E-4642-8BBD-8A45B15A771D"}]}"#;
+        assert_eq!(
+            normalize_scan_json(a).unwrap(),
+            normalize_scan_json(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn normalize_scan_json_keeps_real_diffs_under_uid_normalization() {
+        // Same UID shape, but a genuine content difference (the PURL itself) must survive.
+        let a = r#"{"headers":[],"packages":[{"package_uid":"pkg:golang/x@1?uuid=7d2f562e-87fa-4423-9951-aac2ca7f521f"}]}"#;
+        let b = r#"{"headers":[],"packages":[{"package_uid":"pkg:golang/y@2?uuid=6ce89029-256e-4642-8bbd-8a45b15a771d"}]}"#;
         assert_ne!(
             normalize_scan_json(a).unwrap(),
             normalize_scan_json(b).unwrap()


### PR DESCRIPTION
## Summary

- `perf-ab --check-output` (the byte-identical correctness gate) normalized only the volatile top-level `headers` block, so it could **never pass on a `--package` / `-clupe` profile**: package UID fields (`package_uid`, `dependency_uid`, `for_package_uid`, and the PURLs that reference them) carry a randomly-generated `uuid=<uuid>` that differs on every scan run, regardless of the code under test. This produced false `check-output FAILED` results on any package-emitting profile.
- Normalize `uuid=<uuid>` (canonical 8-4-4-4-12 hex form) to a stable placeholder alongside the existing header normalization, in `normalize_scan_json`. Genuine content diffs (including a changed PURL that happens to also carry a UID) still fail the gate; only the per-run UID churn is masked.

## Issues

- Covers: surfaced while validating the candidate-selection perf work (#1052 / #1054), where `-l -n 1 --check-output` passed but `-clupe -p 18` "failed" purely on random package UIDs.

## Scope and exclusions

- Included: `normalize_scan_json` UID normalization + two unit tests (one asserting UID-only diffs are ignored, one asserting a real PURL diff still fails), and the matching doc updates in `xtask/README.md` and the flag help text.
- Explicit exclusions: no change to scan/output behavior or to package UID generation itself; this only affects perf-ab's comparison.

## How to verify

- `cargo test --manifest-path xtask/Cargo.toml --bin perf-ab normalize_scan_json` (4 tests, including the two added).
- End to end: `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base origin/main --head origin/main --repo-url https://github.com/goharbor/harbor.git --repo-ref <sha> --check-output -- -clupe` now passes (base==head), where before it failed on UID churn.

## Follow-up work

- None.
