### PR TITLE
fix(output): exclude benign binary-content skips from scan_errors

### DIFF
--- a/src/models/diagnostic.rs
+++ b/src/models/diagnostic.rs
@@ -5,6 +5,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DiagnosticSeverity {
+    /// Purely informational outcome that is not a failure. Provenant
+    /// deliberately took a benign action (for example, declining text detection
+    /// on a file that is binary). Info diagnostics stay auditable in the
+    /// internal model and verbose output, but must not surface in the
+    /// ScanCode-compatible `scan_errors` field or inflate error/warning counts.
+    Info,
     Warning,
     Error,
     Timeout,
@@ -17,6 +23,13 @@ pub struct ScanDiagnostic {
 }
 
 impl ScanDiagnostic {
+    pub fn info(message: impl Into<String>) -> Self {
+        Self {
+            severity: DiagnosticSeverity::Info,
+            message: message.into(),
+        }
+    }
+
     pub fn warning(message: impl Into<String>) -> Self {
         Self {
             severity: DiagnosticSeverity::Warning,

--- a/src/output_schema/file_info.rs
+++ b/src/output_schema/file_info.rs
@@ -378,6 +378,7 @@ impl OutputFileInfo {
             scan_errors: value
                 .scan_diagnostics
                 .iter()
+                .filter(|d| d.severity != crate::models::DiagnosticSeverity::Info)
                 .map(|d| d.message.clone())
                 .collect(),
             license_policy: value
@@ -537,9 +538,57 @@ impl TryFrom<&OutputFileInfo> for crate::models::FileInfo {
 #[cfg(test)]
 mod tests {
     use super::OutputFileInfo;
+    use crate::models::{FileInfoBuilder, FileType, ScanDiagnostic};
     use crate::output_schema::OutputFileType;
     use crate::output_schema::license_detection::OutputLicenseDetection;
     use serde_json::json;
+
+    fn file_info_with_diagnostics(diagnostics: Vec<ScanDiagnostic>) -> crate::models::FileInfo {
+        FileInfoBuilder::default()
+            .name("sample.bin".to_string())
+            .base_name("sample".to_string())
+            .extension(".bin".to_string())
+            .path("sample.bin".to_string())
+            .file_type(FileType::File)
+            .size(1)
+            .scan_diagnostics(diagnostics)
+            .build()
+            .expect("builder should produce file info")
+    }
+
+    #[test]
+    fn scan_errors_excludes_info_diagnostics_but_keeps_real_failures() {
+        let file_info = file_info_with_diagnostics(vec![
+            ScanDiagnostic::info("Text skipped from license/copyright detection: likely binary"),
+            ScanDiagnostic::error("PDF text extraction failed after 3 attempts"),
+            ScanDiagnostic::timeout("license detection timed out"),
+        ]);
+
+        let output = OutputFileInfo::from(&file_info);
+
+        assert_eq!(
+            output.scan_errors,
+            vec![
+                "PDF text extraction failed after 3 attempts".to_string(),
+                "license detection timed out".to_string(),
+            ],
+            "Info diagnostics must not surface as scan_errors, but real failures must"
+        );
+    }
+
+    #[test]
+    fn scan_errors_empty_when_only_info_diagnostics_present() {
+        let file_info = file_info_with_diagnostics(vec![ScanDiagnostic::info(
+            "Text skipped from license/copyright detection: likely binary",
+        )]);
+
+        let output = OutputFileInfo::from(&file_info);
+
+        assert!(
+            output.scan_errors.is_empty(),
+            "a benign binary-content skip must not produce any scan_errors"
+        );
+    }
 
     fn base_output_file_info() -> OutputFileInfo {
         OutputFileInfo {

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -276,8 +276,8 @@ fn summarize_header_messages(
                 };
                 errors.push(message);
             }
-            let (_, file_warnings) =
-                crate::progress::partition_scan_diagnostics(&file.scan_diagnostics);
+            let file_warnings =
+                crate::progress::partition_scan_diagnostics(&file.scan_diagnostics).warnings;
             if let Some(summary) =
                 format_default_scan_warning_from_list(Path::new(&file.path), &file_warnings)
             {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -203,7 +203,16 @@ impl ScanProgress {
                 }
             }
             ProgressMode::Verbose => {
-                if self.stderr_is_tty || !errors.is_empty() || !warnings.is_empty() {
+                let infos: Vec<&str> = scan_diagnostics
+                    .iter()
+                    .filter(|d| d.severity == DiagnosticSeverity::Info)
+                    .map(|d| d.message.as_str())
+                    .collect();
+                if self.stderr_is_tty
+                    || !errors.is_empty()
+                    || !warnings.is_empty()
+                    || !infos.is_empty()
+                {
                     self.message(&path.to_string_lossy());
                 }
                 for err in &errors {
@@ -214,6 +223,11 @@ impl ScanProgress {
                 for warning in &warnings {
                     for line in warning.lines() {
                         self.message(&format!("  warning: {line}"));
+                    }
+                }
+                for info in &infos {
+                    for line in info.lines() {
+                        self.message(&format!("  info: {line}"));
                     }
                 }
             }
@@ -550,6 +564,11 @@ pub(crate) fn partition_scan_diagnostics(
                 errors.push(diagnostic.message.clone())
             }
             DiagnosticSeverity::Warning => warnings.push(diagnostic.message.clone()),
+            // Informational outcomes (for example, benign binary-content skips)
+            // are neither failures nor warnings: they are excluded from
+            // `scan_errors` and from error/warning counts. They remain auditable
+            // in the internal model and verbose output.
+            DiagnosticSeverity::Info => {}
         }
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -180,7 +180,11 @@ impl ScanProgress {
         let mut stats = self.stats.lock().expect("stats lock poisoned");
         stats.total_bytes_scanned += bytes;
 
-        let (errors, warnings) = partition_scan_diagnostics(scan_diagnostics);
+        let PartitionedDiagnostics {
+            errors,
+            warnings,
+            infos,
+        } = partition_scan_diagnostics(scan_diagnostics);
 
         if !errors.is_empty() {
             stats.error_count += 1;
@@ -203,11 +207,6 @@ impl ScanProgress {
                 }
             }
             ProgressMode::Verbose => {
-                let infos: Vec<&str> = scan_diagnostics
-                    .iter()
-                    .filter(|d| d.severity == DiagnosticSeverity::Info)
-                    .map(|d| d.message.as_str())
-                    .collect();
                 if self.stderr_is_tty
                     || !errors.is_empty()
                     || !warnings.is_empty()
@@ -552,27 +551,33 @@ pub(crate) fn format_default_scan_warning_from_list(
         .map(|warning| format_default_scan_error(path, warning))
 }
 
+/// Diagnostics split by severity in a single pass.
+#[derive(Default)]
+pub(crate) struct PartitionedDiagnostics {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+    /// Informational outcomes (for example, benign binary-content skips). These
+    /// are neither failures nor warnings: they are excluded from `scan_errors`
+    /// and from error/warning counts, and only surface in verbose output.
+    pub infos: Vec<String>,
+}
+
 pub(crate) fn partition_scan_diagnostics(
     scan_diagnostics: &[ScanDiagnostic],
-) -> (Vec<String>, Vec<String>) {
-    let mut errors = Vec::new();
-    let mut warnings = Vec::new();
+) -> PartitionedDiagnostics {
+    let mut partitioned = PartitionedDiagnostics::default();
 
     for diagnostic in scan_diagnostics {
         match diagnostic.severity {
             DiagnosticSeverity::Error | DiagnosticSeverity::Timeout => {
-                errors.push(diagnostic.message.clone())
+                partitioned.errors.push(diagnostic.message.clone())
             }
-            DiagnosticSeverity::Warning => warnings.push(diagnostic.message.clone()),
-            // Informational outcomes (for example, benign binary-content skips)
-            // are neither failures nor warnings: they are excluded from
-            // `scan_errors` and from error/warning counts. They remain auditable
-            // in the internal model and verbose output.
-            DiagnosticSeverity::Info => {}
+            DiagnosticSeverity::Warning => partitioned.warnings.push(diagnostic.message.clone()),
+            DiagnosticSeverity::Info => partitioned.infos.push(diagnostic.message.clone()),
         }
     }
 
-    (errors, warnings)
+    partitioned
 }
 
 fn concise_scan_error_reason(err: &str) -> String {

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -274,10 +274,10 @@ fn extract_information_from_content(
         }));
     }
 
-    let (text_content, text_kind, text_scan_error) =
+    let (text_content, text_kind, text_diagnostic) =
         extract_text_for_detection_with_diagnostics(&filesystem_path, &buffer);
-    if let Some(text_scan_error) = text_scan_error {
-        scan_diagnostics.push(ScanDiagnostic::error(text_scan_error));
+    if let Some(text_diagnostic) = text_diagnostic {
+        scan_diagnostics.push(text_diagnostic);
     }
     let from_binary_strings = matches!(text_kind, ExtractedTextKind::BinaryStrings);
     // Font metadata text combines a trustworthy curated name-table notice with a

--- a/src/utils/file/encoding.rs
+++ b/src/utils/file/encoding.rs
@@ -7,6 +7,8 @@
 //! Byte-to-text decoding and "does this look like text" heuristics shared by
 //! classification and text-extraction logic.
 
+use crate::models::ScanDiagnostic;
+
 const BINARY_CONTROL_CHAR_THRESHOLD_DIVISOR: usize = 10;
 
 pub(super) const CORRUPTED_UTF16_BOM_PREFIX: &[u8] = &[0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD];
@@ -14,7 +16,10 @@ pub(super) const CORRUPTED_UTF16_BOM_PREFIX: &[u8] = &[0xEF, 0xBF, 0xBD, 0xEF, 0
 /// Diagnostic message emitted when invalid-UTF-8 input is dropped from
 /// detection because it exceeds the binary-control-char threshold. Surfaced via
 /// the scanner's structured `scan_diagnostics` channel so the skip is
-/// observable rather than silent.
+/// observable rather than silent. This is an informational outcome (Provenant
+/// correctly declined text detection on a binary file), not a failure, so it is
+/// recorded at [`DiagnosticSeverity::Info`](crate::models::DiagnosticSeverity)
+/// and excluded from the ScanCode-compatible `scan_errors` field.
 pub(super) const NEAR_BINARY_SKIP_DIAGNOSTIC: &str = "Text skipped from license/copyright detection: invalid UTF-8 with too many control bytes (likely binary)";
 
 /// Decode a byte buffer to a String, trying UTF-16 first when the byte shape
@@ -32,7 +37,9 @@ pub fn decode_bytes_to_string(bytes: &[u8]) -> String {
 /// (invalid UTF-8 with a high control-byte ratio). The decoded result is
 /// unchanged; only the optional diagnostic is added so the silent skip becomes
 /// observable in scan output.
-pub(super) fn decode_bytes_to_string_with_diagnostic(bytes: &[u8]) -> (String, Option<String>) {
+pub(super) fn decode_bytes_to_string_with_diagnostic(
+    bytes: &[u8],
+) -> (String, Option<ScanDiagnostic>) {
     if let Some(decoded) = decode_utf16_text(bytes) {
         return (decoded, None);
     }
@@ -42,7 +49,10 @@ pub(super) fn decode_bytes_to_string_with_diagnostic(bytes: &[u8]) -> (String, O
         Err(e) => {
             let bytes = e.into_bytes();
             if has_binary_control_chars(&bytes) {
-                return (String::new(), Some(NEAR_BINARY_SKIP_DIAGNOSTIC.to_string()));
+                return (
+                    String::new(),
+                    Some(ScanDiagnostic::info(NEAR_BINARY_SKIP_DIAGNOSTIC)),
+                );
             }
             (bytes.iter().map(|&b| b as char).collect(), None)
         }

--- a/src/utils/file/extract.rs
+++ b/src/utils/file/extract.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 
 use object::FileKind;
 
+use crate::models::ScanDiagnostic;
 use crate::parsers::windows_executable::extract_windows_executable_metadata_text;
 use crate::utils::font::extract_font_metadata_text;
 use crate::utils::language::detect_language;
@@ -177,7 +178,7 @@ fn canonical_shields_license_hint(candidate: &str) -> String {
 pub(crate) fn extract_text_for_detection_with_diagnostics(
     path: &Path,
     bytes: &[u8],
-) -> (String, ExtractedTextKind, Option<String>) {
+) -> (String, ExtractedTextKind, Option<ScanDiagnostic>) {
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
@@ -323,7 +324,7 @@ fn combine_extracted_text_fragments(prefix: Option<String>, suffix: String) -> S
 
 pub(super) fn windows_metadata_or_empty_result(
     windows_executable_metadata_text: Option<String>,
-) -> (String, ExtractedTextKind, Option<String>) {
+) -> (String, ExtractedTextKind, Option<ScanDiagnostic>) {
     if let Some(metadata_text) = windows_executable_metadata_text {
         (
             metadata_text,

--- a/src/utils/file/mod.rs
+++ b/src/utils/file/mod.rs
@@ -37,6 +37,7 @@ mod tests {
     use std::path::Path;
 
     use crate::copyright::detect_copyrights;
+    use crate::models::DiagnosticSeverity;
 
     use super::classify::classify_file_info;
     use super::encoding::{
@@ -163,10 +164,12 @@ mod tests {
 
         assert!(text.is_empty());
         assert_eq!(kind, ExtractedTextKind::None);
-        assert!(
-            scan_error
-                .as_deref()
-                .is_some_and(|message| message.contains("PDF text extraction skipped"))
+        let scan_error = scan_error.expect("oversized pdf should be surfaced");
+        assert!(scan_error.message.contains("PDF text extraction skipped"));
+        assert_eq!(
+            scan_error.severity,
+            DiagnosticSeverity::Error,
+            "a real PDF extraction failure must remain an error"
         );
     }
 
@@ -180,7 +183,16 @@ mod tests {
         assert!(text.is_empty());
         assert_eq!(kind, ExtractedTextKind::None);
         let scan_error = scan_error.expect("terminal pdf failure should be surfaced");
-        assert!(scan_error.contains("PDF text extraction failed after"));
+        assert!(
+            scan_error
+                .message
+                .contains("PDF text extraction failed after")
+        );
+        assert_eq!(
+            scan_error.severity,
+            DiagnosticSeverity::Error,
+            "a terminal PDF failure must remain an error"
+        );
     }
 
     #[test]
@@ -976,7 +988,13 @@ mod tests {
             decoded.is_empty(),
             "input over the 10% control-byte threshold must decode to empty"
         );
-        assert_eq!(diagnostic.as_deref(), Some(NEAR_BINARY_SKIP_DIAGNOSTIC));
+        let diagnostic = diagnostic.expect("near-binary skip must emit a diagnostic");
+        assert_eq!(diagnostic.message, NEAR_BINARY_SKIP_DIAGNOSTIC);
+        assert_eq!(
+            diagnostic.severity,
+            DiagnosticSeverity::Info,
+            "benign binary-content skip must be informational, not an error"
+        );
         // The thin public wrapper preserves the empty-string result contract.
         assert!(decode_bytes_to_string(&bytes).is_empty());
     }
@@ -1110,6 +1128,8 @@ mod tests {
 
         assert!(text.is_empty());
         assert_eq!(kind, ExtractedTextKind::None);
-        assert_eq!(diagnostic.as_deref(), Some(NEAR_BINARY_SKIP_DIAGNOSTIC));
+        let diagnostic = diagnostic.expect("near-binary skip must emit a diagnostic");
+        assert_eq!(diagnostic.message, NEAR_BINARY_SKIP_DIAGNOSTIC);
+        assert_eq!(diagnostic.severity, DiagnosticSeverity::Info);
     }
 }

--- a/src/utils/file/pdf.rs
+++ b/src/utils/file/pdf.rs
@@ -7,9 +7,11 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
 
+use crate::models::ScanDiagnostic;
+
 pub(super) const MAX_PDF_TEXT_EXTRACTION_BYTES: usize = 32 * 1024 * 1024;
 
-pub(super) fn extract_pdf_text(path: &Path, bytes: &[u8]) -> (String, Option<String>) {
+pub(super) fn extract_pdf_text(path: &Path, bytes: &[u8]) -> (String, Option<ScanDiagnostic>) {
     if bytes.len() < 5 || &bytes[..5] != b"%PDF-" {
         return (String::new(), None);
     }
@@ -17,10 +19,10 @@ pub(super) fn extract_pdf_text(path: &Path, bytes: &[u8]) -> (String, Option<Str
     if bytes.len() > MAX_PDF_TEXT_EXTRACTION_BYTES {
         return (
             String::new(),
-            Some(format!(
+            Some(ScanDiagnostic::error(format!(
                 "PDF text extraction skipped because file exceeds {} bytes",
                 MAX_PDF_TEXT_EXTRACTION_BYTES
-            )),
+            ))),
         );
     }
 
@@ -92,11 +94,11 @@ pub(super) fn extract_pdf_text(path: &Path, bytes: &[u8]) -> (String, Option<Str
     } else {
         (
             String::new(),
-            Some(format!(
+            Some(ScanDiagnostic::error(format!(
                 "PDF text extraction failed after {} attempts: {}",
                 failures.len(),
                 failures.join("; ")
-            )),
+            ))),
         )
     }
 }


### PR DESCRIPTION
## Summary

- Benign "this file is binary, skipped from text detection" notices (`NEAR_BINARY_SKIP_DIAGNOSTIC`) were recorded as `Error`-severity diagnostics, and the output schema mapped **every** `scan_diagnostic` into the ScanCode-compatible `scan_errors` field. These informational outcomes therefore read as failures and inflated the error count (67 of 82 residual `scan_errors` on chromium; also seen on rust, gitlab, etc.).
- Introduce a `DiagnosticSeverity::Info` variant for purely-informational, non-failure outcomes. The near-binary skip is now classified `Info`; genuine PDF/read/parse failures remain `Error`/`Timeout`.
- `Info` diagnostics are excluded from the `scan_errors` output mapping and from error/warning progress counts, but stay auditable in the internal model and in verbose progress output (`info:` lines).
- The text-extraction diagnostic carrier changed from `Option<String>` to `Option<ScanDiagnostic>`, so severity is decided at the source of truth (`encoding.rs` emits `Info`, `pdf.rs` emits `Error`) instead of being string-matched downstream.

## Issues

- Closes: #1145

## Scope and exclusions

- Included: new `Info` severity + constructor; classification of the near-binary skip as `Info`; `scan_errors` output filter; `partition_scan_diagnostics` and verbose-progress handling of `Info`; unit tests.
- Explicit exclusions: no change to genuine parse/read/timeout error routing; no change to the ScanCode-compatible schema shape (`scan_errors` is still `Vec<String>`).

## How to verify

- CI covers the build/clippy/fmt/unit/golden/integration suites. Beyond that: scan a directory containing a binary file that decodes to empty with a high control-byte ratio (e.g. invalid UTF-8 with many control bytes) and confirm its `scan_errors` array is empty in default JSON output, while running with `--verbose` still surfaces an `info:` line for the skip. A genuinely malformed PDF should still report a `scan_errors` entry.

## Expected-output fixture changes

- Files changed: none. No golden fixture currently contained the near-binary skip message in a `scan_errors` array (verified by grep across the repo), so no expected outputs needed updating. `docs/OUTPUT_FIELD_REFERENCE.md` was regenerated by the pre-commit hook with no diff (the `scan_errors` field shape is unchanged).
