### PR TITLE
fix(assembly): promote Leiningen project.clj to top-level packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -510,6 +510,15 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         // many standalone `.pom` files with distinct GAVs; split per identity.
         mode: AssemblyMode::SiblingMergePerIdentity,
     },
+    // Leiningen `project.clj` declares a `defproject` with Maven coordinates, so
+    // each is an independent package that owns its `:dependencies`. One package
+    // per record (the `deps.edn` datasource carries no own identity and stays
+    // unassembled, pending sibling-merge with a co-located project.clj).
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::ClojureProjectClj],
+        sibling_file_patterns: &["project.clj"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::PypiWheel, DatasourceId::PypiPipOriginJson],
         sibling_file_patterns: &["*.whl", "origin.json"],
@@ -957,7 +966,6 @@ pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::ArchSrcinfo,
     DatasourceId::Axis2ModuleXml,
     DatasourceId::ClojureDepsEdn,
-    DatasourceId::ClojureProjectClj,
     DatasourceId::DebianInstalledFilesList,
     DatasourceId::DebianInstalledMd5Sums,
     DatasourceId::DebianCopyright,

--- a/src/parsers/clojure_scan_test.rs
+++ b/src/parsers/clojure_scan_test.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::super::scan_test_utils::scan_and_assemble;
+
+    #[test]
+    fn test_leiningen_project_promotes_to_top_level_package_with_attached_deps() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("project.clj"),
+            r#"(defproject org.example/sample "1.0.0"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [ring/ring-core "1.9.6"]])
+"#,
+        )
+        .expect("write project.clj");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        // The defproject becomes a top-level package that owns its declared
+        // dependencies, rather than dropping the identity and orphaning the deps.
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("sample"))
+            .expect("project.clj should promote to a top-level package");
+        assert_eq!(
+            package.purl.as_deref(),
+            Some("pkg:maven/org.example/sample@1.0.0")
+        );
+
+        let clojure_dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:maven/org.clojure/clojure@1.11.1"))
+            .expect("declared dependency should be present");
+        assert_eq!(
+            clojure_dep.for_package_uid.as_ref(),
+            Some(&package.package_uid)
+        );
+    }
+}

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -68,6 +68,8 @@ mod citation;
 mod citation_test;
 mod clojure;
 #[cfg(test)]
+mod clojure_scan_test;
+#[cfg(test)]
 mod clojure_test;
 #[cfg(test)]
 mod cocoapods_scan_test;


### PR DESCRIPTION
## Summary

- `DatasourceId::ClojureProjectClj` was in `UNASSEMBLED_DATASOURCE_IDS`, so a Leiningen `defproject` never reached the top-level `packages[]`: its `:dependencies` were orphaned (`for_package_uid: null`) and no `pkg:maven/*` identity appeared in the assembled output (or the CycloneDX/SPDX exports built from it).
- Verified on technomancy/leiningen @ 4022732: 39 named `project.clj` records → **0 promoted, 82/92 deps orphaned**.
- Fix: classify `ClojureProjectClj` with `AssemblyMode::OnePerPackageData` so each `defproject` becomes a top-level package owning its dependencies. `deps.edn` (`ClojureDepsEdn`) carries no own identity and stays unassembled (a future sibling-merge with a co-located `project.clj` is the right home for its deps).

## Issues

- Covers: Clojure `project.clj` package-promotion gap. Same defect class as vcpkg (#1165) and Meson (#1164).

## Scope and exclusions

- Included: assembly classification change + a new scanner/assembly contract test (`clojure_scan_test.rs`) asserting a `defproject` promotes to one `pkg:maven` package owning its declared dependency.
- Excluded: `deps.edn` promotion (no own identity; deferred).

## How to verify

- CI covers the clojure tests and the 36 assembly goldens (unchanged). Beyond CI: scanning a Leiningen project now yields a `pkg:maven/...` package owning its deps instead of orphaned dependencies.

## Intentional differences from Python

- None; ScanCode promotes Leiningen projects. This brings Provenant to parity at the top level.

## Expected-output fixture changes

- Files changed: none. Covered by the new contract test.
