### PR TITLE
fix(license): stop pruning license refs on headers with a 'no' substring word

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -352,12 +352,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.70s`; ScanCode `63.97s`
 - Broader Deno package and dependency extraction (`8` vs `0` packages, `966` vs `0` dependencies) from the root `deno.json`, `deno.lock`, and nested `packages/*/deno.json` manifests, with direct JSR and npm import-map or lockfile package identity where ScanCode stays manifest-blind
 
-##### [denoland/std @ a864f62](https://github.com/denoland/std/tree/a864f62bcc8a5f20716d2becab3cfe224a2ad810) — **34.64× faster**
+##### [denoland/std @ a864f62](https://github.com/denoland/std/tree/a864f62bcc8a5f20716d2becab3cfe224a2ad810) — **25.53× faster**
 
 - Files: 2,812
-- Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `6.56s`; ScanCode `227.22s`
-- Broader Deno package visibility (`42` more packages, `0` missing) from the root and leaf `*/deno.json` manifests across the standard-library tree, plus concrete Cargo lock package identities on embedded Rust fixtures instead of anonymous `cargo_lock` rows; ScanCode detects more file-level MIT here, from the terse one-line `// … the Deno authors. MIT license.` header that Provenant's file-content matcher does not yet pick up
+- Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `8.90s`; ScanCode `227.22s`
+- Broader Deno package visibility (`42` more packages, `0` missing) from the root and leaf `*/deno.json` manifests across the standard-library tree, plus concrete Cargo lock package identities on embedded Rust fixtures instead of anonymous `cargo_lock` rows, with file-level `MIT` header detection now matching ScanCode across the tree's `// … MIT license.` headers
 
 ##### [getsentry/self-hosted @ 8728919](https://github.com/getsentry/self-hosted/tree/8728919e080836c53724f277d4d36cc310fc5011) — **9.54× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -1147,9 +1147,9 @@ Provenant: 13.09s</title></circle>
     <circle cx="642.16" cy="524.25" r="4.5" fill="#2563eb"><title>jgm/pandoc @ d9838eb
 Files: 2768
 Provenant: 9.78s</title></circle>
-    <circle cx="643.24" cy="543.12" r="4.5" fill="#2563eb"><title>denoland/std @ a864f62
+    <circle cx="643.24" cy="528.71" r="4.5" fill="#2563eb"><title>denoland/std @ a864f62
 Files: 2812
-Provenant: 6.56s</title></circle>
+Provenant: 8.90s</title></circle>
     <circle cx="644.96" cy="531.78" r="4.5" fill="#2563eb"><title>rust-lang/cargo @ b54fe55
 Files: 2883
 Provenant: 8.34s</title></circle>

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -963,7 +963,21 @@ fn line_has_possessive_without_license_phrase(lower: &str) -> bool {
 
 fn line_has_negated_license_shorthand_list(line: &str) -> bool {
     let lower = line.to_ascii_lowercase();
-    lower.contains("no ") && line.contains('/') && line.chars().any(|ch| ch.is_ascii_uppercase())
+    line_has_standalone_no(&lower)
+        && line.contains('/')
+        && line.chars().any(|ch| ch.is_ascii_uppercase())
+}
+
+/// True when `lower` contains the standalone negation word "no", not the "no"
+/// inside an unrelated word. The previous `contains("no ")` substring check
+/// misfired on common copyright headers such as
+/// `// Copyright … the Deno authors. MIT license.` (the "no " inside "deno "),
+/// which — combined with the `//` slash and an uppercase letter — wrongly
+/// pruned the real `MIT license.` reference as a negated shorthand list.
+fn line_has_standalone_no(lower: &str) -> bool {
+    lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|word| word == "no")
 }
 
 fn expand_dual_licensed_under_readme_choice_detections(

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -811,6 +811,35 @@ fn test_prune_contextual_short_reference_matches_keeps_short_license_notice_with
 }
 
 #[test]
+fn test_prune_contextual_short_reference_matches_keeps_deno_style_copyright_header_mention() {
+    // Regression: the negated-shorthand-list heuristic matched the "no" inside
+    // "Deno" (substring) plus the `//` comment slash, wrongly pruning the real
+    // `MIT license.` reference on this extremely common header line.
+    let text = "// Copyright 2018-2026 the Deno authors. MIT license.\n";
+    let mut detections = vec![make_public_detection_with_matches(
+        "mit",
+        "MIT",
+        vec![make_public_match("mit", "MIT", 1, 1, 2, "mit_14.RULE")],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("mod.ts"),
+        text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(
+        detections.len(),
+        1,
+        "deno-style copyright+license header must keep its MIT mention: {detections:#?}"
+    );
+    assert_eq!(detections[0].license_expression_spdx, "MIT");
+}
+
+#[test]
 fn test_convert_detection_to_model_includes_diagnostics_when_enabled() {
     let text = concat!(
         "Reproduction and distribution of this file, with or without modification, are\n",


### PR DESCRIPTION
## Summary

Fixes a real, systematic **file-content license under-detection**: Provenant missed the `mit` reference in the extremely common one-line header

```
// Copyright 2018-2026 the Deno authors. MIT license.
```

On deno/std, ScanCode detected `mit` on **1138 / 1171** `.ts` files; Provenant on only **79** — recording no detection or clue on the rest. (Surfaced during the M5 benchmark refresh of deno/std; pre-existing, not introduced there.)

## Root cause

The match itself was fine — the engine matches `MIT license.` → `mit` via `mit_14.RULE`. It was being **pruned afterward** by `prune_contextual_short_reference_matches`, whose `line_has_negated_license_shorthand_list` heuristic (meant for lines like `No GPL/MIT`) fired on the deno header because:

- `lower.contains("no ")` matched the **`no` inside "De*no* authors"** (a substring, not the negation word),
- `line.contains('/')` matched the **`//` comment marker**,
- an uppercase letter was present.

So a positive license statement was misclassified as a negated shorthand list and its real MIT reference was dropped.

## Fix

Match the negation word **`no` at a word boundary** instead of as a substring (new `line_has_standalone_no` helper). `"deno"`, `"casino"`, etc. no longer count as negation; the intended `No GPL/MIT` lines still do.

## Verification

- `// Copyright 2018-2026 the Deno authors. MIT license.` and `bytes/copy.ts` now detect `mit` (were `None`).
- The intended heuristic is preserved: `No GPL/MIT alternatives are bundled here.` still prunes to no hard detection.
- **All golden suites unchanged** — `license_detection_golden` 21/21, `post_processing_golden` 21/21, `parsers_golden` 319/319 — i.e. the change only un-prunes the false-positive case and breaks nothing else (tiny, measured blast radius).
- New regression test `test_prune_contextual_short_reference_matches_keeps_deno_style_copyright_header_mention`; the existing `..._drops_negative_policy_lines` still passes.

## Issues

- Resolves the detection gap flagged in the batch-5 benchmark refresh (#1132).

## How to verify

- `cargo test --lib prune_contextual_short_reference`
- Scan any file with a `// Copyright … the Deno authors. MIT license.` header under `-l`.

## Expected-output fixture changes

- None (no golden changed).
