### PR TITLE
fix(parsers): extract CocoaPods license :type hash value for declared license

### DIFF
--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -259,6 +259,13 @@ static DEPENDENCY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 fn extract_license_statement(content: &str) -> Option<String> {
+    let raw_license = extract_raw_field(content, &LICENSE_PATTERN)?;
+    // For Ruby-hash license declarations, capture the `:type` value so the
+    // extracted statement is the license text (e.g. `BSD`) rather than the
+    // malformed `:type = BSD` key/value pair produced by hash flattening.
+    if let Some(license_type) = extract_ruby_hash_type(&raw_license) {
+        return normalize_podspec_dynamic_metadata_value(&license_type);
+    }
     extract_field(content, &LICENSE_PATTERN)
         .map(|value| normalize_ruby_hash_literal(&value))
         .and_then(|value| normalize_podspec_dynamic_metadata_value(&value))
@@ -889,6 +896,50 @@ end
         assert_eq!(declared.as_deref(), Some("mit"));
         assert_eq!(declared_spdx.as_deref(), Some("MIT"));
         assert_eq!(detections.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_license_statement_type_only_hash_uses_clean_value() {
+        let content = r#"
+Pod::Spec.new do |s|
+  s.license = { :type => 'BSD' }
+end
+"#;
+
+        // The extracted statement must be the clean license value, not the
+        // malformed `:type = BSD` flattened hash.
+        assert_eq!(extract_license_statement(content).as_deref(), Some("BSD"));
+    }
+
+    #[test]
+    fn test_podspec_type_only_hash_resolves_declared_license() {
+        let content = r#"
+Pod::Spec.new do |s|
+  s.name    = 'mypod'
+  s.version = '1.0.0'
+  s.license = { :type => 'BSD' }
+  s.summary = 'test'
+end
+"#;
+
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let file_path = temp_dir.path().join("mypod.podspec");
+        std::fs::write(&file_path, content).expect("write podspec");
+
+        let package_data = PodspecParser::extract_first_package(&file_path);
+
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("BSD")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("bsd-new")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("BSD-3-Clause")
+        );
     }
 
     #[test]

--- a/testdata/cocoapods-golden/podspec/BadgeHub.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/BadgeHub.podspec.expected.json
@@ -41,7 +41,7 @@
         ]
       }
     ],
-    "extracted_license_statement": ":type = MIT, :file = LICENSE",
+    "extracted_license_statement": "MIT",
     "extra_data": {
       "license_file": "LICENSE"
     },

--- a/testdata/cocoapods-golden/podspec/nanopb.podspec.expected.json
+++ b/testdata/cocoapods-golden/podspec/nanopb.podspec.expected.json
@@ -41,7 +41,7 @@
         ]
       }
     ],
-    "extracted_license_statement": ":type = zlib, :file = LICENSE.txt",
+    "extracted_license_statement": "zlib",
     "extra_data": {
       "license_file": "LICENSE.txt"
     },


### PR DESCRIPTION
## Summary

- Fix CocoaPods podspec license extraction for the type-only Ruby hash form `s.license = { :type => 'BSD' }` (no `:file`). The parser previously captured the flattened statement `:type = BSD`, which failed declared-license normalization and left `declared_license_expression` null. It now extracts the `:type` value (`BSD`), which resolves through the existing engine path to `bsd-new` / `BSD-3-Clause`.
- For any Ruby-hash license declaration, the extracted statement now uses the `:type` value when present, falling back to the prior flattening only when there is no `:type` key (so the `:file`-only case from #1087 is unchanged).

## Issues

- Closes: #1091

## Scope and exclusions

- Included: `:type`-only and `:type`+`:file` hash license statement extraction in the podspec parser; two focused unit tests; minimal golden fixture updates for the cleaned statement value.
- Explicit exclusions: no changes to the `:file`-only path (#1087), string-form licenses, or the license detection engine/overlays.

## How to verify

- `cd /tmp && mkdir -p podtype && printf "Pod::Spec.new do |s|\n  s.name = 'mypod'\n  s.version = '1.0.0'\n  s.license = { :type => 'BSD' }\n  s.summary = 'test'\nend\n" > podtype/mypod.podspec`
- `cargo run -q -- scan /tmp/podtype --package --license --json-pp -` and confirm the package `declared_license_expression` is `bsd-new`, `declared_license_expression_spdx` is `BSD-3-Clause`, and `extracted_license_statement` is `BSD` (was `:type = BSD`).

## Expected-output fixture changes

- Files changed: `testdata/cocoapods-golden/podspec/BadgeHub.podspec.expected.json`, `testdata/cocoapods-golden/podspec/nanopb.podspec.expected.json`.
- Why the new expected output is correct: both use combined `{ :type => ..., :file => ... }` hashes. The `extracted_license_statement` is now the clean license value (`MIT`, `zlib`) instead of the malformed flattened `:type = MIT, :file = LICENSE`. The declared expression, license detections, and `:file` referenced-filename data are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
