### PR TITLE
fix(assembly): promote Arch .SRCINFO/.PKGINFO packages to top-level packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -858,6 +858,18 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["APKBUILD"],
         mode: AssemblyMode::SiblingMerge,
     },
+    // Arch Linux package metadata. A `.SRCINFO`/`.PKGINFO`/`.AURINFO` names one
+    // or more `pkg:alpm/*` packages (a split recipe emits several subpackages),
+    // each owning its `depends`/`makedepends`. One package per record.
+    AssemblerConfig {
+        datasource_ids: &[
+            DatasourceId::ArchSrcinfo,
+            DatasourceId::ArchPkginfo,
+            DatasourceId::ArchAurinfo,
+        ],
+        sibling_file_patterns: &[".SRCINFO", ".PKGINFO", ".AURINFO"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     // RPM installed package databases (BDB, NDB, SQLite)
     AssemblerConfig {
         datasource_ids: &[
@@ -952,9 +964,6 @@ pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
     DatasourceId::SharShellArchive,
     DatasourceId::SquashfsDiskImage,
     // Supplementary metadata (not primary package definitions)
-    DatasourceId::ArchAurinfo,
-    DatasourceId::ArchPkginfo,
-    DatasourceId::ArchSrcinfo,
     DatasourceId::Axis2ModuleXml,
     DatasourceId::ClojureDepsEdn,
     DatasourceId::ClojureProjectClj,

--- a/src/parsers/arch_scan_test.rs
+++ b/src/parsers/arch_scan_test.rs
@@ -9,23 +9,39 @@ mod tests {
     use crate::models::DatasourceId;
 
     #[test]
-    fn test_arch_srcinfo_scan_remains_unassembled_and_hoists_dependencies() {
+    fn test_arch_srcinfo_promotes_subpackages_to_top_level_owning_dependencies() {
         let (files, result) = scan_and_assemble(Path::new("testdata/arch/srcinfo/split"));
 
-        assert!(result.packages.is_empty());
+        // A split `.SRCINFO` promotes its subpackages to top-level `pkg:alpm`
+        // packages, each owning its declared depends rather than orphaning them.
+        assert!(!result.packages.is_empty());
+        assert!(result.packages.iter().all(|p| {
+            p.purl
+                .as_deref()
+                .is_some_and(|purl| purl.starts_with("pkg:alpm/"))
+        }));
         assert_dependency_present(&result.dependencies, "pkg:alpm/arch/glibc", ".SRCINFO");
         assert_dependency_present(&result.dependencies, "pkg:alpm/arch/gcc-libs", ".SRCINFO");
-        assert!(
-            result
+        for name in ["glibc", "gcc-libs"] {
+            let purl = format!("pkg:alpm/arch/{name}");
+            let dep = result
                 .dependencies
                 .iter()
-                .all(|dep| dep.for_package_uid.is_none())
-        );
+                .find(|dep| dep.purl.as_deref() == Some(purl.as_str()))
+                .expect("dependency should be present");
+            let owner = dep
+                .for_package_uid
+                .as_ref()
+                .expect("dependency must be owned by a promoted package");
+            assert!(
+                result.packages.iter().any(|p| &p.package_uid == owner),
+                "{name} owner must be one of the promoted packages"
+            );
+        }
         let srcinfo = files
             .iter()
             .find(|file| file.path.ends_with("/.SRCINFO"))
             .expect(".SRCINFO should be scanned");
-        assert!(srcinfo.for_packages.is_empty());
         assert!(
             srcinfo
                 .package_data


### PR DESCRIPTION
## Summary

- `DatasourceId::ArchSrcinfo`, `ArchPkginfo`, and `ArchAurinfo` were in `UNASSEMBLED_DATASOURCE_IDS`, so Arch package metadata never reached the top-level `packages[]`: `depends`/`makedepends` were orphaned (`for_package_uid: null`) and no `pkg:alpm/*` identity appeared in the assembled output (or the CycloneDX/SPDX exports built from it).
- Verified on archlinux `grep`: a single `.SRCINFO` → **0 promoted, 9/9 deps orphaned** (scales with package count; a split recipe emits several subpackages).
- Fix: classify the three datasources with `AssemblyMode::OnePerPackageData` so each named package becomes a top-level package owning its dependencies.

## Issues

- Covers: Arch `.SRCINFO`/`.PKGINFO`/`.AURINFO` package-promotion gap. Same defect class as vcpkg (#1165), clojure, sbt, Meson (#1164).

## Scope and exclusions

- Included: assembly classification change + flipped scanner/assembly contract test (a split `.SRCINFO` now promotes its subpackages, each owning its declared depends).

## How to verify

- CI covers arch tests + 36 assembly goldens (unchanged). Beyond CI: scanning an Arch package tree now yields `pkg:alpm/*` packages owning their deps instead of orphaned dependencies.

## Intentional differences from Python

- None; ScanCode promotes Arch packages. Brings Provenant to parity at the top level.

## Expected-output fixture changes

- Files changed: none. The `arch_scan_test.rs` contract test was updated (previously asserted unassembled; now asserts promotion + dependency ownership).
