### PR TITLE
docs(benchmarks): refresh large-repo rows on M5 + Starlark/OCI parser robustness fixes

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 218 of 218 recorded runs, with a **19.2× median speedup** and **18.8× geometric-mean speedup** overall; the median gap grows from **9.0×** on sub-100-file targets to **32.2×** on 10k+ file targets.
+> Provenant is faster on 218 of 218 recorded runs, with a **19.3× median speedup** and **19.2× geometric-mean speedup** overall; the median gap grows from **9.0×** on sub-100-file targets to **36.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -515,12 +515,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `33.78s`; ScanCode `659.41s`
 - Broader Maven package coverage (`2969` vs `2518`) with richer dependency extraction (`2550` vs `2267`) from parent/module inheritance, `dependencyManagement`, and committed `.pom` fixtures, plus more specific classifier-bearing Maven identities where ScanCode flattens coordinates and quieter unresolved-placeholder handling that preserves Maven semantics without flooding the scan with property/cycle noise
 
-##### [elastic/elasticsearch @ a414f3d](https://github.com/elastic/elasticsearch/tree/a414f3d06c7ab59a5a0b350e80e5674bf9864688) — **32.25× faster**
+##### [elastic/elasticsearch @ a414f3d](https://github.com/elastic/elasticsearch/tree/a414f3d06c7ab59a5a0b350e80e5674bf9864688) — **38.84× faster**
 
 - Files: 40,293
-- Run context: 2026-04-13 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `146.56s`; ScanCode `4726.52s`
-- Matched top-level package coverage (`1` vs `1`) with richer dependency extraction (`2378` vs `2067`) from the large multi-project Gradle build graph, plus extra Docker package visibility on committed fixture and distribution Dockerfiles
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `106.84s`; ScanCode `4149.25s`
+- Matched top-level package coverage (`1` vs `1`) with richer dependency extraction (`2346` vs `2067`) from the large multi-project Gradle build graph, plus extra Docker package visibility on committed fixture and distribution Dockerfiles
 
 ##### [gradle/gradle @ 92068b4](https://github.com/gradle/gradle/tree/92068b4fd4e6f3689b5164d9bf7f3b7c97bc4f4e) — **22.64× faster**
 
@@ -650,12 +650,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.42s`; ScanCode `123.76s`
 - Broader Go module graph dependency visibility (`117` vs `61` dependencies) from committed `go.mod.graph` while preserving matched package coverage (`10` vs `10`) across `go.mod`, `go.sum`, and vendored manifests, plus cleaner rejection of Go AUTHORS boilerplate and code-comment author/copyright fragments
 
-##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **23.90× faster**
+##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **45.07× faster**
 
 - Files: 491,354
-- Run context: 2026-04-14 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `957.91s`; ScanCode `22892.20s`
-- Broader dependency extraction (`16620` vs `12378`) from three tracked `.gitmodules` manifests plus vendored package surfaces, richer package coverage (`1310` vs `1279`), matched `README.chromium` package visibility across 940 vendored README files (`927` package records each), direct Git-submodule visibility where ScanCode reports zero package data on those `.gitmodules`, and fewer scan errors (`1` vs `4`) under the shared profile
+- Run context: 2026-06-25 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `715.21s`; ScanCode `32231.76s`
+- Provenant collapses internal Bazel/Buck build targets to one component per build directory (`255` Bazel + `3` Buck vs ScanCode's per-target `962` + `9`), a documented design choice ([`docs/improvements/bazel-buck-build-targets.md`](improvements/bazel-buck-build-targets.md)), so its top-level package count is lower (`599` vs `1279`) while real-ecosystem coverage holds at or above parity (Cargo `240` vs `239`, npm `46` vs `33`) and dependency extraction stays materially richer (`16793` vs `12378`) from vendored `.gitmodules`, Cargo, and npm surfaces; the remaining Provenant scan-error entries (`82` vs `3`) are almost all safe binary-content skips on test image fixtures, not parse failures
 
 ##### [conan-io/conan-center-index @ bc78dfb](https://github.com/conan-io/conan-center-index/tree/bc78dfb366e6596d21a7a5c51b97970656f73254) — **36.57× faster**
 
@@ -916,12 +916,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `8.34s`; ScanCode `205.19s`
 - Matched top-level Cargo package coverage (`77` vs `77`) with workspace-inherited declared-license resolution so `license.workspace = true` members carry a normalized expression, broader declared-license coverage overall (`66` package licenses ScanCode omits), legacy `dev`/`build` dependency manifest coverage, and zero scan errors on malformed fixture manifests
 
-##### [rust-lang/rust @ dab8d9d](https://github.com/rust-lang/rust/tree/dab8d9d1066c4c95008163c7babf275106ce3f32) — **30.57× faster**
+##### [rust-lang/rust @ dab8d9d](https://github.com/rust-lang/rust/tree/dab8d9d1066c4c95008163c7babf275106ce3f32) — **70.65× faster**
 
 - Files: 58,818
-- Run context: 2026-04-12 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `61.49s`; ScanCode `1879.48s`
-- Largely matched native-tree package and dependency extraction (`341` vs `344` packages, `5771` vs `5921` dependencies) with better nested Cargo lock dependency visibility across mixed workspaces, additional Nix package visibility, and more specific versioned Cargo package identities where ScanCode emits generic lockfile rows or versionless crate names
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `37.12s`; ScanCode `2622.46s`
+- Near-parity native-tree package and dependency extraction (`347` vs `345` packages, `5926` vs `5924` dependencies) with better nested Cargo lock dependency visibility across mixed workspaces, additional Nix package visibility, and more specific versioned Cargo package identities where ScanCode emits generic lockfile rows or versionless crate names; the lone Provenant scan-error entry is a deliberate safety skip of the intentionally malformed `tests/ui/include-macros/invalid-utf8-binary-file.bin` binary fixture
 
 ##### [rustcrypto/aeads @ 9d05d81](https://github.com/rustcrypto/aeads/tree/9d05d810c81719a8859d960220a637da8a2cdcd1) — **10.53× faster**
 
@@ -972,11 +972,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `7.88s`; ScanCode `120.11s`
 - Broader native-build package visibility (`3` vs `2` packages, `52` vs `38` dependencies) from the repo-root `configure.ac`, nested `meson.build`, and tracked `.gitmodules`, with the real `pkg:autotools/opus` identity instead of ScanCode's generic input placeholder, plus stronger `Written by ...` header author recovery and more correct BSD-2 classification on hybrid DNN headers such as `dnn/freq.h` and `dnn/vec_avx.h`
 
-##### [torvalds/linux @ b42ed3b](https://github.com/torvalds/linux/tree/b42ed3bb884e6b399b46d19df3f5cf015a79c804) — **27.47× faster**
+##### [torvalds/linux @ b42ed3b](https://github.com/torvalds/linux/tree/b42ed3bb884e6b399b46d19df3f5cf015a79c804) — **62.36× faster**
 
 - Files: 92,523
-- Run context: 2026-04-10 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 9 proc
-- Timing: Provenant `401.15s`; ScanCode `11017.99s`
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `271.01s`; ScanCode `16900.59s`
 - Broader sparse-tree package visibility (`4` vs `2` packages, `20` vs `19` dependencies), plus cleaner common-profile author extraction on representative native-source docs such as `sysrq`, `cpusets`, and `hwmon` rosters while rejecting several ScanCode-only prose false positives like `the Coreboot BIOS.` and `the Host`
 
 ##### [yoctoproject/poky @ cb2dcb4](https://git.yoctoproject.org/poky/tree/?id=cb2dcb4963e5fbe449f1bcb019eae883ddecc8ec) — **30.75× faster**
@@ -1123,12 +1123,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `20.20s`; ScanCode `769.93s`
 - Broader .NET/NuGet package and dependency extraction (`111` vs `0` packages, `186` vs `0` dependencies) across `*.fsproj`, the `FSharp.ProjectSystem.PropertyPages.vbproj`, shipping `*.nuspec`, `*.csproj`, and `Directory.Build.props` surfaces that ScanCode leaves unassembled, plus matched dual `CC0-1.0 AND MIT` detection on the TaskBuilder-derived files where a public-domain dedication abuts the project-license reference, and cleaner rejection of F# quotation `(c)` code-fragment copyrights and holders, filename- and prose-shaped author noise, a placeholder email, and a malformed concatenated URL
 
-##### [dotnet/runtime @ d1163e5](https://github.com/dotnet/runtime/tree/d1163e5a8f3f3aaa374993e8b5805911689aba28) — **31.49× faster**
+##### [dotnet/runtime @ d1163e5](https://github.com/dotnet/runtime/tree/d1163e5a8f3f3aaa374993e8b5805911689aba28) — **58.40× faster**
 
 - Files: 57,611
-- Run context: 2026-04-29 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `299.53s`; ScanCode `9432.77s`
-- Broader .NET/NuGet and sibling npm package visibility (`2249` vs `5` packages, `983` vs `503` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and committed `package-lock.json` inputs, with zero scan-file timeouts where ScanCode aborts on `EncryptedXmlSample4.xml`
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `107.09s`; ScanCode `6254.44s`
+- Broader .NET/NuGet and sibling npm package visibility (`2249` vs `5` packages, `986` vs `503` dependencies) across many `*.csproj` files, `Directory.Packages.props`, `Directory.Build.props`, and committed `package-lock.json` inputs
 
 ##### [MaxRev-Dev/gdal.netcore @ 6cc0145](https://github.com/MaxRev-Dev/gdal.netcore/tree/6cc0145f3dc182629fb11c4db96ced7a71fedf70) — **10.58× faster**
 
@@ -1188,11 +1188,11 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.40s`; ScanCode `113.37s`
 - Matched Composer package coverage (`40` vs `40`) and dependency extraction across `composer.json` and `composer.lock`, with broader URL recovery and Unicode-preserving author/holder normalization; the remaining ScanCode edge is per-package `declared_license_expression` on `composer.lock` entries, which Provenant's lockfile parser does not yet read from each package's `license` field (tracked as a fix)
 
-##### [gitlabhq/gitlabhq @ 48dc2f5](https://github.com/gitlabhq/gitlabhq/tree/48dc2f58ef713ec3ad4ef81fb03dbb09f9933f7c) — **23.86× faster**
+##### [gitlabhq/gitlabhq @ 48dc2f5](https://github.com/gitlabhq/gitlabhq/tree/48dc2f58ef713ec3ad4ef81fb03dbb09f9933f7c) — **48.63× faster**
 
 - Files: 65,359
-- Run context: 2026-04-30 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `243.06s`; ScanCode `5798.22s`
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `86.65s`; ScanCode `4214.01s`
 - Far broader dependency extraction (`9383` vs `6764`) across the repo-root `Gemfile`, the nested gemspec and `Gemfile.lock` tree, and mixed Go or npm sidecar manifests, with real gem versions resolved from local Ruby constants where ScanCode leaves placeholder `::VERSION` literals and with GitLab export `project.json` fixtures kept out of NuGet output
 
 ##### [laravel/framework @ a3960e8](https://github.com/laravel/framework/tree/a3960e8ff8ae2daa7ff609a245c51d9fe0aca684) — **34.46× faster**
@@ -1316,12 +1316,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.81s`; ScanCode `157.23s`
 - Broader Nix package and dependency extraction (`3` vs `0` packages, `69` vs `0` dependencies) from committed `flake.lock`, root `default.nix`, and other Nix manifest surfaces, with richer structured author, email, and URL recovery across repository docs and release metadata
 
-##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **14.84× faster**
+##### [NixOS/nixpkgs @ c407343](https://github.com/NixOS/nixpkgs/tree/c4073437f5ffeaeee270c37a2eddf370658d1332) — **34.14× faster**
 
 - Files: 52,167
-- Run context: 2026-04-27 · macOS 26.3.1 · Apple M1 Max · 32 GB · arm64 · 4 proc
-- Timing: Provenant `312.87s`; ScanCode `4641.96s`
-- Broader Nix package visibility (`1340` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, plus zero scan-file errors where ScanCode times out on huge metadata captures such as `hackage-packages.nix` and `typst-packages-from-universe.toml`
+- Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `103.10s`; ScanCode `3520.06s`
+- Broader Nix package visibility (`1299` vs `737` packages) across committed Nix manifests, provider metadata, and lockfile-adjacent package surfaces, with zero scan-file errors where ScanCode fails on huge generated metadata such as `hackage-packages.nix` and `typst-packages-from-universe.toml`, and more unique dependencies (`16515` vs `14431`) despite a far smaller raw dependency total because ScanCode duplicates `composer.lock` requirements ~400× (`447627` rows collapsing to `14431` unique)
 
 ##### [numtide/devshell @ 255a2b1](https://github.com/numtide/devshell/tree/255a2b1725a20d060f566e4755dbf571bbbb5f76) — **10.23× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -692,33 +692,33 @@ ScanCode: 4190.35s</title></rect>
     <rect x="818.67" y="238.22" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/camel @ c9c34a1
 Files: 38007
 ScanCode: 3824.09s</title></rect>
-    <rect x="822.70" y="228.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elastic/elasticsearch @ a414f3d
+    <rect x="822.70" y="234.36" width="8" height="8" fill="#d97706" rx="1.5"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
-ScanCode: 4726.52s</title></rect>
-    <rect x="840.49" y="229.06" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nixpkgs @ c407343
+ScanCode: 4149.25s</title></rect>
+    <rect x="840.49" y="242.14" width="8" height="8" fill="#d97706" rx="1.5"><title>NixOS/nixpkgs @ c407343
 Files: 52167
-ScanCode: 4641.96s</title></rect>
+ScanCode: 3520.06s</title></rect>
     <rect x="840.86" y="213.86" width="8" height="8" fill="#d97706" rx="1.5"><title>mongodb/mongo @ d6877a3
 Files: 52443
 ScanCode: 6404.29s</title></rect>
-    <rect x="847.33" y="195.56" width="8" height="8" fill="#d97706" rx="1.5"><title>dotnet/runtime @ d1163e5
+    <rect x="847.33" y="214.97" width="8" height="8" fill="#d97706" rx="1.5"><title>dotnet/runtime @ d1163e5
 Files: 57611
-ScanCode: 9432.77s</title></rect>
-    <rect x="848.76" y="271.78" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/rust @ dab8d9d
+ScanCode: 6254.44s</title></rect>
+    <rect x="848.76" y="256.04" width="8" height="8" fill="#d97706" rx="1.5"><title>rust-lang/rust @ dab8d9d
 Files: 58818
-ScanCode: 1879.48s</title></rect>
+ScanCode: 2622.46s</title></rect>
     <rect x="854.98" y="234.53" width="8" height="8" fill="#d97706" rx="1.5"><title>aboutcode-org/scancode-toolkit @ 6570c13
 Files: 64369
 ScanCode: 4134.60s</title></rect>
-    <rect x="856.03" y="218.55" width="8" height="8" fill="#d97706" rx="1.5"><title>gitlabhq/gitlabhq @ 48dc2f5
+    <rect x="856.03" y="233.63" width="8" height="8" fill="#d97706" rx="1.5"><title>gitlabhq/gitlabhq @ 48dc2f5
 Files: 65359
-ScanCode: 5798.22s</title></rect>
-    <rect x="879.98" y="188.22" width="8" height="8" fill="#d97706" rx="1.5"><title>torvalds/linux @ b42ed3b
+ScanCode: 4214.01s</title></rect>
+    <rect x="879.98" y="168.00" width="8" height="8" fill="#d97706" rx="1.5"><title>torvalds/linux @ b42ed3b
 Files: 92523
-ScanCode: 11017.99s</title></rect>
-    <rect x="995.03" y="153.67" width="8" height="8" fill="#d97706" rx="1.5"><title>chromium/chromium @ 2befda7
+ScanCode: 16900.59s</title></rect>
+    <rect x="995.03" y="137.50" width="8" height="8" fill="#d97706" rx="1.5"><title>chromium/chromium @ 2befda7
 Files: 491354
-ScanCode: 22892.20s</title></rect>
+ScanCode: 32231.76s</title></rect>
   </g>
   <g aria-label="Provenant points">
     <circle cx="96.00" cy="558.68" r="4.5" fill="#2563eb"><title>7zip 25.01-r0 .apk @ sha256:6602ccb
@@ -1348,32 +1348,32 @@ Provenant: 117.09s</title></circle>
     <circle cx="822.67" cy="375.31" r="4.5" fill="#2563eb"><title>apache/camel @ c9c34a1
 Files: 38007
 Provenant: 228.70s</title></circle>
-    <circle cx="826.70" cy="396.34" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
+    <circle cx="826.70" cy="411.27" r="4.5" fill="#2563eb"><title>elastic/elasticsearch @ a414f3d
 Files: 40293
-Provenant: 146.56s</title></circle>
-    <circle cx="844.49" cy="360.50" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
+Provenant: 106.84s</title></circle>
+    <circle cx="844.49" cy="412.96" r="4.5" fill="#2563eb"><title>NixOS/nixpkgs @ c407343
 Files: 52167
-Provenant: 312.87s</title></circle>
+Provenant: 103.10s</title></circle>
     <circle cx="844.86" cy="397.47" r="4.5" fill="#2563eb"><title>mongodb/mongo @ d6877a3
 Files: 52443
 Provenant: 143.10s</title></circle>
-    <circle cx="851.33" cy="362.56" r="4.5" fill="#2563eb"><title>dotnet/runtime @ d1163e5
+    <circle cx="851.33" cy="411.16" r="4.5" fill="#2563eb"><title>dotnet/runtime @ d1163e5
 Files: 57611
-Provenant: 299.53s</title></circle>
-    <circle cx="852.76" cy="437.38" r="4.5" fill="#2563eb"><title>rust-lang/rust @ dab8d9d
+Provenant: 107.09s</title></circle>
+    <circle cx="852.76" cy="461.23" r="4.5" fill="#2563eb"><title>rust-lang/rust @ dab8d9d
 Files: 58818
-Provenant: 61.49s</title></circle>
+Provenant: 37.12s</title></circle>
     <circle cx="858.98" cy="380.00" r="4.5" fill="#2563eb"><title>aboutcode-org/scancode-toolkit @ 6570c13
 Files: 64369
 Provenant: 207.10s</title></circle>
-    <circle cx="860.03" cy="372.43" r="4.5" fill="#2563eb"><title>gitlabhq/gitlabhq @ 48dc2f5
+    <circle cx="860.03" cy="421.17" r="4.5" fill="#2563eb"><title>gitlabhq/gitlabhq @ 48dc2f5
 Files: 65359
-Provenant: 243.06s</title></circle>
-    <circle cx="883.98" cy="348.76" r="4.5" fill="#2563eb"><title>torvalds/linux @ b42ed3b
+Provenant: 86.65s</title></circle>
+    <circle cx="883.98" cy="367.29" r="4.5" fill="#2563eb"><title>torvalds/linux @ b42ed3b
 Files: 92523
-Provenant: 401.15s</title></circle>
-    <circle cx="999.03" cy="307.63" r="4.5" fill="#2563eb"><title>chromium/chromium @ 2befda7
+Provenant: 271.01s</title></circle>
+    <circle cx="999.03" cy="321.44" r="4.5" fill="#2563eb"><title>chromium/chromium @ 2befda7
 Files: 491354
-Provenant: 957.91s</title></circle>
+Provenant: 715.21s</title></circle>
   </g>
 </svg>

--- a/src/parsers/bazel.rs
+++ b/src/parsers/bazel.rs
@@ -29,11 +29,12 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::path::Path;
 
 use crate::parser_warn as warn;
+use starlark_syntax::syntax::AstModule;
 use starlark_syntax::syntax::ast;
-use starlark_syntax::syntax::{AstModule, Dialect};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
+use super::starlark_parse::{self, RECOVERY_MISSING_SEPARATOR};
 
 type StarlarkCallArgs = ast::CallArgsP<ast::AstNoPayload>;
 
@@ -79,14 +80,17 @@ impl PackageParser for BazelBuildParser {
 fn parse_bazel_build(path: &Path) -> Result<Vec<PackageData>, String> {
     let content =
         crate::parsers::utils::read_file_to_string(path, None).map_err(|e| e.to_string())?;
-    let module = parse_starlark_module("<BUILD>", content)?;
+    let (module, repaired) = parse_starlark_module("<BUILD>", content)?;
 
     let mut packages = Vec::new();
 
     let statements = top_level_statements(&module);
     let limit = capped_iteration_limit(statements.len(), "bazel BUILD top-level statements");
     for statement in statements.iter().take(limit) {
-        if let Some(package_data) = extract_package_from_statement(statement) {
+        if let Some(mut package_data) = extract_package_from_statement(statement) {
+            if repaired {
+                starlark_parse::mark_parse_recovery(&mut package_data, RECOVERY_MISSING_SEPARATOR);
+            }
             packages.push(package_data);
         }
     }
@@ -192,7 +196,7 @@ impl PackageParser for BazelModuleParser {
 fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
     let content =
         crate::parsers::utils::read_file_to_string(path, None).map_err(|e| e.to_string())?;
-    let module = parse_starlark_module("<MODULE.bazel>", content)?;
+    let (module, repaired) = parse_starlark_module("<MODULE.bazel>", content)?;
 
     let mut package = default_bazel_module_package_data();
     let mut extra_data = JsonMap::new();
@@ -253,7 +257,11 @@ fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
     }
 
     if package.name.is_none() {
-        return Ok(default_bazel_module_package_data());
+        let mut fallback = default_bazel_module_package_data();
+        if repaired {
+            starlark_parse::mark_parse_recovery(&mut fallback, RECOVERY_MISSING_SEPARATOR);
+        }
+        return Ok(fallback);
     }
 
     if !overrides.is_empty() {
@@ -262,15 +270,14 @@ fn parse_bazel_module(path: &Path) -> Result<PackageData, String> {
 
     package.dependencies = dependencies;
     package.extra_data = (!extra_data.is_empty()).then(|| extra_data.into_iter().collect());
+    if repaired {
+        starlark_parse::mark_parse_recovery(&mut package, RECOVERY_MISSING_SEPARATOR);
+    }
     Ok(package)
 }
 
-fn parse_starlark_module(filename: &str, content: String) -> Result<AstModule, String> {
-    let dialect = Dialect {
-        enable_top_level_stmt: true,
-        ..Dialect::Standard
-    };
-    AstModule::parse(filename, content, &dialect).map_err(|error| error.to_string())
+fn parse_starlark_module(filename: &str, content: String) -> Result<(AstModule, bool), String> {
+    starlark_parse::parse_with_repair(filename, content)
 }
 
 fn top_level_statements(module: &AstModule) -> &[ast::AstStmt] {

--- a/src/parsers/bazel_test.rs
+++ b/src/parsers/bazel_test.rs
@@ -80,6 +80,35 @@ cc_library(
 }
 
 #[test]
+fn test_recovers_from_missing_argument_comma() {
+    // A missing comma after the `hdrs=[...]` list would otherwise fail the parse;
+    // the shared repair pass recovers it and records an auditable breadcrumb.
+    let content = r#"
+cc_library(
+    name = "hello-greet",
+    hdrs = [
+        "hello-greet.h",
+    ]
+    srcs = ["hello-greet.cc"],
+)
+"#;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let build_path = temp_dir.path().join("BUILD");
+    std::fs::write(&build_path, content).unwrap();
+
+    let pkg = BazelBuildParser::extract_first_package(&build_path);
+    assert_eq!(pkg.name, Some("hello-greet".to_string()));
+    let recovery = pkg
+        .extra_data
+        .as_ref()
+        .and_then(|map| map.get(crate::parsers::starlark_parse::PARSE_RECOVERY_KEY));
+    assert!(
+        recovery.is_some(),
+        "recovered Bazel package should record a breadcrumb"
+    );
+}
+
+#[test]
 fn test_extracts_java_binary() {
     let content = r#"
 java_binary(

--- a/src/parsers/buck.rs
+++ b/src/parsers/buck.rs
@@ -27,13 +27,14 @@ use std::path::Path;
 use crate::parser_warn as warn;
 use crate::parsers::utils::{capped_iteration_limit, read_file_to_string, truncate_field};
 use packageurl::PackageUrl;
+use starlark_syntax::syntax::AstModule;
 use starlark_syntax::syntax::ast;
-use starlark_syntax::syntax::{AstModule, Dialect};
 
 use crate::models::{DatasourceId, PackageData, PackageType, Party, PartyType, Sha1Digest};
 
 use super::PackageParser;
 use super::metadata::ParserMetadata;
+use super::starlark_parse::{self, RECOVERY_MISSING_SEPARATOR};
 
 type StarlarkCallArgs = ast::CallArgsP<ast::AstNoPayload>;
 
@@ -105,14 +106,17 @@ impl PackageParser for BuckMetadataBzlParser {
 /// Parse a Buck BUCK file (same logic as Bazel BUILD)
 fn parse_buck_build(path: &Path) -> Result<Vec<PackageData>, String> {
     let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
-    let module = parse_starlark_module("<BUCK>", content)?;
+    let (module, repaired) = parse_starlark_module("<BUCK>", content)?;
 
     let mut packages = Vec::new();
 
     let statements = top_level_statements(&module);
     let limit = capped_iteration_limit(statements.len(), "BUCK top-level statements");
     for statement in statements.iter().take(limit) {
-        if let Some(package_data) = extract_build_package_from_statement(statement) {
+        if let Some(mut package_data) = extract_build_package_from_statement(statement) {
+            if repaired {
+                starlark_parse::mark_parse_recovery(&mut package_data, RECOVERY_MISSING_SEPARATOR);
+            }
             packages.push(package_data);
         }
     }
@@ -123,13 +127,17 @@ fn parse_buck_build(path: &Path) -> Result<Vec<PackageData>, String> {
 /// Parse a Buck METADATA.bzl file
 fn parse_metadata_bzl(path: &Path) -> Result<PackageData, String> {
     let content = read_file_to_string(path, None).map_err(|e| e.to_string())?;
-    let module = parse_starlark_module("<METADATA.bzl>", content)?;
+    let (module, repaired) = parse_starlark_module("<METADATA.bzl>", content)?;
 
     let statements = top_level_statements(&module);
     let limit = capped_iteration_limit(statements.len(), "METADATA.bzl top-level statements");
     for statement in statements.iter().take(limit) {
         if let Some(dict) = extract_metadata_assignment_dict(statement) {
-            return Ok(extract_metadata_dict(dict));
+            let mut package_data = extract_metadata_dict(dict);
+            if repaired {
+                starlark_parse::mark_parse_recovery(&mut package_data, RECOVERY_MISSING_SEPARATOR);
+            }
+            return Ok(package_data);
         }
     }
 
@@ -140,13 +148,9 @@ fn parse_metadata_bzl(path: &Path) -> Result<PackageData, String> {
     })
 }
 
-fn parse_starlark_module(filename: &str, content: String) -> Result<AstModule, String> {
+fn parse_starlark_module(filename: &str, content: String) -> Result<(AstModule, bool), String> {
     let content = preprocess_starlark_content(&content);
-    let dialect = Dialect {
-        enable_top_level_stmt: true,
-        ..Dialect::Standard
-    };
-    AstModule::parse(filename, content, &dialect).map_err(|error| error.to_string())
+    starlark_parse::parse_with_repair(filename, content)
 }
 
 fn preprocess_starlark_content(content: &str) -> String {
@@ -761,5 +765,38 @@ rust_library(
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].package_type, Some(PackageType::Buck));
         assert_eq!(packages[0].name.as_deref(), Some("library"));
+    }
+
+    #[test]
+    fn test_parse_buck_build_recovers_from_missing_argument_comma() {
+        // Mirrors a real vendored zstd BUCK file: a missing comma after the
+        // `exported_headers=[...]` list leaves `srcs=` with no separator.
+        let content = r#"cxx_library(
+    name='errors',
+    visibility=['PUBLIC'],
+    exported_headers=[
+        'zstd_errors.h',
+        'common/error_private.h',
+    ]
+    srcs=['common/error_private.c'],
+)
+"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let buck_path = temp_dir.path().join("BUCK");
+        std::fs::write(&buck_path, content).unwrap();
+
+        let packages = parse_buck_build(&buck_path).expect("BUCK file should parse after repair");
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name.as_deref(), Some("errors"));
+        // Recovered packages carry an auditable breadcrumb rather than a scan error.
+        let recovery = packages[0]
+            .extra_data
+            .as_ref()
+            .and_then(|map| map.get(super::starlark_parse::PARSE_RECOVERY_KEY));
+        assert!(
+            recovery.is_some(),
+            "recovered package should record a breadcrumb"
+        );
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -303,6 +303,7 @@ mod sbt;
 mod sbt_test;
 #[cfg(test)]
 mod scan_test_utils;
+mod starlark_parse;
 mod swift_manifest_json;
 #[cfg(test)]
 mod swift_manifest_json_test;

--- a/src/parsers/oci.rs
+++ b/src/parsers/oci.rs
@@ -181,7 +181,11 @@ fn parse_oci_image_index(content: &str, layout_root: Option<&Path>) -> Vec<Packa
     let index: OciImageIndex = match serde_json::from_str(content) {
         Ok(index) => index,
         Err(error) => {
-            warn!("Failed to parse OCI image index JSON: {}", error);
+            // `index.json` / `manifest.json` are common filenames the parser
+            // matches broadly; content that is not OCI/docker JSON (e.g. a Chrome
+            // extension or web-app manifest, often JSONC) simply is not ours.
+            // Decline quietly rather than emitting a scan error.
+            log::debug!("Declining non-OCI index.json/manifest.json: {error}");
             return Vec::new();
         }
     };
@@ -451,7 +455,9 @@ fn parse_docker_save_manifest(content: &str) -> Vec<PackageData> {
     let entries: Vec<DockerSaveManifestEntry> = match serde_json::from_str(content) {
         Ok(entries) => entries,
         Err(error) => {
-            warn!("Failed to parse docker save manifest JSON: {}", error);
+            // A top-level JSON array that is not a docker-save manifest is not
+            // ours; decline quietly instead of emitting a scan error.
+            log::debug!("Declining non-docker-save manifest.json: {error}");
             return Vec::new();
         }
     };

--- a/src/parsers/oci_test.rs
+++ b/src/parsers/oci_test.rs
@@ -640,3 +640,35 @@ fn schema_version_fallback_requires_descriptor_digest() {
         Some("sha256:3333333333333333333333333333333333333333333333333333333333333333")
     );
 }
+
+#[test]
+fn test_non_oci_manifest_json_declines_without_packages() {
+    // Chrome extension / web-app manifests share the `manifest.json` filename the
+    // parser matches broadly, but are not OCI/docker images. They must yield no
+    // packages (and emit no scan error — the parser declines quietly).
+    let chrome_extension = r#"{
+        "manifest_version": 3,
+        "name": "Example Extension",
+        "version": "1.0",
+        "permissions": ["storage"]
+    }"#;
+    assert!(
+        parse_oci_content(chrome_extension, None).is_empty(),
+        "a Chrome extension manifest.json must not be claimed as an OCI image"
+    );
+
+    // JSONC-style content (comments / not strict JSON) must also decline cleanly
+    // rather than surface a parse failure.
+    let jsonc = "{\n  // a comment\n  \"name\": \"web-app\"\n}";
+    assert!(
+        parse_oci_content(jsonc, None).is_empty(),
+        "non-JSON/JSONC manifest content must decline without packages"
+    );
+
+    // A JSON array that is not a docker-save manifest also declines.
+    let unrelated_array = r#"[{"foo": "bar"}]"#;
+    assert!(
+        parse_oci_content(unrelated_array, None).is_empty(),
+        "an unrelated top-level JSON array must not be claimed as a docker save manifest"
+    );
+}

--- a/src/parsers/starlark_parse.rs
+++ b/src/parsers/starlark_parse.rs
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared Starlark parsing helpers for the Bazel and Buck parsers.
+//!
+//! Both build systems use the same Starlark (Python-like) dialect, so they share a
+//! single parse entry point. The notable behavior here is [`parse_with_repair`]: a
+//! bounded, post-failure recovery pass for the common real-world malformation of a
+//! missing comma between arguments on separate lines. When recovery succeeds, callers
+//! record a [`PARSE_RECOVERY_KEY`] breadcrumb on the produced packages so the result
+//! stays auditable without masquerading as a scan error.
+
+use serde_json::Value as JsonValue;
+use starlark_syntax::syntax::{AstModule, Dialect};
+
+use crate::models::PackageData;
+
+/// `extra_data` key recording that a package was extracted from input recovered by a
+/// fallback parse repair (rather than a clean parse).
+pub(crate) const PARSE_RECOVERY_KEY: &str = "provenant_parse_recovery";
+
+/// Recovery note used when a missing argument/element separator was reinserted.
+pub(crate) const RECOVERY_MISSING_SEPARATOR: &str = "inserted-missing-argument-separator";
+
+/// Parse Starlark `content`, falling back to a conservative comma repair if the first
+/// parse fails. Returns the module and whether the repair pass was the one that
+/// succeeded, so callers can annotate recovered packages.
+pub(crate) fn parse_with_repair(
+    filename: &str,
+    content: String,
+) -> Result<(AstModule, bool), String> {
+    let dialect = Dialect {
+        enable_top_level_stmt: true,
+        ..Dialect::Standard
+    };
+    match AstModule::parse(filename, content.clone(), &dialect) {
+        Ok(module) => Ok((module, false)),
+        Err(first_error) => {
+            // Real-world vendored BUILD/BUCK files occasionally omit a comma between
+            // arguments on separate lines. Retry once with a conservative repair so a
+            // single upstream typo does not cost the whole file's package extraction.
+            // The repair only ever runs on content that already failed to parse, so it
+            // cannot alter the result for any well-formed file.
+            let repaired = repair_missing_argument_commas(&content);
+            if repaired != content
+                && let Ok(module) = AstModule::parse(filename, repaired, &dialect)
+            {
+                return Ok((module, true));
+            }
+            Err(first_error.to_string())
+        }
+    }
+}
+
+/// Record an auditable breadcrumb on a package extracted from repaired input.
+pub(crate) fn mark_parse_recovery(package: &mut PackageData, note: &str) {
+    package
+        .extra_data
+        .get_or_insert_with(Default::default)
+        .insert(
+            PARSE_RECOVERY_KEY.to_string(),
+            JsonValue::String(note.to_string()),
+        );
+}
+
+/// Quote/comment-aware repair that inserts a missing comma between two arguments or
+/// collection elements that sit on separate lines inside `()`, `[]`, or `{}`.
+///
+/// Deliberately conservative: it only acts at a line boundary where a completed value
+/// is followed by the start of a new element, never inside strings, and never when the
+/// next line continues an expression (operator, closer, attribute access, or a
+/// comprehension/conditional keyword). Because it runs only as a post-failure fallback,
+/// any false positive is bounded to input that was already unparseable.
+pub(crate) fn repair_missing_argument_commas(content: &str) -> String {
+    #[derive(Clone, Copy, PartialEq)]
+    enum StrKind {
+        Single,
+        Double,
+        TripleSingle,
+        TripleDouble,
+    }
+
+    struct LineMeta {
+        depth_before: i32,
+        starts_in_string: bool,
+        ends_in_string: bool,
+        last_sig: Option<char>,
+        last_sig_idx: Option<usize>,
+        first_sig: Option<char>,
+        first_word: String,
+    }
+
+    fn leading_word(line: &str) -> String {
+        line.trim_start()
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect()
+    }
+
+    fn is_value_end(c: char) -> bool {
+        c.is_alphanumeric() || c == '_' || matches!(c, '\'' | '"' | ']' | ')' | '}')
+    }
+
+    fn is_element_start(c: char) -> bool {
+        c.is_alphanumeric() || c == '_' || matches!(c, '\'' | '"' | '[' | '(' | '{')
+    }
+
+    fn is_continuation_keyword(word: &str) -> bool {
+        matches!(
+            word,
+            "if" | "else" | "elif" | "for" | "and" | "or" | "not" | "in"
+        )
+    }
+
+    let raw_lines: Vec<&str> = content.split('\n').collect();
+    let mut metas: Vec<LineMeta> = Vec::with_capacity(raw_lines.len());
+    let mut depth: i32 = 0;
+    let mut string: Option<StrKind> = None;
+
+    for line in &raw_lines {
+        let depth_before = depth;
+        let starts_in_string = string.is_some();
+        let mut last_sig: Option<char> = None;
+        let mut last_sig_idx: Option<usize> = None;
+        let mut first_sig: Option<char> = None;
+        let mut escaped = false;
+        let mut in_comment = false;
+        let chars: Vec<char> = line.chars().collect();
+        let mut k = 0;
+        while k < chars.len() {
+            let c = chars[k];
+            if let Some(kind) = string {
+                if matches!(kind, StrKind::Single | StrKind::Double) {
+                    if escaped {
+                        escaped = false;
+                        k += 1;
+                        continue;
+                    }
+                    if c == '\\' {
+                        escaped = true;
+                        k += 1;
+                        continue;
+                    }
+                }
+                let triple = matches!(kind, StrKind::TripleSingle | StrKind::TripleDouble);
+                let closes = match kind {
+                    StrKind::Single => c == '\'',
+                    StrKind::Double => c == '"',
+                    StrKind::TripleSingle => {
+                        c == '\''
+                            && chars.get(k + 1) == Some(&'\'')
+                            && chars.get(k + 2) == Some(&'\'')
+                    }
+                    StrKind::TripleDouble => {
+                        c == '"' && chars.get(k + 1) == Some(&'"') && chars.get(k + 2) == Some(&'"')
+                    }
+                };
+                if closes {
+                    let adv = if triple { 3 } else { 1 };
+                    string = None;
+                    first_sig.get_or_insert(c);
+                    last_sig = Some(c);
+                    last_sig_idx = Some(k + adv - 1);
+                    k += adv;
+                    continue;
+                }
+                k += 1;
+                continue;
+            }
+            if in_comment {
+                k += 1;
+                continue;
+            }
+            if c == '#' {
+                in_comment = true;
+                k += 1;
+                continue;
+            }
+            if c == '"' || c == '\'' {
+                let triple = chars.get(k + 1) == Some(&c) && chars.get(k + 2) == Some(&c);
+                string = Some(match (c, triple) {
+                    ('"', true) => StrKind::TripleDouble,
+                    ('"', false) => StrKind::Double,
+                    ('\'', true) => StrKind::TripleSingle,
+                    _ => StrKind::Single,
+                });
+                first_sig.get_or_insert(c);
+                last_sig = Some(c);
+                last_sig_idx = Some(k);
+                k += if triple { 3 } else { 1 };
+                continue;
+            }
+            if c.is_whitespace() {
+                k += 1;
+                continue;
+            }
+            match c {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => depth = (depth - 1).max(0),
+                _ => {}
+            }
+            first_sig.get_or_insert(c);
+            last_sig = Some(c);
+            last_sig_idx = Some(k);
+            k += 1;
+        }
+        metas.push(LineMeta {
+            depth_before,
+            starts_in_string,
+            ends_in_string: string.is_some(),
+            last_sig,
+            last_sig_idx,
+            first_sig,
+            first_word: leading_word(line),
+        });
+    }
+
+    let mut out_lines: Vec<String> = raw_lines.iter().map(|s| s.to_string()).collect();
+    for i in 0..metas.len() {
+        if metas[i].last_sig.is_none() {
+            continue;
+        }
+        let Some(j) = ((i + 1)..metas.len()).find(|&x| metas[x].first_sig.is_some()) else {
+            continue;
+        };
+        let (a, b) = (&metas[i], &metas[j]);
+        if a.ends_in_string || b.starts_in_string || b.depth_before <= 0 {
+            continue;
+        }
+        let (Some(last), Some(first)) = (a.last_sig, b.first_sig) else {
+            continue;
+        };
+        if !is_value_end(last) || !is_element_start(first) || is_continuation_keyword(&b.first_word)
+        {
+            continue;
+        }
+        let Some(idx) = a.last_sig_idx else { continue };
+        let mut rebuilt = String::with_capacity(out_lines[i].len() + 1);
+        for (ci, ch) in out_lines[i].chars().enumerate() {
+            rebuilt.push(ch);
+            if ci == idx {
+                rebuilt.push(',');
+            }
+        }
+        out_lines[i] = rebuilt;
+    }
+    out_lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_repair_recovers_missing_argument_comma() {
+        // Mirrors a real vendored zstd BUCK file: a missing comma after the
+        // `exported_headers=[...]` list leaves `srcs=` with no separator.
+        let content = "cxx_library(\n    name='errors',\n    exported_headers=[\n        'a.h',\n    ]\n    srcs=['a.c'],\n)\n";
+        let (_, repaired) = parse_with_repair("<BUCK>", content.to_string())
+            .expect("content should parse after repair");
+        assert!(repaired, "the repair pass should be what succeeds");
+    }
+
+    #[test]
+    fn test_repair_leaves_well_formed_content_unchanged() {
+        let content = "cxx_library(\n    name='ok',\n    srcs=['a.c'],\n)\n";
+        assert_eq!(repair_missing_argument_commas(content), content);
+        let (_, repaired) =
+            parse_with_repair("<BUCK>", content.to_string()).expect("well-formed parses");
+        assert!(!repaired, "well-formed input is never repaired");
+    }
+
+    #[test]
+    fn test_repair_preserves_multiline_expressions() {
+        // A multiline binary expression and a comprehension must NOT gain commas.
+        let binary = "x = (\n    a\n    + b\n)\n";
+        assert_eq!(repair_missing_argument_commas(binary), binary);
+
+        let comprehension = "y = [\n    item\n    for item in source\n]\n";
+        assert_eq!(repair_missing_argument_commas(comprehension), comprehension);
+    }
+
+    #[test]
+    fn test_repair_ignores_brackets_inside_strings() {
+        // A bracket character inside a string must not be treated as structure.
+        let content = "name = \"value with ] bracket\"\nother = 1\n";
+        assert_eq!(repair_missing_argument_commas(content), content);
+    }
+
+    #[test]
+    fn test_mark_parse_recovery_sets_breadcrumb() {
+        let mut package = PackageData::default();
+        mark_parse_recovery(&mut package, RECOVERY_MISSING_SEPARATOR);
+        let value = package
+            .extra_data
+            .as_ref()
+            .and_then(|map| map.get(PARSE_RECOVERY_KEY));
+        assert_eq!(
+            value,
+            Some(&JsonValue::String(RECOVERY_MISSING_SEPARATOR.to_string()))
+        );
+    }
+}

--- a/src/parsers/starlark_parse.rs
+++ b/src/parsers/starlark_parse.rs
@@ -288,6 +288,19 @@ mod tests {
     }
 
     #[test]
+    fn test_repair_tracks_strings_inside_bracketed_args() {
+        // A string containing `]` sits inside a depth-1 argument list. Correct
+        // string tracking must NOT count that `]` as a bracket close, so depth
+        // stays > 0 and the missing comma between the two kwargs is still
+        // inserted. If string/bracket tracking miscounted, depth would drop to 0,
+        // the `depth_before > 0` guard would suppress the fix, and this assertion
+        // would fail — so this exercises the path the depth-0 case cannot.
+        let input = "func(\n    a = \"x]y\"\n    b = 1\n)\n";
+        let expected = "func(\n    a = \"x]y\",\n    b = 1\n)\n";
+        assert_eq!(repair_missing_argument_commas(input), expected);
+    }
+
+    #[test]
     fn test_mark_parse_recovery_sets_breadcrumb() {
         let mut package = PackageData::default();
         mark_parse_recovery(&mut package, RECOVERY_MISSING_SEPARATOR);


### PR DESCRIPTION
## Summary

- Refreshes the 7 remaining M1-recorded **large-repo** benchmark rows on the M5 Pro host (elasticsearch, nixpkgs, dotnet/runtime, rust, gitlab, linux, chromium) and regenerates the headline chart (median 19.3×, geomean 19.2×, 10k+ gap 36.6×).
- `fix(starlark)`: recover from a missing argument comma in Bazel/Buck files via a conservative post-failure repair, so a single upstream typo no longer costs a file's package extraction (surfaced by chromium's vendored `zstd/lib/BUCK`).
- `fix(oci)`: stop emitting scan errors when matched `manifest.json`/`index.json` files turn out not to be OCI/docker images (surfaced by chromium, ~180 spurious errors on Chrome-extension manifests).

## Scope and exclusions

- Included: benchmark row refresh + the two parser robustness fixes the refresh surfaced. Kept together per request to land all session changes in one PR.
- Explicit exclusions: no methodology change to `--processes` (M5 set stays at 4 for internal consistency; see note below). Two benign residual chromium scan-error classes left as-is (safe binary-content skips on test images; a couple of text-vs-binary `AndroidManifest.xml`/APK fixture edge cases) — out of scope here.

## How to verify

- Parser fixes are covered by new unit/golden tests (`parsers::starlark_parse`, `parsers::oci`, Bazel/Buck recovery tests). Beyond CI: scan a `manifest.json` that isn't an OCI image (e.g. any Chrome-extension manifest) with `--package` and confirm zero `scan_errors`; scan a BUCK/BUILD file with a missing comma between args and confirm packages are still extracted, each carrying `extra_data.provenant_parse_recovery`.
- Benchmark numbers were produced with `xtask compare-outputs --profile common --build-mode optimized` per row; chromium's row was re-measured against the cached ScanCode result after the OCI fix (ScanCode side unchanged).

## Intentional differences from Python

- dotnet/runtime and chromium package counts are **lower** than ScanCode's because Provenant collapses internal Bazel/Buck build targets into one component per build directory (documented in `docs/improvements/bazel-buck-build-targets.md`); ScanCode emits per-target rows (e.g. chromium 962 Bazel + 9 Buck vs Provenant 255 + 3). Real-ecosystem coverage and dependency extraction stay at or above parity.
- nixpkgs: ScanCode's raw dependency total is far larger only because it duplicates `composer.lock` requirements ~400×; Provenant emits more *unique* dependencies without the duplication.

## Follow-up work

- Methodology: M1→M5 row deltas are confounded by core count — ScanCode is ~1.5× faster at 9 proc than 4 proc on this host, while Provenant scales down gracefully. The M5 set is internally consistent at `--processes 4`; a future pass could standardize a higher count for machine utilization.
- Residual chromium scan-error edge cases (text `AndroidManifest.xml` parsed as binary AXML; APKs lacking a manifest) are minor and deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
