### PR TITLE
fix(assembly): don't attribute co-located LICENSE holder to resolved dependencies

### DIFF
--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -3,11 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
 
-use crate::models::{FileInfo, Package};
+use crate::models::{DatasourceId, FileInfo, Package};
 
 use super::PackageIx;
 use super::output_indexes::OutputIndexes;
 use super::summary_helpers::unique;
+
+/// Packages synthesized purely from a dependency lockfile's resolved entries
+/// (currently Swift `Package.resolved`) describe remote third-party packages, not a
+/// package anchored by a local manifest. A co-located `LICENSE`/`README` therefore
+/// belongs to the enclosing repository, not to these dependency records, so key-file
+/// copyright/holder must not be promoted onto them (matching ScanCode, which leaves
+/// them unset). The primary package retains a manifest datasource alongside the
+/// resolved one, so it is not affected by this guard.
+fn is_resolved_dependency_record(package: &Package) -> bool {
+    !package.datasource_ids.is_empty()
+        && package
+            .datasource_ids
+            .iter()
+            .all(|id| matches!(id, DatasourceId::SwiftPackageResolved))
+}
 
 pub(super) fn promote_package_metadata_from_key_files(
     files: &[FileInfo],
@@ -15,6 +30,10 @@ pub(super) fn promote_package_metadata_from_key_files(
     indexes: &OutputIndexes,
 ) {
     for (idx, package) in packages.iter_mut().enumerate() {
+        if is_resolved_dependency_record(package) {
+            continue;
+        }
+
         let Some(key_file_indices) = indexes.key_file_indices_for_package(PackageIx(idx)) else {
             continue;
         };
@@ -41,5 +60,41 @@ pub(super) fn promote_package_metadata_from_key_files(
                 package.holder = promoted_holders.into_iter().next();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::PackageData;
+
+    fn package_with_datasources(datasources: &[DatasourceId]) -> Package {
+        let mut package =
+            Package::from_package_data(&PackageData::default(), "Package.resolved".to_string());
+        package.datasource_ids = datasources.to_vec();
+        package
+    }
+
+    #[test]
+    fn resolved_dependency_record_detected_only_when_resolved_only() {
+        // A package built purely from `Package.resolved` is a dependency record.
+        assert!(is_resolved_dependency_record(&package_with_datasources(&[
+            DatasourceId::SwiftPackageResolved
+        ])));
+        // The primary package retains its manifest datasource, so it still receives
+        // co-located key-file metadata.
+        assert!(!is_resolved_dependency_record(&package_with_datasources(
+            &[
+                DatasourceId::SwiftPackageManifestJson,
+                DatasourceId::SwiftPackageResolved,
+            ]
+        )));
+        assert!(!is_resolved_dependency_record(&package_with_datasources(
+            &[DatasourceId::SwiftPackageManifestJson]
+        )));
+        // No datasource at all must not be treated as a dependency record.
+        assert!(!is_resolved_dependency_record(&package_with_datasources(
+            &[]
+        )));
     }
 }


### PR DESCRIPTION
## Summary

- `promote_package_metadata_from_key_files` attached a directory's co-located `LICENSE`/`README` copyright and holder onto **every** associated package — including packages synthesized from a Swift `Package.resolved` lockfile, which describe remote third-party dependencies. E.g. `pkg:swift/github.com/apple/swift-collections@1.4.0` wrongly received `holder = "Point-Free, Inc."` / `copyright = "Copyright (c) 2020 Point-Free, Inc."` from the enclosing repo's root LICENSE. ScanCode correctly leaves these unset.
- Skip key-file copyright/holder promotion for packages whose datasources are exclusively resolved-dependency records. The primary package keeps its manifest datasource alongside the resolved one, so it still receives co-located metadata.

## Issues

- Closes: #1065

## Scope and exclusions

- Included: the promotion guard + a unit test for the discriminator.
- Explicit exclusions: this is the only ecosystem that builds standalone packages from a lockfile's resolved entries (cargo/npm lockfiles enrich manifest packages rather than creating standalone records), so no other package type is affected today.

## How to verify

- `compare-outputs` on `pointfreeco/swift-composable-architecture`: swift dependency packages carrying a wrongly-attributed holder dropped from 8 to 0, with no new ScanCode-better deltas. CI covers the post-processing unit suite.

## Intentional differences from Python

- None; this aligns with ScanCode leaving resolved-dependency package holder/copyright unset.

## Follow-up work

- None.

## Expected-output fixture changes

- None.