### PR TITLE
fix(assembly): keep distinct wheels in a wheelhouse as separate packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -539,7 +539,11 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
     AssemblerConfig {
         datasource_ids: &[DatasourceId::PypiWheel, DatasourceId::PypiPipOriginJson],
         sibling_file_patterns: &["*.whl", "origin.json"],
-        mode: AssemblyMode::SiblingMerge,
+        // A wheelhouse (`pip download -d wheelhouse/`) holds many distinct wheels
+        // in one directory, each a distinct `pkg:pypi/<name>@<v>` identity, so one
+        // package per identity. A pip-cache leaf directory (one wheel plus its
+        // `origin.json`, sharing the wheel's identity) falls back to one package.
+        mode: AssemblyMode::SiblingMergePerIdentity,
     },
     // Python/PyPI ecosystem
     AssemblerConfig {

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -3800,10 +3800,14 @@ mod tests {
     }
 
     #[test]
-    fn test_assemble_python_pip_cache_skips_mismatched_second_wheel() {
+    fn test_assemble_python_distinct_wheels_in_one_dir_stay_separate_packages() {
+        // A wheelhouse-style directory holding several distinct wheels yields one
+        // package per identity. The `construct` wheel and its same-identity
+        // `origin.json` merge into one package; the distinct `otherpkg` wheel
+        // surfaces as its own package rather than being dropped.
         let mut files = vec![
             create_test_file_info(
-                ".cache/pip/wheels/eb/60/37/hash/construct-2.10.68-py3-none-any.whl",
+                "wheelhouse/construct-2.10.68-py3-none-any.whl",
                 DatasourceId::PypiWheel,
                 Some("pkg:pypi/construct@2.10.68?extension=py3-none-any"),
                 Some("construct"),
@@ -3811,7 +3815,7 @@ mod tests {
                 vec![],
             ),
             create_test_file_info(
-                ".cache/pip/wheels/eb/60/37/hash/origin.json",
+                "wheelhouse/origin.json",
                 DatasourceId::PypiPipOriginJson,
                 Some("pkg:pypi/construct@2.10.68?extension=py3-none-any"),
                 Some("construct"),
@@ -3819,7 +3823,7 @@ mod tests {
                 vec![],
             ),
             create_test_file_info(
-                ".cache/pip/wheels/eb/60/37/hash/otherpkg-9.9.9-py3-none-any.whl",
+                "wheelhouse/otherpkg-9.9.9-py3-none-any.whl",
                 DatasourceId::PypiWheel,
                 Some("pkg:pypi/otherpkg@9.9.9?extension=py3-none-any"),
                 Some("otherpkg"),
@@ -3828,27 +3832,24 @@ mod tests {
             ),
         ];
 
-        files[1].package_data[0].download_url = Some(
-            "https://files.pythonhosted.org/packages/source/c/construct/construct-2.10.68.tar.gz"
-                .to_string(),
-        );
-
         let result = assemble(&mut files);
 
-        assert_eq!(result.packages.len(), 1);
-        let package = &result.packages[0];
-        assert_eq!(package.name.as_deref(), Some("construct"));
-        assert_eq!(package.version.as_deref(), Some("2.10.68"));
-        assert_eq!(package.datafile_paths.len(), 2);
-        assert!(
-            package
-                .datafile_paths
-                .iter()
-                .all(|path| !path.contains("otherpkg"))
-        );
-        assert!(files[0].for_packages.contains(&package.package_uid));
-        assert!(files[1].for_packages.contains(&package.package_uid));
-        assert!(files[2].for_packages.is_empty());
+        assert_eq!(result.packages.len(), 2, "packages: {:#?}", result.packages);
+        let construct = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("construct"))
+            .expect("construct package should be present");
+        assert_eq!(construct.datafile_paths.len(), 2);
+        let otherpkg = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("otherpkg"))
+            .expect("distinct otherpkg wheel should surface as its own package");
+
+        assert!(files[0].for_packages.contains(&construct.package_uid));
+        assert!(files[1].for_packages.contains(&construct.package_uid));
+        assert!(files[2].for_packages.contains(&otherpkg.package_uid));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- A wheelhouse (`pip download -d wheelhouse/` / `pip wheel -w`) holds many distinct wheels in one directory, each a distinct `pkg:pypi/<name>@<v>` identity. Under `SiblingMerge` the directory collapsed to one package, and the `should_skip_python_pip_cache_merge` guard *silently dropped* the second-and-later distinct wheels (audit-identified).
- Fix: switch the wheel/`origin.json` config to `AssemblyMode::SiblingMergePerIdentity` (the Maven/BitBake/NuGet mechanism). Each distinct wheel surfaces as its own package; a pip-cache leaf directory (one wheel + its same-identity `origin.json`) still falls back to a single package.

## Issues

- Covers: PyPI wheelhouse identity-collapse / silent wheel drop. Same defect class as Maven (#1159), BitBake (#1169), NuGet (#1170).

## Scope and exclusions

- Included: mode change + the assembly contract test (`test_assemble_python_distinct_wheels_in_one_dir_stay_separate_packages`), which replaces the prior `…skips_mismatched_second_wheel` test that asserted the (incorrect) drop behavior.
- The single-wheel pip-cache case (`test_assemble_python_pip_cache_origin_with_wheel_archive`) and standalone-wheel case are unchanged and still pass.

## How to verify

- CI covers the assembly tests (132) + 36 assembly goldens + 126 python tests (unchanged). Beyond CI: scanning a `wheelhouse/` now reports one `pkg:pypi` package per wheel instead of one.

## Intentional differences from Python

- None material; surfaces the full set of distinct wheel identities.

## Expected-output fixture changes

- Files changed: none. The drop-asserting unit test was rewritten to assert the corrected split behavior.
