### PR TITLE
docs(benchmarks): record new-surface verification rows

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 219 of 219 recorded runs, with a **19.3× median speedup** and **19.1× geometric-mean speedup** overall; the median gap grows from **9.0×** on sub-100-file targets to **36.6×** on 10k+ file targets.
+> Provenant is faster on 223 of 223 recorded runs, with a **19.3× median speedup** and **19.2× geometric-mean speedup** overall; the median gap grows from **9.0×** on sub-100-file targets to **36.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -266,6 +266,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 
 #### Hugging Face / AI model repositories
 
+##### [segmind/tiny-sd @ cad0bd7](https://huggingface.co/segmind/tiny-sd/tree/cad0bd7495fa6c4bcca01b19a723dc91627fe84f) — **18.6× faster**
+
+- Files: 17
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.96s`; ScanCode `92.04s`
+- Direct Hugging Face Diffusers pipeline package identity (`1` vs `0`) that ScanCode cannot model because it ships no Hugging Face parser: Provenant assembles the repository's `model_index.json` into one `pkg:huggingface/SG161222/Realistic_Vision_V4.0` Stable Diffusion pipeline package anchored on the config's `_name_or_path`, and folds the `text_encoder`, `unet`, and `vae` component `config.json` files into that pipeline instead of surfacing them as separate identity-less packages, with no copyright noise from the CLIP tokenizer's `merges.txt` and `vocab.json`
+
 ##### [sentence-transformers/all-MiniLM-L6-v2 @ 1110a24](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/tree/1110a243fdf4706b3f48f1d95db1a4f5529b4d41) — **9.75× faster**
 
 - Files: 30
@@ -479,6 +486,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `10.57s`; ScanCode `425.90s`
 - Matched top-level SBT package coverage (`7` vs `7`) with broader dependency extraction (`49` vs `40`) from the root `build.sbt`, sample applications, and native-image test manifests, plus cleaner rejection of weak actor-name author noise such as `the ActorSystem` and `the ReceiveBuilder`
+
+##### [apache/ant-ivy @ dc35d51](https://github.com/apache/ant-ivy/tree/dc35d510d281ab2ab8fb4486e517e838c72a64d2) — **25.5× faster**
+
+- Files: 2,470
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `14.71s`; ScanCode `374.46s`
+- Far broader package coverage (`248` vs `115`) led by direct Apache Ivy `ivy.xml` extraction that ScanCode cannot model at all — `151` `pkg:ivy/*` packages carrying Ivy configuration-scope dependency mappings — plus distinct-GAV Maven POM handling that emits one package per standalone `.pom` coordinate sharing a directory rather than collapsing them into one, with conservative omission of fixture POMs whose version is an unresolved `${property}` placeholder where ScanCode emits a literal placeholder coordinate
 
 ##### [apache/felix-dev @ 20aee77](https://github.com/apache/felix-dev/tree/20aee77cce8cad21493368403701d9c44c168f62) — **24.00× faster**
 
@@ -1274,6 +1288,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.97s`; ScanCode `106.46s`
 - Matched Haxe package and dependency coverage on the repo-root `haxelib.json`, with cleaner copyright and holder recovery on `hxd/fmt/fbx/Writer.hx` and `samples/text_res/trueTypeFont.ttf` plus safer trailing-slash URL normalization
 
+##### [JetBrains/JetBrainsMono @ 1937130](https://github.com/JetBrains/JetBrainsMono/tree/19371302b95d218af43299bce79ddbddd0bc364d) — **24.1× faster**
+
+- Files: 159
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.23s`; ScanCode `125.87s`
+- Cleaner embedded font legal metadata across 120 committed `.otf`, `.ttf`, and `.woff2` files: Provenant decodes each OpenType `name` record individually to recover the exact `OFL-1.1` license, the `Copyright 2020 The JetBrains Mono Project Authors` notice, holder, and project/OFL URLs, where ScanCode mangles the same copyright into run-on strings padded with font family and version text, plus a more accurate empty declared license on `requirements.txt` where ScanCode conflates detected content licenses into a declaration
+
 ##### [jgm/pandoc @ d9838eb](https://github.com/jgm/pandoc/tree/d9838eba11ae18216f52e233dbbca735f0f97ccb) — **22.54× faster**
 
 - Files: 2,768
@@ -1442,6 +1463,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-22 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `4.65s`; ScanCode `42.30s`
 - Matched standalone Alpine installed-db package and license coverage (`16` vs `16` packages) on the shipped `lib/apk/db/installed` snapshot, with one extra maintainer email recovered from package metadata; the exact bytes are archived as a fixture at [`testdata/alpine/benchmark-minirootfs-3.23.3/rootfs/lib/apk/db/installed`](../testdata/alpine/benchmark-minirootfs-3.23.3/rootfs/lib/apk/db/installed) (extracted via `tar -xzf alpine-minirootfs-3.23.3-x86_64.tar.gz lib/apk/db/installed` from the immutable release tarball), scanned as the `benchmark-minirootfs-3.23.3` directory whose second file is the co-located `SOURCE.md`
+
+##### [Conda base environment conda-meta snapshot @ sha256:7de9956](https://hub.docker.com/r/condaforge/miniforge3) — **14.7× faster**
+
+- Files: 89
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.21s`; ScanCode `76.42s`
+- Matched conda installed-environment package coverage (`87` vs `87`) with one package per `conda-meta/<pkg>.json` record carrying its own license, version, and dependency identity from a `condaforge/miniforge3` base environment, treating the conda environment database like the Alpine, RPM, and Debian installed databases rather than collapsing the whole `conda-meta/` directory into a single package
 
 ##### [debian:bookworm-slim dpkg DB snapshot @ sha256:f065376](https://hub.docker.com/layers/library/debian/bookworm-slim/images/sha256-f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a) — **13.08× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -140,6 +140,9 @@ ScanCode: 47.37s</title></rect>
     <rect x="283.05" y="450.63" width="8" height="8" fill="#d97706" rx="1.5"><title>univention/Nubus @ fef2258
 Files: 16
 ScanCode: 42.68s</title></rect>
+    <rect x="287.23" y="414.32" width="8" height="8" fill="#d97706" rx="1.5"><title>segmind/tiny-sd @ cad0bd7
+Files: 17
+ScanCode: 92.04s</title></rect>
     <rect x="291.17" y="449.68" width="8" height="8" fill="#d97706" rx="1.5"><title>distroless base-debian13 status.d @ sha256:57c1e4c
 Files: 18
 ScanCode: 43.55s</title></rect>
@@ -188,6 +191,9 @@ ScanCode: 54.13s</title></rect>
     <rect x="399.74" y="445.22" width="8" height="8" fill="#d97706" rx="1.5"><title>numtide/devshell @ 255a2b1
 Files: 87
 ScanCode: 47.86s</title></rect>
+    <rect x="401.30" y="423.11" width="8" height="8" fill="#d97706" rx="1.5"><title>Conda base environment conda-meta snapshot @ sha256:7de9956
+Files: 89
+ScanCode: 76.42s</title></rect>
     <rect x="402.83" y="447.10" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 ScanCode: 45.99s</title></rect>
@@ -221,6 +227,9 @@ ScanCode: 50.68s</title></rect>
     <rect x="439.98" y="430.21" width="8" height="8" fill="#d97706" rx="1.5"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 ScanCode: 65.75s</title></rect>
+    <rect x="441.29" y="399.53" width="8" height="8" fill="#d97706" rx="1.5"><title>JetBrains/JetBrainsMono @ 1937130
+Files: 159
+ScanCode: 125.87s</title></rect>
     <rect x="441.29" y="409.83" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
 Files: 159
 ScanCode: 101.22s</title></rect>
@@ -467,6 +476,9 @@ ScanCode: 235.22s</title></rect>
     <rect x="627.52" y="350.33" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 ScanCode: 356.55s</title></rect>
+    <rect x="630.31" y="348.01" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/ant-ivy @ dc35d51
+Files: 2470
+ScanCode: 374.46s</title></rect>
     <rect x="633.28" y="388.01" width="8" height="8" fill="#d97706" rx="1.5"><title>playframework/playframework @ c2c114f
 Files: 2579
 ScanCode: 160.61s</title></rect>
@@ -799,6 +811,9 @@ Provenant: 4.90s</title></circle>
     <circle cx="287.05" cy="556.52" r="4.5" fill="#2563eb"><title>univention/Nubus @ fef2258
 Files: 16
 Provenant: 4.94s</title></circle>
+    <circle cx="291.23" cy="556.33" r="4.5" fill="#2563eb"><title>segmind/tiny-sd @ cad0bd7
+Files: 17
+Provenant: 4.96s</title></circle>
     <circle cx="295.17" cy="554.01" r="4.5" fill="#2563eb"><title>distroless base-debian13 status.d @ sha256:57c1e4c
 Files: 18
 Provenant: 5.21s</title></circle>
@@ -847,6 +862,9 @@ Provenant: 4.67s</title></circle>
     <circle cx="403.74" cy="559.08" r="4.5" fill="#2563eb"><title>numtide/devshell @ 255a2b1
 Files: 87
 Provenant: 4.68s</title></circle>
+    <circle cx="405.30" cy="554.01" r="4.5" fill="#2563eb"><title>Conda base environment conda-meta snapshot @ sha256:7de9956
+Files: 89
+Provenant: 5.21s</title></circle>
     <circle cx="406.83" cy="557.98" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 Provenant: 4.79s</title></circle>
@@ -880,6 +898,9 @@ Provenant: 4.79s</title></circle>
     <circle cx="443.98" cy="557.39" r="4.5" fill="#2563eb"><title>elixir-ecto/ecto @ 28d9282
 Files: 156
 Provenant: 4.85s</title></circle>
+    <circle cx="445.29" cy="553.83" r="4.5" fill="#2563eb"><title>JetBrains/JetBrainsMono @ 1937130
+Files: 159
+Provenant: 5.23s</title></circle>
     <circle cx="445.29" cy="556.81" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
 Files: 159
 Provenant: 4.91s</title></circle>
@@ -1126,6 +1147,9 @@ Provenant: 12.03s</title></circle>
     <circle cx="631.52" cy="474.94" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 Provenant: 27.77s</title></circle>
+    <circle cx="634.31" cy="504.96" r="4.5" fill="#2563eb"><title>apache/ant-ivy @ dc35d51
+Files: 2470
+Provenant: 14.71s</title></circle>
     <circle cx="637.28" cy="542.19" r="4.5" fill="#2563eb"><title>playframework/playframework @ c2c114f
 Files: 2579
 Provenant: 6.69s</title></circle>


### PR DESCRIPTION
## Summary

- Records four maintained `compare-outputs` benchmark rows for surfaces verified in this pass, each re-run **serially** in optimized mode on merged `main` for clean timings, and regenerates `scan-duration-vs-files.svg` plus the headline stats (**223 of 223 runs faster**, 19.3× median):
  - **segmind/tiny-sd** (Hugging Face Diffusers `model_index.json` pipeline) — 18.6×
  - **apache/ant-ivy** (Apache Ivy `ivy.xml` + distinct-GAV Maven POM split) — 25.5×
  - **JetBrains/JetBrainsMono** (embedded font legal metadata, 120 font binaries) — 24.1×
  - **Conda base-environment `conda-meta` snapshot** (installed conda-env records) — 14.7×

## Issues

- Covers: benchmark verification of the Diffusers `model_index.json`, Apache Ivy `ivy.xml`, embedded-font, and installed conda-env surfaces.

## Scope and exclusions

- Included: `docs/BENCHMARKS.md` rows + regenerated chart/stats only.
- Explicit exclusions: no code changes. The scanner fixes these rows depend on landed separately in #1155 (tokenizer copyright FPs), #1156 (conda one-package-per-record), #1157 (Diffusers component-config subsumption), #1158 (font name-record decoding), and #1159 (distinct-GAV Maven POM split). This PR is intentionally last, after those merged.

## How to verify

- `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart` is idempotent on this branch (no diff), confirming the rows and chart/stats agree.

## Follow-up work

- Two minor copyright-detector false positives surfaced by JetBrainsMono remain deferred (documented in #1158): GlyphsApp `.glyphs` `key = "value"` copyright bleed and `.idea/shelf/*.patch` diff-marker prefixes. Provenant emits maven-type rather than `pkg:osgi/*` packages for OSGi `MANIFEST.MF` bundles (2 packages on ant-ivy).

## Expected-output fixture changes

- Files changed: `docs/BENCHMARKS.md` (four rows + regenerated stats line), `docs/scan-duration-vs-files.svg` (regenerated). Both are generated/maintained artifacts; the chart binary reproduces them with no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)