### PR TITLE
perf(license): FxHashMap + buffer reuse in sequence-matching hot loop

### DIFF
--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -14,6 +14,7 @@ use crate::license_detection::query::QueryRun;
 use crate::models::LineNumber;
 use crate::models::MatchScore;
 use bit_set::BitSet;
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -63,14 +64,20 @@ fn find_longest_match_impl(
     let mut best_j = rule_lo;
     let mut best_size = 0;
 
-    let mut j2len: HashMap<usize, usize> = HashMap::new();
+    // `j2len` is a pure keyed lookup table (difflib's rolling longest-run map),
+    // never iterated, so FxHash (vs SipHash on `usize` keys) is byte-identical
+    // and much cheaper. The two maps are reused across iterations via clear+swap
+    // to avoid a per-query-position allocation. This loop dominates license
+    // detection on large-file repos (e.g. uv's big lockfiles); see #1061.
+    let mut j2len: FxHashMap<usize, usize> = FxHashMap::default();
+    let mut new_j2len: FxHashMap<usize, usize> = FxHashMap::default();
 
     for (offset, i) in (query_lo..query_hi).enumerate() {
         if offset.is_multiple_of(256) {
             crate::license_detection::ensure_within_deadline(context.deadline)?;
         }
 
-        let mut new_j2len: HashMap<usize, usize> = HashMap::new();
+        new_j2len.clear();
         let cur_a = context.query_tokens[i];
 
         if cur_a.as_usize() < context.len_legalese
@@ -100,7 +107,9 @@ fn find_longest_match_impl(
                 }
             }
         }
-        j2len = new_j2len;
+        // `new_j2len` holds this position's runs; it becomes `j2len` for the next
+        // iteration, and the old `j2len` becomes the reused (cleared) buffer.
+        std::mem::swap(&mut j2len, &mut new_j2len);
     }
 
     if best_size > 0 {


### PR DESCRIPTION
## Summary

- `find_longest_match_impl` (difflib's rolling longest-run map in sequence matching) allocated a fresh `HashMap<usize, usize>` **per query position** and hashed `usize` keys with **SipHash**. A profile of a license-bound large-file repo (astral-sh/uv: `scan:licenses` 64s for 1,259 files, only 7.4% helped by the recent perf wave) showed `seq_match_with_candidates_and_deadline` as the dominant cost, with `HashMap::insert` + `sip::write` + `hash_one` + `reserve_rehash` as the next entries — all from this loop.
- Switch `j2len`/`new_j2len` to `FxHashMap` and reuse the two maps across iterations via `clear` + `std::mem::swap` instead of allocating per position (`rustc_hash` is already a dependency). The maps are pure keyed lookup tables (`get`/`insert`, never iterated), so the hasher swap and reuse are **byte-identical**.

### Measured (`perf-ab`, M5, `--profile common`, vs `main`)

| Target | Before | After | Speedup |
|---|---|---|---|
| astral-sh/uv (sequence-matching-bound) | 67.8s | 61.3s | **1.10× (9.6%)** |
| python/cpython (normal source) | 18.06s | 17.74s | 1.02× (no regression) |

## Issues

- Closes: #1061

## Scope and exclusions

- Included: `FxHashMap` + clear/swap reuse for the `j2len` rolling maps in `find_longest_match_impl`.
- Explicit exclusions: the `high_postings: HashMap<TokenId, Vec<usize>>` parameter is the index's own map (not changed here). **The sequence-matching algorithm itself is unchanged** — see Follow-up.

## How to verify

- Byte-identical: license-detection golden suite (21) passes unchanged; the `j2len` maps are never iterated, so the hasher/reuse change cannot alter results.
- Reproduce: `perf-ab --base origin/main --head HEAD --repo-url https://github.com/astral-sh/uv.git --repo-ref 9581f2b0ea65550a3efe28bd7aabde19d98b39ba --profile common`.

## Follow-up work

- This removes the **hashing/allocation overhead** (~6.8k profile samples) but not the **algorithmic cost**: `seq_match_with_candidates_and_deadline` self-time (~16.4k samples) still dominates license detection on large-file repos like uv, where huge `uv.lock`/`requirements/**` files become candidates and drive expensive token alignment. Reducing that (bounding/short-circuiting sequence matching on very large non-prose query runs, or a denser longest-match structure) is the larger remaining lever — worth its own profiled, byte-identical-gated cycle.
