### PR TITLE
docs(testdata): document fixture provenance and attribution policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Routine scans use the embedded license index. The `reference/scancode-toolkit/` 
 
 Use the Python ScanCode codebase as a behavioral reference, not an implementation template or an unquestioned source of truth. When comparing with ScanCode code or scan output, first identify the user-facing contract it demonstrates, then ask whether Provenant can solve the case more accurately, clearly, or safely before adopting the same behavior.
 
-When an upstream test fixture is needed for Provenant tests, copy it into Provenant-owned `testdata/` and reference that local copy. Do **not** make tests or golden fixtures depend directly on paths under `reference/scancode-toolkit/`.
+When an upstream test fixture is needed for Provenant tests, copy it into Provenant-owned `testdata/` and reference that local copy. Do **not** make tests or golden fixtures depend directly on paths under `reference/scancode-toolkit/`. Prefer synthetic or truncated fixtures over wholesale copies. When you do add a **substantial, wholesale** copy of an identifiable third-party file or package — especially under a copyleft or notice-required license — record its source and license in a short co-located note (a `README`/`SOURCE` in the containing directory), not in a central index. See [`testdata/PROVENANCE.md`](testdata/PROVENANCE.md) for the overall provenance policy.
 
 ## Run-Every-Time Guardrails
 

--- a/testdata/PROVENANCE.md
+++ b/testdata/PROVENANCE.md
@@ -1,0 +1,44 @@
+# testdata/ provenance and attribution
+
+The fixtures in this directory are **test inputs only**. They are not part of any
+Provenant distribution: `testdata/` is excluded from the published crate and the
+release binaries, and from the SPDX license-header scope. It exists solely to
+exercise Provenant's parsers, detectors, and golden comparisons.
+
+## Composition
+
+The corpus is a mix of:
+
+1. **Provenant-authored fixtures** — synthetic inputs (hand-written manifests,
+   minimal parser probes, intentionally malformed negatives, and expected golden
+   outputs) created by Provenant contributors and licensed under Apache-2.0 with
+   the rest of the project.
+
+2. **Fixtures copied or adapted from the ScanCode Toolkit test suite** — mirrored
+   locally per the contributor workflow rather than referenced from the
+   submodule. These remain under their upstream ScanCode licensing (Apache-2.0
+   for code, CC-BY-4.0 for data); see the root [`NOTICE`](../NOTICE).
+
+3. **Small inputs derived from public open-source repositories** encountered while
+   developing and benchmarking Provenant (see [`docs/BENCHMARKS.md`](../docs/BENCHMARKS.md)
+   for the repositories that have been scanned). These are small, representative
+   inputs used to reproduce real-world parsing and detection behavior.
+
+## Attribution policy
+
+Third-party fixture content remains under its original license; Provenant claims
+no ownership of it and includes it solely as test data. Per-fixture provenance is
+**not** individually tracked: the corpus accreted over time and exact origins
+cannot be reliably reconstructed, consistent with common practice for large test
+corpora.
+
+License and copyright **texts** present as fixtures are reproductions of those
+licenses, included to exercise license/copyright detection; reproducing a
+license's own text is not a third-party-code concern.
+
+When a **substantial, wholesale** copy of an identifiable third-party file or
+package is added — especially under a copyleft or notice-required license — its
+source and license are recorded in a **co-located note** next to the fixture (a
+short `README`/`SOURCE` in the containing directory), rather than in a central
+index that would drift as fixtures move. Prefer synthetic or truncated fixtures
+over wholesale copies where they exercise the same behavior.

--- a/testdata/alpine-fixtures/apkbuild/SOURCE.md
+++ b/testdata/alpine-fixtures/apkbuild/SOURCE.md
@@ -1,0 +1,12 @@
+# Source
+
+The Alpine `APKBUILD` packaging-script fixtures under this directory are copied
+from the Alpine Linux aports repository:
+
+- https://github.com/alpinelinux/aports
+
+aports is licensed under the **MIT License**. Each `APKBUILD`'s `license=` field
+describes the *packaged* software (e.g. `custom:multiple` for `linux-firmware`),
+which carries its own license distinct from the MIT-licensed APKBUILD script.
+Included here solely as parser test fixtures. See
+[`../../PROVENANCE.md`](../../PROVENANCE.md).

--- a/testdata/conan/recipes/SOURCE.md
+++ b/testdata/conan/recipes/SOURCE.md
@@ -1,0 +1,13 @@
+# Source
+
+The Conan recipe fixtures in this directory (`conanfile.py`, `conandata.yml`, and
+related files for `boost`, `libgettext`, `libzip`) are copied from the Conan
+Center Index:
+
+- https://github.com/conan-io/conan-center-index
+
+conan-center-index recipes are licensed under the **MIT License**. The recipes
+describe third-party C/C++ libraries that carry their own, separate licenses
+(e.g. Boost Software License, BSD, LGPL); those licenses apply to the described
+libraries, not to these recipe files. Included here solely as parser test
+fixtures. See [`../../PROVENANCE.md`](../../PROVENANCE.md).


### PR DESCRIPTION
## Summary

Document the provenance and attribution policy for `testdata/`, and apply it to the two identifiable wholesale-copied fixture sets.

## Why

`testdata/` is a large (~19.5k files), mixed corpus: Provenant-authored synthetic fixtures, fixtures mirrored from the ScanCode Toolkit test suite, and small inputs derived from public repositories scanned during benchmarking. It is **not part of any distribution** — excluded from the published crate, the release binaries, and the SPDX license-header scope — and per-fixture provenance can't be reliably reconstructed. There was no overall statement of how third-party fixture content is attributed.

## Changes

- **`testdata/PROVENANCE.md`** — a single, **path-free** provenance statement + attribution policy:
  - third-party fixture content stays under its original license; Provenant claims no ownership;
  - license/copyright **texts** are reproductions used to exercise detection (not a third-party-code concern);
  - a **substantial, wholesale** copy (especially copyleft/notice-required) gets a **co-located source note**, not a drift-prone central index;
  - prefer synthetic/truncated fixtures over wholesale copies.
- **`AGENTS.md`** — the forward policy for contributors, pointing at `PROVENANCE.md`.
- **Two co-located `SOURCE.md` notes** for the only identifiable wholesale copies from benchmark targets:
  - `testdata/conan/recipes/` ← conan-io/conan-center-index (**MIT**)
  - `testdata/alpine-fixtures/apkbuild/` ← alpinelinux/aports (**MIT**)
  Both are MIT packaging files that *describe* third-party-licensed packages — not copyleft source.

## Research result (copyleft audit)

An initial round found **no wholesale copyleft source files** in `testdata/`. The copyleft *mentions* are: Provenant golden output (detected expressions), small manifests/recipes that *declare* a copyleft license for the package they describe (the fixture files themselves are MIT or synthetic), and Debian DEP-5 copyright *metadata* files. The two genuinely wholesale copies from scanned repos (conan-center-index, aports) are MIT.

## How to verify

- `testdata/` is absent from `Cargo.toml`'s `include` and present in `.license-headers.toml`'s `exclude`.
- Conan and Alpine parser/golden suites pass with the new `SOURCE.md` notes in place (`cargo test --lib conan` / `alpine`): the notes sit above any scanned fixture path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
