### PR TITLE
fix(parsers): bail to honest null on unresolved R license alternatives

### DIFF
--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -512,13 +512,25 @@ fn normalize_r_declared_license(
     }
 
     // `|` separates OR alternatives. Each alternative may carry a `+ file <NAME>`
-    // (or be a bare `file <NAME>`) clause that is dropped.
-    let normalized: Vec<NormalizedDeclaredLicense> = statement
+    // (or be a bare `file <NAME>`) clause that is dropped. A pure `file <NAME>`
+    // alternative yields no license core and is skipped.
+    let cores: Vec<String> = statement
         .split('|')
         .capped("R License alternatives")
         .filter_map(strip_supplementary_file_clause)
-        .filter_map(normalize_r_license_core)
         .collect();
+
+    // Every remaining license core must normalize. If any real alternative does
+    // not (e.g. a version-range form this idiom layer does not expand, as in
+    // `GPL-2 | GPL (>= 3)`), bail to an honest null via the shared path rather
+    // than silently dropping that alternative and emitting a misleading partial.
+    let mut normalized: Vec<NormalizedDeclaredLicense> = Vec::with_capacity(cores.len());
+    for core in cores {
+        let Some(license) = normalize_r_license_core(core) else {
+            return empty_license_data();
+        };
+        normalized.push(license);
+    }
 
     if normalized.is_empty() {
         return empty_license_data();
@@ -539,11 +551,11 @@ fn normalize_r_declared_license(
 /// separator (`|`), a supplementary `file` clause, or an underscore BSD
 /// spelling.
 fn has_r_license_idiom(statement: &str) -> bool {
+    if statement.contains('|') {
+        return true;
+    }
     let lower = statement.to_ascii_lowercase();
-    statement.contains('|')
-        || lower.contains("file ")
-        || lower.contains("bsd_3_clause")
-        || lower.contains("bsd_2_clause")
+    lower.contains("file ") || lower.contains("bsd_3_clause") || lower.contains("bsd_2_clause")
 }
 
 /// Drops a trailing `+ file <NAME>` supplementary-file clause from one

--- a/src/parsers/cran.rs
+++ b/src/parsers/cran.rs
@@ -497,9 +497,10 @@ fn create_package_url(name: &Option<String>, version: &Option<String>) -> Option
 /// parse. When the statement carries no R-specific idiom (e.g. a bare `GPL` or a
 /// version-range `GPL (>= 3)`), this returns empty data so the statement falls
 /// through to the shared post-extraction populate step, which already resolves
-/// those forms. It is deliberately conservative: an alternative that does not
-/// resolve to a known license is dropped, and if no alternative resolves the
-/// whole statement is left unset rather than guessed.
+/// those forms. It is deliberately conservative: a pure `+ file <NAME>` pointer
+/// is skipped, but if any real license alternative cannot be resolved (e.g. a
+/// version-range form like `GPL (>= 3)` mixed with `|`), the whole statement is
+/// left unset rather than emitting a partial that silently drops an operand.
 fn normalize_r_declared_license(
     statement: Option<&str>,
 ) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
@@ -512,20 +513,19 @@ fn normalize_r_declared_license(
     }
 
     // `|` separates OR alternatives. Each alternative may carry a `+ file <NAME>`
-    // (or be a bare `file <NAME>`) clause that is dropped. A pure `file <NAME>`
+    // (or be a bare `file <NAME>`) clause that is dropped; a pure `file <NAME>`
     // alternative yields no license core and is skipped.
-    let cores: Vec<String> = statement
-        .split('|')
-        .capped("R License alternatives")
-        .filter_map(strip_supplementary_file_clause)
-        .collect();
-
+    //
     // Every remaining license core must normalize. If any real alternative does
     // not (e.g. a version-range form this idiom layer does not expand, as in
     // `GPL-2 | GPL (>= 3)`), bail to an honest null via the shared path rather
     // than silently dropping that alternative and emitting a misleading partial.
-    let mut normalized: Vec<NormalizedDeclaredLicense> = Vec::with_capacity(cores.len());
-    for core in cores {
+    let mut normalized: Vec<NormalizedDeclaredLicense> = Vec::new();
+    for core in statement
+        .split('|')
+        .capped("R License alternatives")
+        .filter_map(strip_supplementary_file_clause)
+    {
         let Some(license) = normalize_r_license_core(core) else {
             return empty_license_data();
         };

--- a/src/parsers/cran_test.rs
+++ b/src/parsers/cran_test.rs
@@ -428,4 +428,15 @@ mod tests {
         assert_eq!(declared.as_deref(), Some("mit"));
         assert_eq!(declared_spdx.as_deref(), Some("MIT"));
     }
+
+    #[test]
+    fn test_license_mixed_concrete_and_version_range_alternative_is_null() {
+        // Regression: a `|` mix of a concrete-version idiom (`GPL-2`) and a
+        // version-range form (`GPL (>= 3)`) the R layer cannot expand must yield
+        // an honest null, not a partial `gpl-2.0` that silently drops the second
+        // operand.
+        let (declared, declared_spdx) = declared_license_for("GPL-2 | GPL (>= 3)");
+        assert_eq!(declared, None, "got {declared:?}");
+        assert_eq!(declared_spdx, None, "got {declared_spdx:?}");
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the two Greptile P2 findings from #1126 (R DESCRIPTION license idiom support):

1. **Silent drop of an alternative in mixed `|` expressions (correctness).** `normalize_r_declared_license` used `.filter_map(normalize_r_license_core)`, which silently discarded any `|` alternative the R idiom layer couldn't expand. For `"GPL-2 | GPL (>= 3)"` it kept only `gpl-2.0` and dropped the `GPL (>= 3)` operand, emitting a misleading partial. Now every real license core must normalize; if any doesn't, the R layer bails to an honest null and defers to the shared path — matching the existing "honest null over partial" contract (`test_compound_version_range_statement_is_null`). Pure `+ file <NAME>` / bare `file <NAME>` pointers are still correctly skipped.

2. **Wasted allocation (perf nit).** `has_r_license_idiom` allocated a lowercased copy before the short-circuiting `|` check (the most common trigger). The `|` check now runs first, allocating only when needed.

## Tests

- New `test_license_mixed_concrete_and_version_range_alternative_is_null`: `"GPL-2 | GPL (>= 3)"` → null (not a partial `gpl-2.0`).
- All existing cran idiom tests unchanged and passing (`GPL-2 | GPL-3` → `gpl-2.0 OR gpl-3.0`, `MIT + file LICENSE` → `mit`, `GPL (>= 2)` → `gpl-2.0-plus`, etc.). `cargo test --lib cran` = 18 passed.

## Issues

- Follow-up to #1126 (Greptile P2s).

## How to verify

- `cargo test --lib cran`.

## Expected-output fixture changes

- None.
