### PR TITLE
fix(parsers): normalize Cargo legacy slash dual-license to SPDX OR

### DIFF
--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -93,9 +93,17 @@ impl PackageParser for CargoParser {
             .and_then(|p| p.get(FIELD_LICENSE))
             .and_then(|v| v.as_str())
             .map(|s| truncate_field(s.to_string()));
+        // Cargo's legacy dual-license syntax uses `/` as the OR separator (e.g.
+        // `Apache-2.0/MIT`), deprecated in favour of SPDX `OR` but still present
+        // in older crates. SPDX license ids never contain `/`, so treat it as an
+        // OR separator before SPDX normalization while keeping the raw statement
+        // source-faithful.
+        let normalized_license = raw_license
+            .as_deref()
+            .map(normalize_cargo_legacy_license_separator);
         let file_references = extract_file_references(&toml_content);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-            raw_license
+            normalized_license
                 .as_deref()
                 .and_then(normalize_spdx_expression)
                 .map(|normalized| {
@@ -234,6 +242,21 @@ fn default_package_data() -> PackageData {
         datasource_id: Some(DatasourceId::CargoToml),
         ..Default::default()
     }
+}
+
+/// Convert Cargo's legacy `/` dual-license separator to SPDX `OR`. SPDX license
+/// ids never contain `/`, so any `/` in a Cargo `license` field is the
+/// deprecated OR separator (e.g. `Apache-2.0/MIT` -> `Apache-2.0 OR MIT`).
+fn normalize_cargo_legacy_license_separator(license: &str) -> String {
+    if !license.contains('/') {
+        return license.to_string();
+    }
+    license
+        .split('/')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" OR ")
 }
 
 /// Reads and parses a TOML file

--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -214,6 +214,35 @@ my-package = "99999.0.0"
     }
 
     #[test]
+    fn test_legacy_slash_dual_license_normalizes_to_or() {
+        // Cargo's deprecated `/` dual-license separator (still present in older
+        // crates) must normalize to SPDX `OR`, while the extracted statement
+        // stays source-faithful.
+        let content = r#"
+[package]
+name = "atomic"
+version = "0.6.1"
+license = "Apache-2.0/MIT"
+        "#;
+
+        let (_temp_file, cargo_path) = create_temp_cargo_toml(content);
+        let package_data = CargoParser::extract_first_package(&cargo_path);
+
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT")
+        );
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("Apache-2.0/MIT")
+        );
+    }
+
+    #[test]
     fn test_extract_short_composite_declared_license_preserves_mit_zero_and_or() {
         let content = r#"
 [package]


### PR DESCRIPTION
## Summary

- Cargo's deprecated dual-license syntax uses `/` as the OR separator (e.g. `license = "Apache-2.0/MIT"`), still present in older crates. The cargo parser passed the raw value straight to SPDX normalization, which rejects the non-SPDX `/`, so such crates got a **null** declared license expression even though ScanCode resolves them to `apache-2.0 OR mit`.
- SPDX license ids never contain `/`, so treat it as the OR separator before normalization while keeping the extracted statement source-faithful.

## Issues

- Covers: the minor slash-syntax follow-up noted in #1086 (surfaced on `Amanieu/atomic-rs`, whose `Cargo.toml` declares `license = "Apache-2.0/MIT"`).

## Scope and exclusions

- Included: a `normalize_cargo_legacy_license_separator` helper applied to the cargo `license` field before SPDX normalization; a unit test.
- Explicit exclusions: only the cargo `license` field is affected; the raw `extracted_license_statement` keeps the original `/` form.

## How to verify

- New unit test `test_legacy_slash_dual_license_normalizes_to_or`: `license = "Apache-2.0/MIT"` → `declared_license_expression: apache-2.0 OR mit`, `..._spdx: Apache-2.0 OR MIT`, `extracted_license_statement: Apache-2.0/MIT`.
- Spot check: scanning a crate with `license = "Apache-2.0/MIT"` now reports the declared expression at both the file-level package_data and the assembled package (previously null).
- Regression: `cargo test --lib parsers::cargo` (41) and the parsers golden suite (317) pass with no fixture churn.

## Intentional differences from Python

- None; matches ScanCode's handling of Cargo's legacy `/` dual-license separator.