### PR TITLE
docs(benchmarks): re-measure ten more M1 targets on M5 (batch 2)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 220 of 220 recorded runs, with a **14.8× median speedup** and **15.1× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
+> Provenant is faster on 220 of 220 recorded runs, with a **15.0× median speedup** and **15.3× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -199,18 +199,18 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `27.77s`; ScanCode `356.55s`
 - Broader Pixi package and dependency extraction (`233` vs `128` packages, `22369` vs `3116` dependencies) from the root and example `pixi.toml` or `pixi.lock` surfaces plus feature-scoped `pypi-dependencies` and cargo workspace members that inherit the declared `BSD-3-Clause` license ScanCode leaves unset, with no example-lock scan errors where ScanCode times out and safer credential stripping or git URL normalization across Pixi source fixtures
 
-##### [pydata/xarray @ f7e47a1](https://github.com/pydata/xarray/tree/f7e47a19726321e56d74bca896eb55c6f330506b) — **14.48× faster**
+##### [pydata/xarray @ f7e47a1](https://github.com/pydata/xarray/tree/f7e47a19726321e56d74bca896eb55c6f330506b) — **22.17× faster**
 
 - Files: 429
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `12.89s`; ScanCode `186.62s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.60s`; ScanCode `124.15s`
 - Broader Pixi and Conda environment coverage (`3` vs `1` packages, `509` vs `84` dependencies) from the repo-root `pixi.toml` plus committed Binder and CI environment manifests, with direct Pixi package identity and cleaner URL normalization across docs and SVG metadata
 
-##### [pyodide/pyodide @ 86e27b0](https://github.com/pyodide/pyodide/tree/86e27b004d06bccd91a937aa5fc2601978642b74) — **12.57× faster**
+##### [pyodide/pyodide @ 86e27b0](https://github.com/pyodide/pyodide/tree/86e27b004d06bccd91a937aa5fc2601978642b74) — **14.25× faster**
 
 - Files: 540
-- Run context: 2026-05-05 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.77s`; ScanCode `135.33s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.67s`; ScanCode `80.78s`
 - Broader dependency extraction (`796` vs `718`) and slightly broader package visibility (`53` vs `52`) from `environment.yml`, `.gitmodules`, and committed wheel artifacts, with extension-qualified wheel PURLs, richer patch-header author recovery, and the fuller `Pyodide contributors and Mozilla` documentation notice
 
 ##### [python/cpython @ 7a468a1](https://github.com/python/cpython/tree/7a468a101268d2b13105f94ae027df8b502d0c87) — **70.74× faster**
@@ -250,11 +250,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.97s`; ScanCode `49.16s`
 - Far broader CRAN package and dependency extraction (`14` vs `1` packages, `45` vs `1` dependencies) from the root `DESCRIPTION` plus committed test-package fixtures, with correct filtering of fake `pkg:cran/R` dependency noise and cleaner maintainer or URL normalization
 
-##### [tidyverse/dplyr @ 2f9f49e](https://github.com/tidyverse/dplyr/tree/2f9f49ef0d361dc612abc55982d68db3fb3854d0) — **12.32× faster**
+##### [tidyverse/dplyr @ 2f9f49e](https://github.com/tidyverse/dplyr/tree/2f9f49ef0d361dc612abc55982d68db3fb3854d0) — **19.42× faster**
 
 - Files: 462
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `13.86s`; ScanCode `170.71s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.52s`; ScanCode `107.21s`
 - Direct CRAN package visibility on the root `DESCRIPTION` plus declared dependency extraction (`29` vs `0`) across `Depends`, `Imports`, `Suggests`, `Enhances`, and `LinkingTo`, with cleaner Rd or markdown URL normalization and preserved shipped license-holder metadata
 
 ##### [tidyverse/ggplot2 @ 7d79c95](https://github.com/tidyverse/ggplot2/tree/7d79c956b5707cb7c762d834caf842dc6496b032) — **12.33× faster**
@@ -301,11 +301,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `59.99s`; ScanCode `2034.56s`
 - Direct OTP application package visibility (`11` vs `0`) across committed `lib/*/src/*.app.src` templates, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable and preserves the same non-stdlib runtime dependency inventory ScanCode finds
 
-##### [phoenixframework/phoenix @ e7b8081](https://github.com/phoenixframework/phoenix/tree/e7b8081792fa51c9fede6d0fb9ddb610bac3f26f) — **11.66× faster**
+##### [phoenixframework/phoenix @ e7b8081](https://github.com/phoenixframework/phoenix/tree/e7b8081792fa51c9fede6d0fb9ddb610bac3f26f) — **14.38× faster**
 
 - Files: 476
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `12.80s`; ScanCode `149.17s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.49s`; ScanCode `78.97s`
 - Direct Hex package visibility on the repo-root, `installer/mix.lock`, and `integration_test/mix.lock` surfaces (`3` vs `0` file-level package records), while preserving top-level package and dependency parity elsewhere and preserving structured npm party metadata
 
 ##### [processone/ejabberd @ 87475d8](https://github.com/processone/ejabberd/tree/87475d813b974492f338720eab5c9c3d4646a4ce) — **12.80× faster**
@@ -601,11 +601,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `48.49s`; ScanCode `1396.87s`
 - Broader Bazel package and dependency extraction (`1746` vs `1711` packages, `129` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, with richer Debian and RPM sidecar package metadata
 
-##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **12.29× faster**
+##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **14.47× faster**
 
 - Files: 241
-- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `12.34s`; ScanCode `151.70s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.20s`; ScanCode `75.26s`
 - Direct `.gitmodules` package-adjacent visibility (`1` vs `0` file-level package records, plus one raw dependency edge) across the umbrella superproject, cleaner XML author extraction that drops prose-tainted suffixes such as `A.Meredith Compiler`, and Unicode-preserving name normalization for identities such as `René Ferdinand Rivera Morell`, `Ion Gaztañaga`, and `J. López`
 
 ##### [boostorg/graph @ ae8e08d](https://github.com/boostorg/graph/tree/ae8e08d88f68669dc3fe5c7043dbc01b3c7c52ae) — **13.04× faster**
@@ -678,11 +678,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.26s`; ScanCode `375.45s`
 - Matched ScanCode's file-level Autotools `configure.ac` coverage while promoting one top-level Autotools package (`1` vs `0`), with the real `pkg:autotools/curl` identity instead of a generic input placeholder, plus extra Docker package and dependency visibility from the committed `Dockerfile`
 
-##### [Debian/apt @ 6b12812](https://github.com/Debian/apt/tree/6b128124271e94bdb0f4e7850d9286170d712b04) — **15.11× faster**
+##### [Debian/apt @ 6b12812](https://github.com/Debian/apt/tree/6b128124271e94bdb0f4e7850d9286170d712b04) — **16.24× faster**
 
 - Files: 889
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `17.56s`; ScanCode `265.28s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `11.53s`; ScanCode `187.26s`
 - Matched Debian source-package coverage (`7` vs `7`) with broader dependency extraction (`32` vs `0`) from the root multi-binary `debian/control` Build-Depends plus runtime relation fields such as `Depends`, `Recommends`, `Suggests`, `Breaks`, `Conflicts`, and `Provides`
 
 ##### [docker-library/official-images @ 71567fb](https://github.com/docker-library/official-images/tree/71567fbcfa7945774c08c32c04f67ef34c9bce82) — **10.27× faster**
@@ -811,11 +811,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `114.17s`; ScanCode `1659.92s`
 - Direct Meson package visibility on the root `meson.build` plus declared dependency extraction (`2` vs `0` packages, `2` vs `0` dependencies) for `boost` and `python2`, with Debian copyright metadata carrying a Debian namespace instead of an unqualified source-package row
 
-##### [madler/zlib @ f9dd600](https://github.com/madler/zlib/tree/f9dd6009be3ed32415edf1e89d1bc38380ecb95d) — **12.06× faster**
+##### [madler/zlib @ f9dd600](https://github.com/madler/zlib/tree/f9dd6009be3ed32415edf1e89d1bc38380ecb95d) — **12.48× faster**
 
 - Files: 261
-- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.86s`; ScanCode `130.94s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.24s`; ScanCode `65.39s`
 - Broader native-build package and dependency visibility (`5` vs `0` packages, `3` vs `0` dependencies) from the root `configure`, `MODULE.bazel`, and committed `.csproj` surfaces, with the real `pkg:autotools/zlib` identity instead of ScanCode's generic input placeholder, direct Bazel and NuGet surface coverage, and the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c`
 
 ##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **49.68× faster**
@@ -839,11 +839,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `25.48s`; ScanCode `686.99s`
 - Broader package/dependency extraction (`19` vs `2` packages, `13` vs `2` dependencies), preserved NPSL/source-available handling across core Nmap and Zenmap reference-notice files, and cleaner rejection of weak translated-manpage GPL bare-word and placeholder noise
 
-##### [nginx/nginx @ 6e14e95](https://github.com/nginx/nginx/tree/6e14e954aaacce9a433d9b07b4653809c7594ab8) — **17.78× faster**
+##### [nginx/nginx @ 6e14e95](https://github.com/nginx/nginx/tree/6e14e954aaacce9a433d9b07b4653809c7594ab8) — **25.10× faster**
 
 - Files: 521
-- Run context: 2026-04-25 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `11.92s`; ScanCode `211.97s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.70s`; ScanCode `143.06s`
 - Direct CPAN package visibility (`1` vs `0` packages) from the embedded Perl `src/http/modules/perl/Makefile.PL`, with concrete `pkg:cpan/nginx@%%VERSION%%` identity and author metadata instead of ScanCode's generic CPAN placeholder, plus safer rejection of nginx's custom `auto/configure` shell script as Autotools package metadata and cleaner author, email, and URL normalization across manpage markup and README badge links
 
 ##### [openembedded/meta-openembedded @ 7bf89d0](https://github.com/openembedded/meta-openembedded/tree/7bf89d06a41405b48fa3af260da36bc686973afc) — **14.04× faster**
@@ -1072,11 +1072,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.66s`; ScanCode `49.57s`
 - Matched top-level package coverage (`7` vs `7`) with broader package-adjacent dependency extraction (`14` vs `0`) from `.gitmodules`, `Cartfile`, `Cartfile.private`, `Cartfile.resolved`, and the sibling podspecs, plus safer `Package.resolved` modeling as one resolved-file package record with structured pinned dependencies instead of exploded duplicate pseudo-packages
 
-##### [rrousselGit/riverpod @ cac77b1](https://github.com/rrousselGit/riverpod/tree/cac77b1ec1c4b4c0ca7c6e9b1436f80250b4edc0) — **14.36× faster**
+##### [rrousselGit/riverpod @ cac77b1](https://github.com/rrousselGit/riverpod/tree/cac77b1ec1c4b4c0ca7c6e9b1436f80250b4edc0) — **26.55× faster**
 
 - Files: 1,930
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `12.13s`; ScanCode `174.19s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.16s`; ScanCode `163.56s`
 - Broader Dart/Flutter workspace package and dependency extraction (`29` vs `26` packages, `1417` vs `1350` dependencies) from package, example, and test `pubspec.yaml` manifests across the monorepo, plus cleaner structured-literal copyright extraction on generated Dart and JSON fixtures
 
 ##### [SDWebImage/SDWebImage @ c3ad5e1](https://github.com/SDWebImage/SDWebImage/tree/c3ad5e1a9bf55c9b76d4c362430b5fcded96c502) — **16.45× faster**
@@ -1302,11 +1302,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `9.05s`; ScanCode `59.81s`
 - Broader Nix package extraction (`39` vs `11` top-level packages) from committed `flake.lock` inputs and flake-compat-backed `default.nix` wrapper surfaces, with version-qualified purls (`pkg:cargo/app@0.1.0` where ScanCode emits an unversioned identity), declared-license enrichment on the bundled `npm/minimal` package, and junk-URL avoidance that skips the `${info.host` template interpolation ScanCode mis-extracts
 
-##### [NixOS/nix @ 6a659e1](https://github.com/NixOS/nix/tree/6a659e16bd2bcd871aedcb38724a1cff77690a31) — **18.21× faster**
+##### [NixOS/nix @ 6a659e1](https://github.com/NixOS/nix/tree/6a659e16bd2bcd871aedcb38724a1cff77690a31) — **27.06× faster**
 
 - Files: 2,917
-- Run context: 2026-04-27 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `12.29s`; ScanCode `223.79s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.81s`; ScanCode `157.23s`
 - Broader Nix package and dependency extraction (`3` vs `0` packages, `69` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and other Nix manifest surfaces, with richer structured author, email, and URL recovery across repository docs and release metadata
 
 ##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.84× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -242,18 +242,18 @@ ScanCode: 54.22s</title></rect>
     <rect x="462.40" y="443.56" width="8" height="8" fill="#d97706" rx="1.5"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 ScanCode: 49.57s</title></rect>
-    <rect x="469.95" y="390.71" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
+    <rect x="469.95" y="423.83" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
 Files: 241
-ScanCode: 151.70s</title></rect>
+ScanCode: 75.26s</title></rect>
     <rect x="471.08" y="443.75" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/apache2 @ 420d824
 Files: 245
 ScanCode: 49.37s</title></rect>
     <rect x="475.18" y="418.07" width="8" height="8" fill="#d97706" rx="1.5"><title>libevent/libevent @ 4829651
 Files: 260
 ScanCode: 85.01s</title></rect>
-    <rect x="475.44" y="397.66" width="8" height="8" fill="#d97706" rx="1.5"><title>madler/zlib @ f9dd600
+    <rect x="475.44" y="430.47" width="8" height="8" fill="#d97706" rx="1.5"><title>madler/zlib @ f9dd600
 Files: 261
-ScanCode: 130.94s</title></rect>
+ScanCode: 65.39s</title></rect>
     <rect x="476.49" y="443.95" width="8" height="8" fill="#d97706" rx="1.5"><title>r-lib/devtools @ a3447b9
 Files: 265
 ScanCode: 49.16s</title></rect>
@@ -287,9 +287,9 @@ ScanCode: 92.26s</title></rect>
     <rect x="508.39" y="412.34" width="8" height="8" fill="#d97706" rx="1.5"><title>debian:bookworm-slim dpkg DB snapshot @ sha256:f065376
 Files: 421
 ScanCode: 95.97s</title></rect>
-    <rect x="509.68" y="380.92" width="8" height="8" fill="#d97706" rx="1.5"><title>pydata/xarray @ f7e47a1
+    <rect x="509.68" y="400.18" width="8" height="8" fill="#d97706" rx="1.5"><title>pydata/xarray @ f7e47a1
 Files: 429
-ScanCode: 186.62s</title></rect>
+ScanCode: 124.15s</title></rect>
     <rect x="510.80" y="432.47" width="8" height="8" fill="#d97706" rx="1.5"><title>PerlDancer/Dancer2 @ a1faa22
 Files: 436
 ScanCode: 62.68s</title></rect>
@@ -299,27 +299,27 @@ ScanCode: 86.10s</title></rect>
     <rect x="512.36" y="396.07" width="8" height="8" fill="#d97706" rx="1.5"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
 ScanCode: 135.43s</title></rect>
-    <rect x="514.79" y="385.13" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/dplyr @ 2f9f49e
+    <rect x="514.79" y="407.11" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
-ScanCode: 170.71s</title></rect>
+ScanCode: 107.21s</title></rect>
     <rect x="516.12" y="400.33" width="8" height="8" fill="#d97706" rx="1.5"><title>chuckha/crispy-tribble @ 20479cf
 Files: 471
 ScanCode: 123.76s</title></rect>
     <rect x="516.70" y="434.73" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaLang/Pkg.jl @ c96cfdf
 Files: 475
 ScanCode: 59.75s</title></rect>
-    <rect x="516.85" y="391.50" width="8" height="8" fill="#d97706" rx="1.5"><title>phoenixframework/phoenix @ e7b8081
+    <rect x="516.85" y="421.56" width="8" height="8" fill="#d97706" rx="1.5"><title>phoenixframework/phoenix @ e7b8081
 Files: 476
-ScanCode: 149.17s</title></rect>
+ScanCode: 78.97s</title></rect>
     <rect x="522.27" y="434.69" width="8" height="8" fill="#d97706" rx="1.5"><title>nix-community/dream2nix @ 69eb01f
 Files: 515
 ScanCode: 59.81s</title></rect>
-    <rect x="523.07" y="374.90" width="8" height="8" fill="#d97706" rx="1.5"><title>nginx/nginx @ 6e14e95
+    <rect x="523.07" y="393.48" width="8" height="8" fill="#d97706" rx="1.5"><title>nginx/nginx @ 6e14e95
 Files: 521
-ScanCode: 211.97s</title></rect>
-    <rect x="525.54" y="396.10" width="8" height="8" fill="#d97706" rx="1.5"><title>pyodide/pyodide @ 86e27b0
+ScanCode: 143.06s</title></rect>
+    <rect x="525.54" y="420.49" width="8" height="8" fill="#d97706" rx="1.5"><title>pyodide/pyodide @ 86e27b0
 Files: 540
-ScanCode: 135.33s</title></rect>
+ScanCode: 80.78s</title></rect>
     <rect x="525.67" y="418.82" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/serialization @ 097a6c6
 Files: 541
 ScanCode: 83.67s</title></rect>
@@ -374,9 +374,9 @@ ScanCode: 70.31s</title></rect>
     <rect x="558.17" y="345.08" width="8" height="8" fill="#d97706" rx="1.5"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 ScanCode: 398.45s</title></rect>
-    <rect x="559.89" y="364.30" width="8" height="8" fill="#d97706" rx="1.5"><title>Debian/apt @ 6b12812
+    <rect x="559.89" y="380.76" width="8" height="8" fill="#d97706" rx="1.5"><title>Debian/apt @ 6b12812
 Files: 889
-ScanCode: 265.28s</title></rect>
+ScanCode: 187.26s</title></rect>
     <rect x="560.43" y="391.49" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/watchman @ 426a7b7
 Files: 896
 ScanCode: 149.22s</title></rect>
@@ -443,9 +443,9 @@ ScanCode: 384.96s</title></rect>
     <rect x="610.17" y="432.56" width="8" height="8" fill="#d97706" rx="1.5"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
 Files: 1844
 ScanCode: 62.57s</title></rect>
-    <rect x="613.31" y="384.18" width="8" height="8" fill="#d97706" rx="1.5"><title>rrousselGit/riverpod @ cac77b1
+    <rect x="613.31" y="387.15" width="8" height="8" fill="#d97706" rx="1.5"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
-ScanCode: 174.19s</title></rect>
+ScanCode: 163.56s</title></rect>
     <rect x="613.49" y="327.10" width="8" height="8" fill="#d97706" rx="1.5"><title>scalatest/scalatest @ f6ba8f2
 Files: 1935
 ScanCode: 582.97s</title></rect>
@@ -497,9 +497,9 @@ ScanCode: 349.11s</title></rect>
     <rect x="641.37" y="349.55" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
 Files: 2900
 ScanCode: 362.51s</title></rect>
-    <rect x="641.77" y="372.34" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
+    <rect x="641.77" y="389.02" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
-ScanCode: 223.79s</title></rect>
+ScanCode: 157.23s</title></rect>
     <rect x="643.66" y="353.67" width="8" height="8" fill="#d97706" rx="1.5"><title>scipy/scipy @ 8a4633f
 Files: 2998
 ScanCode: 332.23s</title></rect>
@@ -904,18 +904,18 @@ Provenant: 5.17s</title></circle>
     <circle cx="466.40" cy="559.28" r="4.5" fill="#2563eb"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 Provenant: 4.66s</title></circle>
-    <circle cx="473.95" cy="513.26" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
+    <circle cx="473.95" cy="554.10" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
 Files: 241
-Provenant: 12.34s</title></circle>
+Provenant: 5.20s</title></circle>
     <circle cx="475.08" cy="557.59" r="4.5" fill="#2563eb"><title>sous-chefs/apache2 @ 420d824
 Files: 245
 Provenant: 4.83s</title></circle>
     <circle cx="479.18" cy="550.34" r="4.5" fill="#2563eb"><title>libevent/libevent @ 4829651
 Files: 260
 Provenant: 5.63s</title></circle>
-    <circle cx="479.44" cy="519.30" r="4.5" fill="#2563eb"><title>madler/zlib @ f9dd600
+    <circle cx="479.44" cy="553.74" r="4.5" fill="#2563eb"><title>madler/zlib @ f9dd600
 Files: 261
-Provenant: 10.86s</title></circle>
+Provenant: 5.24s</title></circle>
     <circle cx="480.49" cy="556.24" r="4.5" fill="#2563eb"><title>r-lib/devtools @ a3447b9
 Files: 265
 Provenant: 4.97s</title></circle>
@@ -949,9 +949,9 @@ Provenant: 5.61s</title></circle>
     <circle cx="512.39" cy="517.17" r="4.5" fill="#2563eb"><title>debian:bookworm-slim dpkg DB snapshot @ sha256:f065376
 Files: 421
 Provenant: 11.36s</title></circle>
-    <circle cx="513.68" cy="511.20" r="4.5" fill="#2563eb"><title>pydata/xarray @ f7e47a1
+    <circle cx="513.68" cy="550.60" r="4.5" fill="#2563eb"><title>pydata/xarray @ f7e47a1
 Files: 429
-Provenant: 12.89s</title></circle>
+Provenant: 5.60s</title></circle>
     <circle cx="514.80" cy="557.10" r="4.5" fill="#2563eb"><title>PerlDancer/Dancer2 @ a1faa22
 Files: 436
 Provenant: 4.88s</title></circle>
@@ -961,27 +961,27 @@ Provenant: 6.12s</title></circle>
     <circle cx="516.36" cy="520.00" r="4.5" fill="#2563eb"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
 Provenant: 10.70s</title></circle>
-    <circle cx="518.79" cy="507.78" r="4.5" fill="#2563eb"><title>tidyverse/dplyr @ 2f9f49e
+    <circle cx="518.79" cy="551.28" r="4.5" fill="#2563eb"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
-Provenant: 13.86s</title></circle>
+Provenant: 5.52s</title></circle>
     <circle cx="520.12" cy="544.14" r="4.5" fill="#2563eb"><title>chuckha/crispy-tribble @ 20479cf
 Files: 471
 Provenant: 6.42s</title></circle>
     <circle cx="520.70" cy="554.01" r="4.5" fill="#2563eb"><title>JuliaLang/Pkg.jl @ c96cfdf
 Files: 475
 Provenant: 5.21s</title></circle>
-    <circle cx="520.85" cy="511.54" r="4.5" fill="#2563eb"><title>phoenixframework/phoenix @ e7b8081
+    <circle cx="520.85" cy="551.53" r="4.5" fill="#2563eb"><title>phoenixframework/phoenix @ e7b8081
 Files: 476
-Provenant: 12.80s</title></circle>
+Provenant: 5.49s</title></circle>
     <circle cx="526.27" cy="527.92" r="4.5" fill="#2563eb"><title>nix-community/dream2nix @ 69eb01f
 Files: 515
 Provenant: 9.05s</title></circle>
-    <circle cx="527.07" cy="514.90" r="4.5" fill="#2563eb"><title>nginx/nginx @ 6e14e95
+    <circle cx="527.07" cy="549.76" r="4.5" fill="#2563eb"><title>nginx/nginx @ 6e14e95
 Files: 521
-Provenant: 11.92s</title></circle>
-    <circle cx="529.54" cy="519.69" r="4.5" fill="#2563eb"><title>pyodide/pyodide @ 86e27b0
+Provenant: 5.70s</title></circle>
+    <circle cx="529.54" cy="550.01" r="4.5" fill="#2563eb"><title>pyodide/pyodide @ 86e27b0
 Files: 540
-Provenant: 10.77s</title></circle>
+Provenant: 5.67s</title></circle>
     <circle cx="529.67" cy="548.53" r="4.5" fill="#2563eb"><title>boostorg/serialization @ 097a6c6
 Files: 541
 Provenant: 5.85s</title></circle>
@@ -1036,9 +1036,9 @@ Provenant: 9.24s</title></circle>
     <circle cx="562.17" cy="488.62" r="4.5" fill="#2563eb"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 Provenant: 20.79s</title></circle>
-    <circle cx="563.89" cy="496.60" r="4.5" fill="#2563eb"><title>Debian/apt @ 6b12812
+    <circle cx="563.89" cy="516.47" r="4.5" fill="#2563eb"><title>Debian/apt @ 6b12812
 Files: 889
-Provenant: 17.56s</title></circle>
+Provenant: 11.53s</title></circle>
     <circle cx="564.43" cy="532.35" r="4.5" fill="#2563eb"><title>facebook/watchman @ 426a7b7
 Files: 896
 Provenant: 8.24s</title></circle>
@@ -1105,9 +1105,9 @@ Provenant: 19.40s</title></circle>
     <circle cx="614.17" cy="538.33" r="4.5" fill="#2563eb"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
 Files: 1844
 Provenant: 7.26s</title></circle>
-    <circle cx="617.31" cy="514.08" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
+    <circle cx="617.31" cy="546.09" r="4.5" fill="#2563eb"><title>rrousselGit/riverpod @ cac77b1
 Files: 1930
-Provenant: 12.13s</title></circle>
+Provenant: 6.16s</title></circle>
     <circle cx="617.49" cy="467.46" r="4.5" fill="#2563eb"><title>scalatest/scalatest @ f6ba8f2
 Files: 1935
 Provenant: 32.53s</title></circle>
@@ -1159,9 +1159,9 @@ Provenant: 16.54s</title></circle>
     <circle cx="645.37" cy="524.20" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
 Files: 2900
 Provenant: 9.79s</title></circle>
-    <circle cx="645.77" cy="513.46" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
+    <circle cx="645.77" cy="548.86" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
-Provenant: 12.29s</title></circle>
+Provenant: 5.81s</title></circle>
     <circle cx="647.66" cy="482.69" r="4.5" fill="#2563eb"><title>scipy/scipy @ 8a4633f
 Files: 2998
 Provenant: 23.57s</title></circle>


### PR DESCRIPTION
## Summary

Batch 2 of the M1→M5 benchmark migration: ten more rows that were recorded on **Apple M1 Max** are re-measured on the current **Apple M5 Pro** host, continuing to make the chart hardware-consistent (it plots M1 and M5 runs together, so leftover M1 rows sit high purely from slower hardware + older code).

Each target re-run with `compare-outputs --profile common --build-mode optimized`; ScanCode ran fresh (`cache_hit: false`). Same-host PV-vs-ScanCode pairs, 4 proc.

| target | files | PV (M1→M5) | ScanCode (M1→M5) | × (old→new) |
|---|---|---|---|---|
| madler/zlib | 261 | 10.86→5.24s | 130.94→65.39s | 12.06→12.48× |
| pyodide/pyodide | 540 | 10.77→5.67s | 135.33→80.78s | 12.57→14.25× |
| phoenixframework/phoenix | 476 | 12.80→5.49s | 149.17→78.97s | 11.66→14.38× |
| boostorg/boost | 241 | 12.34→5.20s | 151.70→75.26s | 12.29→14.47× |
| tidyverse/dplyr | 462 | 13.86→5.52s | 170.71→107.21s | 12.32→19.42× |
| rrousselGit/riverpod | 1,930 | 12.13→6.16s | 174.19→163.56s | 14.36→26.55× |
| pydata/xarray | 429 | 12.89→5.60s | 186.62→124.15s | 14.48→22.17× |
| nginx/nginx | 521 | 11.92→5.70s | 211.97→143.06s | 17.78→25.10× |
| NixOS/nix | 2,917 | 12.29→5.81s | 223.79→157.23s | 18.21→27.06× |
| Debian/apt | 889 | 17.56→11.53s | 265.28→187.26s | 15.11→16.24× |

Headline regenerated: median **14.8→15.0×**, geomean **15.1→15.3×** (220 runs). The rise is the M5 hardware + the perf campaign applied uniformly (the old rows were pre-campaign M1) — the suite converging to its single-host level, not a new speedup.

## Pathology triage (verify-benchmark-target skill)

All deltas resolve to a Provenant advantage or are clean:
- **zlib** — the `minizip` autotools package: ScanCode folds the Info-ZIP file license into the package's *declared* field; PV keeps package-declared separate (architectural, cleaner).
- **phoenix** — PV recovers the `Chris McCord` holder ScanCode misses.
- **boost / riverpod / xarray / nginx / nix / apt** — clean; no package-level deltas; PV net richer on file-level detection (e.g. xarray 522 vs 21, nix 510 vs 46).
- **pyodide** — conda packages: ScanCode folds file-content detection into the conda declared field (`unknown` noise + multi-license compounds) where PV is cleaner; PV net richer (163 vs 29).

### Finding: a recurring declared-license normalization gap (not fixed here)

Across this batch the same gap recurred in **three ecosystems**: a package declares a bare/idiomatic non-SPDX license string, PV captures it as `extracted_license_statement` but `normalize_spdx_declared_license` (the license engine) yields no expression, so `declared_license_expression` is null where ScanCode maps it:
- npm `license: "Apache"` (hadoop, prior batch) → null vs `apache-2.0`
- conda `"PSF"`, `"Boost"` (pyodide) → null vs `python`/`bsl-1.0`
- R `"MIT + file LICENSE"` (dplyr) → null vs `mit`

It's now cross-ecosystem rather than a one-off, so it's worth a **scoped declared-context alias** (applied only to the package declared-license path, not the file-content matcher, restricted to unambiguous-by-convention names) in a future PR. Flagged for follow-up; out of scope for this timing refresh.

## Issues

- Continues the M5 migration (after #1118/#1119); ~87 M1 rows remain.

## Scope and exclusions

- Included: the ten M1 repo rows above + regenerated chart/headline.
- Excluded: scanner/parser code (the declared-license gap is a separate follow-up).

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` — re-running produces no diff.
- Each row reproducible via `compare-outputs --profile common` against the pinned ref.

## Expected-output fixture changes

- None. Docs + generated chart only.
