### PR TITLE
docs(benchmarks): refresh 10 more targets on M5 Pro and regenerate chart

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **12.6× median speedup** and **12.1× geometric-mean speedup** overall; the median gap grows from **7.1×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **12.7× median speedup** and **12.6× geometric-mean speedup** overall; the median gap grows from **7.2×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -150,11 +150,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `10.05s`; ScanCode `117.64s`
 - Broader Conda and Python package coverage (`5` vs `2` packages, `73` vs `26` dependencies) from `conda.recipe/meta.yaml`, multiple `environment.yml` fixtures, and the root `setup.py`, with safer URL credential stripping across authentication test fixtures
 
-##### [conda/conda-build @ 5da509d](https://github.com/conda/conda-build/tree/5da509d13764d96c02c80f24b54ab87d652b2538) — **5.73× faster**
+##### [conda/conda-build @ 5da509d](https://github.com/conda/conda-build/tree/5da509d13764d96c02c80f24b54ab87d652b2538) — **7.61× faster**
 
 - Files: 835
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `17.96s`; ScanCode `102.91s`
+- Run context: 2026-06-14 · conda-build-53275 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.24s`; ScanCode `70.31s`
 - Far broader Conda recipe and dependency extraction (`257` vs `1` packages, `164` vs `13` dependencies) across committed `meta.yaml` recipe fixtures, split-package test recipes, and sidecar Python manifests, with explicit malformed-recipe scan errors on duplicate-key negative fixtures instead of silently treating them as ordinary package metadata
 
 ##### [conda-forge/pandas-feedstock @ 4063b72](https://github.com/conda-forge/pandas-feedstock/tree/4063b725cd252c02b0cebe935a8859a6b540fe00) — **7.59× faster**
@@ -359,11 +359,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `16.30s`; ScanCode `394.76s`
 - Broader Deno package visibility (`45` vs `3` packages) from the root and leaf `*/deno.json` manifests across the standard-library tree, plus concrete Cargo lock package identities on embedded Rust fixtures instead of anonymous `cargo_lock` rows, with zero top-level license-expression deltas under the shared profile
 
-##### [getsentry/self-hosted @ 8728919](https://github.com/getsentry/self-hosted/tree/8728919e080836c53724f277d4d36cc310fc5011) — **6.50× faster**
+##### [getsentry/self-hosted @ 8728919](https://github.com/getsentry/self-hosted/tree/8728919e080836c53724f277d4d36cc310fc5011) — **9.54× faster**
 
 - Files: 129
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `12.14s`; ScanCode `78.89s`
+- Run context: 2026-06-14 · self-hosted-59300 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.74s`; ScanCode `45.20s`
 - Broader mixed Docker/npm/Python package extraction (`2` vs `1` packages, `111` vs `0` dependencies) from the integration-test `package-lock.json`, `uv.lock`, and committed service Dockerfiles, plus the more specific `Apache-2.0 AND FSL-1.1-ALv2` license classification on `LICENSE.md` where ScanCode reports only `FSL-1.1-ALv2`
 
 ##### [iTowns/itowns @ 08e08f5](https://github.com/iTowns/itowns/tree/08e08f512983b6f3d60d04d431b67b3c5e2e1584) — **13.58× faster**
@@ -580,11 +580,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `10.27s`; ScanCode `73.20s`
 - Direct Arch source-package visibility on committed `.SRCINFO` (`1` vs `0` file-level package records) with broader dependency extraction (`9` vs `0`) across runtime, make, and check edges, plus Unicode-preserving maintainer recovery and exact trailing-slash URL normalization on `PKGBUILD` while avoiding ScanCode's low-coverage `LGPL-2.0-or-later` false positive
 
-##### [archlinux/packaging/packages/pacman @ 4ee8983](https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/tree/4ee8983653633d6fad7b2b9d6c35027c9705de5d) — **6.64× faster**
+##### [archlinux/packaging/packages/pacman @ 4ee8983](https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/tree/4ee8983653633d6fad7b2b9d6c35027c9705de5d) — **8.66× faster**
 
 - Files: 12
-- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `11.49s`; ScanCode `76.28s`
+- Run context: 2026-06-14 · pacman-58826 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.65s`; ScanCode `40.26s`
 - Direct Arch source-package visibility on committed `.SRCINFO` (`1` vs `0` file-level package records) with broader dependency extraction (`26` vs `0`) across runtime, make, check, and optional package metadata, plus copyright and holder recovery on the repo-owned `LICENSE` and `REUSE.toml` surfaces that ScanCode leaves empty
 
 ##### [Amanieu/atomic-rs @ 44c213a](https://github.com/Amanieu/atomic-rs/tree/44c213a73cb4e5c4cf04fd6fd6f76dc95092aebf) — **7.24× faster**
@@ -615,11 +615,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `15.37s`; ScanCode `200.37s`
 - Cleaner URL and copyright normalization across Boost metadata files, preserving the real `http://www.boost.org/` target while dropping ScanCode's broken pseudo-URL variant in `example/boost_web.dat`, plus Unicode-preserving `René Ferdinand Rivera Morell` handling on `build.jam` and top-level `.gitattributes` visibility in the final output
 
-##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **6.02× faster**
+##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **11.09× faster**
 
 - Files: 705
-- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `35.76s`; ScanCode `215.32s`
+- Run context: 2026-06-14 · json-54573 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `14.54s`; ScanCode `161.21s`
 - Cleaner benchmark-corpus author extraction in `bench/data/gsoc-2018.json` and `bench/data/github_events.json`, replacing ScanCode junk such as `type' Person name' AadityaNair` and prose fragments with actual participant names while preserving Unicode identities like `Nils Jørgen Mittet`, plus Unicode-preserving holder normalization for `René Ferdinand Rivera Morell` on build metadata
 
 ##### [boostorg/serialization @ 097a6c6](https://github.com/boostorg/serialization/tree/097a6c63a137be836d663cdb27f2e6c803a4100b) — **10.06× faster**
@@ -692,11 +692,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.79s`; ScanCode `49.17s`
 - Matched top-level package coverage (`1` vs `1`) with broader dependency extraction (`9` vs `2`) from the repo-root `Dockerfile` and committed Ruby test `Gemfile`s, plus Docker-library `Maintainers` author recovery across `library/*` definitions with cleaner Unicode-preserving normalization and `GitRepo` trailers left out of author values
 
-##### [docker-library/python @ ced4ac7](https://github.com/docker-library/python/tree/ced4ac7ca9f8f8bdbb113f06fe02c42895875aa4) — **6.42× faster**
+##### [docker-library/python @ ced4ac7](https://github.com/docker-library/python/tree/ced4ac7ca9f8f8bdbb113f06fe02c42895875aa4) — **9.49× faster**
 
 - Files: 53
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `11.96s`; ScanCode `76.81s`
+- Run context: 2026-06-14 · python-58325 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.65s`; ScanCode `44.14s`
 - Broader Docker package visibility across 42 generated image Dockerfiles where ScanCode reports none, plus maintainer-line author recovery on `generate-stackbrew-library.sh`, with exact top-level package, dependency, and license parity elsewhere
 
 ##### [e-ale/meta-pocketbeagle @ 7cb4956](https://github.com/e-ale/meta-pocketbeagle/tree/7cb4956d206728af96833e513594693dec98e163) — **6.69× faster**
@@ -797,18 +797,18 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.63s`; ScanCode `85.01s`
 - Matched ScanCode's file-level Autotools `configure.ac` coverage while promoting one top-level Autotools package (`1` vs `0`) with the real `pkg:autotools/libevent` identity, and avoids ScanCode's prose-fragment author noise such as `Hagne Mahre and then Hannah` and `team of volunteers`
 
-##### [libgit2/libgit2 @ 1f34e2a](https://github.com/libgit2/libgit2/tree/1f34e2a57a3d03f174771203b64aed2b17e8522c) — **7.75× faster**
+##### [libgit2/libgit2 @ 1f34e2a](https://github.com/libgit2/libgit2/tree/1f34e2a57a3d03f174771203b64aed2b17e8522c) — **25.62× faster**
 
 - Files: 8,406
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `22.61s`; ScanCode `175.31s`
+- Run context: 2026-06-14 · libgit2-59805 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.93s`; ScanCode `254.45s`
 - Broader mixed-repository dependency extraction (`12` vs `0`) from committed `script/api-docs/package.json` and `script/api-docs/package-lock.json`, while preserving top-level Autotools package parity (`1` vs `1`)
 
-##### [LinuxCNC/linuxcnc @ cd534c9](https://github.com/LinuxCNC/linuxcnc/tree/cd534c951aefa3c57ced93d84d1eec5aa5596672) — **6.21× faster**
+##### [LinuxCNC/linuxcnc @ cd534c9](https://github.com/LinuxCNC/linuxcnc/tree/cd534c951aefa3c57ced93d84d1eec5aa5596672) — **10.15× faster**
 
 - Files: 9,078
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `419.63s`; ScanCode `2606.91s`
+- Run context: 2026-06-14 · linuxcnc-55282 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `163.61s`; ScanCode `1659.92s`
 - Direct Meson package visibility on the root `meson.build` plus declared dependency extraction (`2` vs `0` packages, `2` vs `0` dependencies) for `boost` and `python2`, with Debian copyright metadata carrying a Debian namespace instead of an unqualified source-package row
 
 ##### [madler/zlib @ f9dd600](https://github.com/madler/zlib/tree/f9dd6009be3ed32415edf1e89d1bc38380ecb95d) — **12.06× faster**
@@ -1371,12 +1371,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 
 #### Linux rootfs images
 
-##### [Alpine 3.23.3 minirootfs @ sha256:42d0e6d](https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-minirootfs-3.23.3-x86_64.tar.gz) — **1.22× faster**
+##### [Alpine 3.23.3 minirootfs @ sha256:42d0e6d](https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-minirootfs-3.23.3-x86_64.tar.gz) — **11.59× faster**
 
 - Files: 84
-- Run context: 2026-04-05 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `19.47s`; ScanCode `23.84s`
-- Equal top-level Alpine package count with Alpine-native installed-db dependency requirements and virtual providers preserved, plus cleaner BusyBox/OpenSSL binary-text normalization and richer `os-release` package identity
+- Run context: 2026-06-14 · rootfs-60685 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.67s`; ScanCode `54.13s`
+- Equal top-level Alpine package coverage emitted with PURL-spec-correct `pkg:apk/alpine/<name>` identities (type `apk`, distro namespace) where ScanCode uses the non-standard `pkg:alpine/<name>` type, with Alpine-native installed-db dependency requirements and virtual providers preserved and cleaner BusyBox/OpenSSL binary-text normalization
 
 ##### [Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9](https://mcr.microsoft.com/product/azurelinux/distroless/minimal/about) — **8.62× faster**
 
@@ -1501,11 +1501,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `9.89s`; ScanCode `69.35s`
 - Direct Arch built-package visibility on real `.PKGINFO` metadata (`1` vs `0` file-level package records) with twenty structured dependency edges across `depend`, `makedepend`, `checkdepend`, and `optdepend`, plus an arch-qualified `pkg:alpm/arch/python-construct@2.10.70-6?arch=any` identity instead of a scanner-silent package file
 
-##### [rubocop 1.86.1 .gem @ sha256:44415f3](https://rubygems.org/gems/rubocop/versions/1.86.1) — **3.71× faster**
+##### [rubocop 1.86.1 .gem @ sha256:44415f3](https://rubygems.org/gems/rubocop/versions/1.86.1) — **8.63× faster**
 
 - Files: 1
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `19.82s`; ScanCode `73.62s`
+- Run context: 2026-06-14 · rubocop-1.86.1.gem-61533 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.66s`; ScanCode `40.20s`
 - Matched shipped gem package and dependency coverage (`1` vs `1` packages, `10` vs `10` dependencies), with semantically combined author/email party data and an extra parser-declared `MIT` license detection on the archive file itself
 
 ##### [sudo 1.9.15-7.p5.fc42 src.rpm @ sha256:96920ba](https://download.fedoraproject.org/pub/fedora/linux/releases/42/Everything/source/tree/Packages/s/sudo-1.9.15-7.p5.fc42.src.rpm) — **7.20× faster**
@@ -1554,11 +1554,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `24.89s`; ScanCode `68.91s`
 - Richer executable metadata extraction on `glazewm-v3.10.1.exe` (`3` vs `1` copyrights, `3` vs `1` holders), plus matched shipped package identity and declared license (`pkg:winexe/GlazeWM@3.10.1`, `GPL-3.0-only`) and cleaner rejection of ScanCode's bogus installer author fragments such as `uri. Failed` and `elements. Failed`
 
-##### [ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4](https://github.com/icsharpcode/ILSpy/releases/download/v9.1/ILSpy_binaries_9.1.0.7988-x64.zip) — **1.71× faster**
+##### [ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4](https://github.com/icsharpcode/ILSpy/releases/download/v9.1/ILSpy_binaries_9.1.0.7988-x64.zip) — **11.14× faster**
 
 - Files: 40
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.50s`; ScanCode `17.97s`
+- Run context: 2026-06-14 · extracted-61095 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.12s`; ScanCode `57.03s`
 - Shipped `.deps.json` coverage on the extracted ILSpy release (`3` vs `0` packages, `86` vs `0` dependencies), with file-level NuGet dependency visibility across `ILSpy.deps.json` and plugin manifests plus cleaner rejection of ScanCode's binary-text holder noise such as `LegalTrademarks OriginalFilename`
 
 ##### [itchyny/gojq v0.12.19 darwin arm64 release snapshot @ sha256:40208d4](https://github.com/itchyny/gojq/releases/tag/v0.12.19) — **1.14× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -107,9 +107,9 @@ ScanCode: 74.17s</title></rect>
     <rect x="92.00" y="427.69" width="8" height="8" fill="#d97706" rx="1.5"><title>python-construct 2.10.70-6 .PKGINFO from Arch package @ sha256:2020ae3
 Files: 1
 ScanCode: 69.35s</title></rect>
-    <rect x="92.00" y="424.87" width="8" height="8" fill="#d97706" rx="1.5"><title>rubocop 1.86.1 .gem @ sha256:44415f3
+    <rect x="92.00" y="453.46" width="8" height="8" fill="#d97706" rx="1.5"><title>rubocop 1.86.1 .gem @ sha256:44415f3
 Files: 1
-ScanCode: 73.62s</title></rect>
+ScanCode: 40.20s</title></rect>
     <rect x="92.00" y="428.71" width="8" height="8" fill="#d97706" rx="1.5"><title>sudo 1.9.15-7.p5.fc42 src.rpm @ sha256:96920ba
 Files: 1
 ScanCode: 67.87s</title></rect>
@@ -146,9 +146,9 @@ ScanCode: 70.75s</title></rect>
     <rect x="257.23" y="327.58" width="8" height="8" fill="#d97706" rx="1.5"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 ScanCode: 577.11s</title></rect>
-    <rect x="263.23" y="423.19" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/pacman @ 4ee8983
+    <rect x="263.23" y="453.39" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
-ScanCode: 76.28s</title></rect>
+ScanCode: 40.26s</title></rect>
     <rect x="283.05" y="425.90" width="8" height="8" fill="#d97706" rx="1.5"><title>univention/Nubus @ fef2258
 Files: 16
 ScanCode: 72.03s</title></rect>
@@ -170,9 +170,9 @@ ScanCode: 68.76s</title></rect>
     <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 ScanCode: 73.99s</title></rect>
-    <rect x="346.19" y="491.51" width="8" height="8" fill="#d97706" rx="1.5"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
+    <rect x="346.19" y="436.94" width="8" height="8" fill="#d97706" rx="1.5"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
-ScanCode: 17.97s</title></rect>
+ScanCode: 57.03s</title></rect>
     <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 74.96s</title></rect>
@@ -185,9 +185,9 @@ ScanCode: 235.99s</title></rect>
     <rect x="362.93" y="430.28" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 ScanCode: 65.66s</title></rect>
-    <rect x="365.59" y="422.87" width="8" height="8" fill="#d97706" rx="1.5"><title>docker-library/python @ ced4ac7
+    <rect x="365.59" y="449.04" width="8" height="8" fill="#d97706" rx="1.5"><title>docker-library/python @ ced4ac7
 Files: 53
-ScanCode: 76.81s</title></rect>
+ScanCode: 44.14s</title></rect>
     <rect x="387.65" y="448.50" width="8" height="8" fill="#d97706" rx="1.5"><title>hello-world multi-arch OCI image layout @ sha256:ec15384
 Files: 73
 ScanCode: 44.65s</title></rect>
@@ -197,9 +197,9 @@ ScanCode: 627.66s</title></rect>
     <rect x="393.09" y="400.80" width="8" height="8" fill="#d97706" rx="1.5"><title>Mantle/Mantle @ 2a8e212
 Files: 79
 ScanCode: 122.53s</title></rect>
-    <rect x="397.32" y="478.15" width="8" height="8" fill="#d97706" rx="1.5"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
+    <rect x="397.32" y="439.40" width="8" height="8" fill="#d97706" rx="1.5"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
-ScanCode: 23.84s</title></rect>
+ScanCode: 54.13s</title></rect>
     <rect x="399.74" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 87
 ScanCode: 65.75s</title></rect>
@@ -224,9 +224,9 @@ ScanCode: 84.73s</title></rect>
     <rect x="423.04" y="408.29" width="8" height="8" fill="#d97706" rx="1.5"><title>jashkenas/backbone @ da75718
 Files: 122
 ScanCode: 104.56s</title></rect>
-    <rect x="426.88" y="421.60" width="8" height="8" fill="#d97706" rx="1.5"><title>getsentry/self-hosted @ 8728919
+    <rect x="426.88" y="447.92" width="8" height="8" fill="#d97706" rx="1.5"><title>getsentry/self-hosted @ 8728919
 Files: 129
-ScanCode: 78.89s</title></rect>
+ScanCode: 45.20s</title></rect>
     <rect x="428.98" y="388.90" width="8" height="8" fill="#d97706" rx="1.5"><title>fmtlib/fmt @ 2cb3983
 Files: 133
 ScanCode: 157.63s</title></rect>
@@ -362,9 +362,9 @@ ScanCode: 169.15s</title></rect>
     <rect x="543.81" y="392.44" width="8" height="8" fill="#d97706" rx="1.5"><title>select2/select2 @ 595494a
 Files: 704
 ScanCode: 146.24s</title></rect>
-    <rect x="543.91" y="374.16" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
+    <rect x="543.91" y="387.84" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/json @ 70efd4b
 Files: 705
-ScanCode: 215.32s</title></rect>
+ScanCode: 161.21s</title></rect>
     <rect x="548.54" y="380.50" width="8" height="8" fill="#d97706" rx="1.5"><title>xiph/opus @ 22244de
 Files: 754
 ScanCode: 188.27s</title></rect>
@@ -374,9 +374,9 @@ ScanCode: 393.40s</title></rect>
     <rect x="555.41" y="408.67" width="8" height="8" fill="#d97706" rx="1.5"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 ScanCode: 103.73s</title></rect>
-    <rect x="555.57" y="409.04" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda-build @ 5da509d
+    <rect x="555.57" y="427.04" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda-build @ 5da509d
 Files: 835
-ScanCode: 102.91s</title></rect>
+ScanCode: 70.31s</title></rect>
     <rect x="558.17" y="345.08" width="8" height="8" fill="#d97706" rx="1.5"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 ScanCode: 398.45s</title></rect>
@@ -608,18 +608,18 @@ ScanCode: 519.01s</title></rect>
     <rect x="709.24" y="331.79" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/react-native @ 179e0cd
 Files: 7765
 ScanCode: 527.81s</title></rect>
-    <rect x="714.70" y="383.87" width="8" height="8" fill="#d97706" rx="1.5"><title>libgit2/libgit2 @ 1f34e2a
+    <rect x="714.70" y="366.27" width="8" height="8" fill="#d97706" rx="1.5"><title>libgit2/libgit2 @ 1f34e2a
 Files: 8406
-ScanCode: 175.31s</title></rect>
+ScanCode: 254.45s</title></rect>
     <rect x="717.50" y="314.45" width="8" height="8" fill="#d97706" rx="1.5"><title>baserow/baserow @ 18a5fc1
 Files: 8755
 ScanCode: 761.82s</title></rect>
     <rect x="719.28" y="309.28" width="8" height="8" fill="#d97706" rx="1.5"><title>flutter/packages @ 06fee7a
 Files: 8983
 ScanCode: 849.94s</title></rect>
-    <rect x="720.00" y="256.33" width="8" height="8" fill="#d97706" rx="1.5"><title>LinuxCNC/linuxcnc @ cd534c9
+    <rect x="720.00" y="277.65" width="8" height="8" fill="#d97706" rx="1.5"><title>LinuxCNC/linuxcnc @ cd534c9
 Files: 9078
-ScanCode: 2606.91s</title></rect>
+ScanCode: 1659.92s</title></rect>
     <rect x="720.30" y="323.62" width="8" height="8" fill="#d97706" rx="1.5"><title>OrchardCMS/OrchardCore @ 01386f3
 Files: 9118
 ScanCode: 627.46s</title></rect>
@@ -775,9 +775,9 @@ Provenant: 9.60s</title></circle>
     <circle cx="96.00" cy="523.72" r="4.5" fill="#2563eb"><title>python-construct 2.10.70-6 .PKGINFO from Arch package @ sha256:2020ae3
 Files: 1
 Provenant: 9.89s</title></circle>
-    <circle cx="96.00" cy="490.88" r="4.5" fill="#2563eb"><title>rubocop 1.86.1 .gem @ sha256:44415f3
+    <circle cx="96.00" cy="559.28" r="4.5" fill="#2563eb"><title>rubocop 1.86.1 .gem @ sha256:44415f3
 Files: 1
-Provenant: 19.82s</title></circle>
+Provenant: 4.66s</title></circle>
     <circle cx="96.00" cy="525.97" r="4.5" fill="#2563eb"><title>sudo 1.9.15-7.p5.fc42 src.rpm @ sha256:96920ba
 Files: 1
 Provenant: 9.43s</title></circle>
@@ -814,9 +814,9 @@ Provenant: 9.77s</title></circle>
     <circle cx="261.23" cy="400.68" r="4.5" fill="#2563eb"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 Provenant: 133.69s</title></circle>
-    <circle cx="267.23" cy="516.64" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/pacman @ 4ee8983
+    <circle cx="267.23" cy="559.38" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
-Provenant: 11.49s</title></circle>
+Provenant: 4.65s</title></circle>
     <circle cx="287.05" cy="520.76" r="4.5" fill="#2563eb"><title>univention/Nubus @ fef2258
 Files: 16
 Provenant: 10.53s</title></circle>
@@ -838,9 +838,9 @@ Provenant: 7.05s</title></circle>
     <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
 Provenant: 11.06s</title></circle>
-    <circle cx="350.19" cy="520.89" r="4.5" fill="#2563eb"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
+    <circle cx="350.19" cy="554.83" r="4.5" fill="#2563eb"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
-Provenant: 10.50s</title></circle>
+Provenant: 5.12s</title></circle>
     <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 10.05s</title></circle>
@@ -853,9 +853,9 @@ Provenant: 27.50s</title></circle>
     <circle cx="366.93" cy="530.00" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 51
 Provenant: 8.66s</title></circle>
-    <circle cx="369.59" cy="514.74" r="4.5" fill="#2563eb"><title>docker-library/python @ ced4ac7
+    <circle cx="369.59" cy="559.38" r="4.5" fill="#2563eb"><title>docker-library/python @ ced4ac7
 Files: 53
-Provenant: 11.96s</title></circle>
+Provenant: 4.65s</title></circle>
     <circle cx="391.65" cy="540.73" r="4.5" fill="#2563eb"><title>hello-world multi-arch OCI image layout @ sha256:ec15384
 Files: 73
 Provenant: 6.90s</title></circle>
@@ -865,9 +865,9 @@ Provenant: 62.51s</title></circle>
     <circle cx="397.09" cy="518.23" r="4.5" fill="#2563eb"><title>Mantle/Mantle @ 2a8e212
 Files: 79
 Provenant: 11.11s</title></circle>
-    <circle cx="401.32" cy="491.72" r="4.5" fill="#2563eb"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
+    <circle cx="401.32" cy="559.18" r="4.5" fill="#2563eb"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
-Provenant: 19.47s</title></circle>
+Provenant: 4.67s</title></circle>
     <circle cx="403.74" cy="529.03" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 87
 Provenant: 8.84s</title></circle>
@@ -892,9 +892,9 @@ Provenant: 10.21s</title></circle>
     <circle cx="427.04" cy="517.55" r="4.5" fill="#2563eb"><title>jashkenas/backbone @ da75718
 Files: 122
 Provenant: 11.27s</title></circle>
-    <circle cx="430.88" cy="514.04" r="4.5" fill="#2563eb"><title>getsentry/self-hosted @ 8728919
+    <circle cx="430.88" cy="558.48" r="4.5" fill="#2563eb"><title>getsentry/self-hosted @ 8728919
 Files: 129
-Provenant: 12.14s</title></circle>
+Provenant: 4.74s</title></circle>
     <circle cx="432.98" cy="514.62" r="4.5" fill="#2563eb"><title>fmtlib/fmt @ 2cb3983
 Files: 133
 Provenant: 11.99s</title></circle>
@@ -1030,9 +1030,9 @@ Provenant: 10.63s</title></circle>
     <circle cx="547.81" cy="512.39" r="4.5" fill="#2563eb"><title>select2/select2 @ 595494a
 Files: 704
 Provenant: 12.57s</title></circle>
-    <circle cx="547.91" cy="462.99" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
+    <circle cx="547.91" cy="505.51" r="4.5" fill="#2563eb"><title>boostorg/json @ 70efd4b
 Files: 705
-Provenant: 35.76s</title></circle>
+Provenant: 14.54s</title></circle>
     <circle cx="552.54" cy="499.85" r="4.5" fill="#2563eb"><title>xiph/opus @ 22244de
 Files: 754
 Provenant: 16.39s</title></circle>
@@ -1042,9 +1042,9 @@ Provenant: 42.96s</title></circle>
     <circle cx="559.41" cy="551.02" r="4.5" fill="#2563eb"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 Provenant: 5.55s</title></circle>
-    <circle cx="559.57" cy="495.53" r="4.5" fill="#2563eb"><title>conda/conda-build @ 5da509d
+    <circle cx="559.57" cy="526.93" r="4.5" fill="#2563eb"><title>conda/conda-build @ 5da509d
 Files: 835
-Provenant: 17.96s</title></circle>
+Provenant: 9.24s</title></circle>
     <circle cx="562.17" cy="488.62" r="4.5" fill="#2563eb"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 Provenant: 20.79s</title></circle>
@@ -1276,18 +1276,18 @@ Provenant: 20.74s</title></circle>
     <circle cx="713.24" cy="464.02" r="4.5" fill="#2563eb"><title>facebook/react-native @ 179e0cd
 Files: 7765
 Provenant: 34.99s</title></circle>
-    <circle cx="718.70" cy="484.65" r="4.5" fill="#2563eb"><title>libgit2/libgit2 @ 1f34e2a
+    <circle cx="718.70" cy="523.53" r="4.5" fill="#2563eb"><title>libgit2/libgit2 @ 1f34e2a
 Files: 8406
-Provenant: 22.61s</title></circle>
+Provenant: 9.93s</title></circle>
     <circle cx="721.50" cy="482.31" r="4.5" fill="#2563eb"><title>baserow/baserow @ 18a5fc1
 Files: 8755
 Provenant: 23.76s</title></circle>
     <circle cx="723.28" cy="461.24" r="4.5" fill="#2563eb"><title>flutter/packages @ 06fee7a
 Files: 8983
 Provenant: 37.11s</title></circle>
-    <circle cx="724.00" cy="346.63" r="4.5" fill="#2563eb"><title>LinuxCNC/linuxcnc @ cd534c9
+    <circle cx="724.00" cy="391.14" r="4.5" fill="#2563eb"><title>LinuxCNC/linuxcnc @ cd534c9
 Files: 9078
-Provenant: 419.63s</title></circle>
+Provenant: 163.61s</title></circle>
     <circle cx="724.30" cy="462.95" r="4.5" fill="#2563eb"><title>OrchardCMS/OrchardCore @ 01386f3
 Files: 9118
 Provenant: 35.79s</title></circle>


### PR DESCRIPTION
## Summary

- Re-verify and refresh `docs/BENCHMARKS.md` timing/end-state rows for 10 targets on the current **M5 Pro / 4-process** methodology: conda-build, boostorg/json, LinuxCNC, docker-library/python, archlinux/pacman, getsentry/self-hosted, libgit2, plus three **artifact/rootfs/single-file** targets — Alpine minirootfs, ILSpy binaries, rubocop `.gem`.
- Regenerate the scatter chart and median headline: **12.7× median**, 12.6× geometric mean.

## How to verify

- Each row cites its `compare-outputs` run id; same-host wall-clock with cached ScanCode timing. Selection targeted the **lowest-speedup** (most stale/suspect) rows; the biggest movers were the artifact rows where Provenant's fixed cost previously dominated tiny scans (Alpine 1.22×→11.59×, ILSpy 1.71×→11.14×, rubocop .gem 3.71×→8.63×).
- Triage was a full shared-scanner compare review (packages, deps, license, copyright/holder/author, URL). All targets are clean Provenant wins or justified advantages, with two tracked exceptions below.

## Notable end-state findings

- **Alpine** emits PURL-spec-correct `pkg:apk/alpine/<name>` (type `apk`, distro namespace) vs ScanCode's non-standard `pkg:alpine/<name>` — the row's "16 vs 16" package identities differ only by this (a Provenant advantage).
- Several "ScanCode-better" deltas were ScanCode over-extraction Provenant correctly rejects: bare-word license noise in `boostorg/json` `bench/data/*.json`, author/holder/license noise in LinuxCNC `docs/po/*.po` translated docs, and PE binary-text holder junk in ILSpy DLLs.
- `getsentry/self-hosted` and `libgit2` declared-license deltas are the documented #1066 by-design behavior (co-located/unreferenced LICENSE not promoted into declared; license still captured as a file-level detection).

## Follow-up work (tracked separately)

- #1072 — ambiguous bare declared-license names (e.g. `setup.py license="BSD"`) not normalized into the declared expression (cross-cutting license policy).
- #1073 — compiled-binary (PE version-info) copyright leaves a `LegalCopyright:` field-label prefix / separator bleed and misses one holder (niche; Provenant net-cleaner there).

## Expected-output fixture changes

- None (documentation + generated chart only).