### PR TITLE
fix(license-index): build automata off the rayon pool to avoid scan deadlock

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -251,6 +251,9 @@ jobs:
   rust-sharded-tests:
     name: Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    # These suites finish in a few minutes; cap the job so a scheduling/deadlock
+    # regression fails fast instead of running to GitHub's 6-hour default.
+    timeout-minutes: 25
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     strategy:

--- a/src/license_detection/index/builder/mod.rs
+++ b/src/license_detection/index/builder/mod.rs
@@ -541,23 +541,32 @@ pub fn build_index(rules: Vec<Rule>, licenses: Vec<License>) -> LicenseIndex {
     // dominate the cold index build. Overlap them so wall time is the longer of
     // the two instead of their sum. Each automaton is deterministic, so the
     // result is byte-identical to building them sequentially.
-    let (rules_automaton, unknown_automaton) = rayon::join(
-        || rules_builder.build(),
-        || {
-            if unknown_automaton_patterns.is_empty() {
-                AutomatonBuilder::new().build()
-            } else {
-                let mut unique_patterns: Vec<Vec<u8>> =
-                    unknown_automaton_patterns.into_iter().collect();
-                unique_patterns.sort();
-                let mut builder = AutomatonBuilder::new();
-                for pattern in &unique_patterns {
-                    builder.add_pattern(pattern);
-                }
-                builder.build()
+    //
+    // Use dedicated OS threads (`std::thread::scope`) rather than `rayon::join`:
+    // this build can run inside a rayon worker — a parser triggers lazy
+    // license-engine initialization while a scan is processing files on the
+    // global rayon pool — and borrowing the ambient pool there deadlocks a
+    // small, saturated pool (e.g. a 2-core CI runner) because the nested work
+    // has no free worker to run on. Plain threads do not depend on the pool.
+    let (rules_automaton, unknown_automaton) = std::thread::scope(|scope| {
+        let rules_handle = scope.spawn(move || rules_builder.build());
+        let unknown_automaton = if unknown_automaton_patterns.is_empty() {
+            AutomatonBuilder::new().build()
+        } else {
+            let mut unique_patterns: Vec<Vec<u8>> =
+                unknown_automaton_patterns.into_iter().collect();
+            unique_patterns.sort();
+            let mut builder = AutomatonBuilder::new();
+            for pattern in &unique_patterns {
+                builder.add_pattern(pattern);
             }
-        },
-    );
+            builder.build()
+        };
+        let rules_automaton = rules_handle
+            .join()
+            .expect("rules automaton build thread panicked");
+        (rules_automaton, unknown_automaton)
+    });
 
     let mut index = LicenseIndex {
         dictionary,


### PR DESCRIPTION
## Summary

- Fixes the recurring **`Tests (contracts)` 6-hour hang**. Root cause is a rayon thread-pool deadlock, not a flake.
- The cold embedded license-index build overlaps its two daachorse automaton builds with `rayon::join` (`src/license_detection/index/builder/mod.rs`). That build is triggered lazily by `parser_license_engine()` (forcing the `PARSER_LICENSE_ENGINE` `LazyLock`) the first time a parser normalizes a declared license — **inside a scan's parallel file loop**. The nested join then borrows the ambient pool; a worker building the index blocks waiting for the stolen half of the join, steals another file task that re-enters the same in-progress `LazyLock`, and self-deadlocks on the non-reentrant `Once`.
- Builds the two independent, deterministic automata on dedicated OS threads via `std::thread::scope` instead of `rayon::join`, so the build never borrows a rayon pool. The regenerated embedded index is **byte-identical**, and the in-scan cold build is ~25% faster (4.2s vs 5.5s) as a side effect.
- Adds a 25-minute job timeout so a future scheduling regression fails fast instead of running to GitHub's 6-hour default.

## Issues

- Covers:
- Closes:

## Scope and exclusions

- **This is a test-harness deadlock, not an end-user bug.** The test scan helper (`scan_and_assemble` -> `process_collected`) runs `par_iter` on the **shared global** rayon pool, and libtest runs ~87 `_scan_test::` cases concurrently in one process; a 2-4 vCPU CI runner with a cold cache saturates the global pool and triggers it. Production CLI and `serve` scans route through a **dedicated** per-scan pool (`run_with_thread_pool`) and were not reproducible (see below). The fix removes the unsafe nested-rayon-on-ambient-pool pattern at the source, so it is safe from any caller regardless.
- Included: the index-builder concurrency fix and a CI job timeout. No change to index contents, detection results, or the production scan thread-pool model.

## How to verify

- Reproduce the hang on a pre-fix build: `RAYON_NUM_THREADS=2 <contracts test bin> _scan_test:: --test-threads 16` stalls (only ~2/87 finish in 110s; a `sample` of the PID shows workers parked in `rayon_core::registry::Registry::in_worker_cold` beneath `parser_license_engine`). After the fix that command — and `RAYON_NUM_THREADS=1 --test-threads 24` — finishes all 87 in ~5s.
- End-user safety: built the pre-fix binary and ran 48 cold-cache `provenant scan --package --copyright` invocations over a 40-manifest corpus across `--processes` 2/3/4/6/8/16 — **0 hangs**. A single scan uses a dedicated pool whose workers park on the engine's `Once` rather than creating the stealable re-entrant work that the multi-test global-pool harness does.
- Index integrity: regenerate `resources/license_detection/license_index.zst` via `cargo run --manifest-path xtask/Cargo.toml --bin generate-index-artifact` — sha256 unchanged (CI's "Verify Embedded License Index" covers this).

## Follow-up work

- Created or intentionally deferred: a deterministic unit-level regression test is hard to author safely (the deadlock needs global-pool saturation across many concurrent callers, and a test that hangs on regression would reintroduce the long-hang); the `timeout-minutes` guard is the pragmatic regression signal.
