### PR TITLE
docs(benchmarks): re-measure ten M1 targets on M5 for a hardware-consistent chart

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 219 of 219 recorded runs, with a **14.6× median speedup** and **14.6× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **20.7×** on 10k+ file targets.
+> Provenant is faster on 219 of 219 recorded runs, with a **14.8× median speedup** and **15.0× geometric-mean speedup** overall; the median gap grows from **7.7×** on sub-100-file targets to **22.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -294,11 +294,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.88s`; ScanCode `51.28s`
 - Locked Hex dependency extraction (`9` vs `0`) for `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
 
-##### [erlang/otp @ 264def5](https://github.com/erlang/otp/tree/264def545b8214ea7100bfede1a4629c676ff1c0) — **23.52× faster**
+##### [erlang/otp @ 264def5](https://github.com/erlang/otp/tree/264def545b8214ea7100bfede1a4629c676ff1c0) — **33.91× faster**
 
 - Files: 11,749
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `135.93s`; ScanCode `3197.26s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `59.99s`; ScanCode `2034.56s`
 - Direct OTP application package visibility (`11` vs `0`) across committed `lib/*/src/*.app.src` templates, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable and preserves the same non-stdlib runtime dependency inventory ScanCode finds
 
 ##### [phoenixframework/phoenix @ e7b8081](https://github.com/phoenixframework/phoenix/tree/e7b8081792fa51c9fede6d0fb9ddb610bac3f26f) — **11.66× faster**
@@ -494,18 +494,18 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `228.70s`; ScanCode `3824.09s`
 - Matched Maven package coverage (`699` vs `699`) with broader dependency extraction (`7694` vs `7645`) across the large multi-module reactor, archetype template POMs, and mixed package-adjacent Helm, Docker, and Cargo surfaces, plus UTF-16 template license detection and broader notice-author recovery across Apache/Spring/OpenShift acknowledgements, with zero scan-file errors where ScanCode times out on the committed `camel-sbom.json` and `camel-sbom.xml`
 
-##### [apache/hadoop @ dbcc7cd](https://github.com/apache/hadoop/tree/dbcc7cd797100e6b32cd84f85b53a5193a5f9af0) — **16.42× faster**
+##### [apache/hadoop @ dbcc7cd](https://github.com/apache/hadoop/tree/dbcc7cd797100e6b32cd84f85b53a5193a5f9af0) — **26.52× faster**
 
 - Files: 16,370
-- Run context: 2026-05-06 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `278.63s`; ScanCode `4575.96s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `121.35s`; ScanCode `3218.68s`
 - Broader dependency extraction (`5849` vs `3794`) and slightly broader package visibility (`123` vs `122`) from the large multi-module Maven reactor, classifier/type-aware WAR identities, committed vcpkg metadata, and property-preserving Maven coordinates, with cleaner sourcemap/minified-banner party handling and reviewed remaining legal-text/author differences
 
-##### [apache/kafka @ 0d9fe51](https://github.com/apache/kafka/tree/0d9fe518b616725fecd96162297fee89a7b7a6a5) — **14.02× faster**
+##### [apache/kafka @ 0d9fe51](https://github.com/apache/kafka/tree/0d9fe518b616725fecd96162297fee89a7b7a6a5) — **28.75× faster**
 
 - Files: 7,179
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `53.61s`; ScanCode `751.77s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `39.52s`; ScanCode `1136.27s`
 - Far broader Gradle and sidecar Python package extraction (`6` vs `4` packages, `662` vs `15` dependencies) from the root multi-project `build.gradle`, Kafka module wiring, and the committed `tests/setup.py`, plus extra Docker package visibility on the bundled image fixtures
 
 ##### [apache/maven @ 459de76](https://github.com/apache/maven/tree/459de765537854376dd499e931ab87e1d53f9c23) — **19.52× faster**
@@ -671,11 +671,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `31.31s`; ScanCode `533.84s`
 - Matched Go package coverage (`2` vs `2`) with slightly richer dependency extraction (`652` vs `651`) from vendored `mkdocs-reqs.txt` and committed Python sidecar requirements, while preserving Go module inventory parity on the root `go.mod` and `go.sum` surfaces
 
-##### [curl/curl @ 2bb5c9b](https://github.com/curl/curl/tree/2bb5c9b5552d37f08a439f2bec400009321d325c) — **14.87× faster**
+##### [curl/curl @ 2bb5c9b](https://github.com/curl/curl/tree/2bb5c9b5552d37f08a439f2bec400009321d325c) — **26.33× faster**
 
 - Files: 4,266
-- Run context: 2026-04-30 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `40.75s`; ScanCode `606.05s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `14.26s`; ScanCode `375.45s`
 - Matched ScanCode's file-level Autotools `configure.ac` coverage while promoting one top-level Autotools package (`1` vs `0`), with the real `pkg:autotools/curl` identity instead of a generic input placeholder, plus extra Docker package and dependency visibility from the committed `Dockerfile`
 
 ##### [Debian/apt @ 6b12812](https://github.com/Debian/apt/tree/6b128124271e94bdb0f4e7850d9286170d712b04) — **15.11× faster**
@@ -734,11 +734,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `11.99s`; ScanCode `157.63s`
 - Matched package and dependency parity (`0` packages, `1` dependency) while collapsing the local `LICENSE-MIT` notice in `support/docopt.py` to plain `MIT`, with cleaner copyright normalization on mkdocstrings support code and consistent URL normalization across README and docs
 
-##### [git/git @ 9f223ef](https://github.com/git/git/tree/9f223ef1c026d91c7ac68cc0211bde255dda6199) — **18.30× faster**
+##### [git/git @ 9f223ef](https://github.com/git/git/tree/9f223ef1c026d91c7ac68cc0211bde255dda6199) — **42.67× faster**
 
 - Files: 4,734
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `24.70s`; ScanCode `452.09s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `14.62s`; ScanCode `623.80s`
 - Broader package-adjacent Git metadata visibility on the tracked `.gitmodules` manifest (`1` vs `0` dependencies on that file), plus one extra top-level package row (`4` vs `3`) from treating the manifest as package metadata instead of leaving it scanner-silent
 
 ##### [go-gitea/gitea @ 47fdf3e2](https://github.com/go-gitea/gitea/tree/47fdf3e284308c6b648936b5c15e136b08f5e1da) — **26.3× faster**
@@ -769,11 +769,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `48.11s`; ScanCode `694.17s`
 - Far broader dependency extraction (`418` vs `92`) from the root `.gitmodules`, `MODULE.bazel`, and vendored package surfaces, richer package coverage (`782` vs `761`), and direct Git-submodule visibility on 17 tracked third-party submodules where ScanCode reports zero package data on the same manifest
 
-##### [guillemj/dpkg @ 0061122](https://github.com/guillemj/dpkg/tree/006112209ac937b373d4497c81998a415cbef0f5) — **20.22× faster**
+##### [guillemj/dpkg @ 0061122](https://github.com/guillemj/dpkg/tree/006112209ac937b373d4497c81998a415cbef0f5) — **32.78× faster**
 
 - Files: 1,766
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `27.87s`; ScanCode `563.43s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `13.06s`; ScanCode `428.07s`
 - Broader Debian source-package and dependency extraction (`23` vs `19` packages, `18` vs `0` dependencies) from the root multi-binary `debian/control` file plus committed `.dsc` fixtures, with explicit package visibility for `dpkg-dev`, `libdpkg-dev`, and `libdpkg-perl` and one extra top-level Autotools package on `configure.ac`
 
 ##### [kubernetes/autoscaler @ 9045d28](https://github.com/kubernetes/autoscaler/tree/9045d287a3458d6ea7440c3dcf921806bc994224) — **32.10× faster**
@@ -818,11 +818,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `10.86s`; ScanCode `130.94s`
 - Broader native-build package and dependency visibility (`5` vs `0` packages, `3` vs `0` dependencies) from the root `configure`, `MODULE.bazel`, and committed `.csproj` surfaces, with the real `pkg:autotools/zlib` identity instead of ScanCode's generic input placeholder, direct Bazel and NuGet surface coverage, and the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c`
 
-##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **24.79× faster**
+##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **49.68× faster**
 
 - Files: 12,375
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `56.00s`; ScanCode `1388.49s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `28.00s`; ScanCode `1391.11s`
 - Matched top-level package coverage (`5` vs `5`) with slightly richer dependency extraction (`1093` vs `1088`) from relative Go module edges, vendored `.gitmodules`, and committed `requirements.txt`, plus extra Docker package visibility on committed Dockerfiles and cleaner rejection of weak prose-only author or holder matches such as `the Prometheus`
 
 ##### [mongodb/mongo @ d6877a3](https://github.com/mongodb/mongo/tree/d6877a33a90e253f4e7a9641a3eb237518a5a495) — **13.91× faster**
@@ -853,11 +853,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `35.69s`; ScanCode `501.03s`
 - Broader BitBake package and dependency visibility (`1437` vs `0` packages, `10149` vs `0` dependencies) from committed `.bb`, `.bbappend`, and `.inc` metadata, plus recipe-side declared-license and source-reference recovery on manifests such as `nilfs-utils_v2.2.11.bb`, with patch-header and comment-style author recovery kept separate from ScanCode's bare-word GPL/LGPL and patch-prose overcalls
 
-##### [openssl/openssl @ 7fb28b9](https://github.com/openssl/openssl/tree/7fb28b9cd05ba89cbbe038dfa85804fe22bc146a) — **20.36× faster**
+##### [openssl/openssl @ 7fb28b9](https://github.com/openssl/openssl/tree/7fb28b9cd05ba89cbbe038dfa85804fe22bc146a) — **38.63× faster**
 
 - Files: 6,074
-- Run context: 2026-04-25 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `58.93s`; ScanCode `1199.73s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `21.79s`; ScanCode `841.78s`
 - Broader package and dependency visibility (`1` vs `0` packages, `41` vs `0` dependencies) from bundled `external/perl/Text-Template-1.56` CPAN metadata plus committed `.gitmodules` and `test/quic-openssl-docker/Dockerfile` surfaces, with stronger `Written by ...` author recovery on OpenSSL-style comment headers and cleaner rejection of weak CPAL or MIT overcalls on standard OpenSSL license footers
 
 ##### [pulseaudio/pulseaudio @ b096704](https://github.com/pulseaudio/pulseaudio/tree/b096704c0d42c5e784deb781a07b23cfb5286a82) — **19.16× faster**
@@ -874,11 +874,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `29.73s`; ScanCode `851.02s`
 - Broader Bazel and cross-language dependency extraction (`551` vs `537` packages, `144` vs `64` dependencies) from root and example `MODULE.bazel`, many `BUILD` files, committed `*.csproj`, and Maven BOM imports, with direct Git-submodule package visibility on `.gitmodules`
 
-##### [qemu/qemu @ da6c4fe](https://github.com/qemu/qemu/tree/da6c4fe60fee30dd77267764d55b38af9cb89d4b) — **31.76× faster**
+##### [qemu/qemu @ da6c4fe](https://github.com/qemu/qemu/tree/da6c4fe60fee30dd77267764d55b38af9cb89d4b) — **46.14× faster**
 
 - Files: 10,989
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `78.51s`; ScanCode `2493.21s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `32.26s`; ScanCode `1488.40s`
 - Broader Meson and package-adjacent dependency extraction (`22` vs `21` packages, `260` vs `176` dependencies) from the root `.gitmodules`, `python/tests/minreqs.txt`, and many committed `subprojects/**/meson.build` manifests, with the real `pkg:autotools/qemu` root identity instead of ScanCode's generic input placeholder
 
 ##### [restic/restic @ 29446b0](https://github.com/restic/restic/tree/29446b0fd853b7765f652584ff90e817890ee389) — **8.47× faster**
@@ -930,11 +930,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.88s`; ScanCode `51.37s`
 - Matched Cargo workspace package and dependency coverage (`14` vs `14` packages, `209` vs `209` dependencies) while preserving the member-crate `Apache-2.0 OR MIT` README semantics, keeping archived NCC Group review URLs intact in `aes-gcm` and `chacha20poly1305`, surfacing a concrete `mgm` lockfile package identity where ScanCode stays anonymous, and filtering weak `team of volunteers` SECURITY.md maintainer prose out of author output
 
-##### [systemd/systemd @ 89d705a](https://github.com/systemd/systemd/tree/89d705a892b3476de14e548f3f9b0af96207d4b0) — **23.26× faster**
+##### [systemd/systemd @ 89d705a](https://github.com/systemd/systemd/tree/89d705a892b3476de14e548f3f9b0af96207d4b0) — **42.92× faster**
 
 - Files: 6,994
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `51.67s`; ScanCode `1201.90s`
+- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `19.44s`; ScanCode `834.45s`
 - Broader Meson dependency extraction (`40` vs `2`) from the root and nested `meson.build` files, with literal `\x2d` filenames preserved on committed unit and fuzz fixtures instead of being path-shaped into different resources
 
 ##### [tensorflow/tensorflow @ 2cd48d2](https://github.com/tensorflow/tensorflow/tree/2cd48d27d98b3fefd565f246f41bf93724f3f23c) — **20.41× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -431,9 +431,9 @@ ScanCode: 155.12s</title></rect>
     <rect x="603.42" y="355.19" width="8" height="8" fill="#d97706" rx="1.5"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 ScanCode: 321.68s</title></rect>
-    <rect x="607.19" y="328.71" width="8" height="8" fill="#d97706" rx="1.5"><title>guillemj/dpkg @ 0061122
+    <rect x="607.19" y="341.69" width="8" height="8" fill="#d97706" rx="1.5"><title>guillemj/dpkg @ 0061122
 Files: 1766
-ScanCode: 563.43s</title></rect>
+ScanCode: 428.07s</title></rect>
     <rect x="607.89" y="346.71" width="8" height="8" fill="#d97706" rx="1.5"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 ScanCode: 384.96s</title></rect>
@@ -536,18 +536,18 @@ ScanCode: 316.25s</title></rect>
     <rect x="666.38" y="352.86" width="8" height="8" fill="#d97706" rx="1.5"><title>triggerdotdev/trigger.dev @ d1f4302
 Files: 4169
 ScanCode: 337.98s</title></rect>
-    <rect x="667.96" y="325.26" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
+    <rect x="667.96" y="347.89" width="8" height="8" fill="#d97706" rx="1.5"><title>curl/curl @ 2bb5c9b
 Files: 4266
-ScanCode: 606.05s</title></rect>
+ScanCode: 375.45s</title></rect>
     <rect x="668.53" y="297.99" width="8" height="8" fill="#d97706" rx="1.5"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
 ScanCode: 1079.38s</title></rect>
     <rect x="673.50" y="319.74" width="8" height="8" fill="#d97706" rx="1.5"><title>akka/akka @ 5ace141
 Files: 4623
 ScanCode: 681.19s</title></rect>
-    <rect x="675.14" y="339.11" width="8" height="8" fill="#d97706" rx="1.5"><title>git/git @ 9f223ef
+    <rect x="675.14" y="323.90" width="8" height="8" fill="#d97706" rx="1.5"><title>git/git @ 9f223ef
 Files: 4734
-ScanCode: 452.09s</title></rect>
+ScanCode: 623.80s</title></rect>
     <rect x="677.07" y="355.67" width="8" height="8" fill="#d97706" rx="1.5"><title>rails/rails @ 27fb2a9
 Files: 4869
 ScanCode: 318.46s</title></rect>
@@ -566,9 +566,9 @@ ScanCode: 1221.65s</title></rect>
     <rect x="690.65" y="315.53" width="8" height="8" fill="#d97706" rx="1.5"><title>kubernetes/autoscaler @ 9045d28
 Files: 5929
 ScanCode: 744.62s</title></rect>
-    <rect x="692.31" y="293.00" width="8" height="8" fill="#d97706" rx="1.5"><title>openssl/openssl @ 7fb28b9
+    <rect x="692.31" y="309.74" width="8" height="8" fill="#d97706" rx="1.5"><title>openssl/openssl @ 7fb28b9
 Files: 6074
-ScanCode: 1199.73s</title></rect>
+ScanCode: 841.78s</title></rect>
     <rect x="694.77" y="315.99" width="8" height="8" fill="#d97706" rx="1.5"><title>yoctoproject/poky @ cb2dcb4
 Files: 6295
 ScanCode: 737.50s</title></rect>
@@ -584,15 +584,15 @@ ScanCode: 2352.73s</title></rect>
     <rect x="701.92" y="334.25" width="8" height="8" fill="#d97706" rx="1.5"><title>openembedded/meta-openembedded @ 7bf89d0
 Files: 6983
 ScanCode: 501.03s</title></rect>
-    <rect x="702.03" y="292.91" width="8" height="8" fill="#d97706" rx="1.5"><title>systemd/systemd @ 89d705a
+    <rect x="702.03" y="310.15" width="8" height="8" fill="#d97706" rx="1.5"><title>systemd/systemd @ 89d705a
 Files: 6994
-ScanCode: 1201.90s</title></rect>
+ScanCode: 834.45s</title></rect>
     <rect x="702.37" y="330.44" width="8" height="8" fill="#d97706" rx="1.5"><title>django/django @ 09f27cc
 Files: 7029
 ScanCode: 543.19s</title></rect>
-    <rect x="703.83" y="315.08" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/kafka @ 0d9fe51
+    <rect x="703.83" y="295.56" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/kafka @ 0d9fe51
 Files: 7179
-ScanCode: 751.77s</title></rect>
+ScanCode: 1136.27s</title></rect>
     <rect x="709.11" y="332.59" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/dune @ b13ab94
 Files: 7751
 ScanCode: 519.01s</title></rect>
@@ -632,24 +632,24 @@ ScanCode: 812.80s</title></rect>
     <rect x="729.11" y="318.85" width="8" height="8" fill="#d97706" rx="1.5"><title>grpc/grpc @ f87c29f
 Files: 10361
 ScanCode: 694.17s</title></rect>
-    <rect x="733.17" y="258.43" width="8" height="8" fill="#d97706" rx="1.5"><title>qemu/qemu @ da6c4fe
+    <rect x="733.17" y="282.81" width="8" height="8" fill="#d97706" rx="1.5"><title>qemu/qemu @ da6c4fe
 Files: 10989
-ScanCode: 2493.21s</title></rect>
+ScanCode: 1488.40s</title></rect>
     <rect x="736.27" y="285.81" width="8" height="8" fill="#d97706" rx="1.5"><title>bazelbuild/bazel @ eb5aeaa
 Files: 11495
 ScanCode: 1396.87s</title></rect>
     <rect x="737.15" y="301.70" width="8" height="8" fill="#d97706" rx="1.5"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 ScanCode: 997.84s</title></rect>
-    <rect x="737.77" y="246.68" width="8" height="8" fill="#d97706" rx="1.5"><title>erlang/otp @ 264def5
+    <rect x="737.77" y="268.04" width="8" height="8" fill="#d97706" rx="1.5"><title>erlang/otp @ 264def5
 Files: 11749
-ScanCode: 3197.26s</title></rect>
+ScanCode: 2034.56s</title></rect>
     <rect x="738.86" y="294.65" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/airflow @ 47ce5f3
 Files: 11935
 ScanCode: 1158.57s</title></rect>
-    <rect x="741.35" y="286.09" width="8" height="8" fill="#d97706" rx="1.5"><title>moby/moby @ 21bd660
+    <rect x="741.35" y="286.00" width="8" height="8" fill="#d97706" rx="1.5"><title>moby/moby @ 21bd660
 Files: 12375
-ScanCode: 1388.49s</title></rect>
+ScanCode: 1391.11s</title></rect>
     <rect x="742.32" y="309.33" width="8" height="8" fill="#d97706" rx="1.5"><title>oven-sh/bun @ 700fc11
 Files: 12551
 ScanCode: 849.10s</title></rect>
@@ -671,9 +671,9 @@ ScanCode: 807.63s</title></rect>
     <rect x="757.62" y="257.15" width="8" height="8" fill="#d97706" rx="1.5"><title>flutter/flutter @ 238d79a
 Files: 15670
 ScanCode: 2561.81s</title></rect>
-    <rect x="760.63" y="229.74" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/hadoop @ dbcc7cd
+    <rect x="760.63" y="246.36" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/hadoop @ dbcc7cd
 Files: 16370
-ScanCode: 4575.96s</title></rect>
+ScanCode: 3218.68s</title></rect>
     <rect x="767.28" y="288.09" width="8" height="8" fill="#d97706" rx="1.5"><title>metabase/metabase @ 10997b1
 Files: 18030
 ScanCode: 1330.92s</title></rect>
@@ -1090,9 +1090,9 @@ Provenant: 8.68s</title></circle>
     <circle cx="607.42" cy="500.64" r="4.5" fill="#2563eb"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 Provenant: 16.12s</title></circle>
-    <circle cx="611.19" cy="474.77" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
+    <circle cx="611.19" cy="510.59" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
 Files: 1766
-Provenant: 27.87s</title></circle>
+Provenant: 13.06s</title></circle>
     <circle cx="611.89" cy="491.89" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 Provenant: 19.40s</title></circle>
@@ -1195,18 +1195,18 @@ Provenant: 17.19s</title></circle>
     <circle cx="670.38" cy="534.16" r="4.5" fill="#2563eb"><title>triggerdotdev/trigger.dev @ d1f4302
 Files: 4169
 Provenant: 7.93s</title></circle>
-    <circle cx="671.96" cy="456.82" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
+    <circle cx="671.96" cy="506.43" r="4.5" fill="#2563eb"><title>curl/curl @ 2bb5c9b
 Files: 4266
-Provenant: 40.75s</title></circle>
+Provenant: 14.26s</title></circle>
     <circle cx="672.53" cy="453.98" r="4.5" fill="#2563eb"><title>DefectDojo/django-DefectDojo @ 2f25c45
 Files: 4301
 Provenant: 43.27s</title></circle>
     <circle cx="677.50" cy="476.32" r="4.5" fill="#2563eb"><title>akka/akka @ 5ace141
 Files: 4623
 Provenant: 26.97s</title></circle>
-    <circle cx="679.14" cy="480.47" r="4.5" fill="#2563eb"><title>git/git @ 9f223ef
+    <circle cx="679.14" cy="505.25" r="4.5" fill="#2563eb"><title>git/git @ 9f223ef
 Files: 4734
-Provenant: 24.70s</title></circle>
+Provenant: 14.62s</title></circle>
     <circle cx="681.07" cy="483.29" r="4.5" fill="#2563eb"><title>rails/rails @ 27fb2a9
 Files: 4869
 Provenant: 23.27s</title></circle>
@@ -1225,9 +1225,9 @@ Provenant: 17.27s</title></circle>
     <circle cx="694.65" cy="483.43" r="4.5" fill="#2563eb"><title>kubernetes/autoscaler @ 9045d28
 Files: 5929
 Provenant: 23.20s</title></circle>
-    <circle cx="696.31" cy="439.39" r="4.5" fill="#2563eb"><title>openssl/openssl @ 7fb28b9
+    <circle cx="696.31" cy="486.40" r="4.5" fill="#2563eb"><title>openssl/openssl @ 7fb28b9
 Files: 6074
-Provenant: 58.93s</title></circle>
+Provenant: 21.79s</title></circle>
     <circle cx="698.77" cy="449.75" r="4.5" fill="#2563eb"><title>yoctoproject/poky @ cb2dcb4
 Files: 6295
 Provenant: 47.33s</title></circle>
@@ -1243,15 +1243,15 @@ Provenant: 58.53s</title></circle>
     <circle cx="705.92" cy="463.08" r="4.5" fill="#2563eb"><title>openembedded/meta-openembedded @ 7bf89d0
 Files: 6983
 Provenant: 35.69s</title></circle>
-    <circle cx="706.03" cy="445.60" r="4.5" fill="#2563eb"><title>systemd/systemd @ 89d705a
+    <circle cx="706.03" cy="491.79" r="4.5" fill="#2563eb"><title>systemd/systemd @ 89d705a
 Files: 6994
-Provenant: 51.67s</title></circle>
+Provenant: 19.44s</title></circle>
     <circle cx="706.37" cy="507.81" r="4.5" fill="#2563eb"><title>django/django @ 09f27cc
 Files: 7029
 Provenant: 13.85s</title></circle>
-    <circle cx="707.83" cy="443.86" r="4.5" fill="#2563eb"><title>apache/kafka @ 0d9fe51
+    <circle cx="707.83" cy="458.27" r="4.5" fill="#2563eb"><title>apache/kafka @ 0d9fe51
 Files: 7179
-Provenant: 53.61s</title></circle>
+Provenant: 39.52s</title></circle>
     <circle cx="713.11" cy="488.73" r="4.5" fill="#2563eb"><title>ocaml/dune @ b13ab94
 Files: 7751
 Provenant: 20.74s</title></circle>
@@ -1291,24 +1291,24 @@ Provenant: 60.60s</title></circle>
     <circle cx="733.11" cy="448.97" r="4.5" fill="#2563eb"><title>grpc/grpc @ f87c29f
 Files: 10361
 Provenant: 48.11s</title></circle>
-    <circle cx="737.17" cy="425.83" r="4.5" fill="#2563eb"><title>qemu/qemu @ da6c4fe
+    <circle cx="737.17" cy="467.86" r="4.5" fill="#2563eb"><title>qemu/qemu @ da6c4fe
 Files: 10989
-Provenant: 78.51s</title></circle>
+Provenant: 32.26s</title></circle>
     <circle cx="740.27" cy="448.60" r="4.5" fill="#2563eb"><title>bazelbuild/bazel @ eb5aeaa
 Files: 11495
 Provenant: 48.49s</title></circle>
     <circle cx="741.15" cy="452.64" r="4.5" fill="#2563eb"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 Provenant: 44.52s</title></circle>
-    <circle cx="741.77" cy="399.90" r="4.5" fill="#2563eb"><title>erlang/otp @ 264def5
+    <circle cx="741.77" cy="438.55" r="4.5" fill="#2563eb"><title>erlang/otp @ 264def5
 Files: 11749
-Provenant: 135.93s</title></circle>
+Provenant: 59.99s</title></circle>
     <circle cx="742.86" cy="446.23" r="4.5" fill="#2563eb"><title>apache/airflow @ 47ce5f3
 Files: 11935
 Provenant: 50.99s</title></circle>
-    <circle cx="745.35" cy="441.80" r="4.5" fill="#2563eb"><title>moby/moby @ 21bd660
+    <circle cx="745.35" cy="474.55" r="4.5" fill="#2563eb"><title>moby/moby @ 21bd660
 Files: 12375
-Provenant: 56.00s</title></circle>
+Provenant: 28.00s</title></circle>
     <circle cx="746.32" cy="454.22" r="4.5" fill="#2563eb"><title>oven-sh/bun @ 700fc11
 Files: 12551
 Provenant: 43.05s</title></circle>
@@ -1330,9 +1330,9 @@ Provenant: 33.41s</title></circle>
     <circle cx="761.62" cy="403.97" r="4.5" fill="#2563eb"><title>flutter/flutter @ 238d79a
 Files: 15670
 Provenant: 124.69s</title></circle>
-    <circle cx="764.63" cy="365.98" r="4.5" fill="#2563eb"><title>apache/hadoop @ dbcc7cd
+    <circle cx="764.63" cy="405.26" r="4.5" fill="#2563eb"><title>apache/hadoop @ dbcc7cd
 Files: 16370
-Provenant: 278.63s</title></circle>
+Provenant: 121.35s</title></circle>
     <circle cx="771.28" cy="445.44" r="4.5" fill="#2563eb"><title>metabase/metabase @ 10997b1
 Files: 18030
 Provenant: 51.84s</title></circle>


### PR DESCRIPTION
## Summary

Re-measures ten benchmark rows that were recorded on **Apple M1 Max** onto the current **Apple M5 Pro** host, so the chart is hardware-consistent. The chart plots M1 and M5 runs together, so the older M1 rows sat high (e.g. apache/hadoop read as a ~280 s outlier) because they were measured on slower M1 hardware **and** on older pre-campaign Provenant code. Re-measuring them on M5 with current code brings them into line with the rest of the (M5) set.

Each target was re-run with `compare-outputs --profile common --build-mode optimized`; ScanCode ran fresh (`cache_hit: false`) and was then reused from cache only to re-time Provenant cleanly. All timings are same-host PV-vs-ScanCode pairs.

| target | files | PV (M1→M5) | ScanCode (M1→M5) | × (old→new) |
|---|---|---|---|---|
| apache/hadoop | 16,370 | 278.63→121.35s | 4575.96→3218.68s | 16.42→26.52× |
| erlang/otp | 11,749 | 135.93→59.99s | 3197.26→2034.56s | 23.52→33.91× |
| qemu/qemu | 10,989 | 78.51→32.26s | 2493.21→1488.40s | 31.76→46.14× |
| systemd/systemd | 6,994 | 51.67→19.44s | 1201.90→834.45s | 23.26→42.92× |
| openssl/openssl | 6,074 | 58.93→21.79s | 1199.73→841.78s | 20.36→38.63× |
| apache/kafka | 7,179 | 53.61→39.52s | 751.77→1136.27s | 14.02→28.75× |
| moby/moby | 12,375 | 56.00→28.00s | 1388.49→1391.11s | 24.79→49.68× |
| git/git | 4,734 | 24.70→14.62s | 452.09→623.80s | 18.30→42.67× |
| curl/curl | 4,266 | 40.75→14.26s | 606.05→375.45s | 14.87→26.33× |
| guillemj/dpkg | 1,766 | 27.87→13.06s | 563.43→428.07s | 20.22→32.79× |

Headline regenerated: **219 of 219 runs**, median **14.6→14.8×**, geomean **14.6→15.0×**, 10k+ gap **20.7→22.4×**.

### Attribution: M5 hardware **and** a substantial perf campaign

The old rows were measured on **M1 in April**, on **pre-perf-campaign** code; the new rows are **M5 + current code**. Current code includes a large license/copyright performance campaign landed 2026-05-28 → 06-18 (~15–18 PRs: seq-match hot-loop rewrites #1054/#1062/#1063, candidate-selection bitset/FxHash #1044/#1048, concurrent automata #1056, per-file SHA-256 skipping #1042, copyright single-pass #1043, thin LTO #1060, oversized-run bounds #1109/#1114, copyright prefilter #1116, and more). So each row's improvement reflects **both** the M1→M5 hardware upgrade **and** that perf campaign — not one or the other. A clean split (pre-campaign baseline vs current HEAD, both on M5) is being measured separately; the per-row deltas here should **not** be read as hardware-only.

### Process-count standardization

kafka/moby/git/dpkg were originally recorded at **9 proc**; they are re-measured at the standard `--profile common` **4 proc**, aligning them with the rest of the set. Both PV and ScanCode run at 4 workers, so each row is internally fair; `--processes` caps Provenant's rayon pool, it does not let it use all cores.

### Pathology triage (verify-benchmark-target skill)

Every target was triaged beyond timing; all deltas resolve to a Provenant advantage or are clean:
- **otp / moby / git** — ScanCode folds co-located/detected `LICENSE` (and even autoconf FSF boilerplate) into a package's *declared* license; Provenant keeps package-declared = true declared metadata and retains the same signal at file level (verified). git's cargo package is a clear win — ScanCode fabricates `(gpl-1.0-plus AND gpl-3.0) AND gpl-2.0 AND …` from repo-wide detection where the Cargo.toml has no `license` field; Provenant correctly emits null.
- **qemu / dpkg** — Provenant extracts richer declared licenses (cargo `gpl-2.0-plus`; deb `gpl-2.0-plus` for dpkg/dselect) where ScanCode emits none.
- **openssl** — Provenant extracts the real CPAN declared license from META.yml/json without fabricating one on the MANIFEST inventory.
- **curl** — ScanCode-favored deltas are `LicenseRef-scancode-unknown-*` / warranty-disclaimer noise that Provenant suppresses.
- **systemd / kafka** — clean; no package-level deltas.

One isolated candidate gap noted (not in scope): hadoop's `pkg:npm/yarn-ui` with bare `license: "Apache"` yields a null declared expression where ScanCode maps `apache-2.0` (single occurrence; did not recur across the other nine).

## Issues

- Refreshes the M1 rows the maintainer circled as chart outliers; complements #1117 (reproducibility cleanup).

## Scope and exclusions

- Included: the ten M1 repo rows + regenerated chart/headline.
- Excluded: the eight artifact rows #1117 left unconfirmed (tracked separately for re-measure/commit).

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` — re-running produces no diff (chart in sync).
- Each row is reproducible via `compare-outputs --profile common` against the pinned ref.

## Expected-output fixture changes

- None. Docs + generated chart only.
