### PR TITLE
perf(license): cache per-file line index for matched-text extraction (3.7× faster on large-file repos)

### DIFF
--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -342,6 +342,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -384,6 +385,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -429,6 +431,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -470,6 +473,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -510,6 +514,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -566,6 +571,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -610,6 +616,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -691,6 +698,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -728,6 +736,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -771,6 +780,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -815,6 +825,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -869,6 +880,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 
@@ -915,6 +927,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: Vec::new(),
             spdx_lines: Vec::new(),
+            line_content_ranges: Default::default(),
             index: &index,
         };
 

--- a/src/license_detection/models/mod_tests.rs
+++ b/src/license_detection/models/mod_tests.rs
@@ -735,6 +735,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         assert!((match_result.qdensity(&query) - 1.0).abs() < 0.001);
@@ -759,6 +760,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         let expected = 2.0 / 11.0;
@@ -785,6 +787,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         assert_eq!(match_result.qdensity(&query), 0.0);
@@ -814,6 +817,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         let expected = 3.0 / (10.0 + 2.0 + 3.0);
@@ -842,6 +846,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         let expected = 11 + 2 + 3;
@@ -869,6 +874,7 @@ mod tests {
             is_binary: false,
             query_run_ranges: vec![],
             spdx_lines: vec![],
+            line_content_ranges: Default::default(),
             index: &index,
         };
         assert_eq!(match_result.qmagnitude(&query), 11);

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -123,6 +123,15 @@ pub struct Query<'a> {
     /// Corresponds to Python: `self.spdx_lines = []` (line 507)
     pub spdx_lines: Vec<(String, usize, usize)>,
 
+    /// Lazily-computed byte ranges (into `text`) of each line's content, in the
+    /// exact form `str::lines()` yields (line terminators and a preceding `\r`
+    /// excluded, no trailing empty line after a final `\n`). Built once on first
+    /// `matched_text` call so per-match extraction is O(lines-in-range) instead
+    /// of re-scanning the whole file via `text.lines()` on every call.
+    ///
+    /// `OnceLock` (not `OnceCell`) so `Query` stays `Sync`.
+    pub(crate) line_content_ranges: std::sync::OnceLock<Vec<std::ops::Range<usize>>>,
+
     /// Reference to the license index for dictionary access and metadata
     pub index: &'a LicenseIndex,
 }
@@ -658,6 +667,7 @@ impl<'a> Query<'a> {
             is_binary,
             query_run_ranges: query_runs,
             spdx_lines,
+            line_content_ranges: std::sync::OnceLock::new(),
             index,
         })
     }
@@ -857,7 +867,61 @@ impl<'a> Query<'a> {
     ///
     /// Corresponds to Python: `matched_text()` method in match.py (lines 757-795)
     pub fn matched_text(&self, start_line: usize, end_line: usize) -> String {
-        matched_text_from_text(&self.text, start_line, end_line)
+        if start_line == 0 || end_line == 0 || start_line > end_line {
+            return String::new();
+        }
+        let ranges = self.line_content_ranges();
+        let from = start_line - 1;
+        if from >= ranges.len() {
+            return String::new();
+        }
+        // `end_line` is an inclusive 1-indexed bound, so `end_line` (not +1) is
+        // the exclusive 0-indexed end; clamp to the available line count.
+        let to = end_line.min(ranges.len());
+        ranges[from..to]
+            .iter()
+            .map(|r| &self.text[r.clone()])
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// True if any line in the inclusive 1-indexed `[start_line, end_line]`
+    /// range has content longer than `max_line_length`. Uses the cached line
+    /// ranges; byte-identical to checking `line.len()` over `text.lines()`.
+    pub(crate) fn line_range_has_oversized_line(
+        &self,
+        start_line: usize,
+        end_line: usize,
+        max_line_length: usize,
+    ) -> bool {
+        if start_line == 0 || end_line == 0 || start_line > end_line {
+            return false;
+        }
+        let ranges = self.line_content_ranges();
+        let from = start_line - 1;
+        if from >= ranges.len() {
+            return false;
+        }
+        let to = end_line.min(ranges.len());
+        ranges[from..to].iter().any(|r| r.len() > max_line_length)
+    }
+
+    /// Byte ranges of each line's content within `text`, computed once and
+    /// cached. Built directly from `str::lines()` so the slices reproduce its
+    /// semantics exactly (terminators / leading `\r` excluded, no trailing empty
+    /// line after a final `\n`), keeping [`Query::matched_text`] byte-identical
+    /// to the previous `text.lines()`-per-call implementation.
+    fn line_content_ranges(&self) -> &[std::ops::Range<usize>] {
+        self.line_content_ranges.get_or_init(|| {
+            let base = self.text.as_ptr() as usize;
+            self.text
+                .lines()
+                .map(|line| {
+                    let start = line.as_ptr() as usize - base;
+                    start..start + line.len()
+                })
+                .collect()
+        })
     }
 }
 

--- a/src/license_detection/query/test.rs
+++ b/src/license_detection/query/test.rs
@@ -411,6 +411,35 @@ mod tests {
     }
 
     #[test]
+    fn test_query_matched_text_byte_identical_to_lines_scan() {
+        // The cached line-index implementation must match the previous
+        // `text.lines()`-per-call behavior exactly, including `\r\n` handling
+        // and the absence of a trailing empty line after a final `\n`.
+        let index = create_query_test_index();
+        let cases = [
+            "license copyright permission",
+            "license\ncopyright\npermission\nlicense",
+            "license\r\ncopyright\r\npermission",
+            "license\ncopyright\n",
+            "license\n\ncopyright",
+            "license\r\n\r\ncopyright\r\n",
+        ];
+        for text in cases {
+            let query = build_query(text, &index)
+                .unwrap_or_else(|_| panic!("query should build for {text:?}"));
+            for start in 0..=6 {
+                for end in 0..=6 {
+                    assert_eq!(
+                        query.matched_text(start, end),
+                        crate::license_detection::query::matched_text_from_text(text, start, end),
+                        "matched_text mismatch for text={text:?} start={start} end={end}",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_query_run_get_index() {
         let index = create_query_test_index();
         let query = build_query("license copyright", &index).unwrap();

--- a/src/license_detection/test_utils.rs
+++ b/src/license_detection/test_utils.rs
@@ -285,6 +285,7 @@ pub fn create_mock_query_with_tokens<'a>(tokens: &[u16], index: &'a LicenseIndex
         is_binary: false,
         query_run_ranges: Vec::new(),
         spdx_lines: Vec::new(),
+        line_content_ranges: Default::default(),
         index,
     }
 }

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -1125,12 +1125,24 @@ fn extract_output_matched_text(
     let start_line = license_match.start_line.get();
     let end_line = license_match.end_line.get();
 
-    if line_range_has_oversized_line(
-        text_content,
-        start_line,
-        end_line,
-        MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH,
-    ) {
+    // When the query is available, `text_content` is the same string the query
+    // was built from, so reuse its cached line index (O(lines-in-range)) instead
+    // of re-scanning the whole file. Falls back to the free functions otherwise.
+    let has_oversized_line = match query {
+        Some(q) => q.line_range_has_oversized_line(
+            start_line,
+            end_line,
+            MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH,
+        ),
+        None => line_range_has_oversized_line(
+            text_content,
+            start_line,
+            end_line,
+            MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH,
+        ),
+    };
+
+    if has_oversized_line {
         if let Some(compact_text) = compact_matched_text_from_query(query, license_match) {
             return cap_output_matched_text(compact_text);
         }
@@ -1142,8 +1154,14 @@ fn extract_output_matched_text(
         ));
     }
 
-    let whole_line =
-        crate::license_detection::query::matched_text_from_text(text_content, start_line, end_line);
+    let whole_line = match query {
+        Some(q) => q.matched_text(start_line, end_line),
+        None => crate::license_detection::query::matched_text_from_text(
+            text_content,
+            start_line,
+            end_line,
+        ),
+    };
 
     if whole_line.len() > MAX_OUTPUT_MATCHED_TEXT_BYTES
         && let Some(compact_text) = compact_matched_text_from_query(query, license_match)


### PR DESCRIPTION
## Summary

- `Query::matched_text` called `text.lines()` on every invocation, re-scanning the **whole file** to extract one line range. It's called per match during match-refinement (`filter_low_quality`) and per detection at output time, so on large/minified files (vscode's bundled JS, big JSON fixtures) it was effectively **O(matches × file_size)** — and a profile showed it as the single largest license-detection cost, larger than candidate selection.
- Cache the line content byte-ranges on `Query`, built **once** from `str::lines()` (the slices reproduce its exact semantics: terminators / a leading `\r` excluded, no trailing empty line after a final `\n`). `matched_text` and the output-path oversized-line check now slice the cached ranges in O(lines-in-range). The output path reuses the query cache when available (the same string the query was built from) and falls back to the free functions otherwise.

### Measured (`perf-ab`, M5 Pro, `--profile common`, vs `main`)

| Target | Before | After | Speedup |
|---|---|---|---|
| microsoft/vscode (large/minified files) | 157.7s | 42.4s | **3.72× (73.1%)** |
| python/cpython (normal source) | 18.31s | 17.40s | 1.05× (no regression) |

The win scales with file size: huge on repos full of large generated/minified files, small-but-positive on normal source. This was the dominant cost behind "vscode-class scans are slow" — package extraction was a red herring (measured at 0.5% of vscode's scan; see #1058 for the audit that redirected here).

## Issues

- Closes: #1058

## Scope and exclusions

- Included: a lazily-built, per-`Query` line-content-range cache; `matched_text` and a new cached `line_range_has_oversized_line` use it; the output path (`scanner/process/license.rs`) routes through the query cache when a query is present.
- Explicit exclusions: the free functions `matched_text_from_text` / `line_range_has_oversized_line` remain as the no-query fallback. Package extraction (the original hypothesis) — not touched; it's 0.5% of vscode's scan.

## How to verify

- **Byte-identical** is the core claim: a parity unit test (`test_query_matched_text_byte_identical_to_lines_scan`) asserts the cached `matched_text` equals the previous `lines()`-scan across `\n` / `\r\n` / trailing-newline / blank-line / out-of-range cases; the **license-detection golden suite (21)** and **output-format golden suite (21)** both pass unchanged (the latter covers `--license-text` matched-text output).
- Reproduce: `perf-ab --base origin/main --head HEAD --repo-url https://github.com/microsoft/vscode.git --repo-ref 0c1e100626c19724d1222c2bc4b63ba3556858a7 --profile common`.

## Follow-up work

- None required. (The build-speed audit is tracked separately in #1057.)
