### PR TITLE
docs(benchmarks): re-measure ten more M1 targets on M5 (batch 5)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 220 of 220 recorded runs, with a **16.6× median speedup** and **15.8× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
+> Provenant is faster on 220 of 220 recorded runs, with a **16.8× median speedup** and **16.1× geometric-mean speedup** overall; the median gap grows from **8.6×** on sub-100-file targets to **22.4×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -227,11 +227,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `8.01s`; ScanCode `118.91s`
 - Far broader Python package and dependency extraction (`72` vs `16` packages, `840` vs `595` dependencies) from the root PEP 621 `pyproject.toml`, Poetry dependency groups, committed `poetry.lock` fixtures, and bundled wheel/sdist metadata, with the project's MIT license placed on the named `poetry` package rather than smeared onto a nameless lockfile aggregate, and clean handling of `.dist-info` `Author`/`Author-email` lines that ScanCode mangles into one malformed party
 
-##### [scipy/scipy @ 8a4633f](https://github.com/scipy/scipy/tree/8a4633fa0e01d62e9ccdd06ebe5bb30551cfa056) — **14.10× faster**
+##### [scipy/scipy @ 8a4633f](https://github.com/scipy/scipy/tree/8a4633fa0e01d62e9ccdd06ebe5bb30551cfa056) — **43.01× faster**
 
 - Files: 2,998
-- Run context: 2026-04-09 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `23.57s`; ScanCode `332.23s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `11.54s`; ScanCode `496.36s`
 - Far broader Python/Conda/Pixi package and dependency extraction (`4` vs `1` packages, `1469` vs `78` dependencies) from `pixi.lock`'s large resolved Conda graph, `environment.yml`, `pixi.toml`, and the aggregated `requirements/*.txt` tree that ScanCode leaves at zero, with cleaner `pyproject.toml` requirement shaping for exact pins and environment markers
 
 ##### [UCBoulder/tardigrade_micromorphic_tools @ d03a8ca](https://github.com/UCBoulder/tardigrade_micromorphic_tools/tree/d03a8cae9e0983040487d2ecf32da98d9b297b92) — **7.70× faster**
@@ -352,12 +352,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.70s`; ScanCode `63.97s`
 - Broader Deno package and dependency extraction (`8` vs `0` packages, `966` vs `0` dependencies) from the root `deno.json`, `deno.lock`, and nested `packages/*/deno.json` manifests, with direct JSR and npm import-map or lockfile package identity where ScanCode stays manifest-blind
 
-##### [denoland/std @ a864f62](https://github.com/denoland/std/tree/a864f62bcc8a5f20716d2becab3cfe224a2ad810) — **24.22× faster**
+##### [denoland/std @ a864f62](https://github.com/denoland/std/tree/a864f62bcc8a5f20716d2becab3cfe224a2ad810) — **34.64× faster**
 
 - Files: 2,812
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `16.30s`; ScanCode `394.76s`
-- Broader Deno package visibility (`45` vs `3` packages) from the root and leaf `*/deno.json` manifests across the standard-library tree, plus concrete Cargo lock package identities on embedded Rust fixtures instead of anonymous `cargo_lock` rows, with zero top-level license-expression deltas under the shared profile
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.56s`; ScanCode `227.22s`
+- Broader Deno package visibility (`42` more packages, `0` missing) from the root and leaf `*/deno.json` manifests across the standard-library tree, plus concrete Cargo lock package identities on embedded Rust fixtures instead of anonymous `cargo_lock` rows; ScanCode detects more file-level MIT here, from the terse one-line `// … the Deno authors. MIT license.` header that Provenant's file-content matcher does not yet pick up
 
 ##### [getsentry/self-hosted @ 8728919](https://github.com/getsentry/self-hosted/tree/8728919e080836c53724f277d4d36cc310fc5011) — **9.54× faster**
 
@@ -380,11 +380,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.03s`; ScanCode `61.74s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and package-level party metadata from `package.json`
 
-##### [jquery/jquery-ui @ eda7aa3](https://github.com/jquery/jquery-ui/tree/eda7aa34fa59d8f764b2164be3e3b7f14639b0db) — **19.49× faster**
+##### [jquery/jquery-ui @ eda7aa3](https://github.com/jquery/jquery-ui/tree/eda7aa34fa59d8f764b2164be3e3b7f14639b0db) — **30.01× faster**
 
 - Files: 1,083
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `15.56s`; ScanCode `303.29s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.70s`; ScanCode `201.04s`
 - Matched Bower package and dependency coverage on the repo-root `bower.json`, with datasource-tagged Bower package identity instead of a bare purl-only row and cleaner Unicode-preserving author normalization across locale files and vendored docs
 
 ##### [lodash/lodash @ cb0b9b9](https://github.com/lodash/lodash/tree/cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e) — **20.62× faster**
@@ -429,11 +429,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `43.05s`; ScanCode `849.10s`
 - Far broader Bun/npm-family package extraction (`382` vs `29` packages, `5773` vs `323` dependencies) from the repo's 52 committed `bun.lock` / `bun.lockb` inputs that ScanCode leaves at zero, plus legacy `bun.lockb` coverage on `bench/bundle` and plainer `BSD-2-Clause` rebucketing where ScanCode uses the over-specific `BSD-2-Clause-Views` label
 
-##### [pnpm/pnpm @ 2a1ffe1](https://github.com/pnpm/pnpm/tree/2a1ffe1956a75746844b1c6cd863ecfbb5a55729) — **21.11× faster**
+##### [pnpm/pnpm @ 2a1ffe1](https://github.com/pnpm/pnpm/tree/2a1ffe1956a75746844b1c6cd863ecfbb5a55729) — **33.85× faster**
 
 - Files: 2,887
-- Run context: 2026-04-27 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `16.54s`; ScanCode `349.11s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.32s`; ScanCode `247.80s`
 - Broader pnpm/npm monorepo package and dependency extraction (`396` vs `282` packages, `11606` vs `3080` dependencies) from the root `pnpm-lock.yaml`, nested workspace member manifests, and shared workspace `npm-shrinkwrap.json` / `pnpm-lock.yaml` roots, plus zero scan-file errors where ScanCode crashes on the root workspace manifests and catalog-protocol fixture inputs
 
 ##### [renovatebot/renovate @ 91a7213](https://github.com/renovatebot/renovate/tree/91a72131e8aefcda8f0dab7499f378f7eb41300f) — **18.82× faster**
@@ -529,11 +529,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `145.05s`; ScanCode `1879.67s`
 - Broader Gradle package and dependency extraction (`73` vs `68` packages, `1675` vs `1541` dependencies) from committed `build.gradle`, `build.gradle.kts`, `gradle.lockfile`, and `.module` metadata across docs and test fixtures
 
-##### [yairm210/Unciv @ d54f33c](https://github.com/yairm210/Unciv/tree/d54f33c881ad2de1ac7136540f59ad8596143ce5) — **19.54× faster**
+##### [yairm210/Unciv @ d54f33c](https://github.com/yairm210/Unciv/tree/d54f33c881ad2de1ac7136540f59ad8596143ce5) — **30.07× faster**
 
 - Files: 4,057
-- Run context: 2026-04-30 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `21.96s`; ScanCode `429.19s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.25s`; ScanCode `278.15s`
 - Far broader Gradle dependency extraction (`51` vs `6` dependencies) from the root multi-project `build.gradle.kts`, module-local `android/build.gradle.kts`, and `buildSrc/build.gradle.kts`, with concrete version recovery for property-backed Kotlin DSL quoted configuration calls such as `"implementation"("io.ktor:ktor-client-core:$ktorVersion")`, `"implementation"("com.badlogicgames.gdx:gdx-tools:$gdxVersion")`, and `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")` where ScanCode leaves `$kotlinVersion` / `$gdxVersion` unresolved and misses most of the centralized root build graph
 
 ##### [playframework/playframework @ c2c114f](https://github.com/playframework/playframework/tree/c2c114ff31eff1557bef65cc3f586fbc53c974a6) — **24.01× faster**
@@ -608,11 +608,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.20s`; ScanCode `75.26s`
 - Direct `.gitmodules` package-adjacent visibility (`1` vs `0` file-level package records, plus one raw dependency edge) across the umbrella superproject, cleaner XML author extraction that drops prose-tainted suffixes such as `A.Meredith Compiler`, and Unicode-preserving name normalization for identities such as `René Ferdinand Rivera Morell`, `Ion Gaztañaga`, and `J. López`
 
-##### [boostorg/graph @ ae8e08d](https://github.com/boostorg/graph/tree/ae8e08d88f68669dc3fe5c7043dbc01b3c7c52ae) — **13.04× faster**
+##### [boostorg/graph @ ae8e08d](https://github.com/boostorg/graph/tree/ae8e08d88f68669dc3fe5c7043dbc01b3c7c52ae) — **18.83× faster**
 
 - Files: 2,117
-- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `15.37s`; ScanCode `200.37s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.01s`; ScanCode `132.02s`
 - Cleaner URL and copyright normalization across Boost metadata files, preserving the real `http://www.boost.org/` target while dropping ScanCode's broken pseudo-URL variant in `example/boost_web.dat`, plus Unicode-preserving `René Ferdinand Rivera Morell` handling on `build.jam` and top-level `.gitattributes` visibility in the final output
 
 ##### [boostorg/json @ 70efd4b](https://github.com/boostorg/json/tree/70efd4b032b7f3e718bb4ca4ae144c3171b21568) — **13.78× faster**
@@ -636,11 +636,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.14s`; ScanCode `121.03s`
 - Broader Conan, Meson, and Bazel package visibility (`2` vs `1` packages, `3` vs `0` dependencies) from the root `conanfile.py`, `MODULE.bazel`, and committed `meson.build` manifests, with the local `LICENSE` notice in `.conan/test_package/conanfile.py` collapsed to plain `BSL-1.0` instead of ScanCode's extra unknown-reference placeholder
 
-##### [chriskohlhoff/asio @ bd500f0](https://github.com/chriskohlhoff/asio/tree/bd500f0a018db9a845ebaaed5c0318343ae9f497) — **17.58× faster**
+##### [chriskohlhoff/asio @ bd500f0](https://github.com/chriskohlhoff/asio/tree/bd500f0a018db9a845ebaaed5c0318343ae9f497) — **23.46× faster**
 
 - Files: 1,468
-- Run context: 2026-05-07 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `18.97s`; ScanCode `333.52s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.95s`; ScanCode `186.47s`
 - More correct root Autotools package identity on `configure.ac` instead of ScanCode's generic input placeholder, plus cleaner holder normalization on `include/asio.hpp` and the Oliver Kowalke C++ notice set; the remaining ScanCode edge is limited to two multiline continuation headers and a small Perl author/copyright-email-tail set
 
 ##### [chuckha/crispy-tribble @ 20479cf](https://github.com/chuckha/crispy-tribble/tree/20479cfe45a694ee4fababd635f1bd8ebcb44ed3) — **19.28× faster**
@@ -1037,11 +1037,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `37.11s`; ScanCode `849.94s`
 - Far broader Dart/Flutter monorepo package and dependency extraction (`293` vs `201` packages, `2087` vs `1167` dependencies) from many package and example `pubspec.yaml` manifests plus committed podspec and Android `build.gradle.kts` inputs, with contributor-roster visibility across `AUTHORS` files that ScanCode leaves empty
 
-##### [i18next/react-i18next @ cb20d18](https://github.com/i18next/react-i18next/tree/cb20d1886bbb113f8005c4324e962e161a449ab9) — **13.77× faster**
+##### [i18next/react-i18next @ cb20d18](https://github.com/i18next/react-i18next/tree/cb20d1886bbb113f8005c4324e962e161a449ab9) — **19.08× faster**
 
 - Files: 590
-- Run context: 2026-05-01 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `14.82s`; ScanCode `204.00s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.71s`; ScanCode `128.04s`
 - Broader mixed-surface package and dependency extraction (`17` vs `1` packages, `21579` vs `911` dependencies) across committed example-app `package.json`, React Native CocoaPods `Podfile`, Android `AndroidManifest.xml`, Gemfile, NuGet `packages.config`, and Buck surfaces, with concrete Flipper coordinates where ScanCode preserves `${FLIPPER_VERSION}` placeholders and Unicode-preserving author normalization for `Jan Mühlemann`
 
 ##### [Mantle/Mantle @ 2a8e212](https://github.com/Mantle/Mantle/tree/2a8e2123a3931038179ee06105c9e6ec336b12ea) — **9.74× faster**
@@ -1274,11 +1274,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.68s`; ScanCode `231.82s`
 - Direct Julia package visibility and broader dependency extraction (`1` vs `0` packages, `53` vs `0` dependencies) from the root legacy v1.0-format `Manifest.toml` and its `Project.toml`, with zero scan errors where ScanCode times out after 120s on `05. Clustering.ipynb` and no spurious low-confidence `GPL-3.0-only` detection bleeding from the binary `data/face_recog_qr.mat` blob
 
-##### [JuliaLang/julia @ afc71c2](https://github.com/JuliaLang/julia/tree/afc71c255e327d8a64b69061c15994e80740974d) — **21.75× faster**
+##### [JuliaLang/julia @ afc71c2](https://github.com/JuliaLang/julia/tree/afc71c255e327d8a64b69061c15994e80740974d) — **40.32× faster**
 
 - Files: 1,948
-- Run context: 2026-04-19 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 10 proc
-- Timing: Provenant `25.28s`; ScanCode `549.75s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.96s`; ScanCode `361.23s`
 - Direct Julia package visibility and much broader dependency extraction (`115` vs `0` packages, `240` vs `0` dependencies) from stdlib, test, and nested `Project.toml` / `Manifest.toml` pairs across the tree, with richer author recovery on Julia metadata and cleaner rejection of prose-only copyright or holder noise
 
 ##### [JuliaLang/Pkg.jl @ c96cfdf](https://github.com/JuliaLang/Pkg.jl/tree/c96cfdf70976e8a5cc21fcef53c0ba137f6b2f64) — **11.47× faster**
@@ -1344,11 +1344,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.79s`; ScanCode `99.19s`
 - Broader opam package visibility (`3` vs `1` packages) with slightly richer dependency extraction (`380` vs `376`) from the root and submodule `.opam` manifests plus `flake.lock`, with cleaner maintainer and email recovery on opam metadata and Unicode-preserving copyright normalization
 
-##### [openfl/openfl @ 74d8f72](https://github.com/openfl/openfl/tree/74d8f72890b9ae70bba589d034ea35b86588e548) — **16.94× faster**
+##### [openfl/openfl @ 74d8f72](https://github.com/openfl/openfl/tree/74d8f72890b9ae70bba589d034ea35b86588e548) — **13.61× faster**
 
 - Files: 1,196
-- Run context: 2026-04-22 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `12.77s`; ScanCode `216.36s`
+- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `10.08s`; ScanCode `137.21s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with richer bundled Windows executable identity on `assets/templates/bin/openfl.exe`, extra Docker package visibility on `Dockerfile`, and cleaner URL normalization across shipped font metadata
 
 ##### [univention/Nubus @ fef2258](https://github.com/univention/Nubus/tree/fef2258483c56cce0e1f14e4c8d8fce24d26b891) — **8.64× faster**

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -335,9 +335,9 @@ ScanCode: 63.97s</title></rect>
     <rect x="529.99" y="401.38" width="8" height="8" fill="#d97706" rx="1.5"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 ScanCode: 121.03s</title></rect>
-    <rect x="531.64" y="376.71" width="8" height="8" fill="#d97706" rx="1.5"><title>i18next/react-i18next @ cb20d18
+    <rect x="531.64" y="398.72" width="8" height="8" fill="#d97706" rx="1.5"><title>i18next/react-i18next @ cb20d18
 Files: 590
-ScanCode: 204.00s</title></rect>
+ScanCode: 128.04s</title></rect>
     <rect x="534.61" y="404.01" width="8" height="8" fill="#d97706" rx="1.5"><title>iTowns/itowns @ 08e08f5
 Files: 616
 ScanCode: 114.48s</title></rect>
@@ -392,9 +392,9 @@ ScanCode: 113.37s</title></rect>
     <rect x="572.02" y="412.37" width="8" height="8" fill="#d97706" rx="1.5"><title>commercialhaskell/stack @ cb6070f
 Files: 1060
 ScanCode: 95.91s</title></rect>
-    <rect x="573.49" y="357.97" width="8" height="8" fill="#d97706" rx="1.5"><title>jquery/jquery-ui @ eda7aa3
+    <rect x="573.49" y="377.40" width="8" height="8" fill="#d97706" rx="1.5"><title>jquery/jquery-ui @ eda7aa3
 Files: 1083
-ScanCode: 303.29s</title></rect>
+ScanCode: 201.04s</title></rect>
     <rect x="574.44" y="417.69" width="8" height="8" fill="#d97706" rx="1.5"><title>pointfreeco/swift-composable-architecture @ 7517cc3
 Files: 1098
 ScanCode: 85.71s</title></rect>
@@ -407,9 +407,9 @@ ScanCode: 117.46s</title></rect>
     <rect x="578.35" y="408.58" width="8" height="8" fill="#d97706" rx="1.5"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
 ScanCode: 103.93s</title></rect>
-    <rect x="580.33" y="373.93" width="8" height="8" fill="#d97706" rx="1.5"><title>openfl/openfl @ 74d8f72
+    <rect x="580.33" y="395.45" width="8" height="8" fill="#d97706" rx="1.5"><title>openfl/openfl @ 74d8f72
 Files: 1196
-ScanCode: 216.36s</title></rect>
+ScanCode: 137.21s</title></rect>
     <rect x="580.51" y="375.16" width="8" height="8" fill="#d97706" rx="1.5"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 ScanCode: 210.82s</title></rect>
@@ -425,9 +425,9 @@ ScanCode: 191.41s</title></rect>
     <rect x="585.23" y="404.76" width="8" height="8" fill="#d97706" rx="1.5"><title>restic/restic @ 29446b0
 Files: 1284
 ScanCode: 112.67s</title></rect>
-    <rect x="594.45" y="353.48" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
+    <rect x="594.45" y="380.96" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
-ScanCode: 333.52s</title></rect>
+ScanCode: 186.47s</title></rect>
     <rect x="596.63" y="389.66" width="8" height="8" fill="#d97706" rx="1.5"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 ScanCode: 155.12s</title></rect>
@@ -449,9 +449,9 @@ ScanCode: 163.56s</title></rect>
     <rect x="613.49" y="327.10" width="8" height="8" fill="#d97706" rx="1.5"><title>scalatest/scalatest @ f6ba8f2
 Files: 1935
 ScanCode: 582.97s</title></rect>
-    <rect x="613.95" y="329.87" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaLang/julia @ afc71c2
+    <rect x="613.95" y="349.71" width="8" height="8" fill="#d97706" rx="1.5"><title>JuliaLang/julia @ afc71c2
 Files: 1948
-ScanCode: 549.75s</title></rect>
+ScanCode: 361.23s</title></rect>
     <rect x="614.44" y="350.37" width="8" height="8" fill="#d97706" rx="1.5"><title>astropy/astropy @ 40280e3
 Files: 1962
 ScanCode: 356.23s</title></rect>
@@ -461,9 +461,9 @@ ScanCode: 341.28s</title></rect>
     <rect x="618.50" y="383.74" width="8" height="8" fill="#d97706" rx="1.5"><title>rubocop/rubocop @ 4e0d642
 Files: 2081
 ScanCode: 175.80s</title></rect>
-    <rect x="619.68" y="377.56" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/graph @ ae8e08d
+    <rect x="619.68" y="397.27" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/graph @ ae8e08d
 Files: 2117
-ScanCode: 200.37s</title></rect>
+ScanCode: 132.02s</title></rect>
     <rect x="619.78" y="321.51" width="8" height="8" fill="#d97706" rx="1.5"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 ScanCode: 656.13s</title></rect>
@@ -485,24 +485,24 @@ ScanCode: 418.88s</title></rect>
     <rect x="638.16" y="373.05" width="8" height="8" fill="#d97706" rx="1.5"><title>jgm/pandoc @ d9838eb
 Files: 2768
 ScanCode: 220.43s</title></rect>
-    <rect x="639.24" y="345.52" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/std @ a864f62
+    <rect x="639.24" y="371.62" width="8" height="8" fill="#d97706" rx="1.5"><title>denoland/std @ a864f62
 Files: 2812
-ScanCode: 394.76s</title></rect>
+ScanCode: 227.22s</title></rect>
     <rect x="640.96" y="376.44" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 ScanCode: 205.19s</title></rect>
-    <rect x="641.06" y="351.33" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
+    <rect x="641.06" y="367.52" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
-ScanCode: 349.11s</title></rect>
+ScanCode: 247.80s</title></rect>
     <rect x="641.37" y="349.55" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
 Files: 2900
 ScanCode: 362.51s</title></rect>
     <rect x="641.77" y="389.02" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nix @ 6a659e1
 Files: 2917
 ScanCode: 157.23s</title></rect>
-    <rect x="643.66" y="353.67" width="8" height="8" fill="#d97706" rx="1.5"><title>scipy/scipy @ 8a4633f
+    <rect x="643.66" y="334.70" width="8" height="8" fill="#d97706" rx="1.5"><title>scipy/scipy @ 8a4633f
 Files: 2998
-ScanCode: 332.23s</title></rect>
+ScanCode: 496.36s</title></rect>
     <rect x="646.82" y="368.39" width="8" height="8" fill="#d97706" rx="1.5"><title>laravel/framework @ a3960e8
 Files: 3139
 ScanCode: 243.30s</title></rect>
@@ -530,9 +530,9 @@ ScanCode: 446.79s</title></rect>
     <rect x="659.81" y="375.65" width="8" height="8" fill="#d97706" rx="1.5"><title>yarnpkg/berry @ c0274d6
 Files: 3790
 ScanCode: 208.66s</title></rect>
-    <rect x="664.50" y="341.57" width="8" height="8" fill="#d97706" rx="1.5"><title>yairm210/Unciv @ d54f33c
+    <rect x="664.50" y="362.06" width="8" height="8" fill="#d97706" rx="1.5"><title>yairm210/Unciv @ d54f33c
 Files: 4057
-ScanCode: 429.19s</title></rect>
+ScanCode: 278.15s</title></rect>
     <rect x="664.98" y="356.00" width="8" height="8" fill="#d97706" rx="1.5"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
 Files: 4085
 ScanCode: 316.25s</title></rect>
@@ -997,9 +997,9 @@ Provenant: 4.70s</title></circle>
     <circle cx="533.99" cy="546.25" r="4.5" fill="#2563eb"><title>catchorg/Catch2 @ 10f6248
 Files: 576
 Provenant: 6.14s</title></circle>
-    <circle cx="535.64" cy="504.61" r="4.5" fill="#2563eb"><title>i18next/react-i18next @ cb20d18
+    <circle cx="535.64" cy="542.05" r="4.5" fill="#2563eb"><title>i18next/react-i18next @ cb20d18
 Files: 590
-Provenant: 14.82s</title></circle>
+Provenant: 6.71s</title></circle>
     <circle cx="538.61" cy="547.42" r="4.5" fill="#2563eb"><title>iTowns/itowns @ 08e08f5
 Files: 616
 Provenant: 5.99s</title></circle>
@@ -1054,9 +1054,9 @@ Provenant: 6.40s</title></circle>
     <circle cx="576.02" cy="544.29" r="4.5" fill="#2563eb"><title>commercialhaskell/stack @ cb6070f
 Files: 1060
 Provenant: 6.40s</title></circle>
-    <circle cx="577.49" cy="502.31" r="4.5" fill="#2563eb"><title>jquery/jquery-ui @ eda7aa3
+    <circle cx="577.49" cy="542.12" r="4.5" fill="#2563eb"><title>jquery/jquery-ui @ eda7aa3
 Files: 1083
-Provenant: 15.56s</title></circle>
+Provenant: 6.70s</title></circle>
     <circle cx="578.44" cy="554.37" r="4.5" fill="#2563eb"><title>pointfreeco/swift-composable-architecture @ 7517cc3
 Files: 1098
 Provenant: 5.17s</title></circle>
@@ -1069,9 +1069,9 @@ Provenant: 6.59s</title></circle>
     <circle cx="582.35" cy="547.57" r="4.5" fill="#2563eb"><title>rpm-software-management/libdnf @ d395731
 Files: 1162
 Provenant: 5.97s</title></circle>
-    <circle cx="584.33" cy="511.65" r="4.5" fill="#2563eb"><title>openfl/openfl @ 74d8f72
+    <circle cx="584.33" cy="522.82" r="4.5" fill="#2563eb"><title>openfl/openfl @ 74d8f72
 Files: 1196
-Provenant: 12.77s</title></circle>
+Provenant: 10.08s</title></circle>
     <circle cx="584.51" cy="534.94" r="4.5" fill="#2563eb"><title>OpenMDAO/OpenMDAO @ bf1fcb6
 Files: 1199
 Provenant: 7.80s</title></circle>
@@ -1087,9 +1087,9 @@ Provenant: 11.28s</title></circle>
     <circle cx="589.23" cy="509.69" r="4.5" fill="#2563eb"><title>restic/restic @ 29446b0
 Files: 1284
 Provenant: 13.31s</title></circle>
-    <circle cx="598.45" cy="492.95" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
+    <circle cx="598.45" cy="534.04" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
-Provenant: 18.97s</title></circle>
+Provenant: 7.95s</title></circle>
     <circle cx="600.63" cy="529.89" r="4.5" fill="#2563eb"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 Provenant: 8.68s</title></circle>
@@ -1111,9 +1111,9 @@ Provenant: 6.16s</title></circle>
     <circle cx="617.49" cy="467.46" r="4.5" fill="#2563eb"><title>scalatest/scalatest @ f6ba8f2
 Files: 1935
 Provenant: 32.53s</title></circle>
-    <circle cx="617.95" cy="479.38" r="4.5" fill="#2563eb"><title>JuliaLang/julia @ afc71c2
+    <circle cx="617.95" cy="528.39" r="4.5" fill="#2563eb"><title>JuliaLang/julia @ afc71c2
 Files: 1948
-Provenant: 25.28s</title></circle>
+Provenant: 8.96s</title></circle>
     <circle cx="618.44" cy="524.98" r="4.5" fill="#2563eb"><title>astropy/astropy @ 40280e3
 Files: 1962
 Provenant: 9.63s</title></circle>
@@ -1123,9 +1123,9 @@ Provenant: 15.74s</title></circle>
     <circle cx="622.50" cy="536.73" r="4.5" fill="#2563eb"><title>rubocop/rubocop @ 4e0d642
 Files: 2081
 Provenant: 7.51s</title></circle>
-    <circle cx="623.68" cy="502.89" r="4.5" fill="#2563eb"><title>boostorg/graph @ ae8e08d
+    <circle cx="623.68" cy="539.99" r="4.5" fill="#2563eb"><title>boostorg/graph @ ae8e08d
 Files: 2117
-Provenant: 15.37s</title></circle>
+Provenant: 7.01s</title></circle>
     <circle cx="623.78" cy="468.34" r="4.5" fill="#2563eb"><title>ocaml/merlin @ 30b4f24
 Files: 2120
 Provenant: 31.93s</title></circle>
@@ -1147,24 +1147,24 @@ Provenant: 13.09s</title></circle>
     <circle cx="642.16" cy="524.25" r="4.5" fill="#2563eb"><title>jgm/pandoc @ d9838eb
 Files: 2768
 Provenant: 9.78s</title></circle>
-    <circle cx="643.24" cy="500.11" r="4.5" fill="#2563eb"><title>denoland/std @ a864f62
+    <circle cx="643.24" cy="543.12" r="4.5" fill="#2563eb"><title>denoland/std @ a864f62
 Files: 2812
-Provenant: 16.30s</title></circle>
+Provenant: 6.56s</title></circle>
     <circle cx="644.96" cy="531.78" r="4.5" fill="#2563eb"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 Provenant: 8.34s</title></circle>
-    <circle cx="645.06" cy="499.42" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
+    <circle cx="645.06" cy="537.94" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
-Provenant: 16.54s</title></circle>
+Provenant: 7.32s</title></circle>
     <circle cx="645.37" cy="524.20" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
 Files: 2900
 Provenant: 9.79s</title></circle>
     <circle cx="645.77" cy="548.86" r="4.5" fill="#2563eb"><title>NixOS/nix @ 6a659e1
 Files: 2917
 Provenant: 5.81s</title></circle>
-    <circle cx="647.66" cy="482.69" r="4.5" fill="#2563eb"><title>scipy/scipy @ 8a4633f
+    <circle cx="647.66" cy="516.43" r="4.5" fill="#2563eb"><title>scipy/scipy @ 8a4633f
 Files: 2998
-Provenant: 23.57s</title></circle>
+Provenant: 11.54s</title></circle>
     <circle cx="650.82" cy="539.65" r="4.5" fill="#2563eb"><title>laravel/framework @ a3960e8
 Files: 3139
 Provenant: 7.06s</title></circle>
@@ -1192,9 +1192,9 @@ Provenant: 23.74s</title></circle>
     <circle cx="663.81" cy="530.05" r="4.5" fill="#2563eb"><title>yarnpkg/berry @ c0274d6
 Files: 3790
 Provenant: 8.65s</title></circle>
-    <circle cx="668.50" cy="486.03" r="4.5" fill="#2563eb"><title>yairm210/Unciv @ d54f33c
+    <circle cx="668.50" cy="526.88" r="4.5" fill="#2563eb"><title>yairm210/Unciv @ d54f33c
 Files: 4057
-Provenant: 21.96s</title></circle>
+Provenant: 9.25s</title></circle>
     <circle cx="668.98" cy="497.60" r="4.5" fill="#2563eb"><title>lambci/lambda:provided.al2 linux/amd64 @ sha256:7765ec11
 Files: 4085
 Provenant: 17.19s</title></circle>


### PR DESCRIPTION
## Summary

Batch 5 of the M1→M5 benchmark migration: ten more rows re-measured on **Apple M5 Pro** (`compare-outputs --profile common --build-mode optimized`, fresh ScanCode, 4 proc, same-host pairs).

| target | files | PV (M1→M5) | ScanCode (M1→M5) | × (old→new) |
|---|---|---|---|---|
| boostorg/graph | 2,117 | 15.37→7.01s | 200.37→132.02s | 13.04→18.83× |
| i18next/react-i18next | 590 | 14.82→6.71s | 204.00→128.04s | 13.77→19.08× |
| openfl/openfl | 1,196 | 12.77→10.08s | 216.36→137.21s | 16.94→13.61× |
| jquery/jquery-ui | 1,083 | 15.56→6.70s | 303.29→201.04s | 19.49→30.01× |
| scipy/scipy | 2,998 | 23.57→11.54s | 332.23→496.36s | 14.10→43.01× |
| chriskohlhoff/asio | 1,468 | 18.97→7.95s | 333.52→186.47s | 17.58→23.45× |
| pnpm/pnpm | 2,887 | 16.54→7.32s | 349.11→247.80s | 21.11→33.85× |
| denoland/std | 2,812 | 16.30→6.56s | 394.76→227.22s | 24.22→34.64× |
| yairm210/Unciv | 4,057 | 21.96→9.25s | 429.19→278.15s | 19.54→30.07× |
| JuliaLang/julia | 1,948 | 25.28→8.96s | 549.75→361.23s | 21.75→40.32× |

Headline regenerated: median **16.6→16.8×**, geomean **16.1×** (220 runs).

Notes on two outliers (faithful same-host measurements):
- **openfl** — ratio *dropped* (16.94→13.61): its PV barely improved on M5 (1.27× vs peers' ~2×), so ScanCode's larger gain lowered the ratio. Likely a single-thread/large-file bottleneck; clean single invocation.
- **scipy** — ScanCode got *slower* on M5 (332→496s, the copyright-heavy phenomenon also seen on kafka/git), which with PV halving drives the 43× figure.

## Pathology triage (verify-benchmark-target skill)

Most clean or Provenant-advantage (PV recovers holders on react-i18next/jquery-ui/openfl/deno-std; package deltas are ScanCode over-aggregating onto lockfile/dependency/test-fixture entries, which PV declines). **One genuine ScanCode-better finding surfaced (see below).** No regressions in package extraction (verified).

### Finding: Provenant under-detects the terse `MIT license.` one-line header

deno/std files use `// Copyright 2018-2026 the Deno authors. MIT license.`. ScanCode detects `mit` on **1138 / 1171** `.ts` files (via `mit_14.RULE`); Provenant detects it on only **79** — on ~1059 files it records *no* detection or clue. This is a real, systematic file-content under-detection of the short `MIT license.` reference (affects any repo with that common header), not introduced by this change — surfaced by triage.

I corrected the deno/std outcome bullet accordingly: it no longer claims "zero top-level license-expression deltas" (now 6) and instead notes ScanCode's broader file-level MIT detection there, while keeping the genuine package-visibility advantage (42 more packages, 0 missing). The gap itself is a candidate for a separate detection fix (sensitive: file-content false-positive risk).

## Issues

- Continues the M5 migration (after #1130/#1131); ~57 M1 rows remain.

## Scope and exclusions

- Included: the ten M1 repo rows + regenerated chart/headline + one corrected outcome bullet.
- Excluded: the file-content MIT-detection fix (separate follow-up).

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` — re-running produces no diff.
- Each row reproducible via `compare-outputs --profile common` against the pinned ref.

## Expected-output fixture changes

- None. Docs + generated chart only.
