### PR TITLE
fix(assembly): promote sbt build.sbt projects to top-level packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -519,6 +519,14 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["project.clj"],
         mode: AssemblyMode::OnePerPackageData,
     },
+    // sbt `build.sbt` declares a project with Maven coordinates and owns its
+    // `libraryDependencies`. One package per record so the project surfaces and
+    // owns its deps instead of orphaning them.
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::SbtBuildSbt],
+        sibling_file_patterns: &["build.sbt"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::PypiWheel, DatasourceId::PypiPipOriginJson],
         sibling_file_patterns: &["*.whl", "origin.json"],
@@ -989,7 +997,6 @@ pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::PubliccodeYaml,
     DatasourceId::RpmPackageLicenses,
     DatasourceId::RustBinary,
-    DatasourceId::SbtBuildSbt,
     DatasourceId::VcpkgConfigurationJson,
     DatasourceId::VcpkgLockJson,
 ];

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -302,6 +302,8 @@ mod ruby_scan_test;
 mod ruby_test;
 mod sbt;
 #[cfg(test)]
+mod sbt_scan_test;
+#[cfg(test)]
 mod sbt_test;
 #[cfg(test)]
 mod scan_test_utils;

--- a/src/parsers/sbt_scan_test.rs
+++ b/src/parsers/sbt_scan_test.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::super::scan_test_utils::scan_and_assemble;
+
+    #[test]
+    fn test_sbt_build_promotes_to_top_level_package_with_attached_deps() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("build.sbt"),
+            r#"ThisBuild / organization := "com.example"
+ThisBuild / version := "1.2.3"
+name := "demo-app"
+libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
+"#,
+        )
+        .expect("write build.sbt");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        // The build.sbt project becomes a top-level package that owns its
+        // libraryDependencies rather than dropping the identity and orphaning
+        // the dependencies.
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.purl.as_deref() == Some("pkg:maven/com.example/demo-app@1.2.3"))
+            .expect("build.sbt should promote to a top-level package");
+
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:maven/org.typelevel/cats-core@2.10.0"))
+            .expect("libraryDependencies entry should be present");
+        assert_eq!(dep.for_package_uid.as_ref(), Some(&package.package_uid));
+    }
+}


### PR DESCRIPTION
## Summary

- `DatasourceId::SbtBuildSbt` was in `UNASSEMBLED_DATASOURCE_IDS`, so a `build.sbt` project never reached the top-level `packages[]`: its `libraryDependencies` were orphaned (`for_package_uid: null`) and no `pkg:maven/*` identity appeared in the assembled output (or the CycloneDX/SPDX exports built from it).
- Verified on akka/akka @ 5ace141: 13 `build.sbt` records → **0 promoted, 13 orphaned deps** (the repo's 7 top-level packages all came from `pom.xml`; the "7 vs 7" benchmark row is Maven POMs, not sbt).
- Fix: classify `SbtBuildSbt` with `AssemblyMode::OnePerPackageData` so each `build.sbt` declaring project coordinates becomes a top-level package owning its dependencies.

## Issues

- Covers: sbt `build.sbt` package-promotion gap. Same defect class as vcpkg (#1165), clojure, and Meson (#1164).

## Scope and exclusions

- Included: assembly classification change + a new scanner/assembly contract test (`sbt_scan_test.rs`).
- Note: `build.sbt` emits Maven-coordinate purls. In the rare case a directory holds both a `build.sbt` and a `pom.xml` describing the same module, both surface (same behavior as ScanCode); no dedup is introduced.

## How to verify

- CI covers sbt tests + the 36 assembly goldens (unchanged). Beyond CI: scanning an sbt project now yields a `pkg:maven/...` package owning its deps instead of orphaned dependencies.

## Intentional differences from Python

- None; ScanCode promotes sbt projects. Brings Provenant to parity at the top level.

## Expected-output fixture changes

- Files changed: none. Covered by the new contract test.
