### PR TITLE
fix(parsers): resolve declared license to canonical index key

### DIFF
--- a/src/parsers/composer_test.rs
+++ b/src/parsers/composer_test.rs
@@ -390,7 +390,7 @@ mod tests {
         );
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("gpl-2.0-only WITH classpath-exception-2.0")
+            Some("gpl-2.0 WITH classpath-exception-2.0")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -1021,27 +1021,20 @@ fn normalize_license_key(key: &str, index: &LicenseIndex) -> Option<NormalizedDe
             return None;
         }
 
-        let canonical_spdx_key = index
+        // The canonical ScanCode key for this license is the rule's own
+        // `license_expression` (e.g. `bsd-new` for SPDX `BSD-3-Clause`,
+        // `bsd-simplified` for `BSD-2-Clause`). Lowercasing the SPDX id only
+        // coincides with the ScanCode key for licenses like `mit`/`apache-2.0`;
+        // for others it fabricated a key absent from the index, diverging from
+        // both ScanCode output and Provenant's own file-level detections.
+        let declared_license_expression_spdx = index
             .licenses_by_key
             .get(&rule_license_expression)
             .and_then(|license| license.spdx_license_key.clone())
             .unwrap_or_else(|| normalized_key.to_string());
 
-        let declared_license_expression =
-            if normalized_key.eq_ignore_ascii_case(&canonical_spdx_key) {
-                normalized_key.to_ascii_lowercase()
-            } else {
-                rule_license_expression
-            };
-
-        let declared_license_expression_spdx = index
-            .licenses_by_key
-            .get(&declared_license_expression)
-            .and_then(|license| license.spdx_license_key.clone())
-            .unwrap_or(canonical_spdx_key);
-
         return Some(NormalizedDeclaredLicense::new(
-            declared_license_expression,
+            rule_license_expression,
             declared_license_expression_spdx,
         ));
     }
@@ -1748,9 +1741,12 @@ mod tests {
             ("GPLv2", "gpl-2.0", "GPL-2.0-only"),
             ("MIT", "mit", "MIT"),
             ("Apache License 2.0", "apache-2.0", "Apache-2.0"),
-            ("BSD-3-Clause", "bsd-3-clause", "BSD-3-Clause"),
+            // SPDX ids whose canonical ScanCode key is not the lowercased SPDX
+            // id must resolve to the real index key, not a fabricated one.
+            ("BSD-3-Clause", "bsd-new", "BSD-3-Clause"),
+            ("BSD-2-Clause", "bsd-simplified", "BSD-2-Clause"),
             ("Artistic-2.0", "artistic-2.0", "Artistic-2.0"),
-            ("WTFPL", "wtfpl", "WTFPL"),
+            ("WTFPL", "wtfpl-2.0", "WTFPL"),
             ("MPL-2.0", "mpl-2.0", "MPL-2.0"),
             ("EPL-2.0", "epl-2.0", "EPL-2.0"),
         ] {
@@ -1766,6 +1762,57 @@ mod tests {
                 "declared spdx for {statement:?}"
             );
         }
+    }
+
+    /// Invariant guard for the whole license set, not a hand-maintained sample:
+    /// for every SPDX id the bundled index knows, declared-license normalization
+    /// must resolve to a ScanCode key that actually exists in the index. This is
+    /// what `normalize_license_key` should do by consulting the authoritative
+    /// index; the earlier lowercase-the-SPDX-id shortcut fabricated keys absent
+    /// from the index (e.g. `bsd-3-clause`, `wtfpl`) for the ~246 licenses whose
+    /// canonical key is not simply the lowercased SPDX id.
+    #[test]
+    fn test_every_indexed_spdx_key_normalizes_to_a_real_index_key() {
+        let engine = parser_license_engine().expect("embedded parser license engine");
+        let index = engine.index();
+
+        let mut checked = 0usize;
+        for license in index.licenses_by_key.values() {
+            let Some(spdx_key) = license.spdx_license_key.as_deref() else {
+                continue;
+            };
+            // LicenseRef-* ids round-trip as themselves; they are not part of the
+            // indexed-key invariant under test here.
+            if spdx_key.starts_with("LicenseRef-") {
+                continue;
+            }
+
+            let Some(normalized) = normalize_license_key(spdx_key, index) else {
+                continue;
+            };
+
+            for token in normalized
+                .declared_license_expression
+                .split([' ', '(', ')'])
+                .filter(|token| !token.is_empty())
+            {
+                if matches!(token, "AND" | "OR" | "WITH" | "and" | "or" | "with")
+                    || token.contains("licenseref-")
+                {
+                    continue;
+                }
+                assert!(
+                    index.licenses_by_key.contains_key(token),
+                    "declared key {token:?} for SPDX {spdx_key:?} is absent from the index"
+                );
+            }
+            checked += 1;
+        }
+
+        assert!(
+            checked > 100,
+            "expected to validate many indexed SPDX keys, only checked {checked}"
+        );
     }
 
     #[test]

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -2312,7 +2312,7 @@ Test package description.
 
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("apache-2.0 AND bsd-3-clause AND mit")
+            Some("apache-2.0 AND bsd-new AND mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),

--- a/src/parsers/rpm_db.rs
+++ b/src/parsers/rpm_db.rs
@@ -834,7 +834,7 @@ mod tests {
 
         assert_eq!(
             package.declared_license_expression.as_deref(),
-            Some("lgpl-2.0-only")
+            Some("lgpl-2.0")
         );
         assert_eq!(
             package.declared_license_expression_spdx.as_deref(),

--- a/src/parsers/rpm_parser.rs
+++ b/src/parsers/rpm_parser.rs
@@ -1424,10 +1424,7 @@ mod tests {
         let pkg = RpmParser::extract_first_package(temp_file.path());
 
         assert_eq!(pkg.extracted_license_statement.as_deref(), Some("LGPLv2"));
-        assert_eq!(
-            pkg.declared_license_expression.as_deref(),
-            Some("lgpl-2.0-only")
-        );
+        assert_eq!(pkg.declared_license_expression.as_deref(), Some("lgpl-2.0"));
         assert_eq!(
             pkg.declared_license_expression_spdx.as_deref(),
             Some("LGPL-2.0-only")

--- a/src/parsers/ruby_test.rs
+++ b/src/parsers/ruby_test.rs
@@ -1103,7 +1103,7 @@ gem "specific-range", ">= 1.0.0", "< 1.5.0", "!= 1.2.3"
 
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("bsd-2-clause AND ruby")
+            Some("bsd-simplified AND ruby")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),
@@ -1268,7 +1268,7 @@ gem "specific-range", ">= 1.0.0", "< 1.5.0", "!= 1.2.3"
         assert_eq!(package_data.name, Some("multi-license-gem".to_string()));
         assert_eq!(
             package_data.declared_license_expression.as_deref(),
-            Some("apache-2.0 AND bsd-2-clause AND mit")
+            Some("apache-2.0 AND bsd-simplified AND mit")
         );
         assert_eq!(
             package_data.declared_license_expression_spdx.as_deref(),

--- a/testdata/alpine/lib/apk/db/installed.expected.json
+++ b/testdata/alpine/lib/apk/db/installed.expected.json
@@ -14,15 +14,15 @@
     ],
     "homepage_url": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
     "vcs_url": "git+https://git.alpinelinux.org/aports/commit/?id=cb70ca5c6d6db0399d2dd09189c5d57827bce5cd",
-    "declared_license_expression": "gpl-2.0-only",
+    "declared_license_expression": "gpl-2.0",
     "declared_license_expression_spdx": "GPL-2.0-only",
     "license_detections": [
       {
-        "license_expression": "gpl-2.0-only",
+        "license_expression": "gpl-2.0",
         "license_expression_spdx": "GPL-2.0-only",
         "matches": [
           {
-            "license_expression": "gpl-2.0-only",
+            "license_expression": "gpl-2.0",
             "license_expression_spdx": "GPL-2.0-only",
             "score": 100.0
           }

--- a/testdata/assembly-golden/alpine-file-refs/expected.json
+++ b/testdata/assembly-golden/alpine-file-refs/expected.json
@@ -49,15 +49,15 @@
         }
       ],
       "homepage_url": "https://busybox.net/",
-      "declared_license_expression": "gpl-2.0-only",
+      "declared_license_expression": "gpl-2.0",
       "declared_license_expression_spdx": "GPL-2.0-only",
       "license_detections": [
         {
-          "license_expression": "gpl-2.0-only",
+          "license_expression": "gpl-2.0",
           "license_expression_spdx": "GPL-2.0-only",
           "matches": [
             {
-              "license_expression": "gpl-2.0-only",
+              "license_expression": "gpl-2.0",
               "license_expression_spdx": "GPL-2.0-only",
               "from_file": "lib/apk/db/installed",
               "start_line": 1,
@@ -72,7 +72,7 @@
               "matched_text": "GPL-2.0-only"
             }
           ],
-          "identifier": "gpl_2_0_only-e6dc0f78-f9bd-2b91-5dff-1cf257f19a41"
+          "identifier": "gpl_2_0-e6dc0f78-f9bd-2b91-5dff-1cf257f19a41"
         }
       ],
       "extracted_license_statement": "GPL-2.0-only",

--- a/testdata/assembly-golden/hackage-basic/expected.json
+++ b/testdata/assembly-golden/hackage-basic/expected.json
@@ -39,15 +39,15 @@
       "vcs_url": "https://github.com/example/aaa-example-hackage.git",
       "copyright": null,
       "holder": null,
-      "declared_license_expression": "bsd-3-clause",
+      "declared_license_expression": "bsd-new",
       "declared_license_expression_spdx": "BSD-3-Clause",
       "license_detections": [
         {
-          "license_expression": "bsd-3-clause",
+          "license_expression": "bsd-new",
           "license_expression_spdx": "BSD-3-Clause",
           "matches": [
             {
-              "license_expression": "bsd-3-clause",
+              "license_expression": "bsd-new",
               "license_expression_spdx": "BSD-3-Clause",
               "from_file": "aaa-example-hackage.cabal",
               "start_line": 1,
@@ -62,7 +62,7 @@
               "matched_text": "BSD-3-Clause"
             }
           ],
-          "identifier": "bsd_3_clause-46908728-c7df-fed1-c2b9-7696dce85622"
+          "identifier": "bsd_new-46908728-c7df-fed1-c2b9-7696dce85622"
         }
       ],
       "other_license_expression": null,

--- a/testdata/bitbake-golden/basic/busybox_1.36.1.bb.expected
+++ b/testdata/bitbake-golden/basic/busybox_1.36.1.bb.expected
@@ -23,15 +23,15 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": "gpl-2.0-only",
+    "declared_license_expression": "gpl-2.0",
     "declared_license_expression_spdx": "GPL-2.0-only",
     "license_detections": [
       {
-        "license_expression": "gpl-2.0-only",
+        "license_expression": "gpl-2.0",
         "license_expression_spdx": "GPL-2.0-only",
         "matches": [
           {
-            "license_expression": "gpl-2.0-only",
+            "license_expression": "gpl-2.0",
             "license_expression_spdx": "GPL-2.0-only",
             "from_file": null,
             "start_line": 1,

--- a/testdata/buck/metadata/METADATA.bzl.expected.json
+++ b/testdata/buck/metadata/METADATA.bzl.expected.json
@@ -16,15 +16,15 @@
     },
     "datasource_id": "buck_metadata",
     "purl": "pkg:buck/example@0.0.1",
-    "declared_license_expression": "bsd-3-clause",
+    "declared_license_expression": "bsd-new",
     "declared_license_expression_spdx": "BSD-3-Clause",
     "license_detections": [
       {
-        "license_expression": "bsd-3-clause",
+        "license_expression": "bsd-new",
         "license_expression_spdx": "BSD-3-Clause",
         "matches": [
           {
-            "license_expression": "bsd-3-clause",
+            "license_expression": "bsd-new",
             "license_expression_spdx": "BSD-3-Clause",
             "from_file": null,
             "start_line": 1,

--- a/testdata/buck/metadata/with-package-url-METADATA.bzl.expected.json
+++ b/testdata/buck/metadata/with-package-url-METADATA.bzl.expected.json
@@ -15,15 +15,15 @@
     "extracted_license_statement": "BSD-3-Clause",
     "datasource_id": "buck_metadata",
     "purl": "pkg:maven/androidx.compose.animation/animation@0.0.1",
-    "declared_license_expression": "bsd-3-clause",
+    "declared_license_expression": "bsd-new",
     "declared_license_expression_spdx": "BSD-3-Clause",
     "license_detections": [
       {
-        "license_expression": "bsd-3-clause",
+        "license_expression": "bsd-new",
         "license_expression_spdx": "BSD-3-Clause",
         "matches": [
           {
-            "license_expression": "bsd-3-clause",
+            "license_expression": "bsd-new",
             "license_expression_spdx": "BSD-3-Clause",
             "from_file": null,
             "start_line": 1,

--- a/testdata/composer-golden/composer-lock/composer.lock.expected
+++ b/testdata/composer-golden/composer-lock/composer.lock.expected
@@ -2194,15 +2194,15 @@
           "vcs_url": null,
           "copyright": null,
           "holder": null,
-          "declared_license_expression": "bsd-3-clause",
+          "declared_license_expression": "bsd-new",
           "declared_license_expression_spdx": "BSD-3-Clause",
           "license_detections": [
             {
-              "license_expression": "bsd-3-clause",
+              "license_expression": "bsd-new",
               "license_expression_spdx": "BSD-3-Clause",
               "matches": [
                 {
-                  "license_expression": "bsd-3-clause",
+                  "license_expression": "bsd-new",
                   "license_expression_spdx": "BSD-3-Clause",
                   "from_file": null,
                   "start_line": 1,
@@ -2548,15 +2548,15 @@
           "vcs_url": null,
           "copyright": null,
           "holder": null,
-          "declared_license_expression": "bsd-3-clause",
+          "declared_license_expression": "bsd-new",
           "declared_license_expression_spdx": "BSD-3-Clause",
           "license_detections": [
             {
-              "license_expression": "bsd-3-clause",
+              "license_expression": "bsd-new",
               "license_expression_spdx": "BSD-3-Clause",
               "matches": [
                 {
-                  "license_expression": "bsd-3-clause",
+                  "license_expression": "bsd-new",
                   "license_expression_spdx": "BSD-3-Clause",
                   "from_file": null,
                   "start_line": 1,

--- a/testdata/conan/recipes/libgettext/manifest/conanfile.py-expected.json
+++ b/testdata/conan/recipes/libgettext/manifest/conanfile.py-expected.json
@@ -8,15 +8,15 @@
     "keywords": ["gettext", "intl", "libintl", "i18n"],
     "homepage_url": "https://www.gnu.org/software/gettext",
     "vcs_url": "https://github.com/conan-io/conan-center-index",
-    "declared_license_expression": "lgpl-2.1-or-later",
+    "declared_license_expression": "lgpl-2.1-plus",
     "declared_license_expression_spdx": "LGPL-2.1-or-later",
     "license_detections": [
       {
-        "license_expression": "lgpl-2.1-or-later",
+        "license_expression": "lgpl-2.1-plus",
         "license_expression_spdx": "LGPL-2.1-or-later",
         "matches": [
           {
-            "license_expression": "lgpl-2.1-or-later",
+            "license_expression": "lgpl-2.1-plus",
             "license_expression_spdx": "LGPL-2.1-or-later",
             "matcher": "parser-declared-license",
             "score": 100.0,

--- a/testdata/conda/conda-meta/tzdata-2024b-h04d1e81_0.json-expected.json
+++ b/testdata/conda/conda-meta/tzdata-2024b-h04d1e81_0.json-expected.json
@@ -40,15 +40,15 @@
     },
     "datasource_id": "conda_meta_json",
     "purl": "pkg:conda/tzdata@2024b",
-    "declared_license_expression": "bsd-3-clause OR cc-pddc",
+    "declared_license_expression": "bsd-new OR cc-pd",
     "declared_license_expression_spdx": "BSD-3-Clause OR CC-PDDC",
     "license_detections": [
       {
-        "license_expression": "bsd-3-clause OR cc-pddc",
+        "license_expression": "bsd-new OR cc-pd",
         "license_expression_spdx": "BSD-3-Clause OR CC-PDDC",
         "matches": [
           {
-            "license_expression": "bsd-3-clause OR cc-pddc",
+            "license_expression": "bsd-new OR cc-pd",
             "license_expression_spdx": "BSD-3-Clause OR CC-PDDC",
             "from_file": null,
             "start_line": 1,

--- a/testdata/hackage-golden/cabal-basic/example-hackage.cabal.expected.json
+++ b/testdata/hackage-golden/cabal-basic/example-hackage.cabal.expected.json
@@ -95,15 +95,15 @@
     "repository_homepage_url": "https://hackage.haskell.org/package/example-hackage-0.1.0.0",
     "datasource_id": "hackage_cabal",
     "purl": "pkg:hackage/example-hackage@0.1.0.0",
-    "declared_license_expression": "bsd-3-clause",
+    "declared_license_expression": "bsd-new",
     "declared_license_expression_spdx": "BSD-3-Clause",
     "license_detections": [
       {
-        "license_expression": "bsd-3-clause",
+        "license_expression": "bsd-new",
         "license_expression_spdx": "BSD-3-Clause",
         "matches": [
           {
-            "license_expression": "bsd-3-clause",
+            "license_expression": "bsd-new",
             "license_expression_spdx": "BSD-3-Clause",
             "from_file": null,
             "start_line": 1,

--- a/testdata/npm-golden/chartist/package.json.expected
+++ b/testdata/npm-golden/chartist/package.json.expected
@@ -36,15 +36,15 @@
     "vcs_url": "git+https://github.com/gionkunz/chartist-js.git",
     "copyright": null,
     "holder": null,
-    "declared_license_expression": "mit OR wtfpl",
+    "declared_license_expression": "mit OR wtfpl-2.0",
     "declared_license_expression_spdx": "MIT OR WTFPL",
     "license_detections": [
       {
-        "license_expression": "mit OR wtfpl",
+        "license_expression": "mit OR wtfpl-2.0",
         "license_expression_spdx": "MIT OR WTFPL",
         "matches": [
           {
-            "license_expression": "mit OR wtfpl",
+            "license_expression": "mit OR wtfpl-2.0",
             "license_expression_spdx": "MIT OR WTFPL",
             "from_file": null,
             "score": 100.0

--- a/testdata/npm/package-lock-v2.json.expected.json
+++ b/testdata/npm/package-lock-v2.json.expected.json
@@ -193,15 +193,15 @@
           "primary_language": "JavaScript",
           "download_url": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
           "sha512": "2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011",
-          "declared_license_expression": "bsd-2-clause",
+          "declared_license_expression": "bsd-simplified",
           "declared_license_expression_spdx": "BSD-2-Clause",
           "license_detections": [
             {
-              "license_expression": "bsd-2-clause",
+              "license_expression": "bsd-simplified",
               "license_expression_spdx": "BSD-2-Clause",
               "matches": [
                 {
-                  "license_expression": "bsd-2-clause",
+                  "license_expression": "bsd-simplified",
                   "license_expression_spdx": "BSD-2-Clause",
                   "from_file": null,
                   "start_line": 1,

--- a/testdata/publiccode-golden/basic/publiccode.yml.expected.json
+++ b/testdata/publiccode-golden/basic/publiccode.yml.expected.json
@@ -6,15 +6,15 @@
   "homepage_url": "https://example.com/service",
   "vcs_url": "https://github.com/example/public-service",
   "copyright": "Example City",
-  "declared_license_expression": "agpl-3.0-or-later",
+  "declared_license_expression": "agpl-3.0-plus",
   "declared_license_expression_spdx": "AGPL-3.0-or-later",
   "license_detections": [
     {
-      "license_expression": "agpl-3.0-or-later",
+      "license_expression": "agpl-3.0-plus",
       "license_expression_spdx": "AGPL-3.0-or-later",
       "matches": [
         {
-          "license_expression": "agpl-3.0-or-later",
+          "license_expression": "agpl-3.0-plus",
           "license_expression_spdx": "AGPL-3.0-or-later",
           "from_file": null,
           "start_line": 1,

--- a/testdata/rpm/rpmdb.sqlite.expected.json
+++ b/testdata/rpm/rpmdb.sqlite.expected.json
@@ -25,15 +25,15 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": "bsd-3-clause AND gpl-2.0-or-later AND gpl-3.0-or-later AND lgpl-2.0-or-later",
+    "declared_license_expression": "bsd-new AND gpl-2.0-plus AND gpl-3.0-plus AND lgpl-2.0-plus",
     "declared_license_expression_spdx": "BSD-3-Clause AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later",
     "license_detections": [
       {
-        "license_expression": "bsd-3-clause AND gpl-2.0-or-later AND gpl-3.0-or-later AND lgpl-2.0-or-later",
+        "license_expression": "bsd-new AND gpl-2.0-plus AND gpl-3.0-plus AND lgpl-2.0-plus",
         "license_expression_spdx": "BSD-3-Clause AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later",
         "matches": [
           {
-            "license_expression": "bsd-3-clause AND gpl-2.0-or-later AND gpl-3.0-or-later AND lgpl-2.0-or-later",
+            "license_expression": "bsd-new AND gpl-2.0-plus AND gpl-3.0-plus AND lgpl-2.0-plus",
             "license_expression_spdx": "BSD-3-Clause AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later",
             "from_file": null,
             "start_line": 1,


### PR DESCRIPTION
## Summary

- Declared-license normalization mapped an SPDX id to its ScanCode key by lowercasing the SPDX id when it equalled the canonical SPDX key. That only coincides with the real ScanCode key for licenses like `mit`/`apache-2.0`; for the **~246 indexed licenses** whose key is not the lowercased SPDX id it fabricated a key absent from the index (`BSD-3-Clause` → `bsd-3-clause` instead of `bsd-new`, `BSD-2-Clause` → `bsd-2-clause` instead of `bsd-simplified`, `WTFPL` → `wtfpl` instead of `wtfpl-2.0`, …).
- The fabricated keys diverged from both ScanCode output and Provenant's own file-level detections, which already use the canonical keys. `normalize_license_key` now resolves the declared key from the rule's own `license_expression` (the authoritative index key).

## Issues

- Covers: declared-license key fabrication surfaced during the M5 benchmark sweep (yarnpkg/berry: 96 declared mismatches → 0 after the fix).

## Scope and exclusions

- Included: `normalize_license_key` canonical-key resolution; updated ruby/python parser test expectations to the real keys; a property test asserting every indexed SPDX key normalizes to a key that exists in the index.
- Explicit exclusions: file-level `detected_license_expression` (non-SPDX) output gap and the dpkg uniform-declared-license bug (#1077) are tracked separately.

## How to verify

- `cargo test --lib license_normalization` — includes `test_every_indexed_spdx_key_normalizes_to_a_real_index_key`, which fails on any fabricated key across the whole bundled index.
- Spot-check: a package declaring `BSD-2-Clause` now yields `declared_license_expression: bsd-simplified` (matching ScanCode), with `declared_license_expression_spdx: BSD-2-Clause` unchanged.

## Expected-output fixture changes

- Files changed: inline `.rs` unit-test expectations in `ruby_test.rs`, `python/test.rs`, `license_normalization.rs`.
- Why the new expected output is correct: `bsd-new`/`bsd-simplified`/`wtfpl-2.0` are the actual ScanCode license keys (the index has no `bsd-3-clause`/`bsd-2-clause`/`wtfpl` license); the old expectations encoded the bug.