### PR TITLE
fix(parsers): resolve Maven multi-license name declarations

### DIFF
--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -199,6 +199,26 @@ pub(crate) fn detect_declared_license_from_text(
     )
 }
 
+/// Resolves a single declared-license *name* into a normalized expression by
+/// running free-text detection over it.
+///
+/// This is the per-name analog of [`detect_declared_license_from_text`] for a
+/// bounded, trustworthy manifest license name (e.g. a Maven `<license><name>`
+/// such as "Mozilla Public License Version 2.0"). It shares the same detection
+/// and clue-promotion path but returns just the normalized declared expression,
+/// so a caller with several distinct license entries can resolve each name and
+/// combine the results itself. Returns `None` when the name does not resolve to
+/// a confident declared expression.
+pub(crate) fn detect_declared_license_name(name: &str) -> Option<NormalizedDeclaredLicense> {
+    let (declared, declared_spdx, _detections) = detect_declared_license_from_text(name, None);
+    match (declared, declared_spdx) {
+        (Some(declared), Some(declared_spdx)) => {
+            Some(NormalizedDeclaredLicense::new(declared, declared_spdx))
+        }
+        _ => None,
+    }
+}
+
 /// Promotes a clue-only whole-statement detection into a confident declared
 /// expression.
 ///

--- a/src/parsers/maven/pom/licenses.rs
+++ b/src/parsers/maven/pom/licenses.rs
@@ -7,7 +7,8 @@ use super::properties::{PropertyResolver, resolve_option};
 use crate::models::LicenseDetection;
 use crate::parsers::license_normalization::{
     DeclaredLicenseMatchMetadata, NormalizedDeclaredLicense, build_declared_license_data,
-    combine_normalized_licenses, empty_declared_license_data, normalize_declared_license_key,
+    combine_normalized_licenses, detect_declared_license_name, empty_declared_license_data,
+    normalize_declared_license_key,
 };
 
 #[derive(Clone, Default)]
@@ -88,17 +89,30 @@ pub(super) fn build_maven_declared_license_data(
     licenses: &[MavenLicenseEntry],
     matched_text: Option<&str>,
 ) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
-    let normalized: Vec<_> = licenses
+    // Each `<license>` is a distinct declared license; a POM that lists several
+    // means all of them apply, so they AND-combine (matching ScanCode).
+    let declared: Vec<&MavenLicenseEntry> = licenses
         .iter()
-        .filter_map(|license| license.name.as_deref())
-        .filter_map(normalize_maven_license_name)
+        .filter(|license| {
+            entry_field(&license.name).is_some() || entry_field(&license.url).is_some()
+        })
         .collect();
 
-    if normalized.is_empty() {
+    if declared.is_empty() {
         return empty_declared_license_data();
     }
 
-    let Some(combined) = combine_normalized_licenses(normalized, " OR ") else {
+    // Resolve every declared entry, mapping any entry that does not resolve to
+    // `unknown-license-reference` rather than dropping it. Dropping an operand
+    // would silently understate the declared licensing, and nulling the whole
+    // expression would discard the entries that *did* resolve; an explicit
+    // unknown operand keeps the result honest and complete.
+    let normalized: Vec<_> = declared
+        .into_iter()
+        .map(normalize_maven_license_entry)
+        .collect();
+
+    let Some(combined) = combine_normalized_licenses(normalized, " AND ") else {
         return empty_declared_license_data();
     };
 
@@ -108,12 +122,65 @@ pub(super) fn build_maven_declared_license_data(
     )
 }
 
-fn normalize_maven_license_name(name: &str) -> Option<NormalizedDeclaredLicense> {
-    match name.trim() {
-        "Public Domain" | "public domain" => Some(NormalizedDeclaredLicense::new(
-            "public-domain",
-            "LicenseRef-scancode-public-domain",
-        )),
-        other => normalize_declared_license_key(other),
+fn entry_field(value: &Option<String>) -> Option<&str> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+/// Resolves a single Maven `<license>` entry into a normalized declared license.
+///
+/// Resolution order, stopping at the first confident match:
+/// 1. exact SPDX-key/identifier lookup on the `<name>`;
+/// 2. free-text detection over the `<name>` alone;
+/// 3. free-text detection over the combined `<name>` and `<url>`.
+///
+/// Step 3 recovers descriptive names that resolve only when paired with their
+/// `<url>`: e.g. "GNU General Lesser Public License (LGPL) version 3.0" with
+/// `http://www.gnu.org/licenses/lgpl.html` resolves to `lgpl-3.0`, where the
+/// name alone matches nothing. It is only used when the name alone fails, so a
+/// name that already resolves (e.g. "GNU Lesser General Public License" ->
+/// `lgpl-2.1-plus`) is not muddied by a second, redundant operand the URL line
+/// would otherwise contribute. The POM `<licenses>` block is trustworthy
+/// declared manifest metadata, so detecting from these bounded fields is
+/// declared normalization, not file-content scanning.
+///
+/// An entry that resolves to nothing maps to `unknown-license-reference` (the
+/// existing convention for an unresolved but declared license reference) so it
+/// is preserved as an explicit operand rather than silently dropped.
+fn normalize_maven_license_entry(license: &MavenLicenseEntry) -> NormalizedDeclaredLicense {
+    let name = entry_field(&license.name);
+
+    if let Some(name) = name {
+        match name {
+            "Public Domain" | "public domain" => {
+                return NormalizedDeclaredLicense::new(
+                    "public-domain",
+                    "LicenseRef-scancode-public-domain",
+                );
+            }
+            other => {
+                if let Some(normalized) = normalize_declared_license_key(other) {
+                    return normalized;
+                }
+                if let Some(normalized) = detect_declared_license_name(other) {
+                    return normalized;
+                }
+            }
+        }
     }
+
+    let detection_text = [name, entry_field(&license.url)]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    detect_declared_license_name(&detection_text).unwrap_or_else(|| {
+        NormalizedDeclaredLicense::new(
+            "unknown-license-reference",
+            "LicenseRef-scancode-unknown-license-reference",
+        )
+    })
 }

--- a/src/parsers/maven/pom_test.rs
+++ b/src/parsers/maven/pom_test.rs
@@ -971,6 +971,111 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_declared_license_from_multiple_descriptive_names() {
+        // Multiple `<license>` entries declared by descriptive name (not SPDX id)
+        // must each resolve and AND-combine, matching ScanCode
+        // (lgpl-3.0 AND mpl-2.0 / LGPL-3.0-only AND MPL-2.0).
+        let content = r#"
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.github.librepdf</groupId>
+              <artifactId>openpdf-parent</artifactId>
+              <version>1.3.11</version>
+              <licenses>
+                <license>
+                  <name>GNU General Lesser Public License (LGPL) version 3.0</name>
+                  <url>http://www.gnu.org/licenses/lgpl.html</url>
+                </license>
+                <license>
+                  <name>Mozilla Public License Version 2.0</name>
+                  <url>http://www.mozilla.org/MPL/2.0/</url>
+                </license>
+              </licenses>
+            </project>
+        "#;
+
+        let (_temp_dir, pom_path) = create_temp_pom_xml(content);
+        let package_data = MavenParser::extract_first_package(&pom_path);
+
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("lgpl-3.0 AND mpl-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("LGPL-3.0-only AND MPL-2.0")
+        );
+        assert!(!package_data.license_detections.is_empty());
+    }
+
+    #[test]
+    fn test_extract_declared_license_from_unrecognized_name() {
+        // A single `<license>` whose name resolves to nothing must be preserved
+        // as an explicit `unknown-license-reference`, not silently dropped.
+        let content = r#"
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.test</groupId>
+              <artifactId>custom</artifactId>
+              <version>1.0.0</version>
+              <licenses>
+                <license>
+                  <name>Totally Made Up Proprietary Thing 9000</name>
+                </license>
+              </licenses>
+            </project>
+        "#;
+
+        let (_temp_dir, pom_path) = create_temp_pom_xml(content);
+        let package_data = MavenParser::extract_first_package(&pom_path);
+
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("unknown-license-reference")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("LicenseRef-scancode-unknown-license-reference")
+        );
+    }
+
+    #[test]
+    fn test_extract_declared_license_resolvable_and_unresolvable_entries() {
+        // One resolvable entry (MIT) plus one that resolves to nothing (a custom
+        // URL-only entry) must AND-combine into `mit AND unknown-license-reference`:
+        // the resolvable sibling is kept and the unresolved entry is preserved as
+        // an explicit unknown operand rather than nulling or dropping anything.
+        let content = r#"
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.test</groupId>
+              <artifactId>mixed</artifactId>
+              <version>1.0.0</version>
+              <licenses>
+                <license>
+                  <name>MIT</name>
+                </license>
+                <license>
+                  <url>http://corp.example.com/custom</url>
+                </license>
+              </licenses>
+            </project>
+        "#;
+
+        let (_temp_dir, pom_path) = create_temp_pom_xml(content);
+        let package_data = MavenParser::extract_first_package(&pom_path);
+
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("mit AND unknown-license-reference")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("LicenseRef-scancode-unknown-license-reference AND MIT")
+        );
+    }
+
+    #[test]
     fn test_multiple_placeholders() {
         let content = r#"
 <project>

--- a/testdata/assembly-golden/maven-basic/expected.json
+++ b/testdata/assembly-golden/maven-basic/expected.json
@@ -52,8 +52,7 @@
               "rule_relevance": 100,
               "rule_identifier": "apache-2.0_771.RULE",
               "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_771.RULE",
-              "matched_text": "- license:\n    name: Apache License 2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0",
-              "referenced_filenames": []
+              "matched_text": "- license:\n    name: Apache License 2.0\n    url: https://www.apache.org/licenses/LICENSE-2.0\n"
             }
           ],
           "identifier": "apache_2_0-c6b77120-5aec-1811-2b12-f22e7b75b1bd"

--- a/testdata/maven-golden/jrecordbind/pom.xml.expected
+++ b/testdata/maven-golden/jrecordbind/pom.xml.expected
@@ -85,16 +85,16 @@
     "api_data_url": "https://repo1.maven.org/maven2/it/assist/jrecordbind/jrecordbind-java5/2.3.4/jrecordbind-java5-2.3.4.pom",
     "datasource_id": "maven_pom",
     "purl": "pkg:maven/it.assist.jrecordbind/jrecordbind-java5@2.3.4",
-    "declared_license_expression": "lgpl-2.0-plus AND lgpl-2.1-plus",
-    "declared_license_expression_spdx": "LGPL-2.0-or-later AND LGPL-2.1-or-later",
+    "declared_license_expression": "lgpl-2.0-plus",
+    "declared_license_expression_spdx": "LGPL-2.0-or-later",
     "license_detections": [
       {
-        "license_expression": "lgpl-2.0-plus AND lgpl-2.1-plus",
-        "license_expression_spdx": "LGPL-2.0-or-later AND LGPL-2.1-or-later",
+        "license_expression": "lgpl-2.0-plus",
+        "license_expression_spdx": "LGPL-2.0-or-later",
         "matches": [
           {
-            "license_expression": "lgpl-2.0-plus AND lgpl-2.1-plus",
-            "license_expression_spdx": "LGPL-2.0-or-later AND LGPL-2.1-or-later",
+            "license_expression": "lgpl-2.0-plus",
+            "license_expression_spdx": "LGPL-2.0-or-later",
             "from_file": null,
             "start_line": 1,
             "end_line": 1,
@@ -103,10 +103,9 @@
             "matched_length": 6,
             "match_coverage": 100.0,
             "rule_relevance": 100,
-            "rule_identifier": "lgpl_bare_single_word.RULE",
-            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl_bare_single_word.RULE",
-            "matched_text": "- license:\n    name: LGPL\n    url: http://www.gnu.org/copyleft/lesser.html",
-            "referenced_filenames": []
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "- license:\n    name: LGPL\n    url: http://www.gnu.org/copyleft/lesser.html\n"
           }
         ],
         "identifier": null

--- a/testdata/maven-golden/logback-access/pom.xml.expected
+++ b/testdata/maven-golden/logback-access/pom.xml.expected
@@ -84,8 +84,7 @@
             "rule_relevance": 100,
             "rule_identifier": "lgpl-2.1-plus_515.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/lgpl-2.1-plus_515.RULE",
-            "matched_text": "- license:\n    name: GNU Lesser General Public License\n    url: http://www.gnu.org/licenses/lgpl.html",
-            "referenced_filenames": []
+            "matched_text": "- license:\n    name: GNU Lesser General Public License\n    url: http://www.gnu.org/licenses/lgpl.html\n"
           }
         ],
         "identifier": null

--- a/testdata/maven-golden/spring/pom.xml.expected
+++ b/testdata/maven-golden/spring/pom.xml.expected
@@ -597,8 +597,7 @@
             "rule_relevance": 100,
             "rule_identifier": "apache-2.0_1309.RULE",
             "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_1309.RULE",
-            "matched_text": "- license:\n    name: The Apache Software License, Version 2.0\n    url: http://www.apache.org/licenses/LICENSE-2.0.txt",
-            "referenced_filenames": []
+            "matched_text": "- license:\n    name: The Apache Software License, Version 2.0\n    url: http://www.apache.org/licenses/LICENSE-2.0.txt\n"
           }
         ],
         "identifier": null


### PR DESCRIPTION
## Summary

- A Maven POM declaring several licenses by descriptive `<name>` (not SPDX id) produced `declared_license_expression: null`; ScanCode resolves `lgpl-3.0 AND mpl-2.0`. Each `<license>` entry now resolves through declared-license normalization and the distinct entries AND-combine.

## Issues

- Closes: #1096

## Scope and exclusions

- Included: Maven POM `<licenses>` declared-license normalization (`src/parsers/maven/pom/licenses.rs`) plus a small shared per-name helper in `src/parsers/license_normalization.rs`.
- Explicit exclusions: no engine/matcher or license-index/overlay changes; one ecosystem only (Maven).

## How to verify

- `cargo run -q -- scan <dir-with-openpdf-pom> --package --json-pp -` and confirm the assembled package's `declared_license_expression` is `lgpl-3.0 AND mpl-2.0` (`LGPL-3.0-only AND MPL-2.0`). A minimal POM with the two `<license>` blocks from the issue reproduces it. CI covers the unit and golden suites.

## Intentional differences from Python

- None intended; this moves Provenant toward ScanCode parity for multi-license POMs. Two pre-existing single-entry artifacts are also cleaned up (see fixture notes).

## Follow-up work

- None.

## Expected-output fixture changes

- Files changed: `testdata/maven-golden/jrecordbind/pom.xml.expected`, `testdata/maven-golden/logback-access/pom.xml.expected`, `testdata/maven-golden/spring/pom.xml.expected`.
- Why the new expected output is correct:
  - jrecordbind (`<name>LGPL</name>`) now resolves to the clean `lgpl-2.0-plus` (bare-LGPL contract) instead of the doubled `lgpl-2.0-plus AND lgpl-2.1-plus` the old free-text fallback produced by ANDing the name clue with the url detection.
  - logback-access keeps `lgpl-2.1-plus` (resolved from the name alone) without a redundant url-derived operand; the detection now originates in the parser, so `matched_text` carries the full serialized statement and `referenced_filenames` is omitted.
  - spring is unchanged in expression (`apache-2.0`); only the detection provenance fields shift the same way.