### PR TITLE
fix(assembly): promote multi-package opam roots and name .opam files by filename

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -776,11 +776,14 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &[".gitmodules"],
         mode: AssemblyMode::SiblingMerge,
     },
-    // OCaml/opam ecosystem
+    // OCaml/opam ecosystem. A multi-package opam project ships several
+    // `<name>.opam` files at its root, each a distinct `pkg:opam/<name>`
+    // identity; collapsing the directory into one package loses the others, so
+    // split per identity. A single-package directory falls back unchanged.
     AssemblerConfig {
         datasource_ids: &[DatasourceId::OpamFile],
         sibling_file_patterns: &["opam", "*.opam"],
-        mode: AssemblyMode::SiblingMerge,
+        mode: AssemblyMode::SiblingMergePerIdentity,
     },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::RpmYumdb],

--- a/src/parsers/opam.rs
+++ b/src/parsers/opam.rs
@@ -70,8 +70,15 @@ impl PackageParser for OpamParser {
     }
 
     fn extract_packages(path: &Path) -> Vec<PackageData> {
+        // opam convention: a `<name>.opam` file names its package after the file
+        // stem when the manifest body omits an explicit `name:` field.
+        let name_fallback = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix(".opam"))
+            .filter(|stem| !stem.is_empty());
         vec![match read_file_to_string(path, None) {
-            Ok(text) => parse_opam(&text),
+            Ok(text) => parse_opam(&text, name_fallback),
             Err(e) => {
                 warn!("Failed to read OPAM file {:?}: {}", path, e);
                 default_package_data()
@@ -111,22 +118,27 @@ fn default_package_data() -> PackageData {
 }
 
 /// Parse an OPAM file from text content
-fn parse_opam(text: &str) -> PackageData {
+fn parse_opam(text: &str, name_fallback: Option<&str>) -> PackageData {
     let opam_data = parse_opam_data(text);
+
+    // Most opam manifests omit `name:` and rely on the `<name>.opam` filename.
+    let name = opam_data
+        .name
+        .clone()
+        .or_else(|| name_fallback.map(str::to_string));
 
     let description = build_description(&opam_data.synopsis, &opam_data.description);
     let parties = extract_parties(&opam_data.authors, &opam_data.maintainers);
     let dependencies = extract_dependencies(&opam_data.dependencies);
 
-    let (repository_homepage_url, api_data_url, purl) =
-        build_opam_urls(&opam_data.name, &opam_data.version);
+    let (repository_homepage_url, api_data_url, purl) = build_opam_urls(&name, &opam_data.version);
     let (declared_license_expression, declared_license_expression_spdx, license_detections) =
         normalize_opam_declared_license(opam_data.license.as_deref());
 
     PackageData {
         package_type: Some(OpamParser::PACKAGE_TYPE),
         namespace: None,
-        name: opam_data.name,
+        name,
         version: opam_data.version,
         qualifiers: None,
         subpath: None,
@@ -757,6 +769,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 "#,
+            None,
         );
 
         assert_eq!(package.name.as_deref(), Some("dune-rpc"));
@@ -817,6 +830,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 "#,
+            None,
         );
 
         assert_eq!(package.name.as_deref(), Some("chrome-trace"));

--- a/src/parsers/opam_scan_test.rs
+++ b/src/parsers/opam_scan_test.rs
@@ -85,4 +85,35 @@ depends: [
                 .any(|pkg_data| pkg_data.datasource_id == Some(DatasourceId::OpamFile))
         );
     }
+
+    #[test]
+    fn test_opam_multi_package_root_promotes_each_named_after_its_filename() {
+        // A multi-package opam project ships several `<name>.opam` files that omit
+        // the `name:` field; each must promote to its own `pkg:opam/<name>`
+        // package named after the filename, not collapse into one.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        for name in ["dune", "dune-rpc"] {
+            std::fs::write(
+                temp_dir.path().join(format!("{name}.opam")),
+                "opam-version: \"2.0\"\nsynopsis: \"part of dune\"\n",
+            )
+            .expect("write opam file");
+        }
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let purls: Vec<&str> = result
+            .packages
+            .iter()
+            .filter_map(|p| p.purl.as_deref())
+            .collect();
+        assert!(
+            purls.contains(&"pkg:opam/dune"),
+            "expected dune package: {purls:?}"
+        );
+        assert!(
+            purls.contains(&"pkg:opam/dune-rpc"),
+            "expected dune-rpc package: {purls:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- opam manifests usually omit the in-file `name:` field and rely on the `<name>.opam` filename for identity. The parser only read `name:`, so most `.opam` files produced **no purl** — on ocaml/dune only **2 of 261** had one — and the `SiblingMerge` mode then collapsed a multi-package root into a single package, orphaning the rest (121/130 deps orphaned).
- Fix (two parts):
  1. **Parser**: derive the package name from the `<name>.opam` filename stem when `name:` is absent (opam convention).
  2. **Assembly**: switch the opam config to `AssemblyMode::SiblingMergePerIdentity` so each named `.opam` at a project root promotes to its own `pkg:opam/<name>` package owning its `depends`. A single-package directory falls back to the one-package result unchanged.

## Issues

- Covers: opam package-promotion gap (the audit's two-part case — parser name gap + collapse).

## Scope and exclusions

- Included: parser filename-fallback + assembly mode change + a contract test (two name-less `<name>.opam` at one root → two `pkg:opam/<name>` packages).

## How to verify

- CI covers opam tests + the 36 assembly goldens (unchanged). Beyond CI: scanning a multi-package opam project (e.g. ocaml/dune: `dune.opam`, `dune-rpc.opam`, …) now reports one `pkg:opam/<name>` package per manifest instead of one collapsed package.

## Intentional differences from Python

- None material; surfaces the real per-package opam identities.

## Expected-output fixture changes

- Files changed: none. No `.opam` golden fixture lacked a `name:` field, so the parser change causes no golden drift; new behavior is covered by the contract test.
