### PR TITLE
docs(benchmarks): re-measure ten more M1 targets on M5 (batch 4)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 220 of 220 recorded runs, with a **15.7× median speedup** and **15.5× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
+> Provenant is faster on 220 of 220 recorded runs, with a **16.6× median speedup** and **15.8× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -178,11 +178,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `13.85s`; ScanCode `543.19s`
 - Far broader Python-family package and dependency extraction (`2` vs `1` packages, `16` vs `6` dependencies) because `pyproject.toml` contributes both a real PyPI root package and 5 Python dependencies while `docs/requirements.txt` adds 5 more documentation dependencies that ScanCode leaves at zero, with clearer `BSD-3-Clause` declared-license capture and visibility into the vendored CVS marker that ScanCode skips
 
-##### [OpenMDAO/OpenMDAO @ bf1fcb6](https://github.com/OpenMDAO/OpenMDAO/tree/bf1fcb6f09a07a49cdba27c2fd765153ec54694c) — **16.66× faster**
+##### [OpenMDAO/OpenMDAO @ bf1fcb6](https://github.com/OpenMDAO/OpenMDAO/tree/bf1fcb6f09a07a49cdba27c2fd765153ec54694c) — **27.03× faster**
 
 - Files: 1,199
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `17.94s`; ScanCode `298.91s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.80s`; ScanCode `210.82s`
 - Broader Pixi, Julia, and Docker package visibility (`3` vs `1` packages, `1489` vs `76` dependencies) from the root `pixi.toml`, resolved `pixi.lock`, and the experimental Julia `Project.toml`, with no `pixi.lock` scan errors where ScanCode times out and much richer lockfile license visibility
 
 ##### [pandas-dev/pandas @ c385d01](https://github.com/pandas-dev/pandas/tree/c385d0188cbfb2294fb6362ec24b514b211c7fb1) — **32.0× faster**
@@ -345,11 +345,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.02s`; ScanCode `40.69s`
 - Deno v4 lockfile dependency extraction (`37` vs `0` from `deno.lock`'s resolved `npm` and `jsr` graphs) where ScanCode is lockfile-blind, plus `deno.json` import-map package visibility and cleaner rejection of a bare-URL holder mistaken from README prose; the deno.lock parser now covers lockfile formats v1–v5 rather than v5 alone
 
-##### [denoland/fresh @ 49c4be1](https://github.com/denoland/fresh/tree/49c4be1ac60603174bad1c6e3c13bd88602c51bb) — **11.69× faster**
+##### [denoland/fresh @ 49c4be1](https://github.com/denoland/fresh/tree/49c4be1ac60603174bad1c6e3c13bd88602c51bb) — **13.61× faster**
 
 - Files: 567
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `13.32s`; ScanCode `155.71s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.70s`; ScanCode `63.97s`
 - Broader Deno package and dependency extraction (`8` vs `0` packages, `966` vs `0` dependencies) from the root `deno.json`, `deno.lock`, and nested `packages/*/deno.json` manifests, with direct JSR and npm import-map or lockfile package identity where ScanCode stays manifest-blind
 
 ##### [denoland/std @ a864f62](https://github.com/denoland/std/tree/a864f62bcc8a5f20716d2becab3cfe224a2ad810) — **24.22× faster**
@@ -387,11 +387,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `15.56s`; ScanCode `303.29s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and cleaner Unicode-preserving author normalization across locale files and vendored docs
 
-##### [lodash/lodash @ cb0b9b9](https://github.com/lodash/lodash/tree/cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e) — **15.67× faster**
+##### [lodash/lodash @ cb0b9b9](https://github.com/lodash/lodash/tree/cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e) — **20.62× faster**
 
 - Files: 159
-- Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.90s`; ScanCode `170.82s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.91s`; ScanCode `101.22s`
 - Matched npm package and dependency coverage on the repo-root `package.json` and `package-lock.json`, with source-faithful copyright recovery across `lodash.js`, `dist/lodash*.js`, and `LICENSE`, plus encoded-query URL preservation and extra Firebug asset URL visibility where ScanCode flattens or misses the underlying source text
 
 ##### [metabase/metabase @ 10997b1](https://github.com/metabase/metabase/tree/10997b10908414ab05773b085a56a37fcdebcd1a) — **25.67× faster**
@@ -536,11 +536,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `21.96s`; ScanCode `429.19s`
 - Far broader Gradle dependency extraction (`51` vs `6` dependencies) from the root multi-project `build.gradle.kts`, module-local `android/build.gradle.kts`, and `buildSrc/build.gradle.kts`, with concrete version recovery for property-backed Kotlin DSL quoted configuration calls such as `"implementation"("io.ktor:ktor-client-core:$ktorVersion")`, `"implementation"("com.badlogicgames.gdx:gdx-tools:$gdxVersion")`, and `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")` where ScanCode leaves `$kotlinVersion` / `$gdxVersion` unresolved and misses most of the centralized root build graph
 
-##### [playframework/playframework @ c2c114f](https://github.com/playframework/playframework/tree/c2c114ff31eff1557bef65cc3f586fbc53c974a6) — **18.23× faster**
+##### [playframework/playframework @ c2c114f](https://github.com/playframework/playframework/tree/c2c114ff31eff1557bef65cc3f586fbc53c974a6) — **24.01× faster**
 
 - Files: 2,579
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `14.94s`; ScanCode `272.30s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.69s`; ScanCode `160.61s`
 - Broader SBT dependency extraction (`7` vs `3`) and file-level SBT package visibility across the root build and committed `play-sbt-plugin` fixture projects, plus correct no-year copyright and holder recovery on vendored jQuery banners that ScanCode-only parity previously exposed
 
 ##### [scalatest/scalatest @ f6ba8f2](https://github.com/scalatest/scalatest/tree/f6ba8f25999f240831362cd7498ba5beee7dc375) — **17.92× faster**
@@ -860,11 +860,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `21.79s`; ScanCode `841.78s`
 - Broader package and dependency visibility (`1` vs `0` packages, `41` vs `0` dependencies) from bundled `external/perl/Text-Template-1.56` CPAN metadata plus committed `.gitmodules` and `test/quic-openssl-docker/Dockerfile` surfaces, with stronger `Written by ...` author recovery on OpenSSL-style comment headers and cleaner rejection of weak CPAL or MIT overcalls on standard OpenSSL license footers
 
-##### [pulseaudio/pulseaudio @ b096704](https://github.com/pulseaudio/pulseaudio/tree/b096704c0d42c5e784deb781a07b23cfb5286a82) — **19.16× faster**
+##### [pulseaudio/pulseaudio @ b096704](https://github.com/pulseaudio/pulseaudio/tree/b096704c0d42c5e784deb781a07b23cfb5286a82) — **29.70× faster**
 
 - Files: 867
-- Run context: 2026-05-26 · macOS 26.5 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `20.79s`; ScanCode `398.45s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.58s`; ScanCode `254.79s`
 - Broader Meson dependency visibility (`8` vs `0` top-level dependencies) from `meson.build`, more correct LGPL-2.0/LGPL-2.1 notice classification across the source and manpage trees, and cleaner rejection of placeholder `COPYRIGHT HOLDER`, contributor-tail, and code-fragment noise, with the remaining deltas concentrated in low-value translation-header placeholders and source-faithful Unicode/name rendering
 
 ##### [protocolbuffers/protobuf @ e3370c2](https://github.com/protocolbuffers/protobuf/tree/e3370c2e26bbfaa63bc9f8e4ac0f8dc066ba3eeb) — **28.62× faster**
@@ -895,11 +895,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.87s`; ScanCode `130.21s`
 - Broader RPM package and dependency extraction (`163` vs `138` packages, `579` vs `1` dependencies) from committed `.rpm` fixtures and sibling `.spec` metadata, with normalized RPM header license expressions and one-package-per-spec ownership across the shipped module fixture trees
 
-##### [rpm-software-management/libdnf @ d395731](https://github.com/rpm-software-management/libdnf/tree/d39573195e24b43687587a8d83b9f6ac274e2412) — **12.33× faster**
+##### [rpm-software-management/libdnf @ d395731](https://github.com/rpm-software-management/libdnf/tree/d39573195e24b43687587a8d83b9f6ac274e2412) — **17.41× faster**
 
 - Files: 1,162
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `13.65s`; ScanCode `168.27s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.97s`; ScanCode `103.93s`
 - Broader RPM package and dependency extraction (`352` vs `327` packages, `1441` vs `0` dependencies) from committed `.rpm` fixture trees and sibling `.spec` metadata, with normalized RPM header license expressions and cleaner rejection of config or doc false positives such as `baseurl` and `doxygen. Using` as holder or author data
 
 ##### [marshallpierce/rust-base64 @ 13f4fe8](https://github.com/marshallpierce/rust-base64/tree/13f4fe86e565b3a8ed9402d3b8b1bcf83ab9817c) — **8.98× faster**
@@ -995,11 +995,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.17s`; ScanCode `54.22s`
 - Matched top-level CocoaPods package coverage (`1` vs `1`) with broader dependency extraction (`124` vs `115`) from `AFNetworking.podspec` subspec edges and the root `Gemfile`
 
-##### [Alamofire/Alamofire @ ac01666](https://github.com/Alamofire/Alamofire/tree/ac016668a19532686e320edf447f79a5cf5bd057) — **11.91× faster**
+##### [Alamofire/Alamofire @ ac01666](https://github.com/Alamofire/Alamofire/tree/ac016668a19532686e320edf447f79a5cf5bd057) — **23.18× faster**
 
 - Files: 567
-- Run context: 2026-04-15 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `14.71s`; ScanCode `175.16s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.25s`; ScanCode `144.88s`
 - Matched top-level CocoaPods package coverage (`1` vs `1`) and main podspec/license parity, with slightly richer dependency extraction (`56` vs `54`) from the root `Gemfile`
 
 ##### [Carthage/Carthage @ e33e133](https://github.com/Carthage/Carthage/tree/e33e133a5427129b38bfb1ae18d8f56b29a93204) — **14.41× faster**
@@ -1216,11 +1216,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.22s`; ScanCode `51.98s`
 - Direct CPAN package identity and broader dependency extraction (`1` vs `0` packages, `22` vs `0` dependencies) from `META.json`, `dist.ini`, and `Makefile.PL`, with CPAN resource metadata preserved from the distribution manifest
 
-##### [rails/rails @ 27fb2a9](https://github.com/rails/rails/tree/27fb2a9192b2492791528fc7c3afb53736696bc5) — **13.69× faster**
+##### [rails/rails @ 27fb2a9](https://github.com/rails/rails/tree/27fb2a9192b2492791528fc7c3afb53736696bc5) — **34.58× faster**
 
 - Files: 4,869
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `23.27s`; ScanCode `318.46s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.27s`; ScanCode `285.98s`
 - Broader Ruby/Bundler package and dependency extraction (`20` vs `17` packages, `899` vs `802` dependencies) from the root `Gemfile`, the multi-gemspec Rails component tree, and resolved `RAILS_VERSION`-backed gemspec versions, with real `8.2.0.alpha` gem identities where ScanCode leaves literal `version` placeholders
 
 ##### [rubocop/rubocop @ 4e0d642](https://github.com/rubocop/rubocop/tree/4e0d642eca6e9a694b8a359d39e0d4b5b6b26bb8) — **23.4× faster**
@@ -1253,18 +1253,18 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.22s`; ScanCode `89.17s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with compound `LicenseRef-scancode-public-domain AND OFL-1.1` font licensing on `assets/fonts/monsterrat.ttf` instead of split duplicate detections and cleaner URL normalization across docs and snippets
 
-##### [HeapsIO/heaps @ d2992b0](https://github.com/HeapsIO/heaps/tree/d2992b061db3f51b47cdb87c39d659a5bb96dd83) — **15.91× faster**
+##### [HeapsIO/heaps @ d2992b0](https://github.com/HeapsIO/heaps/tree/d2992b061db3f51b47cdb87c39d659a5bb96dd83) — **21.42× faster**
 
 - Files: 666
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `10.63s`; ScanCode `169.15s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.97s`; ScanCode `106.46s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with cleaner copyright and holder recovery on `hxd/fmt/fbx/Writer.hx` and `samples/text_res/trueTypeFont.ttf` plus safer trailing-slash URL normalization
 
-##### [jgm/pandoc @ d9838eb](https://github.com/jgm/pandoc/tree/d9838eba11ae18216f52e233dbbca735f0f97ccb) — **14.61× faster**
+##### [jgm/pandoc @ d9838eb](https://github.com/jgm/pandoc/tree/d9838eba11ae18216f52e233dbbca735f0f97ccb) — **22.54× faster**
 
 - Files: 2,768
-- Run context: 2026-04-17 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `22.78s`; ScanCode `332.82s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.78s`; ScanCode `220.43s`
 - Broader mixed Hackage and Nix package extraction (`5` vs `0` packages, `197` vs `0` dependencies) from sibling `pandoc*.cabal` manifests, `stack.yaml`, and `flake.nix` / `flake.lock`, with explicit package identities across `pandoc`, `pandoc-cli`, `pandoc-lua-engine`, and `pandoc-server`
 
 ##### [JuliaAcademy/DataScience @ 201f2e6](https://github.com/JuliaAcademy/DataScience/tree/201f2e66cf2067dacee2df02b546f75d77ed22e7) — **40.81× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -230,9 +230,9 @@ ScanCode: 50.68s</title></rect>
     <rect x="439.98" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 ScanCode: 65.75s</title></rect>
-    <rect x="441.29" y="385.10" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
+    <rect x="441.29" y="409.83" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
 Files: 159
-ScanCode: 170.82s</title></rect>
+ScanCode: 101.22s</title></rect>
     <rect x="450.98" y="426.44" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
 Files: 183
 ScanCode: 71.21s</title></rect>
@@ -326,12 +326,12 @@ ScanCode: 83.67s</title></rect>
     <rect x="526.30" y="410.78" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 ScanCode: 99.19s</title></rect>
-    <rect x="528.90" y="383.91" width="8" height="8" fill="#d97706" rx="1.5"><title>Alamofire/Alamofire @ ac01666
+    <rect x="528.90" y="392.88" width="8" height="8" fill="#d97706" rx="1.5"><title>Alamofire/Alamofire @ ac01666
 Files: 567
-ScanCode: 175.16s</title></rect>
-    <rect x="528.90" y="389.48" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/fresh @ 49c4be1
+ScanCode: 144.88s</title></rect>
+    <rect x="528.90" y="431.51" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/fresh @ 49c4be1
 Files: 567
-ScanCode: 155.71s</title></rect>
+ScanCode: 63.97s</title></rect>
     <rect x="529.99" y="401.38" width="8" height="8" fill="#d97706" rx="1.5"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 ScanCode: 121.03s</title></rect>
@@ -350,9 +350,9 @@ ScanCode: 184.01s</title></rect>
     <rect x="538.84" y="397.93" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/dnf @ e47634f
 Files: 655
 ScanCode: 130.21s</title></rect>
-    <rect x="539.99" y="385.56" width="8" height="8" fill="#d97706" rx="1.5"><title>HeapsIO/heaps @ d2992b0
+    <rect x="539.99" y="407.44" width="8" height="8" fill="#d97706" rx="1.5"><title>HeapsIO/heaps @ d2992b0
 Files: 666
-ScanCode: 169.15s</title></rect>
+ScanCode: 106.46s</title></rect>
     <rect x="543.81" y="413.62" width="8" height="8" fill="#d97706" rx="1.5"><title>select2/select2 @ 595494a
 Files: 704
 ScanCode: 93.41s</title></rect>
@@ -371,9 +371,9 @@ ScanCode: 103.73s</title></rect>
     <rect x="555.57" y="427.04" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda-build @ 5da509d
 Files: 835
 ScanCode: 70.31s</title></rect>
-    <rect x="558.17" y="345.08" width="8" height="8" fill="#d97706" rx="1.5"><title>pulseaudio/pulseaudio @ b096704
+    <rect x="558.17" y="366.21" width="8" height="8" fill="#d97706" rx="1.5"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
-ScanCode: 398.45s</title></rect>
+ScanCode: 254.79s</title></rect>
     <rect x="559.89" y="380.76" width="8" height="8" fill="#d97706" rx="1.5"><title>Debian/apt @ 6b12812
 Files: 889
 ScanCode: 187.26s</title></rect>
@@ -404,15 +404,15 @@ ScanCode: 137.98s</title></rect>
     <rect x="577.87" y="402.80" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 ScanCode: 117.46s</title></rect>
-    <rect x="578.35" y="385.81" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/libdnf @ d395731
+    <rect x="578.35" y="408.58" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
-ScanCode: 168.27s</title></rect>
+ScanCode: 103.93s</title></rect>
     <rect x="580.33" y="373.93" width="8" height="8" fill="#d97706" rx="1.5"><title>openfl/openfl @ 74d8f72
 Files: 1196
 ScanCode: 216.36s</title></rect>
-    <rect x="580.51" y="358.66" width="8" height="8" fill="#d97706" rx="1.5"><title>OpenMDAO/OpenMDAO @ bf1fcb6
+    <rect x="580.51" y="375.16" width="8" height="8" fill="#d97706" rx="1.5"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
-ScanCode: 298.91s</title></rect>
+ScanCode: 210.82s</title></rect>
     <rect x="583.87" y="362.98" width="8" height="8" fill="#d97706" rx="1.5"><title>astral-sh/uv @ 9581f2b
 Files: 1259
 ScanCode: 272.81s</title></rect>
@@ -473,18 +473,18 @@ ScanCode: 235.22s</title></rect>
     <rect x="627.52" y="350.33" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 ScanCode: 356.55s</title></rect>
-    <rect x="633.28" y="363.07" width="8" height="8" fill="#d97706" rx="1.5"><title>playframework/playframework @ c2c114f
+    <rect x="633.28" y="388.01" width="8" height="8" fill="#d97706" rx="1.5"><title>playframework/playframework @ c2c114f
 Files: 2579
-ScanCode: 272.30s</title></rect>
+ScanCode: 160.61s</title></rect>
     <rect x="633.71" y="319.34" width="8" height="8" fill="#d97706" rx="1.5"><title>nmap/nmap @ d9199d7
 Files: 2595
 ScanCode: 686.99s</title></rect>
     <rect x="634.05" y="342.72" width="8" height="8" fill="#d97706" rx="1.5"><title>pandas-dev/pandas @ c385d01
 Files: 2608
 ScanCode: 418.88s</title></rect>
-    <rect x="638.16" y="353.58" width="8" height="8" fill="#d97706" rx="1.5"><title>jgm/pandoc @ d9838eb
+    <rect x="638.16" y="373.05" width="8" height="8" fill="#d97706" rx="1.5"><title>jgm/pandoc @ d9838eb
 Files: 2768
-ScanCode: 332.82s</title></rect>
+ScanCode: 220.43s</title></rect>
     <rect x="639.24" y="345.52" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/std @ a864f62
 Files: 2812
 ScanCode: 394.76s</title></rect>
@@ -551,9 +551,9 @@ ScanCode: 681.19s</title></rect>
     <rect x="675.14" y="323.90" width="8" height="8" fill="#d97706" rx="1.5"><title>git/git @ 9f223ef
 Files: 4734
 ScanCode: 623.80s</title></rect>
-    <rect x="677.07" y="355.67" width="8" height="8" fill="#d97706" rx="1.5"><title>rails/rails @ 27fb2a9
+    <rect x="677.07" y="360.75" width="8" height="8" fill="#d97706" rx="1.5"><title>rails/rails @ 27fb2a9
 Files: 4869
-ScanCode: 318.46s</title></rect>
+ScanCode: 285.98s</title></rect>
     <rect x="681.62" y="343.50" width="8" height="8" fill="#d97706" rx="1.5"><title>go-gitea/gitea @ 47fdf3e2
 Files: 5201
 ScanCode: 412.03s</title></rect>
@@ -892,9 +892,9 @@ Provenant: 4.79s</title></circle>
     <circle cx="443.98" cy="557.39" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 Provenant: 4.85s</title></circle>
-    <circle cx="445.29" cy="519.13" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
+    <circle cx="445.29" cy="556.81" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
 Files: 159
-Provenant: 10.90s</title></circle>
+Provenant: 4.91s</title></circle>
     <circle cx="454.98" cy="556.52" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
 Files: 183
 Provenant: 4.94s</title></circle>
@@ -988,12 +988,12 @@ Provenant: 5.85s</title></circle>
     <circle cx="530.30" cy="549.02" r="4.5" fill="#2563eb"><title>ocaml/ocaml-lsp @ 788ff73
 Files: 546
 Provenant: 5.79s</title></circle>
-    <circle cx="532.90" cy="504.96" r="4.5" fill="#2563eb"><title>Alamofire/Alamofire @ ac01666
+    <circle cx="532.90" cy="545.41" r="4.5" fill="#2563eb"><title>Alamofire/Alamofire @ ac01666
 Files: 567
-Provenant: 14.71s</title></circle>
-    <circle cx="532.90" cy="509.65" r="4.5" fill="#2563eb"><title>denoland/fresh @ 49c4be1
+Provenant: 6.25s</title></circle>
+    <circle cx="532.90" cy="558.88" r="4.5" fill="#2563eb"><title>denoland/fresh @ 49c4be1
 Files: 567
-Provenant: 13.32s</title></circle>
+Provenant: 4.70s</title></circle>
     <circle cx="533.99" cy="546.25" r="4.5" fill="#2563eb"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 Provenant: 6.14s</title></circle>
@@ -1012,9 +1012,9 @@ Provenant: 17.30s</title></circle>
     <circle cx="542.84" cy="540.94" r="4.5" fill="#2563eb"><title>rpm-software-management/dnf @ e47634f
 Files: 655
 Provenant: 6.87s</title></circle>
-    <circle cx="543.99" cy="520.31" r="4.5" fill="#2563eb"><title>HeapsIO/heaps @ d2992b0
+    <circle cx="543.99" cy="556.24" r="4.5" fill="#2563eb"><title>HeapsIO/heaps @ d2992b0
 Files: 666
-Provenant: 10.63s</title></circle>
+Provenant: 4.97s</title></circle>
     <circle cx="547.81" cy="550.68" r="4.5" fill="#2563eb"><title>select2/select2 @ 595494a
 Files: 704
 Provenant: 5.59s</title></circle>
@@ -1033,9 +1033,9 @@ Provenant: 5.55s</title></circle>
     <circle cx="559.57" cy="526.93" r="4.5" fill="#2563eb"><title>conda/conda-build @ 5da509d
 Files: 835
 Provenant: 9.24s</title></circle>
-    <circle cx="562.17" cy="488.62" r="4.5" fill="#2563eb"><title>pulseaudio/pulseaudio @ b096704
+    <circle cx="562.17" cy="530.44" r="4.5" fill="#2563eb"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
-Provenant: 20.79s</title></circle>
+Provenant: 8.58s</title></circle>
     <circle cx="563.89" cy="516.47" r="4.5" fill="#2563eb"><title>Debian/apt @ 6b12812
 Files: 889
 Provenant: 11.53s</title></circle>
@@ -1066,15 +1066,15 @@ Provenant: 6.45s</title></circle>
     <circle cx="581.87" cy="542.91" r="4.5" fill="#2563eb"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 Provenant: 6.59s</title></circle>
-    <circle cx="582.35" cy="508.50" r="4.5" fill="#2563eb"><title>rpm-software-management/libdnf @ d395731
+    <circle cx="582.35" cy="547.57" r="4.5" fill="#2563eb"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
-Provenant: 13.65s</title></circle>
+Provenant: 5.97s</title></circle>
     <circle cx="584.33" cy="511.65" r="4.5" fill="#2563eb"><title>openfl/openfl @ 74d8f72
 Files: 1196
 Provenant: 12.77s</title></circle>
-    <circle cx="584.51" cy="495.58" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
+    <circle cx="584.51" cy="534.94" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
-Provenant: 17.94s</title></circle>
+Provenant: 7.80s</title></circle>
     <circle cx="587.87" cy="525.77" r="4.5" fill="#2563eb"><title>astral-sh/uv @ 9581f2b
 Files: 1259
 Provenant: 9.47s</title></circle>
@@ -1135,18 +1135,18 @@ Provenant: 12.03s</title></circle>
     <circle cx="631.52" cy="474.94" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 Provenant: 27.77s</title></circle>
-    <circle cx="637.28" cy="504.23" r="4.5" fill="#2563eb"><title>playframework/playframework @ c2c114f
+    <circle cx="637.28" cy="542.19" r="4.5" fill="#2563eb"><title>playframework/playframework @ c2c114f
 Files: 2579
-Provenant: 14.94s</title></circle>
+Provenant: 6.69s</title></circle>
     <circle cx="637.71" cy="479.01" r="4.5" fill="#2563eb"><title>nmap/nmap @ d9199d7
 Files: 2595
 Provenant: 25.48s</title></circle>
     <circle cx="638.05" cy="510.48" r="4.5" fill="#2563eb"><title>pandas-dev/pandas @ c385d01
 Files: 2608
 Provenant: 13.09s</title></circle>
-    <circle cx="642.16" cy="484.30" r="4.5" fill="#2563eb"><title>jgm/pandoc @ d9838eb
+    <circle cx="642.16" cy="524.25" r="4.5" fill="#2563eb"><title>jgm/pandoc @ d9838eb
 Files: 2768
-Provenant: 22.78s</title></circle>
+Provenant: 9.78s</title></circle>
     <circle cx="643.24" cy="500.11" r="4.5" fill="#2563eb"><title>denoland/std @ a864f62
 Files: 2812
 Provenant: 16.30s</title></circle>
@@ -1213,9 +1213,9 @@ Provenant: 26.97s</title></circle>
     <circle cx="679.14" cy="505.25" r="4.5" fill="#2563eb"><title>git/git @ 9f223ef
 Files: 4734
 Provenant: 14.62s</title></circle>
-    <circle cx="681.07" cy="483.29" r="4.5" fill="#2563eb"><title>rails/rails @ 27fb2a9
+    <circle cx="681.07" cy="532.18" r="4.5" fill="#2563eb"><title>rails/rails @ 27fb2a9
 Files: 4869
-Provenant: 23.27s</title></circle>
+Provenant: 8.27s</title></circle>
     <circle cx="685.62" cy="502.01" r="4.5" fill="#2563eb"><title>go-gitea/gitea @ 47fdf3e2
 Files: 5201
 Provenant: 15.66s</title></circle>


### PR DESCRIPTION
## Summary

Batch 4 of the M1→M5 benchmark migration: ten more rows recorded on **Apple M1 Max** re-measured on the current **Apple M5 Pro** host (`compare-outputs --profile common --build-mode optimized`, fresh ScanCode, 4 proc, same-host pairs).

| target | files | PV (M1→M5) | ScanCode (M1→M5) | × (old→new) |
|---|---|---|---|---|
| denoland/fresh | 567 | 13.32→4.70s | 155.71→63.97s | 11.69→13.61× |
| rpm-software-management/libdnf | 1,162 | 13.65→5.97s | 168.27→103.93s | 12.33→17.41× |
| HeapsIO/heaps | 666 | 10.63→4.97s | 169.15→106.46s | 15.91→21.42× |
| lodash/lodash | 159 | 10.90→4.91s | 170.82→101.22s | 15.67→20.62× |
| Alamofire/Alamofire | 567 | 14.71→6.25s | 175.16→144.88s | 11.91→23.18× |
| playframework/playframework | 2,579 | 14.94→6.69s | 272.30→160.61s | 18.23→24.01× |
| OpenMDAO/OpenMDAO | 1,199 | 17.94→7.80s | 298.91→210.82s | 16.66→27.03× |
| rails/rails | 4,869 | 23.27→8.27s | 318.46→285.98s | 13.69→34.58× |
| jgm/pandoc | 2,768 | 22.78→9.78s | 332.82→220.43s | 14.61→22.54× |
| pulseaudio/pulseaudio | 867 | 20.79→8.58s | 398.45→254.79s | 19.16→29.70× |

Headline regenerated: median **15.7→16.6×**, geomean **15.8×** (220 runs). The rise is the M5 hardware + current code applied uniformly, not a new speedup.

## Pathology triage (verify-benchmark-target skill)

All clean or Provenant-advantage; **no regressions** (each suspicious delta verified against the real manifest):
- **fresh / heaps / libdnf / playframework / openmdao / pandoc** — clean; PV net far richer on file-level detection (e.g. libdnf 4215 vs 448, fresh 1992 vs 15).
- **lodash / alamofire / rails** — verified the root manifests are correct (lodash `package.json`→mit, Alamofire podspec→mit, all rails gemspecs→mit). The flagged `declared` deltas are ScanCode over-aggregating onto **lockfile/transitive dependency entries** (`cc0-1.0 AND mit`, `mit AND ruby`, etc.); Provenant declines that on dep entries — cleaner, not a loss.
- No bare-name declared-license gaps in this batch.

## Issues

- Continues the M5 migration (after #1125/#1130); ~67 M1 rows remain.

## Scope and exclusions

- Included: the ten M1 repo rows above + regenerated chart/headline.
- Excluded: scanner/parser code.

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` — re-running produces no diff.
- Each row reproducible via `compare-outputs --profile common` against the pinned ref.

## Expected-output fixture changes

- None. Docs + generated chart only.
