### PR TITLE
feat(release): generate and bundle a third-party license disclosure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check release version sync
         run: ./scripts/check_release_version_sync.sh
 
+      - name: Check license config sync (about.toml vs deny.toml)
+        run: ./scripts/check_license_config_sync.sh
+
       - name: Check xtask lockfile sync and supported formats
         run: cargo run --quiet --locked --manifest-path xtask/Cargo.toml --bin generate-supported-formats -- --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,21 @@ jobs:
       - name: Verify crates.io package publish dry-run
         run: cargo publish --locked --dry-run -p provenant-cli
 
+      - name: Install cargo-about
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cargo-about@0.9.0
+
+      - name: Generate third-party license disclosure
+        run: ./scripts/generate_third_party_notices.sh THIRD-PARTY-NOTICES.md
+
+      - name: Upload third-party license disclosure
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: third-party-notices
+          path: THIRD-PARTY-NOTICES.md
+          if-no-files-found: error
+
   build:
     name: Build ${{ matrix.target }}
     needs: verify-release
@@ -129,12 +144,18 @@ jobs:
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}
 
+      - name: Download third-party license disclosure
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        with:
+          name: third-party-notices
+          path: .
+
       - name: Create archive (Unix)
         if: matrix.archive_format == 'tar.gz'
         run: |
           cd target/${{ matrix.target }}/release
-          cp "$GITHUB_WORKSPACE/LICENSE" "$GITHUB_WORKSPACE/NOTICE" .
-          tar czf ${{ matrix.asset_name }}.tar.gz provenant${{ matrix.ext }} LICENSE NOTICE
+          cp "$GITHUB_WORKSPACE/LICENSE" "$GITHUB_WORKSPACE/NOTICE" "$GITHUB_WORKSPACE/THIRD-PARTY-NOTICES.md" .
+          tar czf ${{ matrix.asset_name }}.tar.gz provenant${{ matrix.ext }} LICENSE NOTICE THIRD-PARTY-NOTICES.md
           if command -v sha256sum > /dev/null; then
             sha256sum ${{ matrix.asset_name }}.tar.gz > ${{ matrix.asset_name }}.tar.gz.sha256
           else
@@ -148,7 +169,8 @@ jobs:
           cd target/${{ matrix.target }}/release
           Copy-Item "$env:GITHUB_WORKSPACE\LICENSE" .
           Copy-Item "$env:GITHUB_WORKSPACE\NOTICE" .
-          7z a ${{ matrix.asset_name }}.zip provenant${{ matrix.ext }} LICENSE NOTICE
+          Copy-Item "$env:GITHUB_WORKSPACE\THIRD-PARTY-NOTICES.md" .
+          7z a ${{ matrix.asset_name }}.zip provenant${{ matrix.ext }} LICENSE NOTICE THIRD-PARTY-NOTICES.md
           $hash = (Get-FileHash "${{ matrix.asset_name }}.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
           "$hash  ${{ matrix.asset_name }}.zip" | Out-File -FilePath "${{ matrix.asset_name }}.zip.sha256" -Encoding ascii
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ testdata/**/*.sqlite-wal
 
 # Background agent worktrees
 .claude/worktrees/
+
+# Generated at release time by scripts/generate_third_party_notices.sh
+/THIRD-PARTY-NOTICES.md

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,35 @@
+{{!--
+SPDX-FileCopyrightText: Provenant contributors
+SPDX-License-Identifier: Apache-2.0
+
+Handlebars template for `cargo about generate`. Renders the third-party license
+disclosure for the components bundled in the Provenant binary.
+--}}# Third-Party Software Notices
+
+Provenant's distributed binary statically links the open-source components
+listed below. Each is provided under the license shown, and the full license
+texts follow. This file is generated with `cargo about`; see `about.toml` and
+`scripts/generate_third_party_notices.sh`.
+
+## Overview
+
+{{#each overview}}
+- {{{name}}}: {{count}} component(s)
+{{/each}}
+
+## Licenses
+
+{{#each licenses}}
+### {{{name}}}
+
+Used by:
+
+{{#each used_by}}
+- {{crate.name}} {{crate.version}}{{#if crate.repository}} ({{crate.repository}}){{/if}}
+{{/each}}
+
+```
+{{{text}}}
+```
+
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configuration for `cargo about generate`, which produces the third-party
+# license disclosure (THIRD-PARTY-NOTICES.md) bundled into Provenant's binary
+# release archives. See scripts/generate_third_party_notices.sh.
+#
+# This must stay aligned with the shipped dependency graph that cargo-deny
+# enforces in deny.toml: `targets` mirrors deny.toml's [graph].targets,
+# dev-dependencies are excluded (deny.toml sets exclude-dev), and `accepted`
+# mirrors deny.toml's [licenses].allow plus its per-crate exceptions. The
+# alignment is enforced by scripts/check_license_config_sync.sh.
+
+# Build the disclosure for exactly the platforms we ship, matching deny.toml.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
+# Dev-dependencies are not part of the shipped binary (deny.toml: exclude-dev).
+ignore-dev-dependencies = true
+
+# Accepted SPDX license identifiers. cargo-about fails if a shipped crate uses a
+# license not listed here, which surfaces new transitive licenses for review.
+# Kept equal to deny.toml's allow list plus its exception licenses.
+accepted = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "bzip2-1.0.6",
+]
+
+# Built-in clarifications for crates whose licensing cargo-about cannot detect
+# reliably from their source tree alone.
+workarounds = [
+    "ring",
+]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -77,6 +77,13 @@ pre-commit:
         - tools/license-headers/Cargo.toml
       run: ./scripts/check_dependency_policy.sh
 
+    check-license-config-sync:
+      glob:
+        - about.toml
+        - deny.toml
+        - scripts/check_license_config_sync.sh
+      run: ./scripts/check_license_config_sync.sh
+
     generate-supported-formats:
       glob: src/parsers/*.rs
       exclude:

--- a/release.sh
+++ b/release.sh
@@ -92,6 +92,14 @@ echo "🔎 Verifying ScanCode output format version sync..."
 ./scripts/check_scancode_output_format_sync.sh
 echo "🔎 Verifying NOTICE attribution sync (retained upstream notices verbatim)..."
 ./scripts/check_notice_attribution_sync.sh --require-submodule
+echo "🔎 Validating third-party license disclosure generation..."
+if cargo about --version > /dev/null 2>&1; then
+    ./scripts/generate_third_party_notices.sh /tmp/provenant-third-party-notices.md > /dev/null
+    echo "✅ Third-party license disclosure generates cleanly"
+else
+    echo "⚠️  cargo-about not installed; skipping local disclosure validation (CI enforces it at release)."
+    echo "    Install with: cargo install --locked cargo-about --features cli"
+fi
 echo "🔧 Regenerating embedded license index artifact..."
 cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact
 

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,13 @@
       "depNameTemplate": "rust",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "rust-release-channel"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/release\\.yml$/"],
+      "matchStrings": ["tool:\\s*cargo-about@(?<currentValue>[0-9][^\\s\"]*)"],
+      "depNameTemplate": "cargo-about",
+      "datasourceTemplate": "crate"
     }
   ],
   "lockFileMaintenance": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -116,6 +116,40 @@ Example:
 ./scripts/check_scancode_output_format_sync.sh
 ```
 
+## `generate_third_party_notices.sh`
+
+Generate the third-party license disclosure (`THIRD-PARTY-NOTICES.md`) for the
+dependencies bundled in the Provenant binary, using `cargo-about` and the
+repo-root `about.toml` / `about.hbs`. The release workflow generates this file
+and bundles it into the binary release archives alongside `LICENSE` and
+`NOTICE`; `release.sh` validates it generates cleanly before tagging.
+
+Requires `cargo-about` (`cargo install --locked cargo-about --features cli`). It
+fails if a bundled dependency uses a license not listed in `about.toml`'s
+`accepted` set, surfacing new transitive licenses for review.
+
+Example:
+
+```bash
+./scripts/generate_third_party_notices.sh
+./scripts/generate_third_party_notices.sh THIRD-PARTY-NOTICES.md
+```
+
+## `check_license_config_sync.sh`
+
+Verify that `about.toml` (cargo-about, third-party disclosure) stays aligned
+with `deny.toml` (cargo-deny, license policy). The two tools evaluate the same
+shipped dependency graph but cannot share configuration, so this enforces the
+invariant: `about.toml` `targets` must equal `deny.toml` `[graph].targets`, and
+`about.toml` `accepted` must equal `deny.toml` `[licenses].allow` plus its
+per-crate exception licenses.
+
+Example:
+
+```bash
+./scripts/check_license_config_sync.sh
+```
+
 ## `check_notice_attribution_sync.sh`
 
 Verify that the upstream ScanCode Toolkit attribution notices Provenant retains

--- a/scripts/check_license_config_sync.sh
+++ b/scripts/check_license_config_sync.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify that about.toml (cargo-about, third-party disclosure generation) stays
+# aligned with deny.toml (cargo-deny, license policy). The two tools evaluate
+# the same shipped dependency graph but cannot share configuration, so this
+# check enforces the invariant instead:
+#   - about.toml `targets`  == deny.toml [graph].targets
+#   - about.toml `accepted` == deny.toml [licenses].allow + per-crate exception licenses
+
+set -euo pipefail
+
+python3 - <<'PY'
+import tomllib
+
+with open("about.toml", "rb") as f:
+    about = tomllib.load(f)
+with open("deny.toml", "rb") as f:
+    deny = tomllib.load(f)
+
+problems = []
+
+about_targets = set(about.get("targets", []))
+deny_targets = set(deny.get("graph", {}).get("targets", []))
+if about_targets != deny_targets:
+    problems.append(
+        "targets differ:\n"
+        f"  only in about.toml: {sorted(about_targets - deny_targets)}\n"
+        f"  only in deny.toml:  {sorted(deny_targets - about_targets)}"
+    )
+
+about_accepted = set(about.get("accepted", []))
+deny_licenses = deny.get("licenses", {})
+expected = set(deny_licenses.get("allow", []))
+for exc in deny_licenses.get("exceptions", []):
+    expected.update(exc.get("allow", []))
+if about_accepted != expected:
+    problems.append(
+        "accepted vs (deny allow + exceptions) differ:\n"
+        f"  only in about.toml accepted:        {sorted(about_accepted - expected)}\n"
+        f"  only in deny.toml allow/exceptions: {sorted(expected - about_accepted)}"
+    )
+
+if problems:
+    raise SystemExit(
+        "License config out of sync between about.toml and deny.toml:\n\n"
+        + "\n\n".join(problems)
+        + "\n\nKeep cargo-about (disclosure) aligned with cargo-deny (policy):\n"
+        "  - about.toml `targets`  must equal deny.toml [graph].targets\n"
+        "  - about.toml `accepted` must equal deny.toml [licenses].allow + exception licenses"
+    )
+
+print(
+    "✅ license config in sync: about.toml matches deny.toml "
+    "(targets + accepted/allow)."
+)
+PY

--- a/scripts/generate_third_party_notices.sh
+++ b/scripts/generate_third_party_notices.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate the third-party license disclosure for the dependencies bundled in
+# the Provenant binary into THIRD-PARTY-NOTICES.md, using cargo-about and the
+# repo-root about.toml / about.hbs.
+#
+# Requires cargo-about:
+#   cargo install --locked cargo-about --features cli
+#
+# Usage: ./scripts/generate_third_party_notices.sh [output-file]
+
+set -euo pipefail
+
+OUTPUT="${1:-THIRD-PARTY-NOTICES.md}"
+
+if ! cargo about --version >/dev/null 2>&1; then
+    echo "cargo-about not found. Install with:" >&2
+    echo "  cargo install --locked cargo-about --features cli" >&2
+    exit 1
+fi
+
+# --fail turns license problems (e.g. a dependency whose license is not in the
+# about.toml accepted list) into a non-zero exit so they surface for review.
+cargo about generate --fail -c about.toml about.hbs -o "$OUTPUT"
+echo "Wrote $OUTPUT"


### PR DESCRIPTION
## Summary

- Generate a third-party license **disclosure** (`THIRD-PARTY-NOTICES.md`) for the dependencies bundled in the Provenant binary and ship it in every binary release archive alongside `LICENSE` and `NOTICE`.
- Scope the disclosure to the shipped dependency graph and keep it consistent with the cargo-deny license policy via an enforced sync check.

## Why

The prebuilt binaries (GitHub release archives, and the ORT container that redistributes them) statically link dependencies under permissive licenses (MIT/BSD/Apache/ISC/Zlib/etc.) whose attribution notices must travel with the distributed object form. The crate already ships `LICENSE`+`NOTICE` (and #1084 added them to the binary archives), but neither carried a third-party dependency disclosure — a real, if low-severity (permissive-attribution), gap for the binary distribution. This closes it and lets downstream redistributors (e.g. ORT) satisfy their own disclosure obligations for the bundled binary.

## What this does

**Generation**
- `about.toml` + `about.hbs` + `scripts/generate_third_party_notices.sh` drive `cargo about generate --fail`, producing a complete markdown disclosure (every component has license text; `--fail` surfaces any dependency whose license isn't accepted).
- cargo-about is scoped to the **shipped graph**: `targets` mirror the release build matrix / `deny.toml`, and dev-dependencies are excluded — so the disclosure lists only what actually ships in the binary, not all-platform/dev noise.

**Release wiring (`release.yml`)**
- `verify-release` installs a **pinned, prebuilt** cargo-about via `taiki-e/install-action` (`tool: cargo-about@0.9.0`) — reproducible across releases and fast (no compile-from-source on the gate), generates the disclosure once, and uploads it as an artifact.
- Each `build` matrix job downloads the artifact and adds `THIRD-PARTY-NOTICES.md` to the `.tar.gz` / `.zip` alongside `LICENSE` and `NOTICE`.
- The file is generated fresh at release time and is **gitignored, not committed**, so it always matches the exact dependency set of the shipped binary and never churns on dependency bumps.

**Pre-tag validation (`release.sh`)**
- Validates the disclosure generates cleanly before tagging (soft-skips if cargo-about isn't installed locally; CI enforces regardless).

**Staying consistent**
- cargo-about (disclosure) and cargo-deny (policy) evaluate the same shipped graph but cannot share config. `scripts/check_license_config_sync.sh` enforces the invariant — `about.toml` `targets` == `deny.toml` `[graph].targets`, and `about.toml` `accepted` == `deny.toml` `[licenses].allow` + per-crate exception licenses — wired into CI and the pre-commit hooks.
- Renovate keeps the pinned cargo-about version current (a custom manager in `renovate.json`; the github-actions manager already updates the action digest).

## Scope and exclusions

- Included: cargo-about config + template + generator script, the license-config sync check, release-workflow wiring, `release.sh` pre-tag smoke, `renovate.json` custom manager, `.gitignore`, and `scripts/README.md` entries.
- Excluded: no change to the source crate contents (source consumers resolve their own deps); the disclosure targets the **binary** distribution only.

## How to verify

```bash
cargo install --locked cargo-about --features cli   # or: taiki-e/install-action tool: cargo-about@0.9.0
./scripts/generate_third_party_notices.sh           # -> THIRD-PARTY-NOTICES.md, generates cleanly
./scripts/check_license_config_sync.sh              # about.toml and deny.toml stay aligned
```

Validated locally: scoped generation passes `--fail` with full license text for every shipped component and no unaccepted licenses; `accepted` exactly equals deny.toml's `allow` + exceptions; the sync check passes and catches target/license drift; `release.yml`/`check.yml`/`lefthook.yml` are valid YAML and `renovate.json` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
