### PR TITLE
docs(benchmarks): refresh chromium row (0 scan errors after #1148/#1149)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -650,12 +650,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `6.42s`; ScanCode `123.76s`
 - Broader Go module graph dependency visibility (`117` vs `61` dependencies) from committed `go.mod.graph` while preserving matched package coverage (`10` vs `10`) across `go.mod`, `go.sum`, and vendored manifests, plus cleaner rejection of Go AUTHORS boilerplate and code-comment author/copyright fragments
 
-##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **45.07× faster**
+##### [chromium/chromium @ 2befda7](https://github.com/chromium/chromium/tree/2befda78fcc7fa5649540420eedcdd87a2583fe0) — **42.72× faster**
 
 - Files: 491,354
 - Run context: 2026-06-25 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `715.21s`; ScanCode `32231.76s`
-- Provenant collapses internal Bazel/Buck build targets to one component per build directory (`255` Bazel + `3` Buck vs ScanCode's per-target `962` + `9`), a documented design choice ([`docs/improvements/bazel-buck-build-targets.md`](improvements/bazel-buck-build-targets.md)), so its top-level package count is lower (`599` vs `1279`) while real-ecosystem coverage holds at or above parity (Cargo `240` vs `239`, npm `46` vs `33`) and dependency extraction stays materially richer (`16793` vs `12378`) from vendored `.gitmodules`, Cargo, and npm surfaces; the remaining Provenant scan-error entries (`82` vs `3`) are almost all safe binary-content skips on test image fixtures, not parse failures
+- Timing: Provenant `754.46s`; ScanCode `32231.76s`
+- Provenant collapses internal Bazel/Buck build targets to one component per build directory (`255` Bazel + `3` Buck vs ScanCode's per-target `962` + `9`), a documented design choice ([`docs/improvements/bazel-buck-build-targets.md`](improvements/bazel-buck-build-targets.md)), so its top-level package count is lower (`599` vs `1279`) while real-ecosystem coverage holds at or above parity (Cargo `240` vs `239`, npm `46` vs `33`) and dependency extraction stays materially richer (`16793` vs `12378`) from vendored `.gitmodules`, Cargo, and npm surfaces
 
 ##### [conan-io/conan-center-index @ bc78dfb](https://github.com/conan-io/conan-center-index/tree/bc78dfb366e6596d21a7a5c51b97970656f73254) — **36.57× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -1372,8 +1372,8 @@ Provenant: 86.65s</title></circle>
     <circle cx="883.98" cy="367.29" r="4.5" fill="#2563eb"><title>torvalds/linux @ b42ed3b
 Files: 92523
 Provenant: 271.01s</title></circle>
-    <circle cx="999.03" cy="321.44" r="4.5" fill="#2563eb"><title>chromium/chromium @ 2befda7
+    <circle cx="999.03" cy="318.91" r="4.5" fill="#2563eb"><title>chromium/chromium @ 2befda7
 Files: 491354
-Provenant: 715.21s</title></circle>
+Provenant: 754.46s</title></circle>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Refreshes the chromium benchmark row now that #1148 (Android parser robustness) and #1149 (benign binary-skips out of `scan_errors`) are merged. ScanCode side served from cache (unchanged), so only Provenant was re-measured.
- **Provenant scan errors: 82 → 0** (vs ScanCode 3). The 67 benign binary-content skips are now `Info`-severity and excluded from `scan_errors`; the ~15 Android entries (malformed/manifest-less APKs, text `AndroidManifest.xml`, legacy Soong `METADATA`) now decline quietly. Removed the obsolete "82 vs 3 … safe binary skips" clause from the row.
- Package (`599` vs `1279`) and dependency (`16793` vs `12378`) counts unchanged.

## How to verify

- Reproduced via `xtask compare-outputs --profile common --build-mode optimized --repo-url …/chromium --repo-ref 2befda7` against the cached ScanCode result; the run's `provenant.json` has zero `scan_errors`. Two PV runs measured 754.46s / 762.38s.

## Follow-up work

- PV wall-clock rose from the pre-merge ~715s to ~754s (reproducible across both runs). The increase is attributable to the merged per-file changes — most likely #1149's `Option<String>` → `Option<ScanDiagnostic>` change in the text-decode path, which runs on every file (491k here). It's a ~5% cost on this large tree and does not change the result (~43× faster, clean scan errors); worth a look if the per-file decode cost matters more broadly, but the correctness win is worth it regardless. Speedup recorded as 42.72× accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
