### PR TITLE
perf(license): bound sequence matching on oversized query runs

### DIFF
--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -130,6 +130,27 @@ pub struct LicenseDetectionEngine {
 
 const MAX_DETECTION_SIZE: usize = 10 * 1024 * 1024; // 10MB
 const MAX_REGULAR_SEQ_CANDIDATES: usize = 70;
+
+/// Upper bound on the token length of a query run that is handed to the
+/// approximate sequence matcher.
+///
+/// Sequence matching is the difflib-derived longest-common-substring aligner
+/// (see `seq_match`). On a single very large query run it degrades toward
+/// quadratic time when a handful of "legalese" tokens (e.g. `gnu`, `variant`,
+/// `releases`) recur thousands of times, as happens in big generated data files
+/// and lockfiles (e.g. uv's 2.6 MB `download-metadata.json`, which tokenizes to
+/// a single ~232k-token run). Such a run cannot be a license: the largest
+/// license text in the index is well under 15k tokens, and the largest genuine
+/// query runs observed across real source/license files stay under ~22k tokens.
+///
+/// Above this bound we skip only the *approximate* sequence matcher for that
+/// run. Exact matching (hash, SPDX-LID, Aho-Corasick) has already run and is
+/// unaffected, so verbatim and near-verbatim licenses embedded in a large file
+/// are still detected; only fuzzy alignment against an implausibly large,
+/// license-free run is bypassed. The ceiling is intentionally generous (several
+/// times both the largest rule and the largest legitimate run) so it never
+/// trims detection on real license-bearing content.
+const MAX_SEQ_QUERY_RUN_TOKENS: usize = 50_000;
 const MAX_REDUNDANT_SEQ_CONTAINER_BOUNDARY_GAP: usize = 8;
 const MAX_REDUNDANT_SEQ_CONTAINER_UNMATCHED_GAP: usize = 2;
 
@@ -427,6 +448,12 @@ fn collect_whole_query_exact_followup_matches(
 
     let mut seq_all_matches = Vec::new();
 
+    // Skip the near-duplicate whole-run sequence pass for implausibly large
+    // runs; see `MAX_SEQ_QUERY_RUN_TOKENS`. Exact matchers have already run.
+    if whole_run.tokens().len() > MAX_SEQ_QUERY_RUN_TOKENS {
+        return Ok(seq_all_matches);
+    }
+
     if whole_run.is_matchable(false, matched_qspans) {
         let near_dupe_candidates = if deadline.is_some() {
             select_seq_candidates_with_deadline(
@@ -482,6 +509,12 @@ fn collect_regular_seq_matches(
         }
 
         if !query_run.is_matchable(false, matched_qspans) {
+            continue;
+        }
+
+        // Skip approximate sequence matching for implausibly large runs; see
+        // `MAX_SEQ_QUERY_RUN_TOKENS`. Exact matchers have already run.
+        if query_run.tokens().len() > MAX_SEQ_QUERY_RUN_TOKENS {
             continue;
         }
 

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -1784,3 +1784,75 @@ fn test_detect_with_kind_handles_multibyte_boundary_at_size_limit() {
 
     assert!(detections.is_empty());
 }
+
+// A large, low-license-signal query run (the kind produced by big generated
+// data files and lockfiles) must not drive the difflib-derived sequence matcher
+// into its near-quadratic worst case. The orchestration layer skips sequence
+// matching for runs above `MAX_SEQ_QUERY_RUN_TOKENS`; exact matchers still run,
+// so a verbatim license embedded in such a file is still detected. This test
+// pins both halves of that contract.
+#[test]
+fn test_oversized_low_signal_run_skips_sequence_matching_but_keeps_exact() {
+    let engine = get_engine();
+
+    // Verbatim MIT license: this is caught by exact (hash/aho) matching, which
+    // is unaffected by the sequence-matching size cap.
+    let mit_text = r#"Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE."#;
+
+    // A large blob that tokenizes to far more than MAX_SEQ_QUERY_RUN_TOKENS,
+    // built from frequently-recurring legalese tokens (the autojunk-style
+    // pathology) interleaved with non-legalese filler. The legalese tokens keep
+    // the whole blob in a single query run (no 15-line gap), reproducing the
+    // single-giant-run shape of the regressing input.
+    let mut blob = String::with_capacity(2 * 1024 * 1024);
+    let line = "gnu variant releases name build version url download github\n";
+    while blob.len() < 1_500_000 {
+        blob.push_str(line);
+    }
+    let text = format!("{mit_text}\n\n{blob}");
+
+    let start = Instant::now();
+    let detections = engine
+        .detect_with_kind(&text, false, false)
+        .expect("Detection should succeed on a large low-signal input");
+    let elapsed = start.elapsed();
+
+    // The cap keeps this bounded; without it the difflib matcher runs for many
+    // seconds on the giant run. A generous ceiling keeps the test robust on slow
+    // CI while still failing loudly if the cap is removed.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "large low-signal detection should stay bounded, took {elapsed:?}"
+    );
+
+    let mit_related = detections.iter().any(|d| {
+        d.license_expression
+            .as_ref()
+            .map(|e| e.contains("mit"))
+            .unwrap_or(false)
+    });
+    assert!(
+        mit_related,
+        "verbatim MIT must still be detected via exact matching, got: {:?}",
+        detections
+            .iter()
+            .map(|d| d.license_expression.as_deref().unwrap_or("none"))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Fixes a ~7x license-detection performance regression on repositories that contain large generated data files or lockfiles (root case: astral-sh/uv).
- Root cause: the difflib-derived approximate **sequence matcher** runs over a single very large query run and degrades toward O(n^2). uv's 2.6 MB `crates/uv-python/download-metadata.json` tokenizes to one ~232k-token query run; a few "legalese" tokens (`gnu`, `variant`, `releases`) recur thousands of times, so `find_longest_match`'s divide-and-conquer cannot make large splits, and this is repeated per candidate rule. The cost grew sharply as the embedded rule set expanded between April and June (more candidate rules share those common tokens), turning a ~6s file into a ~43s file.
- Fix: skip only the *approximate* sequence matcher for query runs above a generous `MAX_SEQ_QUERY_RUN_TOKENS` (50,000) ceiling. Such a run cannot be a license — the largest license text in the index is under 15k tokens and the largest genuine query runs across real source/license files stay under ~22k tokens. Exact matching (hash, SPDX-LID, Aho-Corasick) is unaffected, so verbatim and near-verbatim licenses embedded in large files are still detected.
- This is a general scanner bound, not a uv-specific hack.

### Culprit and mechanism

- **Where:** `provenant::license_detection::seq_match::matching::seq_match_with_candidates_and_deadline` (`find_longest_match_impl` at `matching.rs`), driven from `collect_regular_seq_matches` and the whole-run near-dupe pass in `src/license_detection/mod.rs`.
- **Why now:** the matcher and query-run/candidate-selection logic are byte-for-byte equivalent between the April base (`231eae15`) and June `main`; the difference is the embedded rule data ("update license rules to latest" + overlay additions). More rules now share the JSON's ultra-frequent legalese tokens, so far more candidates survive the high-token gate and each is sequence-matched over the same ~232k-token run.
- **Evidence:** profiling the warm `-l` scan attributed ~50%+ self time to `seq_match_with_candidates_and_deadline` (plus SipHash churn inside it). Instrumentation showed the JSON produces a single query run of **232,359 tokens** with 14 regular candidates.

## Issues

- Covers: ~7x license-detection regression scanning astral-sh/uv between `231eae15` (April) and `main` (June), localized to license detection on `download-metadata.json`.

## Scope and exclusions

- Included: per-query-run token-count ceiling guarding both sequence-matching entry points (regular per-run pass and the near-dupe whole-run pass); a unit test pinning the contract.
- Explicit exclusions: no change to the sequence-matching algorithm itself (it stays faithful to ScanCode/difflib), no change to exact matchers, no rule/overlay edits, no embedded-index regeneration.

## How to verify

Beyond the CI golden/unit suites, the load-bearing evidence is the `perf-ab` self-comparison (base `231eae15` vs this branch), measured on Apple M5 Pro:

- Isolated regressing file (`/tmp/uv-json/download-metadata.json`), `-l --strip-root -n 1`, 5 rounds:
  - base median **5.82s**, this branch median **4.49s** (1.30x faster than base; vs ~43.4s on regressed `main` — about 9.7x faster than `main`).
  - `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base 231eae15053a14a37f418df4bb26c0c89d95ddb7 --head <this-branch> --target-path <dir-with-download-metadata.json> --rounds 5 -- -l --strip-root -n 1`
- Full uv repo, `--profile common` (`-clupe --system-package --strip-root --processes 4`), 5 rounds:
  - base median **11.55s**, this branch median **8.86s** (1.30x faster than base; vs ~46s on regressed `main`).
  - `cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- --base 231eae15053a14a37f418df4bb26c0c89d95ddb7 --head <this-branch> --repo-url https://github.com/astral-sh/uv.git --repo-ref 9581f2b0ea65550a3efe28bd7aabde19d98b39ba --profile common --rounds 5`

Detection quality: `cargo test --test license_detection_golden --features golden-tests` passes unchanged (all data-driven fixtures, zero detection-quality regressions). The new unit test `test_oversized_low_signal_run_skips_sequence_matching_but_keeps_exact` confirms a >50k-token low-signal run stays bounded while a verbatim MIT license embedded in it is still detected via exact matching.

## Intentional differences from Python

- ScanCode's `seq.py` has no popular-token/large-run guard; it relies on its Cython matcher and the `match_set.py` candidate gate. Provenant adds a bounded large-run guard so a single pathological run cannot dominate a scan. This only suppresses fuzzy alignment on runs far larger than any license; exact detection is unchanged, so it is a safety/boundedness improvement rather than a parity loss.

## Expected-output fixture changes

- Files changed: none. No golden YAML or `.expected` fixtures changed; the license golden suite passes as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
