### PR TITLE
fix(assembly): keep distinct BitBake recipes as separate packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -926,7 +926,13 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             DatasourceId::BitbakeRecipeAppend,
         ],
         sibling_file_patterns: &["*.bb", "*.bbappend"],
-        mode: AssemblyMode::SiblingMerge,
+        // A recipe directory routinely holds several distinct `.bb` recipes
+        // (e.g. per-version or sibling components) each with its own
+        // `pkg:yocto/<pn>@<pv>` identity; collapsing the directory into one
+        // package loses the others, so split per identity. A single-recipe
+        // directory (recipe + its `.bbappend`/files) falls back to the
+        // one-package result unchanged.
+        mode: AssemblyMode::SiblingMergePerIdentity,
     },
 ];
 

--- a/src/parsers/bitbake_scan_test.rs
+++ b/src/parsers/bitbake_scan_test.rs
@@ -118,4 +118,37 @@ SRC_URI:append = " file://append.patch"
             );
         }
     }
+
+    #[test]
+    fn test_bitbake_distinct_recipes_in_one_dir_stay_separate_packages() {
+        // A recipe directory holding several distinct `.bb` recipes must yield one
+        // package per identity, not collapse them into a single package.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("foo_1.0.bb"),
+            "SUMMARY = \"foo\"\nLICENSE = \"MIT\"\n",
+        )
+        .expect("write foo recipe");
+        fs::write(
+            temp_dir.path().join("bar_2.0.bb"),
+            "SUMMARY = \"bar\"\nLICENSE = \"MIT\"\n",
+        )
+        .expect("write bar recipe");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let purls: Vec<&str> = result
+            .packages
+            .iter()
+            .filter_map(|p| p.purl.as_deref())
+            .collect();
+        assert!(
+            purls.contains(&"pkg:yocto/foo@1.0"),
+            "expected foo package: {purls:?}"
+        );
+        assert!(
+            purls.contains(&"pkg:yocto/bar@2.0"),
+            "expected bar package: {purls:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- A BitBake recipe directory routinely holds several distinct `.bb` recipes (per-version or sibling components), each with its own `pkg:yocto/<pn>@<pv>` identity. The `SiblingMerge` mode collapsed the whole directory into a single package, silently dropping the other identities.
- Verified on openembedded/meta-openembedded @ 7bf89d0: **2446 recipes collapsed into 1437 top-level packages (~1000 identities lost)**. (No orphaned deps — this is identity loss, not dep-orphaning.)
- Fix: switch the BitBake config to `AssemblyMode::SiblingMergePerIdentity` (the Maven `.pom` mechanism). Each distinct recipe identity stays its own package; a single-recipe directory (recipe + its `.bbappend`/files) still falls back to the one-package result unchanged.

## Issues

- Covers: BitBake multi-recipe identity-collapse. Same defect class as Maven (#1159).

## Scope and exclusions

- Included: mode change + a new contract test (two distinct `.bb` in one dir → two packages). The existing single-recipe+bbappend test is unaffected (single identity → fallback).

## How to verify

- CI covers bitbake tests + the 36 assembly goldens (unchanged). Beyond CI: scanning a Yocto layer now reports one `pkg:yocto` package per distinct recipe instead of one per directory.

## Intentional differences from Python

- None material; this surfaces more distinct recipe identities, closer to the real package set.

## Expected-output fixture changes

- Files changed: none. Covered by the new contract test.
