### PR TITLE
fix(assembly): subsume Diffusers pipeline-component config.json into the pipeline package

### DIFF
--- a/src/assembly/huggingface_merge.rs
+++ b/src/assembly/huggingface_merge.rs
@@ -15,10 +15,63 @@
 //! Only `PackageData` carrying a Hugging Face datasource id participates, so
 //! generic `README.md`/`config.json` files (which the parsers decline to claim)
 //! never trigger a merge.
+//!
+//! A Diffusers pipeline repository additionally has per-component subdirectories
+//! (`text_encoder/`, `unet/`, `vae/`, ...), each with its own `config.json`. Those
+//! belong to the pipeline described by the repo-root `model_index.json`, not to
+//! standalone models, so a component `config.json` under a `model_index.json`
+//! parent is subsumed into the pipeline package (it emits no package of its own)
+//! rather than surfacing as a purl-less, name-less junk package.
+
+use std::path::Path;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
 
 type DirectoryMergeOutput = (Option<Package>, Vec<TopLevelDependency>, Vec<usize>);
+
+/// Subdirectory names that a Diffusers pipeline uses for its component models.
+/// A `config.json` (or other Transformers/Diffusers metadata) inside one of these
+/// directories describes a component of the parent pipeline, not a standalone
+/// model, so it must not surface as its own top-level package. The list mirrors
+/// the components a `model_index.json` references across Diffusers pipeline
+/// families — Stable Diffusion (text encoder, UNet/transformer, VAE, tokenizer,
+/// scheduler, feature extractor, safety checker, image encoder), Kandinsky
+/// (prior, decoder, movq), DeepFloyd IF (stage_1/2/3), and AudioLDM/MusicGen
+/// (vocoder). The two-condition guard (name match plus a parent `model_index.json`)
+/// keeps the list safe to extend, so unknown future component names only risk
+/// leaving a stray purl-less package, never a false subsumption.
+const DIFFUSERS_COMPONENT_DIRECTORIES: &[&str] = &[
+    "text_encoder",
+    "text_encoder_2",
+    "text_encoder_3",
+    "unet",
+    "transformer",
+    "vae",
+    "vae_encoder",
+    "vae_decoder",
+    "tokenizer",
+    "tokenizer_2",
+    "tokenizer_3",
+    "scheduler",
+    "feature_extractor",
+    "safety_checker",
+    "image_encoder",
+    "image_normalizer",
+    "image_noising_scheduler",
+    "controlnet",
+    // Kandinsky
+    "prior",
+    "prior_text_encoder",
+    "prior_tokenizer",
+    "decoder",
+    "movq",
+    // DeepFloyd IF
+    "stage_1",
+    "stage_2",
+    "stage_3",
+    // AudioLDM / MusicGen
+    "vocoder",
+];
 
 struct HuggingfaceSource<'a> {
     file_index: usize,
@@ -66,6 +119,16 @@ pub fn assemble_huggingface_packages(
     }
 
     if sources.is_empty() {
+        return Vec::new();
+    }
+
+    // A component `config.json` sitting in a Diffusers pipeline-component
+    // subdirectory (e.g. `text_encoder/`, `unet/`, `vae/`) whose parent directory
+    // carries the pipeline `model_index.json` is part of that pipeline, not a
+    // standalone model. The pipeline `model_index.json` already produces the one
+    // `pkg:huggingface/...` package for the repository, so emit nothing here
+    // rather than a purl-less, name-less junk package for the component.
+    if is_diffusers_component_directory(&sources, files) {
         return Vec::new();
     }
 
@@ -130,6 +193,49 @@ fn choose_anchor(sources: &[HuggingfaceSource]) -> usize {
         .iter()
         .position(|source| source.package_data.purl.is_some())
         .unwrap_or(0)
+}
+
+/// Decide whether the directory being merged is a Diffusers pipeline component
+/// directory that should be subsumed into its parent pipeline rather than emit
+/// its own package. Two conditions must hold:
+///
+/// 1. The directory's own name is a known pipeline-component name
+///    (`text_encoder`, `unet`, `vae`, ...).
+/// 2. The parent directory contains a `model_index.json` that a Hugging Face
+///    parser claimed (a Diffusers pipeline manifest).
+///
+/// The directory is derived from the merge sources' datafile paths; assembly
+/// groups files by parent directory, so every source here shares one parent.
+fn is_diffusers_component_directory(sources: &[HuggingfaceSource], files: &[FileInfo]) -> bool {
+    let Some(directory) = sources
+        .iter()
+        .find_map(|source| Path::new(&source.datafile_path).parent())
+    else {
+        return false;
+    };
+
+    let is_component_name = directory
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| DIFFUSERS_COMPONENT_DIRECTORIES.contains(&name));
+    if !is_component_name {
+        return false;
+    }
+
+    let Some(parent) = directory.parent() else {
+        return false;
+    };
+
+    files.iter().any(|file| {
+        let path = Path::new(&file.path);
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == "model_index.json")
+            && path.parent() == Some(parent)
+            && file.package_data.iter().any(|package_data| {
+                package_data.datasource_id == Some(DatasourceId::HuggingfaceModelIndexJson)
+            })
+    })
 }
 
 fn collect_dependencies(

--- a/src/parsers/huggingface_scan_test.rs
+++ b/src/parsers/huggingface_scan_test.rs
@@ -116,4 +116,58 @@ mod tests {
             "README.md",
         );
     }
+
+    #[test]
+    fn diffusers_pipeline_component_config_does_not_surface_as_a_package() {
+        // A Diffusers pipeline repo has a repo-root `model_index.json` plus
+        // component subdirectories (`text_encoder/`, `unet/`, `vae/`, ...) each
+        // with their own `config.json`. The component config carries only a local
+        // cache path in `_name_or_path`, so on its own it would produce a
+        // purl-less, name-less junk package. Assembly must subsume it into the
+        // pipeline: exactly one `pkg:huggingface/...` package from the
+        // `model_index.json`, and no standalone component package.
+        let (_files, result) = scan_and_assemble(Path::new(
+            "testdata/assembly-golden/huggingface-diffusers-pipeline",
+        ));
+
+        let hf_packages: Vec<_> = result
+            .packages
+            .iter()
+            .filter(|package| package.package_type == Some(PackageType::Huggingface))
+            .collect();
+
+        assert_eq!(
+            hf_packages.len(),
+            1,
+            "expected exactly one pipeline package, got {:?}",
+            hf_packages
+                .iter()
+                .map(|p| p.purl.clone())
+                .collect::<Vec<_>>()
+        );
+
+        let pipeline = hf_packages[0];
+        assert_eq!(
+            pipeline.purl.as_deref(),
+            Some("pkg:huggingface/acme-ai/tiny-sd-demo"),
+            "the surviving package must be the model_index.json pipeline"
+        );
+        assert!(
+            pipeline
+                .datasource_ids
+                .iter()
+                .any(|id| id.as_str() == "huggingface_model_index_json"),
+            "pipeline package must come from model_index.json"
+        );
+
+        // No purl-less component package leaks through.
+        assert!(
+            !hf_packages.iter().any(|package| package.purl.is_none()),
+            "no purl-less component package should be emitted, got {:?}",
+            hf_packages
+                .iter()
+                .map(|p| (p.purl.clone(), p.name.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/testdata/assembly-golden/huggingface-diffusers-pipeline/model_index.json
+++ b/testdata/assembly-golden/huggingface-diffusers-pipeline/model_index.json
@@ -1,0 +1,25 @@
+{
+  "_class_name": "StableDiffusionPipeline",
+  "_diffusers_version": "0.21.0",
+  "_name_or_path": "acme-ai/tiny-sd-demo",
+  "scheduler": [
+    "diffusers",
+    "PNDMScheduler"
+  ],
+  "text_encoder": [
+    "transformers",
+    "CLIPTextModel"
+  ],
+  "tokenizer": [
+    "transformers",
+    "CLIPTokenizer"
+  ],
+  "unet": [
+    "diffusers",
+    "UNet2DConditionModel"
+  ],
+  "vae": [
+    "diffusers",
+    "AutoencoderKL"
+  ]
+}

--- a/testdata/assembly-golden/huggingface-diffusers-pipeline/text_encoder/config.json
+++ b/testdata/assembly-golden/huggingface-diffusers-pipeline/text_encoder/config.json
@@ -1,0 +1,12 @@
+{
+  "_name_or_path": "/home/ubuntu/.cache/huggingface/hub/models--SG161222--Realistic_Vision_V4.0/snapshots/abcd1234/text_encoder",
+  "architectures": [
+    "CLIPTextModel"
+  ],
+  "model_type": "clip_text_model",
+  "hidden_size": 768,
+  "num_attention_heads": 12,
+  "num_hidden_layers": 12,
+  "vocab_size": 49408,
+  "transformers_version": "4.34.0"
+}


### PR DESCRIPTION
## Summary

- A Diffusers pipeline repo has a repo-root `model_index.json` (which Provenant correctly turns into one `pkg:huggingface/...` package) plus component subdirectories (`text_encoder/`, `unet/`, `vae/`, ...) each with their own `config.json`. `HuggingfaceConfigParser` fires on a component `config.json` whose `_name_or_path` is a local cache path, so it carries no usable repo id and on its own produced a top-level package with **no purl and no name** — pure junk (ScanCode emits nothing for it).
- This is a cross-file relationship, so the fix lives in **assembly**, not the file-local parser. The per-directory Hugging Face merger now recognizes when the directory it is merging is a known pipeline-component directory whose **parent** carries a `model_index.json` the parser claimed, and subsumes it: the component config emits no standalone package, leaving the one `model_index.json` pipeline package for the repository.
- The documented root-config contract is preserved: a transformers `config.json` at a model ROOT (no `model_index.json` parent) that lacks a usable `_name_or_path` still emits a package. `config_with_local_name_or_path_omits_purl` and `older_config_without_model_type_is_recognized` continue to pass.

## Issues

- Covers: junk purl-less/name-less Hugging Face packages emitted for Diffusers pipeline component `config.json` files (found verifying segmind/tiny-sd).

## Scope and exclusions

- Included: assembly-side subsumption of Diffusers pipeline-component `config.json` under a `model_index.json` parent; a synthetic assembly-golden fixture and a Layer 3 scanner/assembly contract test.
- Explicit exclusions: no parser-side changes (the root-config "model is here" contract must keep emitting a package); no change to non-Diffusers single-model repos.

## How to verify

- `cargo test --lib huggingface` — the new `diffusers_pipeline_component_config_does_not_surface_as_a_package` plus the existing root-config and merge contract tests.
- Manual: `cargo run -- testdata/assembly-golden/huggingface-diffusers-pipeline --package --json-pp -` shows exactly one `huggingface` package (`pkg:huggingface/acme-ai/tiny-sd-demo`) and no purl-less component package.

## Intentional differences from Python

- N/A — ScanCode emits nothing for these component configs; Provenant now also emits no junk package while still reporting the one pipeline package.

## Expected-output fixture changes

- Files changed: new synthetic fixture `testdata/assembly-golden/huggingface-diffusers-pipeline/` (`model_index.json` + `text_encoder/config.json`). It is consumed by the scanner/assembly contract test, not by an `expected.json` golden, so no expected-output file is added.
- Why the new expected output is correct: the component `config.json` has a local-cache `_name_or_path` (no repo id), so it must not surface as a package; the repo's identity comes solely from the pipeline `model_index.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
