### PR TITLE
docs(benchmarks): refresh next 10 targets on M5 Pro 4-proc methodology

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **13.2× median speedup** and **13.0× geometric-mean speedup** overall; the median gap grows from **7.3×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **13.4× median speedup** and **13.2× geometric-mean speedup** overall; the median gap grows from **7.3×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -55,12 +55,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 
 #### Android / AOSP
 
-##### [aosp-mirror/platform_build @ 045a3d6](https://github.com/aosp-mirror/platform_build/tree/045a3d6a3e359633a14853a5a5e1e4f2a11cbdae) — **9.52× faster**
+##### [aosp-mirror/platform_build @ 045a3d6](https://github.com/aosp-mirror/platform_build/tree/045a3d6a3e359633a14853a5a5e1e4f2a11cbdae) — **17.87× faster**
 
 - Files: 1,515
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `25.23s`; ScanCode `240.24s`
-- Broader Android package visibility (`14` vs `0` file-level package records) across committed Soong `METADATA`, `AndroidManifest.xml`, and `TestApp.apk` surfaces, plus extra `go.work` and Docker metadata detection, with cleaner clue-only handling of bare-word GPL/LGPL, placeholder-author, and URL-shape noise
+- Run context: 2026-06-15 · platform_build-22987 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.68s`; ScanCode `155.12s`
+- Richer file-level Android package extraction (`31` vs `18` package_data records) and dependency coverage (`148` vs `145`) across committed Soong `METADATA`, `AndroidManifest.xml`, `TestApp.apk`, cargo, and `go.work` surfaces, with correct `The Android Open Source Project` holder attribution where ScanCode leaves it null, plus declared licenses that avoid conflating the `tools/compliance` test-fixture licenses ScanCode pulls into the package expression
 
 ##### [facebook/fresco @ c991a69](https://github.com/facebook/fresco/tree/c991a692a254358d1cf56c5b4b06e6c5dd96cfab) — **23.42× faster**
 
@@ -92,11 +92,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.01s`; ScanCode `87.31s`
 - Matched Chef package and dependency coverage on committed `metadata.rb` surfaces, with fuller Debian-style script-header author capture and cleaner rejection of weak README maintainer prose as an author
 
-##### [sous-chefs/mysql @ 6b7110b](https://github.com/sous-chefs/mysql/tree/6b7110bee2bc64c9149f24d524cbb740387e527a) — **6.45× faster**
+##### [sous-chefs/mysql @ 6b7110b](https://github.com/sous-chefs/mysql/tree/6b7110bee2bc64c9149f24d524cbb740387e527a) — **9.60× faster**
 
-- Files: 92
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `11.72s`; ScanCode `75.55s`
+- Files: 91
+- Run context: 2026-06-15 · mysql-57215 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.79s`; ScanCode `45.99s`
 - Matched Chef package and dependency coverage on committed `metadata.rb` surfaces, with cleaner rejection of config-word author noise such as `chef-client` and fuller `Author:: Name (<email>)` identity capture
 
 #### Python / Conda / Pixi
@@ -157,11 +157,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `9.24s`; ScanCode `70.31s`
 - Far broader Conda recipe and dependency extraction (`257` vs `1` packages, `164` vs `13` dependencies) across committed `meta.yaml` recipe fixtures, split-package test recipes, and sidecar Python manifests, with explicit malformed-recipe scan errors on duplicate-key negative fixtures instead of silently treating them as ordinary package metadata
 
-##### [conda-forge/pandas-feedstock @ 4063b72](https://github.com/conda-forge/pandas-feedstock/tree/4063b725cd252c02b0cebe935a8859a6b540fe00) — **7.59× faster**
+##### [conda-forge/pandas-feedstock @ 4063b72](https://github.com/conda-forge/pandas-feedstock/tree/4063b725cd252c02b0cebe935a8859a6b540fe00) — **6.31× faster**
 
-- Files: 51
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `8.66s`; ScanCode `65.66s`
+- Files: 49
+- Run context: 2026-06-15 · pandas-feedstock-68688 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.79s`; ScanCode `42.84s`
 - Direct schema-versioned conda-forge feedstock package visibility (`1` vs `0` packages, `51` vs `0` dependencies) from `recipe/recipe.yaml`, plus assembled top-level Conda package identity and preserved source/about metadata
 
 ##### [DefectDojo/django-DefectDojo @ 2f25c45](https://github.com/DefectDojo/django-DefectDojo/tree/2f25c4510361e2f27f63fbbcff3901cbd2ef4a07) — **18.83× faster**
@@ -192,12 +192,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `13.09s`; ScanCode `418.88s`
 - Far broader Python/Conda/Pixi package and dependency extraction (`4` vs `1` packages, hundreds of additional dependencies) because `pixi.lock` and `environment.yml` surface large resolved Conda/Pixi package graphs with per-package license inventories ScanCode ignores entirely, while avoiding ScanCode's `pixi.lock` timeout, preserving SPDX-aligned `BSD-3-Clause` declared licensing, and skipping ScanCode's data-table copyright false positives such as `(c) Rain (mm) Wind`
 
-##### [prefix-dev/pixi @ 6458b15](https://github.com/prefix-dev/pixi/tree/6458b15a855cf6beeaad1853ef007d9d20a5bccc) — **8.09× faster**
+##### [prefix-dev/pixi @ 6458b15](https://github.com/prefix-dev/pixi/tree/6458b15a855cf6beeaad1853ef007d9d20a5bccc) — **12.84× faster**
 
 - Files: 2,372
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `62.21s`; ScanCode `503.12s`
-- Broader Pixi package and dependency extraction (`223` vs `128` packages, `18016` vs `3116` dependencies) from the root and example `pixi.toml` or `pixi.lock` surfaces plus feature-scoped `pypi-dependencies`, with no example-lock scan errors where ScanCode times out and safer credential stripping or git URL normalization across Pixi source fixtures
+- Run context: 2026-06-15 · pixi-71346 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `27.77s`; ScanCode `356.55s`
+- Broader Pixi package and dependency extraction (`233` vs `128` packages, `22369` vs `3116` dependencies) from the root and example `pixi.toml` or `pixi.lock` surfaces plus feature-scoped `pypi-dependencies` and cargo workspace members that inherit the declared `BSD-3-Clause` license ScanCode leaves unset, with no example-lock scan errors where ScanCode times out and safer credential stripping or git URL normalization across Pixi source fixtures
 
 ##### [pydata/xarray @ f7e47a1](https://github.com/pydata/xarray/tree/f7e47a19726321e56d74bca896eb55c6f330506b) — **14.48× faster**
 
@@ -243,11 +243,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 
 #### R / CRAN
 
-##### [r-lib/devtools @ a3447b9](https://github.com/r-lib/devtools/tree/a3447b9f3d59abb6cc8b63a54db3435819324c1e) — **8.71× faster**
+##### [r-lib/devtools @ a3447b9](https://github.com/r-lib/devtools/tree/a3447b9f3d59abb6cc8b63a54db3435819324c1e) — **9.89× faster**
 
-- Files: 266
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `9.28s`; ScanCode `80.85s`
+- Files: 265
+- Run context: 2026-06-15 · devtools-88197 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.97s`; ScanCode `49.16s`
 - Far broader CRAN package and dependency extraction (`14` vs `1` packages, `45` vs `1` dependencies) from the root `DESCRIPTION` plus committed test-package fixtures, with correct filtering of fake `pkg:cran/R` dependency noise and cleaner maintainer or URL normalization
 
 ##### [tidyverse/dplyr @ 2f9f49e](https://github.com/tidyverse/dplyr/tree/2f9f49ef0d361dc612abc55982d68db3fb3854d0) — **12.32× faster**
@@ -287,12 +287,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.03s`; ScanCode `135.56s`
 - Broader Hex dependency extraction (`16` vs `0`) from the repo-root `mix.lock` plus `examples/friends/mix.lock`, with direct locked package identities for entries such as `ecto_sql`, `postgrex`, and `telemetry` that ScanCode leaves dependency-blind
 
-##### [elixir-plug/plug @ 47649aa](https://github.com/elixir-plug/plug/tree/47649aa7bb910f481b66cc3e98c14b2c3b761c3c) — **8.55× faster**
+##### [elixir-plug/plug @ 47649aa](https://github.com/elixir-plug/plug/tree/47649aa7bb910f481b66cc3e98c14b2c3b761c3c) — **10.51× faster**
 
 - Files: 104
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `10.77s`; ScanCode `92.08s`
-- Direct Hex package visibility on `mix.lock` (`1` vs `0`) plus locked dependency extraction (`9` vs `0`) for `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
+- Run context: 2026-06-15 · plug-85462 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.88s`; ScanCode `51.28s`
+- Locked Hex dependency extraction (`9` vs `0`) for `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
 
 ##### [erlang/otp @ 264def5](https://github.com/erlang/otp/tree/264def545b8214ea7100bfede1a4629c676ff1c0) — **23.52× faster**
 
@@ -373,11 +373,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.53s`; ScanCode `170.19s`
 - Direct `publiccode.yml` package visibility on the root metadata file (`1` vs `0` on that file), with matched top-level package and dependency counts elsewhere plus Unicode-preserving Potree copyright normalization and cleaner URL shaping across README and docs material
 
-##### [jashkenas/backbone @ da75718](https://github.com/jashkenas/backbone/tree/da75718e896e52e84aa1f0411ba67fafcdcf6af3) — **9.28× faster**
+##### [jashkenas/backbone @ da75718](https://github.com/jashkenas/backbone/tree/da75718e896e52e84aa1f0411ba67fafcdcf6af3) — **12.27× faster**
 
 - Files: 122
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `11.27s`; ScanCode `104.56s`
+- Run context: 2026-06-15 · backbone-19202 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.03s`; ScanCode `61.74s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and package-level party metadata from `package.json`
 
 ##### [jquery/jquery-ui @ eda7aa3](https://github.com/jquery/jquery-ui/tree/eda7aa34fa59d8f764b2164be3e3b7f14639b0db) — **19.49× faster**
@@ -415,11 +415,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `295.10s`; ScanCode `3376.85s`
 - Clean root npm workspace manifest coverage without ScanCode's workspace-assembly scan errors, fewer large registry-fixture JSON timeouts, and cleaner handling of duplicated private-workspace dependency exports and repeated MIT-style registry-fixture metadata noise
 
-##### [oakserver/oak @ 185baef](https://github.com/oakserver/oak/tree/185baef02551a84798000f25d3bd01c2fdfcb1ce) — **8.94× faster**
+##### [oakserver/oak @ 185baef](https://github.com/oakserver/oak/tree/185baef02551a84798000f25d3bd01c2fdfcb1ce) — **9.43× faster**
 
 - Files: 103
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `12.95s`; ScanCode `115.73s`
+- Run context: 2026-06-15 · oak-93582 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.09s`; ScanCode `47.99s`
 - Direct Deno package visibility on the root `deno.json` (`1` vs `0` packages), plus Dockerfile package visibility on `.devcontainer/Dockerfile`, with cleaner trailing-slash URL normalization across README and docs material
 
 ##### [oven-sh/bun @ 700fc11](https://github.com/oven-sh/bun/tree/700fc117a2fd01ac0201deaa6fa69c5557acb04f) — **19.72× faster**
@@ -480,12 +480,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `26.97s`; ScanCode `681.19s`
 - Matched top-level SBT package coverage (`7` vs `7`) with broader dependency extraction (`49` vs `40`) from the root `build.sbt`, sample applications, and native-image test manifests, plus cleaner rejection of weak actor-name author noise such as `the ActorSystem` and `the ReceiveBuilder`
 
-##### [apache/felix-dev @ 20aee77](https://github.com/apache/felix-dev/tree/20aee77cce8cad21493368403701d9c44c168f62) — **9.09× faster**
+##### [apache/felix-dev @ 20aee77](https://github.com/apache/felix-dev/tree/20aee77cce8cad21493368403701d9c44c168f62) — **24.00× faster**
 
-- Files: 5,354
-- Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `52.75s`; ScanCode `479.56s`
-- Matched Maven/OSGi package coverage (`196` vs `196`) with richer dependency extraction (`995` vs `962`) from classifier/type-aware Maven coordinates, OSGi integration-test POMs, and committed JAR or `MANIFEST.MF` metadata
+- Files: 5,356
+- Run context: 2026-06-15 · felix-dev-96478 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `26.70s`; ScanCode `640.75s`
+- Broader Maven/OSGi package coverage (`201` vs `196`) with richer dependency extraction (`1033` vs `962`) from classifier/type-aware Maven coordinates, OSGi integration-test POMs, and committed JAR or `MANIFEST.MF` metadata, plus declared licenses that stay faithful to each module's POM where ScanCode conflates bundled JUnit `CPL`/`EPL` licenses into the declared expression
 
 ##### [apache/camel @ c9c34a1](https://github.com/apache/camel/tree/c9c34a1c2fbc5d093241565c0272ca466407a8e1) — **11.38× faster**
 
@@ -557,12 +557,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `67.58s`; ScanCode `776.24s`
 - Broader JVM monorepo package and dependency extraction (`173` vs `165` packages, `4434` vs `4233` dependencies) from nested Maven example POMs, the committed Antora `package-lock.json`, and Docker/WAR metadata, plus more specific SBOM license expressions where ScanCode flattens `EPL-2.0 AND Classpath-exception-2.0` or `BSD-2-Clause-Views AND BSD-3-Clause`
 
-##### [technomancy/leiningen @ 4022732](https://github.com/technomancy/leiningen/tree/40227328d4a9c8945362d6d626d19c2449175df6) — **8.90× faster**
+##### [technomancy/leiningen @ 4022732](https://github.com/technomancy/leiningen/tree/40227328d4a9c8945362d6d626d19c2449175df6) — **10.80× faster**
 
-- Files: 302
-- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.34s`; ScanCode `91.99s`
-- Broader Clojure manifest and dependency extraction (`82` vs `10` dependencies) from the root, nested checkout, and test-project `project.clj` surfaces that ScanCode leaves at manifest-only visibility, plus OFL font-license recovery and cleaner URL normalization where ScanCode preserves regex suffixes, trailing-slash drift, or percent-encoded placeholder text
+- Files: 301
+- Run context: 2026-06-15 · leiningen-90777 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.06s`; ScanCode `54.67s`
+- Broader Clojure manifest and dependency extraction (`92` vs `10` dependencies) from the root, nested checkout, and test-project `project.clj` surfaces that ScanCode leaves at manifest-only visibility, plus OFL font-license recovery and cleaner URL normalization where ScanCode preserves regex suffixes, trailing-slash drift, or percent-encoded placeholder text
 
 #### Rust / Go / native / infrastructure
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -179,12 +179,12 @@ ScanCode: 74.96s</title></rect>
     <rect x="357.31" y="446.42" width="8" height="8" fill="#d97706" rx="1.5"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 ScanCode: 46.66s</title></rect>
+    <rect x="360.18" y="450.45" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
+Files: 49
+ScanCode: 42.84s</title></rect>
     <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 ScanCode: 235.99s</title></rect>
-    <rect x="362.93" y="430.28" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
-Files: 51
-ScanCode: 65.66s</title></rect>
     <rect x="365.59" y="449.04" width="8" height="8" fill="#d97706" rx="1.5"><title>docker-library/python @ ced4ac7
 Files: 53
 ScanCode: 44.14s</title></rect>
@@ -203,27 +203,27 @@ ScanCode: 54.13s</title></rect>
     <rect x="399.74" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 87
 ScanCode: 65.75s</title></rect>
-    <rect x="403.59" y="423.65" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
-Files: 92
-ScanCode: 75.55s</title></rect>
+    <rect x="402.83" y="447.10" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
+Files: 91
+ScanCode: 45.99s</title></rect>
     <rect x="406.52" y="444.93" width="8" height="8" fill="#d97706" rx="1.5"><title>goharbor/harbor-helm @ 7233a81
 Files: 96
 ScanCode: 48.15s</title></rect>
     <rect x="407.94" y="445.56" width="8" height="8" fill="#d97706" rx="1.5"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 ScanCode: 47.52s</title></rect>
-    <rect x="411.37" y="403.50" width="8" height="8" fill="#d97706" rx="1.5"><title>oakserver/oak @ 185baef
+    <rect x="411.37" y="445.09" width="8" height="8" fill="#d97706" rx="1.5"><title>oakserver/oak @ 185baef
 Files: 103
-ScanCode: 115.73s</title></rect>
-    <rect x="412.04" y="414.30" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-plug/plug @ 47649aa
+ScanCode: 47.99s</title></rect>
+    <rect x="412.04" y="441.96" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-plug/plug @ 47649aa
 Files: 104
-ScanCode: 92.08s</title></rect>
+ScanCode: 51.28s</title></rect>
     <rect x="415.27" y="418.23" width="8" height="8" fill="#d97706" rx="1.5"><title>SwiftFiddle/swiftfiddle-web @ df09b80
 Files: 109
 ScanCode: 84.73s</title></rect>
-    <rect x="423.04" y="408.29" width="8" height="8" fill="#d97706" rx="1.5"><title>jashkenas/backbone @ da75718
+    <rect x="423.04" y="433.19" width="8" height="8" fill="#d97706" rx="1.5"><title>jashkenas/backbone @ da75718
 Files: 122
-ScanCode: 104.56s</title></rect>
+ScanCode: 61.74s</title></rect>
     <rect x="426.88" y="447.92" width="8" height="8" fill="#d97706" rx="1.5"><title>getsentry/self-hosted @ 8728919
 Files: 129
 ScanCode: 45.20s</title></rect>
@@ -257,9 +257,9 @@ ScanCode: 85.01s</title></rect>
     <rect x="475.44" y="397.66" width="8" height="8" fill="#d97706" rx="1.5"><title>madler/zlib @ f9dd600
 Files: 261
 ScanCode: 130.94s</title></rect>
-    <rect x="476.75" y="420.44" width="8" height="8" fill="#d97706" rx="1.5"><title>r-lib/devtools @ a3447b9
-Files: 266
-ScanCode: 80.85s</title></rect>
+    <rect x="476.49" y="443.95" width="8" height="8" fill="#d97706" rx="1.5"><title>r-lib/devtools @ a3447b9
+Files: 265
+ScanCode: 49.16s</title></rect>
     <rect x="477.26" y="441.87" width="8" height="8" fill="#d97706" rx="1.5"><title>rustcrypto/aeads @ 9d05d81
 Files: 268
 ScanCode: 51.37s</title></rect>
@@ -269,9 +269,9 @@ ScanCode: 87.06s</title></rect>
     <rect x="481.50" y="402.72" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda @ 37549c4
 Files: 285
 ScanCode: 117.64s</title></rect>
-    <rect x="485.49" y="414.35" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
-Files: 302
-ScanCode: 91.99s</title></rect>
+    <rect x="485.27" y="438.93" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
+Files: 301
+ScanCode: 54.67s</title></rect>
     <rect x="486.18" y="436.80" width="8" height="8" fill="#d97706" rx="1.5"><title>bitwalker/distillery @ 3ab4d61
 Files: 305
 ScanCode: 57.19s</title></rect>
@@ -434,9 +434,9 @@ ScanCode: 112.67s</title></rect>
     <rect x="594.45" y="353.48" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 ScanCode: 333.52s</title></rect>
-    <rect x="596.63" y="368.99" width="8" height="8" fill="#d97706" rx="1.5"><title>aosp-mirror/platform_build @ 045a3d6
+    <rect x="596.63" y="389.66" width="8" height="8" fill="#d97706" rx="1.5"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
-ScanCode: 240.24s</title></rect>
+ScanCode: 155.12s</title></rect>
     <rect x="603.42" y="355.19" width="8" height="8" fill="#d97706" rx="1.5"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 ScanCode: 321.68s</title></rect>
@@ -476,9 +476,9 @@ ScanCode: 656.13s</title></rect>
     <rect x="624.61" y="348.51" width="8" height="8" fill="#d97706" rx="1.5"><title>chef/chef @ 0e353ff
 Files: 2274
 ScanCode: 370.51s</title></rect>
-    <rect x="627.52" y="334.06" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
+    <rect x="627.52" y="350.33" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
-ScanCode: 503.12s</title></rect>
+ScanCode: 356.55s</title></rect>
     <rect x="633.28" y="363.07" width="8" height="8" fill="#d97706" rx="1.5"><title>playframework/playframework @ c2c114f
 Files: 2579
 ScanCode: 272.30s</title></rect>
@@ -566,9 +566,9 @@ ScanCode: 412.03s</title></rect>
     <rect x="682.57" y="336.59" width="8" height="8" fill="#d97706" rx="1.5"><title>AvaloniaUI/Avalonia @ b7e95c2
 Files: 5273
 ScanCode: 476.87s</title></rect>
-    <rect x="683.62" y="336.32" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/felix-dev @ 20aee77
-Files: 5354
-ScanCode: 479.56s</title></rect>
+    <rect x="683.64" y="322.63" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/felix-dev @ 20aee77
+Files: 5356
+ScanCode: 640.75s</title></rect>
     <rect x="687.04" y="292.14" width="8" height="8" fill="#d97706" rx="1.5"><title>python/cpython @ 7a468a1
 Files: 5627
 ScanCode: 1221.65s</title></rect>
@@ -847,12 +847,12 @@ Provenant: 10.05s</title></circle>
     <circle cx="361.31" cy="546.87" r="4.5" fill="#2563eb"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 Provenant: 6.06s</title></circle>
+    <circle cx="364.18" cy="541.49" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
+Files: 49
+Provenant: 6.79s</title></circle>
     <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
 Provenant: 27.50s</title></circle>
-    <circle cx="366.93" cy="530.00" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
-Files: 51
-Provenant: 8.66s</title></circle>
     <circle cx="369.59" cy="559.38" r="4.5" fill="#2563eb"><title>docker-library/python @ ced4ac7
 Files: 53
 Provenant: 4.65s</title></circle>
@@ -871,27 +871,27 @@ Provenant: 4.67s</title></circle>
     <circle cx="403.74" cy="529.03" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 87
 Provenant: 8.84s</title></circle>
-    <circle cx="407.59" cy="515.70" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
-Files: 92
-Provenant: 11.72s</title></circle>
+    <circle cx="406.83" cy="557.98" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
+Files: 91
+Provenant: 4.79s</title></circle>
     <circle cx="410.52" cy="544.58" r="4.5" fill="#2563eb"><title>goharbor/harbor-helm @ 7233a81
 Files: 96
 Provenant: 6.36s</title></circle>
     <circle cx="411.94" cy="555.86" r="4.5" fill="#2563eb"><title>libwww-perl/libwww-perl @ 7420d1b
 Files: 98
 Provenant: 5.01s</title></circle>
-    <circle cx="415.37" cy="510.99" r="4.5" fill="#2563eb"><title>oakserver/oak @ 185baef
+    <circle cx="415.37" cy="555.11" r="4.5" fill="#2563eb"><title>oakserver/oak @ 185baef
 Files: 103
-Provenant: 12.95s</title></circle>
-    <circle cx="416.04" cy="519.69" r="4.5" fill="#2563eb"><title>elixir-plug/plug @ 47649aa
+Provenant: 5.09s</title></circle>
+    <circle cx="416.04" cy="557.10" r="4.5" fill="#2563eb"><title>elixir-plug/plug @ 47649aa
 Files: 104
-Provenant: 10.77s</title></circle>
+Provenant: 4.88s</title></circle>
     <circle cx="419.27" cy="522.22" r="4.5" fill="#2563eb"><title>SwiftFiddle/swiftfiddle-web @ df09b80
 Files: 109
 Provenant: 10.21s</title></circle>
-    <circle cx="427.04" cy="517.55" r="4.5" fill="#2563eb"><title>jashkenas/backbone @ da75718
+    <circle cx="427.04" cy="555.67" r="4.5" fill="#2563eb"><title>jashkenas/backbone @ da75718
 Files: 122
-Provenant: 11.27s</title></circle>
+Provenant: 5.03s</title></circle>
     <circle cx="430.88" cy="558.48" r="4.5" fill="#2563eb"><title>getsentry/self-hosted @ 8728919
 Files: 129
 Provenant: 4.74s</title></circle>
@@ -925,9 +925,9 @@ Provenant: 5.63s</title></circle>
     <circle cx="479.44" cy="519.30" r="4.5" fill="#2563eb"><title>madler/zlib @ f9dd600
 Files: 261
 Provenant: 10.86s</title></circle>
-    <circle cx="480.75" cy="526.73" r="4.5" fill="#2563eb"><title>r-lib/devtools @ a3447b9
-Files: 266
-Provenant: 9.28s</title></circle>
+    <circle cx="480.49" cy="556.24" r="4.5" fill="#2563eb"><title>r-lib/devtools @ a3447b9
+Files: 265
+Provenant: 4.97s</title></circle>
     <circle cx="481.26" cy="557.10" r="4.5" fill="#2563eb"><title>rustcrypto/aeads @ 9d05d81
 Files: 268
 Provenant: 4.88s</title></circle>
@@ -937,9 +937,9 @@ Provenant: 10.04s</title></circle>
     <circle cx="485.50" cy="522.96" r="4.5" fill="#2563eb"><title>conda/conda @ 37549c4
 Files: 285
 Provenant: 10.05s</title></circle>
-    <circle cx="489.49" cy="521.62" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
-Files: 302
-Provenant: 10.34s</title></circle>
+    <circle cx="489.27" cy="555.39" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
+Files: 301
+Provenant: 5.06s</title></circle>
     <circle cx="490.18" cy="543.34" r="4.5" fill="#2563eb"><title>bitwalker/distillery @ 3ab4d61
 Files: 305
 Provenant: 6.53s</title></circle>
@@ -1102,9 +1102,9 @@ Provenant: 13.31s</title></circle>
     <circle cx="598.45" cy="492.95" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 Provenant: 18.97s</title></circle>
-    <circle cx="600.63" cy="479.47" r="4.5" fill="#2563eb"><title>aosp-mirror/platform_build @ 045a3d6
+    <circle cx="600.63" cy="529.89" r="4.5" fill="#2563eb"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
-Provenant: 25.23s</title></circle>
+Provenant: 8.68s</title></circle>
     <circle cx="607.42" cy="500.64" r="4.5" fill="#2563eb"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 Provenant: 16.12s</title></circle>
@@ -1144,9 +1144,9 @@ Provenant: 31.93s</title></circle>
     <circle cx="628.61" cy="470.20" r="4.5" fill="#2563eb"><title>chef/chef @ 0e353ff
 Files: 2274
 Provenant: 30.70s</title></circle>
-    <circle cx="631.52" cy="436.83" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
+    <circle cx="631.52" cy="474.94" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
-Provenant: 62.21s</title></circle>
+Provenant: 27.77s</title></circle>
     <circle cx="637.28" cy="504.23" r="4.5" fill="#2563eb"><title>playframework/playframework @ c2c114f
 Files: 2579
 Provenant: 14.94s</title></circle>
@@ -1234,9 +1234,9 @@ Provenant: 15.66s</title></circle>
     <circle cx="686.57" cy="518.44" r="4.5" fill="#2563eb"><title>AvaloniaUI/Avalonia @ b7e95c2
 Files: 5273
 Provenant: 11.06s</title></circle>
-    <circle cx="687.62" cy="444.62" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
-Files: 5354
-Provenant: 52.75s</title></circle>
+    <circle cx="687.64" cy="476.80" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
+Files: 5356
+Provenant: 26.70s</title></circle>
     <circle cx="691.04" cy="475.47" r="4.5" fill="#2563eb"><title>python/cpython @ 7a468a1
 Files: 5627
 Provenant: 27.46s</title></circle>


### PR DESCRIPTION
## Summary

- Re-ran 10 more benchmark targets (the lowest-speedup stale M1-Max rows, chosen for ecosystem breadth) under the current Apple M5 Pro / 4-proc methodology and refreshed their `docs/BENCHMARKS.md` rows + regenerated chart/headline.
- Median speedup rises **13.2× → 13.4×**.

| Target | Before | After |
|---|---|---|
| apache/felix-dev | 9.09× | **24.00×** |
| aosp-mirror/platform_build | 9.52× | **17.87×** |
| prefix-dev/pixi | 8.09× | **12.84×** |
| jashkenas/backbone | 9.28× | **12.27×** |
| technomancy/leiningen | 8.90× | **10.80×** |
| elixir-plug/plug | 8.55× | **10.51×** |
| r-lib/devtools | 8.71× | **9.89×** |
| sous-chefs/mysql | 6.45× | **9.60×** |
| oakserver/oak | 8.94× | **9.43×** |
| conda-forge/pandas-feedstock | 7.59× | **6.31×** |

## Issues

- Covers: benchmark refresh sweep 4.

## Scope and exclusions

- Included: the 10 rows above + regenerated `scan-duration-vs-files.svg` and median headline.
- Explicit exclusions: no code changes. `pandas-feedstock` dips to 6.31× because it is a 50-file startup-bound recipe that loses the old 9-proc advantage under the standardized 4-proc methodology — recorded honestly.

## How to verify

- Each row's run-id (e.g. `felix-dev-96478`) maps to `.provenant/compare-runs/<ts>-<run-id>/`; timings are same-host wall-clock.
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` reproduces the SVG + headline.

## Notes on triage

- Every target was triaged; all are clean Provenant wins. The recurring ScanCode-"more" signals were all benign: source-faithful copyright rendering (`©`/`Copyright::`/`&copy;` vs ASCII, inline author emails, `Loïc` diacritic), SC junk PV correctly drops (font-binary `.ttf` strings, prose/URL fragments, `FIXME` placeholders, CI badges, `%25` template URLs), honest-`null` declared where SC emits catch-all `unknown` or backfills from unreferenced co-located files, and SC conflating bundled/test-fixture licenses into declared expressions (felix JUnit `CPL`/`EPL`, AOSP `tools/compliance` fixtures) where PV stays faithful to the manifest.
- Re-run counts that shifted vs the stale bullets were updated (pixi, felix, leiningen, plug, platform_build) — see commit body.
- One minor follow-up noted (not blocking): a few felix `build.gradle` modules where ScanCode extracts an `Apache-2.0` declared license and Provenant does not.