### PR TITLE
fix(bazel): resolve BUILD target licenses attribute as file references

### DIFF
--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -109,12 +109,27 @@ fn extract_package_from_statement(statement: &ast::AstStmt) -> Option<PackageDat
     let licenses = extract_string_list_kwarg(&call, "licenses");
     let purl = build_bazel_purl(&name, None).map(truncate_field);
 
+    // A Bazel `licenses` attribute lists license *file* references, not a license
+    // expression. Record them as declared-license file references so reference-
+    // following resolves each to the referenced file's license (else
+    // `unknown-license-reference`), rather than free-text detecting the attribute.
+    let extra_data = licenses.as_ref().map(|licenses| {
+        let references = licenses
+            .iter()
+            .map(|license| JsonValue::String(truncate_field(license.clone())))
+            .collect();
+        let mut map = JsonMap::new();
+        map.insert("license_files".to_string(), JsonValue::Array(references));
+        map.into_iter().collect()
+    });
+
     Some(PackageData {
         package_type: Some(BazelBuildParser::PACKAGE_TYPE),
         name: Some(truncate_field(name)),
         extracted_license_statement: licenses.map(|licenses| truncate_field(licenses.join(", "))),
         datasource_id: Some(DatasourceId::BazelBuild),
         purl,
+        extra_data,
         ..Default::default()
     })
 }

--- a/src/parsers/bazel_test.rs
+++ b/src/parsers/bazel_test.rs
@@ -134,6 +134,23 @@ cc_binary(
         pkg.extracted_license_statement,
         Some("notice, reciprocal".to_string())
     );
+    // `licenses` values become declared-license file references.
+    let license_files = pkg
+        .extra_data
+        .as_ref()
+        .and_then(|extra| extra.get("license_files"))
+        .and_then(serde_json::Value::as_array)
+        .expect("license_files reference list should be set");
+    let license_files: Vec<&str> = license_files
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert_eq!(license_files, vec!["notice", "reciprocal"]);
+    // No sibling file matches, so the reference resolves to an honest unknown.
+    assert_eq!(
+        pkg.declared_license_expression.as_deref(),
+        Some("unknown-license-reference")
+    );
 }
 
 #[test]
@@ -275,6 +292,13 @@ cc_binary(
     assert_eq!(pkg.package_type, Some(PackageType::Bazel));
     assert_eq!(pkg.name, Some("hello-world".to_string()));
     assert_eq!(pkg.extracted_license_statement, None);
+    // No reference, so no declared license is invented.
+    assert!(
+        pkg.extra_data
+            .as_ref()
+            .is_none_or(|extra| !extra.contains_key("license_files"))
+    );
+    assert_eq!(pkg.declared_license_expression, None);
 }
 
 #[test]

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file/codebase/BUILD
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file/codebase/BUILD
@@ -1,0 +1,10 @@
+java_library(
+    name = "with_license_file",
+    srcs = ["A.java"],
+    licenses = ["LICENSE"],
+)
+
+java_library(
+    name = "no_license_attr",
+    srcs = ["B.java"],
+)

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file/codebase/LICENSE
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file/codebase/LICENSE
@@ -1,0 +1,5 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file/expected.json
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file/expected.json
@@ -1,0 +1,293 @@
+{
+  "summary": {
+    "declared_license_expression": "apache-2.0",
+    "license_clarity_score": {
+      "score": 90,
+      "declared_license": true,
+      "identification_precision": true,
+      "has_license_text": true,
+      "declared_copyrights": false,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": false
+    },
+    "declared_holder": null,
+    "primary_language": "Starlark",
+    "other_license_expressions": [],
+    "other_holders": [],
+    "other_languages": []
+  },
+  "tallies": {
+    "detected_license_expression": [
+      {
+        "value": "apache-2.0",
+        "count": 2
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": [
+      {
+        "value": "Starlark",
+        "count": 1
+      }
+    ]
+  },
+  "tallies_of_key_files": {
+    "detected_license_expression": [
+      {
+        "value": "apache-2.0",
+        "count": 2
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": [
+      {
+        "value": "Starlark",
+        "count": 1
+      }
+    ]
+  },
+  "license_detections": [
+    {
+      "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+      "license_expression": "apache-2.0",
+      "license_expression_spdx": "Apache-2.0",
+      "detection_count": 1,
+      "detection_log": ["unknown-reference-to-local-file"],
+      "reference_matches": [
+        {
+          "from_file": "codebase/BUILD",
+          "license_expression": "unknown-license-reference",
+          "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+          "rule_identifier": "parser-declared-license"
+        },
+        {
+          "from_file": "codebase/LICENSE",
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "rule_identifier": "apache-2.0_791.RULE"
+        }
+      ]
+    },
+    {
+      "identifier": "apache_2_0-ea5a2828-6c70-408a-2f20-99577db519fd",
+      "license_expression": "apache-2.0",
+      "license_expression_spdx": "Apache-2.0",
+      "detection_count": 1,
+      "detection_log": [],
+      "reference_matches": [
+        {
+          "from_file": "codebase/LICENSE",
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "rule_identifier": "apache-2.0_791.RULE"
+        }
+      ]
+    }
+  ],
+  "license_references": [
+    {
+      "key": "apache-2.0",
+      "language": "en",
+      "short_name": "Apache 2.0",
+      "name": "Apache License 2.0",
+      "owner": "Apache Software Foundation",
+      "homepage_url": "http://www.apache.org/licenses/",
+      "spdx_license_key": "Apache-2.0",
+      "osi_license_key": "Apache-2.0",
+      "text_urls": ["http://www.apache.org/licenses/LICENSE-2.0"],
+      "osi_url": "http://opensource.org/licenses/apache2.0.php",
+      "faq_url": "http://www.apache.org/foundation/licence-FAQ.html",
+      "other_urls": [
+        "http://www.opensource.org/licenses/Apache-2.0",
+        "https://opensource.org/licenses/Apache-2.0",
+        "https://www.apache.org/licenses/LICENSE-2.0"
+      ],
+      "category": "Permissive",
+      "is_exception": false,
+      "is_unknown": false,
+      "is_generic": false,
+      "minimum_coverage": null,
+      "standard_notice": null
+    }
+  ],
+  "license_rule_references": [
+    {
+      "identifier": "apache-2.0_791.RULE",
+      "license_expression": "apache-2.0",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_791.RULE",
+      "is_synthetic": false,
+      "length": 12,
+      "referenced_filenames": []
+    }
+  ],
+  "packages": [
+    {
+      "type": "bazel",
+      "name": "no_license_attr",
+      "version": null,
+      "declared_license_expression": null,
+      "declared_license_expression_spdx": null,
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "datafile_paths": ["codebase/BUILD"],
+      "license_detections": [],
+      "other_license_detections": []
+    },
+    {
+      "type": "bazel",
+      "name": "with_license_file",
+      "version": null,
+      "declared_license_expression": "apache-2.0",
+      "declared_license_expression_spdx": "Apache-2.0",
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "datafile_paths": ["codebase/BUILD"],
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": ["unknown-reference-to-local-file"],
+          "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+          "matches": [
+            {
+              "from_file": "codebase/BUILD",
+              "matched_text": "LICENSE",
+              "license_expression": "unknown-license-reference",
+              "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            },
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "other_license_detections": []
+    }
+  ],
+  "files": [
+    {
+      "path": "codebase/BUILD",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": true,
+      "detected_license_expression": "apache-2.0",
+      "detected_license_expression_spdx": "Apache-2.0",
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": ["unknown-reference-to-local-file"],
+          "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+          "matches": [
+            {
+              "from_file": "codebase/BUILD",
+              "matched_text": "LICENSE",
+              "license_expression": "unknown-license-reference",
+              "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            },
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "package_data": [
+        {
+          "type": "bazel",
+          "name": "no_license_attr",
+          "version": null,
+          "declared_license_expression": null,
+          "declared_license_expression_spdx": null,
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "license_detections": [],
+          "other_license_detections": []
+        },
+        {
+          "type": "bazel",
+          "name": "with_license_file",
+          "version": null,
+          "declared_license_expression": "apache-2.0",
+          "declared_license_expression_spdx": "Apache-2.0",
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "license_detections": [
+            {
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "detection_log": ["unknown-reference-to-local-file"],
+              "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+              "matches": [
+                {
+                  "from_file": "codebase/BUILD",
+                  "matched_text": "LICENSE",
+                  "license_expression": "unknown-license-reference",
+                  "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+                  "rule_identifier": "parser-declared-license",
+                  "referenced_filenames": ["LICENSE"]
+                },
+                {
+                  "from_file": "codebase/LICENSE",
+                  "matched_text": null,
+                  "license_expression": "apache-2.0",
+                  "license_expression_spdx": "Apache-2.0",
+                  "rule_identifier": "apache-2.0_791.RULE",
+                  "referenced_filenames": []
+                }
+              ]
+            }
+          ],
+          "other_license_detections": []
+        }
+      ]
+    },
+    {
+      "path": "codebase/LICENSE",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": false,
+      "detected_license_expression": "apache-2.0",
+      "detected_license_expression_spdx": "Apache-2.0",
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": [],
+          "identifier": "apache_2_0-ea5a2828-6c70-408a-2f20-99577db519fd",
+          "matches": [
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "package_data": []
+    }
+  ]
+}

--- a/tests/post_processing_golden.rs
+++ b/tests/post_processing_golden.rs
@@ -438,6 +438,14 @@ Copyright - split out libs\0\xff",
     }
 
     #[test]
+    fn test_golden_reference_follow_bazel_build_license_file() {
+        assert_reference_follow_fixture_matches_expected(
+            "testdata/summarycode-golden/reference_following/bazel_build_license_file",
+            "testdata/summarycode-golden/reference_following/bazel_build_license_file/expected.json",
+        );
+    }
+
+    #[test]
     fn test_golden_reference_follow_readme_mit_see_license() {
         assert_reference_follow_fixture_matches_expected(
             "testdata/summarycode-golden/reference_following/readme_mit_see_license",


### PR DESCRIPTION
## Summary

- A Bazel target's `licenses` attribute is a list of license *file* references (this is how ScanCode's `BaseStarlarkManifestHandler.get_license_detections_and_expression` treats it: it tokenizes the values and resolves each against a sibling file in the package), **not** a free-text license expression.
- Provenant previously folded the `licenses` values only into `extracted_license_statement`. The fallback free-text declared-license detection then produced a declared license *only* for values that happen to look like an expression (e.g. `licenses = ["Apache 2.0"]` -> `apache-2.0`), while leaving real file references (`licenses = ["LICENSE"]`), Bazel license-type tokens (`notice`, `restricted`, `permissive`, ...), and label references (`//third_party:LICENSE`) as `None`. That arbitrary split is the root cause of the "some `pkg:bazel/*` targets get a declared license, most do not" inconsistency in #1090.
- This change records the `licenses` values as declared-license file references (`license_files` extra_data) so the existing post-assembly reference-following pass resolves any value that names a sibling license file (e.g. `["LICENSE"]` -> that file's `apache-2.0`), and otherwise yields an honest `unknown-license-reference` (ScanCode parity) rather than a guessed expression. Targets with no `licenses` attribute stay `None`.

### Investigation note on the issue framing

The issue hypothesized that ScanCode promotes the BUILD file's own ASF **header comment** to the target's declared license. Reading `reference/scancode-toolkit/src/packagedcode/build.py` shows ScanCode does **not** read the BUILD header at all; declared license comes solely from resolving the per-target `licenses` attribute against sibling files. On current `main` Provenant already gives a uniform `None` to all targets that lack a `licenses` attribute (e.g. every target in the real `LcovMergerTestUtils` BUILD), so the header is not the divergence. The genuine, reproducible inconsistency is the free-text handling of the `licenses` attribute, which this PR fixes by aligning to ScanCode's file-reference semantics.

## Issues

- Closes: #1090

## Scope and exclusions

- Included: Bazel `BUILD` (`bazel_build` datasource) `licenses` attribute handling and a scanner-wired reference-following golden.
- Explicit exclusions: Buck (`BUCK`/`METADATA.bzl`) shares the same Starlark base in ScanCode but is out of scope for this bazel-focused PR. The package-level `licenses(...)` directive and `default_applicable_licenses`/`rules_license` `license(...)` targets are still not attached to individual targets (unchanged behavior; would be a separate, larger feature).

## How to verify

- `cargo run -q -- scan <dir> --package --license --json-pp -` on a BUILD with `licenses = ["LICENSE"]` beside a real `LICENSE` file: the target's `declared_license_expression` resolves to that file's license (e.g. `apache-2.0`) with detection_log `unknown-reference-to-local-file`; a sibling target with no `licenses` attribute stays `None`; a `licenses = ["notice"]` target yields `unknown-license-reference`.
- New golden `tests/post_processing_golden.rs::test_golden_reference_follow_bazel_build_license_file` exercises the full scanner + assembly + reference-following path.

## Intentional differences from Python

- None intended; this converges Bazel `licenses` handling toward ScanCode's file-reference semantics.

## Follow-up work

- Deferred: applying the same file-reference treatment to Buck, and resolving package-level `default_applicable_licenses`/`rules_license` `license(...)` targets onto BUILD targets.

## Expected-output fixture changes

- Files changed: new fixture `testdata/summarycode-golden/reference_following/bazel_build_license_file/` (BUILD + LICENSE + expected.json).
- Why the new expected output is correct: it asserts the intended contract — `licenses = ["LICENSE"]` resolves to the sibling file's `apache-2.0`, and a target without a `licenses` attribute stays `None`. The detection is keyed to each target's own attribute, so no shared whole-file detection is smeared across targets (the #1077 invariant; its regression test `apply_package_reference_following_does_not_smear_multi_package_db_file_detection` and the #1083 coordinate-less manifest test both still pass).