### PR TITLE
fix(vcpkg): bound CONTROL feature dependency paragraphs

### DIFF
--- a/src/parsers/vcpkg.rs
+++ b/src/parsers/vcpkg.rs
@@ -283,8 +283,14 @@ fn parse_vcpkg_control(content: &str) -> PackageData {
     let homepage_url =
         rfc822::get_header_first(&source_paragraph.headers, "homepage").map(truncate_field);
 
+    let feature_paragraphs = &paragraphs[1..];
+    let feature_limit = capped_iteration_limit(
+        feature_paragraphs.len(),
+        "vcpkg CONTROL feature dependency paragraphs",
+    );
+
     let mut dependencies = extract_control_dependencies(source_paragraph, None);
-    for feature_paragraph in paragraphs.iter().skip(1) {
+    for feature_paragraph in feature_paragraphs.iter().take(feature_limit) {
         if let Some(feature) = rfc822::get_header_first(&feature_paragraph.headers, "feature")
             .map(truncate_field)
             .filter(|feature| !feature.is_empty())
@@ -304,7 +310,7 @@ fn parse_vcpkg_control(content: &str) -> PackageData {
         description,
         homepage_url,
         dependencies,
-        extra_data: build_control_extra_data(source_paragraph, &paragraphs[1..]),
+        extra_data: build_control_extra_data(source_paragraph, feature_paragraphs),
         datasource_id: Some(DatasourceId::VcpkgControl),
         purl: build_vcpkg_purl(&name, version.as_deref()).map(truncate_field),
         is_private: false,


### PR DESCRIPTION
## Summary

- Applies the same paragraph-level bound to vcpkg CONTROL feature dependency extraction that feature metadata extraction already uses.
- Keeps the cleanup from #1140 separate because that PR merged before the follow-up could be pushed.

## Issues

- Follow-up to #1140 / #63.

## Scope and exclusions

- Included: bounded iteration cleanup in the vcpkg CONTROL parser.
- Explicit exclusions: no parser output contract changes and no new fixtures.

## How to verify

- CI covers this; the change is a bounds-consistency cleanup with no expected output change.

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: none.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: not applicable.

Generated with Claude Code.