### PR TITLE
docs(benchmarks): refresh uv, npm/cli, DefectDojo after license perf fix (#1109)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **14.3× median speedup** and **13.9× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.5×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **14.3× median speedup** and **14.1× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.5×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -129,11 +129,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `50.99s`; ScanCode `1158.57s`
 - Far broader Python/provider package coverage (`142` vs `1`) and dependency extraction (`7599` vs `1014`) from `uv.lock`, provider `pyproject.toml`, and committed `pnpm-lock.yaml` inputs, plus extra Docker and Helm package visibility, safer URL credential stripping, and cleaner copyright/author normalization across large documentation and kernel-style metadata blocks
 
-##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **5.98× faster**
+##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **28.81× faster**
 
 - Files: 1,259
-- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `45.62s`; ScanCode `272.81s`
+- Run context: 2026-06-18 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.47s`; ScanCode `272.81s`
 - Far broader Python-family package and dependency extraction (`113` vs `1` packages, `5279` vs `759` dependencies) from the large `test/requirements/**` tree, many fixture/workspace `pyproject.toml` files, and multiple `uv.lock` inputs that ScanCode leaves at zero, with safer URL credential stripping, Unicode-preserving party normalization, and METADATA-backed wheel identity instead of double-counting a misleading filename
 
 ##### [astropy/astropy @ 40280e3](https://github.com/astropy/astropy/tree/40280e3bd715a4968eda816c73bf88f05aa6cdc0) — **36.99× faster**
@@ -164,11 +164,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.79s`; ScanCode `42.84s`
 - Direct schema-versioned conda-forge feedstock package visibility (`1` vs `0` packages, `51` vs `0` dependencies) from `recipe/recipe.yaml`, plus assembled top-level Conda package identity and preserved source/about metadata
 
-##### [DefectDojo/django-DefectDojo @ 2f25c45](https://github.com/DefectDojo/django-DefectDojo/tree/2f25c4510361e2f27f63fbbcff3901cbd2ef4a07) — **16.13× faster**
+##### [DefectDojo/django-DefectDojo @ 2f25c45](https://github.com/DefectDojo/django-DefectDojo/tree/2f25c4510361e2f27f63fbbcff3901cbd2ef4a07) — **24.94× faster**
 
 - Files: 4,301
-- Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `66.90s`; ScanCode `1079.38s`
+- Run context: 2026-06-18 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `43.27s`; ScanCode `1079.38s`
 - Broader full-repo package and dependency extraction (`3` vs `2` packages, `616` vs `535` dependencies) from `.gitmodules`, `helm/defectdojo/Chart.yaml`, `helm/defectdojo/Chart.lock`, and the root `requirements*.txt` manifests, with direct Helm chart package visibility, pinned PostgreSQL or Valkey chart dependencies, Git-submodule package metadata, and zero scan errors where ScanCode reports 3 scan-file failures on large vulnerability fixtures
 
 ##### [django/django @ 09f27cc](https://github.com/django/django/tree/09f27cc373eb1e6e5e8b286204809a79b61d55c3) — **39.22× faster**
@@ -408,11 +408,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `58.96s`; ScanCode `1410.57s`
 - Broader monorepo package and dependency extraction (`138` vs `1` packages, `7718` vs `1815` dependencies) from the root `package-lock.json`, many extension fixture manifests and lockfiles, and embedded Cargo/Docker metadata, plus richer named package identities where ScanCode emits generic lockfile and archive rows
 
-##### [npm/cli @ 05dbba5](https://github.com/npm/cli/tree/05dbba5b8d727ddb2c098ce0553714eae791c5f2) — **22.16× faster**
+##### [npm/cli @ 05dbba5](https://github.com/npm/cli/tree/05dbba5b8d727ddb2c098ce0553714eae791c5f2) — **40.20× faster**
 
 - Files: 6,732
-- Run context: 2026-06-16 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `106.15s`; ScanCode `2352.73s`
+- Run context: 2026-06-18 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `58.53s`; ScanCode `2352.73s`
 - Clean root npm workspace manifest coverage without ScanCode's workspace-assembly scan errors, fewer large registry-fixture JSON timeouts, and cleaner handling of duplicated private-workspace dependency exports and repeated MIT-style registry-fixture metadata noise
 
 ##### [oakserver/oak @ 185baef](https://github.com/oakserver/oak/tree/185baef02551a84798000f25d3bd01c2fdfcb1ce) — **9.43× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -1087,9 +1087,9 @@ Provenant: 12.77s</title></circle>
     <circle cx="584.51" cy="495.58" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 Provenant: 17.94s</title></circle>
-    <circle cx="587.87" cy="451.48" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
+    <circle cx="587.87" cy="525.77" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
 Files: 1259
-Provenant: 45.62s</title></circle>
+Provenant: 9.47s</title></circle>
     <circle cx="588.14" cy="514.39" r="4.5" fill="#2563eb"><title>distroless base-debian12 @ sha256:9dce90e
 Files: 1264
 Provenant: 12.05s</title></circle>
@@ -1216,9 +1216,9 @@ Provenant: 11.71s</title></circle>
     <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
 Files: 4266
 Provenant: 40.75s</title></circle>
-    <circle cx="672.53" cy="433.39" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
+    <circle cx="672.53" cy="453.98" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
-Provenant: 66.90s</title></circle>
+Provenant: 43.27s</title></circle>
     <circle cx="677.50" cy="476.32" r="4.5" fill="#2563eb"><title>akka/akka @ 5ace141
 Files: 4623
 Provenant: 26.97s</title></circle>
@@ -1255,9 +1255,9 @@ Provenant: 31.31s</title></circle>
     <circle cx="702.64" cy="504.58" r="4.5" fill="#2563eb"><title>bitwarden/server @ 051d0ef
 Files: 6658
 Provenant: 14.83s</title></circle>
-    <circle cx="703.40" cy="411.58" r="4.5" fill="#2563eb"><title>npm/cli @ 05dbba5
+    <circle cx="703.40" cy="439.71" r="4.5" fill="#2563eb"><title>npm/cli @ 05dbba5
 Files: 6732
-Provenant: 106.15s</title></circle>
+Provenant: 58.53s</title></circle>
     <circle cx="705.92" cy="463.08" r="4.5" fill="#2563eb"><title>openembedded/meta-openembedded @ 7bf89d0
 Files: 6983
 Provenant: 35.69s</title></circle>


### PR DESCRIPTION
## Summary

The sweep-8 benchmark refresh (#1105) measured three targets **before** the license-detection performance fix (#1109) merged, so their recorded timings captured the O(n²) oversized-run regression and **understated Provenant**. This re-measures them on current `main` (ScanCode reused from cache — Provenant-only re-scan):

| Target | Before | After |
| --- | --- | --- |
| astral-sh/uv | `45.62s` → 5.98× | `9.47s` → **28.81×** |
| npm/cli | `106.15s` → 22.16× | `58.53s` → **40.20×** |
| DefectDojo/django-DefectDojo | `66.90s` → 16.13× | `43.27s` → **24.94×** |

Each has a large low-signal data file that triggered the regressed matcher (uv `download-metadata.json` 2.6MB; npm registry-fixture JSON; DefectDojo security-scan fixtures).

## Why only these three

I re-measured every recently-refreshed target that *could* trigger the bug (largest blob ≳1MB). Only these three got materially faster; the rest were within measurement noise and are left unchanged:

- Unaffected (re-measured ≈ recorded): dejacode, stack, astropy, opus, Vulkan-ValidationLayers, airflow, scancode-toolkit, camel.
- Cannot trigger (largest blob <~0.5MB): conda, maven, Mantle, spring-boot, ReactiveCocoa, select2, django, chef.

Chart regenerated; geometric-mean speedup rises to 14.1×.

## Test plan

- `compare-outputs` re-run per target on current `main` with `scancode.cache_hit: true` (no ScanCode re-scan).
- `generate-benchmark-chart` regenerated the SVG and headline stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
