### PR TITLE
refactor(assembly): require a justified reason for every UNASSEMBLED datasource

### DIFF
--- a/docs/HOW_TO_ADD_A_PARSER.md
+++ b/docs/HOW_TO_ADD_A_PARSER.md
@@ -372,11 +372,32 @@ lockfile parser usually need different datasource IDs.
 
 Edit `src/assembly/assemblers.rs` and do one of the following for every new datasource:
 
-- add it to an `AssemblerConfig` when it participates in assembly
-- add it to `UNASSEMBLED_DATASOURCE_IDS` when it is intentionally standalone
+- add it to an `AssemblerConfig` when it participates in assembly, or
+- add it to `UNASSEMBLED_DATASOURCE_IDS` **with a justified `UnassembledReason`** when it is
+  genuinely standalone.
 
 If you skip this, `test_every_datasource_id_is_accounted_for` will fail even if the parser itself
 works.
+
+**`UNASSEMBLED_DATASOURCE_IDS` is not a "wire assembly later" placeholder.** Each entry must carry
+one of the legitimate `UnassembledReason` values — there is deliberately no "deferred"/"TODO"
+variant:
+
+- `NotAPackage` — the file does not describe a package (README, OS-release, a deployment- or
+  image-descriptor fragment, a Dockerfile).
+- `BinaryArtifact` — a compiled binary or binary archive whose contents are scanned/extracted
+  elsewhere, not a source manifest.
+- `SupplementaryMetadata` — metadata merged into another datasource's package, or consumed by a
+  dedicated post-assembly pass.
+- `DependenciesOnlyNoIdentity` — a dependency/lock list with no package identity of its own; its
+  dependencies are hoisted but it cannot become a package.
+
+If your parser emits a `purl`-bearing package identity (a real, named manifest such as a
+`build.sbt`, a vcpkg port, a `project.clj`, or a `*.opam`), it **must** be assembled — typically
+with an `AssemblyMode::OnePerPackageData` config (one package per standalone manifest), or
+`SiblingMergePerIdentity` when a directory can hold several distinct identities. Leaving such a
+manifest in `UNASSEMBLED_DATASOURCE_IDS` orphans its dependencies (`for_package_uid: null`) and
+drops its identity from the assembled `packages[]` and the SBOM exports built from it.
 
 ### Add assembly config when needed
 

--- a/docs/adr/0006-datasourceid-driven-package-assembly.md
+++ b/docs/adr/0006-datasourceid-driven-package-assembly.md
@@ -34,7 +34,15 @@ We use **`DatasourceId` as the contract between parsers and assembly**, and we r
 2. **Every `DatasourceId` must be explicitly classified.**
    Each datasource is either:
    - listed in an `AssemblerConfig` in `src/assembly/assemblers.rs`, or
-   - listed in `UNASSEMBLED_DATASOURCE_IDS` when it is intentionally not assembled.
+   - listed in `UNASSEMBLED_DATASOURCE_IDS` with a justified `UnassembledReason`.
+
+   `UNASSEMBLED_DATASOURCE_IDS` is **not** a "wire assembly later" placeholder. The only legitimate
+   reasons are `NotAPackage`, `BinaryArtifact`, `SupplementaryMetadata`, and
+   `DependenciesOnlyNoIdentity`; there is deliberately no "deferred"/"TODO" variant. A datasource
+   whose parser emits a `purl`-bearing package identity must be assembled (an `OnePerPackageData`
+   config for standalone manifests, or `SiblingMergePerIdentity` for directories that may hold
+   several identities) — otherwise its dependencies are orphaned and its identity never reaches the
+   assembled `packages[]` or the SBOM exports built from it.
 
 3. **Assembly is a post-scan responsibility, not a parser responsibility.**
    Parsers extract raw `PackageData`; assembly combines related outputs into top-level `Package` objects and hoists dependencies.

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -369,6 +369,15 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
         sibling_file_patterns: &["rebar.config", "rebar.lock"],
         mode: AssemblyMode::SiblingMerge,
     },
+    // Erlang OTP application resource files (`src/<app>.app.src`). The app name
+    // and version live in the `{application, <name>, [{vsn, ...}]}` tuple, so the
+    // `.app.src` is the app's identity source (`pkg:hex/<app>`); one package per
+    // record. (`rebar.config` carries build config/deps, not the app identity.)
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::ErlangOtpAppSrc],
+        sibling_file_patterns: &["*.app.src"],
+        mode: AssemblyMode::OnePerPackageData,
+    },
     // Carthage ecosystem
     AssemblerConfig {
         datasource_ids: &[
@@ -603,6 +612,15 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             "Gemfile.lock",
         ],
         mode: AssemblyMode::SiblingMerge,
+    },
+    // Installed RubyGems specifications (`specifications/*.gemspec`). A
+    // `vendor/bundle` / gem-home `specifications` directory holds one gemspec
+    // per installed gem, each a distinct `pkg:gem/<name>@<v>` identity, so one
+    // package per record.
+    AssemblerConfig {
+        datasource_ids: &[DatasourceId::GemGemspecInstalledSpecifications],
+        sibling_file_patterns: &["**/specifications/*.gemspec"],
+        mode: AssemblyMode::OnePerPackageData,
     },
     AssemblerConfig {
         datasource_ids: &[DatasourceId::GemArchive],
@@ -969,60 +987,182 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
 // This list is runtime-significant: files with these datasource IDs may remain
 // unowned by any Package, while their dependencies are still eligible for
 // top-level hoisting. Tests also use it to enforce explicit assembly accounting.
-pub static UNASSEMBLED_DATASOURCE_IDS: &[DatasourceId] = &[
-    // Non-package metadata
-    DatasourceId::Readme,
-    DatasourceId::EtcOsRelease,
-    // Binary archives (require external extraction via ExtractCode before scanning)
-    DatasourceId::AlpineApkArchive,
-    DatasourceId::AndroidAab,
-    DatasourceId::AndroidApk,
-    DatasourceId::AndroidManifestXml,
-    DatasourceId::AndroidSoongMetadata,
-    DatasourceId::AppleDmg,
-    DatasourceId::Axis2Mar,
-    DatasourceId::ChromeCrx,
-    DatasourceId::DebianOriginalSourceTarball,
-    DatasourceId::DebianSourceMetadataTarball,
-    DatasourceId::InstallshieldInstaller,
-    DatasourceId::IosIpa,
-    DatasourceId::IsoDiskImage,
-    DatasourceId::JavaEarArchive,
-    DatasourceId::JbossSar,
-    DatasourceId::MicrosoftCabinet,
-    DatasourceId::MozillaXpi,
-    DatasourceId::NsisInstaller,
-    DatasourceId::SharShellArchive,
-    DatasourceId::SquashfsDiskImage,
-    // Supplementary metadata (not primary package definitions)
-    DatasourceId::Axis2ModuleXml,
-    DatasourceId::ClojureDepsEdn,
-    DatasourceId::DebianInstalledFilesList,
-    DatasourceId::DebianInstalledMd5Sums,
-    DatasourceId::DebianCopyright,
-    DatasourceId::DebianCopyrightInPackage,
-    DatasourceId::DebianCopyrightStandalone,
-    DatasourceId::GoBinary,
-    DatasourceId::WindowsExecutable,
-    DatasourceId::Dockerfile,
-    DatasourceId::OciImageIndex,
-    DatasourceId::OciImageManifest,
-    DatasourceId::ErlangOtpAppSrc,
-    DatasourceId::HexMixLock,
-    DatasourceId::AntIvyDependenciesProperties,
-    DatasourceId::JavaEarApplicationXml,
-    DatasourceId::JavaWarWebXml,
-    DatasourceId::JbossServiceXml,
-    DatasourceId::GemGemspecInstalledSpecifications,
-    DatasourceId::NugetDirectoryBuildProps,
-    DatasourceId::NugetDirectoryPackagesProps,
-    DatasourceId::CitationCff,
-    DatasourceId::PubliccodeYaml,
-    DatasourceId::RpmPackageLicenses,
-    DatasourceId::RustBinary,
-    DatasourceId::VcpkgConfigurationJson,
-    DatasourceId::VcpkgLockJson,
+/// Why a `DatasourceId` is intentionally not assembled into a top-level package.
+///
+/// Every entry in [`UNASSEMBLED_DATASOURCE_IDS`] must state one of these reasons.
+/// There is deliberately **no** "deferred"/"TODO" variant: a datasource whose
+/// parser emits a `purl`-bearing package identity with dependencies must be
+/// assembled (an `OnePerPackageData` config for standalone manifests), not
+/// parked here. See `docs/HOW_TO_ADD_A_PARSER.md` and ADR 0006.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum UnassembledReason {
+    /// The file does not describe a package (README, OS-release, deployment- or
+    /// image-descriptor fragment, Dockerfile, …). There is no identity to assemble.
+    NotAPackage,
+    /// A compiled binary or binary archive whose contents are scanned or extracted
+    /// elsewhere (ExtractCode), not a source manifest with its own assembled identity.
+    BinaryArtifact,
+    /// Metadata that enriches another datasource's package, or is consumed by a
+    /// dedicated post-assembly pass, rather than defining a package on its own.
+    SupplementaryMetadata,
+    /// A dependency or lock list with no package identity of its own; its
+    /// dependencies are hoisted, but it cannot become a package.
+    DependenciesOnlyNoIdentity,
+}
+
+pub static UNASSEMBLED_DATASOURCE_IDS: &[(DatasourceId, UnassembledReason)] = &[
+    (DatasourceId::Readme, UnassembledReason::NotAPackage),
+    (DatasourceId::EtcOsRelease, UnassembledReason::NotAPackage),
+    (
+        DatasourceId::AndroidManifestXml,
+        UnassembledReason::NotAPackage,
+    ),
+    (
+        DatasourceId::AndroidSoongMetadata,
+        UnassembledReason::NotAPackage,
+    ),
+    (DatasourceId::Dockerfile, UnassembledReason::NotAPackage),
+    (DatasourceId::OciImageIndex, UnassembledReason::NotAPackage),
+    (
+        DatasourceId::OciImageManifest,
+        UnassembledReason::NotAPackage,
+    ),
+    (DatasourceId::Axis2ModuleXml, UnassembledReason::NotAPackage),
+    (
+        DatasourceId::JavaEarApplicationXml,
+        UnassembledReason::NotAPackage,
+    ),
+    (DatasourceId::JavaWarWebXml, UnassembledReason::NotAPackage),
+    (
+        DatasourceId::JbossServiceXml,
+        UnassembledReason::NotAPackage,
+    ),
+    // Compiled binaries and binary archives (extracted/scanned elsewhere).
+    (
+        DatasourceId::AlpineApkArchive,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::AndroidAab, UnassembledReason::BinaryArtifact),
+    (DatasourceId::AndroidApk, UnassembledReason::BinaryArtifact),
+    (DatasourceId::AppleDmg, UnassembledReason::BinaryArtifact),
+    (DatasourceId::Axis2Mar, UnassembledReason::BinaryArtifact),
+    (DatasourceId::ChromeCrx, UnassembledReason::BinaryArtifact),
+    (
+        DatasourceId::DebianOriginalSourceTarball,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (
+        DatasourceId::DebianSourceMetadataTarball,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (
+        DatasourceId::InstallshieldInstaller,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::IosIpa, UnassembledReason::BinaryArtifact),
+    (
+        DatasourceId::IsoDiskImage,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (
+        DatasourceId::JavaEarArchive,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::JbossSar, UnassembledReason::BinaryArtifact),
+    (
+        DatasourceId::MicrosoftCabinet,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::MozillaXpi, UnassembledReason::BinaryArtifact),
+    (
+        DatasourceId::NsisInstaller,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (
+        DatasourceId::SharShellArchive,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (
+        DatasourceId::SquashfsDiskImage,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::GoBinary, UnassembledReason::BinaryArtifact),
+    (
+        DatasourceId::WindowsExecutable,
+        UnassembledReason::BinaryArtifact,
+    ),
+    (DatasourceId::RustBinary, UnassembledReason::BinaryArtifact),
+    // Metadata merged into another datasource's package or a post-assembly pass.
+    (
+        DatasourceId::DebianInstalledFilesList,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::DebianInstalledMd5Sums,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::DebianCopyright,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::DebianCopyrightInPackage,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::DebianCopyrightStandalone,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::AntIvyDependenciesProperties,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::NugetDirectoryBuildProps,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::NugetDirectoryPackagesProps,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::CitationCff,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::PubliccodeYaml,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::RpmPackageLicenses,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::VcpkgConfigurationJson,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    (
+        DatasourceId::VcpkgLockJson,
+        UnassembledReason::SupplementaryMetadata,
+    ),
+    // Dependency/lock lists with no package identity of their own.
+    (
+        DatasourceId::ClojureDepsEdn,
+        UnassembledReason::DependenciesOnlyNoIdentity,
+    ),
+    (
+        DatasourceId::HexMixLock,
+        UnassembledReason::DependenciesOnlyNoIdentity,
+    ),
 ];
+
+/// Whether `datasource_id` is intentionally left unassembled (see
+/// [`UNASSEMBLED_DATASOURCE_IDS`]).
+pub(super) fn is_unassembled_datasource(datasource_id: DatasourceId) -> bool {
+    UNASSEMBLED_DATASOURCE_IDS
+        .iter()
+        .any(|(dsid, _)| *dsid == datasource_id)
+}
 
 #[cfg(test)]
 mod tests {
@@ -1040,7 +1180,12 @@ mod tests {
         }
 
         let unassembled: HashSet<DatasourceId> =
-            UNASSEMBLED_DATASOURCE_IDS.iter().copied().collect();
+            UNASSEMBLED_DATASOURCE_IDS.iter().map(|(d, _)| *d).collect();
+        assert_eq!(
+            unassembled.len(),
+            UNASSEMBLED_DATASOURCE_IDS.len(),
+            "UNASSEMBLED_DATASOURCE_IDS lists a datasource more than once"
+        );
 
         let overlap: Vec<_> = assembled.intersection(&unassembled).collect();
         assert!(

--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -1010,7 +1010,7 @@ pub(super) enum UnassembledReason {
     DependenciesOnlyNoIdentity,
 }
 
-pub static UNASSEMBLED_DATASOURCE_IDS: &[(DatasourceId, UnassembledReason)] = &[
+pub(super) static UNASSEMBLED_DATASOURCE_IDS: &[(DatasourceId, UnassembledReason)] = &[
     (DatasourceId::Readme, UnassembledReason::NotAPackage),
     (DatasourceId::EtcOsRelease, UnassembledReason::NotAPackage),
     (

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -295,7 +295,7 @@ fn should_hoist_unassembled_dependencies(datasource_id: DatasourceId) -> bool {
         return true;
     }
 
-    if !assemblers::UNASSEMBLED_DATASOURCE_IDS.contains(&datasource_id) {
+    if !assemblers::is_unassembled_datasource(datasource_id) {
         return false;
     }
 

--- a/src/parsers/erlang_otp_scan_test.rs
+++ b/src/parsers/erlang_otp_scan_test.rs
@@ -60,4 +60,33 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_erlang_app_src_promotes_to_top_level_package_owning_applications() {
+        // `src/<app>.app.src` carries the app name/version, so it is the app's
+        // identity source and promotes to a top-level package owning its
+        // `applications` dependencies.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir(&src).expect("create src dir");
+        std::fs::write(
+            src.join("demo.app.src"),
+            "{application, demo,\n [{vsn, \"1.0.0\"},\n  {applications, [kernel, stdlib, cowboy]}]}.\n",
+        )
+        .expect("write app.src");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.purl.as_deref() == Some("pkg:hex/demo@1.0.0"))
+            .expect(".app.src should promote to a top-level package");
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:hex/cowboy"))
+            .expect("applications dependency should be present");
+        assert_eq!(dep.for_package_uid.as_ref(), Some(&package.package_uid));
+    }
 }

--- a/src/parsers/ruby_scan_test.rs
+++ b/src/parsers/ruby_scan_test.rs
@@ -150,4 +150,24 @@ mod tests {
             "standalone gem archive should not claim unrelated sibling files"
         );
     }
+
+    #[test]
+    fn test_installed_specifications_gemspec_promotes_to_top_level_package() {
+        // An installed `specifications/*.gemspec` is a real gem identity and
+        // promotes to a top-level `pkg:gem/<name>@<v>` package owning its deps.
+        let (_files, result) =
+            scan_and_assemble(Path::new("testdata/gem/specifications/specifications"));
+
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.purl.as_deref() == Some("pkg:gem/example-gem@1.2.3"))
+            .expect("installed specifications gemspec should promote to a package");
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:gem/rails"))
+            .expect("gemspec dependency should be present");
+        assert_eq!(dep.for_package_uid.as_ref(), Some(&package.package_uid));
+    }
 }


### PR DESCRIPTION
## Summary

- `UNASSEMBLED_DATASOURCE_IDS` had become a catch-all where a real package manifest could be parked instead of wired into assembly — the root cause of the recent vcpkg/clojure/sbt/arch/bitbake/nuget/opam promotion gaps. This makes the category self-justifying so the mistake cannot recur.
- Add an `UnassembledReason` enum with **only legitimate variants** — `NotAPackage`, `BinaryArtifact`, `SupplementaryMetadata`, `DependenciesOnlyNoIdentity` — and **deliberately no "deferred"/"TODO" variant**. `UNASSEMBLED_DATASOURCE_IDS` now pairs each datasource with a reason (+ a uniqueness guard).
- Promote the two remaining identity-bearing entries that had no legitimate reason: installed RubyGems `specifications/*.gemspec` and Erlang `.app.src` (the app's identity source), each via `OnePerPackageData` with a contract test.
- Document the rule in `HOW_TO_ADD_A_PARSER.md` §5 and ADR 0006: a parser that emits a `purl`-bearing package identity **must** be assembled, not parked in `UNASSEMBLED`.

## Issues

- Covers: hardening `UNASSEMBLED_DATASOURCE_IDS` against "wire assembly later" misuse, and the last two audit-identified promotion gaps (gem specifications, erlang `.app.src`).

## Scope and exclusions

- Included: the reason enum + classification of every entry, the two promotions with contract tests, the `is_unassembled_datasource` helper (replacing the old `.contains`), and the doc rules.
- The four reasons cover the genuine cases; entries like Dockerfile/OCI manifests (`NotAPackage`), binaries/archives (`BinaryArtifact`), Debian copyright / NuGet CPM props / vcpkg config+lock (`SupplementaryMetadata`), and `deps.edn`/`mix.lock` (`DependenciesOnlyNoIdentity`) are now explicitly justified.

## How to verify

- CI covers the assembly classification/completeness test, the 36 assembly goldens, and the new ruby/erlang contract tests. Beyond CI: `test_every_datasource_id_is_accounted_for` now also enforces no duplicate entries; adding a new purl-bearing manifest to `UNASSEMBLED` has no honest reason to assign.

## Intentional differences from Python

- N/A — internal assembly-accounting hardening.

## Expected-output fixture changes

- Files changed: none. All 36 assembly goldens pass unchanged; the two promotions are covered by new contract tests (`ruby_scan_test`, `erlang_otp_scan_test`).
