### PR TITLE
fix(assembly): promote Meson project() manifests to top-level packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -800,6 +800,18 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["BUCK", "METADATA.bzl", ".buckconfig"],
         mode: AssemblyMode::SiblingMerge,
     },
+    // Meson (build system). Each `meson.build` that declares a `project()` is an
+    // independent package rooted at its directory, so one package per identity
+    // rather than a sibling merge: nested `meson.build` files in a project's
+    // subdirectories carry no `project()` (hence no purl) and are skipped, so the
+    // top-level package list is not flooded with subdir build files. Using
+    // `OnePerPackageData` also keeps independent sibling projects from collapsing
+    // into one another via nested merge.
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::MesonBuild],
+        sibling_file_patterns: &["meson.build"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     // Ant/Ivy (Java dependency management)
     AssemblerConfig {
         datasource_ids: &[DatasourceId::AntIvyXml],
@@ -951,7 +963,6 @@ pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::JavaEarApplicationXml,
     DatasourceId::JavaWarWebXml,
     DatasourceId::JbossServiceXml,
-    DatasourceId::MesonBuild,
     DatasourceId::GemGemspecInstalledSpecifications,
     DatasourceId::NugetDirectoryBuildProps,
     DatasourceId::NugetDirectoryPackagesProps,

--- a/src/parsers/meson_scan_test.rs
+++ b/src/parsers/meson_scan_test.rs
@@ -51,4 +51,51 @@ custom_target(
                 .any(|package| package.datasource_id == Some(DatasourceId::MesonBuild))
         );
     }
+
+    #[test]
+    fn test_meson_project_promotes_to_top_level_package_with_attached_deps() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("meson.build"),
+            "project('demo', 'c', version: '1.2.3')\nzlib = dependency('zlib')\n",
+        )
+        .expect("write root meson.build");
+        // A subdirectory build file with no project() declaration must not become
+        // its own package.
+        let sub = temp_dir.path().join("sub");
+        fs::create_dir(&sub).expect("create sub dir");
+        fs::write(sub.join("meson.build"), "executable('x', 'x.c')\n")
+            .expect("write sub meson.build");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let meson_pkgs: Vec<_> = result
+            .packages
+            .iter()
+            .filter(|p| {
+                p.purl
+                    .as_deref()
+                    .is_some_and(|purl| purl.starts_with("pkg:meson/"))
+            })
+            .collect();
+        assert_eq!(
+            meson_pkgs.len(),
+            1,
+            "only the project()-bearing meson.build should promote: {:?}",
+            result.packages.iter().map(|p| &p.purl).collect::<Vec<_>>()
+        );
+        assert_eq!(meson_pkgs[0].purl.as_deref(), Some("pkg:meson/demo@1.2.3"));
+
+        // The project's declared dependency is hoisted and owned by that package,
+        // not left orphaned with a null for_package_uid.
+        let zlib = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:generic/meson/zlib"))
+            .expect("zlib dependency should be present");
+        assert_eq!(
+            zlib.for_package_uid.as_ref(),
+            Some(&meson_pkgs[0].package_uid)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `DatasourceId::MesonBuild` sat in `UNASSEMBLED_DATASOURCE_IDS`, so `meson.build` manifests never became top-level packages. Their declared dependencies were emitted with a **null `for_package_uid`** (orphaned — owned by no package) and **no `pkg:meson/*` package identity** reached the output, even though the parser produces a real `pkg:meson/<name>@<version>` purl from `project()`.
- Classify `MesonBuild` with `AssemblyMode::OnePerPackageData`: each `meson.build` that declares a `project()` (and therefore carries a purl) becomes a top-level package owning its dependencies. Subdirectory build files without a `project()` have no purl and are skipped by `OnePerPackageData`, so the package list is not flooded with subdir shells, and `OnePerPackageData` triggers no nested-merge that could collapse independent sibling projects.
- **Impact (mesonbuild/meson @ b300d95):** `0 → 1154` `pkg:meson/*` top-level packages, and orphaned top-level dependencies drop from `376 → 3`.

## Issues

- Covers: Meson package-promotion gap (orphaned dependencies / missing package identity). Same defect class as Maven PR #1159 (assembly promotion misconfigured).
- Closes: —

## Scope and exclusions

- Included: the assembly classification change + a Layer-3 scanner/assembly contract test (`test_meson_project_promotes_to_top_level_package_with_attached_deps`) asserting one `pkg:meson` package per `project()` manifest, dependency ownership, and no package for a subdir build file.
- Explicit exclusions: the ~3 remaining orphaned deps come from the handful of subdir `meson.build` files that declare dependencies but no `project()`; attaching those to the nearest enclosing project would require topology-aware nested merge and is out of scope here.

## How to verify

- CI covers the meson unit/scan tests and the 36 assembly goldens (unchanged). Beyond CI: `compare-outputs --repo-url https://github.com/mesonbuild/meson.git --repo-ref b300d9578fe62c721afbf4e5c4672ad0c94cb96c --profile common` shows 1154 `pkg:meson/*` packages and 3 orphaned deps (was 0 and 376).

## Intentional differences from Python

- ScanCode ships no Meson parser, so it models none of these packages or dependencies; this is pure added coverage.

## Follow-up work

- Created or intentionally deferred: attaching subdir-`meson.build` dependencies to their enclosing project package (topology-aware) is deferred.

## Expected-output fixture changes

- Files changed: none. All 36 assembly goldens and the meson parser/scan tests pass unchanged; the new behavior is covered by the new contract test.

## Notes

- Stacked on #1163 (the benchmark-verification campaign branch); its base retargets to `main` once #1163 merges. The refreshed `mesonbuild/meson` benchmark row in #1163 reflects the post-promotion end-state.
