### PR TITLE
chore(release): bundle LICENSE and NOTICE in binary release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,8 @@ jobs:
         if: matrix.archive_format == 'tar.gz'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ${{ matrix.asset_name }}.tar.gz provenant${{ matrix.ext }}
+          cp "$GITHUB_WORKSPACE/LICENSE" "$GITHUB_WORKSPACE/NOTICE" .
+          tar czf ${{ matrix.asset_name }}.tar.gz provenant${{ matrix.ext }} LICENSE NOTICE
           if command -v sha256sum > /dev/null; then
             sha256sum ${{ matrix.asset_name }}.tar.gz > ${{ matrix.asset_name }}.tar.gz.sha256
           else
@@ -145,7 +146,9 @@ jobs:
         if: matrix.archive_format == 'zip'
         run: |
           cd target/${{ matrix.target }}/release
-          7z a ${{ matrix.asset_name }}.zip provenant${{ matrix.ext }}
+          Copy-Item "$env:GITHUB_WORKSPACE\LICENSE" .
+          Copy-Item "$env:GITHUB_WORKSPACE\NOTICE" .
+          7z a ${{ matrix.asset_name }}.zip provenant${{ matrix.ext }} LICENSE NOTICE
           $hash = (Get-FileHash "${{ matrix.asset_name }}.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
           "$hash  ${{ matrix.asset_name }}.zip" | Out-File -FilePath "${{ matrix.asset_name }}.zip.sha256" -Encoding ascii
         shell: pwsh


### PR DESCRIPTION
## Summary

- Bundle `LICENSE` and `NOTICE` into the prebuilt binary release archives (`.tar.gz` / `.zip`) attached to GitHub releases.

## Why

The crates.io crate already ships `LICENSE` + `NOTICE` (they're in the crate `include` list, verified via `cargo package --list`). But the prebuilt binary archives contained only the `provenant` binary, so that **Object-form distribution** carried neither the Apache-2.0 license text nor the NOTICE attribution — a gap under Apache-2.0 §4(a) (provide the license) and §4(d) (provide the NOTICE attribution). This brings the binary archives in line with the crate.

This was flagged by a downstream integrator reviewing Provenant's distribution compliance.

## Scope and exclusions

- Included: `.github/workflows/release.yml` — copy `LICENSE` and `NOTICE` into the release dir and add them to the Unix tar and Windows zip steps.
- Excluded: no code, no crate-packaging change (the crate already includes both).

## How to verify

CI builds the archives. After a release (or by inspecting a run's build artifacts), each archive should list three entries:

```
tar tzf provenant-linux-x86_64.tar.gz   # -> provenant, LICENSE, NOTICE
```

Locally simulated: valid YAML, and a mock tar/zip confirmed the archive contains `provenant` + `LICENSE` + `NOTICE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
