### PR TITLE
perf(license): build the two index automata concurrently (~24% faster cold build)

### DIFF
--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -535,19 +535,28 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
 
     add_deprecated_spdx_aliases(&mut rid_by_spdx_key);
 
-    let rules_automaton = rules_builder.build();
-
-    let unknown_automaton = if unknown_automaton_patterns.is_empty() {
-        AutomatonBuilder::new().build()
-    } else {
-        let mut unique_patterns: Vec<Vec<u8>> = unknown_automaton_patterns.into_iter().collect();
-        unique_patterns.sort();
-        let mut builder = AutomatonBuilder::new();
-        for pattern in &unique_patterns {
-            builder.add_pattern(pattern);
-        }
-        builder.build()
-    };
+    // The two automata are independent (disjoint pattern sets, separate outputs)
+    // and each build is a single-threaded daachorse construction that together
+    // dominate the cold index build. Overlap them so wall time is the longer of
+    // the two instead of their sum. Each automaton is deterministic, so the
+    // result is byte-identical to building them sequentially.
+    let (rules_automaton, unknown_automaton) = rayon::join(
+        || rules_builder.build(),
+        || {
+            if unknown_automaton_patterns.is_empty() {
+                AutomatonBuilder::new().build()
+            } else {
+                let mut unique_patterns: Vec<Vec<u8>> =
+                    unknown_automaton_patterns.into_iter().collect();
+                unique_patterns.sort();
+                let mut builder = AutomatonBuilder::new();
+                for pattern in &unique_patterns {
+                    builder.add_pattern(pattern);
+                }
+                builder.build()
+            }
+        },
+    );
 
     let mut index = LicenseIndex {
         dictionary,


### PR DESCRIPTION
## Summary

- Cuts the cold license-index build (the fixed cost paid on every unwarmed scan — first run, CI, containers, fresh installs) by building the two Aho-Corasick automata concurrently.
- The rules and unknown automata are independent — disjoint pattern sets, separate outputs, no shared state — and each is a single-threaded daachorse construction. A build-isolated profile showed they together dominate the cold build (~26% of build self-time), and they previously ran sequentially. `rayon::join` overlaps them so wall time is the longer of the two rather than their sum; overlapping also pipelines their associated allocator/sort churn.
- Each automaton build is deterministic, so the constructed index — and therefore all detection output — is **byte-identical** to the sequential build.

### Measured (build-isolated A/B: tiny target, `-l -n 1`, `--no-license-index-cache`, so wall ≈ index build; `perf-ab` interleaved, M5 Pro)

| | base (`main`) | head | speedup |
|---|---|---|---|
| Cold index build | 6.190s | 4.700s | **1.32× / 24.1% faster** |

Rounds were tight (head 4.68–4.74s), and `--check-output` passed (byte-identical after header/UID normalization).

### Why this matters

Profiling (`-l`) showed the cold build is ~26% the daachorse automaton construction + ~9% process startup + allocator/regex/sort churn; the serialized automata are **245 MB**, so embedding a prebuilt index (ruled out in #1053) is doubly infeasible and the snapshot-then-rebuild model is correct. This overlap is the highest-ROI, lowest-risk lever within that model.

## Issues

- Covers: #1053

## Scope and exclusions

- Included: parallelize the two automaton builds in `build_index` via `rayon::join` (rayon is already a dependency).
- Explicit exclusions: the per-rule construction loop is left sequential. Its token-ID interning must stay ordered for byte-identical output, and a build-isolated profile shows the remaining parallelizable slice is small relative to the risk of refactoring the accumulators — not worth it on this evidence.

## How to verify

- Byte-identical: license-detection golden suite passes unchanged (CI), plus `perf-ab --check-output` byte-identical on the build-isolated run.
- Reproduce the speedup: `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base origin/main --head HEAD --target-path <tiny-dir> --check-output -- -l -n 1` (a tiny target makes wall ≈ cold index build).

## Follow-up work

- Per-rule-loop parallelization was profiled and deliberately **not** pursued: bounded upside (the dominant automaton build is unparallelizable internally, ~9% is process startup) against real byte-identical risk (interning order, accumulator merges).
