### PR TITLE
chore: address greptile follow-ups on #1087 and #1088

### DIFF
--- a/src/parsers/cargo_test.rs
+++ b/src/parsers/cargo_test.rs
@@ -243,6 +243,41 @@ license = "Apache-2.0/MIT"
     }
 
     #[test]
+    fn test_legacy_slash_dual_license_handles_spacing_and_chains() {
+        // Space-padded slashes and three-license chains both seen in the wild.
+        for (license, expected, expected_spdx) in [
+            ("Apache-2.0 / MIT", "apache-2.0 OR mit", "Apache-2.0 OR MIT"),
+            (
+                "MIT/Apache-2.0/BSD-3-Clause",
+                "apache-2.0 OR bsd-new OR mit",
+                "Apache-2.0 OR BSD-3-Clause OR MIT",
+            ),
+        ] {
+            let content = format!(
+                "[package]\nname = \"slashed\"\nversion = \"1.0.0\"\nlicense = \"{license}\"\n"
+            );
+            let (_temp_file, cargo_path) = create_temp_cargo_toml(&content);
+            let package_data = CargoParser::extract_first_package(&cargo_path);
+
+            assert_eq!(
+                package_data.declared_license_expression.as_deref(),
+                Some(expected),
+                "declared for {license:?}"
+            );
+            assert_eq!(
+                package_data.declared_license_expression_spdx.as_deref(),
+                Some(expected_spdx),
+                "declared spdx for {license:?}"
+            );
+            assert_eq!(
+                package_data.extracted_license_statement.as_deref(),
+                Some(license),
+                "extracted statement stays source-faithful for {license:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_extract_short_composite_declared_license_preserves_mit_zero_and_or() {
         let content = r#"
 [package]

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1383,6 +1383,12 @@ fn path_is_within_root(path: &str, root: &str) -> bool {
 }
 
 fn join_reference_candidate(base: &str, referenced_filename: &str) -> String {
+    // Deliberately use string concatenation rather than `Path::join` here:
+    // `Path::join` treats an OS-absolute `referenced_filename` as a root
+    // replacement (`Path::new("pkg/ios").join("/LICENSE")` -> `/LICENSE`), which
+    // is wrong for scan-relative file-map keys. Absolute references are handled
+    // separately by the caller, and these keys are never OS-absolute, so joining
+    // onto the base and normalizing is the intended behavior.
     let joined = if base.is_empty() {
         referenced_filename.replace('\\', "/")
     } else {


### PR DESCRIPTION
## Summary

Small post-merge follow-ups for the two valid (non-blocking) greptile P2 suggestions on #1087 and #1088:

- **#1087** (`reference_following`): add a comment documenting why `join_reference_candidate` uses string concatenation instead of `Path::join` (Path::join would treat an OS-absolute `referenced_filename` as a root replacement, wrong for scan-relative file-map keys; absolute references are handled separately by the caller).
- **#1088** (`cargo`): add regression coverage for two real-world legacy slash forms that the implementation already handles but were untested — space-padded `Apache-2.0 / MIT` and the three-license chain `MIT/Apache-2.0/BSD-3-Clause`.

## Issues

- Follow-up to #1087 and #1088 (both merged).

## Scope and exclusions

- Included: one clarifying comment and one new cargo test (no behavior change).

## How to verify

- `cargo test --lib test_legacy_slash_dual_license_handles_spacing_and_chains` (new) and `cargo test --lib reference_following` (27) pass.

## Expected-output fixture changes

- None.