### PR TITLE
fix(license-detection): compare referenced filenames on tokens, not raw substring

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -706,12 +706,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.21s`; ScanCode `45.03s`
 - Broader BitBake package visibility (`4` vs `0` packages) from committed `.bb` and `.bbappend` metadata, with `linuxconsoletools_1.6.0.bb` carrying source URL/checksum plus local file-reference evidence and wildcard append manifests such as `u-boot%.bbappend` and `linux-yocto_%.bbappend` retained as package records instead of scanner-silent inputs
 
-##### [facebook/buck2 @ 3359f75](https://github.com/facebook/buck2/tree/3359f75abe3c7b6f543fdb2c7a775d47347b8897) — **15.27× faster**
+##### [facebook/buck2 @ 3359f75](https://github.com/facebook/buck2/tree/3359f75abe3c7b6f543fdb2c7a775d47347b8897) — **25.46× faster**
 
 - Files: 9,600
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `35.72s`; ScanCode `545.33s`
-- Slightly richer mixed-repository dependency extraction (`7079` vs `7034`) from committed `yarn.lock`, `flake.nix` / `flake.lock`, and Conan fixtures, plus zero scan errors where ScanCode still trips on `prelude/third-party/hmaptool/METADATA.bzl` and richer Buck target visibility on multi-rule `BUCK` files
+- Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `26.73s`; ScanCode `680.60s`
+- Slightly richer mixed-repository dependency extraction (`7079` vs `7034`) from committed `yarn.lock`, `flake.nix` / `flake.lock`, and Conan fixtures, plus zero scan errors where ScanCode still trips on `prelude/third-party/hmaptool/METADATA.bzl`
 
 ##### [facebook/watchman @ 426a7b7](https://github.com/facebook/watchman/tree/426a7b7dbd8600e1f3f9a33fd6715bb08295ca1a) — **18.1× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -617,9 +617,9 @@ ScanCode: 1659.92s</title></rect>
     <rect x="720.30" y="308.28" width="8" height="8" fill="#d97706" rx="1.5"><title>OrchardCMS/OrchardCore @ 01386f3
 Files: 9118
 ScanCode: 868.10s</title></rect>
-    <rect x="723.85" y="330.25" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/buck2 @ 3359f75
+    <rect x="723.85" y="319.78" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/buck2 @ 3359f75
 Files: 9600
-ScanCode: 545.33s</title></rect>
+ScanCode: 680.60s</title></rect>
     <rect x="725.29" y="281.69" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 ScanCode: 1524.08s</title></rect>
@@ -1279,9 +1279,9 @@ Provenant: 114.17s</title></circle>
     <circle cx="724.30" cy="498.91" r="4.5" fill="#2563eb"><title>OrchardCMS/OrchardCore @ 01386f3
 Files: 9118
 Provenant: 16.72s</title></circle>
-    <circle cx="727.85" cy="463.04" r="4.5" fill="#2563eb"><title>facebook/buck2 @ 3359f75
+    <circle cx="727.85" cy="476.74" r="4.5" fill="#2563eb"><title>facebook/buck2 @ 3359f75
 Files: 9600
-Provenant: 35.72s</title></circle>
+Provenant: 26.73s</title></circle>
     <circle cx="729.29" cy="459.45" r="4.5" fill="#2563eb"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 Provenant: 38.54s</title></circle>

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -145,17 +145,6 @@ pub(crate) fn filter_short_matches_scattered_on_too_many_lines(
         .collect()
 }
 
-/// Filter matches that are missing required phrases.
-///
-/// A match to a rule with required phrases ({{...}} markers) must contain
-/// all those required phrases in the matched region. If any required phrase
-/// is missing or interrupted by unknown/stopwords, the match is discarded.
-///
-/// This also handles:
-/// - `is_continuous` rules: the entire match must be continuous
-/// - `is_required_phrase` rules: same as is_continuous
-///
-/// Based on Python: `filter_matches_missing_required_phrases()` (match.py:2154-2328)
 /// True when the referenced filename `name` appears in `matched_text`, compared on
 /// the license tokenizer's tokens rather than as a raw substring.
 ///
@@ -176,6 +165,17 @@ fn referenced_filename_tokens_present(matched_text: &str, name: &str) -> bool {
         .any(|w| w == needle.as_slice())
 }
 
+/// Filter matches that are missing required phrases.
+///
+/// A match to a rule with required phrases ({{...}} markers) must contain
+/// all those required phrases in the matched region. If any required phrase
+/// is missing or interrupted by unknown/stopwords, the match is discarded.
+///
+/// This also handles:
+/// - `is_continuous` rules: the entire match must be continuous
+/// - `is_required_phrase` rules: same as is_continuous
+///
+/// Based on Python: `filter_matches_missing_required_phrases()` (match.py:2154-2328)
 pub(crate) fn filter_matches_missing_required_phrases(
     index: &LicenseIndex,
     matches: &[LicenseMatch],

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -13,6 +13,7 @@ use crate::license_detection::index::LicenseIndex;
 use crate::license_detection::models::{LicenseMatch, MatcherKind};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
+use crate::license_detection::tokenize::tokenize_without_stopwords;
 use std::path::Path;
 
 const INHERIT_LICENSE_FROM_PACKAGE_REFERENCE: &str = "INHERIT_LICENSE_FROM_PACKAGE";
@@ -155,6 +156,26 @@ pub(crate) fn filter_short_matches_scattered_on_too_many_lines(
 /// - `is_required_phrase` rules: same as is_continuous
 ///
 /// Based on Python: `filter_matches_missing_required_phrases()` (match.py:2154-2328)
+/// True when the referenced filename `name` appears in `matched_text`, compared on
+/// the license tokenizer's tokens rather than as a raw substring.
+///
+/// Filenames tokenize identically regardless of separator punctuation, so a rule
+/// referencing `LICENSE_MIT` is satisfied by real-world `LICENSE-MIT` / `LICENSE.MIT`
+/// spellings (and any case), while still requiring the referenced name to actually
+/// occur as a contiguous token run. This keeps the referenced-filename evidence guard
+/// intact — `COPYING` still requires a `copying` token — without discarding otherwise
+/// perfect matches over a `-` vs `_` difference.
+fn referenced_filename_tokens_present(matched_text: &str, name: &str) -> bool {
+    let needle = tokenize_without_stopwords(name);
+    if needle.is_empty() {
+        return false;
+    }
+    let haystack = tokenize_without_stopwords(matched_text);
+    haystack
+        .windows(needle.len())
+        .any(|w| w == needle.as_slice())
+}
+
 pub(crate) fn filter_matches_missing_required_phrases(
     index: &LicenseIndex,
     matches: &[LicenseMatch],
@@ -222,7 +243,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
                     };
                     let has_referenced_filename =
                         concrete_referenced_filenames.iter().any(|filename| {
-                            if matched_text.contains(filename.as_str()) {
+                            if referenced_filename_tokens_present(&matched_text, filename) {
                                 return true;
                             }
 
@@ -235,9 +256,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
 
                             is_path_like
                                 && basename.contains('.')
-                                && matched_text
-                                    .to_ascii_lowercase()
-                                    .contains(&basename.to_ascii_lowercase())
+                                && referenced_filename_tokens_present(&matched_text, basename)
                         });
                     if !has_referenced_filename {
                         discarded.push(m.clone());
@@ -673,6 +692,31 @@ mod tests {
     use crate::license_detection::unknown_match::MATCH_UNKNOWN;
     use crate::models::LineNumber;
     use crate::models::MatchScore;
+
+    #[test]
+    fn test_referenced_filename_tokens_present_is_separator_insensitive() {
+        // A rule referencing `LICENSE_MIT` is satisfied by the real-world hyphenated
+        // and dotted spellings, and is case-insensitive, because filenames tokenize
+        // identically regardless of separator punctuation.
+        assert!(referenced_filename_tokens_present(
+            "licensed under the MIT license found in the LICENSE-MIT file",
+            "LICENSE_MIT"
+        ));
+        assert!(referenced_filename_tokens_present(
+            "see the license.mit file",
+            "LICENSE_MIT"
+        ));
+        // The referenced name must still actually appear: a GPL notice that never
+        // mentions COPYING does not satisfy a COPYING reference (the FP guard).
+        assert!(!referenced_filename_tokens_present(
+            "under the terms of the GNU General Public License version 2 or later",
+            "COPYING"
+        ));
+        assert!(referenced_filename_tokens_present(
+            "see the file COPYING for details",
+            "COPYING"
+        ));
+    }
 
     fn parse_rule_id(rule_identifier: &str) -> Option<usize> {
         let trimmed = rule_identifier.trim();

--- a/src/license_detection/tests.rs
+++ b/src/license_detection/tests.rs
@@ -774,6 +774,49 @@ fn test_engine_does_not_keep_copying_referenced_rule_without_copying_filename_ev
 }
 
 #[test]
+fn test_engine_detects_meta_dual_license_header_as_or_with_hyphenated_license_filenames() {
+    let engine = get_engine();
+
+    // The ubiquitous Meta/Rust dual-license header references LICENSE-MIT /
+    // LICENSE-APACHE (hyphens), while the matching notice rule references the
+    // underscore spelling (LICENSE_MIT / LICENSE_APACHE). The dual-license notice
+    // must still resolve to an OR expression -- the project is dual-licensed and the
+    // licensee may choose either -- rather than an over-restrictive AND of the
+    // individual MIT and Apache-2.0 fragments. Regression for the referenced-filename
+    // presence check discarding the combined notice match over a `-` vs `_` mismatch.
+    let text = "\
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+fn main() {}
+";
+
+    let detections = engine
+        .detect_with_kind(text, false, false)
+        .expect("Detection should succeed");
+
+    let expressions: Vec<&str> = detections
+        .iter()
+        .filter_map(|d| d.license_expression.as_deref())
+        .collect();
+
+    assert!(
+        expressions.contains(&"mit OR apache-2.0"),
+        "expected dual-license OR expression, got: {:?}",
+        expressions
+    );
+    assert!(
+        expressions.iter().all(|expr| !expr.contains(" AND ")),
+        "dual-license header must not produce an AND expression, got: {:?}",
+        expressions
+    );
+}
+
+#[test]
 fn test_engine_detects_squashfs_notice_as_gpl_2_or_later_only() {
     let engine = get_engine();
 


### PR DESCRIPTION
## Summary

Fixes a license-detection bug where the ubiquitous Meta/Rust dual-license header resolves to an over-restrictive `mit AND apache-2.0` instead of `mit OR apache-2.0` whenever the file contains anything beyond the bare notice.

Root cause (confirmed by instrumentation): daachorse correctly produces the combined notice match (`mit_and_apache-2.0_10.RULE`, relevance 100, 100% coverage), but `filter_matches_missing_required_phrases` then **discards** it. Its referenced-filename presence guard required the matched text to *literally* `contains()` the rule's `referenced_filenames` string — and that check is punctuation/case-sensitive. The rule references `LICENSE_MIT`/`LICENSE_APACHE` (underscores); real files say `LICENSE-MIT`/`LICENSE-APACHE` (hyphens), so the guard failed and detection fell back to the individual `mit` + `apache-2.0` fragments combined with `AND`.

This is **not** a daachorse, candidate-generation, or expression-combining bug — the combined rule already carries the correct `OR`; it was just being filtered out.

## Fix

Compare referenced filenames on the **license tokenizer's tokens** rather than as a raw substring, so `LICENSE-MIT` / `LICENSE_MIT` / `LICENSE.MIT` (any case) are equivalent. The guard still requires the referenced name to actually appear as a contiguous token run, so its deliberate false-positive purpose is preserved (`COPYING` still needs a `copying` token).

### Why fix the comparison rather than remove the guard

The referenced-filename guard is a deliberate, tested Provenant noise-reducer (commit `387fe133`, "armijn regression"; `issue4949` requires that a `COPYING`-referencing GPL rule not survive without `COPYING` evidence). ScanCode uses `referenced_filenames` only for reference-*following* (`find_referenced_resource`), never to filter matches in its matcher — so removing the guard to "align with ScanCode" would abandon a PV-only improvement and reintroduce noise ScanCode does not suppress. The token-comparison fix keeps the improvement while fixing the separator sensitivity.

## Validation

- **buck2 re-compare**: `0` remaining `AND`-vs-`OR` package mismatches (was 32). Signal is Provenant-favored (5858 vs 5519).
- **FP guard intact**: `issue4949` (COPYING), `issue4884` (who.c), squashfs, and all referenced-filename unit tests pass unchanged.
- **New regression tests**: detection-level (the `Copyright…\nlicensed under both…LICENSE-MIT…` header → `mit OR apache-2.0`, never `AND`) and a unit test for the token-based presence helper.
- **License golden suite**: `21/21` passed.
- **Zero blast radius**: `update-license-golden --list-mismatches` reports the identical `would update 328` on clean main and with this change — the fix alters detection output on no golden fixture.

## Benchmark

Refreshes the `facebook/buck2` row on M5 (`15.27×` → `25.46×`; the `AND`/`OR` delta that deferred it from batch 6 is now resolved) and drops its unsupported "richer Buck target visibility" clause — current data shows ScanCode extracts more `pkg:buck/*` build-rule targets (820 vs 742), a pre-existing, licensing-orthogonal delta not addressed here.

## Testing

- `cargo test --lib filter_matches_missing_required_phrases` / referenced-filename / regression tests — pass
- `cargo test --lib referenced_filename_tokens_present meta_dual_license_header` — pass (new)
- `cargo test --features golden-tests --test license_detection_golden` — 21/21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
