### PR TITLE
feat(parsers): map bare informal declared license names via a curated alias config

### DIFF
--- a/resources/license_detection/declared_license_aliases.toml
+++ b/resources/license_detection/declared_license_aliases.toml
@@ -1,0 +1,51 @@
+# Declared-license name aliases
+#
+# Maps bare / informal license *names* that are not valid SPDX expressions to a
+# canonical license key. These aliases are applied ONLY when normalizing a
+# package's declared license field (e.g. an npm `"license"`, a Python setup
+# classifier, a Ruby gemspec license) — they are NEVER consulted during
+# file-content license detection and are not part of the license index.
+#
+# Why a declared-only alias instead of a license-index rule:
+#   A rule in the license index matches anywhere the text appears, including
+#   arbitrary file content. Bare license names are unsafe there — "Python" is a
+#   language word, and "Apache"/"Boost" appear inside their own license notices,
+#   so an index rule would either false-positive on prose or fragment a real
+#   detection. Restricting these mappings to the trusted, bounded declared field
+#   removes that risk entirely: the input is the package's own stated license,
+#   not free text. This mirrors how ScanCode normalizes declared license fields
+#   in its package handlers, separately from its file-content detector.
+#
+# Inclusion bar: only names with a single dominant, unambiguous-by-convention
+# target. Genuinely version-ambiguous bare names are deliberately omitted — an
+# honest null is preferable to a guessed version. Deliberately NOT aliased:
+#   - "LGPL"  : ambiguous between LGPL-2.1 and LGPL-3.0, no dominant default
+#               (note: bare "LGPL" already resolves via the bundled
+#               lgpl_bare_single_word index rule, so it needs no alias here).
+#   - "MPL"   : ambiguous between MPL-1.0/1.1/2.0.
+#   - "EPL"   : ambiguous between EPL-1.0 and EPL-2.0.
+#   - "CDDL"  : ambiguous between CDDL-1.0 and CDDL-1.1; no observed declared case.
+#   - "BSD" / "GPL" : already handled as clue-only index rules
+#               (bsd_bare_word_only / gpl_bare_word_only), where the bare word
+#               in file content is reliably a license reference.
+#
+# Schema (array of tables):
+#   names      = case-insensitive declared strings that map to `expression`.
+#   expression = canonical license key; MUST exist in the license index
+#                (enforced by a test).
+#   reason     = required justification for why this mapping is safe and correct.
+
+[[alias]]
+names = ["apache"]
+expression = "apache-2.0"
+reason = "SPDX deprecated the bare 'Apache' identifier in favor of Apache-2.0; a declared `license: \"Apache\"` is conventionally Apache-2.0, and ScanCode resolves it the same. Observed in apache/hadoop's hadoop-yarn-ui package.json."
+
+[[alias]]
+names = ["boost"]
+expression = "boost-1.0"
+reason = "Boost ships a single license, the Boost Software License 1.0 (SPDX BSL-1.0; ScanCode key boost-1.0); a declared 'Boost' has no other meaning. Observed in pyodide's bundled libboost conda metadata."
+
+[[alias]]
+names = ["psf", "python"]
+expression = "python"
+reason = "The Python Software Foundation License (SPDX Python-2.0) is conventionally written 'PSF' or 'Python' in declared license fields; ScanCode maps the PSF family to the 'python' license. Observed in pyodide conda package metadata. Safe only because this is declared-field-only — the bare word 'Python' is a false positive in file content (it is the language name), which is exactly why this is an alias and not an index rule."

--- a/src/parsers/declared_license_aliases.rs
+++ b/src/parsers/declared_license_aliases.rs
@@ -116,4 +116,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn every_alias_expression_resolves_in_the_license_index() {
+        // Enforce the schema contract documented in the TOML: each `expression`
+        // must be a real license key the index can resolve, so a typo such as
+        // "apache-2" instead of "apache-2.0" fails loudly here.
+        for expression in DECLARED_LICENSE_ALIASES.values() {
+            assert!(
+                crate::parsers::license_normalization::normalize_declared_license_key(expression)
+                    .is_some(),
+                "alias expression {expression:?} does not resolve in the license index"
+            );
+        }
+    }
 }

--- a/src/parsers/declared_license_aliases.rs
+++ b/src/parsers/declared_license_aliases.rs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Declared-license name aliases.
+//!
+//! Maps bare / informal license names (e.g. `"Apache"`, `"PSF"`) that are not
+//! valid SPDX expressions to a canonical license key, for use **only** when
+//! normalizing a package's declared license field. These aliases are never
+//! consulted during file-content license detection and are not part of the
+//! license index, so they cannot produce file-content false positives.
+//!
+//! The list — and the justification for every entry — lives in the
+//! checked-in config at
+//! `resources/license_detection/declared_license_aliases.toml`, intentionally
+//! out of the code so the curation stays transparent and reviewable. This
+//! module only loads and indexes it.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use serde::Deserialize;
+
+const DECLARED_LICENSE_ALIASES_TEXT: &str =
+    include_str!("../../resources/license_detection/declared_license_aliases.toml");
+
+#[derive(Debug, Deserialize)]
+struct AliasFile {
+    #[serde(default)]
+    alias: Vec<AliasEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AliasEntry {
+    names: Vec<String>,
+    expression: String,
+    // `reason` is intentionally not deserialized: it is required documentation
+    // in the TOML (enforced by a test), but the runtime only needs the mapping.
+}
+
+/// Lower-cased declared name -> canonical license key.
+static DECLARED_LICENSE_ALIASES: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+    let parsed: AliasFile = toml::from_str(DECLARED_LICENSE_ALIASES_TEXT)
+        .expect("declared_license_aliases.toml must be valid TOML");
+    let mut map = HashMap::new();
+    for entry in parsed.alias {
+        for name in entry.names {
+            map.insert(name.trim().to_ascii_lowercase(), entry.expression.clone());
+        }
+    }
+    map
+});
+
+/// Resolve a declared license statement to a canonical license key via the
+/// curated alias table, or `None` if it is not an aliased name.
+///
+/// Matching is case-insensitive on the trimmed statement; only exact bare-name
+/// matches resolve (this is not a substring or fuzzy match).
+pub(crate) fn declared_license_alias(statement: &str) -> Option<&'static str> {
+    let key = statement.trim().to_ascii_lowercase();
+    DECLARED_LICENSE_ALIASES.get(&key).map(String::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_and_indexes_aliases() {
+        assert_eq!(declared_license_alias("apache"), Some("apache-2.0"));
+        assert_eq!(declared_license_alias("Apache"), Some("apache-2.0"));
+        assert_eq!(declared_license_alias("  APACHE  "), Some("apache-2.0"));
+        assert_eq!(declared_license_alias("boost"), Some("boost-1.0"));
+        assert_eq!(declared_license_alias("PSF"), Some("python"));
+        assert_eq!(declared_license_alias("Python"), Some("python"));
+    }
+
+    #[test]
+    fn unaliased_names_return_none() {
+        // Deliberately-excluded ambiguous names must not resolve here.
+        assert_eq!(declared_license_alias("LGPL"), None);
+        assert_eq!(declared_license_alias("MPL"), None);
+        assert_eq!(declared_license_alias("EPL"), None);
+        // Not a bare alias name.
+        assert_eq!(declared_license_alias("Apache License, Version 2.0"), None);
+        assert_eq!(declared_license_alias(""), None);
+    }
+
+    #[test]
+    fn every_alias_entry_has_a_nonempty_reason() {
+        // Enforce the transparency contract: each curated mapping must justify
+        // itself. Parsed generically so the runtime struct can ignore `reason`.
+        let value: toml::Value =
+            toml::from_str(DECLARED_LICENSE_ALIASES_TEXT).expect("aliases TOML parses");
+        let aliases = value
+            .get("alias")
+            .and_then(toml::Value::as_array)
+            .expect("at least one [[alias]] entry");
+        assert!(!aliases.is_empty());
+        for entry in aliases {
+            let names = entry.get("names").and_then(toml::Value::as_array);
+            assert!(
+                names.is_some_and(|n| !n.is_empty()),
+                "every alias needs at least one name: {entry:?}"
+            );
+            assert!(
+                entry
+                    .get("expression")
+                    .and_then(toml::Value::as_str)
+                    .is_some(),
+                "every alias needs an expression: {entry:?}"
+            );
+            let reason = entry.get("reason").and_then(toml::Value::as_str);
+            assert!(
+                reason.is_some_and(|r| r.trim().len() >= 20),
+                "every alias needs a substantive `reason`: {entry:?}"
+            );
+        }
+    }
+}

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -11,6 +11,7 @@ use std::cell::Cell;
 
 use crate::parser_warn as warn;
 use crate::parsers::active_parser_license_engine;
+use crate::parsers::declared_license_aliases::declared_license_alias;
 use crate::parsers::utils::{RecursionGuard, capped_iteration_limit};
 
 use crate::license_detection::LicenseDetectionEngine;
@@ -128,7 +129,9 @@ pub(crate) fn normalize_spdx_declared_license(
         return empty_declared_license_data();
     };
 
-    let Some(normalized) = normalize_spdx_expression(statement) else {
+    let Some(normalized) =
+        normalize_spdx_expression(statement).or_else(|| resolve_declared_license_alias(statement))
+    else {
         return empty_declared_license_data();
     };
 
@@ -136,6 +139,18 @@ pub(crate) fn normalize_spdx_declared_license(
         normalized,
         DeclaredLicenseMatchMetadata::single_line(statement),
     )
+}
+
+/// Resolve a declared license statement through the curated declared-license
+/// alias table (`resources/license_detection/declared_license_aliases.toml`).
+///
+/// This is applied only to bounded, trustworthy declared license fields — never
+/// to file content — so bare informal names that would be unsafe as license
+/// index rules (e.g. `"Apache"`, `"Python"`) resolve safely here.
+fn resolve_declared_license_alias(statement: &str) -> Option<NormalizedDeclaredLicense> {
+    let expression = declared_license_alias(statement)?;
+    let engine = parser_license_engine()?;
+    normalize_license_key(expression, engine.index())
 }
 
 /// Runs free-text license detection over `text` and shapes the result into
@@ -312,7 +327,7 @@ pub(crate) fn normalize_declared_license_key(key: &str) -> Option<NormalizedDecl
     }
 
     let engine = parser_license_engine()?;
-    normalize_license_key(key, engine.index())
+    normalize_license_key(key, engine.index()).or_else(|| resolve_declared_license_alias(key))
 }
 
 pub(crate) fn combine_normalized_licenses(
@@ -1960,6 +1975,34 @@ mod tests {
                 declared_spdx.is_none(),
                 "{statement:?} -> {declared_spdx:?}"
             );
+        }
+    }
+
+    #[test]
+    fn test_bare_informal_declared_names_resolve_via_alias() {
+        // Bare, non-SPDX declared license names map through the curated alias
+        // table (resources/license_detection/declared_license_aliases.toml).
+        // This path is declared-field-only and never touches file content.
+        for (statement, expr) in [
+            ("Apache", "apache-2.0"),
+            ("apache", "apache-2.0"),
+            ("Boost", "boost-1.0"),
+            ("PSF", "python"),
+            ("Python", "python"),
+        ] {
+            let (declared, declared_spdx) = declared_for(statement);
+            assert_eq!(declared.as_deref(), Some(expr), "{statement:?}");
+            assert!(declared_spdx.is_some(), "{statement:?} spdx missing");
+        }
+    }
+
+    #[test]
+    fn test_ambiguous_bare_names_are_not_force_aliased() {
+        // Deliberately-excluded version-ambiguous names must not be mapped by
+        // the alias table — an honest null beats a guessed version.
+        for statement in ["MPL", "EPL", "CDDL"] {
+            let (declared, _) = declared_for(statement);
+            assert!(declared.is_none(), "{statement:?} -> {declared:?}");
         }
     }
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -115,6 +115,7 @@ mod dart_scan_test;
 #[cfg(test)]
 mod dart_test;
 mod debian;
+mod declared_license_aliases;
 mod deno;
 mod deno_lock;
 #[cfg(test)]

--- a/testdata/readme-golden/chromium/basic/README.chromium.expected.json
+++ b/testdata/readme-golden/chromium/basic/README.chromium.expected.json
@@ -23,9 +23,32 @@
     "vcs_url": null,
     "copyright": null,
     "holder": null,
-    "declared_license_expression": null,
-    "declared_license_expression_spdx": null,
-    "license_detections": [],
+    "declared_license_expression": "apache-2.0",
+    "declared_license_expression_spdx": "Apache-2.0",
+    "license_detections": [
+      {
+        "license_expression": "apache-2.0",
+        "license_expression_spdx": "Apache-2.0",
+        "matches": [
+          {
+            "license_expression": "apache-2.0",
+            "license_expression_spdx": "Apache-2.0",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "parser-declared-license",
+            "rule_url": null,
+            "matched_text": "Apache"
+          }
+        ],
+        "identifier": null
+      }
+    ],
     "other_license_expression": null,
     "other_license_expression_spdx": null,
     "other_license_detections": [],


### PR DESCRIPTION
## Summary

Adds a curated, config-driven **declared-license name alias** so package manifests that declare a bare, informal (non-SPDX) license name get a normalized `declared_license_expression`, matching ScanCode — with **zero file-content risk**.

This supersedes #1127 (closed). Probing showed the overlay/clue-rule path is the wrong mechanism: anything in the license index also matches file content, so bare-word rules either fragment a license's own notice (Apache, Boost) or false-positive on common words (e.g. the language word "Python" injected a bogus `python` license into an Apache-licensed package — caught by the post-processing golden). The fix is to map these names **only** in the bounded, trusted declared-license field, never in file content — which is how ScanCode itself normalizes declared license fields, separately from its detector.

## Mechanism

- Aliases live in a checked-in config, **not** in code: `resources/license_detection/declared_license_aliases.toml`. Each entry has `names`, an `expression` (canonical license key), and a **required `reason`** justifying why the mapping is safe and correct — so the curation is transparent and reviewable (mirrors the `index_build_policy.toml` style). A test enforces that every entry carries a substantive reason.
- `src/parsers/declared_license_aliases.rs` loads/indexes it (`include_str!` + `toml`, like `build_policy.rs`).
- `normalize_spdx_declared_license` / `normalize_declared_license_key` consult the alias **only after** SPDX parsing fails, then route the canonical key through the existing `normalize_license_key` to produce both scancode + SPDX forms. Matching is exact, case-insensitive — never substring/fuzzy.

## Names included (with real cases)

| declared name(s) | → expression | why |
|---|---|---|
| `Apache` | `apache-2.0` | SPDX deprecated bare `Apache` toward Apache-2.0; ScanCode agrees. (apache/hadoop hadoop-yarn-ui package.json) |
| `Boost` | `boost-1.0` | Boost ships one license (BSL-1.0). (pyodide libboost) |
| `PSF`, `Python` | `python` | PSF License (SPDX Python-2.0); ScanCode maps the PSF family to `python`. (pyodide conda metadata) — safe *only* because declared-field-only. |

**Deliberately excluded** (honest null beats a guessed version), documented in the config: `LGPL`/`MPL`/`EPL`/`CDDL` (version-ambiguous, no dominant default); `BSD`/`GPL` (already handled as clue-only index rules, where the bare word in file content is reliably a license reference).

## Why this is safe (no file-content impact)

The alias is consulted only in declared-license normalization, never by the license engine/index:
- `license_detection_golden`: **21/21 unchanged** — the engine is untouched.
- `post_processing_golden`: **21/21 pass**, including the `use_holder_from_package_resource` summary fixture (an Apache-licensed Python package) that the clue-rule approach broke — it stays correct because the alias never sees the file-content word "Python".

## Tests

- `declared_license_aliases.rs`: loading, case-insensitivity, excluded names, and the reason-required transparency check.
- `license_normalization.rs`: `Apache`/`Boost`/`PSF`/`Python` resolve end-to-end via the shared declared path; `MPL`/`EPL`/`CDDL` stay null.
- Golden: `testdata/readme-golden/chromium/basic` README.chromium declares bare `License: Apache` → now correctly `apache-2.0` (regenerated; the only golden change, a strict improvement).

## Issues

- Fixes the bare-`Apache` declared-license gap first seen in the M5 benchmark triage (apache/hadoop), recurring in conda (pyodide) — see closed #1127 for the dead-end overlay approach.

## How to verify

- `cargo test --lib declared_license_aliases` and the `license_normalization` alias tests.
- `cargo test --features golden-tests --test post_processing_golden` / `--test license_detection_golden` (both unchanged) and `--test parsers_golden` (only the chromium README improvement).

## Expected-output fixture changes

- One: `testdata/readme-golden/chromium/basic/README.chromium.expected.json` — `declared_license_expression` null → `apache-2.0` (the package declares bare `Apache`). Correct improvement, regenerated via `update-parser-golden`.
