### PR TITLE
fix(cargo): resolve workspace-inherited license into declared expression

### DIFF
--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -311,7 +311,13 @@ pub(crate) fn build_output_model(
             progress.assembly_step("Using preloaded assembly...");
             session.preloaded_assembly
         } else {
-            assembly::assemble(&mut session.scan_result.files)
+            // Share the scan's already-built license engine with assembly so cross-file
+            // declared-license resolution (e.g. Cargo workspace inheritance) reuses it
+            // instead of triggering a redundant engine build.
+            let engine = session.active_license_engine.clone();
+            crate::parsers::with_parser_license_engine(engine, || {
+                assembly::assemble(&mut session.scan_result.files)
+            })
         };
 
         progress.assembly_step("Backfilling package license provenance...");

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -314,6 +314,11 @@ pub(crate) fn build_output_model(
             // Share the scan's already-built license engine with assembly so cross-file
             // declared-license resolution (e.g. Cargo workspace inheritance) reuses it
             // instead of triggering a redundant engine build.
+            //
+            // `with_parser_license_engine` pushes onto a thread-local stack, so the shared
+            // engine is only visible on this thread. That is sufficient because assembly is
+            // single-threaded; if assembly is ever parallelized, the engine must also be made
+            // available on the worker threads (otherwise they rebuild a per-thread engine).
             let engine = session.active_license_engine.clone();
             crate::parsers::with_parser_license_engine(engine, || {
                 assembly::assemble(&mut session.scan_result.files)

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -2457,6 +2457,79 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_cargo_workspace_resolves_member_inherited_license() {
+        let mut root = create_test_file_info(
+            "workspace/Cargo.toml",
+            DatasourceId::CargoToml,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        root.package_data[0].package_type = Some(PackageType::Cargo);
+        root.package_data[0].extra_data = Some(HashMap::from([(
+            "workspace".to_string(),
+            json!({
+                "members": ["crates/app"],
+                "package": { "license": "MIT OR Apache-2.0" },
+            }),
+        )]));
+
+        let mut member_manifest = create_test_file_info(
+            "workspace/crates/app/Cargo.toml",
+            DatasourceId::CargoToml,
+            Some("pkg:cargo/app@0.1.0"),
+            Some("app"),
+            Some("0.1.0"),
+            vec![],
+        );
+        member_manifest.package_data[0].package_type = Some(PackageType::Cargo);
+        // Member declares `license.workspace = true`, recorded as a marker by the parser.
+        member_manifest.package_data[0].extra_data =
+            Some(HashMap::from([("license".to_string(), json!("workspace"))]));
+
+        let mut files = vec![root, member_manifest];
+        let result = assemble(&mut files);
+
+        let member = result
+            .packages
+            .iter()
+            .find(|pkg| pkg.purl.as_deref() == Some("pkg:cargo/app@0.1.0"))
+            .expect("member package should be assembled");
+        // Inherited license is both captured as a statement and normalized into the
+        // declared expression / SPDX fields with a backing detection.
+        assert_eq!(
+            member.extracted_license_statement.as_deref(),
+            Some("MIT OR Apache-2.0")
+        );
+        assert_eq!(
+            member.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            member.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT")
+        );
+        assert!(!member.license_detections.is_empty());
+
+        // The inherited license must also land on the member's file-level package
+        // data, so the later license resync from file data does not clear it.
+        let member_file_pkg = &files[1].package_data[0];
+        assert_eq!(
+            member_file_pkg.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            member_file_pkg
+                .extra_data
+                .as_ref()
+                .and_then(|extra| extra.get("license")),
+            None,
+            "workspace license marker should be consumed once resolved"
+        );
+    }
+
+    #[test]
     fn test_assemble_cargo_workspace_keeps_root_package_when_root_is_real_member() {
         let mut root = create_test_file_info(
             "workspace/Cargo.toml",

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -2527,6 +2527,13 @@ mod tests {
             None,
             "workspace license marker should be consumed once resolved"
         );
+        // File-level detections must carry the manifest path as `from_file`; the inherited
+        // detection is cloned in with `from_file: None` and backfilled during assembly.
+        let file_match = &member_file_pkg.license_detections[0].matches[0];
+        assert_eq!(
+            file_match.from_file.as_deref(),
+            Some("workspace/crates/app/Cargo.toml")
+        );
     }
 
     #[test]

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -191,6 +191,34 @@ pub(super) fn apply_cargo_workspace_domain(
     packages: &mut Vec<Package>,
     dependencies: &mut Vec<TopLevelDependency>,
 ) {
+    // Normalize the workspace license once; every member shares the same license
+    // string, so per-member SPDX normalization would be wasteful on large workspaces.
+    let resolved_license = resolve_workspace_license(&workspace_root.workspace_data);
+
+    // Resolve workspace inheritance onto the file-level member and root manifests so
+    // the declared license (and other inherited fields) appear in file output and
+    // survive the later package/file license resync, matching ScanCode's
+    // per-manifest resolution.
+    let mut manifest_indices: Vec<usize> = workspace_root
+        .members
+        .iter()
+        .map(|member| member.manifest_idx)
+        .collect();
+    manifest_indices.push(workspace_root.root_cargo_toml_idx);
+    for idx in manifest_indices {
+        if let Some(pkg_data) = files[idx]
+            .package_data
+            .iter_mut()
+            .find(|pkg| pkg.datasource_id == Some(DatasourceId::CargoToml))
+        {
+            apply_workspace_inheritance(
+                pkg_data,
+                &workspace_root.workspace_data,
+                resolved_license.as_ref(),
+            );
+        }
+    }
+
     let keep_root_package = root_workspace_manifest_is_package(files, workspace_root);
     let mut root_package_uid = None;
     if !keep_root_package {
@@ -200,7 +228,9 @@ pub(super) fn apply_cargo_workspace_domain(
             packages,
             dependencies,
         );
-    } else if let Some((pkg, deps)) = create_root_package(files, workspace_root) {
+    } else if let Some((pkg, deps)) =
+        create_root_package(files, workspace_root, resolved_license.as_ref())
+    {
         root_package_uid = Some(pkg.package_uid.clone());
         packages.push(pkg);
         dependencies.extend(deps);
@@ -220,6 +250,7 @@ pub(super) fn apply_cargo_workspace_domain(
         files,
         &workspace_root.members,
         &workspace_root.workspace_data,
+        resolved_license.as_ref(),
     );
 
     let mut member_uids: Vec<PackageUid> = member_packages
@@ -393,6 +424,7 @@ fn create_member_packages(
     files: &[FileInfo],
     members: &[CargoWorkspaceMemberDomain],
     workspace_data: &WorkspaceData,
+    resolved_license: Option<&ResolvedWorkspaceLicense>,
 ) -> Vec<(Package, Vec<TopLevelDependency>)> {
     let mut results = Vec::new();
 
@@ -409,7 +441,7 @@ fn create_member_packages(
             };
 
         let mut resolved_pkg_data = pkg_data.clone();
-        apply_workspace_inheritance(&mut resolved_pkg_data, workspace_data);
+        apply_workspace_inheritance(&mut resolved_pkg_data, workspace_data, resolved_license);
 
         let datafile_path = file.path.clone();
         let datasource_id = DatasourceId::CargoToml;
@@ -476,6 +508,7 @@ fn create_member_packages(
 fn create_root_package(
     files: &[FileInfo],
     workspace_root: &CargoWorkspaceDomain,
+    resolved_license: Option<&ResolvedWorkspaceLicense>,
 ) -> Option<(Package, Vec<TopLevelDependency>)> {
     let file = &files[workspace_root.root_cargo_toml_idx];
     let pkg_data = file
@@ -484,7 +517,11 @@ fn create_root_package(
         .find(|pkg| pkg.datasource_id == Some(DatasourceId::CargoToml) && pkg.purl.is_some())?;
 
     let mut resolved_pkg_data = pkg_data.clone();
-    apply_workspace_inheritance(&mut resolved_pkg_data, &workspace_root.workspace_data);
+    apply_workspace_inheritance(
+        &mut resolved_pkg_data,
+        &workspace_root.workspace_data,
+        resolved_license,
+    );
 
     let datafile_path = file.path.clone();
     let datasource_id = DatasourceId::CargoToml;
@@ -595,7 +632,46 @@ fn hoist_root_lock_dependencies(
     }
 }
 
-fn apply_workspace_inheritance(pkg_data: &mut PackageData, workspace_data: &WorkspaceData) {
+/// Workspace-inherited license normalized once so it can be cloned onto every
+/// member without re-running SPDX normalization per manifest.
+struct ResolvedWorkspaceLicense {
+    statement: String,
+    declared_expression: Option<String>,
+    declared_expression_spdx: Option<String>,
+    detections: Vec<crate::models::LicenseDetection>,
+}
+
+/// Normalize the workspace `[workspace.package].license`, if any, a single time.
+fn resolve_workspace_license(workspace_data: &WorkspaceData) -> Option<ResolvedWorkspaceLicense> {
+    use crate::parsers::license_normalization::{
+        DeclaredLicenseMatchMetadata, build_declared_license_data, empty_declared_license_data,
+        normalize_spdx_expression,
+    };
+
+    let license_str = workspace_data.package.get("license")?.as_str()?;
+    let (declared_expression, declared_expression_spdx, detections) =
+        normalize_spdx_expression(license_str)
+            .map(|normalized| {
+                build_declared_license_data(
+                    normalized,
+                    DeclaredLicenseMatchMetadata::single_line(license_str),
+                )
+            })
+            .unwrap_or_else(empty_declared_license_data);
+
+    Some(ResolvedWorkspaceLicense {
+        statement: license_str.to_string(),
+        declared_expression,
+        declared_expression_spdx,
+        detections,
+    })
+}
+
+fn apply_workspace_inheritance(
+    pkg_data: &mut PackageData,
+    workspace_data: &WorkspaceData,
+    resolved_license: Option<&ResolvedWorkspaceLicense>,
+) {
     use packageurl::PackageUrl;
 
     let extra_data = if let Some(ed) = &mut pkg_data.extra_data {
@@ -613,10 +689,12 @@ fn apply_workspace_inheritance(pkg_data: &mut PackageData, workspace_data: &Work
     }
 
     if extra_data.get("license").and_then(|v| v.as_str()) == Some("workspace")
-        && let Some(license_value) = workspace_data.package.get("license")
-        && let Some(license_str) = license_value.as_str()
+        && let Some(resolved) = resolved_license
     {
-        pkg_data.extracted_license_statement = Some(license_str.to_string());
+        pkg_data.extracted_license_statement = Some(resolved.statement.clone());
+        pkg_data.declared_license_expression = resolved.declared_expression.clone();
+        pkg_data.declared_license_expression_spdx = resolved.declared_expression_spdx.clone();
+        pkg_data.license_detections = resolved.detections.clone();
         extra_data.remove("license");
     }
 

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -206,6 +206,7 @@ pub(super) fn apply_cargo_workspace_domain(
         .collect();
     manifest_indices.push(workspace_root.root_cargo_toml_idx);
     for idx in manifest_indices {
+        let datafile_path = files[idx].path.clone();
         if let Some(pkg_data) = files[idx]
             .package_data
             .iter_mut()
@@ -216,6 +217,14 @@ pub(super) fn apply_cargo_workspace_domain(
                 &workspace_root.workspace_data,
                 resolved_license.as_ref(),
             );
+            // Inherited detections are cloned in with `from_file: None`; backfill the
+            // manifest path here since parser-time provenance enrichment has already run.
+            for detection in &mut pkg_data.license_detections {
+                crate::models::file_info::enrich_license_detection_provenance(
+                    detection,
+                    &datafile_path,
+                );
+            }
         }
     }
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -438,6 +438,23 @@ pub(crate) fn with_parser_scan_root<T>(scan_root: Option<&Path>, f: impl FnOnce(
     result
 }
 
+/// Make a license-detection engine the active one for parser-level declared-license
+/// normalization within `f`. Used to share the scan's already-built engine with the
+/// assembly phase so cross-file resolution does not rebuild a redundant engine.
+pub(crate) fn with_parser_license_engine<T>(
+    engine: Option<Arc<LicenseDetectionEngine>>,
+    f: impl FnOnce() -> T,
+) -> T {
+    PARSER_LICENSE_ENGINE_STACK.with(|stack| {
+        stack.borrow_mut().push(engine);
+    });
+    let result = f();
+    PARSER_LICENSE_ENGINE_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+    result
+}
+
 pub(crate) fn record_parser_diagnostic(message: String, severity: DiagnosticSeverity) -> bool {
     PARSER_DIAGNOSTIC_STACK.with(|stack| {
         let mut stack = stack.borrow_mut();

--- a/testdata/assembly-golden/cargo-workspace-lowercase/expected.json
+++ b/testdata/assembly-golden/cargo-workspace-lowercase/expected.json
@@ -42,12 +42,37 @@
       "api_data_url": "https://crates.io/api/v1/crates/lowercase-core",
       "datafile_paths": ["crates/core/cargo.toml"],
       "datasource_ids": ["cargo_toml"],
+      "declared_license_expression": "mit",
+      "declared_license_expression_spdx": "MIT",
       "description": "Core library for lowercase workspace",
       "extra_data": {
         "rust_edition": "2021"
       },
       "extracted_license_statement": "MIT",
       "homepage_url": "https://crates.io/crates/lowercase-core",
+      "license_detections": [
+        {
+          "identifier": "mit-baa8883e-2a3e-91b8-cdd5-5b082d60e708",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "matches": [
+            {
+              "end_line": 1,
+              "from_file": "crates/core/cargo.toml",
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "match_coverage": 100.0,
+              "matched_length": 1,
+              "matched_text": "MIT",
+              "matcher": "parser-declared-license",
+              "rule_identifier": "parser-declared-license",
+              "rule_relevance": 100,
+              "score": 100.0,
+              "start_line": 1
+            }
+          ]
+        }
+      ],
       "name": "lowercase-core",
       "package_uid": "pkg:cargo/lowercase-core@0.7.0?uuid=fixed-uid-done-for-testing-5642512d1758",
       "parties": [],

--- a/testdata/assembly-golden/cargo-workspace/expected.json
+++ b/testdata/assembly-golden/cargo-workspace/expected.json
@@ -131,12 +131,38 @@
       "api_data_url": "https://crates.io/api/v1/crates/myproject-cli",
       "datafile_paths": ["crates/cli/Cargo.toml"],
       "datasource_ids": ["cargo_toml"],
+      "declared_license_expression": "apache-2.0 OR mit",
+      "declared_license_expression_spdx": "Apache-2.0 OR MIT",
       "description": "CLI for myproject",
       "extra_data": {
         "rust_edition": "2021"
       },
       "extracted_license_statement": "MIT OR Apache-2.0",
       "homepage_url": "https://crates.io/crates/myproject-cli",
+      "license_detections": [
+        {
+          "identifier": "apache_2_0_OR_mit-bca08772-52bd-7f7b-5521-bf57bb110569",
+          "license_expression": "apache-2.0 OR mit",
+          "license_expression_spdx": "Apache-2.0 OR MIT",
+          "matches": [
+            {
+              "end_line": 1,
+              "from_file": "crates/cli/Cargo.toml",
+              "license_expression": "apache-2.0 OR mit",
+              "license_expression_spdx": "Apache-2.0 OR MIT",
+              "match_coverage": 100.0,
+              "matched_length": 3,
+              "matched_text": "MIT OR Apache-2.0",
+              "matcher": "parser-declared-license",
+              "rule_identifier": "mit_or_apache-2.0_15.RULE",
+              "rule_relevance": 100,
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
+              "score": 100.0,
+              "start_line": 1
+            }
+          ]
+        }
+      ],
       "name": "myproject-cli",
       "package_uid": "pkg:cargo/myproject-cli@0.5.0?uuid=fixed-uid-done-for-testing-5642512d1758",
       "parties": [],
@@ -151,12 +177,38 @@
       "api_data_url": "https://crates.io/api/v1/crates/myproject-core",
       "datafile_paths": ["crates/core/Cargo.toml"],
       "datasource_ids": ["cargo_toml"],
+      "declared_license_expression": "apache-2.0 OR mit",
+      "declared_license_expression_spdx": "Apache-2.0 OR MIT",
       "description": "Core library for myproject",
       "extra_data": {
         "rust_edition": "2021"
       },
       "extracted_license_statement": "MIT OR Apache-2.0",
       "homepage_url": "https://crates.io/crates/myproject-core",
+      "license_detections": [
+        {
+          "identifier": "apache_2_0_OR_mit-bca08772-52bd-7f7b-5521-bf57bb110569",
+          "license_expression": "apache-2.0 OR mit",
+          "license_expression_spdx": "Apache-2.0 OR MIT",
+          "matches": [
+            {
+              "end_line": 1,
+              "from_file": "crates/core/Cargo.toml",
+              "license_expression": "apache-2.0 OR mit",
+              "license_expression_spdx": "Apache-2.0 OR MIT",
+              "match_coverage": 100.0,
+              "matched_length": 3,
+              "matched_text": "MIT OR Apache-2.0",
+              "matcher": "parser-declared-license",
+              "rule_identifier": "mit_or_apache-2.0_15.RULE",
+              "rule_relevance": 100,
+              "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_or_apache-2.0_15.RULE",
+              "score": 100.0,
+              "start_line": 1
+            }
+          ]
+        }
+      ],
       "name": "myproject-core",
       "package_uid": "pkg:cargo/myproject-core@0.5.0?uuid=fixed-uid-done-for-testing-5642512d1758",
       "parties": [],


### PR DESCRIPTION
## Summary

- Cargo workspace members that inherit their license via `license.workspace = true` only recorded the raw `extracted_license_statement`; the normalized `declared_license_expression`/`_spdx` and a backing detection were never produced. Every inheriting crate (e.g. `home`, `rustfix` in rust-lang/cargo, ~22 members) reported a null declared license where ScanCode resolves it.
- Resolve the inherited license onto the member and root **file-level** package data during cargo workspace assembly (matching ScanCode's per-manifest resolution) so it also survives the downstream package/file license resync. The workspace license is normalized once per workspace and cloned onto members.

## Issues

- Covers: workspace-inherited declared-license resolution for Cargo.

## Scope and exclusions

- Included: cargo workspace license resolution; a shared license-engine scope for assembly; unit test; regenerated cargo-workspace assembly goldens.
- Explicit exclusions: none.

## How to verify

- `compare-outputs` on `rust-lang/cargo`: workspace members (`home@0.5.13`, `rustfix@0.9.6`, …) now carry `apache-2.0 OR mit`; Provenant net-leads ScanCode on declared-license coverage (66 vs 22). Total scan time is unchanged (8.34s vs 8.30s baseline) — see the perf note below. CI covers the assembly unit + golden suites.

## Intentional differences from Python

- None; this matches ScanCode resolving workspace-inherited licenses onto each member manifest.

## Performance note for reviewers

Declared-license normalization during assembly previously fell back to building a **second** license engine (the per-file parser engine scope does not extend to assembly), which added ~4s on workspace-heavy repos. This PR shares the scan's already-built engine with assembly via `with_parser_license_engine`, restoring baseline timing. Assembly is single-threaded, so the thread-local engine scope is sufficient — please sanity-check that assumption.

## Follow-up work

- None for this change.

## Expected-output fixture changes

- Files changed: `testdata/assembly-golden/cargo-workspace/expected.json`, `testdata/assembly-golden/cargo-workspace-lowercase/expected.json`.
- Why the new expected output is correct: workspace members now carry the normalized `declared_license_expression` / `_spdx` and a backing detection for their inherited license (`MIT OR Apache-2.0` → `apache-2.0 OR mit`); the additive license fields are the only change (package/dependency sets are identical).