### PR TITLE
fix(assembly): emit one package per conda-meta installed record

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -574,13 +574,10 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["*.gem"],
         mode: AssemblyMode::OnePerPackageData,
     },
-    // Conda ecosystem
+    // Conda ecosystem: recipes and environment files describe one package per
+    // directory, so they sibling-merge.
     AssemblerConfig {
-        datasource_ids: &[
-            DatasourceId::CondaMetaYaml,
-            DatasourceId::CondaYaml,
-            DatasourceId::CondaMetaJson,
-        ],
+        datasource_ids: &[DatasourceId::CondaMetaYaml, DatasourceId::CondaYaml],
         sibling_file_patterns: &[
             "meta.yaml",
             "meta.yml",
@@ -601,6 +598,15 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             "*.json",
         ],
         mode: AssemblyMode::SiblingMerge,
+    },
+    // Conda installed-environment records: each `conda-meta/<pkg>.json` is one
+    // installed package, like the Alpine/RPM/Debian installed databases below,
+    // so every record becomes its own package rather than collapsing the whole
+    // `conda-meta/` directory into a single sibling-merged package.
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::CondaMetaJson],
+        sibling_file_patterns: &["*.json"],
+        mode: AssemblyMode::OnePerPackageData,
     },
     // RPM specfile (source packages)
     AssemblerConfig {

--- a/src/parsers/conda_scan_test.rs
+++ b/src/parsers/conda_scan_test.rs
@@ -58,6 +58,34 @@ mod tests {
     }
 
     #[test]
+    fn test_conda_meta_records_assemble_one_package_each() {
+        // Each `conda-meta/<pkg>.json` is a distinct installed package. They must
+        // not collapse into a single sibling-merged package just because they
+        // share the `conda-meta/` directory.
+        let (_files, result) = scan_and_assemble(Path::new("testdata/conda/assembly"));
+
+        let conda_meta_purls: Vec<&str> = result
+            .packages
+            .iter()
+            .filter(|package| {
+                package
+                    .datasource_ids
+                    .contains(&DatasourceId::CondaMetaJson)
+            })
+            .filter_map(|package| package.purl.as_deref())
+            .collect();
+
+        assert!(
+            conda_meta_purls.contains(&"pkg:conda/requests@2.32.3"),
+            "expected a distinct requests package, got: {conda_meta_purls:?}"
+        );
+        assert!(
+            conda_meta_purls.contains(&"pkg:conda/zlib@1.3.1"),
+            "expected a distinct zlib package, got: {conda_meta_purls:?}"
+        );
+    }
+
+    #[test]
     fn test_conda_hyphenated_environment_alias_scans_and_assembles() {
         let temp_dir = tempfile::TempDir::new().expect("create temp dir");
         fs::write(

--- a/testdata/conda/assembly/opt/conda/conda-meta/zlib-1.3.1-hb9d3cd8_2.json
+++ b/testdata/conda/assembly/opt/conda/conda-meta/zlib-1.3.1-hb9d3cd8_2.json
@@ -1,0 +1,18 @@
+{
+    "arch": "x86_64",
+    "build": "hb9d3cd8_2",
+    "build_number": 2,
+    "channel": "https://conda.anaconda.org/conda-forge/linux-64",
+    "depends": [
+        "libgcc >=13",
+        "libzlib 1.3.1 hb9d3cd8_2"
+    ],
+    "extracted_package_dir": "/opt/conda/pkgs/zlib-1.3.1-hb9d3cd8_2",
+    "fn": "zlib-1.3.1-hb9d3cd8_2.conda",
+    "license": "Zlib",
+    "license_family": "Other",
+    "name": "zlib",
+    "platform": "linux",
+    "subdir": "linux-64",
+    "version": "1.3.1"
+}


### PR DESCRIPTION
## Summary

- A conda environment's `conda-meta/<pkg>.json` files are installed-package records — one package each, like the Alpine/RPM/Debian installed databases. They were grouped with conda recipe/environment datasources under a `SiblingMerge` config whose `*.json` sibling pattern collapsed every record in a `conda-meta/` directory into a single package (an 87-package base environment became one package).
- Splits `CondaMetaJson` into its own `OnePerPackageData` assembler config so each installed record becomes its own package. This also lets the conda-rootfs post-assembly merge correlate every record with its extracted recipe, which the single collapsed package made impossible.

## Scope and exclusions

- Included: assembly classification of `CondaMetaJson` (installed conda-env records).
- Explicit exclusions: conda recipe/environment (`meta.yaml`, `environment.yml`, `recipe.yaml`) handling is unchanged — those still sibling-merge per directory.

## How to verify

- Extract `/opt/conda/conda-meta` from a `condaforge/miniforge3` image into a directory and scan it with `--package`; expect one `pkg:conda/<name>@<version>` package per record (87 for the base env), not a single collapsed package.

## Follow-up work

- None.

## Expected-output fixture changes

- Files changed: none. Conda parser/scan and assembly lib suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)