### PR TITLE
fix(assembly): enrich coordinate-less manifest declared license from its own file

### DIFF
--- a/src/post_processing/output_test/reference_following_package_test.rs
+++ b/src/post_processing/output_test/reference_following_package_test.rs
@@ -886,3 +886,66 @@ fn apply_package_reference_following_does_not_smear_multi_package_db_file_detect
     assert_eq!(packages[0].declared_license_expression, None);
     assert!(packages[0].license_detections.is_empty());
 }
+
+#[test]
+fn apply_package_reference_following_adopts_own_license_for_coordinateless_manifest() {
+    // A coordinate-less manifest (e.g. an ASF-header `build.gradle` with no
+    // group/artifact) never assembles into a top-level package, so the top-level
+    // manifest-adopt never runs. Its declared license must instead be enriched
+    // from the manifest file's own detection, matching how ScanCode promotes the
+    // file header. The single-package guard keeps this distinct from the
+    // multi-package smear case.
+    let gradle_path = "dependencymanager/build.gradle";
+    let mut manifest = file(gradle_path);
+    manifest.detected_license_expression = Some("apache-2.0".to_string());
+    manifest.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "apache-2.0".to_string(),
+        license_expression_spdx: "Apache-2.0".to_string(),
+        matches: vec![Match {
+            license_expression: "apache-2.0".to_string(),
+            license_expression_spdx: "Apache-2.0".to_string(),
+            from_file: Some(gradle_path.to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(10).unwrap(),
+            matcher: MatcherKind::Hash,
+            score: MatchScore::MAX,
+            matched_length: Some(50),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: "apache-2.0.LICENSE".to_string(),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: "apache".to_string(),
+    }];
+    // Coordinate-less package_data (no purl): the gradle parser found no
+    // group/artifact, and the parser extracted no declared license.
+    manifest.package_data = vec![PackageData {
+        package_type: Some(PackageType::Maven),
+        ..Default::default()
+    }];
+
+    let mut files = vec![dir("dependencymanager"), manifest];
+    let mut packages = vec![];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    let package_data = &files[1].package_data[0];
+    assert_eq!(
+        package_data.declared_license_expression.as_deref(),
+        Some("apache-2.0")
+    );
+    assert_eq!(
+        package_data.declared_license_expression_spdx.as_deref(),
+        Some("Apache-2.0")
+    );
+    // The adopted detections must back the declared expression, so the package
+    // does not end up with a declared license but an empty detection list.
+    assert_eq!(package_data.license_detections.len(), 1);
+    assert_eq!(
+        package_data.license_detections[0].license_expression,
+        "apache-2.0"
+    );
+}

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -585,6 +585,37 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
         }
     }
 
+    // File-level analog of the post-assembly manifest-adopt enrichment
+    // (sync_packages_from_followed_package_data): a manifest file's own detected
+    // license enriches its sole package_data's declared license when the parser
+    // extracted none and the package carries no coordinates of its own to be
+    // assembled into a top-level package (e.g. an ASF-header `build.gradle` with
+    // no group/artifact, where the top-level manifest-adopt never runs). Guarded
+    // to single-package manifest files so a multi-package database's whole-file
+    // detection is never smeared across its entries (see #1077).
+    if file.package_data.len() == 1 && !file.license_detections.is_empty() {
+        let own_detections = file.license_detections.clone();
+        let package_data = &mut file.package_data[0];
+        if package_data.purl.is_none()
+            && package_data.license_detections.is_empty()
+            && package_data.declared_license_expression.is_none()
+        {
+            package_data.declared_license_expression = combine_license_expressions(
+                own_detections
+                    .iter()
+                    .map(|detection| detection.license_expression.clone()),
+            );
+            package_data.declared_license_expression_spdx = combine_license_expressions(
+                own_detections
+                    .iter()
+                    .filter(|detection| !detection.license_expression_spdx.is_empty())
+                    .map(|detection| detection.license_expression_spdx.clone()),
+            );
+            package_data.license_detections = own_detections;
+            modified = true;
+        }
+    }
+
     if modified {
         file.detected_license_expression = combine_license_expressions(
             file.license_detections


### PR DESCRIPTION
## Summary

- Reference-following's post-assembly manifest-adopt enriches a package's declared license from its own manifest file's detection — but only for package_data that assemble into the top-level package list. A coordinate-less manifest such as an ASF-header `build.gradle` with no group/artifact never becomes a top-level package, so its `build_gradle` package_data kept a `null` declared license while ScanCode promotes the file's own Apache-2.0 header detection.
- Apply the same sanctioned enrichment at the file-level package_data: when a manifest file holds exactly one **purl-less** package_data with no parser-extracted license, adopt the file's own detections as that package_data's declared license.

## Issues

- Covers: the felix `build.gradle` declared-license follow-up noted in #1082.

## Scope and exclusions

- Included: file-level analog of the manifest-adopt in `follow_references_for_file`, guarded to single-package manifest files (`file.package_data.len() == 1`) and purl-less package_data; a positive regression test.
- Explicit exclusions: purl-bearing manifests (npm/cargo/maven/…) are unchanged — they continue to be enriched via the existing top-level manifest-adopt. Multi-package databases are unaffected (the single-package guard from #1077 still holds).

## How to verify

- New unit test `apply_package_reference_following_adopts_own_license_for_coordinateless_manifest` asserts a purl-less `build_gradle` package_data with a file-level Apache-2.0 detection gains `declared_license_expression: apache-2.0`.
- The `#1077` no-smear test still passes (multi-package `var/lib/dpkg/status` keeps null per-package declared).
- Spot check: scanning a felix `build.gradle` now reports `declared_license_expression: apache-2.0` (previously null), matching ScanCode.
- Full `cargo test --lib` (5198) and the post-processing / assembly / parsers golden suites pass with no fixture churn.

## Intentional differences from Python

- None here; this aligns Provenant with ScanCode's promotion of a build manifest's own header license to the package's declared expression, via Provenant's sanctioned reference-following enrichment rather than a parser backfill.