### PR TITLE
docs(benchmarks): refresh next 10 targets on M5 Pro 4-proc methodology

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **13.4× median speedup** and **13.4× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **19.7×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **13.6× median speedup** and **13.5× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **19.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -108,12 +108,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `24.48s`; ScanCode `272.67s`
 - Broader ABOUT, Python, wheel, and Docker package visibility (`126` vs `1` packages, `117` vs `104` dependencies) across committed `.ABOUT` sidecars, bundled `thirdparty/dist/*.whl` artifacts, and product manifests, with real ecosystem PURLs derived from `download_url` metadata instead of fallback `pkg:about/...` identities
 
-##### [aboutcode-org/scancode.io @ 904373a](https://github.com/aboutcode-org/scancode.io/tree/904373abf472e0567a99a3b1b5213e084040b5c1) — **9.16× faster**
+##### [aboutcode-org/scancode.io @ 904373a](https://github.com/aboutcode-org/scancode.io/tree/904373abf472e0567a99a3b1b5213e084040b5c1) — **12.82× faster**
 
-- Files: 764
-- Run context: 2026-04-24 · scancode.io-63382 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `42.96s`; ScanCode `393.40s`
-- Broader ABOUT and Python package visibility (`25` vs `1` packages, `284` vs `56` dependencies) across committed `.ABOUT` files, root and suffixed `pyproject.toml` manifests, and `uv.lock`, plus zero scan-file errors where ScanCode times out on large generated scan-result JSON fixtures
+- Files: 763
+- Run context: 2026-06-15 · scancode.io-34771 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `22.82s`; ScanCode `292.75s`
+- Broader ABOUT and Python package visibility (`28` vs `1` packages, `292` vs `56` dependencies) across committed `.ABOUT` files, root and suffixed `pyproject.toml` manifests, and `uv.lock`, plus zero scan-file errors where ScanCode times out on large generated scan-result JSON fixtures
 
 ##### [aboutcode-org/scancode-toolkit @ 6570c13](https://github.com/aboutcode-org/scancode-toolkit/tree/6570c131e2821388286f661368a70e0120aaf2c6) — **13.48× faster**
 
@@ -280,12 +280,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.53s`; ScanCode `57.19s`
 - Direct Hex dependency extraction (`367` vs `0` dependencies) from the root `mix.lock`'s legacy 7-element hex tuples that ScanCode does not parse, defaulting `hexpm` as the repository for tuples that omit it, with MIT license detection preserved across the Elixir source tree
 
-##### [elixir-ecto/ecto @ 28d9282](https://github.com/elixir-ecto/ecto/tree/28d928267388018d5b0bb1f83e04368b7e8cae50) — **9.66× faster**
+##### [elixir-ecto/ecto @ 28d9282](https://github.com/elixir-ecto/ecto/tree/28d928267388018d5b0bb1f83e04368b7e8cae50) — **13.56× faster**
 
 - Files: 156
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `14.03s`; ScanCode `135.56s`
-- Broader Hex dependency extraction (`16` vs `0`) from the repo-root `mix.lock` plus `examples/friends/mix.lock`, with direct locked package identities for entries such as `ecto_sql`, `postgrex`, and `telemetry` that ScanCode leaves dependency-blind
+- Run context: 2026-06-15 · ecto-66264 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.85s`; ScanCode `65.75s`
+- Broader Hex dependency extraction (`19` vs `0`) from the repo-root `mix.lock` plus `examples/friends/mix.lock`, with direct locked package identities for entries such as `ecto_sql`, `postgrex`, and `telemetry` that ScanCode leaves dependency-blind
 
 ##### [elixir-plug/plug @ 47649aa](https://github.com/elixir-plug/plug/tree/47649aa7bb910f481b66cc3e98c14b2c3b761c3c) — **10.51× faster**
 
@@ -315,11 +315,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `16.74s`; ScanCode `214.30s`
 - Broader Erlang/Rebar package and dependency extraction (`2` vs `1` packages, `43` vs `3` dependencies) from the root `rebar.config`, `rebar.lock`, nested `_checkouts/configure_deps` manifests, and committed Dockerfiles, with the bundled `priv/mod_invites/copyright` notice kept as clue-level license evidence instead of being overstated as Debian package metadata
 
-##### [vernemq/vernemq @ 4681e54](https://github.com/vernemq/vernemq/tree/4681e5490cc42e6cc26a504bb4b3c5413315c21f) — **10.74× faster**
+##### [vernemq/vernemq @ 4681e54](https://github.com/vernemq/vernemq/tree/4681e5490cc42e6cc26a504bb4b3c5413315c21f) — **14.07× faster**
 
 - Files: 441
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `13.90s`; ScanCode `149.29s`
+- Run context: 2026-06-15 · vernemq-36332 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.12s`; ScanCode `86.10s`
 - Broader Erlang/Rebar dependency extraction (`119` vs `0`) from the repo-root and per-app `rebar.config` / `.app.src` manifests, plus direct `.gitmodules` package visibility and mixed Hex or git package identity across the VerneMQ app tree where ScanCode stays manifest-blind
 
 #### JavaScript / TypeScript / web stacks
@@ -594,12 +594,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.71s`; ScanCode `43.86s`
 - Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) while preserving the repository's `Apache-2.0 OR MIT` README license semantics and normalizing docs.rs and Keep a Changelog links without trailing-slash drift
 
-##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **9.83× faster**
+##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **14.51× faster**
 
-- Files: 11,496
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `200.80s`; ScanCode `1974.56s`
-- Broader Bazel package and dependency extraction (`1729` vs `1711` packages, `79` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, with richer Debian and RPM sidecar package metadata
+- Files: 11,495
+- Run context: 2026-06-15 · bazel-69519 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `96.27s`; ScanCode `1396.87s`
+- Broader Bazel package and dependency extraction (`1746` vs `1711` packages, `129` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, with richer Debian and RPM sidecar package metadata
 
 ##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **12.29× faster**
 
@@ -622,11 +622,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.54s`; ScanCode `161.21s`
 - Cleaner benchmark-corpus author extraction in `bench/data/gsoc-2018.json` and `bench/data/github_events.json`, replacing ScanCode junk such as `type' Person name' AadityaNair` and prose fragments with actual participant names while preserving Unicode identities like `Nils Jørgen Mittet`, plus Unicode-preserving holder normalization for `René Ferdinand Rivera Morell` on build metadata
 
-##### [boostorg/serialization @ 097a6c6](https://github.com/boostorg/serialization/tree/097a6c63a137be836d663cdb27f2e6c803a4100b) — **10.06× faster**
+##### [boostorg/serialization @ 097a6c6](https://github.com/boostorg/serialization/tree/097a6c63a137be836d663cdb27f2e6c803a4100b) — **14.30× faster**
 
-- Files: 542
-- Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `13.15s`; ScanCode `132.33s`
+- Files: 541
+- Run context: 2026-06-15 · serialization-18869 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.85s`; ScanCode `83.67s`
 - Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with multi-person codecvt attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
 
 ##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
@@ -1051,11 +1051,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `11.11s`; ScanCode `122.53s`
 - Matched top-level package coverage (`1` vs `1`) with broader package-adjacent dependency extraction (`11` vs `0`) from `.gitmodules`, `Cartfile.private`, and `Cartfile.resolved`, plus Unicode-preserving author recovery for `Robert Böhnke` and cleaner normalization of repeated workflow contact addresses and GitHub query URLs
 
-##### [ocetnik/react-native-background-timer @ 244ea3e](https://github.com/ocetnik/react-native-background-timer/tree/244ea3e554a6c480f22c818831ea0dd7c0587708) — **10.34× faster**
+##### [ocetnik/react-native-background-timer @ 244ea3e](https://github.com/ocetnik/react-native-background-timer/tree/244ea3e554a6c480f22c818831ea0dd7c0587708) — **9.46× faster**
 
 - Files: 19
-- Run context: 2026-05-07 · react-native-background-timer-68507 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `9.41s`; ScanCode `97.28s`
+- Run context: 2026-06-15 · react-native-background-timer-29353 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.79s`; ScanCode `45.33s`
 - Broader React Native mobile dependency extraction (`1493` vs `1492`) from the Android `build.gradle` React Native coordinate, plus direct AndroidManifest package visibility and Unicode-preserving `Dávid Ocetník` copyright and holder recovery instead of ScanCode's ASCII fallback
 
 ##### [pointfreeco/swift-composable-architecture @ 7517cc3](https://github.com/pointfreeco/swift-composable-architecture/tree/7517cc3) — **16.6× faster**
@@ -1079,11 +1079,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `12.13s`; ScanCode `174.19s`
 - Broader Dart/Flutter workspace package and dependency extraction (`29` vs `26` packages, `1417` vs `1350` dependencies) from package, example, and test `pubspec.yaml` manifests across the monorepo, plus cleaner structured-literal copyright extraction on generated Dart and JSON fixtures
 
-##### [SDWebImage/SDWebImage @ c3ad5e1](https://github.com/SDWebImage/SDWebImage/tree/c3ad5e1a9bf55c9b76d4c362430b5fcded96c502) — **10.20× faster**
+##### [SDWebImage/SDWebImage @ c3ad5e1](https://github.com/SDWebImage/SDWebImage/tree/c3ad5e1a9bf55c9b76d4c362430b5fcded96c502) — **16.45× faster**
 
-- Files: 371
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `12.61s`; ScanCode `128.67s`
+- Files: 369
+- Run context: 2026-06-15 · SDWebImage-25316 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.61s`; ScanCode `92.26s`
 - Matched top-level CocoaPods package coverage (`3` vs `3`) with broader dependency extraction (`10` vs `0`) from `Podfile`-declared pod relationships, while preserving separate package identities for the sibling test podspecs
 
 ##### [SwiftFiddle/swiftfiddle-web @ df09b80](https://github.com/SwiftFiddle/swiftfiddle-web/tree/df09b80) — **9.88× faster**
@@ -1195,11 +1195,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.01s`; ScanCode `47.52s`
 - Direct CPAN package identity and broader dependency extraction (`1` vs `0` packages, `44` vs `0` dependencies) from `META.json` prereq scopes, with repository and homepage metadata preserved from CPAN resources
 
-##### [PerlDancer/Dancer2 @ a1faa22](https://github.com/PerlDancer/Dancer2/tree/a1faa22a78ff6f3c40ef5b71424dbe3f2c4a13a8) — **10.44× faster**
+##### [PerlDancer/Dancer2 @ a1faa22](https://github.com/PerlDancer/Dancer2/tree/a1faa22a78ff6f3c40ef5b71424dbe3f2c4a13a8) — **12.84× faster**
 
 - Files: 436
-- Run context: 2026-04-18 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `9.33s`; ScanCode `97.37s`
+- Run context: 2026-06-15 · Dancer2-33278 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.88s`; ScanCode `62.68s`
 - Direct CPAN package identity on the root `dist.ini`, extra dependency visibility from the shipped skeleton `Makefile.PL`, plus Docker package visibility on `share/docker/Dockerfile`, with unresolved template placeholders kept out of CPAN names and PURLs
 
 ##### [Plack/Plack @ b3984f1](https://github.com/Plack/Plack/tree/b3984f1c59de36903bb924c9da1273f3e11d4d2b) — **9.96× faster**
@@ -1281,11 +1281,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.21s`; ScanCode `59.75s`
 - Direct Julia package visibility and much broader dependency extraction (`110` vs `0` packages, `150` vs `0` dependencies) from `Project.toml`, `Manifest.toml`, and sibling project-plus-manifest assembly across root, docs, and test fixture trees, with safer URL credential stripping in Julia metadata examples
 
-##### [JuliaPlots/Plots.jl @ 70f0cd7](https://github.com/JuliaPlots/Plots.jl/tree/70f0cd7a59dc667791503eaf0ab14190069a9be4) — **9.58× faster**
+##### [JuliaPlots/Plots.jl @ 70f0cd7](https://github.com/JuliaPlots/Plots.jl/tree/70f0cd7a59dc667791503eaf0ab14190069a9be4) — **13.16× faster**
 
-- Files: 327
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `10.67s`; ScanCode `102.27s`
+- Files: 324
+- Run context: 2026-06-15 · Plots.jl-63266 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.80s`; ScanCode `63.17s`
 - Direct Julia package visibility and much broader dependency extraction (`7` vs `0` packages, `202` vs `0` dependencies) from sibling `Project.toml` files across `Plots`, `GraphRecipes`, `RecipesBase`, and test environments, with richer author recovery on Julia metadata or README ownership lines and safer URL normalization
 
 ##### [nix-community/dream2nix @ 69eb01f](https://github.com/nix-community/dream2nix/tree/69eb01fa0995e1e90add49d8ca5bcba213b0416f) — **6.61× faster**
@@ -1351,12 +1351,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.94s`; ScanCode `42.68s`
 - Direct `publiccode.yml` package visibility on the root metadata file (`1` vs `0` on that file), with cleaner SPDX copyright placeholder normalization for `Univention GmbH` and the same zero-scan-error behavior under the shared profile
 
-##### [yesodweb/yesod @ 1b033c7](https://github.com/yesodweb/yesod/tree/1b033c741ce81d01070de993b285a17e71178156) — **9.32× faster**
+##### [yesodweb/yesod @ 1b033c7](https://github.com/yesodweb/yesod/tree/1b033c741ce81d01070de993b285a17e71178156) — **12.00× faster**
 
-- Files: 324
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.62s`; ScanCode `99.03s`
-- Broader multi-package Hackage extraction (`16` vs `0` packages, `391` vs `0` dependencies) from the repo's many sibling `yesod-*/*.cabal` manifests, with explicit package identities across the Yesod family where ScanCode stays manifest-blind
+- Files: 318
+- Run context: 2026-06-15 · yesod-53259 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.86s`; ScanCode `58.32s`
+- Broader multi-package Hackage extraction (`16` vs `0` packages, `392` vs `0` dependencies) from the repo's many sibling `yesod-*/*.cabal` manifests, with explicit package identities across the Yesod family where ScanCode stays manifest-blind
 
 ### Artifact/rootfs-backed targets
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -155,9 +155,9 @@ ScanCode: 42.68s</title></rect>
     <rect x="291.17" y="427.52" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 ScanCode: 69.61s</title></rect>
-    <rect x="294.90" y="411.70" width="8" height="8" fill="#d97706" rx="1.5"><title>ocetnik/react-native-background-timer @ 244ea3e
+    <rect x="294.90" y="447.79" width="8" height="8" fill="#d97706" rx="1.5"><title>ocetnik/react-native-background-timer @ 244ea3e
 Files: 19
-ScanCode: 97.28s</title></rect>
+ScanCode: 45.33s</title></rect>
     <rect x="305.00" y="436.72" width="8" height="8" fill="#d97706" rx="1.5"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 ScanCode: 57.29s</title></rect>
@@ -230,9 +230,9 @@ ScanCode: 45.20s</title></rect>
     <rect x="428.98" y="388.90" width="8" height="8" fill="#d97706" rx="1.5"><title>fmtlib/fmt @ 2cb3983
 Files: 133
 ScanCode: 157.63s</title></rect>
-    <rect x="439.98" y="396.02" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-ecto/ecto @ 28d9282
+    <rect x="439.98" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
-ScanCode: 135.56s</title></rect>
+ScanCode: 65.75s</title></rect>
     <rect x="441.29" y="385.10" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
 Files: 159
 ScanCode: 170.82s</title></rect>
@@ -275,30 +275,30 @@ ScanCode: 54.67s</title></rect>
     <rect x="486.18" y="436.80" width="8" height="8" fill="#d97706" rx="1.5"><title>bitwalker/distillery @ 3ab4d61
 Files: 305
 ScanCode: 57.19s</title></rect>
-    <rect x="490.34" y="410.86" width="8" height="8" fill="#d97706" rx="1.5"><title>yesodweb/yesod @ 1b033c7
+    <rect x="489.05" y="435.88" width="8" height="8" fill="#d97706" rx="1.5"><title>yesodweb/yesod @ 1b033c7
+Files: 318
+ScanCode: 58.32s</title></rect>
+    <rect x="490.34" y="432.10" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaPlots/Plots.jl @ 70f0cd7
 Files: 324
-ScanCode: 99.03s</title></rect>
-    <rect x="490.97" y="409.34" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaPlots/Plots.jl @ 70f0cd7
-Files: 327
-ScanCode: 102.27s</title></rect>
+ScanCode: 63.17s</title></rect>
     <rect x="498.55" y="443.94" width="8" height="8" fill="#d97706" rx="1.5"><title>docker-library/official-images @ 71567fb
 Files: 365
 ScanCode: 49.17s</title></rect>
-    <rect x="499.67" y="398.49" width="8" height="8" fill="#d97706" rx="1.5"><title>SDWebImage/SDWebImage @ c3ad5e1
-Files: 371
-ScanCode: 128.67s</title></rect>
+    <rect x="499.30" y="414.21" width="8" height="8" fill="#d97706" rx="1.5"><title>SDWebImage/SDWebImage @ c3ad5e1
+Files: 369
+ScanCode: 92.26s</title></rect>
     <rect x="508.39" y="412.34" width="8" height="8" fill="#d97706" rx="1.5"><title>debian:bookworm-slim dpkg DB snapshot @ sha256:f065376
 Files: 421
 ScanCode: 95.97s</title></rect>
     <rect x="509.68" y="380.92" width="8" height="8" fill="#d97706" rx="1.5"><title>pydata/xarray @ f7e47a1
 Files: 429
 ScanCode: 186.62s</title></rect>
-    <rect x="510.80" y="411.66" width="8" height="8" fill="#d97706" rx="1.5"><title>PerlDancer/Dancer2 @ a1faa22
+    <rect x="510.80" y="432.47" width="8" height="8" fill="#d97706" rx="1.5"><title>PerlDancer/Dancer2 @ a1faa22
 Files: 436
-ScanCode: 97.37s</title></rect>
-    <rect x="511.58" y="391.47" width="8" height="8" fill="#d97706" rx="1.5"><title>vernemq/vernemq @ 4681e54
+ScanCode: 62.68s</title></rect>
+    <rect x="511.58" y="417.47" width="8" height="8" fill="#d97706" rx="1.5"><title>vernemq/vernemq @ 4681e54
 Files: 441
-ScanCode: 149.29s</title></rect>
+ScanCode: 86.10s</title></rect>
     <rect x="512.36" y="396.07" width="8" height="8" fill="#d97706" rx="1.5"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
 ScanCode: 135.43s</title></rect>
@@ -323,9 +323,9 @@ ScanCode: 211.97s</title></rect>
     <rect x="525.54" y="396.10" width="8" height="8" fill="#d97706" rx="1.5"><title>pyodide/pyodide @ 86e27b0
 Files: 540
 ScanCode: 135.33s</title></rect>
-    <rect x="525.79" y="397.16" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/serialization @ 097a6c6
-Files: 542
-ScanCode: 132.33s</title></rect>
+    <rect x="525.67" y="418.82" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/serialization @ 097a6c6
+Files: 541
+ScanCode: 83.67s</title></rect>
     <rect x="526.30" y="381.25" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 ScanCode: 185.33s</title></rect>
@@ -368,9 +368,9 @@ ScanCode: 161.21s</title></rect>
     <rect x="548.54" y="380.50" width="8" height="8" fill="#d97706" rx="1.5"><title>xiph/opus @ 22244de
 Files: 754
 ScanCode: 188.27s</title></rect>
-    <rect x="549.45" y="345.68" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode.io @ 904373a
-Files: 764
-ScanCode: 393.40s</title></rect>
+    <rect x="549.36" y="359.65" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode.io @ 904373a
+Files: 763
+ScanCode: 292.75s</title></rect>
     <rect x="555.41" y="408.67" width="8" height="8" fill="#d97706" rx="1.5"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 ScanCode: 103.73s</title></rect>
@@ -644,9 +644,9 @@ ScanCode: 694.17s</title></rect>
     <rect x="733.17" y="258.43" width="8" height="8" fill="#d97706" rx="1.5"><title>qemu/qemu @ da6c4fe
 Files: 10989
 ScanCode: 2493.21s</title></rect>
-    <rect x="736.27" y="269.45" width="8" height="8" fill="#d97706" rx="1.5"><title>bazelbuild/bazel @ eb5aeaa
-Files: 11496
-ScanCode: 1974.56s</title></rect>
+    <rect x="736.27" y="285.81" width="8" height="8" fill="#d97706" rx="1.5"><title>bazelbuild/bazel @ eb5aeaa
+Files: 11495
+ScanCode: 1396.87s</title></rect>
     <rect x="736.95" y="313.57" width="8" height="8" fill="#d97706" rx="1.5"><title>spring-projects/spring-boot @ 53827d4
 Files: 11610
 ScanCode: 776.24s</title></rect>
@@ -823,9 +823,9 @@ Provenant: 4.94s</title></circle>
     <circle cx="295.17" cy="521.76" r="4.5" fill="#2563eb"><title>distroless base-debian13 status.d @ sha256:c83f022
 Files: 18
 Provenant: 10.31s</title></circle>
-    <circle cx="298.90" cy="526.07" r="4.5" fill="#2563eb"><title>ocetnik/react-native-background-timer @ 244ea3e
+    <circle cx="298.90" cy="557.98" r="4.5" fill="#2563eb"><title>ocetnik/react-native-background-timer @ 244ea3e
 Files: 19
-Provenant: 9.41s</title></circle>
+Provenant: 4.79s</title></circle>
     <circle cx="309.00" cy="542.62" r="4.5" fill="#2563eb"><title>Apress pro-html5-vs2015 legacy NuGet manifests @ 3599d94
 Files: 22
 Provenant: 6.63s</title></circle>
@@ -898,9 +898,9 @@ Provenant: 4.74s</title></circle>
     <circle cx="432.98" cy="514.62" r="4.5" fill="#2563eb"><title>fmtlib/fmt @ 2cb3983
 Files: 133
 Provenant: 11.99s</title></circle>
-    <circle cx="443.98" cy="507.20" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
+    <circle cx="443.98" cy="557.39" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
-Provenant: 14.03s</title></circle>
+Provenant: 4.85s</title></circle>
     <circle cx="445.29" cy="519.13" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
 Files: 159
 Provenant: 10.90s</title></circle>
@@ -943,30 +943,30 @@ Provenant: 5.06s</title></circle>
     <circle cx="490.18" cy="543.34" r="4.5" fill="#2563eb"><title>bitwalker/distillery @ 3ab4d61
 Files: 305
 Provenant: 6.53s</title></circle>
-    <circle cx="494.34" cy="520.36" r="4.5" fill="#2563eb"><title>yesodweb/yesod @ 1b033c7
+    <circle cx="493.05" cy="557.29" r="4.5" fill="#2563eb"><title>yesodweb/yesod @ 1b033c7
+Files: 318
+Provenant: 4.86s</title></circle>
+    <circle cx="494.34" cy="557.88" r="4.5" fill="#2563eb"><title>JuliaPlots/Plots.jl @ 70f0cd7
 Files: 324
-Provenant: 10.62s</title></circle>
-    <circle cx="494.97" cy="520.14" r="4.5" fill="#2563eb"><title>JuliaPlots/Plots.jl @ 70f0cd7
-Files: 327
-Provenant: 10.67s</title></circle>
+Provenant: 4.80s</title></circle>
     <circle cx="502.55" cy="557.98" r="4.5" fill="#2563eb"><title>docker-library/official-images @ 71567fb
 Files: 365
 Provenant: 4.79s</title></circle>
-    <circle cx="503.67" cy="512.24" r="4.5" fill="#2563eb"><title>SDWebImage/SDWebImage @ c3ad5e1
-Files: 371
-Provenant: 12.61s</title></circle>
+    <circle cx="503.30" cy="550.51" r="4.5" fill="#2563eb"><title>SDWebImage/SDWebImage @ c3ad5e1
+Files: 369
+Provenant: 5.61s</title></circle>
     <circle cx="512.39" cy="517.17" r="4.5" fill="#2563eb"><title>debian:bookworm-slim dpkg DB snapshot @ sha256:f065376
 Files: 421
 Provenant: 11.36s</title></circle>
     <circle cx="513.68" cy="511.20" r="4.5" fill="#2563eb"><title>pydata/xarray @ f7e47a1
 Files: 429
 Provenant: 12.89s</title></circle>
-    <circle cx="514.80" cy="526.48" r="4.5" fill="#2563eb"><title>PerlDancer/Dancer2 @ a1faa22
+    <circle cx="514.80" cy="557.10" r="4.5" fill="#2563eb"><title>PerlDancer/Dancer2 @ a1faa22
 Files: 436
-Provenant: 9.33s</title></circle>
-    <circle cx="515.58" cy="507.64" r="4.5" fill="#2563eb"><title>vernemq/vernemq @ 4681e54
+Provenant: 4.88s</title></circle>
+    <circle cx="515.58" cy="546.40" r="4.5" fill="#2563eb"><title>vernemq/vernemq @ 4681e54
 Files: 441
-Provenant: 13.90s</title></circle>
+Provenant: 6.12s</title></circle>
     <circle cx="516.36" cy="520.00" r="4.5" fill="#2563eb"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
 Provenant: 10.70s</title></circle>
@@ -991,9 +991,9 @@ Provenant: 11.92s</title></circle>
     <circle cx="529.54" cy="519.69" r="4.5" fill="#2563eb"><title>pyodide/pyodide @ 86e27b0
 Files: 540
 Provenant: 10.77s</title></circle>
-    <circle cx="529.79" cy="510.26" r="4.5" fill="#2563eb"><title>boostorg/serialization @ 097a6c6
-Files: 542
-Provenant: 13.15s</title></circle>
+    <circle cx="529.67" cy="548.53" r="4.5" fill="#2563eb"><title>boostorg/serialization @ 097a6c6
+Files: 541
+Provenant: 5.85s</title></circle>
     <circle cx="530.30" cy="507.88" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 Provenant: 13.83s</title></circle>
@@ -1036,9 +1036,9 @@ Provenant: 14.54s</title></circle>
     <circle cx="552.54" cy="499.85" r="4.5" fill="#2563eb"><title>xiph/opus @ 22244de
 Files: 754
 Provenant: 16.39s</title></circle>
-    <circle cx="553.45" cy="454.32" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode.io @ 904373a
-Files: 764
-Provenant: 42.96s</title></circle>
+    <circle cx="553.36" cy="484.22" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode.io @ 904373a
+Files: 763
+Provenant: 22.82s</title></circle>
     <circle cx="559.41" cy="551.02" r="4.5" fill="#2563eb"><title>tokio-rs/tokio @ 5db10f5
 Files: 833
 Provenant: 5.55s</title></circle>
@@ -1312,9 +1312,9 @@ Provenant: 48.11s</title></circle>
     <circle cx="737.17" cy="425.83" r="4.5" fill="#2563eb"><title>qemu/qemu @ da6c4fe
 Files: 10989
 Provenant: 78.51s</title></circle>
-    <circle cx="740.27" cy="381.46" r="4.5" fill="#2563eb"><title>bazelbuild/bazel @ eb5aeaa
-Files: 11496
-Provenant: 200.80s</title></circle>
+    <circle cx="740.27" cy="416.20" r="4.5" fill="#2563eb"><title>bazelbuild/bazel @ eb5aeaa
+Files: 11495
+Provenant: 96.27s</title></circle>
     <circle cx="740.95" cy="432.92" r="4.5" fill="#2563eb"><title>spring-projects/spring-boot @ 53827d4
 Files: 11610
 Provenant: 67.58s</title></circle>


### PR DESCRIPTION
## Summary

- Re-ran 10 more stale M1-Max benchmark rows (lowest-speedup repos, chosen for ecosystem breadth) under the current Apple M5 Pro / 4-proc methodology and refreshed their rows + regenerated the chart/headline. Median rises **13.4× → 13.6×**.

| Target | Before | After |
|---|---|---|
| SDWebImage/SDWebImage | 10.20× | **16.45×** |
| bazelbuild/bazel | 9.83× | **14.51×** |
| boostorg/serialization | 10.06× | **14.30×** |
| vernemq/vernemq | 10.74× | **14.07×** |
| elixir-ecto/ecto | 9.66× | **13.56×** |
| JuliaPlots/Plots.jl | 9.58× | **13.16×** |
| PerlDancer/Dancer2 | 10.44× | **12.84×** |
| aboutcode-org/scancode.io | 9.16× | **12.82×** |
| yesodweb/yesod | 9.32× | **12.00×** |
| ocetnik/react-native-background-timer | 10.34× | **9.46×** |

## Issues

- Covers: benchmark refresh sweep 6.
- Filed during triage: #1090 (Bazel BUILD-target declared-license inconsistency), #1091 (CocoaPods `license = { :type => 'X' }` not normalized).

## Scope and exclusions

- Included: the 10 rows above + regenerated SVG/headline; outcome-bullet counts updated where they grew since the M1 runs (scancode.io, yesod, ecto, bazel).
- Explicit exclusions: no code changes.

## How to verify

- Each run-id (e.g. `bazel-69519`) maps to `.provenant/compare-runs/<ts>-<run-id>/`; timings are same-host wall-clock.
- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` reproduces the SVG/headline.

## Notes on triage

- All 10 are Provenant wins. Recurring ScanCode-"more" signals were benign: source-faithful copyright rendering (Haskell `-- Copyright :`, Erlang `%% Copyright`, markdown `> Copyright`, Unicode `René`/`Dávid`, full names where ScanCode truncates), SC junk PV drops (the bare word `copyrights`, binary-symbol/`COPR (url)`/prose false positives), and honest-`null` declared where ScanCode backfills from co-located/test-fixture files. `react-native-background-timer` dips (10.34→9.46×) as a 19-file startup-bound repo under the standardized 4-proc methodology.
- Two genuine gaps were filed rather than blocking the refresh: **#1090** (Bazel BUILD targets get the BUILD header's Apache license inconsistently — net −94 vs ScanCode) and **#1091** (`license = { :type => 'X' }` podspec form left unnormalized). flutterfire's earlier cocoapods `../LICENSE` gap (#1085) is already fixed and merged (#1087).