### PR TITLE
fix(copyright): strip PE version-info field labels and separator runs

### DIFF
--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -322,7 +322,7 @@ pub(super) fn strip_known_copyright_wrappers(s: &str) -> String {
 /// punctuation (single/double dashes, `(c)`, etc.) intact.
 pub(super) fn trim_separator_rule_runs(s: &str) -> String {
     static SEPARATOR_RUN_RE: LazyLock<Regex> =
-        LazyLock::new(|| compile_static_regex(r"[=_*]{3,}|-{3,}"));
+        LazyLock::new(|| compile_static_regex(r"={3,}|_{3,}|\*{3,}|-{3,}"));
     if !SEPARATOR_RUN_RE.is_match(s) {
         return s.to_string();
     }

--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -30,6 +30,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     }
     let mut c = original.clone();
     c = strip_known_copyright_wrappers(&c);
+    c = trim_separator_rule_runs(&c);
     c = strip_trailing_quote_before_email(&c);
     c = normalize_b_dot_angle_emails(&c);
     c = strip_nickname_quotes(&c);
@@ -229,8 +230,36 @@ pub(super) fn strip_known_copyright_wrappers(s: &str) -> String {
             "#,
         )
     });
+    // PE / Windows version-info field labels (e.g. `LegalCopyright:`,
+    // `LegalTrademarks:`) extracted from compiled binaries are emitted as
+    // `Label: <value>` lines. When the value is itself a copyright statement,
+    // the bare label leaks into the detected copyright/holder. Strip a single
+    // leading `Word:` / `WordWord:`-style label that immediately precedes a
+    // `Copyright` / `(c)` / `©` token so the statement starts at the actual
+    // copyright. Kept conservative: only one alphabetic label token, and the
+    // remainder must begin with a copyright marker.
+    static VERSION_INFO_LABEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?x)
+            ^[A-Za-z][A-Za-z0-9]*\s*:\s*
+            (?P<value>
+                (?i:(?:copyright|copr\.?|\u{0040}copyright)\b | \(c\) | \u{00a9})
+                .*
+            )$",
+        )
+    });
 
     let trimmed = s.trim();
+    if let Some(captures) = VERSION_INFO_LABEL_RE.captures(trimmed) {
+        let value = captures
+            .name("value")
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .trim();
+        if !value.is_empty() {
+            return value.to_string();
+        }
+    }
     if let Some(captures) = VALUE_LEGALCOPYRIGHT_RE.captures(trimmed) {
         let value = captures
             .name("value")
@@ -281,6 +310,23 @@ pub(super) fn strip_known_copyright_wrappers(s: &str) -> String {
     }
 
     s.to_string()
+}
+
+/// Trim ASCII separator/rule runs (e.g. `====`, `----`, `____`, long `***`
+/// runs) that bleed into a detected copyright statement from adjacent layout
+/// in compiled-binary version-info blobs.
+///
+/// Such a run is decorative, never part of a holder name, so it is collapsed
+/// to a single space and the result re-squeezed. Conservative: only runs of
+/// three or more identical separator characters are touched, leaving ordinary
+/// punctuation (single/double dashes, `(c)`, etc.) intact.
+pub(super) fn trim_separator_rule_runs(s: &str) -> String {
+    static SEPARATOR_RUN_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r"[=_*]{3,}|-{3,}"));
+    if !SEPARATOR_RUN_RE.is_match(s) {
+        return s.to_string();
+    }
+    normalize_whitespace(&SEPARATOR_RUN_RE.replace_all(s, " "))
 }
 
 pub(super) fn strip_trailing_all_rights_reserved_clause(s: &str) -> String {

--- a/src/copyright/refiner/holder.rs
+++ b/src/copyright/refiner/holder.rs
@@ -80,7 +80,7 @@ pub(super) fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<
         &*HOLDERS_PREFIXES
     };
 
-    let mut h = s.replace("build.year", " ");
+    let mut h = trim_separator_rule_runs(&s.replace("build.year", " "));
     let had_lowercase_handle_angle_email = is_lowercase_handle_angle_email(&h);
     h = strip_trailing_lowercase_handle_angle_email(&h);
     h = strip_trailing_quote_before_email(&h);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2517,3 +2517,85 @@ fn test_refine_holder_keeps_holders_after_long_url() {
         Some("securityhub-enabled The AWS Account".to_string())
     );
 }
+
+// ── PE / Windows version-info field-label + separator-run cleanup ─────
+
+#[test]
+fn test_refine_copyright_strips_pe_version_info_field_label() {
+    // A `LegalCopyright:` field label extracted from a compiled PE binary must
+    // not leak into the detected copyright (issue #1073).
+    assert_eq!(
+        refine_copyright("LegalCopyright: Copyright \u{a9} Nate McMaster"),
+        Some("Copyright \u{a9} Nate McMaster".to_string())
+    );
+    // The generic `Word:` label strip works for any leaked field label. The
+    // `refine_copyright` junk gate already drops `LegalTrademarks`-bearing text
+    // entirely, so exercise the label strip directly through the wrapper.
+    assert_eq!(
+        strip_known_copyright_wrappers("ProductCopyright: Copyright (c) 2020 Acme Inc."),
+        "Copyright (c) 2020 Acme Inc."
+    );
+    // The value may start at a `(c)` or `©` marker rather than the word.
+    assert_eq!(
+        strip_known_copyright_wrappers("LegalCopyright: (c) 2020 Acme Inc."),
+        "(c) 2020 Acme Inc."
+    );
+    assert_eq!(
+        strip_known_copyright_wrappers("LegalCopyright: \u{a9} 2020 Acme Inc."),
+        "\u{a9} 2020 Acme Inc."
+    );
+}
+
+#[test]
+fn test_refine_copyright_field_label_strip_is_conservative() {
+    // A `Word:` prefix that is not immediately followed by a copyright marker is
+    // left untouched, so ordinary copyrights and prose are unaffected.
+    assert_eq!(
+        refine_copyright("Copyright (c) 2020 Acme Inc."),
+        Some("Copyright (c) 2020 Acme Inc.".to_string())
+    );
+    // No copyright marker after the label: not treated as a leaked field label.
+    assert_eq!(
+        strip_known_copyright_wrappers("Foo: Acme Inc."),
+        "Foo: Acme Inc."
+    );
+    // A word boundary is required: `copyrightable` is not a leaked marker.
+    assert_eq!(
+        strip_known_copyright_wrappers("Foo: copyrightable works"),
+        "Foo: copyrightable works"
+    );
+}
+
+#[test]
+fn test_trim_separator_rule_runs_in_copyright() {
+    // An ASCII rule run bleeding into the statement is collapsed away while the
+    // surrounding holder/URL text is preserved (issue #1073).
+    assert_eq!(
+        refine_copyright(
+            "Copyright (c) 2013 Scott Kirkland ============== ByteSize (https://github.com/omar/ByteSize)"
+        ),
+        Some(
+            "Copyright (c) 2013 Scott Kirkland ByteSize (https://github.com/omar/ByteSize)"
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn test_trim_separator_rule_runs_unit() {
+    assert_eq!(trim_separator_rule_runs("a ==== b"), "a b");
+    assert_eq!(trim_separator_rule_runs("a ---- b"), "a b");
+    assert_eq!(trim_separator_rule_runs("a ____ b"), "a b");
+    assert_eq!(trim_separator_rule_runs("a **** b"), "a b");
+    // Short punctuation runs and ordinary text are left intact.
+    assert_eq!(trim_separator_rule_runs("a -- b"), "a -- b");
+    assert_eq!(trim_separator_rule_runs("Acme Corp"), "Acme Corp");
+}
+
+#[test]
+fn test_refine_holder_trims_separator_rule_runs() {
+    assert_eq!(
+        refine_holder("Scott Kirkland ============== ByteSize"),
+        Some("Scott Kirkland ByteSize".to_string())
+    );
+}

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2590,6 +2590,9 @@ fn test_trim_separator_rule_runs_unit() {
     // Short punctuation runs and ordinary text are left intact.
     assert_eq!(trim_separator_rule_runs("a -- b"), "a -- b");
     assert_eq!(trim_separator_rule_runs("Acme Corp"), "Acme Corp");
+    // Only runs of one identical separator are collapsed; mixed runs are left intact.
+    assert_eq!(trim_separator_rule_runs("a =*= b"), "a =*= b");
+    assert_eq!(trim_separator_rule_runs("a *=* b"), "a *=* b");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Strip a leaked PE/Windows version-info field-label prefix (e.g. `LegalCopyright:`) that precedes a copyright statement, so compiled-binary scans no longer report `LegalCopyright: Copyright (c) Nate McMaster`.
- Trim ASCII separator/rule runs (`====`, `----`, `____`, long `***`) that bleed into a detected copyright/holder, e.g. `Copyright (c) 2013 Scott Kirkland ============== ByteSize`.

Both fixes are generic copyright-detection normalizations in `src/copyright/refiner/` and are deliberately conservative.

## Issues

- Closes: #1073

## Scope and exclusions

- Included: leading field-label strip + separator-run trim in the copyright refiner (`refine_copyright` and `refine_holder`).
- Explicit exclusions: the secondary "iced project and contributors" missed-holder case. Investigation showed it does **not** share a root cause with this issue — it stems from neighboring version-info lines (`ProductVersion`) being concatenated into the copyright span, a separate multi-line-bleed problem. Per the issue's guidance, it is left for separate follow-up.

## Root cause

`extract_windows_executable_metadata_text` emits PE string-table fields as `Label: <value>` lines (e.g. `LegalCopyright: Copyright © Nate McMaster`), joined and fed to copyright detection. When the value is itself a copyright statement, the bare label leaked through refinement, and decorative rule runs from the version-info blob survived into the holder. The refiner already special-cased the `VALUE "LegalCopyright", "..."` resource-script form but not the bare `Label: <value>` form or separator runs.

## How to verify

Beyond the unit/golden suites CI runs:

- `cargo test --lib copyright::refiner` — new tests:
  - `test_refine_copyright_strips_pe_version_info_field_label`
  - `test_refine_copyright_field_label_strip_is_conservative`
  - `test_trim_separator_rule_runs_in_copyright` / `_unit`
  - `test_refine_holder_trims_separator_rule_runs`
- Spot check: `refine_copyright("LegalCopyright: Copyright © Nate McMaster")` → `Copyright © Nate McMaster`; the `====` ByteSize string → separator removed; ordinary copyrights (Acme, FSF, iced) unchanged.

Local runs: `cargo test --lib copyright` (1082 pass), `cargo test --features golden-tests --test copyright_golden` (36 pass), clippy/fmt/license-headers/DCO hooks all clean.

## Intentional differences from Python

- N/A — this is a Provenant-side residual-cleanup improvement; Provenant was already net-cleaner than ScanCode here (it correctly rejects worse PE junk like `LegalTrademarks OriginalFilename`).

## Follow-up work

- The "iced project and contributors" missed-holder case (trailing version-info-line bleed) is deferred as a separate multi-line-concatenation fix.

## Expected-output fixture changes

- Files changed: none. No golden fixtures changed; all existing copyright goldens still pass unmodified.