### PR TITLE
fix(assembly): promote vcpkg ports and manifests to top-level packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -481,6 +481,17 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         ],
         mode: AssemblyMode::SiblingMerge,
     },
+    // vcpkg (C/C++) ports and manifests. Each `CONTROL` or `vcpkg.json` that
+    // names a port/project is an independent package, so one package per record:
+    // a ports tree holds hundreds of distinct `CONTROL`/`vcpkg.json` files that
+    // must each surface (and own their `Build-Depends`/`dependencies`) rather
+    // than being dropped. `vcpkg-configuration.json` and `vcpkg-lock.json` carry
+    // no package identity and stay unassembled.
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::VcpkgControl, DatasourceId::VcpkgJson],
+        sibling_file_patterns: &["CONTROL", "vcpkg.json"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     // Maven/Java ecosystem (nested merge via META-INF)
     AssemblerConfig {
         datasource_ids: &[
@@ -971,10 +982,8 @@ pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::RpmPackageLicenses,
     DatasourceId::RustBinary,
     DatasourceId::SbtBuildSbt,
-    DatasourceId::VcpkgJson,
     DatasourceId::VcpkgConfigurationJson,
     DatasourceId::VcpkgLockJson,
-    DatasourceId::VcpkgControl,
 ];
 
 #[cfg(test)]

--- a/src/parsers/vcpkg_scan_test.rs
+++ b/src/parsers/vcpkg_scan_test.rs
@@ -9,10 +9,16 @@ mod tests {
     use crate::models::DatasourceId;
 
     #[test]
-    fn test_vcpkg_scan_remains_unassembled_and_hoists_dependencies() {
+    fn test_vcpkg_manifest_promotes_to_top_level_package_owning_dependencies() {
         let (files, result) = scan_and_assemble(Path::new("testdata/vcpkg/project"));
 
-        assert!(result.packages.is_empty());
+        // The manifest becomes a top-level package that owns its declared deps,
+        // rather than dropping the identity and orphaning the dependencies.
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.purl.as_deref() == Some("pkg:generic/vcpkg/sample-project@1.0.0"))
+            .expect("vcpkg.json should promote to a top-level package");
         assert_dependency_present(&result.dependencies, "pkg:generic/vcpkg/fmt", "vcpkg.json");
         assert_dependency_present(
             &result.dependencies,
@@ -23,13 +29,13 @@ mod tests {
             result
                 .dependencies
                 .iter()
-                .all(|dep| dep.for_package_uid.is_none())
+                .all(|dep| dep.for_package_uid.as_ref() == Some(&package.package_uid)),
+            "dependencies must be owned by the promoted package"
         );
         let manifest = files
             .iter()
             .find(|file| file.path.ends_with("/vcpkg.json"))
             .expect("vcpkg.json should be scanned");
-        assert!(manifest.for_packages.is_empty());
         assert!(
             manifest
                 .package_data
@@ -119,10 +125,15 @@ mod tests {
     }
 
     #[test]
-    fn test_vcpkg_control_scan_remains_unassembled_and_hoists_dependencies() {
+    fn test_vcpkg_control_promotes_to_top_level_package_owning_dependencies() {
         let (files, result) = scan_and_assemble(Path::new("testdata/vcpkg/classic"));
 
-        assert!(result.packages.is_empty());
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("ace"))
+            .expect("ports/ace/CONTROL should promote to a top-level package");
+        assert_eq!(package.version.as_deref(), Some("6.5.5#2"));
         assert_dependency_present(&result.dependencies, "pkg:generic/vcpkg/zlib", "CONTROL");
         assert_dependency_present(&result.dependencies, "pkg:generic/vcpkg/curl", "CONTROL");
         assert_dependency_present(
@@ -130,20 +141,24 @@ mod tests {
             "pkg:generic/vcpkg/vcpkg-cmake",
             "CONTROL",
         );
+        assert!(
+            result
+                .dependencies
+                .iter()
+                .all(|dep| dep.for_package_uid.as_ref() == Some(&package.package_uid)),
+            "CONTROL dependencies must be owned by the promoted port package"
+        );
 
         let control = files
             .iter()
             .find(|file| file.path.ends_with("/ports/ace/CONTROL"))
             .expect("ports/ace/CONTROL should be scanned");
-        assert!(control.for_packages.is_empty());
-
-        let package = control
+        let package_data = control
             .package_data
             .iter()
             .find(|pkg_data| pkg_data.datasource_id == Some(DatasourceId::VcpkgControl))
             .expect("vcpkg CONTROL package data should be present");
-        assert_eq!(package.name.as_deref(), Some("ace"));
-        assert_eq!(package.version.as_deref(), Some("6.5.5#2"));
+        assert_eq!(package_data.version.as_deref(), Some("6.5.5#2"));
     }
 
     #[test]
@@ -167,8 +182,13 @@ mod tests {
 
         let (files, result) = scan_and_assemble(temp_dir.path());
 
-        // vcpkg datasources stay unassembled, so neither file produces a top-level package.
-        assert!(result.packages.is_empty());
+        // The manifest promotes to a top-level package; the standalone
+        // configuration carries no identity and stays unassembled.
+        assert_eq!(result.packages.len(), 1);
+        assert_eq!(
+            result.packages[0].purl.as_deref(),
+            Some("pkg:generic/vcpkg/colocated-sample@1.0.0")
+        );
 
         let manifest = files
             .iter()


### PR DESCRIPTION
## Summary

- `DatasourceId::VcpkgControl` and `VcpkgJson` were in `UNASSEMBLED_DATASOURCE_IDS`, so vcpkg ports/manifests never reached the top-level `packages[]`: their dependencies were orphaned (`for_package_uid: null`) and no `pkg:generic/vcpkg/*` identity appeared in the assembled output — or in the CycloneDX/SPDX exports, which are built from the top-level arrays.
- Verified on microsoft/vcpkg @ 0bf3923: **1444 `CONTROL` + 77 `vcpkg.json`** records (all carrying a purl) produced **0 top-level packages and 4677 orphaned dependencies**.
- Fix: classify both with `AssemblyMode::OnePerPackageData` (the same mechanism just shipped for Meson), so each port/manifest that names a package becomes a top-level package owning its `Build-Depends`/`dependencies`. `vcpkg-configuration.json`/`vcpkg-lock.json` carry no identity and stay unassembled.

## Issues

- Covers: vcpkg package-promotion gap (orphaned deps / dropped identities). Same defect class as Meson (#1164) and the Maven per-identity work (#1159).

## Scope and exclusions

- Included: the assembly classification change + updated scanner/assembly contract tests (manifest and `CONTROL` now promote and own their deps; the colocated manifest+configuration case promotes only the manifest).
- Excluded: `vcpkg-configuration.json` and `vcpkg-lock.json` stay unassembled (no package identity).

## How to verify

- CI covers the vcpkg scan tests and the 36 assembly goldens (unchanged). Beyond CI: scanning microsoft/vcpkg now yields `pkg:generic/vcpkg/*` packages with owned dependencies instead of 4677 orphaned deps.

## Intentional differences from Python

- None; ScanCode also promotes vcpkg ports. This brings Provenant to parity at the top level.

## Expected-output fixture changes

- Files changed: none. All 36 assembly goldens pass unchanged; behavior is covered by the updated `vcpkg_scan_test.rs` contract tests (previously asserted the unassembled behavior; now assert promotion + dependency ownership).
