### PR TITLE
docs(benchmarks): re-measure ten more M1 targets on M5 (batch 3)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 220 of 220 recorded runs, with a **15.0× median speedup** and **15.3× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
+> Provenant is faster on 220 of 220 recorded runs, with a **15.7× median speedup** and **15.5× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -257,11 +257,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.52s`; ScanCode `107.21s`
 - Direct CRAN package visibility on the root `DESCRIPTION` plus declared dependency extraction (`29` vs `0`) across `Depends`, `Imports`, `Suggests`, `Enhances`, and `LinkingTo`, with cleaner Rd or markdown URL normalization and preserved shipped license-holder metadata
 
-##### [tidyverse/ggplot2 @ 7d79c95](https://github.com/tidyverse/ggplot2/tree/7d79c956b5707cb7c762d834caf842dc6496b032) — **12.33× faster**
+##### [tidyverse/ggplot2 @ 7d79c95](https://github.com/tidyverse/ggplot2/tree/7d79c956b5707cb7c762d834caf842dc6496b032) — **17.82× faster**
 
 - Files: 1,154
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `14.46s`; ScanCode `178.35s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.59s`; ScanCode `117.46s`
 - Direct CRAN package visibility on the root `DESCRIPTION` plus declared dependency extraction (`41` vs `0`) across `Imports`, `Suggests`, and `Enhances`, with correct hyphenated CRAN version constraints such as `sf (>= 0.7-3)` and cleaner Rd or roxygen URL recovery
 
 #### Hugging Face / AI model repositories
@@ -308,11 +308,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.49s`; ScanCode `78.97s`
 - Direct Hex package visibility on the repo-root, `installer/mix.lock`, and `integration_test/mix.lock` surfaces (`3` vs `0` file-level package records), while preserving top-level package and dependency parity elsewhere and preserving structured npm party metadata
 
-##### [processone/ejabberd @ 87475d8](https://github.com/processone/ejabberd/tree/87475d813b974492f338720eab5c9c3d4646a4ce) — **12.80× faster**
+##### [processone/ejabberd @ 87475d8](https://github.com/processone/ejabberd/tree/87475d813b974492f338720eab5c9c3d4646a4ce) — **15.15× faster**
 
 - Files: 623
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `16.74s`; ScanCode `214.30s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.01s`; ScanCode `121.38s`
 - Broader Erlang/Rebar package and dependency extraction (`2` vs `1` packages, `43` vs `3` dependencies) from the root `rebar.config`, `rebar.lock`, nested `_checkouts/configure_deps` manifests, and committed Dockerfiles, with the bundled `priv/mod_invites/copyright` notice kept as clue-level license evidence instead of being overstated as Debian package metadata
 
 ##### [vernemq/vernemq @ 4681e54](https://github.com/vernemq/vernemq/tree/4681e5490cc42e6cc26a504bb4b3c5413315c21f) — **14.07× faster**
@@ -366,11 +366,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.74s`; ScanCode `45.20s`
 - Broader mixed Docker/npm/Python package extraction (`2` vs `1` packages, `111` vs `0` dependencies) from the integration-test `package-lock.json`, `uv.lock`, and committed service Dockerfiles, plus the more specific `Apache-2.0 AND FSL-1.1-ALv2` license classification on `LICENSE.md` where ScanCode reports only `FSL-1.1-ALv2`
 
-##### [iTowns/itowns @ 08e08f5](https://github.com/iTowns/itowns/tree/08e08f512983b6f3d60d04d431b67b3c5e2e1584) — **13.58× faster**
+##### [iTowns/itowns @ 08e08f5](https://github.com/iTowns/itowns/tree/08e08f512983b6f3d60d04d431b67b3c5e2e1584) — **19.11× faster**
 
 - Files: 616
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `12.53s`; ScanCode `170.19s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.99s`; ScanCode `114.48s`
 - Direct `publiccode.yml` package visibility on the root metadata file (`1` vs `0` on that file), with matched top-level package and dependency counts elsewhere plus Unicode-preserving Potree copyright normalization and cleaner URL shaping across README and docs material
 
 ##### [jashkenas/backbone @ da75718](https://github.com/jashkenas/backbone/tree/da75718e896e52e84aa1f0411ba67fafcdcf6af3) — **12.27× faster**
@@ -629,11 +629,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.85s`; ScanCode `83.67s`
 - Richer and cleaner serialization notice recovery across headers, tests, and legacy HTML docs, with multi-person codecvt attribution that preserves both Ronald Garcia and Andrew Lumsdaine, `Peter Dimov` author attribution on `test/test_mi.cpp`, fuller `Joaquin M Lopez Munoz` identity capture, and Unicode-preserving `René Ferdinand Rivera Morell` normalization
 
-##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **15.10× faster**
+##### [catchorg/Catch2 @ 10f6248](https://github.com/catchorg/Catch2/tree/10f62484bff73e3a58a411e2e10b4e1c13cfba9f) — **19.71× faster**
 
 - Files: 576
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `14.57s`; ScanCode `219.94s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.14s`; ScanCode `121.03s`
 - Broader Conan, Meson, and Bazel package visibility (`2` vs `1` packages, `3` vs `0` dependencies) from the root `conanfile.py`, `MODULE.bazel`, and committed `meson.build` manifests, with the local `LICENSE` notice in `.conan/test_package/conanfile.py` collapsed to plain `BSL-1.0` instead of ScanCode's extra unknown-reference placeholder
 
 ##### [chriskohlhoff/asio @ bd500f0](https://github.com/chriskohlhoff/asio/tree/bd500f0a018db9a845ebaaed5c0318343ae9f497) — **17.58× faster**
@@ -727,11 +727,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `60.60s`; ScanCode `812.80s`
 - Matched ScanCode's file-level Autotools `configure` package identity while also promoting one top-level Autotools package (`1` vs `0`), plus cleaner clue-only handling of weak `configure` variable-name and bare-word GPL noise such as `EXTERNAL_LIBRARY_GPL_LIST` and `LICENSE_LIST="gpl"`
 
-##### [fmtlib/fmt @ 2cb3983](https://github.com/fmtlib/fmt/tree/2cb39832132a5c56a802bc817179e85d5f32fb9c) — **13.15× faster**
+##### [fmtlib/fmt @ 2cb3983](https://github.com/fmtlib/fmt/tree/2cb39832132a5c56a802bc817179e85d5f32fb9c) — **13.57× faster**
 
 - Files: 133
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `11.99s`; ScanCode `157.63s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.60s`; ScanCode `76.01s`
 - Matched package and dependency parity (`0` packages, `1` dependency) while collapsing the local `LICENSE-MIT` notice in `support/docopt.py` to plain `MIT`, with cleaner copyright normalization on mkdocstrings support code and consistent URL normalization across README and docs
 
 ##### [git/git @ 9f223ef](https://github.com/git/git/tree/9f223ef1c026d91c7ac68cc0211bde255dda6199) — **42.67× faster**
@@ -888,11 +888,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `13.31s`; ScanCode `112.67s`
 - Broader Go module and RPM spec dependency extraction (`2` vs `1` packages, `352` vs `348` dependencies) from `go.mod`/`go.sum` plus `contrib/restic.spec`, with correct `rpm_specfile` datasource spelling and valid RPM purl construction where ScanCode emits a typo (`rpm_spefile`) and null purl, cleaner `BSD-2-Clause` detection without ScanCode's low-relevance `unknown-license-reference` false positive on README.md, extra Docker package visibility on `docker/Dockerfile`, and correct rejection of `sftp.X` Go-identifier URLs, `dnf copr` copyright noise, and bash `${var[@]}` array-expansion copyright artifacts
 
-##### [rpm-software-management/dnf @ e47634f](https://github.com/rpm-software-management/dnf/tree/e47634fbe3565d0580e89ec21adb7c1b308642ce) — **14.16× faster**
+##### [rpm-software-management/dnf @ e47634f](https://github.com/rpm-software-management/dnf/tree/e47634fbe3565d0580e89ec21adb7c1b308642ce) — **18.95× faster**
 
 - Files: 655
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `14.37s`; ScanCode `203.47s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.87s`; ScanCode `130.21s`
 - Broader RPM package and dependency extraction (`163` vs `138` packages, `579` vs `1` dependencies) from committed `.rpm` fixtures and sibling `.spec` metadata, with normalized RPM header license expressions and one-package-per-spec ownership across the shipped module fixture trees
 
 ##### [rpm-software-management/libdnf @ d395731](https://github.com/rpm-software-management/libdnf/tree/d39573195e24b43687587a8d83b9f6ac274e2412) — **12.33× faster**
@@ -1002,11 +1002,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.71s`; ScanCode `175.16s`
 - Matched top-level CocoaPods package coverage (`1` vs `1`) and main podspec/license parity, with slightly richer dependency extraction (`56` vs `54`) from the root `Gemfile`
 
-##### [Carthage/Carthage @ e33e133](https://github.com/Carthage/Carthage/tree/e33e133a5427129b38bfb1ae18d8f56b29a93204) — **12.22× faster**
+##### [Carthage/Carthage @ e33e133](https://github.com/Carthage/Carthage/tree/e33e133a5427129b38bfb1ae18d8f56b29a93204) — **14.41× faster**
 
 - Files: 183
-- Run context: 2026-04-20 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `10.76s`; ScanCode `131.47s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.94s`; ScanCode `71.21s`
 - Matched top-level package coverage (`9` vs `9`) with direct Carthage manifest visibility and hoisted declared or pinned dependency extraction (`20` vs `0`) from committed `Cartfile`, `Cartfile.private`, and `Cartfile.resolved`, plus safer `Package.resolved` modeling as one resolved-file package record with structured pinned dependencies instead of exploded duplicate pseudo-packages
 
 ##### [facebook/react-native @ 179e0cd](https://github.com/facebook/react-native/tree/179e0cdef68d12249a5a13b975a82f72bca7f368) — **15.08× faster**
@@ -1144,11 +1144,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `54.99s`; ScanCode `1313.69s`
 - Broader mixed-repository package and dependency extraction (`45` vs `1` packages, `3607` vs `80` dependencies) from `cmake/vcpkg.json` plus committed `cmake/vcpkg-ports/*/vcpkg.json` manifests, with the large `package-lock.json` license-count gap reduced with any residual license delta concentrated in ONNX model fixtures that still stay scan-error-free and explicit vcpkg package identities where ScanCode stays manifest-blind
 
-##### [microsoft/regorus @ 7f42115](https://github.com/microsoft/regorus/tree/7f42115b6338999efd13916e89b81ac278bc6273) — **13.37× faster**
+##### [microsoft/regorus @ 7f42115](https://github.com/microsoft/regorus/tree/7f42115b6338999efd13916e89b81ac278bc6273) — **21.39× faster**
 
 - Files: 1,121
-- Run context: 2026-04-30 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `16.29s`; ScanCode `217.76s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.45s`; ScanCode `137.98s`
 - Broader mixed Rust/.NET/Ruby package and dependency extraction (`19` vs `14` packages, `1253` vs `1238` dependencies) across committed `bindings/csharp/Directory.Packages.props`, consumer `*.csproj`, and Ruby sidecar manifests, with resolved `Microsoft.Regorus` central package version `0.9.1` propagated from same-file property composition instead of leaving the CPM expression unresolved
 
 ##### [microsoft/terminal @ 84ae7ad](https://github.com/microsoft/terminal/tree/84ae7adec6b3975314d8ca73d8f0bf2128ae59e2) — **14.55× faster**
@@ -1246,11 +1246,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.40s`; ScanCode `95.91s`
 - Far broader Hackage package and dependency extraction (`76` vs `1` packages, `525` vs `4` dependencies) from the root `stack.cabal`, `stack.yaml`, `cabal.project`, and committed integration-fixture manifests, with richer maintainer identity on Cabal metadata
 
-##### [HaxeFlixel/flixel @ ec54c5a](https://github.com/HaxeFlixel/flixel/tree/ec54c5a582b252de3aca69283045719d3201778b) — **12.66× faster**
+##### [HaxeFlixel/flixel @ ec54c5a](https://github.com/HaxeFlixel/flixel/tree/ec54c5a582b252de3aca69283045719d3201778b) — **17.08× faster**
 
 - Files: 446
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.70s`; ScanCode `135.43s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.22s`; ScanCode `89.17s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with compound `LicenseRef-scancode-public-domain AND OFL-1.1` font licensing on `assets/fonts/monsterrat.ttf` instead of split duplicate detections and cleaner URL normalization across docs and snippets
 
 ##### [HeapsIO/heaps @ d2992b0](https://github.com/HeapsIO/heaps/tree/d2992b061db3f51b47cdb87c39d659a5bb96dd83) — **15.91× faster**
@@ -1337,11 +1337,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `31.93s`; ScanCode `656.13s`
 - Direct opam package visibility (`1` vs `0` packages) with broader dependency extraction (`27` vs `24`) from the repo-root `merlin*.opam`, `dot-merlin-reader.opam`, `ocaml-index.opam`, and `flake.lock` surfaces, plus Unicode-preserving copyright normalization across the Merlin source tree
 
-##### [ocaml/ocaml-lsp @ 788ff73](https://github.com/ocaml/ocaml-lsp/tree/788ff738991189537141776bfa07652547bff9c4) — **13.40× faster**
+##### [ocaml/ocaml-lsp @ 788ff73](https://github.com/ocaml/ocaml-lsp/tree/788ff738991189537141776bfa07652547bff9c4) — **17.13× faster**
 
 - Files: 546
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `13.83s`; ScanCode `185.33s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.79s`; ScanCode `99.19s`
 - Broader opam package visibility (`3` vs `1` packages) with slightly richer dependency extraction (`380` vs `376`) from the root and submodule `.opam` manifests plus `flake.lock`, with cleaner maintainer and email recovery on opam metadata and Unicode-preserving copyright normalization
 
 ##### [openfl/openfl @ 74d8f72](https://github.com/openfl/openfl/tree/74d8f72890b9ae70bba589d034ea35b86588e548) — **16.94× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -221,9 +221,9 @@ ScanCode: 61.74s</title></rect>
     <rect x="426.88" y="447.92" width="8" height="8" fill="#d97706" rx="1.5"><title>getsentry/self-hosted @ 8728919
 Files: 129
 ScanCode: 45.20s</title></rect>
-    <rect x="428.98" y="388.90" width="8" height="8" fill="#d97706" rx="1.5"><title>fmtlib/fmt @ 2cb3983
+    <rect x="428.98" y="423.36" width="8" height="8" fill="#d97706" rx="1.5"><title>fmtlib/fmt @ 2cb3983
 Files: 133
-ScanCode: 157.63s</title></rect>
+ScanCode: 76.01s</title></rect>
     <rect x="439.98" y="442.51" width="8" height="8" fill="#d97706" rx="1.5"><title>MaxRev-Dev/gdal.netcore @ 6cc0145
 Files: 156
 ScanCode: 50.68s</title></rect>
@@ -233,9 +233,9 @@ ScanCode: 65.75s</title></rect>
     <rect x="441.29" y="385.10" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
 Files: 159
 ScanCode: 170.82s</title></rect>
-    <rect x="450.98" y="397.47" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
+    <rect x="450.98" y="426.44" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
 Files: 183
-ScanCode: 131.47s</title></rect>
+ScanCode: 71.21s</title></rect>
     <rect x="460.46" y="439.32" width="8" height="8" fill="#d97706" rx="1.5"><title>AFNetworking/AFNetworking @ d9f589c
 Files: 210
 ScanCode: 54.22s</title></rect>
@@ -296,9 +296,9 @@ ScanCode: 62.68s</title></rect>
     <rect x="511.58" y="417.47" width="8" height="8" fill="#d97706" rx="1.5"><title>vernemq/vernemq @ 4681e54
 Files: 441
 ScanCode: 86.10s</title></rect>
-    <rect x="512.36" y="396.07" width="8" height="8" fill="#d97706" rx="1.5"><title>HaxeFlixel/flixel @ ec54c5a
+    <rect x="512.36" y="415.82" width="8" height="8" fill="#d97706" rx="1.5"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
-ScanCode: 135.43s</title></rect>
+ScanCode: 89.17s</title></rect>
     <rect x="514.79" y="407.11" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
 ScanCode: 107.21s</title></rect>
@@ -323,33 +323,33 @@ ScanCode: 80.78s</title></rect>
     <rect x="525.67" y="418.82" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/serialization @ 097a6c6
 Files: 541
 ScanCode: 83.67s</title></rect>
-    <rect x="526.30" y="381.25" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
+    <rect x="526.30" y="410.78" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
-ScanCode: 185.33s</title></rect>
+ScanCode: 99.19s</title></rect>
     <rect x="528.90" y="383.91" width="8" height="8" fill="#d97706" rx="1.5"><title>Alamofire/Alamofire @ ac01666
 Files: 567
 ScanCode: 175.16s</title></rect>
     <rect x="528.90" y="389.48" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/fresh @ 49c4be1
 Files: 567
 ScanCode: 155.71s</title></rect>
-    <rect x="529.99" y="373.16" width="8" height="8" fill="#d97706" rx="1.5"><title>catchorg/Catch2 @ 10f6248
+    <rect x="529.99" y="401.38" width="8" height="8" fill="#d97706" rx="1.5"><title>catchorg/Catch2 @ 10f6248
 Files: 576
-ScanCode: 219.94s</title></rect>
+ScanCode: 121.03s</title></rect>
     <rect x="531.64" y="376.71" width="8" height="8" fill="#d97706" rx="1.5"><title>i18next/react-i18next @ cb20d18
 Files: 590
 ScanCode: 204.00s</title></rect>
-    <rect x="534.61" y="385.27" width="8" height="8" fill="#d97706" rx="1.5"><title>iTowns/itowns @ 08e08f5
+    <rect x="534.61" y="404.01" width="8" height="8" fill="#d97706" rx="1.5"><title>iTowns/itowns @ 08e08f5
 Files: 616
-ScanCode: 170.19s</title></rect>
-    <rect x="535.39" y="374.38" width="8" height="8" fill="#d97706" rx="1.5"><title>processone/ejabberd @ 87475d8
+ScanCode: 114.48s</title></rect>
+    <rect x="535.39" y="401.24" width="8" height="8" fill="#d97706" rx="1.5"><title>processone/ejabberd @ 87475d8
 Files: 623
-ScanCode: 214.30s</title></rect>
+ScanCode: 121.38s</title></rect>
     <rect x="537.57" y="381.59" width="8" height="8" fill="#d97706" rx="1.5"><title>Apache Tomcat 10.1.52 extracted release snapshot
 Files: 643
 ScanCode: 184.01s</title></rect>
-    <rect x="538.84" y="376.84" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/dnf @ e47634f
+    <rect x="538.84" y="397.93" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/dnf @ e47634f
 Files: 655
-ScanCode: 203.47s</title></rect>
+ScanCode: 130.21s</title></rect>
     <rect x="539.99" y="385.56" width="8" height="8" fill="#d97706" rx="1.5"><title>HeapsIO/heaps @ d2992b0
 Files: 666
 ScanCode: 169.15s</title></rect>
@@ -398,12 +398,12 @@ ScanCode: 303.29s</title></rect>
     <rect x="574.44" y="417.69" width="8" height="8" fill="#d97706" rx="1.5"><title>pointfreeco/swift-composable-architecture @ 7517cc3
 Files: 1098
 ScanCode: 85.71s</title></rect>
-    <rect x="575.87" y="373.63" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/regorus @ 7f42115
+    <rect x="575.87" y="395.19" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/regorus @ 7f42115
 Files: 1121
-ScanCode: 217.76s</title></rect>
-    <rect x="577.87" y="383.06" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/ggplot2 @ 7d79c95
+ScanCode: 137.98s</title></rect>
+    <rect x="577.87" y="402.80" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
-ScanCode: 178.35s</title></rect>
+ScanCode: 117.46s</title></rect>
     <rect x="578.35" y="385.81" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
 ScanCode: 168.27s</title></rect>
@@ -883,9 +883,9 @@ Provenant: 5.03s</title></circle>
     <circle cx="430.88" cy="558.48" r="4.5" fill="#2563eb"><title>getsentry/self-hosted @ 8728919
 Files: 129
 Provenant: 4.74s</title></circle>
-    <circle cx="432.98" cy="514.62" r="4.5" fill="#2563eb"><title>fmtlib/fmt @ 2cb3983
+    <circle cx="432.98" cy="550.60" r="4.5" fill="#2563eb"><title>fmtlib/fmt @ 2cb3983
 Files: 133
-Provenant: 11.99s</title></circle>
+Provenant: 5.60s</title></circle>
     <circle cx="443.98" cy="557.98" r="4.5" fill="#2563eb"><title>MaxRev-Dev/gdal.netcore @ 6cc0145
 Files: 156
 Provenant: 4.79s</title></circle>
@@ -895,9 +895,9 @@ Provenant: 4.85s</title></circle>
     <circle cx="445.29" cy="519.13" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
 Files: 159
 Provenant: 10.90s</title></circle>
-    <circle cx="454.98" cy="519.74" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
+    <circle cx="454.98" cy="556.52" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
 Files: 183
-Provenant: 10.76s</title></circle>
+Provenant: 4.94s</title></circle>
     <circle cx="464.46" cy="554.37" r="4.5" fill="#2563eb"><title>AFNetworking/AFNetworking @ d9f589c
 Files: 210
 Provenant: 5.17s</title></circle>
@@ -958,9 +958,9 @@ Provenant: 4.88s</title></circle>
     <circle cx="515.58" cy="546.40" r="4.5" fill="#2563eb"><title>vernemq/vernemq @ 4681e54
 Files: 441
 Provenant: 6.12s</title></circle>
-    <circle cx="516.36" cy="520.00" r="4.5" fill="#2563eb"><title>HaxeFlixel/flixel @ ec54c5a
+    <circle cx="516.36" cy="553.92" r="4.5" fill="#2563eb"><title>HaxeFlixel/flixel @ ec54c5a
 Files: 446
-Provenant: 10.70s</title></circle>
+Provenant: 5.22s</title></circle>
     <circle cx="518.79" cy="551.28" r="4.5" fill="#2563eb"><title>tidyverse/dplyr @ 2f9f49e
 Files: 462
 Provenant: 5.52s</title></circle>
@@ -985,33 +985,33 @@ Provenant: 5.67s</title></circle>
     <circle cx="529.67" cy="548.53" r="4.5" fill="#2563eb"><title>boostorg/serialization @ 097a6c6
 Files: 541
 Provenant: 5.85s</title></circle>
-    <circle cx="530.30" cy="507.88" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
+    <circle cx="530.30" cy="549.02" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
-Provenant: 13.83s</title></circle>
+Provenant: 5.79s</title></circle>
     <circle cx="532.90" cy="504.96" r="4.5" fill="#2563eb"><title>Alamofire/Alamofire @ ac01666
 Files: 567
 Provenant: 14.71s</title></circle>
     <circle cx="532.90" cy="509.65" r="4.5" fill="#2563eb"><title>denoland/fresh @ 49c4be1
 Files: 567
 Provenant: 13.32s</title></circle>
-    <circle cx="533.99" cy="505.42" r="4.5" fill="#2563eb"><title>catchorg/Catch2 @ 10f6248
+    <circle cx="533.99" cy="546.25" r="4.5" fill="#2563eb"><title>catchorg/Catch2 @ 10f6248
 Files: 576
-Provenant: 14.57s</title></circle>
+Provenant: 6.14s</title></circle>
     <circle cx="535.64" cy="504.61" r="4.5" fill="#2563eb"><title>i18next/react-i18next @ cb20d18
 Files: 590
 Provenant: 14.82s</title></circle>
-    <circle cx="538.61" cy="512.54" r="4.5" fill="#2563eb"><title>iTowns/itowns @ 08e08f5
+    <circle cx="538.61" cy="547.42" r="4.5" fill="#2563eb"><title>iTowns/itowns @ 08e08f5
 Files: 616
-Provenant: 12.53s</title></circle>
-    <circle cx="539.39" cy="498.86" r="4.5" fill="#2563eb"><title>processone/ejabberd @ 87475d8
+Provenant: 5.99s</title></circle>
+    <circle cx="539.39" cy="533.68" r="4.5" fill="#2563eb"><title>processone/ejabberd @ 87475d8
 Files: 623
-Provenant: 16.74s</title></circle>
+Provenant: 8.01s</title></circle>
     <circle cx="541.57" cy="497.30" r="4.5" fill="#2563eb"><title>Apache Tomcat 10.1.52 extracted release snapshot
 Files: 643
 Provenant: 17.30s</title></circle>
-    <circle cx="542.84" cy="506.07" r="4.5" fill="#2563eb"><title>rpm-software-management/dnf @ e47634f
+    <circle cx="542.84" cy="540.94" r="4.5" fill="#2563eb"><title>rpm-software-management/dnf @ e47634f
 Files: 655
-Provenant: 14.37s</title></circle>
+Provenant: 6.87s</title></circle>
     <circle cx="543.99" cy="520.31" r="4.5" fill="#2563eb"><title>HeapsIO/heaps @ d2992b0
 Files: 666
 Provenant: 10.63s</title></circle>
@@ -1060,12 +1060,12 @@ Provenant: 15.56s</title></circle>
     <circle cx="578.44" cy="554.37" r="4.5" fill="#2563eb"><title>pointfreeco/swift-composable-architecture @ 7517cc3
 Files: 1098
 Provenant: 5.17s</title></circle>
-    <circle cx="579.87" cy="500.14" r="4.5" fill="#2563eb"><title>microsoft/regorus @ 7f42115
+    <circle cx="579.87" cy="543.92" r="4.5" fill="#2563eb"><title>microsoft/regorus @ 7f42115
 Files: 1121
-Provenant: 16.29s</title></circle>
-    <circle cx="581.87" cy="505.77" r="4.5" fill="#2563eb"><title>tidyverse/ggplot2 @ 7d79c95
+Provenant: 6.45s</title></circle>
+    <circle cx="581.87" cy="542.91" r="4.5" fill="#2563eb"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
-Provenant: 14.46s</title></circle>
+Provenant: 6.59s</title></circle>
     <circle cx="582.35" cy="508.50" r="4.5" fill="#2563eb"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
 Provenant: 13.65s</title></circle>


### PR DESCRIPTION
## Summary

Batch 3 of the M1→M5 benchmark migration: ten more rows recorded on **Apple M1 Max** re-measured on the current **Apple M5 Pro** host (`compare-outputs --profile common --build-mode optimized`, fresh ScanCode, 4 proc, same-host pairs).

| target | files | PV (M1→M5) | ScanCode (M1→M5) | × (old→new) |
|---|---|---|---|---|
| Carthage/Carthage | 183 | 10.76→4.94s | 131.47→71.21s | 12.22→14.41× |
| HaxeFlixel/flixel | 446 | 10.70→5.22s | 135.43→89.17s | 12.66→17.08× |
| fmtlib/fmt | 133 | 11.99→5.60s | 157.63→76.01s | 13.15→13.57× |
| iTowns/itowns | 616 | 12.53→5.99s | 170.19→114.48s | 13.58→19.11× |
| tidyverse/ggplot2 | 1,154 | 14.46→6.59s | 178.35→117.46s | 12.33→17.82× |
| ocaml/ocaml-lsp | 546 | 13.83→5.79s | 185.33→99.19s | 13.40→17.13× |
| rpm-software-management/dnf | 655 | 14.37→6.87s | 203.47→130.21s | 14.16→18.95× |
| processone/ejabberd | 623 | 16.74→8.01s | 214.30→121.38s | 12.80→15.15× |
| microsoft/regorus | 1,121 | 16.29→6.45s | 217.76→137.98s | 13.37→21.39× |
| catchorg/Catch2 | 576 | 14.57→6.14s | 219.94→121.03s | 15.10→19.71× |

Headline regenerated: median **15.0→15.7×**, geomean **15.5×** (220 runs). The rise is the M5 hardware + current code applied uniformly, not a new speedup.

## Pathology triage (verify-benchmark-target skill)

All clean or Provenant-advantage:
- **ggplot2** — live confirmation of the just-merged R-idiom support (#1126): its DESCRIPTION `License: MIT + file LICENSE` now resolves to `mit` (matches ScanCode, no delta).
- **catch2** — PV emits clean `boost-1.0` where ScanCode adds `AND unknown-license-reference` noise.
- **carthage / ocaml-lsp / dnf / ejabberd / regorus** — the recurring architectural divergence: ScanCode folds co-located/file-content license detections into a package's *declared* field (e.g. `gpl-2.0 AND gpl-2.0-plus`, vendored `apache-2.0 AND bsd-new AND …`); Provenant keeps package-declared separate (cleaner) and is net far richer on file-level detection (e.g. dnf 2557 vs 232). regorus/ocaml-lsp also recover holders ScanCode misses.
- **flixel / fmt / itowns** — clean; no package-level deltas.
- No bare-name declared-license gaps in this batch.

## Issues

- Continues the M5 migration (after #1118/#1125); ~77 M1 rows remain.

## Scope and exclusions

- Included: the ten M1 repo rows above + regenerated chart/headline.
- Excluded: scanner/parser code.

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` — re-running produces no diff.
- Each row reproducible via `compare-outputs --profile common` against the pinned ref.

## Expected-output fixture changes

- None. Docs + generated chart only.
