### PR TITLE
perf(license): hoist candidate-independent work out of sequence-matching driver (~23% on uv)

### DIFF
--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -247,6 +247,21 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
 ) -> Result<Vec<LicenseMatch>, LicenseDetectionError> {
     let mut matches = Vec::new();
 
+    // Candidate-independent query-run setup, hoisted out of the per-candidate
+    // loop: uv-class inputs produce many candidates against one huge query run,
+    // and none of this depends on the candidate.
+    let query_tokens = query_run.tokens();
+    let len_legalese = index.len_legalese;
+    let qfinish = query_tokens.len().saturating_sub(1);
+    let matchables: BitSet = query_run
+        .matchables(true)
+        .iter()
+        .map(|pos| pos - query_run.start)
+        .collect();
+    // `qstart <= max_matchable` is an O(1) equivalent of
+    // `matchables.iter().any(|p| p >= qstart)`, avoiding an O(N) scan per round.
+    let max_matchable = matchables.iter().max();
+
     for (candidate_index, candidate) in candidates.iter().enumerate() {
         if candidate_index.is_multiple_of(8) {
             crate::license_detection::ensure_within_deadline(deadline)?;
@@ -266,17 +281,6 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
             .unwrap_or_default();
 
         if let Some(rule_tokens) = rule_tokens {
-            let query_tokens = query_run.tokens();
-            let len_legalese = index.len_legalese;
-
-            let qbegin = 0usize;
-            let qfinish = query_tokens.len().saturating_sub(1);
-
-            let matchables: BitSet = query_run
-                .matchables(true)
-                .iter()
-                .map(|pos| pos - query_run.start)
-                .collect();
             let context = MatchSearchContext {
                 query_tokens,
                 rule_tokens,
@@ -286,7 +290,7 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
                 deadline,
             };
 
-            let mut qstart = qbegin;
+            let mut qstart = 0usize;
             let mut loop_count = 0usize;
 
             while qstart <= qfinish {
@@ -295,7 +299,7 @@ pub(crate) fn seq_match_with_candidates_and_deadline(
                 }
                 loop_count += 1;
 
-                let has_remaining_matchables = matchables.iter().any(|pos| pos >= qstart);
+                let has_remaining_matchables = max_matchable.is_some_and(|m| m >= qstart);
                 if !has_remaining_matchables {
                     break;
                 }


### PR DESCRIPTION
## Summary

- Follow-up to #1062. After the j2len `FxHashMap` change merged, profiling a sequence-matching-bound repo (astral-sh/uv) showed `seq_match_with_candidates_and_deadline` *still* dominating license detection — but the cost is in the **driver's per-candidate overhead**, not the difflib algorithm (`find_longest_match`/`match_blocks` have negligible self-time when forced out-of-line).
- **Hoist candidate-independent setup out of the per-candidate loop.** The `matchables` `BitSet` (and the other query-run-only values) were rebuilt for every candidate, even though they don't depend on the candidate. uv-class inputs produce many candidates against one huge query run, so this was O(candidates × query_len).
- **O(1) remaining-matchables check.** Replace the per-round `matchables.iter().any(|p| p >= qstart)` O(N) scan with `qstart <= max_matchable` using a precomputed max.

### Measured (`perf-ab`, M5, `--profile common`, vs current `main` which already includes #1062)

| Target | Before (main) | After | Speedup |
|---|---|---|---|
| astral-sh/uv (sequence-matching-bound) | 59.2s | 45.5s | **1.30× (23.1%)** |
| python/cpython (normal source) | 17.70s | 17.37s | 1.02× (no regression) |

Combined with #1062, uv's scan went ~67.8s → ~45.5s (~1.49×) across the two seq_match PRs.

## Issues

- Relates to #1061 (the investigation that surfaced this; the SipHash/alloc part was #1062).

## Scope and exclusions

- Included: hoist `query_tokens`/`len_legalese`/`qfinish`/`matchables` out of the candidate loop; precompute `max_matchable` for an O(1) per-round check.
- Explicit exclusions: the difflib matching algorithm itself is unchanged (it is not the bottleneck). The per-candidate `high_postings` map stays a std `HashMap` (its remaining SipHash cost is comparatively small and converting it touches ~20 sites).

## How to verify

- Byte-identical: license-detection golden suite (21) passes unchanged; the hoist moves identical work earlier and `max_matchable >= qstart` is logically equivalent to `any(p >= qstart)`.
- Reproduce: `perf-ab --base origin/main --head HEAD --repo-url https://github.com/astral-sh/uv.git --repo-ref 9581f2b0ea65550a3efe28bd7aabde19d98b39ba --profile common`.

## Follow-up work

- `high_postings` std `HashMap` → `FxHashMap` would remove the remaining per-query-position SipHash lookups (~3k profile samples), if the ~20-site churn is judged worthwhile.
