### PR TITLE
verify: refresh ten benchmark targets on M5 Pro (sweep 8)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **14.1× median speedup** and **13.8× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.4×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **14.3× median speedup** and **13.9× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.5×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -62,27 +62,27 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `8.68s`; ScanCode `155.12s`
 - Richer file-level Android package extraction (`31` vs `18` package_data records) and dependency coverage (`148` vs `145`) across committed Soong `METADATA`, `AndroidManifest.xml`, `TestApp.apk`, cargo, and `go.work` surfaces, with correct `The Android Open Source Project` holder attribution where ScanCode leaves it null, plus declared licenses that avoid conflating the `tools/compliance` test-fixture licenses ScanCode pulls into the package expression
 
-##### [facebook/fresco @ c991a69](https://github.com/facebook/fresco/tree/c991a692a254358d1cf56c5b4b06e6c5dd96cfab) — **23.42× faster**
+##### [facebook/fresco @ c991a69](https://github.com/facebook/fresco/tree/c991a692a254358d1cf56c5b4b06e6c5dd96cfab) — **37.03× faster**
 
 - Files: 2,900
-- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `21.38s`; ScanCode `500.76s`
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.79s`; ScanCode `362.51s`
 - Richer Android and Gradle dependency extraction (`768` vs `688`) across committed `build.gradle`, nearby Kotlin `buildSrc` constant catalogs, and `AndroidManifest.xml` surfaces, with exact Maven coordinates for symbolic Gradle references such as `Deps.AndroidX.*`, `Deps.Bolts.*`, and `TestDeps.*` where ScanCode emits placeholder-only names like `AndroidX`, `Bolts`, or `junit`, plus direct Android package visibility and cleaner URL normalization
 
-##### [KhronosGroup/Vulkan-ValidationLayers @ d72c5f5](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/d72c5f52886913598d4064fe8d03bf8ac471e215) — **17.97× faster**
+##### [KhronosGroup/Vulkan-ValidationLayers @ d72c5f5](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/d72c5f52886913598d4064fe8d03bf8ac471e215) — **33.22× faster**
 
 - Files: 979
-- Run context: 2026-04-21 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `38.32s`; ScanCode `688.72s`
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `12.37s`; ScanCode `410.98s`
 - Direct AndroidManifest package visibility (`1` vs `0` on `tests/android/AndroidManifest.xml`), clue-only weak GPL handling across Graphics Pipeline Library acronym sites instead of ScanCode's hard `GPL-1.0-or-later` detections, and cleaner Khronos documentation copyright or holder recovery without appended `- ! Khronos Vulkan` noise
 
 #### Chef
 
-##### [chef/chef @ 0e353ff](https://github.com/chef/chef/tree/0e353ffcc8c03ac5b57025081787913121c785d5) — **12.07× faster**
+##### [chef/chef @ 0e353ff](https://github.com/chef/chef/tree/0e353ffcc8c03ac5b57025081787913121c785d5) — **19.55× faster**
 
 - Files: 2,274
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `30.70s`; ScanCode `370.51s`
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `12.03s`; ScanCode `235.22s`
 - Richer mixed-surface package identity with fewer placeholder-only Debian rows and far broader dependency extraction (`351` vs `278`) across `Gemfile`, `Gemfile.lock`, `chef-*/Gemfile`, gemspec, Dockerfile, and fixture archive/control surfaces, plus email-preserving author normalization and cleaner placeholder-holder filtering
 
 ##### [sous-chefs/apache2 @ 420d824](https://github.com/sous-chefs/apache2/tree/420d82402811a131729a6bcc80aaac08d307ac87) — **10.22× faster**
@@ -115,39 +115,39 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `22.82s`; ScanCode `292.75s`
 - Broader ABOUT and Python package visibility (`28` vs `1` packages, `292` vs `56` dependencies) across committed `.ABOUT` files, root and suffixed `pyproject.toml` manifests, and `uv.lock`, plus zero scan-file errors where ScanCode times out on large generated scan-result JSON fixtures
 
-##### [aboutcode-org/scancode-toolkit @ 6570c13](https://github.com/aboutcode-org/scancode-toolkit/tree/6570c131e2821388286f661368a70e0120aaf2c6) — **13.48× faster**
+##### [aboutcode-org/scancode-toolkit @ 6570c13](https://github.com/aboutcode-org/scancode-toolkit/tree/6570c131e2821388286f661368a70e0120aaf2c6) — **19.96× faster**
 
 - Files: 64,369
-- Run context: 2026-04-25 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `535.40s`; ScanCode `7214.43s`
-- Far broader ABOUT-adjacent package and dependency visibility (`1281` vs `6` packages, `10943` vs `377` dependencies) across committed `.ABOUT` sidecars, Python/Swift/Dart/CocoaPods fixture manifests, and bounded RPM header metadata recovery, with real ecosystem PURLs derived from ABOUT `download_url` metadata instead of `pkg:about/...` fallbacks and zero scan-file errors where ScanCode times out on heavy fixture snapshots; the remaining ScanCode edge is concentrated in a small set of license-detection corpus and legal-text cases where it still preserves extra detections beyond Provenant’s current policy or refinement choices
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `207.10s`; ScanCode `4134.60s`
+- Far broader ABOUT-adjacent package and dependency visibility (`1294` vs `6` packages, `10952` vs `377` dependencies) across committed `.ABOUT` sidecars, Python/Swift/Dart/CocoaPods fixture manifests, and bounded RPM header metadata recovery, with real ecosystem PURLs derived from ABOUT `download_url` metadata instead of `pkg:about/...` fallbacks and zero scan-file errors where ScanCode times out on heavy fixture snapshots; the remaining ScanCode edge is concentrated in a small set of license-detection corpus and legal-text cases where it still preserves extra detections beyond Provenant’s current policy or refinement choices
 
-##### [apache/airflow @ 47ce5f3](https://github.com/apache/airflow/tree/47ce5f32b4fae95f5865ba256d409c778d53a3d5) — **14.33× faster**
+##### [apache/airflow @ 47ce5f3](https://github.com/apache/airflow/tree/47ce5f32b4fae95f5865ba256d409c778d53a3d5) — **22.72× faster**
 
-- Files: 11,854
-- Run context: 2026-04-11 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `65.32s`; ScanCode `936.34s`
-- Far broader Python/provider package coverage (`142` vs `1`) and dependency extraction (`7579` vs `450`) from `uv.lock`, provider `pyproject.toml`, and committed `pnpm-lock.yaml` inputs, plus extra Docker and Helm package visibility, safer URL credential stripping, and cleaner copyright/author normalization across large documentation and kernel-style metadata blocks
+- Files: 11,935
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `50.99s`; ScanCode `1158.57s`
+- Far broader Python/provider package coverage (`142` vs `1`) and dependency extraction (`7599` vs `1014`) from `uv.lock`, provider `pyproject.toml`, and committed `pnpm-lock.yaml` inputs, plus extra Docker and Helm package visibility, safer URL credential stripping, and cleaner copyright/author normalization across large documentation and kernel-style metadata blocks
 
-##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **17.90× faster**
+##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **5.98× faster**
 
 - Files: 1,259
-- Run context: 2026-04-23 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `20.79s`; ScanCode `372.18s`
-- Far broader Python-family package and dependency extraction (`112` vs `1` packages, `5277` vs `759` dependencies) from the large `test/requirements/**` tree, many fixture/workspace `pyproject.toml` files, and multiple `uv.lock` inputs that ScanCode leaves at zero, with safer URL credential stripping, Unicode-preserving party normalization, and METADATA-backed wheel identity instead of double-counting a misleading filename
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `45.62s`; ScanCode `272.81s`
+- Far broader Python-family package and dependency extraction (`113` vs `1` packages, `5279` vs `759` dependencies) from the large `test/requirements/**` tree, many fixture/workspace `pyproject.toml` files, and multiple `uv.lock` inputs that ScanCode leaves at zero, with safer URL credential stripping, Unicode-preserving party normalization, and METADATA-backed wheel identity instead of double-counting a misleading filename
 
-##### [astropy/astropy @ 40280e3](https://github.com/astropy/astropy/tree/40280e3bd715a4968eda816c73bf88f05aa6cdc0) — **22.04× faster**
+##### [astropy/astropy @ 40280e3](https://github.com/astropy/astropy/tree/40280e3bd715a4968eda816c73bf88f05aa6cdc0) — **36.99× faster**
 
-- Files: 1,970
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `24.26s`; ScanCode `534.66s`
-- Direct `CITATION.cff` package visibility on the root citation metadata (`1` vs `0` on that file), plus far broader Python dependency extraction (`79` vs `1`) from `pyproject.toml` and `docs/rtd_environment.yaml`, with cleaner vendored holder recovery and Unicode-preserving copyright normalization
+- Files: 1,962
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.63s`; ScanCode `356.23s`
+- Broader Python package coverage (`3` vs `1` packages) including direct `CITATION.cff` citation-metadata visibility, with matched dependency coverage (`79` vs `77`) from `pyproject.toml` and `docs/rtd_environment.yaml`, cleaner vendored holder recovery, and Unicode-preserving copyright normalization
 
-##### [conda/conda @ 37549c4](https://github.com/conda/conda/tree/37549c41a1925b0625e346e2823a5e15af03b862) — **11.70× faster**
+##### [conda/conda @ 37549c4](https://github.com/conda/conda/tree/37549c41a1925b0625e346e2823a5e15af03b862) — **15.79× faster**
 
-- Files: 285
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.05s`; ScanCode `117.64s`
+- Files: 284
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.02s`; ScanCode `79.28s`
 - Broader Conda and Python package coverage (`5` vs `2` packages, `73` vs `26` dependencies) from `conda.recipe/meta.yaml`, multiple `environment.yml` fixtures, and the root `setup.py`, with safer URL credential stripping across authentication test fixtures
 
 ##### [conda/conda-build @ 5da509d](https://github.com/conda/conda-build/tree/5da509d13764d96c02c80f24b54ab87d652b2538) — **7.61× faster**
@@ -164,18 +164,18 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.79s`; ScanCode `42.84s`
 - Direct schema-versioned conda-forge feedstock package visibility (`1` vs `0` packages, `51` vs `0` dependencies) from `recipe/recipe.yaml`, plus assembled top-level Conda package identity and preserved source/about metadata
 
-##### [DefectDojo/django-DefectDojo @ 2f25c45](https://github.com/DefectDojo/django-DefectDojo/tree/2f25c4510361e2f27f63fbbcff3901cbd2ef4a07) — **18.83× faster**
+##### [DefectDojo/django-DefectDojo @ 2f25c45](https://github.com/DefectDojo/django-DefectDojo/tree/2f25c4510361e2f27f63fbbcff3901cbd2ef4a07) — **16.13× faster**
 
 - Files: 4,301
-- Run context: 2026-04-16 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `78.26s`; ScanCode `1473.92s`
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `66.90s`; ScanCode `1079.38s`
 - Broader full-repo package and dependency extraction (`3` vs `2` packages, `616` vs `535` dependencies) from `.gitmodules`, `helm/defectdojo/Chart.yaml`, `helm/defectdojo/Chart.lock`, and the root `requirements*.txt` manifests, with direct Helm chart package visibility, pinned PostgreSQL or Valkey chart dependencies, Git-submodule package metadata, and zero scan errors where ScanCode reports 3 scan-file failures on large vulnerability fixtures
 
-##### [django/django @ 09f27cc](https://github.com/django/django/tree/09f27cc373eb1e6e5e8b286204809a79b61d55c3) — **12.03× faster**
+##### [django/django @ 09f27cc](https://github.com/django/django/tree/09f27cc373eb1e6e5e8b286204809a79b61d55c3) — **39.22× faster**
 
-- Files: 6,994
-- Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `29.74s`; ScanCode `357.65s`
+- Files: 7,029
+- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `13.85s`; ScanCode `543.19s`
 - Far broader Python-family package and dependency extraction (`2` vs `1` packages, `16` vs `6` dependencies) because `pyproject.toml` contributes both a real PyPI root package and 5 Python dependencies while `docs/requirements.txt` adds 5 more documentation dependencies that ScanCode leaves at zero, with clearer `BSD-3-Clause` declared-license capture and visibility into the vendored CVS marker that ScanCode skips
 
 ##### [OpenMDAO/OpenMDAO @ bf1fcb6](https://github.com/OpenMDAO/OpenMDAO/tree/bf1fcb6f09a07a49cdba27c2fd765153ec54694c) — **16.66× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -266,9 +266,9 @@ ScanCode: 51.37s</title></rect>
     <rect x="479.04" y="441.32" width="8" height="8" fill="#d97706" rx="1.5"><title>Plack/Plack @ b3984f1
 Files: 275
 ScanCode: 51.98s</title></rect>
-    <rect x="481.50" y="402.72" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda @ 37549c4
-Files: 285
-ScanCode: 117.64s</title></rect>
+    <rect x="481.26" y="421.37" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda @ 37549c4
+Files: 284
+ScanCode: 79.28s</title></rect>
     <rect x="485.27" y="438.93" width="8" height="8" fill="#d97706" rx="1.5"><title>technomancy/leiningen @ 4022732
 Files: 301
 ScanCode: 54.67s</title></rect>
@@ -386,9 +386,9 @@ ScanCode: 265.28s</title></rect>
     <rect x="560.43" y="391.49" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/watchman @ 426a7b7
 Files: 896
 ScanCode: 149.22s</title></rect>
-    <rect x="566.54" y="319.22" width="8" height="8" fill="#d97706" rx="1.5"><title>KhronosGroup/Vulkan-ValidationLayers @ d72c5f5
+    <rect x="566.54" y="343.62" width="8" height="8" fill="#d97706" rx="1.5"><title>KhronosGroup/Vulkan-ValidationLayers @ d72c5f5
 Files: 979
-ScanCode: 688.72s</title></rect>
+ScanCode: 410.98s</title></rect>
     <rect x="567.10" y="402.22" width="8" height="8" fill="#d97706" rx="1.5"><title>python-poetry/poetry @ bfce511
 Files: 987
 ScanCode: 118.91s</title></rect>
@@ -419,9 +419,9 @@ ScanCode: 216.36s</title></rect>
     <rect x="580.51" y="358.66" width="8" height="8" fill="#d97706" rx="1.5"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 ScanCode: 298.91s</title></rect>
-    <rect x="583.87" y="348.30" width="8" height="8" fill="#d97706" rx="1.5"><title>astral-sh/uv @ 9581f2b
+    <rect x="583.87" y="362.98" width="8" height="8" fill="#d97706" rx="1.5"><title>astral-sh/uv @ 9581f2b
 Files: 1259
-ScanCode: 372.18s</title></rect>
+ScanCode: 272.81s</title></rect>
     <rect x="584.14" y="405.69" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian12 @ sha256:9dce90e
 Files: 1264
 ScanCode: 110.49s</title></rect>
@@ -458,9 +458,9 @@ ScanCode: 582.97s</title></rect>
     <rect x="613.95" y="329.87" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaLang/julia @ afc71c2
 Files: 1948
 ScanCode: 549.75s</title></rect>
-    <rect x="614.72" y="331.19" width="8" height="8" fill="#d97706" rx="1.5"><title>astropy/astropy @ 40280e3
-Files: 1970
-ScanCode: 534.66s</title></rect>
+    <rect x="614.44" y="350.37" width="8" height="8" fill="#d97706" rx="1.5"><title>astropy/astropy @ 40280e3
+Files: 1962
+ScanCode: 356.23s</title></rect>
     <rect x="615.38" y="337.97" width="8" height="8" fill="#d97706" rx="1.5"><title>Fedora Minimal 42 container rootfs @ sha256:c30f069
 Files: 1989
 ScanCode: 463.11s</title></rect>
@@ -473,9 +473,9 @@ ScanCode: 200.37s</title></rect>
     <rect x="619.78" y="321.51" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 ScanCode: 656.13s</title></rect>
-    <rect x="624.61" y="348.51" width="8" height="8" fill="#d97706" rx="1.5"><title>chef/chef @ 0e353ff
+    <rect x="624.61" y="369.98" width="8" height="8" fill="#d97706" rx="1.5"><title>chef/chef @ 0e353ff
 Files: 2274
-ScanCode: 370.51s</title></rect>
+ScanCode: 235.22s</title></rect>
     <rect x="627.52" y="350.33" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 ScanCode: 356.55s</title></rect>
@@ -500,9 +500,9 @@ ScanCode: 205.19s</title></rect>
     <rect x="641.06" y="351.33" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 ScanCode: 349.11s</title></rect>
-    <rect x="641.37" y="334.28" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
+    <rect x="641.37" y="349.55" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
 Files: 2900
-ScanCode: 500.76s</title></rect>
+ScanCode: 362.51s</title></rect>
     <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
 ScanCode: 223.79s</title></rect>
@@ -548,9 +548,9 @@ ScanCode: 337.98s</title></rect>
     <rect x="667.96" y="325.26" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
 Files: 4266
 ScanCode: 606.05s</title></rect>
-    <rect x="668.53" y="283.27" width="8" height="8" fill="#d97706" rx="1.5"><title>DefectDojo/django-DefectDojo @ 2f25c45
+    <rect x="668.53" y="297.99" width="8" height="8" fill="#d97706" rx="1.5"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
-ScanCode: 1473.92s</title></rect>
+ScanCode: 1079.38s</title></rect>
     <rect x="673.50" y="319.74" width="8" height="8" fill="#d97706" rx="1.5"><title>akka/akka @ 5ace141
 Files: 4623
 ScanCode: 681.19s</title></rect>
@@ -593,12 +593,12 @@ ScanCode: 2352.73s</title></rect>
     <rect x="701.92" y="334.25" width="8" height="8" fill="#d97706" rx="1.5"><title>openembedded/meta-openembedded @ 7bf89d0
 Files: 6983
 ScanCode: 501.03s</title></rect>
-    <rect x="702.03" y="350.18" width="8" height="8" fill="#d97706" rx="1.5"><title>django/django @ 09f27cc
-Files: 6994
-ScanCode: 357.65s</title></rect>
     <rect x="702.03" y="292.91" width="8" height="8" fill="#d97706" rx="1.5"><title>systemd/systemd @ 89d705a
 Files: 6994
 ScanCode: 1201.90s</title></rect>
+    <rect x="702.37" y="330.44" width="8" height="8" fill="#d97706" rx="1.5"><title>django/django @ 09f27cc
+Files: 7029
+ScanCode: 543.19s</title></rect>
     <rect x="703.83" y="315.08" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/kafka @ 0d9fe51
 Files: 7179
 ScanCode: 751.77s</title></rect>
@@ -653,9 +653,9 @@ ScanCode: 997.84s</title></rect>
     <rect x="737.77" y="246.68" width="8" height="8" fill="#d97706" rx="1.5"><title>erlang/otp @ 264def5
 Files: 11749
 ScanCode: 3197.26s</title></rect>
-    <rect x="738.39" y="304.71" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/airflow @ 47ce5f3
-Files: 11854
-ScanCode: 936.34s</title></rect>
+    <rect x="738.86" y="294.65" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/airflow @ 47ce5f3
+Files: 11935
+ScanCode: 1158.57s</title></rect>
     <rect x="741.35" y="286.09" width="8" height="8" fill="#d97706" rx="1.5"><title>moby/moby @ 21bd660
 Files: 12375
 ScanCode: 1388.49s</title></rect>
@@ -719,9 +719,9 @@ ScanCode: 9432.77s</title></rect>
     <rect x="848.76" y="271.78" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/rust @ dab8d9d
 Files: 58818
 ScanCode: 1879.48s</title></rect>
-    <rect x="854.98" y="208.23" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode-toolkit @ 6570c13
+    <rect x="854.98" y="234.53" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode-toolkit @ 6570c13
 Files: 64369
-ScanCode: 7214.43s</title></rect>
+ScanCode: 4134.60s</title></rect>
     <rect x="856.03" y="218.55" width="8" height="8" fill="#d97706" rx="1.5"><title>gitlabhq/gitlabhq @ 48dc2f5
 Files: 65359
 ScanCode: 5798.22s</title></rect>
@@ -934,9 +934,9 @@ Provenant: 4.88s</title></circle>
     <circle cx="483.04" cy="553.92" r="4.5" fill="#2563eb"><title>Plack/Plack @ b3984f1
 Files: 275
 Provenant: 5.22s</title></circle>
-    <circle cx="485.50" cy="522.96" r="4.5" fill="#2563eb"><title>conda/conda @ 37549c4
-Files: 285
-Provenant: 10.05s</title></circle>
+    <circle cx="485.26" cy="555.76" r="4.5" fill="#2563eb"><title>conda/conda @ 37549c4
+Files: 284
+Provenant: 5.02s</title></circle>
     <circle cx="489.27" cy="555.39" r="4.5" fill="#2563eb"><title>technomancy/leiningen @ 4022732
 Files: 301
 Provenant: 5.06s</title></circle>
@@ -1054,9 +1054,9 @@ Provenant: 17.56s</title></circle>
     <circle cx="564.43" cy="532.35" r="4.5" fill="#2563eb"><title>facebook/watchman @ 426a7b7
 Files: 896
 Provenant: 8.24s</title></circle>
-    <circle cx="570.54" cy="459.72" r="4.5" fill="#2563eb"><title>KhronosGroup/Vulkan-ValidationLayers @ d72c5f5
+    <circle cx="570.54" cy="513.15" r="4.5" fill="#2563eb"><title>KhronosGroup/Vulkan-ValidationLayers @ d72c5f5
 Files: 979
-Provenant: 38.32s</title></circle>
+Provenant: 12.37s</title></circle>
     <circle cx="571.10" cy="533.68" r="4.5" fill="#2563eb"><title>python-poetry/poetry @ bfce511
 Files: 987
 Provenant: 8.01s</title></circle>
@@ -1087,9 +1087,9 @@ Provenant: 12.77s</title></circle>
     <circle cx="584.51" cy="495.58" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 Provenant: 17.94s</title></circle>
-    <circle cx="587.87" cy="488.62" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
+    <circle cx="587.87" cy="451.48" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
 Files: 1259
-Provenant: 20.79s</title></circle>
+Provenant: 45.62s</title></circle>
     <circle cx="588.14" cy="514.39" r="4.5" fill="#2563eb"><title>distroless base-debian12 @ sha256:9dce90e
 Files: 1264
 Provenant: 12.05s</title></circle>
@@ -1126,9 +1126,9 @@ Provenant: 32.53s</title></circle>
     <circle cx="617.95" cy="479.38" r="4.5" fill="#2563eb"><title>JuliaLang/julia @ afc71c2
 Files: 1948
 Provenant: 25.28s</title></circle>
-    <circle cx="618.72" cy="481.32" r="4.5" fill="#2563eb"><title>astropy/astropy @ 40280e3
-Files: 1970
-Provenant: 24.26s</title></circle>
+    <circle cx="618.44" cy="524.98" r="4.5" fill="#2563eb"><title>astropy/astropy @ 40280e3
+Files: 1962
+Provenant: 9.63s</title></circle>
     <circle cx="619.38" cy="464.43" r="4.5" fill="#2563eb"><title>Fedora Minimal 42 container rootfs @ sha256:c30f069
 Files: 1989
 Provenant: 34.69s</title></circle>
@@ -1141,9 +1141,9 @@ Provenant: 15.37s</title></circle>
     <circle cx="623.78" cy="468.34" r="4.5" fill="#2563eb"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 Provenant: 31.93s</title></circle>
-    <circle cx="628.61" cy="470.20" r="4.5" fill="#2563eb"><title>chef/chef @ 0e353ff
+    <circle cx="628.61" cy="514.47" r="4.5" fill="#2563eb"><title>chef/chef @ 0e353ff
 Files: 2274
-Provenant: 30.70s</title></circle>
+Provenant: 12.03s</title></circle>
     <circle cx="631.52" cy="474.94" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 Provenant: 27.77s</title></circle>
@@ -1168,9 +1168,9 @@ Provenant: 8.34s</title></circle>
     <circle cx="645.06" cy="499.42" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 Provenant: 16.54s</title></circle>
-    <circle cx="645.37" cy="487.30" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
+    <circle cx="645.37" cy="524.20" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
 Files: 2900
-Provenant: 21.38s</title></circle>
+Provenant: 9.79s</title></circle>
     <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
 Provenant: 12.29s</title></circle>
@@ -1216,9 +1216,9 @@ Provenant: 11.71s</title></circle>
     <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
 Files: 4266
 Provenant: 40.75s</title></circle>
-    <circle cx="672.53" cy="425.98" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
+    <circle cx="672.53" cy="433.39" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
-Provenant: 78.26s</title></circle>
+Provenant: 66.90s</title></circle>
     <circle cx="677.50" cy="476.32" r="4.5" fill="#2563eb"><title>akka/akka @ 5ace141
 Files: 4623
 Provenant: 26.97s</title></circle>
@@ -1261,12 +1261,12 @@ Provenant: 106.15s</title></circle>
     <circle cx="705.92" cy="463.08" r="4.5" fill="#2563eb"><title>openembedded/meta-openembedded @ 7bf89d0
 Files: 6983
 Provenant: 35.69s</title></circle>
-    <circle cx="706.03" cy="471.70" r="4.5" fill="#2563eb"><title>django/django @ 09f27cc
-Files: 6994
-Provenant: 29.74s</title></circle>
     <circle cx="706.03" cy="445.60" r="4.5" fill="#2563eb"><title>systemd/systemd @ 89d705a
 Files: 6994
 Provenant: 51.67s</title></circle>
+    <circle cx="706.37" cy="507.81" r="4.5" fill="#2563eb"><title>django/django @ 09f27cc
+Files: 7029
+Provenant: 13.85s</title></circle>
     <circle cx="707.83" cy="443.86" r="4.5" fill="#2563eb"><title>apache/kafka @ 0d9fe51
 Files: 7179
 Provenant: 53.61s</title></circle>
@@ -1321,9 +1321,9 @@ Provenant: 44.52s</title></circle>
     <circle cx="741.77" cy="399.90" r="4.5" fill="#2563eb"><title>erlang/otp @ 264def5
 Files: 11749
 Provenant: 135.93s</title></circle>
-    <circle cx="742.39" cy="434.52" r="4.5" fill="#2563eb"><title>apache/airflow @ 47ce5f3
-Files: 11854
-Provenant: 65.32s</title></circle>
+    <circle cx="742.86" cy="446.23" r="4.5" fill="#2563eb"><title>apache/airflow @ 47ce5f3
+Files: 11935
+Provenant: 50.99s</title></circle>
     <circle cx="745.35" cy="441.80" r="4.5" fill="#2563eb"><title>moby/moby @ 21bd660
 Files: 12375
 Provenant: 56.00s</title></circle>
@@ -1387,9 +1387,9 @@ Provenant: 299.53s</title></circle>
     <circle cx="852.76" cy="437.38" r="4.5" fill="#2563eb"><title>rust-lang/rust @ dab8d9d
 Files: 58818
 Provenant: 61.49s</title></circle>
-    <circle cx="858.98" cy="335.12" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode-toolkit @ 6570c13
+    <circle cx="858.98" cy="380.00" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode-toolkit @ 6570c13
 Files: 64369
-Provenant: 535.40s</title></circle>
+Provenant: 207.10s</title></circle>
     <circle cx="860.03" cy="372.43" r="4.5" fill="#2563eb"><title>gitlabhq/gitlabhq @ 48dc2f5
 Files: 65359
 Provenant: 243.06s</title></circle>


### PR DESCRIPTION
## Summary

Benchmark-verification sweep refreshing ten `docs/BENCHMARKS.md` rows on the Apple M5 Pro host. All ten remain Provenant wins; median speedup rises to **14.3×**. No code changes in this PR — the genuine issues found during triage are queued as separate follow-up PRs (see below).

| Target | Before | After |
| --- | --- | --- |
| django | 12.03× | 39.22× |
| fresco | 23.42× | 37.03× |
| astropy | 22.04× | 36.99× |
| Vulkan-ValidationLayers | 17.97× | 33.22× |
| airflow | 14.33× | 22.72× |
| scancode-toolkit | 13.48× | 19.96× |
| chef | 12.07× | 19.55× |
| DefectDojo | 18.83× | 16.13× |
| conda | 11.70× | 15.79× |
| uv | 17.90× | 5.98× |

(Speedups shift with the new host; prior numbers were on M1 Max. uv's drop reflects several multi-MB test files — `lock.rs` 1.7MB, `download-metadata.json` 2.6MB — making it a detection-heavy workload; still 6× faster, no regression.)

## Triage outcome

Across all ten, the remaining ScanCode-favored deltas are justified Provenant behavior:

- **License-detection counts** (e.g. django 1356, astropy 449) are detection-granularity/rule-identity differences — Provenant has full file-level license coverage (0 files where SC detects a license and Provenant doesn't).
- **Declared-vs-detected separation** (ADR 0002): internal sub-packages with no manifest license field (airflow `ui`, astropy vendored `wcslib`, django npm assets) correctly report `None` rather than backfilling from a sibling/repo LICENSE the way ScanCode does.
- **ScanCode license false positives**: `GPL` in Vulkan code means *Graphics Pipeline Library* (`VK_EXT_graphics_pipeline_library`), not GNU GPL — Provenant correctly avoids it.
- **Home-turf recall**: scancode-toolkit is ScanCode's own 64k-file license corpus, so its extra license detections concentrate in `src/licensedcode/` and `tests/`.

Provenant advantages: far broader package/dependency extraction (e.g. scancode-toolkit `1294` vs `6` packages, airflow `7599` vs `1014` deps), workspace-inherited license resolution (uv `apache-2.0 OR mit`), and faster runtime everywhere.

## Follow-ups (separate PRs)

Triage surfaced recurring Provenant-side junk classes, queued as focused fixes:

1. Author refiner: strip trailing parenthesized email contact `Name (<email>)` → bare name (chef Ruby `Author::` headers, 1228 instances; email already captured separately).
2. Copyright/author/holder: reject values that are obviously source code (django `Author.objects.create(...)` → 1113 false authors; Vulkan `copyRegion` → false copyright holder).
3. `compare-outputs`: add a cross-file frequency rollup of `extra_in_provenant` / `missing_in_provenant` field values (neutral diagnostic, not a gate) to make these classes self-evident.
4. Region-aware suppression of copyright/holder/author detection inside detected license-text spans (scancode-toolkit shows ~9400 such false positives; CC/GPL/FSF prose).
5. Cargo parser: resolve `authors = { workspace = true }` instead of emitting the literal `"workspace"` as an author (uv, 65 instances).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
