### PR TITLE
fix(copyright): suppress Creative Commons license-text false positives

### DIFF
--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -827,6 +827,10 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^[A-Z_][A-Z0-9_]*\(c\);\s*[a-z_][a-z0-9_]*->[a-z_][a-z0-9_]*\s*=\s*[a-z_][a-z0-9_]*$",
         r#"(?i)^[a-z_][a-z0-9_]*\("copyright:\s*%s",\s*[a-z_][a-z0-9_]*->copyright\)$"#,
         r"(?i)^copyright\s*(?:\(c\)\s*)?(?:19|20)\d{2}(?:-(?:19|20)\d{2})?\s+.*copyright holder$",
+        // Creative Commons license-body prose (e.g. "Copyright and Similar Rights")
+        // is handled generally by `is_creative_commons_license_prose` in junk.rs.
+        // The CC-BY-SA text also truncates a sentence to this bare "(c)" fragment.
+        r"(?i)^\(c\)\s+may\s+be\s+implemented\s+in\b",
     ];
     patterns.iter().filter_map(|p| Regex::new(p).ok()).collect()
 });

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -710,11 +710,14 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^contributor,\s*path$",
         r"(?x)\b[A-Za-z_][A-Za-z0-9_]*\([^)]*\).*[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\(",
         r"^(?:[\u{0080}-\u{00FF}]+\s*){6,}$",
-        // Creative Commons license-body prose. The CC texts truncate to bare
-        // "Similar" / "resulting" holders, and yield several generic legal-prose
-        // fragments. The "Similar Rights ..." family and CC/treaty vocabulary are
+        // Short legal-prose holder fragments seen in full CC license texts. The
+        // "Similar Rights ..." family and CC/treaty-exclusive vocabulary are
         // handled by the shared `is_creative_commons_license_prose` predicate in
-        // junk.rs; these are the remaining short prose fragments.
+        // junk.rs; these are the remaining short fragments. Note that several of
+        // these (e.g. "including, without limitation", "notice, terms of
+        // service") are general legal boilerplate, not CC-exclusive vocabulary;
+        // they merely surface here from CC bodies. The `^` anchor keeps them
+        // narrow enough to stay safe against real holder names.
         r"(?i)^similar$",
         r"(?i)^resulting$",
         r"(?i)^including\s*,\s*without\s+limitation\b",

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -710,6 +710,18 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^contributor,\s*path$",
         r"(?x)\b[A-Za-z_][A-Za-z0-9_]*\([^)]*\).*[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\(",
         r"^(?:[\u{0080}-\u{00FF}]+\s*){6,}$",
+        // Creative Commons license-body prose. The CC texts truncate to bare
+        // "Similar" / "resulting" holders, and yield several generic legal-prose
+        // fragments. The "Similar Rights ..." family and CC/treaty vocabulary are
+        // handled by the shared `is_creative_commons_license_prose` predicate in
+        // junk.rs; these are the remaining short prose fragments.
+        r"(?i)^similar$",
+        r"(?i)^resulting$",
+        r"(?i)^including\s*,\s*without\s+limitation\b",
+        r"(?i)^as\s+requested(?:\.\s+if)?$",
+        r"(?i)^notice\s*,\s*terms\s+of\s+service\b",
+        r"(?i)^may\s+be\s+implemented\s+in\b",
+        r"(?i)^certain\s+other$",
     ];
     patterns.iter().filter_map(|p| Regex::new(p).ok()).collect()
 });

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -29,6 +29,62 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_junk_copyright_code_fragment(s)
         || is_junk_copyright_symbol_garbage(s)
         || is_junk_c_sign_path_fragment(s)
+        || is_creative_commons_license_prose(s)
+}
+
+/// Return true if `s` is a fragment of Creative Commons (or cited treaty)
+/// license body text rather than a real copyright statement or holder.
+///
+/// Full CC public-license texts (CC-BY, CC-BY-SA, etc.) contain legal prose that
+/// repeatedly uses the words "copyright", "Licensor", "Similar Rights", and
+/// treaty names. The copyright detector extracts fragments of that prose as
+/// spurious copyrights and holders.
+///
+/// "Strong" markers are phrases that appear only in CC/treaty license bodies and
+/// never in a real copyright line, so they classify as prose regardless of any
+/// embedded year (the WIPO/Berne paragraph cites treaty years). "Weak" markers
+/// are shorter CC phrases that are only treated as prose when the candidate
+/// carries no copyright year, which keeps genuine notices such as
+/// `Copyright (c) 2016 Jane Doe` untouched.
+pub(super) fn is_creative_commons_license_prose(s: &str) -> bool {
+    const CC_STRONG_PROSE_MARKERS: &[&str] = &[
+        "rights granted under",
+        "effective technological measures",
+        "berne convention",
+        "wipo copyright treaty",
+        "wipo performances and phonograms",
+        "universal copyright convention",
+        "rome convention",
+        "convention as revised",
+        "certain other rights specified in the public",
+        "declarations recited in the",
+        "arising from limitations or exceptions",
+    ];
+    const CC_WEAK_PROSE_MARKERS: &[&str] = &[
+        "similar rights",
+        "copyright and/or",
+        "copyright and certain other rights",
+        "certain other rights",
+        "other rights in the material",
+    ];
+
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if CC_STRONG_PROSE_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+    {
+        return true;
+    }
+
+    !has_copyright_year(trimmed)
+        && CC_WEAK_PROSE_MARKERS
+            .iter()
+            .any(|marker| lower.contains(marker))
 }
 
 pub(super) fn looks_like_structured_copyright_notice_with_year(s: &str) -> bool {
@@ -136,6 +192,7 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
     HOLDERS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
         || is_junk_holder_code_fragment(s)
         || is_junk_holder_symbol_garbage(s)
+        || is_creative_commons_license_prose(s)
         || s.eq_ignore_ascii_case("MIT")
 }
 

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -591,6 +591,21 @@ fn test_cc_prose_suppression_preserves_real_notices() {
     assert!(!is_junk_holder("Acme Inc."));
 }
 
+#[test]
+fn test_cc_prose_year_guard_keeps_weak_marker_notices() {
+    // The year guard protects the *weak* CC markers. A real notice that both
+    // carries a copyright year AND contains a weak marker phrase ("similar
+    // rights", "certain other rights") must NOT be dropped as junk. The year
+    // lives in the copyright statement, so this invariant is exercised at the
+    // copyright level (refined holders do not carry years).
+    assert!(!is_junk_copyright(
+        "Copyright 2020 Foundation for Similar Rights"
+    ));
+    assert!(!is_junk_copyright(
+        "Copyright 2020 Acme and certain other rights reserved"
+    ));
+}
+
 // ── refine_copyright ─────────────────────────────────────────────
 
 #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -531,6 +531,66 @@ fn test_is_junk_copyright_c_sign_path_fragment() {
     assert!(is_junk_copyright("(c) Ljoptsimple/AbstractOptionSpec"));
 }
 
+// ── Creative Commons license-prose suppression ───────────────────
+
+#[test]
+fn test_is_junk_copyright_cc_license_prose() {
+    // "Copyright and Similar Rights" and its continuations from CC license text.
+    assert!(is_junk_copyright("Copyright and Similar Rights"));
+    assert!(is_junk_copyright(
+        "Copyright and Similar Rights held by the Licensor"
+    ));
+    assert!(is_junk_copyright("Copyright and Similar Rights in Your"));
+    assert!(is_junk_copyright(
+        "copyright and/or similar rights closely related to"
+    ));
+    assert!(is_junk_copyright(
+        "copyright and certain other rights. Our licenses are irrevocable"
+    ));
+    assert!(is_junk_copyright(
+        "copyright declarations recited in the relevant treaty"
+    ));
+}
+
+#[test]
+fn test_is_junk_copyright_cc_treaty_paragraph_with_years() {
+    // The WIPO/Berne paragraph cites treaty years but is still license prose,
+    // not a copyright notice. Strong markers classify it regardless of year.
+    assert!(is_junk_copyright(
+        "The rights granted under, and the subject matter referenced, in this \
+         License were drafted utilizing the terminology of the Berne Convention \
+         of 1979, the Rome Convention of 1961, the WIPO Copyright Treaty of 1996."
+    ));
+}
+
+#[test]
+fn test_is_junk_holder_cc_license_prose() {
+    assert!(is_junk_holder("Similar"));
+    assert!(is_junk_holder("Similar Rights"));
+    assert!(is_junk_holder("Similar Rights held by the Licensor"));
+    assert!(is_junk_holder("Similar Rights in Your"));
+    assert!(is_junk_holder(
+        "certain other rights specified in the public"
+    ));
+    assert!(is_junk_holder("certain other"));
+    assert!(is_junk_holder("Convention as revised"));
+    assert!(is_junk_holder("declarations recited in the"));
+    assert!(is_junk_holder("arising from limitations or exceptions"));
+    assert!(is_junk_holder("resulting"));
+}
+
+#[test]
+fn test_cc_prose_suppression_preserves_real_notices() {
+    // Real copyright notices and holders must survive even when they share
+    // tokens with CC prose; the year guard protects weak-marker phrases.
+    assert!(!is_junk_copyright("Copyright (c) 2016 Jane Doe"));
+    assert!(!is_junk_copyright(
+        "Copyright 2020 Acme Inc. All rights reserved."
+    ));
+    assert!(!is_junk_holder("Jane Doe"));
+    assert!(!is_junk_holder("Acme Inc."));
+}
+
 // ── refine_copyright ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Provenant over-extracted fragments of Creative Commons license body text as copyright statements and holders. CC license texts (CC-BY, CC-BY-SA, and variants) define and repeatedly reference "Copyright and Similar Rights" and cite the Berne/WIPO copyright treaties; the copyright detector treated that legal prose as notices. ScanCode does not emit these. This recurs in any repo containing CC license files (found via dejacode and select2).
- Adds a shared `is_creative_commons_license_prose` predicate wired into both `is_junk_copyright` and `is_junk_holder` in `src/copyright/refiner/junk.rs`, plus a small number of targeted junk patterns for short truncated fragments.

### Approach

- **Strong** CC/treaty signatures (e.g. `rights granted under`, `Berne Convention`, `WIPO Copyright Treaty`, `Universal Copyright Convention`) classify a candidate as license prose regardless of any embedded year, because the WIPO/Berne paragraph cites treaty years (1979, 1961, 1996, ...) yet is not a copyright notice.
- **Weak** CC phrases (`similar rights`, `certain other rights`, `copyright and/or`) are only treated as prose when the candidate carries no copyright year, so genuine notices such as `Copyright (c) 2016 Jane Doe` are preserved even when they sit inside or next to a license file.

A region-aware approach (suppressing copyright statements inside a detected full license-text span) was considered but rejected as too invasive: copyright detection runs before license detection in the scan pipeline, so license-region information is not available at copyright time, and reordering the pipeline carries real risk. The phrase-signature predicate is a single, principled, year-safe lever rather than open-ended phrase whack-a-mole.

### Before / after

`cargo run -- testdata/.../cc-by-4.0.txt --copyright --json-pp -`

Before:

```
C: ['Copyright and Similar Rights', 'Copyright and Similar Rights held by the Licensor',
    'Copyright and Similar Rights in Your', 'copyright and/or similar rights closely related to',
    'Copyright and Similar Rights. Effective Technological Measures', ... ]
H: ['Similar', 'Similar Rights by the Licensor', 'Similar Rights in Your',
    'including, without limitation, performance, broadcast, sound recording',
    'resulting', 'Similar Rights. Section', ... ]
```

After:

```
C: []
H: []
```

Every CC license fixture now produces zero spurious copyrights/holders, and a full `--license --copyright` scan still detects the license correctly (e.g. `cc-by-sa-4.0`).

## Scope and exclusions

- Included: CC-BY / CC-BY-SA / CC-BY-NC / CC-BY-NC-ND family license-text false positives for copyrights and holders.
- Explicit exclusions: no change to license detection, parsers, or output schema.

## How to verify

- Run `cargo run -- <any full CC license file> --copyright --json-pp -` and confirm no `copyrights`/`holders` are emitted, while a `--license --copyright` run still reports the CC license.
- Confirm a real notice survives: a file containing `Copyright (c) 2016 Jane Doe` alongside CC prose still yields the Jane Doe copyright and holder.

## Intentional differences from Python

- None. This brings Provenant closer to ScanCode, which already excludes these CC license-body fragments.

## Expected-output fixture changes

- Files changed: none. The existing `copyright_golden` suite stays green with no golden updates; new behavior is covered by focused unit tests in `src/copyright/refiner/tests.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
