### PR TITLE
docs(benchmarks): round scancode.io speedup to 12.83x

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -108,7 +108,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `24.48s`; ScanCode `272.67s`
 - Broader ABOUT, Python, wheel, and Docker package visibility (`126` vs `1` packages, `117` vs `104` dependencies) across committed `.ABOUT` sidecars, bundled `thirdparty/dist/*.whl` artifacts, and product manifests, with real ecosystem PURLs derived from `download_url` metadata instead of fallback `pkg:about/...` identities
 
-##### [aboutcode-org/scancode.io @ 904373a](https://github.com/aboutcode-org/scancode.io/tree/904373abf472e0567a99a3b1b5213e084040b5c1) — **12.82× faster**
+##### [aboutcode-org/scancode.io @ 904373a](https://github.com/aboutcode-org/scancode.io/tree/904373abf472e0567a99a3b1b5213e084040b5c1) — **12.83× faster**
 
 - Files: 763
 - Run context: 2026-06-15 · scancode.io-34771 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc


### PR DESCRIPTION
## Summary

- `aboutcode-org/scancode.io` reported **12.82×** but `292.75 / 22.82 = 12.8287`, which rounds to **12.83×** (the value was truncated). Addresses the greptile rounding nit raised on #1092; every other sweep-6 entry already rounds correctly.

## Issues

- Follow-up to the greptile review on #1092.

## How to verify

- `292.75 / 22.82 = 12.83` (2 d.p.). No other rows change; chart/headline unaffected.