### PR TITLE
fix(copyright): drop false positives from subword-tokenizer data files

### DIFF
--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -26,6 +26,7 @@ use super::detector_input_normalization::{
 use super::lexer::get_tokens;
 use super::line_tracking::{LineNumberIndex, PreparedLineCache};
 use super::parser::{parse, parse_with_deadline};
+use super::refiner::looks_like_bpe_merges_table;
 #[cfg(test)]
 use super::refiner::refine_copyright;
 use super::types::{
@@ -222,6 +223,12 @@ pub fn detect_copyrights_from_text_with_deadline(
     let deadline = max_runtime.and_then(|d| Instant::now().checked_add(d));
 
     if content.is_empty() {
+        return (copyrights, holders, authors);
+    }
+
+    // BPE tokenizer merge tables (e.g. `merges.txt`) embed the `©` symbol and
+    // mojibake byte pairs as merge rules but carry no genuine copyright notice.
+    if looks_like_bpe_merges_table(content) {
         return (copyrights, holders, authors);
     }
 
@@ -432,6 +439,12 @@ pub fn detect_copyrights_from_text_with_deadline(
         &raw_lines,
         &mut copyrights,
         &mut holders,
+    );
+    drop_tokenizer_data_fragment_detections(
+        &raw_lines,
+        &mut copyrights,
+        &mut holders,
+        &mut authors,
     );
 
     for group in &groups {
@@ -692,7 +705,7 @@ pub(super) use token_utils::collect_all_leaves;
 use token_utils::{
     apply_written_by_for_markers, drop_path_fragment_holders_from_bare_c_code_lines,
     drop_scan_only_holders_from_copyright_scan_lines,
-    drop_test_label_false_positive_copyrights_and_holders,
+    drop_test_label_false_positive_copyrights_and_holders, drop_tokenizer_data_fragment_detections,
     extract_original_author_additional_contributors,
 };
 use tree_walk::{

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -7,6 +7,45 @@
 use super::*;
 
 #[test]
+fn test_bpe_tokenizer_data_lines_do_not_produce_copyrights_or_holders() {
+    // Hugging Face subword-tokenizer artifacts: merges.txt BPE pairs and
+    // vocab.json token:id entries embed the `©` symbol and the literal
+    // `copyright` token. They must not be surfaced as copyright/holder notices.
+    let input = concat!(
+        "Ã© goo gle</w> fren ch</w>\n",
+        "âģ ©</w> f ren st y</w>\n",
+        "\"©\": 102,\n",
+        "\"copyright</w>\": 15778,\n",
+    );
+
+    let (copyrights, holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+    assert!(holders.is_empty(), "holders: {holders:?}");
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_bpe_merges_table_produces_no_copyrights() {
+    // A full BPE merges.txt (header + two-token merge rules) embeds `©` and
+    // mojibake byte pairs that are not copyright notices.
+    let input = concat!(
+        "#version: 0.2\n",
+        "i n\n",
+        "t h\n",
+        "Â ©\n",
+        "pok Ã©\n",
+        "Ú ©\n",
+    );
+
+    let (copyrights, holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:?}");
+    assert!(holders.is_empty(), "holders: {holders:?}");
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_swift_convention_c_signatures_do_not_produce_copyrights_or_holders() {
     let input = concat!(
         "let invokeSuperSetter: @convention(c) (NSObject, AnyClass, Selector, AnyObject?) -> Void = { object, superclass, selector, delegate in\n",

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -10,9 +10,9 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use super::normalize_whitespace;
-use crate::copyright::refiner::is_path_like_code_fragment;
+use crate::copyright::refiner::{is_path_like_code_fragment, is_tokenizer_data_fragment};
 use crate::copyright::types::{
-    CopyrightDetection, HolderDetection, ParseNode, PosTag, Token, TreeLabel,
+    AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, Token, TreeLabel,
 };
 use crate::models::LineNumber;
 
@@ -285,6 +285,39 @@ fn collect_filtered_leaves_inner<'a>(
             }
         }
     }
+}
+
+/// Drop copyright, holder, and author detections that originate from machine
+/// subword-tokenizer data lines.
+///
+/// Hugging Face `merges.txt` BPE merge tables and `vocab.json` vocabularies
+/// embed the `©` symbol and the literal word `copyright` as tokens, which the
+/// detector would otherwise surface as dozens of spurious notices (e.g.
+/// `"©": 102,` or `Ã © goo gle</w> fren ch</w>`). A detection is dropped when any
+/// raw source line it spans is a tokenizer data fragment. Matching on the raw
+/// source line (rather than the refined statement) is robust because holder
+/// refinement strips the `</w>` markers and quotes that identify the data.
+pub fn drop_tokenizer_data_fragment_detections(
+    raw_lines: &[&str],
+    copyrights: &mut Vec<CopyrightDetection>,
+    holders: &mut Vec<HolderDetection>,
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if raw_lines.is_empty() {
+        return;
+    }
+
+    let spans_tokenizer_line = |start: usize, end: usize| -> bool {
+        (start..=end).any(|line_no| {
+            raw_lines
+                .get(line_no.saturating_sub(1))
+                .is_some_and(|line| is_tokenizer_data_fragment(line))
+        })
+    };
+
+    copyrights.retain(|c| !spans_tokenizer_line(c.start_line.get(), c.end_line.get()));
+    holders.retain(|h| !spans_tokenizer_line(h.start_line.get(), h.end_line.get()));
+    authors.retain(|a| !spans_tokenizer_line(a.start_line.get(), a.end_line.get()));
 }
 
 pub fn drop_scan_only_holders_from_copyright_scan_lines(

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -18,6 +18,61 @@ use super::*;
 
 // ─── Junk detection ──────────────────────────────────────────────────────────
 
+/// Return true if `s` is a fragment of machine subword-tokenizer data rather
+/// than a real copyright, holder, or author.
+///
+/// Subword-tokenizer artifacts (e.g. Hugging Face `merges.txt` BPE merge tables
+/// and `vocab.json` vocabularies) embed the `©` symbol and the literal word
+/// `copyright` as tokens, which the detector would otherwise surface as dozens of
+/// spurious notices. Two signals are decisive and never occur in genuine
+/// copyright text: the BPE end-of-word marker `</w>`, and a line that is wholly a
+/// sequence of JSON `"token": <id>` vocabulary entries (e.g. `"©": 102,`).
+///
+/// The JSON check is anchored to the whole (trimmed) line so that a genuine
+/// notice which merely *contains* a `"key": 5` fragment (e.g.
+/// `Copyright 2024 Foo, "version": 5`) is never mistaken for tokenizer data — a
+/// real `vocab.json` line is nothing but quoted-token/integer-id pairs.
+pub(crate) fn is_tokenizer_data_fragment(s: &str) -> bool {
+    static JSON_TOKEN_ID_LINE_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r#"^\{?\s*("[^"]*"\s*:\s*-?\d+\s*,?\s*)+\}?$"#));
+    s.contains("</w>") || JSON_TOKEN_ID_LINE_RE.is_match(s.trim())
+}
+
+/// Return true if `content` is a Byte-Pair-Encoding (BPE) merges table, such as
+/// a Hugging Face / GPT-2 tokenizer `merges.txt`.
+///
+/// These files open with a `#version:` header and list one whitespace-separated
+/// token pair per line. They embed the `©` symbol and accented/mojibake byte
+/// pairs (e.g. `Â ©`, `pok Ã©`) as merge rules, which the detector would
+/// otherwise mistake for copyright notices — but a merge table never contains a
+/// genuine copyright statement. The `#version:` header plus the strict two-token
+/// line shape make this signature specific enough that it cannot match ordinary
+/// source or text files.
+pub(crate) fn looks_like_bpe_merges_table(content: &str) -> bool {
+    let mut lines = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+
+    if !lines
+        .next()
+        .is_some_and(|first| first.starts_with("#version:"))
+    {
+        return false;
+    }
+
+    // Every merge rule is exactly two whitespace-separated tokens. Sample a
+    // bounded prefix and require all sampled rules to match the pair shape.
+    let mut sampled = 0;
+    for line in lines.take(64) {
+        if line.split_whitespace().count() != 2 {
+            return false;
+        }
+        sampled += 1;
+    }
+    sampled > 0
+}
+
 /// Return true if `s` matches any known junk copyright pattern.
 pub fn is_junk_copyright(s: &str) -> bool {
     if looks_like_structured_copyright_notice_with_year(s) {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -63,7 +63,8 @@ pub use copyright::refine_copyright;
 pub use holder::{refine_holder, refine_holder_in_copyright_context};
 pub use junk::is_junk_copyright;
 pub(crate) use junk::{
-    has_copyright_year, is_junk_holder, is_path_like_code_fragment, looks_like_source_code,
+    has_copyright_year, is_junk_holder, is_path_like_code_fragment, is_tokenizer_data_fragment,
+    looks_like_bpe_merges_table, looks_like_source_code,
 };
 
 /// Compile a static regex literal.

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -471,6 +471,62 @@ fn test_refine_holder_drops_trailing_preposition_fragment() {
     );
 }
 
+// ── is_tokenizer_data_fragment ───────────────────────────────────
+
+#[test]
+fn test_tokenizer_data_fragment_bpe_word_marker() {
+    // Hugging Face merges.txt / vocab.json BPE artifacts carrying the `©`
+    // token must not be surfaced as copyright/holder notices.
+    assert!(is_tokenizer_data_fragment("Ã © goo gle</w> fren ch</w>"));
+    assert!(is_tokenizer_data_fragment("âģ ©</w> f ren st y</w>"));
+}
+
+#[test]
+fn test_tokenizer_data_fragment_json_token_id_entry() {
+    assert!(is_tokenizer_data_fragment(r#""©": 102,"#));
+    assert!(is_tokenizer_data_fragment(r#""copyright</w>": 15778,"#));
+    assert!(is_tokenizer_data_fragment(r#""Â©": 31148,"#));
+    // Multiple entries on one line (and a minified-object line) are still data.
+    assert!(is_tokenizer_data_fragment(
+        r#""andré": 35609, "ands": 32257,"#
+    ));
+    assert!(is_tokenizer_data_fragment(r#"{"a": 1, "b": 2}"#));
+}
+
+#[test]
+fn test_tokenizer_data_fragment_keeps_real_notices() {
+    assert!(!is_tokenizer_data_fragment("Copyright (c) 2024 Acme Inc."));
+    assert!(!is_tokenizer_data_fragment("(c) 2003 The Regents"));
+    // A normal URL with a port is not a JSON token:id entry.
+    assert!(!is_tokenizer_data_fragment(
+        "Copyright 2020 Foo http://example.com:8080"
+    ));
+    // A real notice that merely contains a mid-line `"key": <digit>` fragment
+    // must NOT be treated as tokenizer data (anchored whole-line match).
+    assert!(!is_tokenizer_data_fragment(
+        r#"Copyright 2024 Foo, "version": 5"#
+    ));
+    assert!(!is_tokenizer_data_fragment(
+        r#"Copyright 2020 Foo (see "config": 5)"#
+    ));
+}
+
+#[test]
+fn test_looks_like_bpe_merges_table() {
+    let merges = "#version: 0.2\ni n\nt h\nÂ ©\npok Ã©\n";
+    assert!(looks_like_bpe_merges_table(merges));
+}
+
+#[test]
+fn test_looks_like_bpe_merges_table_rejects_ordinary_text() {
+    // A normal source file with a #version-style comment is not a merge table:
+    // its lines are not all two-token pairs.
+    let src = "#version: 1.0\n// Copyright (c) 2024 Acme Inc. All rights reserved.\nfn main() {}\n";
+    assert!(!looks_like_bpe_merges_table(src));
+    // No `#version:` header at all.
+    assert!(!looks_like_bpe_merges_table("i n\nt h\n"));
+}
+
 // ── is_junk_copyright ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Hugging Face subword-tokenizer artifacts (`merges.txt` BPE merge tables, `vocab.json` vocabularies) embed the `©` symbol and the literal `copyright` token as dictionary entries. The copyright detector surfaced these as dozens of spurious copyrights/holders per file (e.g. `"©": 102,`, `Ã © goo gle</w> fren ch</w>`), where ScanCode emits none.
- Adds `is_tokenizer_data_fragment` + a `drop_tokenizer_data_fragment_detections` finalize pass (drops detections whose raw source line carries a BPE `</w>` marker or a JSON `"token": <int>` entry), plus a `looks_like_bpe_merges_table` content guard at the detector entry (`#version:` header + strict two-token lines) for merge-pair mojibake lines that lack `</w>`.
- Matching the raw source line (not the refined statement) is robust because holder refinement strips the markers/quotes.

## Scope and exclusions

- Included: copyright/holder/author false-positive suppression for BPE tokenizer data files.
- Explicit exclusions: no changes to package extraction or other detectors.

## How to verify

- Scan any Hugging Face model repo containing `tokenizer/merges.txt` + `tokenizer/vocab.json` with `--copyright`; observe zero copyrights/holders on those files (previously ~100 garbage entries on a CLIP tokenizer).

## Follow-up work

- None.

## Expected-output fixture changes

- Files changed: none. All copyright golden suites pass unchanged; new unit + end-to-end tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)