### PR TITLE
fix(copyright): drop source-code FPs and bracketed email author contacts

### DIFF
--- a/src/copyright/mod.rs
+++ b/src/copyright/mod.rs
@@ -29,6 +29,7 @@ mod types;
 
 pub use credits::{detect_credits_authors, is_credits_file};
 pub(crate) use prepare::prepare_text_line;
+pub(crate) use refiner::looks_like_source_code;
 pub(crate) use refiner::refine_author;
 pub use refiner::refine_copyright;
 pub use types::{AuthorDetection, CopyrightDetection, HolderDetection};

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -13,6 +13,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     }
     let had_obfuscated_angle_contact = contains_obfuscated_angle_contact(s);
     let mut a = remove_some_extra_words_and_punct(s);
+    a = strip_trailing_parenthesized_email_contact(&a);
     a = truncate_trailing_collective_contributors_prose(&a);
     a = strip_leading_maintainers_label(&a);
     a = strip_trailing_javadoc_tags(&a);
@@ -111,6 +112,37 @@ fn contains_obfuscated_angle_contact(s: &str) -> bool {
         LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
 
     OBFUSCATED_ANGLE_CONTACT_RE.is_match(s)
+}
+
+/// Strip a trailing parenthesized angle-bracketed email contact from an author
+/// name.
+///
+/// Ruby and other headers write `Author:: Adam Jacob (<adam@chef.io>)`, which the
+/// parser captures as the author `Adam Jacob (<adam@chef.io>)`. The bracketed
+/// email is redundant — it is already captured in the file's `emails[]` list —
+/// and refinement otherwise renders it as the malformed
+/// `Adam Jacob ( <adam@chef.io> )`. Reduce it to the bare name.
+///
+/// Only the **angle-bracketed-inside-parens** form `(<email>)` (any spacing
+/// variant) is stripped. The bare parenthesized form `Name (email@host)` is an
+/// established author contract elsewhere and is left intact, as is a bare
+/// angle-bracketed `Name <email>` author.
+fn strip_trailing_parenthesized_email_contact(s: &str) -> String {
+    static PAREN_EMAIL_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?P<prefix>.+?)\s*\(\s*<\s*[^\s@()<>]+@[^\s@()<>]+\s*>\s*\)\s*$")
+            .expect("valid parenthesized email contact regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = PAREN_EMAIL_CONTACT_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+    if prefix.is_empty() || !prefix.chars().any(|ch| ch.is_alphabetic()) {
+        return s.to_string();
+    }
+
+    prefix.to_string()
 }
 
 fn looks_like_prose_fragment_author(s: &str) -> bool {

--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -29,6 +29,9 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     {
         return None;
     }
+    if looks_like_source_code(&original) {
+        return None;
+    }
     let mut c = original.clone();
     c = strip_known_copyright_wrappers(&c);
     c = trim_separator_rule_runs(&c);

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -868,25 +868,36 @@ pub(crate) fn is_path_like_code_fragment(s: &str) -> bool {
 ///
 /// This is intentionally strict about what counts as code: real legal notices
 /// and names use commas, periods, `Inc.`, `(c)`, angle-bracketed emails, and
-/// even `&` (as in `R&D`, `AT&T`), so those alone never trip this predicate. We
-/// require syntax specific to code: namespace `::`, a method/property call
-/// (`ident.ident(`), a C-style address-of a variable (` &lowerCamel`), a
-/// keyword/assignment call argument (`create(pk=1`), or a Django-style ORM
-/// access (`.objects.`, `models.ForeignKey`/`ManyToManyField`/`OneToOneField`).
+/// even `&` (as in `R&D`, `AT&T`, `Ernst &young`), so those alone never trip
+/// this predicate. We require syntax specific to code: namespace `::`, a
+/// method/property call (`ident.ident(`), a C-style address-of argument closing
+/// a call or statement (` &copyRegion)` / ` &result;`), a keyword/assignment
+/// call argument (`create(pk=1`), or a Django-style ORM access (`.objects.`,
+/// `models.ForeignKey`/`ManyToManyField`/`OneToOneField`).
+///
+/// The strong structural signals (namespace, method call, address-of-in-call,
+/// ORM) are always honoured — including on a raw source span that happens to
+/// embed an email or URL literal, e.g. `ns::f("a@b.com", &result)`. Only the
+/// weaker assignment-argument heuristic defers when a URL scheme is present,
+/// because a parenthesized URL query string (`(...?y=z)`) can otherwise look
+/// like a `name=value` call argument.
 pub(crate) fn looks_like_source_code(s: &str) -> bool {
-    static SOURCE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Structural code signals that never appear in a real name or notice.
+    static STRONG_SOURCE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| {
         compile_static_regex(
             r"(?x)
             # namespace resolution: ident::ident
             \b[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_~]
-            # method or property call: foo.bar( ... )  (dot immediately before a call)
-          | \b[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\s*\(
-            # C-style address-of a variable: ` &copyRegion`. Require a space (or
-            # paren/comma) before `&` and a lowercase start after it so real org
-            # names such as `R&D` / `AT&T` (letter-`&`-uppercase) are not matched.
-          | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*
-            # call with a keyword/assignment argument: create(pk=1
-          | \([^()]*[A-Za-z_][A-Za-z0-9_]*\s*=
+            # method or property call: foo.bar(...). The `(` must follow the
+            # member name with no space, so a filename or domain followed by a
+            # parenthesized URL/name (`AUTHORS.txt (http://...)`,
+            # `google.com (Name)`) is not mistaken for a call.
+          | \b[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\(
+            # C-style address-of a variable that closes a call or statement:
+            # ` &copyRegion)` / `, &result;`. Requiring the trailing `)` or `;`
+            # excludes name fragments such as `Ernst &young` or `Foo &co, Ltd.`,
+            # which are not followed by call/statement punctuation.
+          | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*\s*[);]
             ",
         )
     });
@@ -898,27 +909,23 @@ pub(crate) fn looks_like_source_code(s: &str) -> bool {
             ",
         )
     });
+    // Weaker heuristic: a `name = value` argument inside a call, e.g. `create(pk=1`.
+    static CALL_ASSIGN_ARG_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r"\([^()]*[A-Za-z_][A-Za-z0-9_]*\s*="));
 
     let trimmed = s.trim();
     if trimmed.is_empty() {
         return false;
     }
 
-    if ORM_RE.is_match(trimmed) {
+    if STRONG_SOURCE_CODE_RE.is_match(trimmed) || ORM_RE.is_match(trimmed) {
         return true;
     }
 
-    // Angle-bracketed emails and URLs legitimately contain `=`, `;`, and `&`
-    // (query strings, mailto links), so do not treat those as code on their own.
+    // A parenthesized URL query string can mimic a `name=value` call argument,
+    // so only apply the assignment-argument heuristic when no URL scheme is
+    // present. Strong signals above are unaffected by this guard.
     let lower = trimmed.to_ascii_lowercase();
-    let has_web_contact = trimmed.contains('@')
-        || lower.contains("http://")
-        || lower.contains("https://")
-        || lower.contains("www.")
-        || lower.contains("mailto:");
-    if has_web_contact {
-        return false;
-    }
-
-    SOURCE_CODE_RE.is_match(trimmed)
+    let has_url = lower.contains("http://") || lower.contains("https://") || lower.contains("www.");
+    !has_url && CALL_ASSIGN_ARG_RE.is_match(trimmed)
 }

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -30,6 +30,7 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_junk_copyright_symbol_garbage(s)
         || is_junk_c_sign_path_fragment(s)
         || is_creative_commons_license_prose(s)
+        || looks_like_source_code(s)
 }
 
 /// Return true if `s` is a fragment of Creative Commons (or cited treaty)
@@ -184,7 +185,7 @@ pub(super) fn is_junk_copyright_code_fragment(s: &str) -> bool {
 
 /// Return true if `s` matches any known junk author pattern.
 pub(super) fn is_junk_author(s: &str) -> bool {
-    AUTHORS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
+    AUTHORS_JUNK_PATTERNS.iter().any(|re| re.is_match(s)) || looks_like_source_code(s)
 }
 
 /// Return true if `s` matches any known junk holder pattern.
@@ -193,6 +194,7 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
         || is_junk_holder_code_fragment(s)
         || is_junk_holder_symbol_garbage(s)
         || is_creative_commons_license_prose(s)
+        || looks_like_source_code(s)
         || s.eq_ignore_ascii_case("MIT")
 }
 
@@ -852,4 +854,71 @@ pub(crate) fn is_path_like_code_fragment(s: &str) -> bool {
     });
 
     PATH_LIKE_CODE_FRAGMENT_RE.is_match(s.trim())
+}
+
+/// Return true if `s` is obviously a fragment of source code rather than a
+/// copyright notice, holder, or author name.
+///
+/// Detected authors/copyrights/holders are sometimes lifted out of program
+/// source (Ruby `Author::` headers near code, ORM model definitions such as
+/// `Author.objects.create(...)`, C++ API calls such as
+/// `vk::CmdCopyImage(..., &copyRegion);`). These carry method-call, operator,
+/// or namespace syntax that never appears in a real name or notice, so we can
+/// reject them conservatively.
+///
+/// This is intentionally strict about what counts as code: real legal notices
+/// and names use commas, periods, `Inc.`, `(c)`, angle-bracketed emails, and
+/// even `&` (as in `R&D`, `AT&T`), so those alone never trip this predicate. We
+/// require syntax specific to code: namespace `::`, a method/property call
+/// (`ident.ident(`), a C-style address-of a variable (` &lowerCamel`), a
+/// keyword/assignment call argument (`create(pk=1`), or a Django-style ORM
+/// access (`.objects.`, `models.ForeignKey`/`ManyToManyField`/`OneToOneField`).
+pub(crate) fn looks_like_source_code(s: &str) -> bool {
+    static SOURCE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?x)
+            # namespace resolution: ident::ident
+            \b[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_~]
+            # method or property call: foo.bar( ... )  (dot immediately before a call)
+          | \b[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\s*\(
+            # C-style address-of a variable: ` &copyRegion`. Require a space (or
+            # paren/comma) before `&` and a lowercase start after it so real org
+            # names such as `R&D` / `AT&T` (letter-`&`-uppercase) are not matched.
+          | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*
+            # call with a keyword/assignment argument: create(pk=1
+          | \([^()]*[A-Za-z_][A-Za-z0-9_]*\s*=
+            ",
+        )
+    });
+    static ORM_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?ix)
+            \.objects\.
+          | \bmodels\.(?:ForeignKey|ManyToManyField|OneToOneField)\b
+            ",
+        )
+    });
+
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if ORM_RE.is_match(trimmed) {
+        return true;
+    }
+
+    // Angle-bracketed emails and URLs legitimately contain `=`, `;`, and `&`
+    // (query strings, mailto links), so do not treat those as code on their own.
+    let lower = trimmed.to_ascii_lowercase();
+    let has_web_contact = trimmed.contains('@')
+        || lower.contains("http://")
+        || lower.contains("https://")
+        || lower.contains("www.")
+        || lower.contains("mailto:");
+    if has_web_contact {
+        return false;
+    }
+
+    SOURCE_CODE_RE.is_match(trimmed)
 }

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -62,7 +62,7 @@ pub use utils::{
 pub use copyright::refine_copyright;
 pub use holder::{refine_holder, refine_holder_in_copyright_context};
 pub use junk::is_junk_copyright;
-pub(crate) use junk::{is_junk_holder, is_path_like_code_fragment};
+pub(crate) use junk::{is_junk_holder, is_path_like_code_fragment, looks_like_source_code};
 
 /// Compile a static regex literal.
 ///

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2724,3 +2724,97 @@ fn test_refine_holder_trims_separator_rule_runs() {
         Some("Scott Kirkland ByteSize".to_string())
     );
 }
+
+// ── Fix: strip trailing parenthesized email contact from author names ──
+
+#[test]
+fn test_strip_trailing_parenthesized_email_contact_from_author() {
+    // Ruby `Author:: Adam Jacob (<adam@chef.io>)` style: the bracketed email is
+    // redundant (it is captured in emails[]) and otherwise renders malformed.
+    assert_eq!(
+        refine_author("Adam Jacob (<adam@chef.io>)"),
+        Some("Adam Jacob".to_string())
+    );
+    // Spacing variants must collapse to the same bare name.
+    assert_eq!(
+        refine_author("Adam Jacob ( <adam@chef.io> )"),
+        Some("Adam Jacob".to_string())
+    );
+    // The bare parenthesized form (no angle brackets) is an established author
+    // contract and must be preserved, not stripped.
+    assert_eq!(
+        refine_author("Elias Ioup (ezioup@alumni.uchicago.edu)"),
+        Some("Elias Ioup (ezioup@alumni.uchicago.edu)".to_string())
+    );
+}
+
+#[test]
+fn test_angle_only_email_author_is_preserved() {
+    // A bare `Name <email>` author (no parentheses) must survive intact.
+    assert_eq!(
+        refine_author("Björn Lindström <bjorn@example.com>"),
+        Some("Björn Lindström <bjorn@example.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("Jane Doe <jane@example.org>"),
+        Some("Jane Doe <jane@example.org>".to_string())
+    );
+}
+
+// ── Fix: reject values that are obviously source code ──
+
+#[test]
+fn test_looks_like_source_code_rejects_code() {
+    assert!(looks_like_source_code(
+        "vk::CmdCopyImage(m_command_buffer, srcImage, srcLayout, dstImage, dstLayout, 1, &copyRegion);"
+    ));
+    assert!(looks_like_source_code(
+        "Author.objects.create(pk=1, name=Baudelaire)"
+    ));
+    assert!(looks_like_source_code("models.ForeignKey(Author)"));
+    assert!(looks_like_source_code("models.ManyToManyField(Author)"));
+    assert!(looks_like_source_code("models.OneToOneField(Author)"));
+}
+
+#[test]
+fn test_looks_like_source_code_keeps_real_notices_and_names() {
+    assert!(!looks_like_source_code("Copyright (c) 2020 Acme, Inc."));
+    assert!(!looks_like_source_code("Adam Jacob"));
+    assert!(!looks_like_source_code("Björn Lindström"));
+    assert!(!looks_like_source_code(
+        "Red Hat, Inc. and/or its affiliates"
+    ));
+    assert!(!looks_like_source_code("The Foo Bar Team"));
+    // Angle-bracketed email is a contact form, not code.
+    assert!(!looks_like_source_code("Jane Doe <jane@example.org>"));
+    // A holder name that is a single common word is not, by itself, code.
+    assert!(!looks_like_source_code("Region"));
+}
+
+#[test]
+fn test_source_code_is_junk_for_copyright_holder_author() {
+    let code = "vk::CmdCopyImage(m_command_buffer, &copyRegion);";
+    assert!(is_junk_copyright(code));
+    assert!(is_junk_holder(code));
+    assert!(is_junk_author(code));
+
+    let orm = "Author.objects.create(pk=1)";
+    assert!(is_junk_copyright(orm));
+    assert!(is_junk_holder(orm));
+    assert!(is_junk_author(orm));
+}
+
+#[test]
+fn test_refine_copyright_rejects_source_code() {
+    assert_eq!(
+        refine_copyright(
+            "vk::CmdCopyImage(m_command_buffer, srcImage, srcLayout, dstImage, dstLayout, 1, &copyRegion);"
+        ),
+        None
+    );
+    // Real notice still refines.
+    assert_eq!(
+        refine_copyright("Copyright (c) 2020 Acme, Inc."),
+        Some("Copyright (c) 2020 Acme, Inc.".to_string())
+    );
+}

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2792,6 +2792,40 @@ fn test_looks_like_source_code_keeps_real_notices_and_names() {
 }
 
 #[test]
+fn test_looks_like_source_code_keeps_ampersand_company_names() {
+    // `&` in a company name (with or without surrounding spaces, including the
+    // malformed `space-&-lowercase` OCR/header variant) is not source code: the
+    // address-of rule only fires when `&var` closes a call or statement.
+    assert!(!looks_like_source_code("R&D"));
+    assert!(!looks_like_source_code("AT&T"));
+    assert!(!looks_like_source_code("Ernst &young"));
+    assert!(!looks_like_source_code("Foo &co, Ltd."));
+    assert!(!looks_like_source_code("Foo &associates, Ltd."));
+    // The same `&var` token inside a call is still caught.
+    assert!(looks_like_source_code("foo(bar, &result)"));
+    assert!(looks_like_source_code("compute(&result);"));
+}
+
+#[test]
+fn test_looks_like_source_code_catches_code_with_embedded_email_or_url() {
+    // A code line whose argument list embeds an email or URL literal must still
+    // be classified as code: the structural namespace/address-of signals are not
+    // bypassed by the presence of a contact-looking substring.
+    assert!(looks_like_source_code(
+        r#"ns::func(handler, "admin@example.com", &result)"#
+    ));
+    assert!(looks_like_source_code(
+        r#"client.connect("https://example.com", &session)"#
+    ));
+    // A genuine `Name <email>` / parenthesized-URL author still survives because
+    // it carries no structural code signal.
+    assert!(!looks_like_source_code("Jane Doe <jane@example.org>"));
+    assert!(!looks_like_source_code(
+        "Mathias Bynens (https://mathiasbynens.be)"
+    ));
+}
+
+#[test]
 fn test_source_code_is_junk_for_copyright_holder_author() {
     let code = "vk::CmdCopyImage(m_command_buffer, &copyRegion);";
     assert!(is_junk_copyright(code));

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -9,8 +9,8 @@ use super::binary_text::{
     has_sufficient_alphabetic_content, is_binary_string_author_candidate, is_company_like_suffix,
 };
 use crate::copyright::{
-    self, AuthorDetection, CopyrightDetection, HolderDetection, prepare_text_line, refine_author,
-    refine_copyright,
+    self, AuthorDetection, CopyrightDetection, HolderDetection, looks_like_source_code,
+    prepare_text_line, refine_author, refine_copyright,
 };
 use crate::models::{Author, Copyright, FileInfoBuilder, Holder, LineNumber};
 use regex::Regex;
@@ -89,8 +89,10 @@ pub(super) fn extract_copyright_information(
             // name-table field labels and are never a legitimate copyright prefix in
             // real source, so rejecting them universally is safe and path-independent.
             .filter(|c| {
+                let raw_span = render_raw_span(text_content, c.start_line, c.end_line);
                 !is_binary_garbage_party_value(&c.copyright)
                     && !is_font_metadata_label_copyright(&c.copyright)
+                    && !detection_is_source_code(&c.copyright, &raw_span)
                     && !c
                         .normalized_copyright
                         .as_deref()
@@ -105,6 +107,10 @@ pub(super) fn extract_copyright_information(
     file_info_builder.holders(
         holders
             .into_iter()
+            .filter(|h| {
+                let raw_span = render_raw_span(text_content, h.start_line, h.end_line);
+                !detection_is_source_code(&h.holder, &raw_span)
+            })
             .map(|h| Holder {
                 holder: h.holder,
                 start_line: h.start_line,
@@ -117,7 +123,9 @@ pub(super) fn extract_copyright_information(
     authors.extend(extract_comment_author_supplements(text_content));
     let mut seen_authors = HashSet::new();
     authors.retain(|author| {
+        let raw_span = render_raw_span(text_content, author.start_line, author.end_line);
         !is_binary_garbage_party_value(&author.author)
+            && !detection_is_source_code(&author.author, &raw_span)
             && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
     });
 
@@ -163,6 +171,32 @@ fn render_raw_copyright_from_text(
     } else {
         project_native_copyright_value(&rendered, fallback)
     }
+}
+
+/// Render the raw source span backing a detection so it can be tested for
+/// source-code shape. Holder and author detections only carry a refined value
+/// (`Region`, `Author`), which can look like an ordinary name; the underlying
+/// source line (`vk::CmdCopyImage(..., &copyRegion);`,
+/// `Author.objects.create(...)`) is what reveals it as code.
+fn render_raw_span(text_content: &str, start_line: LineNumber, end_line: LineNumber) -> String {
+    let raw_lines: Vec<&str> = text_content.lines().collect();
+    let start_index = start_line.get().saturating_sub(1);
+    let end_index = end_line.get();
+    let Some(span) = raw_lines.get(start_index..end_index) else {
+        return String::new();
+    };
+
+    span.iter()
+        .map(|line| strip_common_comment_wrappers(line.trim()))
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Return true when a detection's refined value or its backing source span is
+/// obviously source code, so it should be dropped from output.
+fn detection_is_source_code(value: &str, raw_span: &str) -> bool {
+    looks_like_source_code(value) || looks_like_source_code(raw_span)
 }
 
 fn project_wrapped_copyright_value(rendered: &str, _fallback: &str) -> Option<String> {

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -70,6 +70,11 @@ pub(super) fn extract_copyright_information(
         .filter(|h| !is_binary_garbage_party_value(&h.holder))
         .collect();
 
+    // Collect the file's lines once and reuse the slice for every detection's
+    // raw-span rendering, instead of re-splitting the whole file per copyright,
+    // holder, and author.
+    let raw_lines: Vec<&str> = text_content.lines().collect();
+
     file_info_builder.copyrights(
         copyrights
             .into_iter()
@@ -89,7 +94,7 @@ pub(super) fn extract_copyright_information(
             // name-table field labels and are never a legitimate copyright prefix in
             // real source, so rejecting them universally is safe and path-independent.
             .filter(|c| {
-                let raw_span = render_raw_span(text_content, c.start_line, c.end_line);
+                let raw_span = render_raw_span(&raw_lines, c.start_line, c.end_line);
                 !is_binary_garbage_party_value(&c.copyright)
                     && !is_font_metadata_label_copyright(&c.copyright)
                     && !detection_is_source_code(&c.copyright, &raw_span)
@@ -108,7 +113,7 @@ pub(super) fn extract_copyright_information(
         holders
             .into_iter()
             .filter(|h| {
-                let raw_span = render_raw_span(text_content, h.start_line, h.end_line);
+                let raw_span = render_raw_span(&raw_lines, h.start_line, h.end_line);
                 !detection_is_source_code(&h.holder, &raw_span)
             })
             .map(|h| Holder {
@@ -123,7 +128,7 @@ pub(super) fn extract_copyright_information(
     authors.extend(extract_comment_author_supplements(text_content));
     let mut seen_authors = HashSet::new();
     authors.retain(|author| {
-        let raw_span = render_raw_span(text_content, author.start_line, author.end_line);
+        let raw_span = render_raw_span(&raw_lines, author.start_line, author.end_line);
         !is_binary_garbage_party_value(&author.author)
             && !detection_is_source_code(&author.author, &raw_span)
             && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
@@ -178,8 +183,10 @@ fn render_raw_copyright_from_text(
 /// (`Region`, `Author`), which can look like an ordinary name; the underlying
 /// source line (`vk::CmdCopyImage(..., &copyRegion);`,
 /// `Author.objects.create(...)`) is what reveals it as code.
-fn render_raw_span(text_content: &str, start_line: LineNumber, end_line: LineNumber) -> String {
-    let raw_lines: Vec<&str> = text_content.lines().collect();
+///
+/// `raw_lines` is the file split into lines once by the caller, so this stays
+/// O(span length) per detection rather than re-splitting the whole file.
+fn render_raw_span(raw_lines: &[&str], start_line: LineNumber, end_line: LineNumber) -> String {
     let start_index = start_line.get().saturating_sub(1);
     let end_index = end_line.get();
     let Some(span) = raw_lines.get(start_index..end_index) else {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1046,3 +1046,52 @@ fn test_extract_copyright_information_ipynb_detects_notice_in_output() {
         file.copyrights
     );
 }
+
+#[test]
+fn test_extract_copyright_information_drops_cpp_copy_call_source_line() {
+    // Vulkan C++ API call: the `Copy`/`copyRegion` tokens trip the copyright
+    // grammar, producing a spurious holder `Region` and a copyright whose rendered
+    // value is the full source line. Both must be dropped as source code.
+    let text = "vk::CmdCopyImage(m_command_buffer, srcImage, srcLayout, dstImage, dstLayout, 1, &copyRegion);";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("copy.cpp"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(
+        file.copyrights.is_empty(),
+        "source-code copyright leaked: {:?}",
+        file.copyrights
+            .iter()
+            .map(|c| &c.copyright)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        file.holders.is_empty(),
+        "source-code holder leaked: {:?}",
+        file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_extract_copyright_information_keeps_real_notice_and_name_with_email() {
+    let text = "Copyright (c) 2020 Acme, Inc.\nAuthor: Jane Doe <jane@example.org>";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("LICENSE"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(
+        file.copyrights
+            .iter()
+            .any(|c| c.copyright.contains("Acme, Inc.")),
+        "real copyright dropped: {:?}",
+        file.copyrights
+            .iter()
+            .map(|c| &c.copyright)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        file.authors.iter().any(|a| a.author.contains("Jane Doe")),
+        "name-with-email author dropped: {:?}",
+        file.authors.iter().map(|a| &a.author).collect::<Vec<_>>()
+    );
+}

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1095,3 +1095,33 @@ fn test_extract_copyright_information_keeps_real_notice_and_name_with_email() {
         file.authors.iter().map(|a| &a.author).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn test_extract_copyright_information_drops_code_line_with_embedded_email_literal() {
+    // A C++ source line whose argument list embeds an email literal must still be
+    // rejected: the namespace/address-of code signals are not bypassed by the
+    // contact-looking substring in the raw span.
+    let text = "ns::registerHandler(\"admin@example.com\", &copyResult);\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("handler.cpp"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(
+        file.copyrights.is_empty(),
+        "source-code copyright leaked: {:?}",
+        file.copyrights
+            .iter()
+            .map(|c| &c.copyright)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        file.holders.is_empty(),
+        "source-code holder leaked: {:?}",
+        file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+    );
+    assert!(
+        file.authors.is_empty(),
+        "source-code author leaked: {:?}",
+        file.authors.iter().map(|a| &a.author).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Strip a trailing parenthesized **angle-bracketed** email contact `(<email>)` from author names. Ruby/other `Author:: Adam Jacob (<adam@chef.io>)` headers were emitting the malformed `Adam Jacob ( <adam@chef.io> )`; the email is already captured in `emails[]`. The established bare-paren contract `Name (email@host)` is left intact. (chef/chef: ~1228 instances across ~962 files)
- Add a shared, conservative `looks_like_source_code` predicate and wire it into the copyright, holder, and author junk checks plus `refine_copyright`, so source code stops leaking into parties. Covers django ORM (`Author.objects.create(...)`, `models.ForeignKey(Author)` — django/django ~1113 instances) and Vulkan C++ (`vk::CmdCopyImage(..., &copyRegion);` → holder `Region`). Same FP family as the prior `724901db` copr/bash fix.
- The scanner also tests the rendered raw source span for holders/authors, because a benign-looking value (`Region`, `Author`) can be backed by an obviously-code source line.

Before / after:

| Input | Before | After |
|---|---|---|
| `# Author:: Adam Jacob (<adam@chef.io>)` | author `Adam Jacob ( <adam@chef.io> )` | author `Adam Jacob` (email still in `emails[]`) |
| `# Author: Author.objects.create(pk=1, name=Baudelaire)` | author `Author.objects.create pk=1` | (none) |
| `# Author: models.ForeignKey(Author)` | author `models.ForeignKey Author` | (none) |
| `vk::CmdCopyImage(m_command_buffer, ..., &copyRegion);` | copyright = full line, holder `Region` | (none) |

Non-regressions verified: `Copyright (c) 2020 Acme, Inc.` (+ holder `Acme, Inc.`), `Adam Jacob`, `Björn Lindström`, `R&D`/`AT&T`-style org names, `Name <email>` angle-only authors, and the established `Name (email@host)` bare-paren author form all survive.

## Issues

- Covers: copyright/author/holder source-code and bracketed-email false positives found during benchmark verification.

## Scope and exclusions

- Included: author refiner Fix 1; shared `looks_like_source_code` predicate wired into copyright/holder/author junk checks, `refine_copyright`, and the scanner rendered-span filter; focused unit + scanner-pipeline tests.
- Explicit exclusions: no grammar/lexer changes; the predicate is deliberately conservative and rejects only clear code syntax.

## How to verify

- `cargo test --lib copyright` and `cargo test --features golden-tests --test copyright_golden` (both green; goldens unchanged).
- Manual: scan a file containing `# Author:: Adam Jacob (<adam@chef.io>)` with `--copyright --email --json-pp -` and confirm author is `Adam Jacob` while `emails[]` still has `adam@chef.io`; scan the Vulkan/django lines above and confirm no copyright/holder/author is emitted.

## Intentional differences from Python

- None intended; this drops fragments ScanCode also would not consider legitimate notices, while keeping Provenant's source-faithful rendering.

## Expected-output fixture changes

- Files changed: none. Copyright golden suite stays green with no fixture updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)