### PR TITLE
perf(build): thin LTO for profiling profile (~3.5x faster profiling builds)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,3 +230,9 @@ strip = false
 inherits = "release"
 strip = false
 debug = true
+# Profiling builds are for iteration, not shipping: skip the slow fat-LTO +
+# single-codegen-unit link inherited from `release`. Thin LTO with parallel
+# codegen units builds ~3.5x faster (measured: 310s -> 88s clean) for a small
+# runtime cost that does not change which functions dominate a profile.
+lto = "thin"
+codegen-units = 16


### PR DESCRIPTION
## Summary

- The `profiling` profile inherited `[profile.release]`'s `lto = true` (fat) + `codegen-units = 1`, so every profiling/iteration build paid the same slow whole-program LTO link as the shipped binary — for no benefit, since profiling builds aren't shipped and a profile's self-time rankings don't depend on fat LTO. Override `profiling` with `lto = "thin"` + `codegen-units = 16`.
- **Measured (clean build, M5): 310s → 88s, ~3.5× faster.** Runtime is ~5% slower (irrelevant for profiling; the hot functions are unchanged).

## Investigation: can the *regular `release` build* be sped up? (measured — answer: not worth it)

The only meaningful build-time lever for `release` is the same fat→thin LTO switch. Measured on `main`, M5, clean builds + a `perf-ab` runtime A/B (cpython, `--profile common`):

| `release` config | clean build | binary | runtime (cpython) |
|---|---|---|---|
| `lto = true`, `codegen-units = 1` (current) | 310s | 34.2 MB | baseline |
| `lto = "thin"`, `codegen-units = 16` | 88s (**3.5× faster**) | 45.1 MB (**+32%**) | **~5% slower** |

So fat LTO is doing real work: it buys ~5% runtime and a 32%-smaller binary at the cost of build time. For a perf-critical, distributed binary whose value proposition is speed, trading 5% runtime + 32% size for faster builds is a bad deal — **`release` is intentionally left unchanged.** The slow release build is inherent to fat LTO being the correct choice for the shipped artifact; there's no free lunch (a faster linker doesn't help — LLVM, not the linker, does the LTO work; and `ZSTD`/dep compilation isn't the bottleneck).

## Issues

- Closes: #1057

## Scope and exclusions

- Included: `profiling` profile → thin LTO + 16 codegen units.
- Explicit exclusions: `[profile.release]` (shipped binary) unchanged — measured regression not worth it. `ci-release` already uses `lto = false` and is fast.

## How to verify

- `cargo build --profile profiling --bin provenant` is materially faster; `target/profiling/provenant` still has symbols (`debug = true`, `strip = false`) and profiles identically.
- `cargo build --release` (shipped) is byte-for-byte unchanged in configuration.

## Follow-up work

- `perf-ab` builds each ref with `cargo build --release` (fat LTO, ~5 min/ref). Since an A/B is a *relative* comparison with both sides on the same profile, a thin-LTO bench profile would build ~3.5× faster without affecting relative results — worth wiring into `perf-ab` for faster benchmark iteration (recorded `docs/BENCHMARKS.md` absolute numbers should still use fat-LTO `release`).
