### PR TITLE
fix(assembly): stop smearing a multi-package DB file's license onto its packages

### DIFF
--- a/src/post_processing/output_test/reference_following_package_test.rs
+++ b/src/post_processing/output_test/reference_following_package_test.rs
@@ -822,3 +822,67 @@ fn apply_package_reference_following_leaves_ambiguous_multi_package_file_unresol
     assert_eq!(shared_file.license_detections[0].matches.len(), 1);
     assert!(shared_file.license_detections[0].detection_log.is_empty());
 }
+
+#[test]
+fn apply_package_reference_following_does_not_smear_multi_package_db_file_detection() {
+    // A multi-package installed database (e.g. `var/lib/dpkg/status`) carries many
+    // `package_data` entries sharing one file. A bare license mention anywhere in
+    // that file yields a single whole-file detection that belongs to no single
+    // package and must not be smeared onto every package built from the database.
+    let status_path = "var/lib/dpkg/status";
+
+    let pkg_uid = "pkg:deb/debian/pkga?uuid=test".to_string();
+    let mut package = super::test_utils::package(&pkg_uid, status_path);
+    package.datafile_paths = vec![status_path.to_string()];
+
+    // Two package_data entries on the shared status file, neither with a declared
+    // license (dpkg status has no per-package license field).
+    let pkg_a_data = PackageData {
+        package_type: Some(PackageType::Deb),
+        name: Some("inspec-bin".to_string()),
+        version: Some("6.8.2".to_string()),
+        ..Default::default()
+    };
+    let pkg_b_data = PackageData {
+        package_type: Some(PackageType::Deb),
+        name: Some("other".to_string()),
+        version: Some("1.0".to_string()),
+        ..Default::default()
+    };
+
+    let mut status = file(status_path);
+    status.for_packages = vec![PackageUid::from_raw(pkg_uid.clone())];
+    status.package_data = vec![pkg_a_data, pkg_b_data];
+    status.detected_license_expression = Some("lgpl-2.0-plus".to_string());
+    status.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "lgpl-2.0-plus".to_string(),
+        license_expression_spdx: "LGPL-2.0-or-later".to_string(),
+        matches: vec![Match {
+            license_expression: "lgpl-2.0-plus".to_string(),
+            license_expression_spdx: "LGPL-2.0-or-later".to_string(),
+            from_file: Some(status_path.to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+            matcher: MatcherKind::Hash,
+            score: MatchScore::MAX,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: "lgpl_bare_single_word.RULE".to_string(),
+            rule_url: None,
+            matched_text: Some("LGPL".to_string()),
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: "lgpl".to_string(),
+    }];
+
+    let mut files = vec![dir("var/lib/dpkg"), status];
+    let mut packages = vec![package];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    // The whole-file detection must not become the package's declared license.
+    assert_eq!(packages[0].declared_license_expression, None);
+    assert!(packages[0].license_detections.is_empty());
+}

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -764,8 +764,17 @@ fn sync_packages_from_followed_package_data(
             // co-located files.
             if package.datafile_paths.len() == 1
                 && next_license_detections.is_empty()
-                && let Some(manifest_file) =
-                    manifest_file.filter(|file| !file.license_detections.is_empty())
+                && let Some(manifest_file) = manifest_file.filter(|file| {
+                    // Only adopt a manifest file's own file-level detection when the
+                    // file describes exactly one package. A multi-package installed
+                    // database (e.g. `var/lib/dpkg/status`) carries many `package_data`
+                    // entries sharing one file; its whole-file detection — such as a
+                    // bare "LGPL" mention in some package's `Description` — does not
+                    // belong to any single package and must not be smeared across all
+                    // of them. Per-package licenses still arrive via the package's own
+                    // referenced copyright file.
+                    !file.license_detections.is_empty() && file.package_data.len() == 1
+                })
             {
                 next_license_detections = manifest_file.license_detections.clone();
                 if next_declared_license_expression.is_none() {


### PR DESCRIPTION
## Summary

- Reference-following adopts a manifest file's own file-level license detection as a single-datafile package's declared license when the package's `package_data` carried none. That is correct for an ordinary one-package manifest, but a multi-package installed database such as `var/lib/dpkg/status` has many `package_data` entries sharing one file.
- A bare license mention anywhere in that file (e.g. `LGPL` in some package's `Description`, matched as `lgpl-2.0-plus` via `lgpl_bare_single_word.RULE`) produced one whole-file detection that was then smeared as the declared license of **every** package built from the database. On `debian:bookworm-slim` this set all 88 deb packages to `lgpl-2.0-plus` regardless of their real license.
- Fix: only adopt the manifest file's own detection when the file describes exactly one package. Multi-package databases keep an honest `null` declared license per package and still receive per-package licenses via each package's referenced copyright file.

## Issues

- Closes: #1077

## Scope and exclusions

- Included: a one-line guard (`file.package_data.len() == 1`) on the reference-following manifest-adopt path, plus a regression test.
- Explicit exclusions: per-package copyright-file resolution for dpkg is unchanged; this only stops the incorrect smear.

## How to verify

- Unit test `apply_package_reference_following_does_not_smear_multi_package_db_file_detection` asserts a two-`package_data` file with a whole-file `lgpl-2.0-plus` detection leaves the package's declared license `null`. It fails without the guard (`left: Some("lgpl-2.0-plus")` vs `right: None`).
- End-to-end on a `debian:bookworm-slim` rootfs: all 88 deb packages now report `declared_license_expression: null` (previously all `lgpl-2.0-plus`).
- Regression: reference-following unit tests and post-processing goldens pass; the single-package manifest-adopt path is unchanged.

## Intentional differences from Python

- Prefers an honest `null` per-package declared license over a misattributed whole-file detection on multi-package databases.