### PR TITLE
fix(assembly): keep distinct NuGet projects/nuspecs as separate packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -719,7 +719,12 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             "*.packages.lock.json",
             "*.vbproj",
         ],
-        mode: AssemblyMode::SiblingMerge,
+        // A directory can hold one project (its `.csproj`/`.nuspec` plus
+        // supplementary `packages.config`/lock siblings) or several independent
+        // projects / `.nuspec` packaging outputs with distinct identities;
+        // collapsing the latter into one package loses the others, so split per
+        // identity. A single-identity directory falls back to one package.
+        mode: AssemblyMode::SiblingMergePerIdentity,
     },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::NugetDepsJson],

--- a/src/parsers/nuget/nuget_scan_test.rs
+++ b/src/parsers/nuget/nuget_scan_test.rs
@@ -12,6 +12,40 @@ mod tests {
     use crate::models::{DatasourceId, PackageType};
 
     #[test]
+    fn test_nuget_distinct_nuspecs_in_one_dir_stay_separate_packages() {
+        // A directory holding several distinct `.nuspec` packaging outputs must
+        // yield one package per identity, not collapse them into a single one.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        for (id, version) in [("Foo", "1.0.0"), ("Bar", "2.3.4")] {
+            fs::write(
+                temp_dir.path().join(format!("{id}.nuspec")),
+                format!(
+                    r#"<?xml version="1.0"?>
+<package><metadata><id>{id}</id><version>{version}</version></metadata></package>
+"#
+                ),
+            )
+            .expect("write nuspec");
+        }
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let purls: Vec<&str> = result
+            .packages
+            .iter()
+            .filter_map(|p| p.purl.as_deref())
+            .collect();
+        assert!(
+            purls.contains(&"pkg:nuget/Foo@1.0.0"),
+            "expected Foo package: {purls:?}"
+        );
+        assert!(
+            purls.contains(&"pkg:nuget/Bar@2.3.4"),
+            "expected Bar package: {purls:?}"
+        );
+    }
+
+    #[test]
     fn test_nuget_basic_scan_assembles_csproj_and_packages_config() {
         let (files, result) = scan_and_assemble(Path::new("testdata/assembly-golden/nuget-basic"));
 


### PR DESCRIPTION
## Summary

- A directory can hold several independent `.csproj`/`.vbproj`/`.fsproj` projects or `.nuspec` packaging outputs, each with a distinct `pkg:nuget/<id>@<v>` identity. The `SiblingMerge` mode collapsed the whole directory into one package, dropping the others.
- Fix: switch the NuGet config to `AssemblyMode::SiblingMergePerIdentity` (the Maven `.pom` / BitBake mechanism). A single-project directory (project + supplementary `packages.config`/`packages.lock.json` siblings) falls back to the one-package result unchanged.

## Issues

- Covers: NuGet multi-project/nuspec identity-collapse. Same defect class as Maven (#1159) and BitBake (#1169).

## Scope and exclusions

- Included: mode change + a new contract test (two distinct `.nuspec` in one dir → two packages).
- The Central Package Management post-assembly pass is unaffected — all 7 `nuget_cpm_*` assembly goldens pass unchanged.

## How to verify

- CI covers nuget tests + the 36 assembly goldens (unchanged). Beyond CI: scanning a multi-project directory now reports one `pkg:nuget` package per project instead of one per directory.

## Intentional differences from Python

- None material; surfaces more distinct project identities.

## Expected-output fixture changes

- Files changed: none. Covered by the new contract test.
