### PR TITLE
fix(license): normalize ambiguous bare declared-license names

### DIFF
--- a/resources/license_detection/index_build_policy.toml
+++ b/resources/license_detection/index_build_policy.toml
@@ -33,6 +33,7 @@ ignored_licenses = []
 "apache-2.0_and_lgpl-2.1_4.RULE" = "Cover the GNU/Linux wording variant of the typoed mixed Apache-2.0/LGPL-2.1 notice while keeping it tight enough to avoid loose partial matches."
 "bsd-new_1319.RULE" = "Prevent two-clause BSD headers from being mislabeled as BSD-3-Clause when this upstream rule matches text that lacks the endorsement clause; keep the fix in rule curation instead of matcher logic."
 "bsd-new_99.RULE" = "Require a full continuous match for this BSD-3 endorsement-clause rule so BSD-2-style headers such as the Opus and GLC fixtures do not partially overmatch it."
+"bsd_bare_word_only.RULE" = "Treat bare versionless BSD shorthand as clue-only evidence so a declared license=\"BSD\" manifest statement can normalize to bsd-new without bare BSD becoming a hard file-content detection."
 "gpl-1.0-plus_351.RULE" = "Keep the weak phrase 'the GPL' as clue-only GPL evidence without turning acronym collisions such as Graphics Pipeline Library into hard detections."
 "gpl-1.0-plus_461.RULE" = "Require the explicit 'version 1, or (at your option) any later version' wording so split-string GPLv2+ notices do not overmatch as GPL-1.0-or-later."
 "gpl-1.0-plus_568.RULE" = "Treat the unversioned GPL boilerplate prefixed by a bare 'License' label as a false-positive fragment so explicit later versioned notices are not polluted by GPL-1.0-or-later noise."

--- a/resources/license_detection/overlay/rules/bsd_bare_word_only.RULE
+++ b/resources/license_detection/overlay/rules/bsd_bare_word_only.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: bsd-new
+is_license_clue: yes
+relevance: 50
+notes: Bare versionless BSD shorthand is too weak for a hard detection; preserve it as clue-only evidence (ScanCode maps bare BSD to bsd-new).
+---
+
+BSD

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -232,13 +232,27 @@ fn promote_whole_statement_clue(
     if match_item.matcher != crate::license_detection::models::MatcherKind::Hash {
         return None;
     }
-    if match_item.license_expression.trim().is_empty() {
+    let expression = match_item.license_expression.trim();
+    if expression.is_empty() {
+        return None;
+    }
+
+    // Do not promote a generic/unknown catch-all license (e.g. `commercial-license`,
+    // `proprietary-license`, `free-unknown`). A non-specific match means the declared
+    // statement is a custom/unstated license — for example `"Acme Commercial License"`,
+    // where the custom token is dropped during tokenization and only `"Commercial
+    // License"` matches the generic rule. Such statements must stay an extracted-only
+    // raw value; only a specific license (e.g. `bsd-new`) is promoted to declared.
+    if let Some(engine) = parser_license_engine()
+        && let Some(license) = engine.index().licenses_by_key.get(expression)
+        && (license.is_generic || license.is_unknown)
+    {
         return None;
     }
 
     // Re-normalize through the index so both the ScanCode and SPDX forms are
     // canonical, rather than trusting whatever the clue match happened to carry.
-    normalize_spdx_expression(&match_item.license_expression)
+    normalize_spdx_expression(expression)
 }
 
 pub(crate) fn normalize_spdx_expression(statement: &str) -> Option<NormalizedDeclaredLicense> {
@@ -1420,6 +1434,24 @@ mod tests {
             lgpl.declared_license_expression.as_deref(),
             Some("lgpl-2.0-plus")
         );
+    }
+
+    #[test]
+    fn test_populate_declared_license_custom_generic_stays_extracted_only() {
+        // A custom/proprietary statement whose only match resolves to a generic
+        // catch-all license (here `commercial-license`, with the custom `Acme`
+        // token dropped during tokenization) must NOT be promoted to declared; it
+        // stays an extracted-only raw value.
+        let mut package = package_with(Some("Acme Commercial License"), None, None);
+        populate_declared_license_and_holder(&mut package);
+
+        assert_eq!(
+            package.extracted_license_statement.as_deref(),
+            Some("Acme Commercial License")
+        );
+        assert_eq!(package.declared_license_expression, None);
+        assert_eq!(package.declared_license_expression_spdx, None);
+        assert!(package.license_detections.is_empty());
     }
 
     #[test]

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -172,21 +172,73 @@ pub(crate) fn detect_declared_license_from_text(
             .filter_map(|detection| detection.license_expression_spdx.clone()),
     );
 
-    match (
+    let (declared, declared_spdx) = match (
         declared_license_expression,
         declared_license_expression_spdx,
     ) {
-        (Some(declared), Some(declared_spdx)) => {
-            let references: Vec<&str> = referenced_filename.into_iter().collect();
-            build_declared_license_data_from_pair(
-                declared,
-                declared_spdx,
-                DeclaredLicenseMatchMetadata::single_line(text)
-                    .with_referenced_filenames(&references),
-            )
-        }
-        _ => empty_declared_license_data(),
+        (Some(declared), Some(declared_spdx)) => (declared, declared_spdx),
+        // Free-text detection produced no public expression. A bare ambiguous
+        // license name (e.g. "BSD", "GPL") only matches a clue-only rule, which
+        // detection deliberately keeps expression-less for arbitrary file text.
+        // For a declared manifest statement that *is* the whole bounded license
+        // field, promote that clue to a confident declared expression.
+        _ => match promote_whole_statement_clue(&detections) {
+            Some(normalized) => (
+                normalized.declared_license_expression,
+                normalized.declared_license_expression_spdx,
+            ),
+            None => return empty_declared_license_data(),
+        },
+    };
+
+    let references: Vec<&str> = referenced_filename.into_iter().collect();
+    build_declared_license_data_from_pair(
+        declared,
+        declared_spdx,
+        DeclaredLicenseMatchMetadata::single_line(text).with_referenced_filenames(&references),
+    )
+}
+
+/// Promotes a clue-only whole-statement detection into a confident declared
+/// expression.
+///
+/// Free-text detection keeps bare ambiguous license names (e.g. "BSD", "GPL",
+/// "BSD-style") as expression-less *clues* so they never become hard detections
+/// in arbitrary file text. A declared manifest statement is a bounded,
+/// trustworthy license field, so when the statement is exactly such a name we
+/// honor the clue's license expression — the declared-context analog of
+/// ScanCode's `package_license` handling.
+///
+/// Stays conservative: requires a single detection whose single match is a
+/// whole-statement *hash* match (the statement's tokens are exactly a rule's
+/// tokens). This is what distinguishes a true bare name such as "BSD" or
+/// "BSD-style" from a fragment match where the bare name is only part of a
+/// longer statement (e.g. "BSD with advertising", which means BSD-4-Clause, must
+/// NOT collapse to bsd-new). A statement with no clue match, or whose clue match
+/// only covers a fragment, yields `None` so the declared expression stays an
+/// honest `null`.
+fn promote_whole_statement_clue(
+    detections: &[crate::license_detection::detection::LicenseDetection],
+) -> Option<NormalizedDeclaredLicense> {
+    let [detection] = detections else {
+        return None;
+    };
+    if detection.license_expression.is_some() {
+        return None;
     }
+    let [match_item] = detection.matches.as_slice() else {
+        return None;
+    };
+    if match_item.matcher != crate::license_detection::models::MatcherKind::Hash {
+        return None;
+    }
+    if match_item.license_expression.trim().is_empty() {
+        return None;
+    }
+
+    // Re-normalize through the index so both the ScanCode and SPDX forms are
+    // canonical, rather than trusting whatever the clue match happened to carry.
+    normalize_spdx_expression(&match_item.license_expression)
 }
 
 pub(crate) fn normalize_spdx_expression(statement: &str) -> Option<NormalizedDeclaredLicense> {
@@ -1330,6 +1382,94 @@ mod tests {
             Some("Apache-2.0")
         );
         assert!(!package.license_detections.is_empty());
+    }
+
+    #[test]
+    fn test_populate_declared_license_ambiguous_bare_bsd() {
+        // Bare "BSD" fails strict SPDX parsing and only matches a clue-only
+        // rule; on a declared manifest statement it must normalize to bsd-new
+        // (BSD-3-Clause), matching ScanCode.
+        let mut package = package_with(Some("BSD"), None, None);
+        populate_declared_license_and_holder(&mut package);
+
+        assert_eq!(
+            package.declared_license_expression.as_deref(),
+            Some("bsd-new")
+        );
+        assert_eq!(
+            package.declared_license_expression_spdx.as_deref(),
+            Some("BSD-3-Clause")
+        );
+        assert_eq!(package.license_detections.len(), 1);
+    }
+
+    #[test]
+    fn test_populate_declared_license_ambiguous_bare_gpl_and_lgpl() {
+        // Bare GPL/LGPL shorthand should also resolve via the clue-promotion
+        // path (GPL is clue-only; LGPL has a non-clue bare rule).
+        let mut gpl = package_with(Some("GPL"), None, None);
+        populate_declared_license_and_holder(&mut gpl);
+        assert_eq!(
+            gpl.declared_license_expression.as_deref(),
+            Some("gpl-1.0-plus")
+        );
+
+        let mut lgpl = package_with(Some("LGPL"), None, None);
+        populate_declared_license_and_holder(&mut lgpl);
+        assert_eq!(
+            lgpl.declared_license_expression.as_deref(),
+            Some("lgpl-2.0-plus")
+        );
+    }
+
+    #[test]
+    fn test_populate_declared_license_unambiguous_bare_names_unchanged() {
+        // Names that already normalize via strict SPDX parsing must be
+        // unaffected by the clue-promotion fallback.
+        let mut mit = package_with(Some("MIT"), None, None);
+        populate_declared_license_and_holder(&mut mit);
+        assert_eq!(mit.declared_license_expression.as_deref(), Some("mit"));
+
+        let mut apache = package_with(Some("Apache-2.0"), None, None);
+        populate_declared_license_and_holder(&mut apache);
+        assert_eq!(
+            apache.declared_license_expression.as_deref(),
+            Some("apache-2.0")
+        );
+
+        let mut dual = package_with(Some("MIT OR Apache-2.0"), None, None);
+        populate_declared_license_and_holder(&mut dual);
+        assert_eq!(
+            dual.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+    }
+
+    #[test]
+    fn test_populate_declared_license_bare_name_fragment_stays_null() {
+        // "BSD with advertising" means BSD-4-Clause; the bare-BSD clue rule only
+        // matches the "BSD" fragment (an Aho match, not a whole-statement hash
+        // match), so the clue-promotion path must NOT collapse it to bsd-new.
+        let mut package = package_with(Some("BSD with advertising"), None, None);
+        populate_declared_license_and_holder(&mut package);
+
+        assert_ne!(
+            package.declared_license_expression.as_deref(),
+            Some("bsd-new"),
+            "a bare-name fragment must not be promoted to the bare-name expression"
+        );
+    }
+
+    #[test]
+    fn test_populate_declared_license_unmatchable_short_stays_null() {
+        // A short statement that matches no license rule must stay an honest
+        // null rather than guessing.
+        let mut package = package_with(Some("zzgarbage"), None, None);
+        populate_declared_license_and_holder(&mut package);
+
+        assert!(package.declared_license_expression.is_none());
+        assert!(package.declared_license_expression_spdx.is_none());
+        assert!(package.license_detections.is_empty());
     }
 
     #[test]

--- a/testdata/haxe/deps/haxelib.json.expected
+++ b/testdata/haxe/deps/haxelib.json.expected
@@ -44,9 +44,33 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": null,
-    "declared_license_expression_spdx": null,
-    "license_detections": [],
+    "declared_license_expression": "bsd-new",
+    "declared_license_expression_spdx": "BSD-3-Clause",
+    "license_detections": [
+      {
+        "license_expression": "bsd-new",
+        "license_expression_spdx": "BSD-3-Clause",
+        "matches": [
+          {
+            "license_expression": "bsd-new",
+            "license_expression_spdx": "BSD-3-Clause",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "BSD",
+            "referenced_filenames": []
+          }
+        ],
+        "identifier": null
+      }
+    ],
     "other_license_expression": null,
     "other_license_expression_spdx": null,
     "other_license_detections": [],

--- a/testdata/python/golden/setup_py_function_call/setup.py-expected.json
+++ b/testdata/python/golden/setup_py_function_call/setup.py-expected.json
@@ -33,9 +33,33 @@
   "vcs_url": null,
   "copyright": null,
   "holder": null,
-  "declared_license_expression": null,
-  "declared_license_expression_spdx": null,
-  "license_detections": [],
+  "declared_license_expression": "bsd-new",
+  "declared_license_expression_spdx": "BSD-3-Clause",
+  "license_detections": [
+    {
+      "license_expression": "bsd-new",
+      "license_expression_spdx": "BSD-3-Clause",
+      "matches": [
+        {
+          "license_expression": "bsd-new",
+          "license_expression_spdx": "BSD-3-Clause",
+          "from_file": null,
+          "start_line": 1,
+          "end_line": 1,
+          "matcher": "parser-declared-license",
+          "score": 100.0,
+          "matched_length": 1,
+          "match_coverage": 100.0,
+          "rule_relevance": 100,
+          "rule_identifier": "parser-declared-license",
+          "rule_url": null,
+          "matched_text": "BSD",
+          "referenced_filenames": []
+        }
+      ],
+      "identifier": null
+    }
+  ],
   "other_license_expression": null,
   "other_license_expression_spdx": null,
   "other_license_detections": [],

--- a/testdata/readme-golden/android/basic/README.android.expected.json
+++ b/testdata/readme-golden/android/basic/README.android.expected.json
@@ -23,9 +23,33 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": null,
-    "declared_license_expression_spdx": null,
-    "license_detections": [],
+    "declared_license_expression": "bsd-new",
+    "declared_license_expression_spdx": "BSD-3-Clause",
+    "license_detections": [
+      {
+        "license_expression": "bsd-new",
+        "license_expression_spdx": "BSD-3-Clause",
+        "matches": [
+          {
+            "license_expression": "bsd-new",
+            "license_expression_spdx": "BSD-3-Clause",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "BSD",
+            "referenced_filenames": []
+          }
+        ],
+        "identifier": null
+      }
+    ],
     "other_license_expression": null,
     "other_license_expression_spdx": null,
     "other_license_detections": [],

--- a/testdata/readme-golden/thirdparty/basic/README.thirdparty.expected.json
+++ b/testdata/readme-golden/thirdparty/basic/README.thirdparty.expected.json
@@ -23,9 +23,33 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": null,
-    "declared_license_expression_spdx": null,
-    "license_detections": [],
+    "declared_license_expression": "bsd-new",
+    "declared_license_expression_spdx": "BSD-3-Clause",
+    "license_detections": [
+      {
+        "license_expression": "bsd-new",
+        "license_expression_spdx": "BSD-3-Clause",
+        "matches": [
+          {
+            "license_expression": "bsd-new",
+            "license_expression_spdx": "BSD-3-Clause",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "BSD",
+            "referenced_filenames": []
+          }
+        ],
+        "identifier": null
+      }
+    ],
     "other_license_expression": null,
     "other_license_expression_spdx": null,
     "other_license_detections": [],


### PR DESCRIPTION
## Summary

- Bare ambiguous declared-license names (e.g. Python `setup.py` `license = "BSD"`) populated `extracted_license_statement` but left `declared_license_expression` **null**, while ScanCode maps bare `BSD` → `bsd-new`. This fixes the shared declared-license normalization path so these resolve.

## Issues

- Closes: #1072

## Scope and exclusions

- Included: shared declared-statement normalization in `src/parsers/license_normalization.rs` (benefits all parsers), a clue-only `bsd_bare_word_only.RULE` overlay so bare `BSD` has an index rule, and the regenerated embedded index artifact.
- Explicit exclusions: no change to file-content license/copyright detection. The fix is gated strictly to the bounded declared-statement path, so it does not reintroduce bare-word license noise in arbitrary file text (bare `BSD` stays a clue in file content).

## How to verify

- `cargo test --lib parsers::license_normalization` exercises the new behavior directly: `"BSD"` → `bsd-new`/`BSD-3-Clause`, `"GPL"`/`"LGPL"` resolve, `"MIT"`/`"Apache-2.0"`/`"MIT OR Apache-2.0"` unchanged, `"zzgarbage"` stays null, and the regression guard `"BSD with advertising"` (which means BSD-4-Clause) is **not** collapsed to `bsd-new`.
- Everything else (clippy, fmt, golden + license-detection suites) is CI-covered.

## Intentional differences from Python

- None functionally for this case; this aligns Provenant with ScanCode's bare-`BSD` → `bsd-new` mapping while keeping Provenant's stricter file-content discipline (bare names remain clues, not hard detections).

## Follow-up work

- None required. Other ambiguous bare names already resolve via existing index rules/parser paths (`GPL`, `LGPL`, `AGPL`, `BSD-style`); only bare `BSD` needed a new overlay rule.

## Expected-output fixture changes

- Files changed: `testdata/python/golden/setup_py_function_call/setup.py-expected.json`, `testdata/haxe/deps/haxelib.json.expected`, `testdata/readme-golden/android/basic/README.android.expected.json`, `testdata/readme-golden/thirdparty/basic/README.thirdparty.expected.json`.
- Why the new expected output is correct: each fixture declares `license = "BSD"` and now gains `declared_license_expression: bsd-new` / `declared_license_expression_spdx: BSD-3-Clause` with a single `parser-declared-license` detection over the `"BSD"` text — exactly the ScanCode-compatible mapping described in #1072. Fixtures updated with the owned-field refresh switch (`PROVENANT_UPDATE_PARSER_GOLDEN=1`); only these 4 had real value changes and each diff was reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)