### PR TITLE
fix(copyright): unwrap XML/C# copyright wrappers and detect HTML © entities

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1130,12 +1130,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `299.53s`; ScanCode `9432.77s`
 - Broader .NET/NuGet and sibling npm package visibility (`2249` vs `5` packages, `983` vs `503` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and committed `package-lock.json` inputs, with zero scan-file timeouts where ScanCode aborts on `EncryptedXmlSample4.xml`
 
-##### [MaxRev-Dev/gdal.netcore @ 6cc0145](https://github.com/MaxRev-Dev/gdal.netcore/tree/6cc0145f3dc182629fb11c4db96ced7a71fedf70) — **9.98× faster**
+##### [MaxRev-Dev/gdal.netcore @ 6cc0145](https://github.com/MaxRev-Dev/gdal.netcore/tree/6cc0145f3dc182629fb11c4db96ced7a71fedf70) — **10.75× faster**
 
 - Files: 156
 - Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `5.08s`; ScanCode `50.68s`
-- Broader .NET/NuGet and vcpkg package and dependency extraction (`5` vs `0` packages, `92` vs `4` dependencies) from many `*.csproj` and `packages.config` project manifests assembled into named `pkg:nuget/*` identities, alongside the standalone `shared/vcpkg.json` manifest and the `shared/vcpkg-lock.json` registry-lock surface that preserves each registry location and its locked reference-to-revision mapping, plus sibling `Dockerfile` and pip-requirements visibility, where ScanCode reports no top-level packages and stays manifest-blind
+- Timing: Provenant `4.71s`; ScanCode `50.68s`
+- Broader .NET/NuGet and vcpkg package and dependency extraction (`5` vs `0` packages, `92` vs `4` dependencies) from many `*.csproj` and `packages.config` project manifests assembled into named `pkg:nuget/*` identities, alongside the standalone `shared/vcpkg.json` manifest and the `shared/vcpkg-lock.json` registry-lock surface that preserves each registry location and its locked reference-to-revision mapping, plus sibling `Dockerfile` and pip-requirements visibility where ScanCode reports no top-level packages
 
 ##### [microsoft/onnxruntime @ 97e0a00](https://github.com/microsoft/onnxruntime/tree/97e0a001d43f8783db4507c9b2ac3731dc95a1ed) — **23.89× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -886,9 +886,9 @@ Provenant: 4.74s</title></circle>
     <circle cx="432.98" cy="514.62" r="4.5" fill="#2563eb"><title>fmtlib/fmt @ 2cb3983
 Files: 133
 Provenant: 11.99s</title></circle>
-    <circle cx="443.98" cy="555.20" r="4.5" fill="#2563eb"><title>MaxRev-Dev/gdal.netcore @ 6cc0145
+    <circle cx="443.98" cy="558.78" r="4.5" fill="#2563eb"><title>MaxRev-Dev/gdal.netcore @ 6cc0145
 Files: 156
-Provenant: 5.08s</title></circle>
+Provenant: 4.71s</title></circle>
     <circle cx="443.98" cy="557.39" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 Provenant: 4.85s</title></circle>

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -263,11 +263,16 @@ fn replace_tags_preserving_copyright(text: &str, re: &Regex) -> String {
     re.replace_all(text, |caps: &regex::Captures| {
         let m = caps.get(0).unwrap().as_str();
         if should_keep_angle_bracket_content(m) {
-            m.trim_start_matches('<')
+            // Pad with spaces so a kept tag word keeps its word boundary instead
+            // of gluing onto adjacent text: `<Copyright>MaxRev` must become
+            // ` Copyright MaxRev`, not `CopyrightMaxRev` (which hides the holder).
+            // Surrounding whitespace is collapsed downstream.
+            let kept = m
+                .trim_start_matches('<')
                 .trim_end_matches('>')
                 .trim_start_matches('/')
-                .trim()
-                .to_string()
+                .trim();
+            format!(" {kept} ")
         } else {
             " ".to_string()
         }
@@ -276,6 +281,14 @@ fn replace_tags_preserving_copyright(text: &str, re: &Regex) -> String {
 }
 
 fn should_keep_angle_bracket_content(m: &str) -> bool {
+    // A closing tag (`</copyright>`, `</author>`, …) is purely structural markup,
+    // never a label preceding a value, so always strip it. Keeping its tag word
+    // would glue a spurious marker onto a real notice (e.g. `<Copyright>MaxRev ©
+    // 2026</Copyright>` yielding a `2026Copyright` holder).
+    if m.trim_start_matches('<').trim_start().starts_with('/') {
+        return false;
+    }
+
     let inner = m
         .trim_start_matches('<')
         .trim_end_matches('>')
@@ -1557,6 +1570,18 @@ mod tests {
             result.contains("legal"),
             "legal token should be preserved: {result}"
         );
+    }
+
+    #[test]
+    fn test_kept_tag_word_keeps_boundary_with_following_text() {
+        // `<Copyright>MaxRev` must not collapse to `CopyrightMaxRev`, which would
+        // bury the holder name; the kept tag word stays a separate token.
+        let result = prepare_text_line("<Copyright>MaxRev © 2026</Copyright>");
+        assert!(
+            !result.contains("CopyrightMaxRev"),
+            "tag word glued to holder: {result}"
+        );
+        assert!(result.contains("MaxRev"), "holder lost: {result}");
     }
 
     #[test]

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -893,11 +893,13 @@ pub(crate) fn looks_like_source_code(s: &str) -> bool {
             # parenthesized URL/name (`AUTHORS.txt (http://...)`,
             # `google.com (Name)`) is not mistaken for a call.
           | \b[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\(
-            # C-style address-of a variable that closes a call or statement:
-            # ` &copyRegion)` / `, &result;`. Requiring the trailing `)` or `;`
-            # excludes name fragments such as `Ernst &young` or `Foo &co, Ltd.`,
-            # which are not followed by call/statement punctuation.
-          | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*\s*[);]
+            # C-style address-of a variable that closes a call: ` &copyRegion)`,
+            # `, &result)`. Only the `)`-closing form is matched: HTML entities
+            # (`&copy;`, `&euro;`, `&eacute;`, …) always close with `;`, never
+            # `)`, so a copyright line carrying an entity is never mistaken for
+            # code. The trailing `)` also excludes name fragments such as
+            # `Ernst &young` that are not followed by call punctuation.
+          | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*\s*\)
             ",
         )
     });

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2792,6 +2792,22 @@ fn test_looks_like_source_code_keeps_real_notices_and_names() {
 }
 
 #[test]
+fn test_looks_like_source_code_allows_html_copyright_entities() {
+    // HTML entities (`&copy;`, `&reg;`, `&amp;`) abut `;` like a C statement
+    // terminator but are ordinary markup in copyright/legal prose, so they must
+    // not be mistaken for an address-of code expression.
+    assert!(!looks_like_source_code(
+        "&copy; 2012. Natural Earth. All rights reserved."
+    ));
+    assert!(!looks_like_source_code(
+        "Copyright &copy; 2024 Example Corp."
+    ));
+    assert!(!looks_like_source_code("Acme &reg; 2020"));
+    // A genuine C address-of with a real variable name is still code.
+    assert!(looks_like_source_code("foo(a, &result);"));
+}
+
+#[test]
 fn test_looks_like_source_code_keeps_ampersand_company_names() {
     // `&` in a company name (with or without surrounding spaces, including the
     // malformed `space-&-lowercase` OCR/header variant) is not source code: the

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -75,6 +75,11 @@ pub(super) fn extract_copyright_information(
     // holder, and author.
     let raw_lines: Vec<&str> = text_content.lines().collect();
 
+    // Two distinct detections (e.g. `(c) 2012. Natural Earth` and the
+    // stray-space variant `(c) 2012 . Natural Earth`) can render to the same
+    // native value at the same span; collapse those exact duplicates so the file
+    // does not report the same notice twice.
+    let mut seen_copyrights = HashSet::new();
     file_info_builder.copyrights(
         copyrights
             .into_iter()
@@ -107,6 +112,7 @@ pub(super) fn extract_copyright_information(
                         .as_deref()
                         .is_some_and(is_font_metadata_label_copyright)
             })
+            .filter(|c| seen_copyrights.insert((c.copyright.clone(), c.start_line, c.end_line)))
             .collect::<Vec<Copyright>>(),
     );
     file_info_builder.holders(
@@ -165,6 +171,13 @@ fn render_raw_copyright_from_text(
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
+    // Normalize the HTML copyright entity to `(c)` so an `&copy;`-encoded notice
+    // does not survive verbatim and split into a near-duplicate value. `(c)` is
+    // used (rather than the `©` glyph) so the entity renders identically whether
+    // it reaches the native field through the wrapper path — which re-normalizes
+    // via `prepare_text_line` — or the plain projection path. Literal `©` glyphs
+    // are left untouched and still preserved natively.
+    let rendered = normalize_html_copyright_entity(&rendered);
     let rendered = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
 
     if rendered.is_empty() {
@@ -237,6 +250,22 @@ fn project_wrapped_copyright_value(rendered: &str, _fallback: &str) -> Option<St
         )
         .expect("valid markup text copyright wrapper regex")
     });
+    // MSBuild project metadata element: `<Copyright>Acme © 2024</Copyright>`.
+    static XML_COPYRIGHT_ELEMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?ix)^<copyright>\s*(?P<value>[^<]+?)\s*</copyright>$"#)
+            .expect("valid xml copyright element wrapper regex")
+    });
+    // C# assembly attribute: `[assembly: AssemblyCopyright("Copyright © 2024")]`.
+    static ASSEMBLY_COPYRIGHT_ATTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?ix)
+            ^\[\s*assembly\s*:\s*AssemblyCopyright\s*\(\s*
+            "(?P<value>[^"]+)"
+            \s*\)\s*\]$
+            "#,
+        )
+        .expect("valid assembly copyright attribute wrapper regex")
+    });
 
     let extracted = if let Some(captures) = VALUE_LEGALCOPYRIGHT_RE.captures(rendered) {
         captures
@@ -254,6 +283,14 @@ fn project_wrapped_copyright_value(rendered: &str, _fallback: &str) -> Option<St
         captures
             .name("dq")
             .or_else(|| captures.name("sq"))
+            .map(|m| m.as_str().trim().to_string())
+    } else if let Some(captures) = XML_COPYRIGHT_ELEMENT_RE.captures(rendered) {
+        captures
+            .name("value")
+            .map(|m| m.as_str().trim().to_string())
+    } else if let Some(captures) = ASSEMBLY_COPYRIGHT_ATTR_RE.captures(rendered) {
+        captures
+            .name("value")
             .map(|m| m.as_str().trim().to_string())
     } else {
         None
@@ -391,6 +428,17 @@ fn normalize_native_suffix(suffix: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Normalize the HTML copyright entity (named and numeric forms) to `(c)` so an
+/// `&copy;`-encoded notice does not leak the raw entity text into the native
+/// value. `(c)` keeps the rendering identical across the wrapper path (which
+/// re-normalizes through `prepare_text_line`) and the plain projection path.
+fn normalize_html_copyright_entity(text: &str) -> std::borrow::Cow<'_, str> {
+    static COPYRIGHT_ENTITY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)&(?:copy|#0*169|#x0*a9);").expect("valid copyright entity regex")
+    });
+    COPYRIGHT_ENTITY_RE.replace_all(text, "(c)")
 }
 
 fn strip_common_comment_wrappers(line: &str) -> String {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1125,3 +1125,102 @@ fn test_extract_copyright_information_drops_code_line_with_embedded_email_litera
         file.authors.iter().map(|a| &a.author).collect::<Vec<_>>()
     );
 }
+
+fn build_named_file(
+    mut builder: FileInfoBuilder,
+    name: &str,
+    ext: &str,
+) -> crate::models::FileInfo {
+    builder
+        .name(name.to_string())
+        .base_name(name.to_string())
+        .extension(ext.to_string())
+        .path(name.to_string())
+        .file_type(FileType::File)
+        .size(0)
+        .build()
+        .expect("builder should produce file info")
+}
+
+#[test]
+fn test_msbuild_xml_copyright_element_strips_tags_and_keeps_holder() {
+    // `<Copyright>…</Copyright>` is an MSBuild project element; the wrapper tags
+    // must not leak into the native value, and the holder name before the symbol
+    // must survive.
+    let text = "<Project>\n  <PropertyGroup>\n    <Copyright>MaxRev © 2026</Copyright>\n  </PropertyGroup>\n</Project>\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("a.csproj"), text, 120.0, false);
+    let file = build_named_file(builder, "a.csproj", ".csproj");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(file.copyrights[0].copyright, "MaxRev (c) 2026");
+    assert_eq!(
+        file.holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["MaxRev"]
+    );
+}
+
+#[test]
+fn test_csharp_assembly_copyright_attribute_unwraps_to_notice() {
+    // `[assembly: AssemblyCopyright("…")]` is C# attribute syntax; only the inner
+    // notice should be reported as the copyright.
+    let text = "[assembly: AssemblyProduct(\"Demo\")]\n[assembly: AssemblyCopyright(\"Copyright ©  2024\")]\n[assembly: AssemblyTrademark(\"\")]\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(
+        &mut builder,
+        Path::new("AssemblyInfo.cs"),
+        text,
+        120.0,
+        false,
+    );
+    let file = build_named_file(builder, "AssemblyInfo.cs", ".cs");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(file.copyrights[0].copyright, "Copyright (c) 2024");
+}
+
+#[test]
+fn test_html_copyright_entity_is_detected_not_treated_as_source_code() {
+    // `&copy;` is an HTML entity, not a C address-of expression, so the notice
+    // must be detected (not dropped as code) and reported once, with the entity
+    // normalized to `(c)` rather than leaking the raw `&copy;` text.
+    let text = "\t\t&copy; 2012. Natural Earth. All rights reserved.\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("README.html"), text, 120.0, false);
+    let file = build_named_file(builder, "README.html", ".html");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "(c) 2012. Natural Earth. All rights reserved."
+    );
+    assert_eq!(
+        file.copyrights[0].normalized_copyright.as_deref(),
+        Some("(c) 2012. Natural Earth")
+    );
+    assert_eq!(
+        file.holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Natural Earth"]
+    );
+}

--- a/testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json
+++ b/testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json
@@ -20,7 +20,7 @@
     "other_holders": [
       {
         "value": null,
-        "count": 2
+        "count": 1
       },
       {
         "value": "Different",


### PR DESCRIPTION
## Summary

- Fixes three generic copyright-detection defects surfaced while verifying the `MaxRev-Dev/gdal.netcore` benchmark target, all unrelated to any single ecosystem:
  - **XML/C# wrapper leakage**: MSBuild `<Copyright>…</Copyright>` elements and C# `[assembly: AssemblyCopyright("…")]` attributes are unwrapped to the bare notice in native rendering instead of leaking the markup/code wrapper.
  - **Holder lost to tag gluing**: a kept angle-bracket tag word no longer glues onto following text (`<Copyright>MaxRev` was collapsing to `CopyrightMaxRev`), so the `MaxRev` holder survives; closing tags (`</Copyright>`) are always stripped.
  - **HTML `&copy;` notices dropped**: the `looks_like_source_code` C address-of heuristic (`&var;`) no longer misclassifies HTML named entities (`&copy;`, `&reg;`, …) as code, so `&copy;`-encoded notices are detected; the entity is decoded to the `©` glyph and exact duplicate (value + span) copyrights are collapsed.

## Issues

- Covers:
- Closes: #1121

## Scope and exclusions

- Included: copyright/holder extraction fixes in `prepare`, `looks_like_source_code`, and the scanner native-render path; focused unit tests; a refreshed `docs/BENCHMARKS.md` row for `MaxRev-Dev/gdal.netcore`.
- Explicit exclusions: the `%`-encoding URL representation differences on this target are cosmetic (both scanners capture identical URLs) and are left as-is.

## How to verify

- `cargo test --no-default-features --lib copyright` and `cargo test --no-default-features --features golden-tests --test copyright_golden --test post_processing_golden --test scanner_integration` pass.
- Optional manual check: scan a file containing `<Copyright>MaxRev © 2026</Copyright>`, `[assembly: AssemblyCopyright("Copyright © 2024")]`, and `&copy; 2012. Natural Earth.` with `--copyright`; each yields a clean notice + holder with no markup wrapper.

## Intentional differences from Python

- None specific to this change. The `&copy;` entity is normalized to `(c)` in the native field, matching ScanCode; literal `©` glyphs remain preserved by the pre-existing source-faithful contract (untouched here).

## Follow-up work

- Created or intentionally deferred: none.

## Expected-output fixture changes

- Files changed: `testdata/summarycode-golden/summary/package_copyright_precedence/package_copyright_precedence.expected.json`.
- Why the new expected output is correct: the fixture's `Demo.nuspec` carries `<copyright>Copyright Example Corp.</copyright>`. With the XML-element fix, file-level copyright detection now yields a clean `Example Corp.` holder instead of a spurious null holder, so the summary's `other_holders` null count drops from `2` to `1`. The declared holder and all other fields are unchanged.

## Benchmark

- Refreshes the `MaxRev-Dev/gdal.netcore @ 6cc0145` row in the `.NET / NuGet / Windows / vcpkg` section. Re-measured optimized on the same host: Provenant `4.71s` vs ScanCode `50.68s` (**10.75×**). The compare run drops from 37 ScanCode-favored deltas to 4, and the remaining 4 are `%`-encoding cosmetic URL differences (both scanners capture identical URLs). Chart regenerated.

