### PR TITLE
chore(attribution): retain ScanCode trademark notice in derived-file headers

### DIFF
--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/bazel_merge.rs
+++ b/src/assembly/bazel_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/conda_rootfs_merge.rs
+++ b/src/assembly/conda_rootfs_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/debian_source_merge.rs
+++ b/src/assembly/debian_source_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/nested_merge.rs
+++ b/src/assembly/nested_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/npm_resource_assign.rs
+++ b/src/assembly/npm_resource_assign.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/ruby_resource_assign.rs
+++ b/src/assembly/ruby_resource_assign.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/assembly/swift_merge.rs
+++ b/src/assembly/swift_merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/credits.rs
+++ b/src/copyright/credits.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/pattern_extract/extraction/content.rs
+++ b/src/copyright/detector/pattern_extract/extraction/content.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/pattern_extract/extraction/groups.rs
+++ b/src/copyright/detector/pattern_extract/extraction/groups.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/pattern_extract/extraction/mod.rs
+++ b/src/copyright/detector/pattern_extract/extraction/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tests_copyright_holder_pipeline.rs
+++ b/src/copyright/detector/tests_copyright_holder_pipeline.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tests_parser_internals.rs
+++ b/src/copyright/detector/tests_parser_internals.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/token_utils/builders.rs
+++ b/src/copyright/detector/token_utils/builders.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/author.rs
+++ b/src/copyright/detector/tree_walk/author.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/absorb.rs
+++ b/src/copyright/detector/tree_walk/copyright/absorb.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/bare.rs
+++ b/src/copyright/detector/tree_walk/copyright/bare.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/merge.rs
+++ b/src/copyright/detector/tree_walk/copyright/merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/node_classify.rs
+++ b/src/copyright/detector/tree_walk/copyright/node_classify.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/prefix.rs
+++ b/src/copyright/detector/tree_walk/copyright/prefix.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/detector/tree_walk/copyright/tree_nodes.rs
+++ b/src/copyright/detector/tree_walk/copyright/tree_nodes.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/grammar/rules.rs
+++ b/src/copyright/grammar/rules.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/hints.rs
+++ b/src/copyright/hints.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/lexer.rs
+++ b/src/copyright/lexer.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/patterns.rs
+++ b/src/copyright/patterns.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/constants.rs
+++ b/src/copyright/refiner/constants.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/copyright_clauses.rs
+++ b/src/copyright/refiner/copyright_clauses.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/holder.rs
+++ b/src/copyright/refiner/holder.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/refiner/utils.rs
+++ b/src/copyright/refiner/utils.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/copyright/types.rs
+++ b/src/copyright/types.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/finder/host.rs
+++ b/src/finder/host.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/finder/junk_data.rs
+++ b/src/finder/junk_data.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/aho_match.rs
+++ b/src/license_detection/aho_match.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/detection/analysis.rs
+++ b/src/license_detection/detection/analysis.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/detection/grouping.rs
+++ b/src/license_detection/detection/grouping.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/detection/identifier.rs
+++ b/src/license_detection/detection/identifier.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/detection/mod.rs
+++ b/src/license_detection/detection/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/detection/types.rs
+++ b/src/license_detection/detection/types.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/hash_match.rs
+++ b/src/license_detection/hash_match.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/index/dictionary.rs
+++ b/src/license_detection/index/dictionary.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/index/mod.rs
+++ b/src/license_detection/index/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/match_refine/false_positive.rs
+++ b/src/license_detection/match_refine/false_positive.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/match_refine/handle_overlaps.rs
+++ b/src/license_detection/match_refine/handle_overlaps.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/match_refine/merge.rs
+++ b/src/license_detection/match_refine/merge.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/match_refine/mod.rs
+++ b/src/license_detection/match_refine/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/license.rs
+++ b/src/license_detection/models/license.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/license_match.rs
+++ b/src/license_detection/models/license_match.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/loaded_license.rs
+++ b/src/license_detection/models/loaded_license.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/loaded_rule.rs
+++ b/src/license_detection/models/loaded_rule.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/position_span.rs
+++ b/src/license_detection/models/position_span.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/models/rule.rs
+++ b/src/license_detection/models/rule.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/rules/legalese.rs
+++ b/src/license_detection/rules/legalese.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/rules/loader.rs
+++ b/src/license_detection/rules/loader.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/rules/thresholds.rs
+++ b/src/license_detection/rules/thresholds.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/seq_match/candidates/mod.rs
+++ b/src/license_detection/seq_match/candidates/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/seq_match/matching.rs
+++ b/src/license_detection/seq_match/matching.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/seq_match/mod.rs
+++ b/src/license_detection/seq_match/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/spdx_mapping/mod.rs
+++ b/src/license_detection/spdx_mapping/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/tokenize.rs
+++ b/src/license_detection/tokenize.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/license_detection/unknown_match.rs
+++ b/src/license_detection/unknown_match.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/models/datasource_id.rs
+++ b/src/models/datasource_id.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/models/package_type.rs
+++ b/src/models/package_type.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/output/debian.rs
+++ b/src/output/debian.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/about.rs
+++ b/src/parsers/about.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/autotools.rs
+++ b/src/parsers/autotools.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/bower.rs
+++ b/src/parsers/bower.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/cargo.rs
+++ b/src/parsers/cargo.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/cargo_lock.rs
+++ b/src/parsers/cargo_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/chef.rs
+++ b/src/parsers/chef.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/composer.rs
+++ b/src/parsers/composer.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/conan.rs
+++ b/src/parsers/conan.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/conan_data.rs
+++ b/src/parsers/conan_data.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/conda.rs
+++ b/src/parsers/conda.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/conda_meta_json.rs
+++ b/src/parsers/conda_meta_json.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/cpan_dist_ini.rs
+++ b/src/parsers/cpan_dist_ini.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/dart.rs
+++ b/src/parsers/dart.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/control.rs
+++ b/src/parsers/debian/control.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/copyright.rs
+++ b/src/parsers/debian/copyright.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/dsc.rs
+++ b/src/parsers/debian/dsc.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/file_list.rs
+++ b/src/parsers/debian/file_list.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/mod.rs
+++ b/src/parsers/debian/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/debian/utils.rs
+++ b/src/parsers/debian/utils.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/freebsd.rs
+++ b/src/parsers/freebsd.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/go_mod_graph.rs
+++ b/src/parsers/go_mod_graph.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/haxe.rs
+++ b/src/parsers/haxe.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/coordinates.rs
+++ b/src/parsers/maven/coordinates.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/manifest.rs
+++ b/src/parsers/maven/manifest.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/mod.rs
+++ b/src/parsers/maven/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/pom/dependencies.rs
+++ b/src/parsers/maven/pom/dependencies.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/pom/licenses.rs
+++ b/src/parsers/maven/pom/licenses.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/pom/state/dependencies.rs
+++ b/src/parsers/maven/pom/state/dependencies.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/maven/pom/state/project.rs
+++ b/src/parsers/maven/pom/state/project.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/microsoft_update_manifest.rs
+++ b/src/parsers/microsoft_update_manifest.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/misc.rs
+++ b/src/parsers/misc.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/npm.rs
+++ b/src/parsers/npm.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/npm_lock.rs
+++ b/src/parsers/npm_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/npm_workspace.rs
+++ b/src/parsers/npm_workspace.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/nuget/mod.rs
+++ b/src/parsers/nuget/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/nuget/nupkg.rs
+++ b/src/parsers/nuget/nupkg.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/nuget/nuspec.rs
+++ b/src/parsers/nuget/nuspec.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/nuget/packages_lock.rs
+++ b/src/parsers/nuget/packages_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/opam.rs
+++ b/src/parsers/opam.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/os_release.rs
+++ b/src/parsers/os_release.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/pip_inspect_deplock.rs
+++ b/src/parsers/pip_inspect_deplock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/pipfile_lock.rs
+++ b/src/parsers/pipfile_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/podfile_lock.rs
+++ b/src/parsers/podfile_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/podspec.rs
+++ b/src/parsers/podspec.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/podspec_json.rs
+++ b/src/parsers/podspec_json.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/poetry_lock.rs
+++ b/src/parsers/poetry_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/pypi_json.rs
+++ b/src/parsers/python/pypi_json.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/pyproject.rs
+++ b/src/parsers/python/pyproject.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/rfc822_meta.rs
+++ b/src/parsers/python/rfc822_meta.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/setup_cfg.rs
+++ b/src/parsers/python/setup_cfg.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/setup_py.rs
+++ b/src/parsers/python/setup_py.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/python/utils.rs
+++ b/src/parsers/python/utils.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/readme.rs
+++ b/src/parsers/readme.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/rpm_license_files.rs
+++ b/src/parsers/rpm_license_files.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/rpm_mariner_manifest.rs
+++ b/src/parsers/rpm_mariner_manifest.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/swift_manifest_json.rs
+++ b/src/parsers/swift_manifest_json.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/swift_resolved.rs
+++ b/src/parsers/swift_resolved.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/windows_executable.rs
+++ b/src/parsers/windows_executable.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/parsers/yarn_lock.rs
+++ b/src/parsers/yarn_lock.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/classification.rs
+++ b/src/post_processing/classification.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/license_policy.rs
+++ b/src/post_processing/license_policy.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/license_references.rs
+++ b/src/post_processing/license_references.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/package_file_index.rs
+++ b/src/post_processing/package_file_index.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/summary/mod.rs
+++ b/src/post_processing/summary/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/summary_helpers.rs
+++ b/src/post_processing/summary_helpers.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/post_processing/tallies.rs
+++ b/src/post_processing/tallies.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/scan_result_shaping/selection.rs
+++ b/src/scan_result_shaping/selection.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/utils/file/encoding.rs
+++ b/src/utils/file/encoding.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/utils/file/extract.rs
+++ b/src/utils/file/extract.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/utils/generated.rs
+++ b/src/utils/generated.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/utils/sourcemap.rs
+++ b/src/utils/sourcemap.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.

--- a/tools/license-headers/src/main.rs
+++ b/tools/license-headers/src/main.rs
@@ -16,6 +16,9 @@ const LICENSE_LINE: &str = "SPDX-License-Identifier: Apache-2.0";
 /// Upstream attribution carried by files derived from ScanCode Toolkit, in
 /// addition to the Provenant copyright line.
 const UPSTREAM_COPYRIGHT_LINE: &str = "SPDX-FileCopyrightText: nexB Inc. and others";
+/// Trademark notice retained verbatim from upstream ScanCode source-file headers
+/// (Apache-2.0 section 4(c)) for derived files.
+const UPSTREAM_TRADEMARK_LINE: &str = "ScanCode is a trademark of nexB Inc.";
 /// "Stating changes" notice (Apache-2.0 section 4(b)) for derived files. The
 /// set of derived files is enumerated in `.license-headers.toml`; this line
 /// stays uniform across them so the header remains idempotent.
@@ -365,6 +368,7 @@ fn expected_header(prefix: &str, derived: bool) -> Vec<String> {
     let mut header = Vec::new();
     if derived {
         header.push(format!("{prefix} {UPSTREAM_COPYRIGHT_LINE}"));
+        header.push(format!("{prefix} {UPSTREAM_TRADEMARK_LINE}"));
     }
     header.push(format!("{prefix} {COPYRIGHT_LINE}"));
     header.push(format!("{prefix} {LICENSE_LINE}"));
@@ -378,6 +382,7 @@ fn rewrite_with_header(path: &Path, original: &str, derived: bool) -> Result<Str
     let prefix = comment_prefix(path)
         .with_context(|| format!("no comment prefix configured for {}", path.display()))?;
     let expected = expected_header(prefix, derived);
+    let trademark = format!("{prefix} {UPSTREAM_TRADEMARK_LINE}");
     let derived_note = format!("{prefix} {DERIVED_NOTE}");
     let mut lines: Vec<&str> = original.lines().collect();
 
@@ -392,16 +397,15 @@ fn rewrite_with_header(path: &Path, original: &str, derived: bool) -> Result<Str
         index += 1;
     }
 
-    while lines.get(index).is_some_and(|line| line.contains("SPDX-")) {
-        index += 1;
-    }
-
-    // Consume any existing derived-note line so the header stays idempotent
-    // whether or not the file was previously classified as derived.
-    while lines
-        .get(index)
-        .is_some_and(|line| line.trim() == derived_note.trim())
-    {
+    // Consume any existing header comment lines — SPDX tags, the upstream
+    // trademark notice, and the derived-note line — in whatever order they
+    // appear, so the header stays idempotent and reclassifying a file
+    // (derived <-> non-derived) cleanly strips the upstream-only lines. The
+    // trademark notice is not an SPDX tag, so it must be matched explicitly.
+    while lines.get(index).is_some_and(|line| {
+        let trimmed = line.trim();
+        trimmed.contains("SPDX-") || trimmed == trademark.trim() || trimmed == derived_note.trim()
+    }) {
         index += 1;
     }
 
@@ -442,6 +446,7 @@ mod tests {
         assert_eq!(
             rewrite("mod a;\n", true),
             "// SPDX-FileCopyrightText: nexB Inc. and others\n\
+             // ScanCode is a trademark of nexB Inc.\n\
              // SPDX-FileCopyrightText: Provenant contributors\n\
              // SPDX-License-Identifier: Apache-2.0\n\
              // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.\n\


### PR DESCRIPTION
## Summary

- Retain the upstream **trademark notice** — `ScanCode is a trademark of nexB Inc.` — in the SPDX header the license-header tool stamps on ScanCode-derived files, and apply it across the derived set.

## Why

Upstream ScanCode source files carry `# ScanCode is a trademark of nexB Inc.` as the second line of their header block (confirmed in 161 `.py` files). Apache-2.0 **§4(c)** requires retaining "copyright, patent, **trademark**, and attribution notices from the Source form of the Work" in derivatives. Our derived-file headers already retain the nexB copyright, the license, and a §4(b) change notice, but dropped that one trademark line — a small §4(c) retention shortfall, and a notably relevant one given trademark is an explicit point in the upstream maintainer's concerns. This closes it; the line is a verbatim retention of nexB's own notice.

## What changed

- `tools/license-headers/src/main.rs`: new `UPSTREAM_TRADEMARK_LINE` constant, added to the derived header right after the nexB copyright line (mirroring upstream order).
- The tool's header-consume logic now strips **all** known header lines (SPDX tags, the trademark notice, the derived note) regardless of order — necessary because the trademark line is not an SPDX tag and sits between the two copyright lines. Keeps the header idempotent and reclassification (derived ↔ non-derived) clean. Covered by the existing idempotency/reclassify tests.
- Applied via `--fix` across all derived files. Non-derived files are unchanged.

Resulting derived header:

```
// SPDX-FileCopyrightText: nexB Inc. and others
// ScanCode is a trademark of nexB Inc.
// SPDX-FileCopyrightText: Provenant contributors
// SPDX-License-Identifier: Apache-2.0
// Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
```

## How to verify

```bash
cargo test --manifest-path tools/license-headers/Cargo.toml
cargo run --quiet --locked --manifest-path tools/license-headers/Cargo.toml -- --check
```

Both pass: the 6 tool tests (incl. idempotency + reclassify-strip) and the repo-wide header check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
