### PR TITLE
feat(gradle): normalize declared licenses via shared name/url resolver

### DIFF
--- a/src/parsers/gradle.rs
+++ b/src/parsers/gradle.rs
@@ -45,8 +45,7 @@ use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
 use crate::parsers::PackageParser;
 
 use super::license_normalization::{
-    DeclaredLicenseMatchMetadata, build_declared_license_data, empty_declared_license_data,
-    normalize_spdx_expression,
+    DeclaredLicenseMatchMetadata, build_declared_license_data, normalize_declared_name_and_url,
 };
 
 /// Parses Gradle build files (build.gradle, build.gradle.kts).
@@ -1894,29 +1893,22 @@ fn extract_gradle_license_metadata(
             if let Some((license_name, license_url)) = parse_license_block(inner) {
                 let extracted =
                     format_gradle_license_statement(&license_name, license_url.as_deref());
-                let declared_candidate =
-                    derive_gradle_license_expression(&license_name, license_url.as_deref());
-                if let Some(declared_candidate) = declared_candidate
-                    && let Some(normalized) = normalize_spdx_expression(&declared_candidate)
-                {
-                    let matched_text = extracted.as_deref().unwrap_or(&declared_candidate);
-                    let (declared, declared_spdx, detections) = build_declared_license_data(
-                        normalized,
-                        DeclaredLicenseMatchMetadata::single_line(matched_text),
-                    );
-                    return (
-                        extracted.map(truncate_field),
-                        declared.map(truncate_field),
-                        declared_spdx.map(truncate_field),
-                        detections,
-                    );
-                }
-
+                // Resolve the declared `license { name; url }` through the shared
+                // name/url normalizer so Gradle recognizes the same breadth of
+                // declared licenses as Maven (free-text names, license URLs, SPDX
+                // keys) instead of a handful of hardcoded patterns.
+                let normalized =
+                    normalize_declared_name_and_url(Some(&license_name), license_url.as_deref());
+                let matched_text = extracted.as_deref().unwrap_or(&license_name);
+                let (declared, declared_spdx, detections) = build_declared_license_data(
+                    normalized,
+                    DeclaredLicenseMatchMetadata::single_line(matched_text),
+                );
                 return (
                     extracted.map(truncate_field),
-                    None,
-                    None,
-                    empty_declared_license_data().2,
+                    declared.map(truncate_field),
+                    declared_spdx.map(truncate_field),
+                    detections,
                 );
             }
             i = block_end + 1;
@@ -2011,30 +2003,6 @@ fn format_gradle_license_statement(name: &str, url: Option<&str>) -> Option<Stri
         output.push_str(&format!("    url: {url}\n"));
     }
     Some(truncate_field(output))
-}
-
-fn derive_gradle_license_expression(name: &str, url: Option<&str>) -> Option<String> {
-    let trimmed = name.trim();
-    let candidates = [trimmed, url.unwrap_or("")];
-
-    for candidate in candidates {
-        let lower = candidate.to_ascii_lowercase();
-        if trimmed == "Apache-2.0"
-            || lower.contains("apache-2.0")
-            || lower.contains("apache license, version 2.0")
-            || lower.contains("apache.org/licenses/license-2.0")
-        {
-            return Some(truncate_field("Apache-2.0".to_string()));
-        }
-        if trimmed == "MIT" || lower.contains("opensource.org/licenses/mit") {
-            return Some(truncate_field("MIT".to_string()));
-        }
-        if trimmed == "BSD-2-Clause" || trimmed == "BSD-3-Clause" {
-            return Some(truncate_field(trimmed.to_string()));
-        }
-    }
-
-    None
 }
 
 #[cfg(test)]

--- a/src/parsers/gradle_test.rs
+++ b/src/parsers/gradle_test.rs
@@ -642,6 +642,44 @@ configure(install.repositories.mavenInstaller) {
 }
 
 #[test]
+fn test_gradle_license_resolves_descriptive_name_via_shared_normalizer() {
+    // The classic ASF declared name "The Apache Software License, Version 2.0"
+    // was missed by the previous hardcoded patterns (which only matched the
+    // literal "apache license, version 2.0"). The shared name/url normalizer
+    // resolves it, matching Maven's handling of the same declared name.
+    let content = r#"
+plugins {
+    id 'java-library'
+}
+
+configure(install.repositories.mavenInstaller) {
+    pom.project {
+        licenses {
+            license {
+                name 'The Apache Software License, Version 2.0'
+            }
+        }
+    }
+}
+"#;
+
+    let temp_dir = tempdir().unwrap();
+    let build_gradle = temp_dir.path().join("build.gradle");
+    std::fs::write(&build_gradle, content).unwrap();
+
+    let package_data = GradleParser::extract_first_package(&build_gradle);
+
+    assert_eq!(
+        package_data.declared_license_expression.as_deref(),
+        Some("apache-2.0")
+    );
+    assert_eq!(
+        package_data.declared_license_expression_spdx.as_deref(),
+        Some("Apache-2.0")
+    );
+}
+
+#[test]
 fn test_parse_gradle_version_catalog_helper() {
     let temp_dir = tempdir().unwrap();
     let catalog_path = temp_dir.path().join("libs.versions.toml");

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -330,6 +330,65 @@ pub(crate) fn normalize_declared_license_key(key: &str) -> Option<NormalizedDecl
     normalize_license_key(key, engine.index()).or_else(|| resolve_declared_license_alias(key))
 }
 
+/// Resolves a declared license `name`/`url` pair — as found in manifest license
+/// blocks such as Maven `<license><name>/<url>` and Gradle `license { name; url }`
+/// — into a normalized declared license, stopping at the first confident match:
+///
+/// 1. `Public Domain` special case;
+/// 2. exact SPDX-key/identifier lookup on the name;
+/// 3. free-text detection over the name alone;
+/// 4. free-text detection over the combined name and url.
+///
+/// Step 4 recovers descriptive names that resolve only when paired with their
+/// url (e.g. "GNU General Lesser Public License (LGPL) version 3.0" with
+/// `http://www.gnu.org/licenses/lgpl.html` -> `lgpl-3.0`); it is used only when
+/// the name alone fails, so a name that already resolves is not muddied by a
+/// redundant url-derived operand. These are bounded, trustworthy declared
+/// manifest fields, so this is declared normalization, not file-content scanning.
+///
+/// An entry that resolves to nothing maps to `unknown-license-reference` (the
+/// existing convention for an unresolved but declared license reference) so it is
+/// preserved as an explicit operand rather than silently dropped.
+pub(crate) fn normalize_declared_name_and_url(
+    name: Option<&str>,
+    url: Option<&str>,
+) -> NormalizedDeclaredLicense {
+    let name = name.map(str::trim).filter(|value| !value.is_empty());
+    let url = url.map(str::trim).filter(|value| !value.is_empty());
+
+    if let Some(name) = name {
+        match name {
+            "Public Domain" | "public domain" => {
+                return NormalizedDeclaredLicense::new(
+                    "public-domain",
+                    "LicenseRef-scancode-public-domain",
+                );
+            }
+            other => {
+                if let Some(normalized) = normalize_declared_license_key(other) {
+                    return normalized;
+                }
+                if let Some(normalized) = detect_declared_license_name(other) {
+                    return normalized;
+                }
+            }
+        }
+    }
+
+    let detection_text = [name, url]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    detect_declared_license_name(&detection_text).unwrap_or_else(|| {
+        NormalizedDeclaredLicense::new(
+            "unknown-license-reference",
+            "LicenseRef-scancode-unknown-license-reference",
+        )
+    })
+}
+
 pub(crate) fn combine_normalized_licenses(
     licenses: Vec<NormalizedDeclaredLicense>,
     separator: &str,

--- a/src/parsers/maven/pom/licenses.rs
+++ b/src/parsers/maven/pom/licenses.rs
@@ -8,8 +8,7 @@ use super::properties::{PropertyResolver, resolve_option};
 use crate::models::LicenseDetection;
 use crate::parsers::license_normalization::{
     DeclaredLicenseMatchMetadata, NormalizedDeclaredLicense, build_declared_license_data,
-    combine_normalized_licenses, detect_declared_license_name, empty_declared_license_data,
-    normalize_declared_license_key,
+    combine_normalized_licenses, empty_declared_license_data, normalize_declared_name_and_url,
 };
 
 #[derive(Clone, Default)]
@@ -132,56 +131,9 @@ fn entry_field(value: &Option<String>) -> Option<&str> {
 
 /// Resolves a single Maven `<license>` entry into a normalized declared license.
 ///
-/// Resolution order, stopping at the first confident match:
-/// 1. exact SPDX-key/identifier lookup on the `<name>`;
-/// 2. free-text detection over the `<name>` alone;
-/// 3. free-text detection over the combined `<name>` and `<url>`.
-///
-/// Step 3 recovers descriptive names that resolve only when paired with their
-/// `<url>`: e.g. "GNU General Lesser Public License (LGPL) version 3.0" with
-/// `http://www.gnu.org/licenses/lgpl.html` resolves to `lgpl-3.0`, where the
-/// name alone matches nothing. It is only used when the name alone fails, so a
-/// name that already resolves (e.g. "GNU Lesser General Public License" ->
-/// `lgpl-2.1-plus`) is not muddied by a second, redundant operand the URL line
-/// would otherwise contribute. The POM `<licenses>` block is trustworthy
-/// declared manifest metadata, so detecting from these bounded fields is
-/// declared normalization, not file-content scanning.
-///
-/// An entry that resolves to nothing maps to `unknown-license-reference` (the
-/// existing convention for an unresolved but declared license reference) so it
-/// is preserved as an explicit operand rather than silently dropped.
+/// Delegates to the shared `name`/`url` declared-license resolver so Maven and
+/// Gradle stay aligned; see [`normalize_declared_name_and_url`] for the
+/// resolution order and rationale.
 fn normalize_maven_license_entry(license: &MavenLicenseEntry) -> NormalizedDeclaredLicense {
-    let name = entry_field(&license.name);
-
-    if let Some(name) = name {
-        match name {
-            "Public Domain" | "public domain" => {
-                return NormalizedDeclaredLicense::new(
-                    "public-domain",
-                    "LicenseRef-scancode-public-domain",
-                );
-            }
-            other => {
-                if let Some(normalized) = normalize_declared_license_key(other) {
-                    return normalized;
-                }
-                if let Some(normalized) = detect_declared_license_name(other) {
-                    return normalized;
-                }
-            }
-        }
-    }
-
-    let detection_text = [name, entry_field(&license.url)]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    detect_declared_license_name(&detection_text).unwrap_or_else(|| {
-        NormalizedDeclaredLicense::new(
-            "unknown-license-reference",
-            "LicenseRef-scancode-unknown-license-reference",
-        )
-    })
+    normalize_declared_name_and_url(entry_field(&license.name), entry_field(&license.url))
 }


### PR DESCRIPTION
## Summary

- Extract Maven's `<license>` name/url resolution into a shared `normalize_declared_name_and_url` helper and have both Maven and Gradle use it.
- Gradle's `license { name; url }` block now recognizes the same breadth of declared licenses as Maven (free-text names, license URLs, SPDX keys) instead of a handful of hardcoded patterns.

## Issues

- Covers: follow-up to #1142 (Maven/Gradle declared-license normalization)

## Scope and exclusions

- Included: shared name/url declared-license resolver; Gradle delegating to it; Maven refactored onto it with no behavior change.
- Explicit exclusions: multiple `license {}` blocks in one Gradle file (still first-only); attaching sibling/top-level `LICENSE` files to a package's declared license (tracked separately as an ADR-gated design decision).

## How to verify

- CI covers the maven/gradle unit + golden suites. Beyond that: `cargo test --lib gradle_license` exercises the new `test_gradle_license_resolves_descriptive_name_via_shared_normalizer`, which asserts the classic ASF name `The Apache Software License, Version 2.0` now resolves to `apache-2.0` (the previous hardcoded matcher dropped it to an extracted-only statement).

## Intentional differences from Python

- None new. This aligns Gradle declared-license normalization with Maven's existing ScanCode-compatible behavior; unresolved declared entries map to `unknown-license-reference`, matching the established convention.

## Follow-up work

- Created or intentionally deferred: ADR for whether Provenant should attach sibling/datafile-detected `LICENSE` files to a package's declared license (the ScanCode `add_license_from_file` behavior), which is a separate architectural decision.

## Expected-output fixture changes

- Files changed: none. Maven goldens are unchanged (the refactor is behavior-preserving) and existing Gradle goldens still pass.
