### PR TITLE
fix(buck): synthesize pkg:buck purl for BUCK and METADATA.bzl targets

### DIFF
--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -661,9 +661,12 @@ fn fallback_package_data(path: &Path) -> PackageData {
         .and_then(|n| n.to_str())
         .map(|s| s.to_string());
 
+    let purl = build_buck_purl(None, name.as_deref(), None);
+
     PackageData {
         package_type: Some(BuckBuildParser::PACKAGE_TYPE),
         name,
+        purl,
         datasource_id: Some(DatasourceId::BuckFile),
         ..Default::default()
     }

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -317,6 +317,49 @@ fn insert_license_reference_extra_data(
     }
 }
 
+/// Synthesize a `pkg:buck/<name>` purl from extracted fields, mirroring ScanCode's
+/// behavior of always emitting a Buck purl when a target name is known. Returns
+/// `None` when the name is missing or the purl cannot be constructed.
+fn build_buck_purl(
+    namespace: Option<&str>,
+    name: Option<&str>,
+    version: Option<&str>,
+) -> Option<String> {
+    let name = name.filter(|value| !value.is_empty())?;
+    let mut package_url = match PackageUrl::new(PackageType::Buck.as_str(), name) {
+        Ok(purl) => purl,
+        Err(e) => {
+            warn!(
+                "Failed to create PackageUrl for buck package '{}': {}",
+                name, e
+            );
+            return None;
+        }
+    };
+
+    if let Some(namespace) = namespace.filter(|value| !value.is_empty())
+        && let Err(e) = package_url.with_namespace(namespace)
+    {
+        warn!(
+            "Failed to set namespace '{}' for buck package '{}': {}",
+            namespace, name, e
+        );
+        return None;
+    }
+
+    if let Some(version) = version.filter(|value| !value.is_empty())
+        && let Err(e) = package_url.with_version(version)
+    {
+        warn!(
+            "Failed to set version '{}' for buck package '{}': {}",
+            version, name, e
+        );
+        return None;
+    }
+
+    Some(truncate_field(package_url.to_string()))
+}
+
 /// Build PackageData from extracted metadata fields
 fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> PackageData {
     let mut pkg = PackageData {
@@ -480,6 +523,16 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
         }
     }
 
+    // Fall back to a synthesized `pkg:buck/<name>` purl when no explicit
+    // `package_url` field provided one.
+    if pkg.purl.is_none() {
+        pkg.purl = build_buck_purl(
+            pkg.namespace.as_deref(),
+            pkg.name.as_deref(),
+            pkg.version.as_deref(),
+        );
+    }
+
     pkg
 }
 
@@ -531,9 +584,12 @@ fn extract_build_package_from_statement(statement: &ast::AstStmt) -> Option<Pack
     let mut extra_data = HashMap::new();
     insert_license_reference_extra_data(&mut extra_data, &license_references);
 
+    let purl = build_buck_purl(None, Some(&package_name), None);
+
     Some(PackageData {
         package_type: Some(BuckBuildParser::PACKAGE_TYPE),
         name: Some(truncate_field(package_name)),
+        purl,
         extracted_license_statement,
         extra_data: (!extra_data.is_empty()).then_some(extra_data),
         datasource_id: Some(DatasourceId::BuckFile),

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -524,8 +524,11 @@ fn build_package_from_metadata(fields: HashMap<String, MetadataValue>) -> Packag
     }
 
     // Fall back to a synthesized `pkg:buck/<name>` purl when no explicit
-    // `package_url` field provided one.
-    if pkg.purl.is_none() {
+    // `package_url` field provided one. Only do this for Buck-typed metadata: when an
+    // `ecosystem` field set a non-Buck `package_type` (e.g. Maven) without a
+    // `package_url`, synthesizing a `pkg:buck/...` purl would contradict the
+    // `package_type`, so leave the purl unset in that case.
+    if pkg.purl.is_none() && matches!(pkg.package_type, None | Some(PackageType::Buck)) {
         pkg.purl = build_buck_purl(
             pkg.namespace.as_deref(),
             pkg.name.as_deref(),

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -32,6 +32,8 @@ fn test_parse_empty_buck_fallback() {
 
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("end2end".to_string()));
+    // Directory-name fallback still synthesizes a purl from the package name.
+    assert_eq!(pkg.purl, Some("pkg:buck/end2end".to_string()));
 }
 
 #[test]
@@ -70,6 +72,7 @@ android_binary(
     let pkg = BuckBuildParser::extract_first_package(&buck_path);
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("my-app".to_string()));
+    assert_eq!(pkg.purl, Some("pkg:buck/my-app".to_string()));
 }
 
 #[test]
@@ -87,6 +90,7 @@ android_library(
     let pkg = BuckBuildParser::extract_first_package(&buck_path);
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("my-lib".to_string()));
+    assert_eq!(pkg.purl, Some("pkg:buck/my-lib".to_string()));
 }
 
 #[test]
@@ -104,6 +108,7 @@ java_binary(
     let pkg = BuckBuildParser::extract_first_package(&buck_path);
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("my-app".to_string()));
+    assert_eq!(pkg.purl, Some("pkg:buck/my-app".to_string()));
 }
 
 #[test]
@@ -126,6 +131,7 @@ android_binary(
     let pkg = BuckBuildParser::extract_first_package(&buck_path);
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("app".to_string()));
+    assert_eq!(pkg.purl, Some("pkg:buck/app".to_string()));
 }
 
 #[test]
@@ -149,6 +155,7 @@ android_binary(
     // Should return first rule
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("app1".to_string()));
+    assert_eq!(pkg.purl, Some("pkg:buck/app1".to_string()));
 }
 
 // ============================================================================

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -21,6 +21,8 @@ fn test_parse_buck_with_rules() {
 
     assert_eq!(pkg.package_type, Some(PackageType::Buck));
     assert_eq!(pkg.name, Some("app".to_string()));
+    // BUCK targets carry no version, so the synthesized purl is name-only.
+    assert_eq!(pkg.purl, Some("pkg:buck/app".to_string()));
 }
 
 #[test]
@@ -162,6 +164,8 @@ fn test_parse_metadata_bzl_basic() {
     assert_eq!(pkg.datasource_id, Some(DatasourceId::BuckMetadata));
     assert_eq!(pkg.name, Some("example".to_string()));
     assert_eq!(pkg.version, Some("0.0.1".to_string()));
+    // No explicit `package_url`, so the purl is synthesized from name and version.
+    assert_eq!(pkg.purl, Some("pkg:buck/example@0.0.1".to_string()));
     assert_eq!(
         pkg.extracted_license_statement,
         Some("BSD-3-Clause".to_string())

--- a/src/parsers/buck_test.rs
+++ b/src/parsers/buck_test.rs
@@ -433,6 +433,9 @@ METADATA = {
     assert_eq!(pkg.namespace, Some("com.example".to_string()));
     assert_eq!(pkg.name, Some("artifact".to_string()));
     assert_eq!(pkg.version, Some("1.2.3".to_string()));
+    // A non-Buck ecosystem without an explicit `package_url` must not get a synthesized
+    // `pkg:buck/...` purl that contradicts `package_type`.
+    assert_eq!(pkg.purl, None);
     assert_eq!(
         pkg.homepage_url,
         Some("https://github.com/example/artifact".to_string())

--- a/testdata/buck/end2end/subdir2/BUCK.expected.json
+++ b/testdata/buck/end2end/subdir2/BUCK.expected.json
@@ -32,6 +32,7 @@
       "license_file": "LICENSE"
     },
     "dependencies": [],
-    "datasource_id": "buck_file"
+    "datasource_id": "buck_file",
+    "purl": "pkg:buck/bin"
   }
 ]

--- a/testdata/buck/metadata/METADATA.bzl.expected.json
+++ b/testdata/buck/metadata/METADATA.bzl.expected.json
@@ -15,6 +15,7 @@
       "upstream_hash": "deadbeef"
     },
     "datasource_id": "buck_metadata",
+    "purl": "pkg:buck/example@0.0.1",
     "declared_license_expression": "bsd-3-clause",
     "declared_license_expression_spdx": "BSD-3-Clause",
     "license_detections": [

--- a/testdata/buck/oss-guarded/BUCK.expected.json
+++ b/testdata/buck/oss-guarded/BUCK.expected.json
@@ -3,6 +3,7 @@
     "type": "buck",
     "name": "library",
     "parties": [],
-    "datasource_id": "buck_file"
+    "datasource_id": "buck_file",
+    "purl": "pkg:buck/library"
   }
 ]

--- a/testdata/buck/parse/BUCK.expected.json
+++ b/testdata/buck/parse/BUCK.expected.json
@@ -3,6 +3,7 @@
     "type": "buck",
     "name": "app",
     "parties": [],
-    "datasource_id": "buck_file"
+    "datasource_id": "buck_file",
+    "purl": "pkg:buck/app"
   }
 ]


### PR DESCRIPTION
## Summary

- Buck `package_data` only carried a `purl` when a `METADATA.bzl` provided an explicit `package_url`. BUCK build targets and inheritance-only metadata were emitted with `purl: null`, so identity matching against ScanCode (which always emits `pkg:buck/<name>`) failed and downstream package identity was weaker.
- Synthesize `pkg:buck/<namespace>/<name>@<version>` from the extracted fields when no explicit `package_url` is present, for both the BUCK build-file path and the METADATA.bzl path.

## Scope and exclusions

- Included: purl synthesis for both Buck datasources; regenerated buck parser goldens; purl assertions added to `buck_test`.
- Explicit exclusions: deriving declared license from co-located README/LICENSE and parsing additional BUCK rule types — tracked in #1066.

## How to verify

- Verified against `facebook/watchman` via `compare-outputs`: Buck packages went from 0/103 carrying a purl to 90/103 (the remainder are unrecognized-rule fallbacks tracked in #1066). CI covers the buck unit + golden suites.

## Intentional differences from Python

- None; this matches ScanCode's `pkg:buck/<name>` identity behavior.

## Follow-up work

- #1066 — co-located README/LICENSE declared-license and additional BUCK rule-type parsing.

## Expected-output fixture changes

- Files changed: `testdata/buck/parse/BUCK.expected.json`, `testdata/buck/end2end/subdir2/BUCK.expected.json`, `testdata/buck/oss-guarded/BUCK.expected.json`, `testdata/buck/metadata/METADATA.bzl.expected.json`.
- Why the new expected output is correct: each gains the `purl` ScanCode also emits (`pkg:buck/app`, `pkg:buck/bin`, `pkg:buck/library`, `pkg:buck/example@0.0.1`); no other fields change.