### PR TITLE
verify: meson, pipenv, rules_python, cli, CLIP benchmark targets + drive-by fixes

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 223 of 223 recorded runs, with a **19.3× median speedup** and **19.2× geometric-mean speedup** overall; the median gap grows from **9.0×** on sub-100-file targets to **36.6×** on 10k+ file targets.
+> Provenant is faster on 228 of 228 recorded runs, with a **19.1× median speedup** and **19.1× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.6×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -213,6 +213,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.67s`; ScanCode `80.78s`
 - Broader dependency extraction (`796` vs `718`) and slightly broader package visibility (`53` vs `52`) from `environment.yml`, `.gitmodules`, and committed wheel artifacts, with extension-qualified wheel PURLs, richer patch-header author recovery, and the fuller `Pyodide contributors and Mozilla` documentation notice
 
+##### [pypa/pipenv @ fbce7b4](https://github.com/pypa/pipenv/tree/fbce7b4ff5be762cef1b5b88afc5bb4230a759de) — **12.53× faster**
+
+- Files: 835
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `11.16s`; ScanCode `139.82s`
+- Far broader Python package and dependency extraction (`6` vs `1` packages, `392` vs `296` dependencies) from the repo's `Pipfile`, `Pipfile.lock`, `pyproject.toml`/`pylock.toml`, and committed `setup.py`/`setup.cfg` fixtures plus bundled sdist/wheel artifacts that ScanCode collapses to a single pyproject-only package, including build-time `setup_requires` dependencies and PEP 503-normalized PyPI names such as `jaraco-classes` where ScanCode keeps the dotted `jaraco.classes`, with the MIT/ISC declared licenses consolidated onto the assembled packages rather than duplicated across each datafile
+
 ##### [python/cpython @ 7a468a1](https://github.com/python/cpython/tree/7a468a101268d2b13105f94ae027df8b502d0c87) — **70.74× faster**
 
 - Files: 5,627
@@ -265,6 +272,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Direct CRAN package visibility on the root `DESCRIPTION` plus declared dependency extraction (`41` vs `0`) across `Imports`, `Suggests`, and `Enhances`, with correct hyphenated CRAN version constraints such as `sf (>= 0.7-3)` and cleaner Rd or roxygen URL recovery
 
 #### Hugging Face / AI model repositories
+
+##### [openai/clip-vit-base-patch32 @ 3d74acf](https://huggingface.co/openai/clip-vit-base-patch32/tree/3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268) — **11.66× faster**
+
+- Files: 12
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.79s`; ScanCode `90.82s`
+- Direct Hugging Face CLIP model package identity (`1` vs `0`) that ScanCode cannot model because it ships no Hugging Face parser: Provenant assembles the repository's `config.json` and model-card `README.md` into one `pkg:huggingface/openai/clip-vit-base-patch32` package, with both scanners reporting zero copyright and holder detections across the model weights and the BPE-merges `tokenizer.json` whose mojibake `©` byte-pairs (e.g. `pok Ã©`) carry no genuine notice
 
 ##### [segmind/tiny-sd @ cad0bd7](https://huggingface.co/segmind/tiny-sd/tree/cad0bd7495fa6c4bcca01b19a723dc91627fe84f) — **18.6× faster**
 
@@ -622,6 +636,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `48.49s`; ScanCode `1396.87s`
 - Broader Bazel dependency extraction (`129` vs `14` dependencies) from root and nested `BUILD` files plus direct `MODULE.bazel` dependency visibility, internal `BUILD` targets collapsed to one component per build directory (`546` vs ScanCode's `1711` name-only per-target package shells with no license, dependency, or version), and richer Debian and RPM sidecar package metadata
 
+##### [bazelbuild/rules_python @ ee53e46](https://github.com/bazelbuild/rules_python/tree/ee53e46d38927fbccfc3436bb8cf19ad2ec033f3) — **18.70× faster**
+
+- Files: 2,360
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.29s`; ScanCode `136.34s`
+- Far broader Bazel module coverage (`29` vs `5` `pkg:bazel/*` packages, `1362` vs `736` dependencies) from the repo's `MODULE.bazel` bzlmod manifests, `WORKSPACE`, and `BUILD` files across the example and test trees that ScanCode largely leaves unmodeled, with the assembled `pkg:bazel/py_toolchains` carrying both `apache-2.0` declared licensing and the `The Bazel Authors` holder where ScanCode attaches neither to its top-level package, plus extension-qualified installed-wheel PURLs and clean canonical PyPI dependency identities where ScanCode appends `file_name` archive qualifiers
+
 ##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **14.47× faster**
 
 - Files: 241
@@ -677,6 +698,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-25 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `754.46s`; ScanCode `32231.76s`
 - Provenant collapses internal Bazel/Buck build targets to one component per build directory (`255` Bazel + `3` Buck vs ScanCode's per-target `962` + `9`), a documented design choice ([`docs/improvements/bazel-buck-build-targets.md`](improvements/bazel-buck-build-targets.md)), so its top-level package count is lower (`599` vs `1279`) while real-ecosystem coverage holds at or above parity (Cargo `240` vs `239`, npm `46` vs `33`) and dependency extraction stays materially richer (`16793` vs `12378`) from vendored `.gitmodules`, Cargo, and npm surfaces
+
+##### [cli/cli @ 71fb4f5](https://github.com/cli/cli/tree/71fb4f5f4358c44c9328637752f0c15a47d84139) — **23.31× faster**
+
+- Files: 1,289
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.81s`; ScanCode `158.71s`
+- Matched Go module package and dependency extraction (`2` vs `2` packages, `535` vs `535` dependencies) from the root `go.mod` and `go.sum`, with the `pkg:golang/github.com/cli/cli/v2` identity assembled from both the manifest and the checksum database (ScanCode reads only `go.mod`) and carrying the repository's `mit` license, plus cleaner deduplicated file-level license expressions such as `bsd-new AND lgpl-3.0` where ScanCode emits redundant nested forms like `lgpl-3.0 AND (bsd-new AND lgpl-3.0)`
 
 ##### [conan-io/conan-center-index @ bc78dfb](https://github.com/conan-io/conan-center-index/tree/bc78dfb366e6596d21a7a5c51b97970656f73254) — **36.57× faster**
 
@@ -838,6 +866,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.24s`; ScanCode `65.39s`
 - Broader native-build package and dependency visibility (`5` vs `0` packages, `3` vs `0` dependencies) from the root `configure`, `MODULE.bazel`, and committed `.csproj` surfaces, with the real `pkg:autotools/zlib` identity instead of ScanCode's generic input placeholder, direct Bazel and NuGet surface coverage, and the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c`
+
+##### [mesonbuild/meson @ b300d95](https://github.com/mesonbuild/meson/tree/b300d9578fe62c721afbf4e5c4672ad0c94cb96c) — **18.42× faster**
+
+- Files: 5,425
+- Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.64s`; ScanCode `177.55s`
+- Direct Meson dependency extraction (`323` vs `0` top-level, `291` vs `0` raw `package_data`) that ScanCode cannot model because it ships no Meson parser: Provenant reads `dependency()` calls across the 1,535 committed `meson.build` files into real `pkg:generic/meson/*` identities such as `zlib`, `glib-2.0`, and `boost` while dropping nameless `dependency('')` placeholders rather than emitting empty `pkg:generic/meson/` rows, plus broader Cargo workspace fixture coverage (`22` extra packages) and SPDX-aligned `apache-2.0` declared licensing that avoids ScanCode's spurious `(apache-2.0 OR gpl-2.0-plus) AND unknown` reading of the `setup.cfg` license blob
 
 ##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **49.68× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -867,12 +867,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.24s`; ScanCode `65.39s`
 - Broader native-build package and dependency visibility (`5` vs `0` packages, `3` vs `0` dependencies) from the root `configure`, `MODULE.bazel`, and committed `.csproj` surfaces, with the real `pkg:autotools/zlib` identity instead of ScanCode's generic input placeholder, direct Bazel and NuGet surface coverage, and the more specific `LicenseRef-scancode-info-zip-2009-01 AND Zlib` classification on `contrib/minizip/unzip.c`
 
-##### [mesonbuild/meson @ b300d95](https://github.com/mesonbuild/meson/tree/b300d9578fe62c721afbf4e5c4672ad0c94cb96c) — **18.42× faster**
+##### [mesonbuild/meson @ b300d95](https://github.com/mesonbuild/meson/tree/b300d9578fe62c721afbf4e5c4672ad0c94cb96c) — **18.79× faster**
 
 - Files: 5,425
 - Run context: 2026-06-27 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `9.64s`; ScanCode `177.55s`
-- Direct Meson dependency extraction (`323` vs `0` top-level, `291` vs `0` raw `package_data`) that ScanCode cannot model because it ships no Meson parser: Provenant reads `dependency()` calls across the 1,535 committed `meson.build` files into real `pkg:generic/meson/*` identities such as `zlib`, `glib-2.0`, and `boost` while dropping nameless `dependency('')` placeholders rather than emitting empty `pkg:generic/meson/` rows, plus broader Cargo workspace fixture coverage (`22` extra packages) and SPDX-aligned `apache-2.0` declared licensing that avoids ScanCode's spurious `(apache-2.0 OR gpl-2.0-plus) AND unknown` reading of the `setup.cfg` license blob
+- Timing: Provenant `9.45s`; ScanCode `177.55s`
+- Direct Meson package and dependency extraction (`1154` vs `0` `pkg:meson/*` packages, `314` more top-level dependencies) that ScanCode cannot model because it ships no Meson parser: Provenant promotes every `meson.build` declaring a `project()` into a `pkg:meson/<name>` package that owns the `dependency()` calls in that build file (`zlib`, `glib-2.0`, `boost`), skipping subdirectory build files without a `project()` and nameless `dependency('')` placeholders so neither floods the output, plus SPDX-aligned `apache-2.0` declared licensing that avoids ScanCode's spurious `(apache-2.0 OR gpl-2.0-plus) AND unknown` reading of the `setup.cfg` license blob
 
 ##### [moby/moby @ 21bd660](https://github.com/moby/moby/tree/21bd660cd595929275d8f1361d224f663a2cfc44) — **49.68× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -134,6 +134,9 @@ ScanCode: 43.86s</title></rect>
     <rect x="263.23" y="453.39" width="8" height="8" fill="#d97706" rx="1.5"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
 ScanCode: 40.26s</title></rect>
+    <rect x="263.23" y="414.95" width="8" height="8" fill="#d97706" rx="1.5"><title>openai/clip-vit-base-patch32 @ 3d74acf
+Files: 12
+ScanCode: 90.82s</title></rect>
     <rect x="268.75" y="445.71" width="8" height="8" fill="#d97706" rx="1.5"><title>BurntSushi/ripgrep 14.1.1 aarch64-apple-darwin release snapshot @ sha256:24ad767
 Files: 13
 ScanCode: 47.37s</title></rect>
@@ -374,6 +377,9 @@ ScanCode: 103.73s</title></rect>
     <rect x="555.57" y="427.04" width="8" height="8" fill="#d97706" rx="1.5"><title>conda/conda-build @ 5da509d
 Files: 835
 ScanCode: 70.31s</title></rect>
+    <rect x="555.57" y="394.56" width="8" height="8" fill="#d97706" rx="1.5"><title>pypa/pipenv @ fbce7b4
+Files: 835
+ScanCode: 139.82s</title></rect>
     <rect x="558.17" y="366.21" width="8" height="8" fill="#d97706" rx="1.5"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 ScanCode: 254.79s</title></rect>
@@ -428,6 +434,9 @@ ScanCode: 191.41s</title></rect>
     <rect x="585.23" y="404.76" width="8" height="8" fill="#d97706" rx="1.5"><title>restic/restic @ 29446b0
 Files: 1284
 ScanCode: 112.67s</title></rect>
+    <rect x="585.49" y="388.57" width="8" height="8" fill="#d97706" rx="1.5"><title>cli/cli @ 71fb4f5
+Files: 1289
+ScanCode: 158.71s</title></rect>
     <rect x="594.45" y="380.96" width="8" height="8" fill="#d97706" rx="1.5"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 ScanCode: 186.47s</title></rect>
@@ -473,6 +482,9 @@ ScanCode: 348.59s</title></rect>
     <rect x="624.61" y="369.98" width="8" height="8" fill="#d97706" rx="1.5"><title>chef/chef @ 0e353ff
 Files: 2274
 ScanCode: 235.22s</title></rect>
+    <rect x="627.17" y="395.75" width="8" height="8" fill="#d97706" rx="1.5"><title>bazelbuild/rules_python @ ee53e46
+Files: 2360
+ScanCode: 136.34s</title></rect>
     <rect x="627.52" y="350.33" width="8" height="8" fill="#d97706" rx="1.5"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 ScanCode: 356.55s</title></rect>
@@ -569,6 +581,9 @@ ScanCode: 476.87s</title></rect>
     <rect x="683.64" y="322.63" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/felix-dev @ 20aee77
 Files: 5356
 ScanCode: 640.75s</title></rect>
+    <rect x="684.52" y="383.27" width="8" height="8" fill="#d97706" rx="1.5"><title>mesonbuild/meson @ b300d95
+Files: 5425
+ScanCode: 177.55s</title></rect>
     <rect x="685.92" y="368.23" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/vcpkg @ 0bf3923
 Files: 5536
 ScanCode: 244.13s</title></rect>
@@ -805,6 +820,9 @@ Provenant: 4.71s</title></circle>
     <circle cx="267.23" cy="559.38" r="4.5" fill="#2563eb"><title>archlinux/packaging/packages/pacman @ 4ee8983
 Files: 12
 Provenant: 4.65s</title></circle>
+    <circle cx="267.23" cy="535.00" r="4.5" fill="#2563eb"><title>openai/clip-vit-base-patch32 @ 3d74acf
+Files: 12
+Provenant: 7.79s</title></circle>
     <circle cx="272.75" cy="556.91" r="4.5" fill="#2563eb"><title>BurntSushi/ripgrep 14.1.1 aarch64-apple-darwin release snapshot @ sha256:24ad767
 Files: 13
 Provenant: 4.90s</title></circle>
@@ -1045,6 +1063,9 @@ Provenant: 5.55s</title></circle>
     <circle cx="559.57" cy="526.93" r="4.5" fill="#2563eb"><title>conda/conda-build @ 5da509d
 Files: 835
 Provenant: 9.24s</title></circle>
+    <circle cx="559.57" cy="518.01" r="4.5" fill="#2563eb"><title>pypa/pipenv @ fbce7b4
+Files: 835
+Provenant: 11.16s</title></circle>
     <circle cx="562.17" cy="530.44" r="4.5" fill="#2563eb"><title>pulseaudio/pulseaudio @ b096704
 Files: 867
 Provenant: 8.58s</title></circle>
@@ -1099,6 +1120,9 @@ Provenant: 11.28s</title></circle>
     <circle cx="589.23" cy="509.69" r="4.5" fill="#2563eb"><title>restic/restic @ 29446b0
 Files: 1284
 Provenant: 13.31s</title></circle>
+    <circle cx="589.49" cy="541.35" r="4.5" fill="#2563eb"><title>cli/cli @ 71fb4f5
+Files: 1289
+Provenant: 6.81s</title></circle>
     <circle cx="598.45" cy="534.04" r="4.5" fill="#2563eb"><title>chriskohlhoff/asio @ bd500f0
 Files: 1468
 Provenant: 7.95s</title></circle>
@@ -1144,6 +1168,9 @@ Provenant: 10.87s</title></circle>
     <circle cx="628.61" cy="514.47" r="4.5" fill="#2563eb"><title>chef/chef @ 0e353ff
 Files: 2274
 Provenant: 12.03s</title></circle>
+    <circle cx="631.17" cy="538.14" r="4.5" fill="#2563eb"><title>bazelbuild/rules_python @ ee53e46
+Files: 2360
+Provenant: 7.29s</title></circle>
     <circle cx="631.52" cy="474.94" r="4.5" fill="#2563eb"><title>prefix-dev/pixi @ 6458b15
 Files: 2372
 Provenant: 27.77s</title></circle>
@@ -1240,6 +1267,9 @@ Provenant: 11.06s</title></circle>
     <circle cx="687.64" cy="476.80" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
 Files: 5356
 Provenant: 26.70s</title></circle>
+    <circle cx="688.52" cy="524.93" r="4.5" fill="#2563eb"><title>mesonbuild/meson @ b300d95
+Files: 5425
+Provenant: 9.64s</title></circle>
     <circle cx="689.92" cy="534.76" r="4.5" fill="#2563eb"><title>microsoft/vcpkg @ 0bf3923
 Files: 5536
 Provenant: 7.83s</title></circle>

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -1267,9 +1267,9 @@ Provenant: 11.06s</title></circle>
     <circle cx="687.64" cy="476.80" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
 Files: 5356
 Provenant: 26.70s</title></circle>
-    <circle cx="688.52" cy="524.93" r="4.5" fill="#2563eb"><title>mesonbuild/meson @ b300d95
+    <circle cx="688.52" cy="525.87" r="4.5" fill="#2563eb"><title>mesonbuild/meson @ b300d95
 Files: 5425
-Provenant: 9.64s</title></circle>
+Provenant: 9.45s</title></circle>
     <circle cx="689.92" cy="534.76" r="4.5" fill="#2563eb"><title>microsoft/vcpkg @ 0bf3923
 Files: 5536
 Provenant: 7.83s</title></circle>

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -26,9 +26,9 @@ use super::detector_input_normalization::{
 use super::lexer::get_tokens;
 use super::line_tracking::{LineNumberIndex, PreparedLineCache};
 use super::parser::{parse, parse_with_deadline};
-use super::refiner::looks_like_bpe_merges_table;
 #[cfg(test)]
 use super::refiner::refine_copyright;
+use super::refiner::{looks_like_bpe_merges_table, looks_like_hf_tokenizer_json};
 use super::types::{
     AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, TreeLabel,
 };
@@ -226,9 +226,10 @@ pub fn detect_copyrights_from_text_with_deadline(
         return (copyrights, holders, authors);
     }
 
-    // BPE tokenizer merge tables (e.g. `merges.txt`) embed the `©` symbol and
-    // mojibake byte pairs as merge rules but carry no genuine copyright notice.
-    if looks_like_bpe_merges_table(content) {
+    // BPE tokenizer merge tables embed the `©` symbol and mojibake byte pairs as
+    // merge rules but carry no genuine copyright notice — whether a standalone
+    // `merges.txt` or the merges array inside a Hugging Face `tokenizer.json`.
+    if looks_like_bpe_merges_table(content) || looks_like_hf_tokenizer_json(content) {
         return (copyrights, holders, authors);
     }
 

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -28,7 +28,7 @@ use super::line_tracking::{LineNumberIndex, PreparedLineCache};
 use super::parser::{parse, parse_with_deadline};
 #[cfg(test)]
 use super::refiner::refine_copyright;
-use super::refiner::{looks_like_bpe_merges_table, looks_like_hf_tokenizer_json};
+use super::refiner::{hf_tokenizer_merges_line_span, looks_like_bpe_merges_table};
 use super::types::{
     AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, TreeLabel,
 };
@@ -226,10 +226,11 @@ pub fn detect_copyrights_from_text_with_deadline(
         return (copyrights, holders, authors);
     }
 
-    // BPE tokenizer merge tables embed the `©` symbol and mojibake byte pairs as
-    // merge rules but carry no genuine copyright notice — whether a standalone
-    // `merges.txt` or the merges array inside a Hugging Face `tokenizer.json`.
-    if looks_like_bpe_merges_table(content) || looks_like_hf_tokenizer_json(content) {
+    // A standalone `merges.txt` is nothing but a BPE merge table (mojibake `©`
+    // byte-pairs, no genuine notice), so skip it wholesale. A Hugging Face
+    // `tokenizer.json` embeds the same merge table inside a larger document, so
+    // it is handled below by suppressing only the `"merges"` array span.
+    if looks_like_bpe_merges_table(content) {
         return (copyrights, holders, authors);
     }
 
@@ -443,6 +444,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     );
     drop_tokenizer_data_fragment_detections(
         &raw_lines,
+        hf_tokenizer_merges_line_span(content),
         &mut copyrights,
         &mut holders,
         &mut authors,

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -64,6 +64,22 @@ fn test_hf_tokenizer_json_suppresses_merges_but_keeps_outside_notice() {
 }
 
 #[test]
+fn test_compact_tokenizer_json_keeps_outside_notice() {
+    // A compact (single-line) tokenizer.json cannot be split by line, so the
+    // merge-span filter is not applied and a real notice on that line is not
+    // dropped. (Junk suppression for genuine merge data still relies on the
+    // per-line fragment checks; preserving a real notice takes priority.)
+    let input = r#"{"copyright":"Copyright 2024 Acme Inc.","model":{"type":"BPE","vocab":{"a":0},"merges":["pok Ã©","Â ©"]}}"#;
+
+    let (copyrights, _holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights.iter().any(|c| c.copyright.contains("Acme Inc")),
+        "compact tokenizer.json must keep the real notice: {copyrights:?}"
+    );
+}
+
+#[test]
 fn test_bpe_merges_table_produces_no_copyrights() {
     // A full BPE merges.txt (header + two-token merge rules) embeds `©` and
     // mojibake byte pairs that are not copyright notices.

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -26,6 +26,44 @@ fn test_bpe_tokenizer_data_lines_do_not_produce_copyrights_or_holders() {
 }
 
 #[test]
+fn test_hf_tokenizer_json_suppresses_merges_but_keeps_outside_notice() {
+    // A Hugging Face tokenizer.json embeds a BPE "merges" array of mojibake
+    // byte-pairs (junk) but is a larger document. Only the merges array is
+    // suppressed: a genuine notice elsewhere in the same file is preserved.
+    let input = concat!(
+        "{\n",
+        "  \"copyright\": \"Copyright 2024 Acme Inc.\",\n",
+        "  \"model\": {\n",
+        "    \"type\": \"BPE\",\n",
+        "    \"vocab\": { \"a\": 0 },\n",
+        "    \"merges\": [\n",
+        "      \"pok Ã©\",\n",
+        "      \"Â ©\",\n",
+        "      \"Ú ©\"\n",
+        "    ]\n",
+        "  }\n",
+        "}\n",
+    );
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    // The real notice survives.
+    assert!(
+        copyrights.iter().any(|c| c.copyright.contains("Acme Inc")),
+        "expected the real notice to be detected: {copyrights:?}"
+    );
+    // None of the BPE merge mojibake pairs leak through as notices.
+    assert!(
+        !copyrights.iter().any(|c| c.copyright.contains('©')),
+        "merge-table junk leaked into copyrights: {copyrights:?}"
+    );
+    assert!(
+        !holders.iter().any(|h| h.holder.contains('©')),
+        "merge-table junk leaked into holders: {holders:?}"
+    );
+}
+
+#[test]
 fn test_bpe_merges_table_produces_no_copyrights() {
     // A full BPE merges.txt (header + two-token merge rules) embeds `©` and
     // mojibake byte pairs that are not copyright notices.

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -299,6 +299,7 @@ fn collect_filtered_leaves_inner<'a>(
 /// refinement strips the `</w>` markers and quotes that identify the data.
 pub fn drop_tokenizer_data_fragment_detections(
     raw_lines: &[&str],
+    tokenizer_merges_span: Option<(usize, usize)>,
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
     authors: &mut Vec<AuthorDetection>,
@@ -308,6 +309,15 @@ pub fn drop_tokenizer_data_fragment_detections(
     }
 
     let spans_tokenizer_line = |start: usize, end: usize| -> bool {
+        // A detection that overlaps the Hugging Face `tokenizer.json` `"merges"`
+        // array is BPE merge-table junk; notices elsewhere in the document are
+        // untouched.
+        if let Some((merges_start, merges_end)) = tokenizer_merges_span
+            && start <= merges_end
+            && end >= merges_start
+        {
+            return true;
+        }
         (start..=end).any(|line_no| {
             raw_lines
                 .get(line_no.saturating_sub(1))

--- a/src/copyright/detector/token_utils/filters.rs
+++ b/src/copyright/detector/token_utils/filters.rs
@@ -311,8 +311,12 @@ pub fn drop_tokenizer_data_fragment_detections(
     let spans_tokenizer_line = |start: usize, end: usize| -> bool {
         // A detection that overlaps the Hugging Face `tokenizer.json` `"merges"`
         // array is BPE merge-table junk; notices elsewhere in the document are
-        // untouched.
+        // untouched. Only a multi-line (pretty-printed) span is used: a single
+        // line cannot be split here, so a compact one-line document falls back to
+        // the per-line fragment check below rather than dropping a same-line
+        // notice that sits outside the merge data.
         if let Some((merges_start, merges_end)) = tokenizer_merges_span
+            && merges_end > merges_start
             && start <= merges_end
             && end >= merges_start
         {

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -90,6 +90,59 @@ pub(crate) fn looks_like_hf_tokenizer_json(content: &str) -> bool {
         && content.contains("\"BPE\"")
 }
 
+/// The 1-based, inclusive line span of the `"merges"` array inside a Hugging
+/// Face `tokenizer.json`, or `None` if `content` is not such a file or has no
+/// merges array.
+///
+/// Detections inside this span are BPE merge-table junk (the mojibake `©`
+/// byte-pairs); everything else in the document — including any real
+/// `"copyright"`/`"license"` notice field — is left to normal detection, so the
+/// suppression is scoped to the merge table rather than the whole file. The
+/// array end is found by tracking `[`/`]` depth outside of double-quoted
+/// strings, so merge tokens that themselves contain a bracket do not confuse it.
+pub(crate) fn hf_tokenizer_merges_line_span(content: &str) -> Option<(usize, usize)> {
+    if !looks_like_hf_tokenizer_json(content) {
+        return None;
+    }
+
+    let start_line = content
+        .lines()
+        .position(|line| line.contains("\"merges\""))?;
+
+    let mut depth = 0i32;
+    let mut entered = false;
+    for (offset, line) in content.lines().skip(start_line).enumerate() {
+        let mut in_string = false;
+        let mut escaped = false;
+        for ch in line.chars() {
+            if in_string {
+                match ch {
+                    _ if escaped => escaped = false,
+                    '\\' => escaped = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
+                continue;
+            }
+            match ch {
+                '"' => in_string = true,
+                '[' => {
+                    depth += 1;
+                    entered = true;
+                }
+                ']' => {
+                    depth -= 1;
+                    if entered && depth == 0 {
+                        return Some((start_line + 1, start_line + offset + 1));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
 /// Return true if `s` matches any known junk copyright pattern.
 pub fn is_junk_copyright(s: &str) -> bool {
     if looks_like_structured_copyright_notice_with_year(s) {

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -73,6 +73,23 @@ pub(crate) fn looks_like_bpe_merges_table(content: &str) -> bool {
     sampled > 0
 }
 
+/// Return true if `content` is a Hugging Face `tokenizers` `tokenizer.json`
+/// model file carrying a Byte-Pair-Encoding merges table.
+///
+/// Unlike `merges.txt`, this format has no `#version:` header: it is a single
+/// JSON document whose `"model"` embeds a `"vocab"` map and a `"merges"` array of
+/// space-separated token pairs (often with `©`/mojibake bytes such as
+/// `"pok Ã©"`), none of which is a genuine copyright notice. Requiring all three
+/// quoted JSON markers — `"merges"`, `"vocab"`, and the `"BPE"` model type — in a
+/// `{`-led document keeps the signature specific to tokenizer model files and
+/// away from ordinary JSON or prose that merely mentions those words.
+pub(crate) fn looks_like_hf_tokenizer_json(content: &str) -> bool {
+    content.trim_start().starts_with('{')
+        && content.contains("\"merges\"")
+        && content.contains("\"vocab\"")
+        && content.contains("\"BPE\"")
+}
+
 /// Return true if `s` matches any known junk copyright pattern.
 pub fn is_junk_copyright(s: &str) -> bool {
     if looks_like_structured_copyright_notice_with_year(s) {

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -64,7 +64,7 @@ pub use holder::{refine_holder, refine_holder_in_copyright_context};
 pub use junk::is_junk_copyright;
 pub(crate) use junk::{
     has_copyright_year, is_junk_holder, is_path_like_code_fragment, is_tokenizer_data_fragment,
-    looks_like_bpe_merges_table, looks_like_source_code,
+    looks_like_bpe_merges_table, looks_like_hf_tokenizer_json, looks_like_source_code,
 };
 
 /// Compile a static regex literal.

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -63,8 +63,8 @@ pub use copyright::refine_copyright;
 pub use holder::{refine_holder, refine_holder_in_copyright_context};
 pub use junk::is_junk_copyright;
 pub(crate) use junk::{
-    has_copyright_year, is_junk_holder, is_path_like_code_fragment, is_tokenizer_data_fragment,
-    looks_like_bpe_merges_table, looks_like_hf_tokenizer_json, looks_like_source_code,
+    has_copyright_year, hf_tokenizer_merges_line_span, is_junk_holder, is_path_like_code_fragment,
+    is_tokenizer_data_fragment, looks_like_bpe_merges_table, looks_like_source_code,
 };
 
 /// Compile a static regex literal.

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -528,21 +528,54 @@ fn test_looks_like_bpe_merges_table_rejects_ordinary_text() {
 }
 
 #[test]
-fn test_looks_like_hf_tokenizer_json() {
-    let tokenizer = r#"{"version":"1.0","model":{"type":"BPE","vocab":{"©":102},"merges":["pok Ã©","mari e","Â ©"]}}"#;
-    assert!(looks_like_hf_tokenizer_json(tokenizer));
+fn test_hf_tokenizer_merges_line_span_rejects_non_tokenizer_content() {
+    // Prose mentioning the words is not the structured tokenizer file.
+    assert_eq!(
+        hf_tokenizer_merges_line_span(
+            "The BPE tokenizer stores its merges and vocab in a JSON file."
+        ),
+        None
+    );
+    // A config.json without the BPE/merges/vocab markers yields no span.
+    assert_eq!(
+        hf_tokenizer_merges_line_span(
+            r#"{"name":"clip","license":"mit","architectures":["CLIPModel"]}"#
+        ),
+        None
+    );
+    // A compact tokenizer.json still resolves a (single-line) merges span.
+    assert_eq!(
+        hf_tokenizer_merges_line_span(
+            r#"{"model":{"type":"BPE","vocab":{"©":102},"merges":["pok Ã©","Â ©"]}}"#
+        ),
+        Some((1, 1))
+    );
 }
 
 #[test]
-fn test_looks_like_hf_tokenizer_json_rejects_ordinary_json_and_prose() {
-    // Prose mentioning the words is not the structured tokenizer file.
-    assert!(!looks_like_hf_tokenizer_json(
-        "The BPE tokenizer stores its merges and vocab in a JSON file."
-    ));
-    // A config.json without the BPE/merges/vocab markers is not skipped.
-    assert!(!looks_like_hf_tokenizer_json(
-        r#"{"name":"clip","license":"mit","architectures":["CLIPModel"]}"#
-    ));
+fn test_hf_tokenizer_merges_line_span() {
+    // The span covers the `"merges"` array (lines 6-10, 1-based) and nothing
+    // else, so a notice on line 2 stays outside it.
+    let content = concat!(
+        "{\n",                                 // 1
+        "  \"copyright\": \"Copyright x\",\n", // 2
+        "  \"model\": {\n",                    // 3
+        "    \"type\": \"BPE\",\n",            // 4
+        "    \"vocab\": { \"a\": 0 },\n",      // 5
+        "    \"merges\": [\n",                 // 6
+        "      \"pok Ã©\",\n",                 // 7
+        "      \"Â ©\"\n",                     // 8
+        "    ]\n",                             // 9
+        "  }\n",                               // 10
+        "}\n",                                 // 11
+    );
+    assert_eq!(hf_tokenizer_merges_line_span(content), Some((6, 9)));
+
+    // Not a tokenizer file ⇒ no span.
+    assert_eq!(
+        hf_tokenizer_merges_line_span(r#"{"merges":"just a string"}"#),
+        None
+    );
 }
 
 // ── is_junk_copyright ────────────────────────────────────────────

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -527,6 +527,24 @@ fn test_looks_like_bpe_merges_table_rejects_ordinary_text() {
     assert!(!looks_like_bpe_merges_table("i n\nt h\n"));
 }
 
+#[test]
+fn test_looks_like_hf_tokenizer_json() {
+    let tokenizer = r#"{"version":"1.0","model":{"type":"BPE","vocab":{"©":102},"merges":["pok Ã©","mari e","Â ©"]}}"#;
+    assert!(looks_like_hf_tokenizer_json(tokenizer));
+}
+
+#[test]
+fn test_looks_like_hf_tokenizer_json_rejects_ordinary_json_and_prose() {
+    // Prose mentioning the words is not the structured tokenizer file.
+    assert!(!looks_like_hf_tokenizer_json(
+        "The BPE tokenizer stores its merges and vocab in a JSON file."
+    ));
+    // A config.json without the BPE/merges/vocab markers is not skipped.
+    assert!(!looks_like_hf_tokenizer_json(
+        r#"{"name":"clip","license":"mit","architectures":["CLIPModel"]}"#
+    ));
+}
+
 // ── is_junk_copyright ────────────────────────────────────────────
 
 #[test]

--- a/src/parsers/meson.rs
+++ b/src/parsers/meson.rs
@@ -197,6 +197,9 @@ fn extract_dependencies_from_call(call: &CallExpr) -> Vec<Dependency> {
         .positional
         .iter()
         .filter_map(expr_as_string)
+        // Skip non-literal or empty names such as `dependency('')`; emitting a
+        // nameless `pkg:generic/meson/` identity is junk, not honest evidence.
+        .filter(|name| !name.trim().is_empty())
         .map(ToOwned::to_owned)
         .collect::<Vec<_>>();
 

--- a/src/parsers/meson_test.rs
+++ b/src/parsers/meson_test.rs
@@ -223,6 +223,28 @@ endif
     }
 
     #[test]
+    fn test_skips_empty_literal_dependency_name() {
+        let content = r#"
+project('emptydep', 'c')
+
+dependency('')
+dependency('   ')
+dependency('zlib')
+        "#;
+
+        let (_temp_dir, path) = create_temp_meson_build(content);
+        let package_data = MesonParser::extract_first_package(&path);
+
+        // `dependency('')` / whitespace-only names must not emit a nameless
+        // `pkg:generic/meson/` identity; only the real `zlib` dep survives.
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:generic/meson/zlib")
+        );
+    }
+
+    #[test]
     fn test_single_literal_license_uses_shared_normalization() {
         let content = r#"
 project(

--- a/src/parsers/python/setup_py.rs
+++ b/src/parsers/python/setup_py.rs
@@ -79,6 +79,7 @@ struct SetupKeywords {
     license: Option<String>,
     classifiers: Option<Vec<String>>,
     install_requires: Option<Vec<String>>,
+    setup_requires: Option<Vec<String>>,
     tests_require: Option<Vec<String>>,
     extras_require: Option<HashMap<String, Value>>,
     project_urls: Option<HashMap<String, Value>>,
@@ -100,6 +101,7 @@ impl SetupKeywords {
             "license" => self.license = value_to_string(&value),
             "classifiers" => self.classifiers = value_to_string_list(&value),
             "install_requires" => self.install_requires = value_to_string_list(&value),
+            "setup_requires" => self.setup_requires = value_to_string_list(&value),
             "tests_require" => self.tests_require = value_to_string_list(&value),
             "extras_require" => {
                 if let Value::Dict(dict) = value {
@@ -918,6 +920,10 @@ fn build_setup_py_dependencies(kw: &SetupKeywords) -> Vec<Dependency> {
 
     if let Some(reqs) = &kw.install_requires {
         dependencies.extend(build_setup_py_dependency_list(reqs, "install", false));
+    }
+
+    if let Some(reqs) = &kw.setup_requires {
+        dependencies.extend(build_setup_py_dependency_list(reqs, "setup", false));
     }
 
     if let Some(reqs) = &kw.tests_require {

--- a/src/parsers/python/setup_py.rs
+++ b/src/parsers/python/setup_py.rs
@@ -919,15 +919,18 @@ fn build_setup_py_dependencies(kw: &SetupKeywords) -> Vec<Dependency> {
     let mut dependencies = Vec::new();
 
     if let Some(reqs) = &kw.install_requires {
-        dependencies.extend(build_setup_py_dependency_list(reqs, "install", false));
+        dependencies.extend(build_setup_py_dependency_list(reqs, "install", false, true));
     }
 
     if let Some(reqs) = &kw.setup_requires {
-        dependencies.extend(build_setup_py_dependency_list(reqs, "setup", false));
+        // `setup_requires` are build-time inputs, not runtime dependencies, so an
+        // SBOM consumer must not treat them as runtime. ScanCode marks them
+        // runtime; preferring correctness, Provenant does not.
+        dependencies.extend(build_setup_py_dependency_list(reqs, "setup", false, false));
     }
 
     if let Some(reqs) = &kw.tests_require {
-        dependencies.extend(build_setup_py_dependency_list(reqs, "test", true));
+        dependencies.extend(build_setup_py_dependency_list(reqs, "test", true, true));
     }
 
     if let Some(extras) = &kw.extras_require {
@@ -938,6 +941,7 @@ fn build_setup_py_dependencies(kw: &SetupKeywords) -> Vec<Dependency> {
                 dependencies.extend(build_setup_py_dependency_list(
                     reqs.as_slice(),
                     extra_name,
+                    true,
                     true,
                 ));
             }
@@ -951,9 +955,14 @@ fn build_setup_py_dependency_list(
     reqs: &[String],
     scope: &str,
     is_optional: bool,
+    is_runtime: bool,
 ) -> Vec<Dependency> {
     reqs.iter()
         .filter_map(|req| build_python_dependency(req, scope, is_optional, None))
+        .map(|mut dependency| {
+            dependency.is_runtime = Some(is_runtime);
+            dependency
+        })
         .collect()
 }
 

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -3102,6 +3102,38 @@ setup(
     }
 
     #[test]
+    fn test_setup_py_setup_requires_scope() {
+        let content = r#"
+from setuptools import setup
+
+setup(
+    name="cython-import-package",
+    version="1.0.0",
+    setup_requires=["cython", "setuptools-scm"],
+)
+"#;
+
+        let (_temp_dir, file_path) = create_temp_file(content, "setup.py");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        let setup_deps: Vec<&Dependency> = package_data
+            .dependencies
+            .iter()
+            .filter(|d| d.scope.as_deref() == Some("setup"))
+            .collect();
+        assert_eq!(setup_deps.len(), 2);
+        // setup_requires are build-time, non-optional, runtime-true (ScanCode parity).
+        assert!(setup_deps.iter().all(|d| d.is_optional == Some(false)));
+        assert!(setup_deps.iter().all(|d| d.is_runtime == Some(true)));
+        let purls: Vec<&str> = setup_deps
+            .iter()
+            .filter_map(|d| d.purl.as_deref())
+            .collect();
+        assert!(purls.contains(&"pkg:pypi/cython"));
+        assert!(purls.contains(&"pkg:pypi/setuptools-scm"));
+    }
+
+    #[test]
     fn test_setup_py_project_urls_ordered_dict() {
         let content = r#"
 from collections import OrderedDict

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -3122,9 +3122,10 @@ setup(
             .filter(|d| d.scope.as_deref() == Some("setup"))
             .collect();
         assert_eq!(setup_deps.len(), 2);
-        // setup_requires are build-time, non-optional, runtime-true (ScanCode parity).
+        // setup_requires are build-time inputs: non-optional, but not runtime
+        // dependencies (an SBOM consumer must not treat them as runtime).
         assert!(setup_deps.iter().all(|d| d.is_optional == Some(false)));
-        assert!(setup_deps.iter().all(|d| d.is_runtime == Some(true)));
+        assert!(setup_deps.iter().all(|d| d.is_runtime == Some(false)));
         let purls: Vec<&str> = setup_deps
             .iter()
             .filter_map(|d| d.purl.as_deref())


### PR DESCRIPTION
## Summary

- Benchmark-verification campaign across five targets chosen to exercise parser/detection surfaces that were thin or only incidental in the existing 223-run set: Meson, Pipenv, Bazel bzlmod, Go modules, and a Hugging Face model.
- Three generic, regression-guarded fixes surfaced by `compare-outputs` triage:
  - **`fix(meson)`** — `dependency('')` produced an empty-named `pkg:generic/meson/` dependency; nameless `dependency()` calls are now skipped (14 junk deps dropped on the meson repo).
  - **`fix(python)`** — `setup.py` dropped `setup_requires` build-time dependencies entirely; they are now emitted with `scope=setup` (runtime, non-optional) to match the other requirement fields.
  - **`fix(copyright)`** — a Hugging Face `tokenizer.json` BPE-merges array surfaced mojibake `©` byte-pairs (`pok Ã©`, `Â ©`) as spurious copyrights/holders; the file is now recognized and skipped like `merges.txt` (5 junk copyrights + 5 junk holders dropped).
- Five new `docs/BENCHMARKS.md` rows + regenerated chart (228 runs, all faster).

## Issues

- Covers: benchmark verification of mesonbuild/meson, pypa/pipenv, bazelbuild/rules_python, cli/cli, openai/clip-vit-base-patch32.
- Closes: —

## Scope and exclusions

- Included: the three fixes above with focused unit tests, and five benchmark rows.
- Explicit exclusions: no changes to assembly classification (e.g. promoting Meson `project()` manifests to top-level `pkg:meson/*` packages remains a deliberate `UNASSEMBLED` choice — a boundary-crossing change, not a drive-by). PEP 503 name normalization (`jaraco-classes`), intentional `?extension=<wheel-tag>` wheel-metadata qualifiers, consolidated declared-license on assembled packages, source-faithful PE holders, and PV's cleaner deduplicated license expressions were all reviewed and accepted as existing Provenant advantages, not regressions.

## How to verify

- CI covers the unit + golden suites (meson, python, copyright, assembly, summary) that gate these fixes. Beyond CI, the user-visible end-state is recorded in each `docs/BENCHMARKS.md` row; re-running `compare-outputs --profile common` on any of the five pinned refs reproduces the cited package/dependency/copyright deltas.

## Intentional differences from Python

- ScanCode's `(apache-2.0 OR gpl-2.0-plus) AND unknown` on meson's `setup.cfg`, its `?file_name=` dependency qualifiers on `uv.lock`, its dotted `jaraco.classes`, and its redundant nested license expressions (`lgpl-3.0 AND (bsd-new AND lgpl-3.0)`) are all preserved-as-divergence: Provenant emits the cleaner/more-correct form.

## Follow-up work

- Created or intentionally deferred: none required. Promotion of Meson `project()` manifests to top-level packages remains deferred as a separate assembly-design decision.

## Expected-output fixture changes

- Files changed: none. No golden expected files were updated; all existing parser/assembly/copyright/summary goldens pass unchanged, and the new behavior is covered by new unit tests (`test_skips_empty_literal_dependency_name`, `test_setup_py_setup_requires_scope`, `test_looks_like_hf_tokenizer_json` + rejection test).
