### PR TITLE
fix(copyright): stop binary files from emitting junk copyrights and holders

### DIFF
--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -84,6 +84,10 @@ pub(super) fn extract_copyright_information(
                 start_line: c.start_line,
                 end_line: c.end_line,
             })
+            // The font-metadata-label check is applied to every copyright, not only
+            // font paths: `License Description:` / `License Info URL:` are OpenType
+            // name-table field labels and are never a legitimate copyright prefix in
+            // real source, so rejecting them universally is safe and path-independent.
             .filter(|c| {
                 !is_binary_garbage_party_value(&c.copyright)
                     && !is_font_metadata_label_copyright(&c.copyright)
@@ -457,10 +461,6 @@ fn is_binary_garbage_party_value(text: &str) -> bool {
     }
 
     let total = trimmed.chars().count();
-    if total == 0 {
-        return false;
-    }
-
     let replacement = trimmed.chars().filter(|&ch| ch == '\u{FFFD}').count();
     if replacement as f64 / total as f64 > MAX_REPLACEMENT_RATIO {
         return true;

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -484,8 +484,13 @@ fn is_binary_garbage_party_value(text: &str) -> bool {
 fn is_font_metadata_label_copyright(text: &str) -> bool {
     const FONT_METADATA_LABELS: &[&str] = &["License Description:", "License Info URL:"];
     let trimmed = text.trim_start();
+    // Compare on bytes so a multi-byte UTF-8 char at the slice boundary cannot panic;
+    // the labels are pure ASCII, so a byte-level case-insensitive prefix is exact.
     FONT_METADATA_LABELS.iter().any(|label| {
-        trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label)
+        trimmed
+            .as_bytes()
+            .get(..label.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(label.as_bytes()))
     })
 }
 

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -59,6 +59,17 @@ pub(super) fn extract_copyright_information(
         (copyrights, holders, authors)
     };
 
+    // Universal guard against binary garbage leaking into parties. Real copyright
+    // and holder values are short and printable; a multi-kilobyte blob or a string
+    // dense with replacement / non-printable bytes (e.g. a raw image or font byte
+    // run) is never a legitimate notice, regardless of the detection source path.
+    // The rendered copyright value is checked alongside the normalized one because
+    // raw-text projection can re-expand a blob the normalized value had collapsed.
+    let holders: Vec<HolderDetection> = holders
+        .into_iter()
+        .filter(|h| !is_binary_garbage_party_value(&h.holder))
+        .collect();
+
     file_info_builder.copyrights(
         copyrights
             .into_iter()
@@ -72,6 +83,18 @@ pub(super) fn extract_copyright_information(
                 ),
                 start_line: c.start_line,
                 end_line: c.end_line,
+            })
+            .filter(|c| {
+                !is_binary_garbage_party_value(&c.copyright)
+                    && !is_font_metadata_label_copyright(&c.copyright)
+                    && !c
+                        .normalized_copyright
+                        .as_deref()
+                        .is_some_and(is_binary_garbage_party_value)
+                    && !c
+                        .normalized_copyright
+                        .as_deref()
+                        .is_some_and(is_font_metadata_label_copyright)
             })
             .collect::<Vec<Copyright>>(),
     );
@@ -90,7 +113,8 @@ pub(super) fn extract_copyright_information(
     authors.extend(extract_comment_author_supplements(text_content));
     let mut seen_authors = HashSet::new();
     authors.retain(|author| {
-        seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
+        !is_binary_garbage_party_value(&author.author)
+            && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
     });
 
     file_info_builder.authors(
@@ -406,6 +430,63 @@ fn ranges_overlap(
     b_end: LineNumber,
 ) -> bool {
     a_start <= b_end && b_start <= a_end
+}
+
+/// Hard reject for party values (copyright / holder / author) that are obviously
+/// scraped binary content rather than a human-authored notice. This is a last-line
+/// correctness guard applied on every emit path: a legitimate notice is short and
+/// printable, so a very long value or one dense with replacement / non-printable
+/// bytes can be dropped outright without risking real source-file detections.
+fn is_binary_garbage_party_value(text: &str) -> bool {
+    // Longest realistic notices (multi-holder lines with URLs) stay well under
+    // this bound; a value beyond it is a binary blob, not a notice.
+    const MAX_PARTY_VALUE_BYTES: usize = 1_000;
+    // Replacement chars come from lossy decoding of non-UTF-8 binary runs.
+    const MAX_REPLACEMENT_RATIO: f64 = 0.02;
+    // Non-printable controls (excluding ordinary whitespace) never appear in a
+    // genuine notice but pepper binary scrapes.
+    const MAX_CONTROL_RATIO: f64 = 0.02;
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.len() > MAX_PARTY_VALUE_BYTES {
+        return true;
+    }
+
+    let total = trimmed.chars().count();
+    if total == 0 {
+        return false;
+    }
+
+    let replacement = trimmed.chars().filter(|&ch| ch == '\u{FFFD}').count();
+    if replacement as f64 / total as f64 > MAX_REPLACEMENT_RATIO {
+        return true;
+    }
+
+    let control = trimmed
+        .chars()
+        .filter(|ch| ch.is_control() && !ch.is_whitespace())
+        .count();
+    if control as f64 / total as f64 > MAX_CONTROL_RATIO {
+        return true;
+    }
+
+    false
+}
+
+/// Reject copyright values that are actually font name-table metadata lines wrapped
+/// with their field label (e.g. `License Description: ...`). The license/URL text
+/// of a font may embed a copyright notice, but the labeled wrapper line is metadata,
+/// not a copyright statement, and license detection already owns that text.
+fn is_font_metadata_label_copyright(text: &str) -> bool {
+    const FONT_METADATA_LABELS: &[&str] = &["License Description:", "License Info URL:"];
+    let trimmed = text.trim_start();
+    FONT_METADATA_LABELS.iter().any(|label| {
+        trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label)
+    })
 }
 
 fn is_binary_string_copyright_candidate(text: &str) -> bool {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -3,12 +3,113 @@
 
 use super::{
     extract_comment_author_supplements, extract_copyright_information,
-    extract_patch_header_author_supplements, is_binary_string_copyright_candidate,
+    extract_patch_header_author_supplements, is_binary_garbage_party_value,
+    is_binary_string_copyright_candidate, is_font_metadata_label_copyright,
 };
 use crate::copyright;
 use crate::models::{FileInfoBuilder, FileType};
 use std::path::Path;
 use std::time::Duration;
+
+fn build_single_file(mut builder: FileInfoBuilder) -> crate::models::FileInfo {
+    builder
+        .name("fixture".to_string())
+        .base_name("fixture".to_string())
+        .extension(String::new())
+        .path("fixture".to_string())
+        .file_type(FileType::File)
+        .size(0)
+        .build()
+        .expect("builder should produce file info")
+}
+
+#[test]
+fn test_binary_garbage_party_value_rejects_oversized_blob() {
+    let blob = "Copyright ".to_string() + &"a".repeat(2_000);
+    assert!(is_binary_garbage_party_value(&blob));
+}
+
+#[test]
+fn test_binary_garbage_party_value_rejects_control_byte_dense_value() {
+    let noisy = "Copyright 2020 \u{0001}\u{0002}\u{0001}\u{0002}\u{0001}\u{0002}Acme";
+    assert!(is_binary_garbage_party_value(noisy));
+}
+
+#[test]
+fn test_binary_garbage_party_value_rejects_replacement_char_dense_value() {
+    let noisy = format!("Copyright 2020 {}", "\u{FFFD}".repeat(30));
+    assert!(is_binary_garbage_party_value(&noisy));
+}
+
+#[test]
+fn test_binary_garbage_party_value_keeps_legitimate_notice() {
+    assert!(!is_binary_garbage_party_value(
+        "Copyright (c) 2010-2011 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)"
+    ));
+    assert!(!is_binary_garbage_party_value(
+        "Copyright 2013 Google Inc. All Rights Reserved."
+    ));
+}
+
+#[test]
+fn test_font_metadata_label_copyright_rejects_license_description_wrapper() {
+    assert!(is_font_metadata_label_copyright(
+        "License Description: Copyright (c) 2009-2010, Design Science, Inc."
+    ));
+    assert!(is_font_metadata_label_copyright(
+        "License Info URL: http://scripts.sil.org/OFL"
+    ));
+    assert!(!is_font_metadata_label_copyright(
+        "Copyright (c) 2009-2010 Design Science, Inc."
+    ));
+}
+
+#[test]
+fn test_extract_copyright_information_drops_font_name_table_glyph_run() {
+    // A printable-string scrape of a font binary: a clean curated notice followed
+    // by a glyph-name concatenation run with no year or copyright marker.
+    let text = "Copyright 2013 Google Inc. All Rights Reserved.\n\
+        (c) ordfeminine guillemotleft danish ae oe period comma";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("font.ttf"), text, 120.0, true);
+
+    let file = build_single_file(builder);
+    let copyrights: Vec<&str> = file
+        .copyrights
+        .iter()
+        .map(|c| c.copyright.as_str())
+        .collect();
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.contains("Copyright 2013 Google Inc.")),
+        "copyrights: {copyrights:?}"
+    );
+    assert!(
+        !copyrights.iter().any(|c| c.contains("ordfeminine")),
+        "glyph-name run leaked into copyrights: {copyrights:?}"
+    );
+}
+
+#[test]
+fn test_extract_copyright_information_drops_oversized_rendered_blob_copyright() {
+    // A single line carrying a copyright marker followed by a multi-kilobyte run of
+    // text: detection latches onto the marker, but the rendered raw value re-expands
+    // into the full blob, which must be dropped rather than emitted as a copyright.
+    let blob = format!("Copyright 2020 Acme Inc. {}", "word ".repeat(500));
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("photo.jpg"), &blob, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(
+        file.copyrights.iter().all(|c| c.copyright.len() <= 1_000),
+        "oversized blob leaked as copyright: {:?}",
+        file.copyrights
+            .iter()
+            .map(|c| c.copyright.len())
+            .collect::<Vec<_>>()
+    );
+}
 
 #[test]
 fn test_binary_string_copyright_candidate_rejects_gibberish_holder_text() {

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -270,6 +270,13 @@ fn extract_information_from_content(
         scan_diagnostics.push(ScanDiagnostic::error(text_scan_error));
     }
     let from_binary_strings = matches!(text_kind, ExtractedTextKind::BinaryStrings);
+    // Font metadata text combines a trustworthy curated name-table notice with a
+    // raw printable-string scrape of the font binary; the scrape leaks name-table
+    // and glyph-name junk into copyrights/holders. Prune it like binary strings so
+    // only the legitimate (year- or marker-bearing) notice survives, while keeping
+    // the unpruned text for license and contact detection.
+    let prune_copyright_binary_strings =
+        from_binary_strings || matches!(text_kind, ExtractedTextKind::FontMetadata);
 
     if is_timeout_exceeded(started, text_options.timeout_seconds) {
         return Err(FileScanError::Timeout(FileScanTimeout {
@@ -289,7 +296,7 @@ fn extract_information_from_content(
             path,
             &text_content,
             text_options.timeout_seconds,
-            from_binary_strings,
+            prune_copyright_binary_strings,
         );
         progress.record_detail_timing(
             "scan:copyrights",


### PR DESCRIPTION
## Summary

- Stops binary-derived files from emitting junk copyrights/holders where ScanCode emits nothing or only clean values.
- Adds a universal party-value guard: any copyright/holder/author value that is very long (>1000 bytes) or dense with replacement / non-printable control bytes is rejected outright, regardless of detection source path. This kills the multi-kilobyte image/decoded blob that could appear as a single "copyright".
- Routes font-metadata text through the existing binary-string copyright pruning (separate from the shared license/contact flag) so the raw printable-string scrape of the font binary no longer leaks name-table and glyph-name concatenation runs as holders/copyrights; only the legitimate year-/marker-bearing notice survives.
- Drops copyright values that are actually font name-table wrapper labels (`License Description:` / `License Info URL:`).

### Root cause

`.jpg` images that fail container parsing fell through to the decoded/raw-strings path, which had no binary pruning, so a giant raw-byte run could be emitted as a copyright. Font files (`.ttf`/`.eot`/...) appended a raw `extract_printable_strings()` scrape of the entire font binary onto the curated name-table metadata and tagged the combined text `FontMetadata` (not `BinaryStrings`), so the scrape's glyph names and name-table junk reached the copyright/holder detector unpruned.

### Before / after

`KaTeX_Main-Regular.ttf` copyrights (before):
```
Copyright (c) 2009-2010 Design Science, Inc.
Copyright (c) 2014-2018 Khan Academy
Copyright (c) 2009-2010 Design Science, Inc
License Description: Copyright (c) 2009-2010, Design Science, Inc. (<www.mathjax.org>) ... http://scripts.sil.org/OFL   (x2, 326 chars each)
```
after:
```
Copyright (c) 2009-2010 Design Science, Inc.
Copyright (c) 2014-2018 Khan Academy
Copyright (c) 2009-2010 Design Science, Inc
```

`DarkGardenMK.ttf` copyrights (before): a clean inner notice plus a 1315-char `?`-laden binary blob (a GPL notice mashed together with embedded control bytes).
after: the blob is dropped; the inner notice remains.

Synthetic `.jpg` that falls through to the decoded path with a control-byte-dense / replacement-char-dense blob: before could surface the blob; after emits no junk copyright (only any clean notice survives).

Font license detection (OFL-1.1) and image EXIF copyright detection are unchanged.

## Scope and exclusions

- Included: scanner copyright emit guard (`src/scanner/process/copyright.rs`), font-metadata copyright pruning routing (`src/scanner/process/pipeline.rs`), focused unit tests.
- Explicit exclusions: no changes to `detect_copyrights` core grammar/refiner (the copyright golden suite feeds it directly and stays green); image/font text extraction strategy unchanged; license/contact detection text unchanged.

## How to verify

- `cargo test --lib copyright`
- `cargo test --features golden-tests --test copyright_golden`
- Scan a font and observe no glyph-name/name-table junk or `License Description:` lines in copyrights:
  `provenant --copyright --json-pp - some-font.ttf`

## Expected-output fixture changes

- Files changed: none. The copyright golden suite calls `detect_copyrights` directly (not the scanner emit path) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)