### PR TITLE
fix(assembly): resolve parent-relative manifest license-file references

### DIFF
--- a/src/post_processing/output_test/reference_following_package_test.rs
+++ b/src/post_processing/output_test/reference_following_package_test.rs
@@ -949,3 +949,81 @@ fn apply_package_reference_following_adopts_own_license_for_coordinateless_manif
         "apache-2.0"
     );
 }
+
+#[test]
+fn apply_package_reference_following_resolves_parent_relative_license_file_reference() {
+    // A CocoaPods podspec in an `ios/` subdirectory declares its license via a
+    // parent-relative file reference (`s.license = { :file => '../LICENSE' }`).
+    // Reference-following must collapse the `../` and resolve it to the package's
+    // root LICENSE, not leave it as `unknown-license-reference`. (See #1085.)
+    let podspec_path = "pkg/ios/pkg.podspec";
+    let package_uid = "pkg:cocoapods/pkg@1.0.0?uuid=test".to_string();
+    let mut package = super::test_utils::package(&package_uid, podspec_path);
+    package.datafile_paths = vec![podspec_path.to_string()];
+    package.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "unknown-license-reference".to_string(),
+        license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+        matches: vec![Match {
+            license_expression: "unknown-license-reference".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+            from_file: Some(podspec_path.to_string()),
+            start_line: LineNumber::new(4).unwrap(),
+            end_line: LineNumber::new(4).unwrap(),
+            matcher: MatcherKind::Declared,
+            score: MatchScore::MAX,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: "parser-declared-license".to_string(),
+            rule_url: None,
+            matched_text: Some("../LICENSE".to_string()),
+            referenced_filenames: Some(vec!["../LICENSE".to_string()]),
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: "unknown-ref-podspec".to_string(),
+    }];
+
+    let mut podspec = file(podspec_path);
+    podspec.for_packages = vec![PackageUid::from_raw(package_uid.clone())];
+    podspec.package_data = vec![PackageData {
+        package_type: Some(PackageType::Cocoapods),
+        license_detections: package.license_detections.clone(),
+        ..Default::default()
+    }];
+
+    let mut license = file("pkg/LICENSE");
+    license.detected_license_expression = Some("mit".to_string());
+    license.license_detections = vec![crate::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("pkg/LICENSE".to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(20).unwrap(),
+            matcher: MatcherKind::Hash,
+            score: MatchScore::MAX,
+            matched_length: Some(100),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: "mit.LICENSE".to_string(),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: "mit-license".to_string(),
+    }];
+
+    let mut files = vec![dir("pkg"), dir("pkg/ios"), podspec, license];
+    let mut packages = vec![package];
+    apply_package_reference_following(&mut files, &mut packages);
+
+    assert_eq!(
+        packages[0].declared_license_expression.as_deref(),
+        Some("mit")
+    );
+}

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1383,13 +1383,46 @@ fn path_is_within_root(path: &str, root: &str) -> bool {
 }
 
 fn join_reference_candidate(base: &str, referenced_filename: &str) -> String {
-    if base.is_empty() {
-        referenced_filename.to_string()
+    let joined = if base.is_empty() {
+        referenced_filename.replace('\\', "/")
     } else {
-        Path::new(base)
-            .join(referenced_filename)
-            .to_string_lossy()
-            .replace('\\', "/")
+        format!("{}/{}", base, referenced_filename.replace('\\', "/"))
+    };
+    normalize_relative_path(&joined)
+}
+
+/// Lexically collapse `.` and `..` segments in a scan-relative path so a
+/// manifest reference like `../LICENSE` from a `pkg/ios/foo.podspec` resolves to
+/// `pkg/LICENSE`. Operates purely on the string (no filesystem access), matching
+/// the way scan-relative paths are compared elsewhere. A leading `..` that cannot
+/// be collapsed is preserved so it simply fails to match any real file.
+fn normalize_relative_path(path: &str) -> String {
+    let is_absolute = path.starts_with('/');
+    // Preserve a leading `./` so candidates keep the same path style as the
+    // scan-relative keys they are matched against (some scans prefix paths with
+    // `./`); only the `..`/`.` traversal is collapsed.
+    let has_dot_prefix = path.starts_with("./");
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                if matches!(segments.last(), Some(&last) if last != "..") {
+                    segments.pop();
+                } else {
+                    segments.push("..");
+                }
+            }
+            other => segments.push(other),
+        }
+    }
+    let joined = segments.join("/");
+    if is_absolute {
+        format!("/{joined}")
+    } else if has_dot_prefix && !joined.is_empty() {
+        format!("./{joined}")
+    } else {
+        joined
     }
 }
 


### PR DESCRIPTION
## Summary

- Reference-following joined a manifest's referenced license filename onto the manifest directory with `Path::join`, which does not collapse `..`/`.`. A CocoaPods podspec in an `ios/` subdirectory declaring `s.license = { :file => '../LICENSE' }` produced the literal candidate `pkg/ios/../LICENSE`, never matched the real `pkg/LICENSE`, and the package kept `declared_license_expression: unknown-license-reference` instead of the referenced license (e.g. `bsd-new`/`BSD-3-Clause`).
- Lexically normalize the joined candidate path (collapse `..`/`.`) while preserving the scan-relative path style (bare, `./`-prefixed, or absolute) so it still matches the exact-keyed file lookup.

## Issues

- Closes: #1085

## Scope and exclusions

- Included: `..`/`.` collapsing in `join_reference_candidate` (new `normalize_relative_path` helper) + a regression test for the parent-relative podspec license reference.
- Explicit exclusions: no change to which references are followed — only the path arithmetic that resolves them.

## How to verify

- New unit test `apply_package_reference_following_resolves_parent_relative_license_file_reference` asserts a podspec at `pkg/ios/pkg.podspec` referencing `../LICENSE` resolves the package's declared license to `mit` (was `unknown-license-reference`).
- End-to-end: scanning `firebase/flutterfire`'s `cloud_firestore_web` now reports `pkg:cocoapods/cloud_firestore_web@0.1.0` declared `bsd-new` (was `unknown-license-reference`); 38 `*_web` cocoapods packages were affected.
- Regression: reference-following unit tests (incl. the #1077 no-smear and #1083 gradle cases) and the post-processing / assembly / parsers / license-detection golden suites pass with no fixture churn.

## Intentional differences from Python

- None; this aligns Provenant with ScanCode's resolution of a podspec's `:file` license reference to the referenced file's detected license.