### PR TITLE
docs(benchmarks): refresh DataScience and bazel outliers after license perf fix

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 222 of 222 recorded runs, with a **14.3× median speedup** and **14.1× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.5×** on 10k+ file targets.
+> Provenant is faster on 222 of 222 recorded runs, with a **14.4× median speedup** and **14.3× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.7×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -594,11 +594,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.71s`; ScanCode `43.86s`
 - Matched Cargo package and dependency coverage (`1` vs `1` packages, `5` vs `5` dependencies) while preserving the repository's `Apache-2.0 OR MIT` README license semantics and normalizing docs.rs and Keep a Changelog links without trailing-slash drift
 
-##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **14.51× faster**
+##### [bazelbuild/bazel @ eb5aeaa](https://github.com/bazelbuild/bazel/tree/eb5aeaaa23d52601a2aca11ff6fd1a74ea97f0d6) — **28.81× faster**
 
 - Files: 11,495
-- Run context: 2026-06-15 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `96.27s`; ScanCode `1396.87s`
+- Run context: 2026-06-18 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `48.49s`; ScanCode `1396.87s`
 - Broader Bazel package and dependency extraction (`1746` vs `1711` packages, `129` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, with richer Debian and RPM sidecar package metadata
 
 ##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **12.29× faster**
@@ -1260,11 +1260,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `22.78s`; ScanCode `332.82s`
 - Broader mixed Hackage and Nix package extraction (`5` vs `0` packages, `197` vs `0` dependencies) from sibling `pandoc*.cabal` manifests, `stack.yaml`, and `flake.nix` / `flake.lock`, with explicit package identities across `pandoc`, `pandoc-cli`, `pandoc-lua-engine`, and `pandoc-server`
 
-##### [JuliaAcademy/DataScience @ 201f2e6](https://github.com/JuliaAcademy/DataScience/tree/201f2e66cf2067dacee2df02b546f75d77ed22e7) — **8.58× faster**
+##### [JuliaAcademy/DataScience @ 201f2e6](https://github.com/JuliaAcademy/DataScience/tree/201f2e66cf2067dacee2df02b546f75d77ed22e7) — **40.81× faster**
 
 - Files: 50
-- Run context: 2026-06-06 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `27.50s`; ScanCode `235.99s`
+- Run context: 2026-06-18 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.68s`; ScanCode `231.82s`
 - Direct Julia package visibility and broader dependency extraction (`1` vs `0` packages, `53` vs `0` dependencies) from the root legacy v1.0-format `Manifest.toml` and its `Project.toml`, with zero scan errors where ScanCode times out after 120s on `05. Clustering.ipynb` and no spurious low-confidence `GPL-3.0-only` detection bleeding from the binary `data/face_recog_qr.mat` blob
 
 ##### [JuliaLang/julia @ afc71c2](https://github.com/JuliaLang/julia/tree/afc71c255e327d8a64b69061c15994e80740974d) — **21.75× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -182,9 +182,9 @@ ScanCode: 46.66s</title></rect>
     <rect x="360.18" y="450.45" width="8" height="8" fill="#d97706" rx="1.5"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 49
 ScanCode: 42.84s</title></rect>
-    <rect x="361.57" y="369.83" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
+    <rect x="361.57" y="370.67" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
-ScanCode: 235.99s</title></rect>
+ScanCode: 231.82s</title></rect>
     <rect x="365.59" y="449.04" width="8" height="8" fill="#d97706" rx="1.5"><title>docker-library/python @ ced4ac7
 Files: 53
 ScanCode: 44.14s</title></rect>
@@ -850,9 +850,9 @@ Provenant: 6.06s</title></circle>
     <circle cx="364.18" cy="541.49" r="4.5" fill="#2563eb"><title>conda-forge/pandas-feedstock @ 4063b72
 Files: 49
 Provenant: 6.79s</title></circle>
-    <circle cx="365.57" cy="475.40" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
+    <circle cx="365.57" cy="549.93" r="4.5" fill="#2563eb"><title>JuliaAcademy/DataScience @ 201f2e6
 Files: 50
-Provenant: 27.50s</title></circle>
+Provenant: 5.68s</title></circle>
     <circle cx="369.59" cy="559.38" r="4.5" fill="#2563eb"><title>docker-library/python @ ced4ac7
 Files: 53
 Provenant: 4.65s</title></circle>
@@ -1312,9 +1312,9 @@ Provenant: 48.11s</title></circle>
     <circle cx="737.17" cy="425.83" r="4.5" fill="#2563eb"><title>qemu/qemu @ da6c4fe
 Files: 10989
 Provenant: 78.51s</title></circle>
-    <circle cx="740.27" cy="416.20" r="4.5" fill="#2563eb"><title>bazelbuild/bazel @ eb5aeaa
+    <circle cx="740.27" cy="448.60" r="4.5" fill="#2563eb"><title>bazelbuild/bazel @ eb5aeaa
 Files: 11495
-Provenant: 96.27s</title></circle>
+Provenant: 48.49s</title></circle>
     <circle cx="741.15" cy="452.64" r="4.5" fill="#2563eb"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 Provenant: 44.52s</title></circle>


### PR DESCRIPTION
## Summary

Two of the benchmark chart's Provenant outliers were **stale rows** measured before the license-detection perf fix (#1109). Both have a large low-signal data file that triggered the O(n²) oversized-run matcher; #1109 already fixes it, so these rows just understated Provenant. Re-measured on current `main`:

| Target | Before | After |
| --- | --- | --- |
| JuliaAcademy/DataScience | 27.50s → 8.58× | `5.68s` → **40.81×** |
| bazelbuild/bazel | 96.27s → 14.51× | `48.49s` → **28.81×** |

- **DataScience**: full `compare-outputs` re-run (its ScanCode is small, ~4 min, and was no longer cached). The fresh ScanCode `231.82s` matches the recorded `235.99s` — confirming ScanCode is stable for a pinned ref.
- **bazel**: Provenant-only re-measure (matching the recorded `compare-outputs` PV flags); the recorded M5 Pro ScanCode `1396.87s` is reused, since re-running it would only reproduce the same value at ~23 min cost.

## Deliberately left as-is (need a full re-run; deferred)

- **erlang/otp** — its recorded row is on **M1 Max**; a Provenant-only refresh would pair an M5 Pro PV with an M1 Max ScanCode and mix hardware into the ratio. (It is the same stale bug: 135.93s M1 Max → ~45s M5 Pro.)
- **Artifact outliers** (Windows update extract, WSUS `wsusscn2`, `bash .deb`, glazewm/fishnet app snapshots) — `--target-path` targets whose original input files aren't available to re-scan.

These were verified stale (not perf regressions) but would each require a full re-run (including ScanCode) to refresh validly, so they're held rather than churned.

## Note

A separate genuine perf outlier — **LinuxCNC/linuxcnc** (163.6s, unchanged pre/post #1109) — is **not** a stale row; it's a real hotspot under investigation in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
