### PR TITLE
fix(assembly): propagate declared license across collapsed Bazel/Buck build targets

### DIFF
--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -14,7 +14,8 @@ use crate::license_detection::detection::{
 use crate::license_detection::expression::parse_expression;
 use crate::license_detection::models::RuleId;
 use crate::models::{
-    FileInfo, FileType, LicenseDetection, Match, Package, PackageUid, TopLevelLicenseDetection,
+    DatasourceId, FileInfo, FileType, LicenseDetection, Match, Package, PackageUid,
+    TopLevelLicenseDetection,
 };
 use crate::utils::spdx::combine_license_expressions;
 
@@ -783,6 +784,50 @@ fn sync_packages_from_followed_package_data(
                 matched_package_data
                     .and_then(|package_data| package_data.other_license_expression_spdx.clone())
             });
+
+            // Bazel/Buck build files collapse all of a directory's build targets into one
+            // component (see docs/improvements/bazel-buck-build-targets.md). Reference-following
+            // resolves each target's `licenses=` reference on its own `package_data`, so syncing
+            // only the base target's `package_data` would drop a license declared by a sibling
+            // target — making the result depend on target declaration order. Take the union of
+            // all the file's targets' resolved declared licenses instead. Restricted to build-file
+            // datasources so multi-package databases and lockfiles are never smeared.
+            if let Some(build_targets) =
+                package_data_by_path
+                    .get(datafile_path.as_str())
+                    .filter(|package_datas| {
+                        package_datas.len() > 1
+                            && package_datas.iter().all(|package_data| {
+                                matches!(
+                                    package_data.datasource_id,
+                                    Some(DatasourceId::BazelBuild) | Some(DatasourceId::BuckFile)
+                                )
+                            })
+                    })
+            {
+                let mut merged_detections: Vec<LicenseDetection> = Vec::new();
+                for package_data in build_targets.iter() {
+                    for detection in &package_data.license_detections {
+                        if !merged_detections.contains(detection) {
+                            merged_detections.push(detection.clone());
+                        }
+                    }
+                }
+                if !merged_detections.is_empty() {
+                    next_declared_license_expression = combine_license_expressions(
+                        merged_detections
+                            .iter()
+                            .map(|detection| detection.license_expression.clone()),
+                    );
+                    next_declared_license_expression_spdx = combine_license_expressions(
+                        merged_detections
+                            .iter()
+                            .filter(|detection| !detection.license_expression_spdx.is_empty())
+                            .map(|detection| detection.license_expression_spdx.clone()),
+                    );
+                    next_license_detections = merged_detections;
+                }
+            }
 
             // Reference-following enrichment (NOT a parser backfill). For a single-datafile
             // package whose package_data carried no detections, adopt the detections found

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -736,7 +736,7 @@ fn sync_packages_from_followed_package_data(
             } else {
                 package.license_detections.clone()
             };
-            let next_other_license_detections = if !preserve_existing_package_license_fields
+            let mut next_other_license_detections = if !preserve_existing_package_license_fields
                 || package.other_license_detections.is_empty()
             {
                 matched_package_data
@@ -766,7 +766,7 @@ fn sync_packages_from_followed_package_data(
                         package_data.declared_license_expression_spdx.clone()
                     })
                 });
-            let next_other_license_expression = if preserve_existing_package_license_fields {
+            let mut next_other_license_expression = if preserve_existing_package_license_fields {
                 package.other_license_expression.clone()
             } else {
                 None
@@ -775,25 +775,29 @@ fn sync_packages_from_followed_package_data(
                 matched_package_data
                     .and_then(|package_data| package_data.other_license_expression.clone())
             });
-            let next_other_license_expression_spdx = if preserve_existing_package_license_fields {
-                package.other_license_expression_spdx.clone()
-            } else {
-                None
-            }
-            .or_else(|| {
-                matched_package_data
-                    .and_then(|package_data| package_data.other_license_expression_spdx.clone())
-            });
+            let mut next_other_license_expression_spdx =
+                if preserve_existing_package_license_fields {
+                    package.other_license_expression_spdx.clone()
+                } else {
+                    None
+                }
+                .or_else(|| {
+                    matched_package_data
+                        .and_then(|package_data| package_data.other_license_expression_spdx.clone())
+                });
 
             // Bazel/Buck build files collapse all of a directory's build targets into one
             // component (see docs/improvements/bazel-buck-build-targets.md). Reference-following
             // resolves each target's `licenses=` reference on its own `package_data`, so syncing
             // only the base target's `package_data` would drop a license declared by a sibling
             // target — making the result depend on target declaration order. Take the union of
-            // all the file's targets' resolved declared licenses instead. Restricted to build-file
-            // datasources so multi-package databases and lockfiles are never smeared.
-            if let Some(build_targets) =
-                package_data_by_path
+            // all the file's targets' resolved licenses instead. Restricted to build-file
+            // datasources so multi-package databases and lockfiles are never smeared, and gated on
+            // the same `preserve_existing_package_license_fields` flag as the per-field logic above
+            // so a multi-datafile package's already-established license fields are left intact on a
+            // BUILD-datafile iteration.
+            if !preserve_existing_package_license_fields
+                && let Some(build_targets) = package_data_by_path
                     .get(datafile_path.as_str())
                     .filter(|package_datas| {
                         package_datas.len() > 1
@@ -806,10 +810,16 @@ fn sync_packages_from_followed_package_data(
                     })
             {
                 let mut merged_detections: Vec<LicenseDetection> = Vec::new();
+                let mut merged_other_detections: Vec<LicenseDetection> = Vec::new();
                 for package_data in build_targets.iter() {
                     for detection in &package_data.license_detections {
                         if !merged_detections.contains(detection) {
                             merged_detections.push(detection.clone());
+                        }
+                    }
+                    for detection in &package_data.other_license_detections {
+                        if !merged_other_detections.contains(detection) {
+                            merged_other_detections.push(detection.clone());
                         }
                     }
                 }
@@ -826,6 +836,20 @@ fn sync_packages_from_followed_package_data(
                             .map(|detection| detection.license_expression_spdx.clone()),
                     );
                     next_license_detections = merged_detections;
+                }
+                if !merged_other_detections.is_empty() {
+                    next_other_license_expression = combine_license_expressions(
+                        merged_other_detections
+                            .iter()
+                            .map(|detection| detection.license_expression.clone()),
+                    );
+                    next_other_license_expression_spdx = combine_license_expressions(
+                        merged_other_detections
+                            .iter()
+                            .filter(|detection| !detection.license_expression_spdx.is_empty())
+                            .map(|detection| detection.license_expression_spdx.clone()),
+                    );
+                    next_other_license_detections = merged_other_detections;
                 }
             }
 

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/codebase/BUILD
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/codebase/BUILD
@@ -1,0 +1,10 @@
+java_library(
+    name = "no_license_attr",
+    srcs = ["B.java"],
+)
+
+java_library(
+    name = "with_license_file",
+    srcs = ["A.java"],
+    licenses = ["LICENSE"],
+)

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/codebase/LICENSE
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/codebase/LICENSE
@@ -1,0 +1,5 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

--- a/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/expected.json
+++ b/testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/expected.json
@@ -1,0 +1,281 @@
+{
+  "summary": {
+    "declared_license_expression": "apache-2.0",
+    "license_clarity_score": {
+      "score": 90,
+      "declared_license": true,
+      "identification_precision": true,
+      "has_license_text": true,
+      "declared_copyrights": false,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": false
+    },
+    "declared_holder": null,
+    "primary_language": "Starlark",
+    "other_license_expressions": [],
+    "other_holders": [],
+    "other_languages": []
+  },
+  "tallies": {
+    "detected_license_expression": [
+      {
+        "value": "apache-2.0",
+        "count": 2
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": [
+      {
+        "value": "Starlark",
+        "count": 1
+      }
+    ]
+  },
+  "tallies_of_key_files": {
+    "detected_license_expression": [
+      {
+        "value": "apache-2.0",
+        "count": 2
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": [
+      {
+        "value": "Starlark",
+        "count": 1
+      }
+    ]
+  },
+  "license_detections": [
+    {
+      "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+      "license_expression": "apache-2.0",
+      "license_expression_spdx": "Apache-2.0",
+      "detection_count": 1,
+      "detection_log": ["unknown-reference-to-local-file"],
+      "reference_matches": [
+        {
+          "from_file": "codebase/BUILD",
+          "license_expression": "unknown-license-reference",
+          "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+          "rule_identifier": "parser-declared-license"
+        },
+        {
+          "from_file": "codebase/LICENSE",
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "rule_identifier": "apache-2.0_791.RULE"
+        }
+      ]
+    },
+    {
+      "identifier": "apache_2_0-ea5a2828-6c70-408a-2f20-99577db519fd",
+      "license_expression": "apache-2.0",
+      "license_expression_spdx": "Apache-2.0",
+      "detection_count": 1,
+      "detection_log": [],
+      "reference_matches": [
+        {
+          "from_file": "codebase/LICENSE",
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "rule_identifier": "apache-2.0_791.RULE"
+        }
+      ]
+    }
+  ],
+  "license_references": [
+    {
+      "key": "apache-2.0",
+      "language": "en",
+      "short_name": "Apache 2.0",
+      "name": "Apache License 2.0",
+      "owner": "Apache Software Foundation",
+      "homepage_url": "http://www.apache.org/licenses/",
+      "spdx_license_key": "Apache-2.0",
+      "osi_license_key": "Apache-2.0",
+      "text_urls": ["http://www.apache.org/licenses/LICENSE-2.0"],
+      "osi_url": "http://opensource.org/licenses/apache2.0.php",
+      "faq_url": "http://www.apache.org/foundation/licence-FAQ.html",
+      "other_urls": [
+        "http://www.opensource.org/licenses/Apache-2.0",
+        "https://opensource.org/licenses/Apache-2.0",
+        "https://www.apache.org/licenses/LICENSE-2.0"
+      ],
+      "category": "Permissive",
+      "is_exception": false,
+      "is_unknown": false,
+      "is_generic": false,
+      "minimum_coverage": null,
+      "standard_notice": null
+    }
+  ],
+  "license_rule_references": [
+    {
+      "identifier": "apache-2.0_791.RULE",
+      "license_expression": "apache-2.0",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/apache-2.0_791.RULE",
+      "is_synthetic": false,
+      "length": 12,
+      "referenced_filenames": []
+    }
+  ],
+  "packages": [
+    {
+      "type": "bazel",
+      "name": "no_license_attr",
+      "version": null,
+      "declared_license_expression": "apache-2.0",
+      "declared_license_expression_spdx": "Apache-2.0",
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "datafile_paths": ["codebase/BUILD"],
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": ["unknown-reference-to-local-file"],
+          "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+          "matches": [
+            {
+              "from_file": "codebase/BUILD",
+              "matched_text": "LICENSE",
+              "license_expression": "unknown-license-reference",
+              "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            },
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "other_license_detections": []
+    }
+  ],
+  "files": [
+    {
+      "path": "codebase/BUILD",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": true,
+      "detected_license_expression": "apache-2.0",
+      "detected_license_expression_spdx": "Apache-2.0",
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": ["unknown-reference-to-local-file"],
+          "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+          "matches": [
+            {
+              "from_file": "codebase/BUILD",
+              "matched_text": "LICENSE",
+              "license_expression": "unknown-license-reference",
+              "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            },
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "package_data": [
+        {
+          "type": "bazel",
+          "name": "no_license_attr",
+          "version": null,
+          "declared_license_expression": null,
+          "declared_license_expression_spdx": null,
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "license_detections": [],
+          "other_license_detections": []
+        },
+        {
+          "type": "bazel",
+          "name": "with_license_file",
+          "version": null,
+          "declared_license_expression": "apache-2.0",
+          "declared_license_expression_spdx": "Apache-2.0",
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "license_detections": [
+            {
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "detection_log": ["unknown-reference-to-local-file"],
+              "identifier": "apache_2_0-cdcb17de-f01d-73ed-8eda-17263a964487",
+              "matches": [
+                {
+                  "from_file": "codebase/BUILD",
+                  "matched_text": "LICENSE",
+                  "license_expression": "unknown-license-reference",
+                  "license_expression_spdx": "LicenseRef-scancode-unknown-license-reference",
+                  "rule_identifier": "parser-declared-license",
+                  "referenced_filenames": ["LICENSE"]
+                },
+                {
+                  "from_file": "codebase/LICENSE",
+                  "matched_text": null,
+                  "license_expression": "apache-2.0",
+                  "license_expression_spdx": "Apache-2.0",
+                  "rule_identifier": "apache-2.0_791.RULE",
+                  "referenced_filenames": []
+                }
+              ]
+            }
+          ],
+          "other_license_detections": []
+        }
+      ]
+    },
+    {
+      "path": "codebase/LICENSE",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": false,
+      "detected_license_expression": "apache-2.0",
+      "detected_license_expression_spdx": "Apache-2.0",
+      "license_detections": [
+        {
+          "license_expression": "apache-2.0",
+          "license_expression_spdx": "Apache-2.0",
+          "detection_log": [],
+          "identifier": "apache_2_0-ea5a2828-6c70-408a-2f20-99577db519fd",
+          "matches": [
+            {
+              "from_file": "codebase/LICENSE",
+              "matched_text": null,
+              "license_expression": "apache-2.0",
+              "license_expression_spdx": "Apache-2.0",
+              "rule_identifier": "apache-2.0_791.RULE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "package_data": []
+    }
+  ]
+}

--- a/tests/post_processing_golden.rs
+++ b/tests/post_processing_golden.rs
@@ -446,6 +446,18 @@ Copyright - split out libs\0\xff",
     }
 
     #[test]
+    // Reverse of the fixture above: the license-bearing target is declared *last*.
+    // Bazel/Buck collapse all of a directory's targets into one component, so this
+    // guards that a license declared by a non-first target still resolves onto the
+    // merged component (target declaration order must not change the declared license).
+    fn test_golden_reference_follow_bazel_build_license_file_reversed() {
+        assert_reference_follow_fixture_matches_expected(
+            "testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed",
+            "testdata/summarycode-golden/reference_following/bazel_build_license_file_reversed/expected.json",
+        );
+    }
+
+    #[test]
     fn test_golden_reference_follow_readme_mit_see_license() {
         assert_reference_follow_fixture_matches_expected(
             "testdata/summarycode-golden/reference_following/readme_mit_see_license",


### PR DESCRIPTION
## Summary

Fixes the order-dependent declared-license drop that Greptile flagged on #1136: when a Bazel/Buck build directory has multiple targets and the license-bearing one is **not** declared first, the collapsed component silently lost its declared license.

## Root cause

Reference-following resolves each target's `licenses=` reference on its own `file.package_data` (per parsed target). `sync_packages_from_followed_package_data` (`reference_following.rs`) then copies the resolved license back onto the assembled top-level package by matching **one** `package_data` per datafile via purl/name. A collapsed Bazel/Buck component carries only the **first** target's purl, so:

- first target has the license → matched → resolved ✅
- a *later* target has the license → the matched (first, empty) `package_data` wins → declared license `None` ❌

`Package::update()` merges correctly at assembly time; the loss happens at this post-assembly sync.

## Fix

For a collapsed build file, take the **union** of all the file's targets' resolved declared licenses for the component, instead of a single matched `package_data`. Scoped strictly to `BazelBuild`/`BuckFile` datasources with `>1` target, so multi-package databases and lockfiles — where per-entry licenses must never be smeared across entries (the existing `#1077` guard) — are provably unaffected (the branch can't fire for them).

## Validation

- New reverse-order regression fixture (`bazel_build_license_file_reversed`, license-bearing target declared **last**) → now resolves `apache-2.0`; forward fixture unchanged. Both pass.
- `post_processing_golden` (22) and `assembly_golden` (35) green — no cross-package smearing, chromium collapse unchanged.
- 55 bazel/buck parser/assembly tests pass; clippy + fmt clean.

Follow-up to #1136 (the Bazel/Buck build-target collapse). Closes the propagation gap noted in that PR's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
