### PR TITLE
docs(benchmarks): refresh next 10 targets on M5 Pro 4-proc methodology

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **13.4× median speedup** and **13.2× geometric-mean speedup** overall; the median gap grows from **7.3×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **13.4× median speedup** and **13.4× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -85,11 +85,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `30.70s`; ScanCode `370.51s`
 - Richer mixed-surface package identity with fewer placeholder-only Debian rows and far broader dependency extraction (`351` vs `278`) across `Gemfile`, `Gemfile.lock`, `chef-*/Gemfile`, gemspec, Dockerfile, and fixture archive/control surfaces, plus email-preserving author normalization and cleaner placeholder-holder filtering
 
-##### [sous-chefs/apache2 @ 420d824](https://github.com/sous-chefs/apache2/tree/420d82402811a131729a6bcc80aaac08d307ac87) — **7.27× faster**
+##### [sous-chefs/apache2 @ 420d824](https://github.com/sous-chefs/apache2/tree/420d82402811a131729a6bcc80aaac08d307ac87) — **10.22× faster**
 
-- Files: 246
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `12.01s`; ScanCode `87.31s`
+- Files: 245
+- Run context: 2026-06-15 · apache2-8552 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.83s`; ScanCode `49.37s`
 - Matched Chef package and dependency coverage on committed `metadata.rb` surfaces, with fuller Debian-style script-header author capture and cleaner rejection of weak README maintainer prose as an author
 
 ##### [sous-chefs/mysql @ 6b7110b](https://github.com/sous-chefs/mysql/tree/6b7110bee2bc64c9149f24d524cbb740387e527a) — **9.60× faster**
@@ -587,11 +587,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.65s`; ScanCode `40.26s`
 - Direct Arch source-package visibility on committed `.SRCINFO` (`1` vs `0` file-level package records) with broader dependency extraction (`26` vs `0`) across runtime, make, check, and optional package metadata, plus copyright and holder recovery on the repo-owned `LICENSE` and `REUSE.toml` surfaces that ScanCode leaves empty
 
-##### [Amanieu/atomic-rs @ 44c213a](https://github.com/Amanieu/atomic-rs/tree/44c213a73cb4e5c4cf04fd6fd6f76dc95092aebf) — **7.24× faster**
+##### [Amanieu/atomic-rs @ 44c213a](https://github.com/Amanieu/atomic-rs/tree/44c213a73cb4e5c4cf04fd6fd6f76dc95092aebf) — **9.31× faster**
 
 - Files: 11
-- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `9.77s`; ScanCode `70.75s`
+- Run context: 2026-06-15 · atomic-rs-5496 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.71s`; ScanCode `43.86s`
 - Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) while preserving the repository's `Apache-2.0 OR MIT` README license semantics and normalizing docs.rs and Keep a Changelog links without trailing-slash drift
 
 ##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **9.83× faster**
@@ -699,11 +699,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.65s`; ScanCode `44.14s`
 - Broader Docker package visibility across 42 generated image Dockerfiles where ScanCode reports none, plus maintainer-line author recovery on `generate-stackbrew-library.sh`, with exact top-level package, dependency, and license parity elsewhere
 
-##### [e-ale/meta-pocketbeagle @ 7cb4956](https://github.com/e-ale/meta-pocketbeagle/tree/7cb4956d206728af96833e513594693dec98e163) — **6.69× faster**
+##### [e-ale/meta-pocketbeagle @ 7cb4956](https://github.com/e-ale/meta-pocketbeagle/tree/7cb4956d206728af96833e513594693dec98e163) — **8.64× faster**
 
 - Files: 31
-- Run context: 2026-04-21 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `11.06s`; ScanCode `73.99s`
+- Run context: 2026-06-15 · meta-pocketbeagle-92393 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.21s`; ScanCode `45.03s`
 - Broader BitBake package visibility (`4` vs `0` packages) from committed `.bb` and `.bbappend` metadata, with `linuxconsoletools_1.6.0.bb` carrying source URL/checksum plus local file-reference evidence and wildcard append manifests such as `u-boot%.bbappend` and `linux-yocto_%.bbappend` retained as package records instead of scanner-silent inputs
 
 ##### [facebook/buck2 @ 3359f75](https://github.com/facebook/buck2/tree/3359f75abe3c7b6f543fdb2c7a775d47347b8897) — **15.27× faster**
@@ -902,11 +902,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `13.65s`; ScanCode `168.27s`
 - Broader RPM package and dependency extraction (`352` vs `327` packages, `1441` vs `0` dependencies) from committed `.rpm` fixture trees and sibling `.spec` metadata, with normalized RPM header license expressions and cleaner rejection of config or doc false positives such as `baseurl` and `doxygen. Using` as holder or author data
 
-##### [marshallpierce/rust-base64 @ 13f4fe8](https://github.com/marshallpierce/rust-base64/tree/13f4fe86e565b3a8ed9402d3b8b1bcf83ab9817c) — **7.46× faster**
+##### [marshallpierce/rust-base64 @ 13f4fe8](https://github.com/marshallpierce/rust-base64/tree/13f4fe86e565b3a8ed9402d3b8b1bcf83ab9817c) — **8.98× faster**
 
 - Files: 42
-- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.05s`; ScanCode `74.96s`
+- Run context: 2026-06-15 · rust-base64-14805 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.00s`; ScanCode `44.92s`
 - Matched Cargo workspace package and dependency coverage (`2` vs `2` packages, `190` vs `190` dependencies) while preserving the repository's dual-license README and manifest semantics, recovering SVG-linked URL evidence, and avoiding trailing-slash URL drift across the docs surfaces
 
 ##### [rust-lang/cargo @ b54fe55](https://github.com/rust-lang/cargo/tree/b54fe551a982d75d299e0d54daeac70cb854eef0) — **24.6× faster**
@@ -988,11 +988,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 
 #### Apple / Swift / Flutter / mobile
 
-##### [AFNetworking/AFNetworking @ d9f589c](https://github.com/AFNetworking/AFNetworking/tree/d9f589cc2c1fe9d55eb5eea00558010afea7a41e) — **8.07× faster**
+##### [AFNetworking/AFNetworking @ d9f589c](https://github.com/AFNetworking/AFNetworking/tree/d9f589cc2c1fe9d55eb5eea00558010afea7a41e) — **10.49× faster**
 
-- Files: 211
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.94s`; ScanCode `88.26s`
+- Files: 210
+- Run context: 2026-06-15 · AFNetworking-17973 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.17s`; ScanCode `54.22s`
 - Matched top-level CocoaPods package coverage (`1` vs `1`) with broader dependency extraction (`124` vs `115`) from `AFNetworking.podspec` subspec edges and the root `Gemfile`
 
 ##### [Alamofire/Alamofire @ ac01666](https://github.com/Alamofire/Alamofire/tree/ac016668a19532686e320edf447f79a5cf5bd057) — **11.91× faster**
@@ -1016,12 +1016,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `34.99s`; ScanCode `527.81s`
 - Far broader CocoaPods and sidecar package extraction (`111` vs `34` packages, `2134` vs `1572` dependencies) from many committed `.podspec` files plus the root `Gemfile` and Kotlin `build.gradle.kts` plugin manifests, with richer package author visibility across React Native podspecs
 
-##### [firebase/flutterfire @ 90d2e1f](https://github.com/firebase/flutterfire/tree/90d2e1f70b23fdad8f2fa4ca0c5e5d744d4e4f69) — **8.77× faster**
+##### [firebase/flutterfire @ 90d2e1f](https://github.com/firebase/flutterfire/tree/90d2e1f70b23fdad8f2fa4ca0c5e5d744d4e4f69) — **22.74× faster**
 
-- Files: 3,544
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `25.02s`; ScanCode `219.35s`
-- Broader Flutter/Firebase package and dependency extraction (`102` vs `100` packages, `964` vs `803` dependencies) from many committed `pubspec.yaml`, CocoaPods `podspec` / `Podfile`, and Android Gradle inputs, plus contributor-roster visibility from `AUTHORS` where ScanCode stays silent
+- Files: 3,615
+- Run context: 2026-06-15 · flutterfire-25986 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `10.56s`; ScanCode `240.18s`
+- Spec-correct, internally consistent `pkg:pub` PURLs for the Flutter/Firebase graph (`65` Dart packages, `690` Dart dependencies) from many committed `pubspec.yaml`, CocoaPods `podspec` / `Podfile`, and Android Gradle inputs, where ScanCode emits non-standard `pkg:dart` packages alongside `pkg:pubspec` dependencies, with more complete copyright-holder capture (e.g. `Chromium project authors`) and contributor-roster visibility from `AUTHORS` where ScanCode stays silent
 
 ##### [flutter/flutter @ 238d79a](https://github.com/flutter/flutter/tree/238d79aba784bc75c87f226ca7e7e7015b12bfd6) — **20.54× faster**
 
@@ -1086,11 +1086,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.61s`; ScanCode `128.67s`
 - Matched top-level CocoaPods package coverage (`3` vs `3`) with broader dependency extraction (`10` vs `0`) from `Podfile`-declared pod relationships, while preserving separate package identities for the sibling test podspecs
 
-##### [SwiftFiddle/swiftfiddle-web @ df09b80](https://github.com/SwiftFiddle/swiftfiddle-web/tree/df09b80) — **8.30× faster**
+##### [SwiftFiddle/swiftfiddle-web @ df09b80](https://github.com/SwiftFiddle/swiftfiddle-web/tree/df09b80) — **9.88× faster**
 
-- Files: 109
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.21s`; ScanCode `84.73s`
+- Files: 114
+- Run context: 2026-06-15 · swiftfiddle-web-20663 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.24s`; ScanCode `51.75s`
 - Much richer dependency extraction (`297` vs `36`) from committed `Resources/Package.swift.json`, `Package.resolved`, and `package-lock.json`, matched Swift package coverage (`32` vs `32`), and extra Docker package visibility
 
 #### .NET / NuGet / Windows / vcpkg
@@ -1202,11 +1202,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `9.33s`; ScanCode `97.37s`
 - Direct CPAN package identity on the root `dist.ini`, extra dependency visibility from the shipped skeleton `Makefile.PL`, plus Docker package visibility on `share/docker/Dockerfile`, with unresolved template placeholders kept out of CPAN names and PURLs
 
-##### [Plack/Plack @ b3984f1](https://github.com/Plack/Plack/tree/b3984f1c59de36903bb924c9da1273f3e11d4d2b) — **8.67× faster**
+##### [Plack/Plack @ b3984f1](https://github.com/Plack/Plack/tree/b3984f1c59de36903bb924c9da1273f3e11d4d2b) — **9.96× faster**
 
 - Files: 275
-- Run context: 2026-04-18 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.04s`; ScanCode `87.06s`
+- Run context: 2026-06-15 · Plack-23341 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.22s`; ScanCode `51.98s`
 - Direct CPAN package identity and broader dependency extraction (`1` vs `0` packages, `22` vs `0` dependencies) from `META.json`, `dist.ini`, and `Makefile.PL`, with CPAN resource metadata preserved from the distribution manifest
 
 ##### [rails/rails @ 27fb2a9](https://github.com/rails/rails/tree/27fb2a9192b2492791528fc7c3afb53736696bc5) — **13.69× faster**
@@ -1309,11 +1309,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `312.87s`; ScanCode `4641.96s`
 - Broader Nix package visibility (`1340` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
 
-##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **7.44× faster**
+##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **10.23× faster**
 
 - Files: 87
-- Run context: 2026-04-27 · devshell-25970 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `8.84s`; ScanCode `65.75s`
+- Run context: 2026-06-15 · devshell-12112 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.68s`; ScanCode `47.86s`
 - Broader Nix package and dependency extraction (`5` vs `0` packages, `17` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and template flake surfaces, with cleaner structured author, copyright, and URL recovery
 
 ##### [ocaml/dune @ b13ab94](https://github.com/ocaml/dune/tree/b13ab949e185a205a39eb6163eea050b7d60a047) — **25.02× faster**
@@ -1344,11 +1344,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.77s`; ScanCode `216.36s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with richer bundled Windows executable identity on `assets/templates/bin/openfl.exe`, extra Docker package visibility on `Dockerfile`, and cleaner URL normalization across shipped font metadata
 
-##### [univention/Nubus @ fef2258](https://github.com/univention/Nubus/tree/fef2258483c56cce0e1f14e4c8d8fce24d26b891) — **6.84× faster**
+##### [univention/Nubus @ fef2258](https://github.com/univention/Nubus/tree/fef2258483c56cce0e1f14e4c8d8fce24d26b891) — **8.64× faster**
 
 - Files: 16
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `10.53s`; ScanCode `72.03s`
+- Run context: 2026-06-15 · Nubus-3100 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.94s`; ScanCode `42.68s`
 - Direct `publiccode.yml` package visibility on the root metadata file (`1` vs `0` on that file), with cleaner SPDX copyright placeholder normalization for `Univention GmbH` and the same zero-scan-error behavior under the shared profile
 
 ##### [yesodweb/yesod @ 1b033c7](https://github.com/yesodweb/yesod/tree/1b033c741ce81d01070de993b285a17e71178156) — **9.32× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -140,18 +140,18 @@ ScanCode: 89.38s</title></rect>
     <rect x="215.47" y="425.14" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/grep @ 29d2e10
 Files: 6
 ScanCode: 73.20s</title></rect>
-    <rect x="257.23" y="426.75" width="8" height="8" fill="#d97706" rx="1.5"><title>Amanieu/atomic-rs @ 44c213a
+    <rect x="257.23" y="449.34" width="8" height="8" fill="#d97706" rx="1.5"><title>Amanieu/atomic-rs @ 44c213a
 Files: 11
-ScanCode: 70.75s</title></rect>
+ScanCode: 43.86s</title></rect>
     <rect x="257.23" y="327.58" width="8" height="8" fill="#d97706" rx="1.5"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 ScanCode: 577.11s</title></rect>
     <rect x="263.23" y="453.39" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
 ScanCode: 40.26s</title></rect>
-    <rect x="283.05" y="425.90" width="8" height="8" fill="#d97706" rx="1.5"><title>univention/Nubus @ fef2258
+    <rect x="283.05" y="450.63" width="8" height="8" fill="#d97706" rx="1.5"><title>univention/Nubus @ fef2258
 Files: 16
-ScanCode: 72.03s</title></rect>
+ScanCode: 42.68s</title></rect>
     <rect x="291.17" y="427.52" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 ScanCode: 69.61s</title></rect>
@@ -167,15 +167,15 @@ ScanCode: 40.69s</title></rect>
     <rect x="326.37" y="428.10" width="8" height="8" fill="#d97706" rx="1.5"><title>sentence-transformers/all-MiniLM-L6-v2 @ 1110a24
 Files: 30
 ScanCode: 68.76s</title></rect>
-    <rect x="328.63" y="424.63" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
+    <rect x="328.63" y="448.10" width="8" height="8" fill="#d97706" rx="1.5"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
-ScanCode: 73.99s</title></rect>
+ScanCode: 45.03s</title></rect>
     <rect x="346.19" y="436.94" width="8" height="8" fill="#d97706" rx="1.5"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
 ScanCode: 57.03s</title></rect>
-    <rect x="349.56" y="424.02" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
+    <rect x="349.56" y="448.21" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
-ScanCode: 74.96s</title></rect>
+ScanCode: 44.92s</title></rect>
     <rect x="357.31" y="446.42" width="8" height="8" fill="#d97706" rx="1.5"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 ScanCode: 46.66s</title></rect>
@@ -200,9 +200,9 @@ ScanCode: 122.53s</title></rect>
     <rect x="397.32" y="439.40" width="8" height="8" fill="#d97706" rx="1.5"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
 ScanCode: 54.13s</title></rect>
-    <rect x="399.74" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
+    <rect x="399.74" y="445.22" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 87
-ScanCode: 65.75s</title></rect>
+ScanCode: 47.86s</title></rect>
     <rect x="402.83" y="447.10" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 ScanCode: 45.99s</title></rect>
@@ -218,9 +218,9 @@ ScanCode: 47.99s</title></rect>
     <rect x="412.04" y="441.96" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-plug/plug @ 47649aa
 Files: 104
 ScanCode: 51.28s</title></rect>
-    <rect x="415.27" y="418.23" width="8" height="8" fill="#d97706" rx="1.5"><title>SwiftFiddle/swiftfiddle-web @ df09b80
-Files: 109
-ScanCode: 84.73s</title></rect>
+    <rect x="418.36" y="441.53" width="8" height="8" fill="#d97706" rx="1.5"><title>SwiftFiddle/swiftfiddle-web @ df09b80
+Files: 114
+ScanCode: 51.75s</title></rect>
     <rect x="423.04" y="433.19" width="8" height="8" fill="#d97706" rx="1.5"><title>jashkenas/backbone @ da75718
 Files: 122
 ScanCode: 61.74s</title></rect>
@@ -239,18 +239,18 @@ ScanCode: 170.82s</title></rect>
     <rect x="450.98" y="397.47" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
 Files: 183
 ScanCode: 131.47s</title></rect>
-    <rect x="460.79" y="416.30" width="8" height="8" fill="#d97706" rx="1.5"><title>AFNetworking/AFNetworking @ d9f589c
-Files: 211
-ScanCode: 88.26s</title></rect>
+    <rect x="460.46" y="439.32" width="8" height="8" fill="#d97706" rx="1.5"><title>AFNetworking/AFNetworking @ d9f589c
+Files: 210
+ScanCode: 54.22s</title></rect>
     <rect x="462.40" y="401.49" width="8" height="8" fill="#d97706" rx="1.5"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 ScanCode: 120.75s</title></rect>
     <rect x="469.95" y="390.71" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
 Files: 241
 ScanCode: 151.70s</title></rect>
-    <rect x="471.36" y="416.81" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/apache2 @ 420d824
-Files: 246
-ScanCode: 87.31s</title></rect>
+    <rect x="471.08" y="443.75" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/apache2 @ 420d824
+Files: 245
+ScanCode: 49.37s</title></rect>
     <rect x="475.18" y="418.07" width="8" height="8" fill="#d97706" rx="1.5"><title>libevent/libevent @ 4829651
 Files: 260
 ScanCode: 85.01s</title></rect>
@@ -263,9 +263,9 @@ ScanCode: 49.16s</title></rect>
     <rect x="477.26" y="441.87" width="8" height="8" fill="#d97706" rx="1.5"><title>rustcrypto/aeads @ 9d05d81
 Files: 268
 ScanCode: 51.37s</title></rect>
-    <rect x="479.04" y="416.95" width="8" height="8" fill="#d97706" rx="1.5"><title>Plack/Plack @ b3984f1
+    <rect x="479.04" y="441.32" width="8" height="8" fill="#d97706" rx="1.5"><title>Plack/Plack @ b3984f1
 Files: 275
-ScanCode: 87.06s</title></rect>
+ScanCode: 51.98s</title></rect>
     <rect x="481.50" y="402.72" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda @ 37549c4
 Files: 285
 ScanCode: 117.64s</title></rect>
@@ -521,9 +521,9 @@ ScanCode: 241.45s</title></rect>
     <rect x="653.59" y="309.22" width="8" height="8" fill="#d97706" rx="1.5"><title>protocolbuffers/protobuf @ e3370c2
 Files: 3463
 ScanCode: 851.02s</title></rect>
-    <rect x="655.19" y="373.28" width="8" height="8" fill="#d97706" rx="1.5"><title>firebase/flutterfire @ 90d2e1f
-Files: 3544
-ScanCode: 219.35s</title></rect>
+    <rect x="656.55" y="369.00" width="8" height="8" fill="#d97706" rx="1.5"><title>firebase/flutterfire @ 90d2e1f
+Files: 3615
+ScanCode: 240.18s</title></rect>
     <rect x="656.74" y="353.11" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/terminal @ 84ae7ad
 Files: 3625
 ScanCode: 336.14s</title></rect>
@@ -808,18 +808,18 @@ Provenant: 24.22s</title></circle>
     <circle cx="219.47" cy="521.94" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/grep @ 29d2e10
 Files: 6
 Provenant: 10.27s</title></circle>
-    <circle cx="261.23" cy="524.30" r="4.5" fill="#2563eb"><title>Amanieu/atomic-rs @ 44c213a
+    <circle cx="261.23" cy="558.78" r="4.5" fill="#2563eb"><title>Amanieu/atomic-rs @ 44c213a
 Files: 11
-Provenant: 9.77s</title></circle>
+Provenant: 4.71s</title></circle>
     <circle cx="261.23" cy="400.68" r="4.5" fill="#2563eb"><title>Windows 10 KB5049993 cumulative update extracted snapshot
 Files: 11
 Provenant: 133.69s</title></circle>
     <circle cx="267.23" cy="559.38" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
 Provenant: 4.65s</title></circle>
-    <circle cx="287.05" cy="520.76" r="4.5" fill="#2563eb"><title>univention/Nubus @ fef2258
+    <circle cx="287.05" cy="556.52" r="4.5" fill="#2563eb"><title>univention/Nubus @ fef2258
 Files: 16
-Provenant: 10.53s</title></circle>
+Provenant: 4.94s</title></circle>
     <circle cx="295.17" cy="521.76" r="4.5" fill="#2563eb"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 Provenant: 10.31s</title></circle>
@@ -835,15 +835,15 @@ Provenant: 6.02s</title></circle>
     <circle cx="330.37" cy="539.72" r="4.5" fill="#2563eb"><title>sentence-transformers/all-MiniLM-L6-v2 @ 1110a24
 Files: 30
 Provenant: 7.05s</title></circle>
-    <circle cx="332.63" cy="518.44" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
+    <circle cx="332.63" cy="554.01" r="4.5" fill="#2563eb"><title>e-ale/meta-pocketbeagle @ 7cb4956
 Files: 31
-Provenant: 11.06s</title></circle>
+Provenant: 5.21s</title></circle>
     <circle cx="350.19" cy="554.83" r="4.5" fill="#2563eb"><title>ILSpy v9.1 binaries x64 snapshot @ sha256:1e925a4
 Files: 40
 Provenant: 5.12s</title></circle>
-    <circle cx="353.56" cy="522.96" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
+    <circle cx="353.56" cy="555.95" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
-Provenant: 10.05s</title></circle>
+Provenant: 5.00s</title></circle>
     <circle cx="361.31" cy="546.87" r="4.5" fill="#2563eb"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 Provenant: 6.06s</title></circle>
@@ -868,9 +868,9 @@ Provenant: 11.11s</title></circle>
     <circle cx="401.32" cy="559.18" r="4.5" fill="#2563eb"><title>Alpine 3.23.3 minirootfs @ sha256:42d0e6d
 Files: 84
 Provenant: 4.67s</title></circle>
-    <circle cx="403.74" cy="529.03" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
+    <circle cx="403.74" cy="559.08" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 87
-Provenant: 8.84s</title></circle>
+Provenant: 4.68s</title></circle>
     <circle cx="406.83" cy="557.98" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 Provenant: 4.79s</title></circle>
@@ -886,9 +886,9 @@ Provenant: 5.09s</title></circle>
     <circle cx="416.04" cy="557.10" r="4.5" fill="#2563eb"><title>elixir-plug/plug @ 47649aa
 Files: 104
 Provenant: 4.88s</title></circle>
-    <circle cx="419.27" cy="522.22" r="4.5" fill="#2563eb"><title>SwiftFiddle/swiftfiddle-web @ df09b80
-Files: 109
-Provenant: 10.21s</title></circle>
+    <circle cx="422.36" cy="553.74" r="4.5" fill="#2563eb"><title>SwiftFiddle/swiftfiddle-web @ df09b80
+Files: 114
+Provenant: 5.24s</title></circle>
     <circle cx="427.04" cy="555.67" r="4.5" fill="#2563eb"><title>jashkenas/backbone @ da75718
 Files: 122
 Provenant: 5.03s</title></circle>
@@ -907,18 +907,18 @@ Provenant: 10.90s</title></circle>
     <circle cx="454.98" cy="519.74" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
 Files: 183
 Provenant: 10.76s</title></circle>
-    <circle cx="464.79" cy="518.95" r="4.5" fill="#2563eb"><title>AFNetworking/AFNetworking @ d9f589c
-Files: 211
-Provenant: 10.94s</title></circle>
+    <circle cx="464.46" cy="554.37" r="4.5" fill="#2563eb"><title>AFNetworking/AFNetworking @ d9f589c
+Files: 210
+Provenant: 5.17s</title></circle>
     <circle cx="466.40" cy="520.98" r="4.5" fill="#2563eb"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 Provenant: 10.48s</title></circle>
     <circle cx="473.95" cy="513.26" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
 Files: 241
 Provenant: 12.34s</title></circle>
-    <circle cx="475.36" cy="514.55" r="4.5" fill="#2563eb"><title>sous-chefs/apache2 @ 420d824
-Files: 246
-Provenant: 12.01s</title></circle>
+    <circle cx="475.08" cy="557.59" r="4.5" fill="#2563eb"><title>sous-chefs/apache2 @ 420d824
+Files: 245
+Provenant: 4.83s</title></circle>
     <circle cx="479.18" cy="550.34" r="4.5" fill="#2563eb"><title>libevent/libevent @ 4829651
 Files: 260
 Provenant: 5.63s</title></circle>
@@ -931,9 +931,9 @@ Provenant: 4.97s</title></circle>
     <circle cx="481.26" cy="557.10" r="4.5" fill="#2563eb"><title>rustcrypto/aeads @ 9d05d81
 Files: 268
 Provenant: 4.88s</title></circle>
-    <circle cx="483.04" cy="523.01" r="4.5" fill="#2563eb"><title>Plack/Plack @ b3984f1
+    <circle cx="483.04" cy="553.92" r="4.5" fill="#2563eb"><title>Plack/Plack @ b3984f1
 Files: 275
-Provenant: 10.04s</title></circle>
+Provenant: 5.22s</title></circle>
     <circle cx="485.50" cy="522.96" r="4.5" fill="#2563eb"><title>conda/conda @ 37549c4
 Files: 285
 Provenant: 10.05s</title></circle>
@@ -1189,9 +1189,9 @@ Provenant: 13.31s</title></circle>
     <circle cx="657.59" cy="471.72" r="4.5" fill="#2563eb"><title>protocolbuffers/protobuf @ e3370c2
 Files: 3463
 Provenant: 29.73s</title></circle>
-    <circle cx="659.19" cy="479.87" r="4.5" fill="#2563eb"><title>firebase/flutterfire @ 90d2e1f
-Files: 3544
-Provenant: 25.02s</title></circle>
+    <circle cx="660.55" cy="520.63" r="4.5" fill="#2563eb"><title>firebase/flutterfire @ 90d2e1f
+Files: 3615
+Provenant: 10.56s</title></circle>
     <circle cx="660.74" cy="483.64" r="4.5" fill="#2563eb"><title>microsoft/terminal @ 84ae7ad
 Files: 3625
 Provenant: 23.10s</title></circle>


### PR DESCRIPTION
## Summary

- Re-ran 10 more stale M1-Max benchmark rows (lowest-speedup repos, chosen for ecosystem breadth) under the current Apple M5 Pro / 4-proc methodology and refreshed their `docs/BENCHMARKS.md` rows + regenerated chart/headline. Median holds at **13.4×** (geometric mean 13.2× → 13.4×).

| Target | Before | After |
|---|---|---|
| firebase/flutterfire | 8.77× | **22.74×** |
| AFNetworking/AFNetworking | 8.07× | **10.49×** |
| numtide/devshell | 7.44× | **10.23×** |
| sous-chefs/apache2 | 7.27× | **10.22×** |
| Plack/Plack | 8.67× | **9.96×** |
| SwiftFiddle/swiftfiddle-web | 8.30× | **9.88×** |
| Amanieu/atomic-rs | 7.24× | **9.31×** |
| marshallpierce/rust-base64 | 7.46× | **8.98×** |
| e-ale/meta-pocketbeagle | 6.69× | **8.64×** |
| univention/Nubus | 6.84× | **8.64×** |

## Issues

- Covers: benchmark refresh sweep 5.
- Filed during triage: #1085 (CocoaPods podspec `:file => '../LICENSE'` reference not resolved — affects flutterfire's `*_web` packages).

## Scope and exclusions

- Included: the 10 rows above + regenerated `scan-duration-vs-files.svg` and headline.
- Explicit exclusions: no code changes.

## How to verify

- Each row's run-id (e.g. `flutterfire-25986`) maps to `.provenant/compare-runs/<ts>-<run-id>/`; timings are same-host wall-clock.
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` reproduces the SVG + headline.

## Notes on triage

- All 10 are Provenant wins. Recurring ScanCode-"more" signals were benign: source-faithful copyright rendering (Unicode en-dash `2011–2016`, REUSE `SPDX-FileCopyrightText:` prefix, complete `…contributors`/`…authors` where ScanCode truncates), SC junk PV drops (README prose authors, `.mailmap` throwaway emails, shields/CI-badge and `${info.host}` template URLs, podspec template-string "packages"), and honest-`null` declared where SC backfills from co-located/unreferenced LICENSE files (npm/bower with no `license` field) or attributes a license to a remote resolved dependency.
- **flutterfire**: the apparent package/dependency "gap" is a PURL-type difference — Provenant emits spec-correct, internally consistent `pkg:pub` (65 packages, 690 deps) while ScanCode emits non-standard `pkg:dart` packages + `pkg:pubspec` dependencies (analogous to the `pkg:apk/alpine` vs `pkg:alpine` case). The one genuine deficiency — CocoaPods `../LICENSE` file references left as `unknown-license-reference` — is tracked in #1085.
- Minor follow-up noted: `Amanieu/atomic-rs`'s file-level Cargo.toml package_data has a `null` declared license for the old `Apache-2.0/MIT` slash dual-license syntax (the assembled top-level package is correct).