### PR TITLE
feat(compare-outputs): add cross-file field-value frequency rollup

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -221,7 +221,7 @@ aggregates the value-level differences across **all** common-path files and
 ranks them by total occurrence count, so systematic patterns become visible
 (for example one author value appearing hundreds of times instead of as
 hundreds of scattered one-count entries). It is framed by direction
-(`extra_in_provenant` = PV-only, `missing_in_scancode` = SC-only); PV-extra is
+(`extra_in_provenant` = PV-only, `extra_in_scancode` = SC-only); PV-extra is
 **not** inherently junk, since much of it is legitimate source-faithful or
 richer output, so the rollup is a triage aid and the reviewer decides
 junk-vs-advantage. It is a pure diagnostic: it never feeds `comparison_status`,

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -214,6 +214,20 @@ for the first time, enabling it can surface pre-existing ScanCode-vs-Provenant
 declared-license deltas that have nothing to do with any recent change; that is
 expected, valuable parity signal to classify, not automatically a regression.
 
+`comparison/samples/field_value_frequency.json` is a cross-file frequency
+rollup of the per-file value diffs in `file_metric_value_differences.json`. For
+each field (authors, holders, copyrights, license expressions/clues, etc.) it
+aggregates the value-level differences across **all** common-path files and
+ranks them by total occurrence count, so systematic patterns become visible
+(for example one author value appearing hundreds of times instead of as
+hundreds of scattered one-count entries). It is framed by direction
+(`extra_in_provenant` = PV-only, `missing_in_scancode` = SC-only); PV-extra is
+**not** inherently junk, since much of it is legitimate source-faithful or
+richer output, so the rollup is a triage aid and the reviewer decides
+junk-vs-advantage. It is a pure diagnostic: it never feeds `comparison_status`,
+the signal counts, or any pass/fail gate. `summary.json` also surfaces a short
+per-field top-N preview under `field_value_frequency_top`.
+
 Optional diagnostic logs when available:
 
 - `raw/scancode-stdout.txt`

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -1857,6 +1857,12 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         "no_detected_differences"
     };
 
+    // Cross-file, frequency-ranked rollup of the per-file value diffs. Pure
+    // aggregation of `value_differences`; diagnostic only and intentionally not
+    // wired into any signal count or `comparison_status`.
+    let field_value_frequency =
+        field_value_frequency_rollup(&value_differences, FIELD_VALUE_FREQUENCY_TOP_N);
+
     let sample_paths = [
         (
             "scancode_only_output_paths",
@@ -1926,6 +1932,10 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
                 .samples_dir
                 .join("package_field_content_value_differences.json"),
         ),
+        (
+            "field_value_frequency",
+            context.samples_dir.join("field_value_frequency.json"),
+        ),
     ];
     write_pretty_json(&sample_paths[0].1, &scancode_only_output_paths)?;
     write_pretty_json(&sample_paths[1].1, &provenant_only_output_paths)?;
@@ -1944,6 +1954,7 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         &sample_paths[13].1,
         &package_field_content_value_differences,
     )?;
+    write_pretty_json(&sample_paths[14].1, &field_value_frequency)?;
 
     let summary = json!({
         "comparison_status": comparison_status,
@@ -1996,6 +2007,7 @@ fn generate_comparison_artifacts(context: &ContextState) -> Result<()> {
         "top_level_scancode_favored_differences": top_level_scancode_favored_differences,
         "top_level_provenant_favored_differences": top_level_provenant_favored_differences,
         "top_level_license_expression_delta_count": license_deltas.len(),
+        "field_value_frequency_top": field_value_frequency_summary(&field_value_frequency, FIELD_VALUE_FREQUENCY_SUMMARY_TOP_N),
         "sample_artifacts": BTreeMap::from(sample_paths.map(|(name, path)| (name.to_string(), path.display().to_string()))),
     });
     write_pretty_json(&context.summary_json, &summary)?;
@@ -2241,6 +2253,132 @@ fn raw_dependency_differences(scancode: &Value, provenant: &Value) -> Vec<ValueD
         }
     }
     differences
+}
+
+/// Maximum number of values retained per field/direction in the cross-file
+/// frequency rollup. The rollup is a triage aid, so a bounded top-N keeps the
+/// artifact readable while still surfacing the systematic patterns.
+const FIELD_VALUE_FREQUENCY_TOP_N: usize = 50;
+
+#[derive(Debug, Serialize, Clone)]
+struct FieldValueFrequencyEntry {
+    value: String,
+    /// Total occurrences of this value summed across every common-path file.
+    total_count: usize,
+    /// Number of distinct files contributing at least one occurrence.
+    file_count: usize,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+struct FieldValueFrequencyDirections {
+    /// Values present only in Provenant output (`extra_in_provenant`).
+    extra_in_provenant: Vec<FieldValueFrequencyEntry>,
+    /// Values present only in ScanCode output (`missing_in_provenant`).
+    missing_in_scancode: Vec<FieldValueFrequencyEntry>,
+}
+
+/// Roll the per-file value-level diffs up into a cross-file, frequency-ranked
+/// view so systematic patterns become visible (e.g. one author value appearing
+/// hundreds of times across files instead of as scattered one-count entries).
+///
+/// This is a pure aggregation of `value_differences`, which the tool already
+/// computes per file. It is a neutral diagnostic only: PV-only values are not
+/// necessarily junk (much is legitimate source-faithful or richer output), so
+/// the rollup is framed by direction and never feeds pass/fail or signal counts.
+fn field_value_frequency_rollup(
+    value_differences: &BTreeMap<String, Vec<ValueDifferenceEntry>>,
+    top_n: usize,
+) -> BTreeMap<String, FieldValueFrequencyDirections> {
+    value_differences
+        .iter()
+        .map(|(field, entries)| {
+            let extra = aggregate_direction(entries, |entry| &entry.extra_in_provenant, top_n);
+            let missing = aggregate_direction(entries, |entry| &entry.missing_in_provenant, top_n);
+            (
+                field.clone(),
+                FieldValueFrequencyDirections {
+                    extra_in_provenant: extra,
+                    missing_in_scancode: missing,
+                },
+            )
+        })
+        .collect()
+}
+
+fn aggregate_direction(
+    entries: &[ValueDifferenceEntry],
+    select: impl Fn(&ValueDifferenceEntry) -> &Vec<ValueCountEntry>,
+    top_n: usize,
+) -> Vec<FieldValueFrequencyEntry> {
+    let mut totals: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for entry in entries {
+        for value_count in select(entry) {
+            let slot = totals.entry(value_count.value.clone()).or_insert((0, 0));
+            slot.0 += value_count.count;
+            slot.1 += 1;
+        }
+    }
+    let mut ranked: Vec<FieldValueFrequencyEntry> = totals
+        .into_iter()
+        .map(
+            |(value, (total_count, file_count))| FieldValueFrequencyEntry {
+                value,
+                total_count,
+                file_count,
+            },
+        )
+        .collect();
+    // Sort by total count descending, then by value ascending for a stable,
+    // deterministic order across runs. Starting from a BTreeMap keeps the
+    // by-value tie-break deterministic regardless of input ordering.
+    ranked.sort_by(|a, b| {
+        b.total_count
+            .cmp(&a.total_count)
+            .then_with(|| a.value.cmp(&b.value))
+    });
+    ranked.truncate(top_n);
+    ranked
+}
+
+/// How many top values per field/direction to surface inline in `summary.json`.
+/// The standalone samples file carries the full top-N; this is just a glanceable
+/// preview. Fields with no values in a direction are omitted entirely.
+const FIELD_VALUE_FREQUENCY_SUMMARY_TOP_N: usize = 5;
+
+fn field_value_frequency_summary(
+    rollup: &BTreeMap<String, FieldValueFrequencyDirections>,
+    top_n: usize,
+) -> Map<String, Value> {
+    let mut summary = Map::new();
+    for (field, directions) in rollup {
+        let extra = &directions.extra_in_provenant;
+        let missing = &directions.missing_in_scancode;
+        if extra.is_empty() && missing.is_empty() {
+            continue;
+        }
+        summary.insert(
+            field.clone(),
+            json!({
+                "extra_in_provenant": field_value_frequency_preview(extra, top_n),
+                "missing_in_scancode": field_value_frequency_preview(missing, top_n),
+            }),
+        );
+    }
+    summary
+}
+
+fn field_value_frequency_preview(entries: &[FieldValueFrequencyEntry], top_n: usize) -> Vec<Value> {
+    entries
+        .iter()
+        .take(top_n)
+        .map(|entry| {
+            json!({
+                "value": entry.value,
+                "total_count": entry.total_count,
+                "file_count": entry.file_count,
+            })
+        })
+        .collect()
 }
 
 fn write_manifest(context: &ContextState) -> Result<()> {
@@ -4623,5 +4761,173 @@ mod tests {
             by_field_total
         );
         assert_eq!(by_field_total, differences.len());
+    }
+
+    fn value_diff(
+        path: &str,
+        missing: &[(&str, usize)],
+        extra: &[(&str, usize)],
+    ) -> ValueDifferenceEntry {
+        let to_entries = |pairs: &[(&str, usize)]| {
+            pairs
+                .iter()
+                .map(|(value, count)| ValueCountEntry {
+                    value: (*value).to_string(),
+                    count: *count,
+                })
+                .collect::<Vec<_>>()
+        };
+        ValueDifferenceEntry {
+            path: path.to_string(),
+            scancode: 0,
+            provenant: 0,
+            missing_in_provenant: to_entries(missing),
+            extra_in_provenant: to_entries(extra),
+        }
+    }
+
+    #[test]
+    fn field_value_frequency_rollup_aggregates_counts_across_files() {
+        let mut value_differences: BTreeMap<String, Vec<ValueDifferenceEntry>> = BTreeMap::new();
+        value_differences.insert(
+            "authors".to_string(),
+            vec![
+                value_diff("a.rs", &[], &[("Adam Jacob", 2), ("rare", 1)]),
+                value_diff("b.rs", &[], &[("Adam Jacob", 1)]),
+                value_diff("c.rs", &[("Only In SC", 4)], &[("Adam Jacob", 1)]),
+            ],
+        );
+
+        let rollup = field_value_frequency_rollup(&value_differences, 50);
+        let authors = &rollup["authors"];
+
+        // Extra (PV-only) values roll up across all three files.
+        assert_eq!(authors.extra_in_provenant.len(), 2);
+        let adam = &authors.extra_in_provenant[0];
+        assert_eq!(adam.value, "Adam Jacob");
+        assert_eq!(adam.total_count, 4);
+        assert_eq!(adam.file_count, 3);
+        // Sorted by total_count descending: Adam (4) before rare (1).
+        assert_eq!(authors.extra_in_provenant[1].value, "rare");
+        assert_eq!(authors.extra_in_provenant[1].total_count, 1);
+        assert_eq!(authors.extra_in_provenant[1].file_count, 1);
+
+        // Missing (SC-only) values aggregate independently.
+        assert_eq!(authors.missing_in_scancode.len(), 1);
+        assert_eq!(authors.missing_in_scancode[0].value, "Only In SC");
+        assert_eq!(authors.missing_in_scancode[0].total_count, 4);
+    }
+
+    #[test]
+    fn field_value_frequency_rollup_is_deterministic_and_capped() {
+        let entries: Vec<ValueDifferenceEntry> = (0..10)
+            .map(|i| value_diff(&format!("f{i}.rs"), &[], &[("tie-a", 3), ("tie-b", 3)]))
+            .collect();
+        let mut value_differences = BTreeMap::new();
+        value_differences.insert("holders".to_string(), entries);
+
+        let rollup = field_value_frequency_rollup(&value_differences, 1);
+        let holders = &rollup["holders"];
+        // Cap honored: only the single top-ranked value survives.
+        assert_eq!(holders.extra_in_provenant.len(), 1);
+        // Equal totals break ties by value ascending, so "tie-a" wins.
+        assert_eq!(holders.extra_in_provenant[0].value, "tie-a");
+        assert_eq!(holders.extra_in_provenant[0].total_count, 30);
+        assert_eq!(holders.extra_in_provenant[0].file_count, 10);
+    }
+
+    #[test]
+    fn field_value_frequency_summary_omits_empty_fields() {
+        let mut rollup: BTreeMap<String, FieldValueFrequencyDirections> = BTreeMap::new();
+        rollup.insert(
+            "copyrights".to_string(),
+            FieldValueFrequencyDirections::default(),
+        );
+        rollup.insert(
+            "authors".to_string(),
+            FieldValueFrequencyDirections {
+                extra_in_provenant: vec![FieldValueFrequencyEntry {
+                    value: "Adam Jacob".to_string(),
+                    total_count: 9,
+                    file_count: 4,
+                }],
+                missing_in_scancode: Vec::new(),
+            },
+        );
+
+        let summary = field_value_frequency_summary(&rollup, 5);
+        assert!(!summary.contains_key("copyrights"));
+        assert_eq!(
+            summary["authors"]["extra_in_provenant"][0]["value"],
+            "Adam Jacob"
+        );
+        assert_eq!(
+            summary["authors"]["extra_in_provenant"][0]["total_count"],
+            9
+        );
+        assert_eq!(summary["authors"]["missing_in_scancode"], json!([]));
+    }
+
+    #[test]
+    fn generate_comparison_artifacts_writes_field_value_frequency() {
+        let temp_root = unique_temp_dir("field-value-frequency-artifact");
+        fs::create_dir_all(&temp_root).unwrap();
+        let mut context = test_context();
+        context.compare_mode = CompareMode::DirectJson;
+        context.scan_args = Vec::new();
+        context.run_dir = temp_root.join("run");
+        context.raw_dir = context.run_dir.join("raw");
+        context.comparison_dir = context.run_dir.join("comparison");
+        context.samples_dir = context.comparison_dir.join("samples");
+        context.run_manifest = context.run_dir.join("run-manifest.json");
+        context.summary_json = context.comparison_dir.join("summary.json");
+        context.summary_tsv = context.comparison_dir.join("summary.tsv");
+        context.scancode_json = context.raw_dir.join("scancode.json");
+        context.provenant_json = context.raw_dir.join("provenant.json");
+        fs::create_dir_all(&context.raw_dir).unwrap();
+        fs::create_dir_all(&context.samples_dir).unwrap();
+
+        // Same author appears as PV-only in two files; the rollup must collapse
+        // them into a single frequency-ranked entry.
+        let scancode = json!({
+            "files": [
+                {"path": "a.rs", "type": "file", "authors": []},
+                {"path": "b.rs", "type": "file", "authors": []}
+            ],
+            "packages": [], "dependencies": [],
+            "license_detections": [], "license_references": [], "license_rule_references": []
+        });
+        let provenant = json!({
+            "files": [
+                {"path": "a.rs", "type": "file", "authors": [{"author": "Adam Jacob"}]},
+                {"path": "b.rs", "type": "file", "authors": [{"author": "Adam Jacob"}]}
+            ],
+            "packages": [], "dependencies": [],
+            "license_detections": [], "license_references": [], "license_rule_references": []
+        });
+        fs::write(&context.scancode_json, scancode.to_string()).unwrap();
+        fs::write(&context.provenant_json, provenant.to_string()).unwrap();
+
+        generate_comparison_artifacts(&context).unwrap();
+
+        let artifact: Value = serde_json::from_str(
+            &fs::read_to_string(context.samples_dir.join("field_value_frequency.json")).unwrap(),
+        )
+        .unwrap();
+        let adam = &artifact["authors"]["extra_in_provenant"][0];
+        assert_eq!(adam["value"], "Adam Jacob");
+        assert_eq!(adam["total_count"], 2);
+        assert_eq!(adam["file_count"], 2);
+
+        let summary: Value =
+            serde_json::from_str(&fs::read_to_string(&context.summary_json).unwrap()).unwrap();
+        assert_eq!(
+            summary["field_value_frequency_top"]["authors"]["extra_in_provenant"][0]["value"],
+            "Adam Jacob"
+        );
+        // Diagnostic only: it must not flip pass/fail or signal direction.
+        assert!(summary.get("field_value_frequency_top").is_some());
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 }

--- a/xtask/src/bin/compare_outputs.rs
+++ b/xtask/src/bin/compare_outputs.rs
@@ -2271,10 +2271,10 @@ struct FieldValueFrequencyEntry {
 
 #[derive(Debug, Serialize, Clone, Default)]
 struct FieldValueFrequencyDirections {
-    /// Values present only in Provenant output (`extra_in_provenant`).
+    /// Values present only in Provenant output (PV-only).
     extra_in_provenant: Vec<FieldValueFrequencyEntry>,
-    /// Values present only in ScanCode output (`missing_in_provenant`).
-    missing_in_scancode: Vec<FieldValueFrequencyEntry>,
+    /// Values present only in ScanCode output (SC-only).
+    extra_in_scancode: Vec<FieldValueFrequencyEntry>,
 }
 
 /// Roll the per-file value-level diffs up into a cross-file, frequency-ranked
@@ -2292,13 +2292,13 @@ fn field_value_frequency_rollup(
     value_differences
         .iter()
         .map(|(field, entries)| {
-            let extra = aggregate_direction(entries, |entry| &entry.extra_in_provenant, top_n);
-            let missing = aggregate_direction(entries, |entry| &entry.missing_in_provenant, top_n);
+            let pv_only = aggregate_direction(entries, |entry| &entry.extra_in_provenant, top_n);
+            let sc_only = aggregate_direction(entries, |entry| &entry.missing_in_provenant, top_n);
             (
                 field.clone(),
                 FieldValueFrequencyDirections {
-                    extra_in_provenant: extra,
-                    missing_in_scancode: missing,
+                    extra_in_provenant: pv_only,
+                    extra_in_scancode: sc_only,
                 },
             )
         })
@@ -2342,7 +2342,9 @@ fn aggregate_direction(
 
 /// How many top values per field/direction to surface inline in `summary.json`.
 /// The standalone samples file carries the full top-N; this is just a glanceable
-/// preview. Fields with no values in a direction are omitted entirely.
+/// preview. A field with values in only one direction still appears, with the
+/// empty direction rendered as `[]`; only fields empty in both directions are
+/// omitted.
 const FIELD_VALUE_FREQUENCY_SUMMARY_TOP_N: usize = 5;
 
 fn field_value_frequency_summary(
@@ -2351,16 +2353,16 @@ fn field_value_frequency_summary(
 ) -> Map<String, Value> {
     let mut summary = Map::new();
     for (field, directions) in rollup {
-        let extra = &directions.extra_in_provenant;
-        let missing = &directions.missing_in_scancode;
-        if extra.is_empty() && missing.is_empty() {
+        let pv_only = &directions.extra_in_provenant;
+        let sc_only = &directions.extra_in_scancode;
+        if pv_only.is_empty() && sc_only.is_empty() {
             continue;
         }
         summary.insert(
             field.clone(),
             json!({
-                "extra_in_provenant": field_value_frequency_preview(extra, top_n),
-                "missing_in_scancode": field_value_frequency_preview(missing, top_n),
+                "extra_in_provenant": field_value_frequency_preview(pv_only, top_n),
+                "extra_in_scancode": field_value_frequency_preview(sc_only, top_n),
             }),
         );
     }
@@ -4812,10 +4814,10 @@ mod tests {
         assert_eq!(authors.extra_in_provenant[1].total_count, 1);
         assert_eq!(authors.extra_in_provenant[1].file_count, 1);
 
-        // Missing (SC-only) values aggregate independently.
-        assert_eq!(authors.missing_in_scancode.len(), 1);
-        assert_eq!(authors.missing_in_scancode[0].value, "Only In SC");
-        assert_eq!(authors.missing_in_scancode[0].total_count, 4);
+        // SC-only values aggregate independently.
+        assert_eq!(authors.extra_in_scancode.len(), 1);
+        assert_eq!(authors.extra_in_scancode[0].value, "Only In SC");
+        assert_eq!(authors.extra_in_scancode[0].total_count, 4);
     }
 
     #[test]
@@ -4851,7 +4853,7 @@ mod tests {
                     total_count: 9,
                     file_count: 4,
                 }],
-                missing_in_scancode: Vec::new(),
+                extra_in_scancode: Vec::new(),
             },
         );
 
@@ -4865,7 +4867,9 @@ mod tests {
             summary["authors"]["extra_in_provenant"][0]["total_count"],
             9
         );
-        assert_eq!(summary["authors"]["missing_in_scancode"], json!([]));
+        // Field non-empty in one direction still appears, with the empty
+        // direction rendered as `[]`.
+        assert_eq!(summary["authors"]["extra_in_scancode"], json!([]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a cross-file frequency rollup of field-value differences to `compare-outputs`. The new `comparison/samples/field_value_frequency.json` artifact aggregates the per-file value-level diffs the tool already computes (`file_metric_value_differences.json`) across **all** common-path files and ranks each field's values by total occurrence count, so systematic patterns become visible instead of scattered one-count entries.
- For each field (authors, holders, copyrights, license expressions/clues, emails, urls, etc.) it lists top PV-only (`extra_in_provenant`) and SC-only (`extra_in_scancode`) values, sorted by total count descending with a stable by-value tie-break, capped at top-N (50).
- `summary.json` also surfaces a short per-field top-N preview under `field_value_frequency_top` (empty fields omitted).
- Framing is **neutral and by direction**: PV-extra is not treated as junk (much of it is legitimate source-faithful or richer output). It is a triage aid; the reviewer decides junk-vs-advantage.
- **Diagnostic only**: it is a pure aggregation of existing in-memory diffs and never feeds `comparison_status`, the signal counts, or any pass/fail gate.

### Sample artifact

From a small direct-JSON compare (`Adam Jacob ( <adam@chef.io> )` as a PV-only author in two files, `The Foo Project` as an SC-only holder in two files):

```json
{
  "authors": {
    "extra_in_provenant": [
      { "value": "Adam Jacob ( <adam@chef.io> )", "total_count": 2, "file_count": 2 }
    ],
    "extra_in_scancode": []
  },
  "copyrights": {
    "extra_in_provenant": [
      { "value": "Copyright 2024 Adam Jacob", "total_count": 2, "file_count": 2 }
    ],
    "extra_in_scancode": []
  },
  "holders": {
    "extra_in_provenant": [],
    "extra_in_scancode": [
      { "value": "The Foo Project", "total_count": 2, "file_count": 2 }
    ]
  }
}
```

## Scope and exclusions

- Included: aggregation function + types, wiring into `generate_comparison_artifacts`, the new samples file, the `summary.json` preview, unit tests, and an `xtask/README.md` doc paragraph.
- Explicit exclusions: no change to `comparison_status`, signal buckets, TSV rows, or any existing artifact contents.

## How to verify

- Run a compare (any mode) and inspect `comparison/samples/field_value_frequency.json` and `summary.json`'s `field_value_frequency_top`. Confirm a value appearing across many files is collapsed into one frequency-ranked entry, and that `comparison_status` is unchanged from before this change for the same inputs.
- Unit tests cover deterministic ordering, the by-value tie-break, the top-N cap, empty-field omission in the summary, and the end-to-end artifact write: `cargo test --manifest-path xtask/Cargo.toml --bin compare-outputs field_value_frequency`.

## Intentional differences from Python

- N/A (maintainer compare tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

