### PR TITLE
fix(android): handle text manifests, malformed APKs, and legacy METADATA gracefully

### DIFF
--- a/src/parsers/android.rs
+++ b/src/parsers/android.rs
@@ -134,7 +134,7 @@ impl PackageParser for AndroidSoongMetadataParser {
             }
         };
 
-        vec![parse_soong_metadata(&content)]
+        parse_soong_metadata(&content).into_iter().collect()
     }
 }
 
@@ -194,29 +194,35 @@ impl PackageParser for AndroidApkParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let package_data = match read_best_zip_entry(path, |entry_name| {
+        match read_best_zip_entry(path, |entry_name| {
             if entry_name == "AndroidManifest.xml" {
                 Some(0)
             } else {
                 None
             }
         }) {
-            Ok(Some((_, bytes))) => parse_binary_manifest_bytes(&bytes, DatasourceId::AndroidApk)
-                .unwrap_or_else(|error| {
-                    warn!("Failed to parse APK manifest {:?}: {}", path, error);
-                    default_package_data(DatasourceId::AndroidApk)
-                }),
+            Ok(Some((_, bytes))) => {
+                let package_data = parse_binary_manifest_bytes(&bytes, DatasourceId::AndroidApk)
+                    .unwrap_or_else(|error| {
+                        warn!("Failed to parse APK manifest {:?}: {}", path, error);
+                        default_package_data(DatasourceId::AndroidApk)
+                    });
+                vec![package_data]
+            }
             Ok(None) => {
-                warn!("No AndroidManifest.xml found in APK {:?}", path);
-                default_package_data(DatasourceId::AndroidApk)
+                // A `.apk` with no AndroidManifest.xml is not a usable Android
+                // package (e.g. a deliberately broken test fixture); decline
+                // quietly instead of emitting a scan error.
+                log::debug!("Declining .apk without AndroidManifest.xml {:?}", path);
+                Vec::new()
             }
             Err(error) => {
-                warn!("Failed to read APK archive {:?}: {}", path, error);
-                default_package_data(DatasourceId::AndroidApk)
+                // The file claimed a `.apk` extension and a zip magic but is not
+                // a readable archive; decline quietly rather than erroring.
+                log::debug!("Declining unreadable .apk archive {:?}: {}", path, error);
+                Vec::new()
             }
-        };
-
-        vec![package_data]
+        }
     }
 }
 
@@ -238,7 +244,7 @@ impl PackageParser for AndroidAabParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
-        let package_data = match read_best_zip_entry(path, |entry_name| {
+        match read_best_zip_entry(path, |entry_name| {
             if entry_name == "base/manifest/AndroidManifest.xml" {
                 Some(0)
             } else if entry_name.ends_with("/manifest/AndroidManifest.xml") {
@@ -248,25 +254,31 @@ impl PackageParser for AndroidAabParser {
             }
         }) {
             Ok(Some((entry_name, bytes))) => {
-                parse_proto_manifest_bytes(&bytes).unwrap_or_else(|error| {
+                let package_data = parse_proto_manifest_bytes(&bytes).unwrap_or_else(|error| {
                     warn!(
                         "Failed to parse AAB manifest {:?} ({}): {}",
                         path, entry_name, error
                     );
                     default_package_data(DatasourceId::AndroidAab)
-                })
+                });
+                vec![package_data]
             }
             Ok(None) => {
-                warn!("No proto AndroidManifest.xml found in AAB {:?}", path);
-                default_package_data(DatasourceId::AndroidAab)
+                // An `.aab` with no proto manifest is not a usable App Bundle;
+                // decline quietly instead of emitting a scan error.
+                log::debug!(
+                    "Declining .aab without proto AndroidManifest.xml {:?}",
+                    path
+                );
+                Vec::new()
             }
             Err(error) => {
-                warn!("Failed to read AAB archive {:?}: {}", path, error);
-                default_package_data(DatasourceId::AndroidAab)
+                // Claimed a `.aab` extension and zip magic but is not a readable
+                // archive; decline quietly rather than erroring.
+                log::debug!("Declining unreadable .aab archive {:?}: {}", path, error);
+                Vec::new()
             }
-        };
-
-        vec![package_data]
+        }
     }
 }
 
@@ -292,11 +304,18 @@ fn read_file_bytes(path: &Path, max_size: Option<u64>) -> Result<Vec<u8>, String
     Ok(bytes)
 }
 
-fn parse_soong_metadata(content: &str) -> PackageData {
-    let parsed = parse_textproto_map(content).unwrap_or_else(|error| {
-        warn!("Failed to parse Android Soong METADATA: {}", error);
-        ProtoMap::default()
-    });
+fn parse_soong_metadata(content: &str) -> Option<PackageData> {
+    let parsed = match parse_textproto_map(content) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            // `METADATA` is matched by filename, so we also see real-world
+            // textproto variants (e.g. legacy `Key: value` chromium METADATA
+            // with unquoted multi-word values) that this conservative parser
+            // does not model. Decline quietly instead of emitting a scan error.
+            log::debug!("Declining unparseable Android Soong METADATA: {error}");
+            return None;
+        }
+    };
 
     let mut package = default_package_data(DatasourceId::AndroidSoongMetadata);
     package.name = parsed.get_first_string("name").map(truncate_field);
@@ -444,36 +463,59 @@ fn parse_soong_metadata(content: &str) -> PackageData {
         }
     }
 
-    package
+    Some(package)
 }
+
+/// Magic header of a compiled binary Android XML (AXML) resource: a
+/// `RES_XML_TYPE` chunk (type `0x0003`, header size `0x0008`).
+const BINARY_AXML_MAGIC: [u8; 4] = [0x03, 0x00, 0x08, 0x00];
+
+/// Leading byte-order mark some text editors prepend to UTF-8 XML files.
+const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
 fn parse_manifest_bytes(
     bytes: &[u8],
     datasource_id: DatasourceId,
     context: &str,
 ) -> Option<PackageData> {
-    if looks_like_text_xml(bytes) {
-        match parse_text_manifest_bytes(bytes, datasource_id) {
-            Ok(package) => return Some(package),
-            Err(error) => {
-                warn!("Failed to parse {} as text XML: {}", context, error);
-                return None;
-            }
-        }
+    if looks_like_binary_axml(bytes) {
+        return parse_binary_manifest_bytes(bytes, datasource_id)
+            .map(Some)
+            .unwrap_or_else(|error| {
+                warn!(
+                    "Failed to parse {} as binary Android XML: {}",
+                    context, error
+                );
+                None
+            });
     }
 
-    parse_binary_manifest_bytes(bytes, datasource_id)
-        .map(Some)
-        .unwrap_or_else(|error| {
-            warn!(
-                "Failed to parse {} as binary Android XML: {}",
-                context, error
-            );
-            None
-        })
+    if looks_like_text_xml(bytes) {
+        return match parse_text_manifest_bytes(bytes, datasource_id) {
+            Ok(package) => Some(package),
+            Err(error) => {
+                warn!("Failed to parse {} as text XML: {}", context, error);
+                None
+            }
+        };
+    }
+
+    // Neither a compiled AXML chunk nor recognizable text XML: this is not a
+    // manifest we can parse, so decline quietly without a scan error rather
+    // than feeding non-AXML bytes to rusty-axml (which panics on them).
+    log::debug!(
+        "Declining unrecognized {} content (neither binary AXML nor text XML)",
+        context
+    );
+    None
+}
+
+fn looks_like_binary_axml(bytes: &[u8]) -> bool {
+    bytes.starts_with(&BINARY_AXML_MAGIC)
 }
 
 fn looks_like_text_xml(bytes: &[u8]) -> bool {
+    let bytes = bytes.strip_prefix(&UTF8_BOM).unwrap_or(bytes);
     bytes
         .iter()
         .find(|byte| !byte.is_ascii_whitespace())

--- a/src/parsers/android_test.rs
+++ b/src/parsers/android_test.rs
@@ -542,6 +542,129 @@ third_party {
     }
 
     #[test]
+    fn test_bom_prefixed_text_manifest_parses_without_panic_or_scan_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let manifest_path = temp_dir.path().join("AndroidManifest.xml");
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(
+            br#"<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.bomapp"
+    android:versionName="1.2.3">
+    <uses-sdk android:targetSdkVersion="34" />
+    <application android:label="BOM App" />
+</manifest>
+"#,
+        );
+        fs::write(&manifest_path, &bytes).expect("write BOM manifest");
+
+        let result =
+            try_parse_file(&manifest_path).expect("android manifest should be claimed by dispatch");
+
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "BOM-prefixed text manifest must not produce scan errors: {:?}",
+            result.scan_diagnostics
+        );
+        assert_eq!(result.packages.len(), 1);
+        assert_eq!(
+            result.packages[0].name.as_deref(),
+            Some("com.example.bomapp")
+        );
+        assert_eq!(result.packages[0].version.as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn test_text_manifest_routed_away_from_binary_parser_without_panic() {
+        // A plain source-tree text manifest must never reach the binary AXML
+        // parser (rusty-axml panics on non-AXML input). Confirm a leading
+        // comment ahead of the root element still routes to the text path.
+        let temp_dir = TempDir::new().expect("temp dir");
+        let manifest_path = temp_dir.path().join("AndroidManifest.xml");
+        fs::write(
+            &manifest_path,
+            br#"<!-- generated -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.commentapp" />
+"#,
+        )
+        .expect("write commented manifest");
+
+        let result =
+            try_parse_file(&manifest_path).expect("android manifest should be claimed by dispatch");
+
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "commented text manifest must not produce scan errors: {:?}",
+            result.scan_diagnostics
+        );
+        assert_eq!(result.packages.len(), 1);
+        assert_eq!(
+            result.packages[0].name.as_deref(),
+            Some("com.example.commentapp")
+        );
+    }
+
+    #[test]
+    fn test_malformed_apk_declines_without_scan_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let apk_path = temp_dir.path().join("broken.apk");
+        // A valid local-file-header zip magic followed by truncated bytes: it
+        // passes the `is_zip` magic check but is not a readable archive.
+        fs::write(&apk_path, b"PK\x03\x04 truncated not a real zip").expect("write broken apk");
+
+        let packages = AndroidApkParser::extract_packages(&apk_path);
+        assert!(packages.is_empty());
+
+        let result = try_parse_file(&apk_path);
+        if let Some(result) = result {
+            assert!(
+                result.scan_diagnostics.is_empty(),
+                "malformed .apk must not produce scan errors: {:?}",
+                result.scan_diagnostics
+            );
+            assert!(result.packages.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_manifestless_apk_declines_without_scan_error() {
+        let (_temp_dir, apk_path) = create_zip(&[("classes.dex", b"dex")], "no-manifest.apk");
+
+        let packages = AndroidApkParser::extract_packages(&apk_path);
+        assert!(packages.is_empty());
+
+        let result =
+            try_parse_file(&apk_path).expect("apk should be claimed by zip-magic dispatch");
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "manifest-less .apk must not produce scan errors: {:?}",
+            result.scan_diagnostics
+        );
+        assert!(result.packages.is_empty());
+    }
+
+    #[test]
+    fn test_legacy_keyvalue_soong_metadata_declines_without_scan_error() {
+        let metadata_path =
+            PathBuf::from("testdata/android/metadata/chromium_legacy_keyvalue/METADATA");
+
+        // The fixture matches the Soong METADATA heuristics but uses a legacy
+        // key/value shape this parser does not model; it must decline quietly.
+        assert!(AndroidSoongMetadataParser::is_match(&metadata_path));
+        assert!(AndroidSoongMetadataParser::extract_packages(&metadata_path).is_empty());
+
+        let result =
+            try_parse_file(&metadata_path).expect("METADATA should be claimed by dispatch");
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "legacy key/value METADATA must not produce scan errors: {:?}",
+            result.scan_diagnostics
+        );
+        assert!(result.packages.is_empty());
+    }
+
+    #[test]
     fn test_invalid_text_manifest_reports_single_scan_error_without_package() {
         let temp_dir = TempDir::new().expect("temp dir");
         let manifest_path = temp_dir.path().join("AndroidManifest.xml");

--- a/src/parsers/android_test.rs
+++ b/src/parsers/android_test.rs
@@ -645,6 +645,46 @@ third_party {
     }
 
     #[test]
+    fn test_malformed_aab_declines_without_scan_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let aab_path = temp_dir.path().join("broken.aab");
+        // A valid local-file-header zip magic followed by truncated bytes: it
+        // passes the `is_zip` magic check but is not a readable archive.
+        fs::write(&aab_path, b"PK\x03\x04 truncated not a real zip").expect("write broken aab");
+
+        let packages = AndroidAabParser::extract_packages(&aab_path);
+        assert!(packages.is_empty());
+
+        let result = try_parse_file(&aab_path);
+        if let Some(result) = result {
+            assert!(
+                result.scan_diagnostics.is_empty(),
+                "malformed .aab must not produce scan errors: {:?}",
+                result.scan_diagnostics
+            );
+            assert!(result.packages.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_manifestless_aab_declines_without_scan_error() {
+        let (_temp_dir, aab_path) =
+            create_zip(&[("BundleConfig.pb", b"config")], "no-manifest.aab");
+
+        let packages = AndroidAabParser::extract_packages(&aab_path);
+        assert!(packages.is_empty());
+
+        let result =
+            try_parse_file(&aab_path).expect("aab should be claimed by zip-magic dispatch");
+        assert!(
+            result.scan_diagnostics.is_empty(),
+            "manifest-less .aab must not produce scan errors: {:?}",
+            result.scan_diagnostics
+        );
+        assert!(result.packages.is_empty());
+    }
+
+    #[test]
     fn test_legacy_keyvalue_soong_metadata_declines_without_scan_error() {
         let metadata_path =
             PathBuf::from("testdata/android/metadata/chromium_legacy_keyvalue/METADATA");

--- a/testdata/android/metadata/chromium_legacy_keyvalue/METADATA
+++ b/testdata/android/metadata/chromium_legacy_keyvalue/METADATA
@@ -1,0 +1,17 @@
+Name: SRE
+Short Name: speech-rule-engine
+URL: https://github.com/zorkow/speech-rule-engine
+Version: 3.3.3
+License: Apache 2.0
+License File: LICENSE
+Security Critical: no
+
+Description:
+Speech Rule Engine used by ChromeVox.
+
+third_party {
+  identifier {
+    type: "Git"
+    value: "https://github.com/zorkow/speech-rule-engine"
+  }
+}


### PR DESCRIPTION
## Summary

- Fix three Android-parser robustness gaps in `src/parsers/android.rs` surfaced by a chromium scan, so malformed-or-mismatched Android inputs are declined gracefully instead of producing spurious `scan_errors` or panics.
- **Text manifest panic**: positively detect compiled binary AXML by its `03 00 08 00` magic before invoking rusty-axml (which panics on non-AXML input), skip a leading UTF-8 BOM in the text-XML heuristic, and decline cleanly (no scan error) when content is neither valid binary AXML nor text XML. This removes the panic path reachable from a plain text `AndroidManifest.xml` (e.g. one with a BOM or leading comment).
- **Malformed APKs/AABs**: apply the decline-quietly pattern (`log::debug!` instead of `parser_warn!`, mirroring the OCI parser) so a `.apk`/`.aab` that is not a readable zip or has no manifest produces no package and no scan error.
- **Legacy METADATA**: `parse_soong_metadata` now declines quietly when the textproto parser cannot model the content (e.g. legacy chromium key/value `METADATA` with unquoted multi-word values), instead of emitting "Unexpected token after key".

## Issues

- Closes: #1144

## Scope and exclusions

- Included: robustness fixes for the Android manifest/APK/AAB/Soong-METADATA parsers and unit tests with representative `testdata/` fixtures.
- Explicit exclusions: no changes to parser metadata or supported-format surface; no benchmark/compare-run changes.

## How to verify

- `cargo test --lib parsers::android` exercises the new cases: BOM-prefixed and comment-prefixed text manifests parse without panic/scan error, malformed and manifest-less APKs decline without scan error, and the legacy key/value METADATA fixture declines without scan error.

## Expected-output fixture changes

- Files changed: added `testdata/android/metadata/chromium_legacy_keyvalue/METADATA` (synthetic, representative legacy key/value Soong METADATA shape).
- Why the new expected output is correct: the fixture matches the Soong METADATA heuristics but is not modeled by the conservative textproto parser, so the correct behavior is to decline quietly (no package, no scan error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)