### PR TITLE
perf(license): window query-run matchables instead of scanning whole query

### DIFF
--- a/src/license_detection/position_set.rs
+++ b/src/license_detection/position_set.rs
@@ -123,6 +123,55 @@ impl PositionSet {
         range_end > self.min_pos && range_start <= self.max_pos
     }
 
+    /// Build the subset of positions that fall within the half-open range
+    /// `[start, end)`.
+    ///
+    /// The naive form is `self.iter().filter(|p| start <= p < end)`, which
+    /// always walks the *entire* set. When this set is a whole-query matchables
+    /// set (hundreds of thousands of positions for a multi-MB file) but the
+    /// range is a single small query run (tens of tokens), that full scan is
+    /// repeated once per run and the per-file cost degrades to
+    /// `O(num_runs * total_positions)` — quadratic in file size. Translation
+    /// catalogs (`.po`) are the pathological case: thousands of small runs over
+    /// a single huge token stream.
+    ///
+    /// Instead, iterate whichever side is smaller. The clamped range can never
+    /// be longer than the set's own span, and for a small run it is far
+    /// shorter, so we probe `range.contains` against this set's O(1) membership
+    /// test. For a range that spans the whole set (the whole-query run) we fall
+    /// back to walking the set directly, which is the same work as before.
+    pub fn restricted_to_range(&self, start: usize, end: usize) -> PositionSet {
+        if self.min_pos == usize::MAX || end <= start {
+            return PositionSet::new();
+        }
+
+        // Clamp to the set's populated bounds; positions outside cannot be present.
+        let lo = start.max(self.min_pos);
+        let hi = end.min(self.max_pos + 1);
+        if hi <= lo {
+            return PositionSet::new();
+        }
+
+        // `iter()` walks the bit vector across the set's whole populated span,
+        // so use that span as its cost proxy. Probing the clamped range costs
+        // `range_len` O(1) membership tests. Probe only when the clamped range
+        // is strictly narrower than the set's span; when it already covers the
+        // span (the whole-query run, `range_len == set_span`) iterate the set
+        // directly, which is the original behavior and avoids probing every
+        // gap position. The clamp guarantees `range_len <= set_span`, so `<`
+        // (not `<=`) is what keeps the whole-query case on the set-iter path.
+        let range_len = hi - lo;
+        let set_span = self.max_pos - self.min_pos + 1;
+        if range_len < set_span {
+            (lo..hi).filter(|&pos| self.bitset.contains(pos)).collect()
+        } else {
+            self.bitset
+                .iter()
+                .filter(|&pos| pos >= lo && pos < hi)
+                .collect()
+        }
+    }
+
     /// Compute the union of this set with another PositionSet.
     ///
     /// Returns a new PositionSet containing all positions from both sets.
@@ -244,6 +293,59 @@ mod tests {
         let set = PositionSet::from_usize_iter(vec![1, 2, 2, 3, 3, 3]);
         assert_eq!(set.len(), 3);
         assert_eq!(set.iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    // `restricted_to_range` must equal the naive `iter().filter(start <= p < end)`
+    // form for every range, regardless of which internal branch it picks (probe
+    // the range vs. walk the set). This pins the contract that the perf
+    // optimization is purely behavior-preserving.
+    #[test]
+    fn test_restricted_to_range_matches_naive_filter() {
+        let positions = vec![0usize, 1, 5, 6, 7, 100, 101, 5000, 5001, 9999];
+        let set = PositionSet::from_usize_iter(positions.iter().copied());
+
+        let naive = |start: usize, end: usize| -> Vec<usize> {
+            set.iter().filter(|&p| p >= start && p < end).collect()
+        };
+
+        let cases = [
+            (0, 0),         // empty range
+            (3, 3),         // empty range mid-set
+            (0, 10000),     // whole span (walk-the-set branch)
+            (5, 8),         // small interior run (probe-the-range branch)
+            (6, 7),         // single element
+            (0, 2),         // at the low bound
+            (5000, 6000),   // straddles populated and empty
+            (200, 5000),    // gap then boundary (exclusive end)
+            (12000, 99999), // entirely above max_pos
+        ];
+
+        for (start, end) in cases {
+            let got: Vec<usize> = set.restricted_to_range(start, end).iter().collect();
+            assert_eq!(
+                got,
+                naive(start, end),
+                "restricted_to_range({start}, {end}) diverged from naive filter"
+            );
+        }
+    }
+
+    #[test]
+    fn test_restricted_to_range_empty_set() {
+        let set = PositionSet::new();
+        assert!(set.restricted_to_range(0, 100).is_empty());
+    }
+
+    #[test]
+    fn test_restricted_to_range_unbounded_end() {
+        // The whole-query run uses end == usize::MAX; it must return every
+        // position at or after `start` without overflowing.
+        let set = PositionSet::from_usize_iter(vec![1usize, 50, 999]);
+        let got: Vec<usize> = set.restricted_to_range(0, usize::MAX).iter().collect();
+        assert_eq!(got, vec![1, 50, 999]);
+
+        let got: Vec<usize> = set.restricted_to_range(50, usize::MAX).iter().collect();
+        assert_eq!(got, vec![50, 999]);
     }
 
     #[test]

--- a/src/license_detection/query/mod.rs
+++ b/src/license_detection/query/mod.rs
@@ -1165,12 +1165,8 @@ impl<'a> QueryRun<'a> {
             .get_or_init(|| {
                 let start = self.start;
                 let end = self.end.map(|e| e + 1).unwrap_or(usize::MAX);
-                let source = self.source_high_matchables();
-                let live_span = PositionSpan::new(start, end);
-                source
-                    .iter()
-                    .filter(|&pos| live_span.contains(pos))
-                    .collect()
+                self.source_high_matchables()
+                    .restricted_to_range(start, end)
             })
             .clone()
     }
@@ -1180,12 +1176,7 @@ impl<'a> QueryRun<'a> {
             .get_or_init(|| {
                 let start = self.start;
                 let end = self.end.map(|e| e + 1).unwrap_or(usize::MAX);
-                let source = self.source_low_matchables();
-                let live_span = PositionSpan::new(start, end);
-                source
-                    .iter()
-                    .filter(|&pos| live_span.contains(pos))
-                    .collect()
+                self.source_low_matchables().restricted_to_range(start, end)
             })
             .clone()
     }


### PR DESCRIPTION
## Summary

- License detection on large files that tokenize into many query runs (gettext `.po` catalogs are the worst case) was near-quadratic in file size. `QueryRun::high_matchables` / `low_matchables` rebuilt each run's matchables by walking the **whole-query** matchables `PositionSet` and filtering to the run window: `source.iter().filter(|p| live_span.contains(p))`. That is `O(total_query_positions)` per run, so a file with N runs over one large token stream costs `O(N × total_positions)`.
- Replaced the full-set scan with `PositionSet::restricted_to_range`, which probes the (small) run window against the set's O(1) membership test, and only falls back to the whole-set walk when the range already spans the set (the whole-query run) — so the whole-query path is never regressed. Output is byte-for-byte identical; only the traversal changed.

This is a general scanner bound, complementary to #1109. #1109 skipped sequence matching for a *single oversized run* (>50k tokens); this fixes the orthogonal case of *many small runs* over a large token stream, which #1109 never triggered on.

### Root cause evidence (LinuxCNC/linuxcnc @ cd534c9)

- linuxcnc scans slowly for its size; 60% of its bytes (223 MB of 371 MB across 84 files) are `docs/po/*.po` gettext catalogs.
- Per-subsystem single-worker (`-n 1`) breakdown on the whole repo: license `-l` 113s (dominant), copyright `-c` 81s, package 8.5s, info 3s, url 2.5s, email 2.2s. The `docs/po` subtree alone was 91s of the 113s license cost (81%).
- Profiling (samply) the `docs/po` license scan: `PositionSet::from_usize_iter` was 45.6% of self time, all under `collect_regular_seq_matches → select_seq_candidates_with_deadline → QueryRun::matchables / matchable_tokens`.
- Probe of one catalog (`de.po`): 1.19M tokens split into 7,848 query runs (4,349 matchable, median 85 tokens each). The old code rescanned all ~1.19M positions 4,349 times to extract ~85-token windows.

## Issues

- Covers: LinuxCNC/linuxcnc license-detection performance outlier (~17.7 ms/file vs ~4.3 ms/file for comparable repos)

## Scope and exclusions

- Included: `PositionSet::restricted_to_range` and its use in `QueryRun::high_matchables` / `low_matchables`; unit tests pinning it against the naive filter.
- Explicit exclusions: copyright `-c` (the second-largest subsystem on linuxcnc, ~81s) is a separate hotspot driven by the same large catalogs; not addressed here. No `docs/BENCHMARKS.md` change — that file is the ScanCode-comparison record; refreshing the linuxcnc entry via `verify-benchmark-target` is follow-up.

## How to verify

Beyond CI, attribute the speedup to this edit with the A/B harness (byte-identical correctness gate + interleaved medians):

```
cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
  --base 230bfa85 --head perf/license-windowed-matchables \
  --target-path <linuxcnc worktree @ cd534c9> \
  --rounds 5 --check-output -- -l -n 1
```

Measured on this machine (Apple M-series, license isolated with `-l -n 1`, 5 interleaved rounds after a discarded warmup):

- `check-output`: **byte-identical** after header/UID normalization.
- base median **119.193s** → head median **72.302s** = **1.649× faster (39.34% reduction)** in license-detection wall time on linuxcnc.

Stop condition (set before implementing): ">= 10% median wall-clock reduction on a license-text/run-dense repo with `-l -n 1`, output byte-identical." Met with large margin.

## Expected-output fixture changes

- Files changed: none. The change is behavior-preserving (byte-identical scan output; license golden suite passes unchanged). New unit tests in `position_set.rs` pin `restricted_to_range` against the naive `iter().filter` form across interior, whole-span, empty, above-max, and unbounded-end (`usize::MAX`, the whole-query run) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
