### PR TITLE
feat(helm): read declared license from artifacthub.io/license annotation

### DIFF
--- a/docs/improvements/helm-parser.md
+++ b/docs/improvements/helm-parser.md
@@ -21,6 +21,12 @@ That static file-format coverage remains compatible with current Helm v4 chart m
 - Root packages are emitted with Helm package identities such as `pkg:helm/nginx@22.1.1`.
 - The same static metadata path works for legacy `apiVersion: v1`, Helm 3 `apiVersion: v2`, and current Helm 4 `apiVersion: v3` charts.
 
+### Declared license from the `artifacthub.io/license` annotation
+
+- Helm's `Chart.yaml` has no first-class license field; the conventional declared-license surface is the Artifact Hub `artifacthub.io/license` annotation, whose value is an SPDX expression.
+- Rust reads that annotation and normalizes it through the shared declared-license path (SPDX expression, then the declared-license alias table), populating `extracted_license_statement`, `declared_license_expression`, `declared_license_expression_spdx`, and parser-side `license_detections`.
+- The annotation remains preserved verbatim in `extra_data.annotations`. Charts without the annotation keep an unset declared license rather than guessing.
+
 ### Declared dependency extraction from `Chart.yaml`
 
 - Rust now extracts chart dependencies declared in `Chart.yaml`.

--- a/src/parsers/helm.rs
+++ b/src/parsers/helm.rs
@@ -13,6 +13,7 @@ use yaml_serde::{Mapping, Value};
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType, Party, PartyType};
 
 use super::PackageParser;
+use super::license_normalization::normalize_spdx_declared_license;
 use super::metadata::ParserMetadata;
 
 pub struct HelmChartYamlParser;
@@ -118,6 +119,14 @@ fn parse_chart_yaml(yaml_content: &Value) -> PackageData {
     let dependencies = extract_chart_yaml_dependencies(yaml_content);
     let extra_data = build_chart_yaml_extra_data(yaml_content);
 
+    // Helm's Chart.yaml has no first-class license field; the conventional
+    // declared-license surface is the Artifact Hub `artifacthub.io/license`
+    // annotation, whose value is an SPDX expression. Normalize it through the shared
+    // declared-license path (SPDX expression, then alias fallback).
+    let extracted_license_statement = extract_chart_license_statement(yaml_content);
+    let (declared_license_expression, declared_license_expression_spdx, license_detections) =
+        normalize_spdx_declared_license(extracted_license_statement.as_deref());
+
     PackageData {
         package_type: Some(PackageType::Helm),
         name: name.clone(),
@@ -128,6 +137,10 @@ fn parse_chart_yaml(yaml_content: &Value) -> PackageData {
         keywords,
         homepage_url,
         code_view_url,
+        extracted_license_statement,
+        declared_license_expression,
+        declared_license_expression_spdx,
+        license_detections,
         is_private: false,
         extra_data,
         dependencies,
@@ -137,6 +150,17 @@ fn parse_chart_yaml(yaml_content: &Value) -> PackageData {
             .and_then(|name| build_helm_purl(name, version.as_deref())),
         ..default_package_data(Some(DatasourceId::HelmChartYaml))
     }
+}
+
+/// Reads the Artifact Hub `artifacthub.io/license` annotation, the conventional
+/// declared-license surface for a Helm chart (an SPDX expression such as
+/// `Apache-2.0`). Helm's `Chart.yaml` spec has no dedicated license field.
+fn extract_chart_license_statement(yaml_content: &Value) -> Option<String> {
+    yaml_content
+        .get("annotations")
+        .and_then(|annotations| annotations.get("artifacthub.io/license"))
+        .and_then(yaml_value_to_string)
+        .filter(|value| !value.trim().is_empty())
 }
 
 fn parse_chart_lock(yaml_content: &Value) -> PackageData {

--- a/src/parsers/helm_test.rs
+++ b/src/parsers/helm_test.rs
@@ -345,6 +345,7 @@ annotations:
             package_data.declared_license_expression_spdx.as_deref(),
             Some("Apache-2.0 OR MIT")
         );
+        assert_eq!(package_data.license_detections.len(), 1);
     }
 
     #[test]

--- a/src/parsers/helm_test.rs
+++ b/src/parsers/helm_test.rs
@@ -164,6 +164,21 @@ dependencies:
             Some("Apache-2.0")
         );
 
+        // The `artifacthub.io/license` annotation is promoted to the declared license.
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("Apache-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0")
+        );
+        assert_eq!(package_data.license_detections.len(), 1);
+
         assert_eq!(package_data.dependencies.len(), 3);
         let common = package_data
             .dependencies
@@ -297,6 +312,38 @@ home: https://example.com/legacy
                 .and_then(|value| value.get("api_version"))
                 .and_then(|value| value.as_str()),
             Some("v1")
+        );
+        // No `artifacthub.io/license` annotation: declared license stays unset.
+        assert_eq!(package_data.extracted_license_statement, None);
+        assert_eq!(package_data.declared_license_expression, None);
+        assert_eq!(package_data.declared_license_expression_spdx, None);
+        assert!(package_data.license_detections.is_empty());
+    }
+
+    #[test]
+    fn test_chart_yaml_license_annotation_normalizes_spdx_expression() {
+        let content = r#"
+apiVersion: v2
+name: dual-licensed
+version: 1.0.0
+annotations:
+  artifacthub.io/license: "MIT OR Apache-2.0"
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("Chart.yaml", content);
+        let package_data = HelmChartYamlParser::extract_first_package(&path);
+
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("MIT OR Apache-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT")
         );
     }
 

--- a/testdata/helm-golden/chart-basic/Chart.yaml.expected.json
+++ b/testdata/helm-golden/chart-basic/Chart.yaml.expected.json
@@ -1,10 +1,14 @@
 [
   {
     "type": "helm",
+    "namespace": null,
     "name": "nginx",
     "version": "22.1.1",
+    "qualifiers": {},
+    "subpath": null,
     "primary_language": "YAML",
     "description": "Example Helm chart",
+    "release_date": null,
     "parties": [
       {
         "type": "person",
@@ -16,17 +20,62 @@
     ],
     "keywords": ["nginx", "reverse-proxy"],
     "homepage_url": "https://example.com/nginx",
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
     "code_view_url": "https://github.com/example/nginx-chart",
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": "apache-2.0",
+    "declared_license_expression_spdx": "Apache-2.0",
+    "license_detections": [
+      {
+        "license_expression": "apache-2.0",
+        "license_expression_spdx": "Apache-2.0",
+        "matches": [
+          {
+            "license_expression": "apache-2.0",
+            "license_expression_spdx": "Apache-2.0",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "parser-declared-license",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "matched_text": "Apache-2.0"
+          }
+        ],
+        "identifier": null
+      }
+    ],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": "Apache-2.0",
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
     "extra_data": {
-      "api_version": "v2",
+      "kube_version": ">=1.25.0-0",
       "icon": "https://example.com/icon.png",
-      "app_version": "1.29.1",
+      "api_version": "v2",
       "sources": ["https://github.com/example/nginx-chart"],
+      "chart_type": "application",
       "annotations": {
         "artifacthub.io/license": "Apache-2.0"
       },
-      "kube_version": ">=1.25.0-0",
-      "chart_type": "application"
+      "app_version": "1.29.1"
     },
     "dependencies": [
       {
@@ -37,10 +86,11 @@
         "is_optional": true,
         "is_pinned": false,
         "is_direct": true,
+        "resolved_package": null,
         "extra_data": {
+          "repository": "oci://registry-1.docker.io/bitnamicharts",
           "alias": "shared",
-          "tags": ["common"],
-          "repository": "oci://registry-1.docker.io/bitnamicharts"
+          "tags": ["common"]
         }
       },
       {
@@ -51,15 +101,16 @@
         "is_optional": true,
         "is_pinned": true,
         "is_direct": true,
+        "resolved_package": null,
         "extra_data": {
           "condition": "metrics.enabled",
-          "repository": "https://charts.example.test",
           "import_values": [
             {
               "child": "exports.data",
               "parent": "metricsData"
             }
-          ]
+          ],
+          "repository": "https://charts.example.test"
         }
       },
       {
@@ -70,11 +121,15 @@
         "is_optional": false,
         "is_pinned": true,
         "is_direct": true,
+        "resolved_package": null,
         "extra_data": {
           "repository": "https://charts.example.test"
         }
       }
     ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
     "datasource_id": "helm_chart_yaml",
     "purl": "pkg:helm/nginx@22.1.1"
   }


### PR DESCRIPTION
## Summary

- Read a Helm chart's declared license from the Artifact Hub `artifacthub.io/license` annotation and populate `extracted_license_statement`, `declared_license_expression`, `declared_license_expression_spdx`, and parser-side `license_detections`.

## Issues

- Covers: follow-up flagged by ADR 0010 (#1152) — for Helm the accurate fix is reading the chart's own license surface, not co-hosted-file attribution.

## Scope and exclusions

- Included: parser-local extraction of the `artifacthub.io/license` annotation, normalized through the shared declared-license path (SPDX expression, then the declared-license alias table); unit coverage; regenerated `chart-basic` golden.
- Explicit exclusions: no `values.yaml`/template evaluation, no remote/OCI resolution. Charts without the annotation keep an unset declared license (no guessing).

## How to verify

- CI covers the helm unit + golden suites. Beyond that: `cargo test --lib helm_test` includes the promotion case (`Apache-2.0` → declared `apache-2.0`/spdx `Apache-2.0`), an SPDX-expression case (`MIT OR Apache-2.0`), and the absence case (no annotation → declared stays unset).

## Intentional differences from Python

- ScanCode ships no Helm `packagedcode` parser, so this is Provenant-only behavior. Helm's `Chart.yaml` has no first-class license field; the `artifacthub.io/license` annotation is the conventional declared-license surface, so reading it is the parser-local, ADR-0002-compliant analog of how other ecosystems normalize a declared SPDX field.

## Follow-up work

- None. This closes the Helm item from ADR 0010's blast-radius table; Helm now belongs in the "declared license already populated" tier rather than relying on the co-hosted-LICENSE pass.

## Expected-output fixture changes

- Files changed: `testdata/helm-golden/chart-basic/Chart.yaml.expected.json`.
- Why the new expected output is correct: the fixture's `artifacthub.io/license: Apache-2.0` annotation now yields `declared_license_expression: apache-2.0` / `declared_license_expression_spdx: Apache-2.0` with a parser-declared `license_detections` entry; the annotation remains preserved verbatim in `extra_data.annotations`.
