### PR TITLE
fix(assembly): keep distinct Ruby gemspecs in one directory as separate packages

### DIFF
--- a/src/assembly/assemblers.rs
+++ b/src/assembly/assemblers.rs
@@ -611,7 +611,12 @@ pub static ASSEMBLERS: &[AssemblerConfig] = &[
             "Gemfile",
             "Gemfile.lock",
         ],
-        mode: AssemblyMode::SiblingMerge,
+        // A directory usually holds one gem (its `.gemspec` plus a `Gemfile`/
+        // `Gemfile.lock`), but can hold several independent `.gemspec` files with
+        // distinct identities; collapsing the latter into one package loses the
+        // others, so split per identity. A single-gem directory (one purled
+        // gemspec plus purl-less `Gemfile`/lock siblings) falls back unchanged.
+        mode: AssemblyMode::SiblingMergePerIdentity,
     },
     // Installed RubyGems specifications (`specifications/*.gemspec`). A
     // `vendor/bundle` / gem-home `specifications` directory holds one gemspec

--- a/src/parsers/ruby_scan_test.rs
+++ b/src/parsers/ruby_scan_test.rs
@@ -152,6 +152,38 @@ mod tests {
     }
 
     #[test]
+    fn test_distinct_gemspecs_in_one_dir_stay_separate_packages() {
+        // A directory holding several independent `.gemspec` files yields one
+        // package per identity, not a single collapsed package.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        for (name, version) in [("foo", "1.0.0"), ("bar", "2.3.4")] {
+            fs::write(
+                temp_dir.path().join(format!("{name}.gemspec")),
+                format!(
+                    "Gem::Specification.new do |s|\n  s.name = \"{name}\"\n  s.version = \"{version}\"\nend\n"
+                ),
+            )
+            .expect("write gemspec");
+        }
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        let purls: Vec<&str> = result
+            .packages
+            .iter()
+            .filter_map(|p| p.purl.as_deref())
+            .collect();
+        assert!(
+            purls.contains(&"pkg:gem/foo@1.0.0"),
+            "expected foo gem: {purls:?}"
+        );
+        assert!(
+            purls.contains(&"pkg:gem/bar@2.3.4"),
+            "expected bar gem: {purls:?}"
+        );
+    }
+
+    #[test]
     fn test_installed_specifications_gemspec_promotes_to_top_level_package() {
         // An installed `specifications/*.gemspec` is a real gem identity and
         // promotes to a top-level `pkg:gem/<name>@<v>` package owning its deps.


### PR DESCRIPTION
## Summary

- A directory can hold several independent `.gemspec` files with distinct `pkg:gem/<name>@<v>` identities. Under `SiblingMerge` the directory collapsed to one package, dropping the others.
- Fix: switch the Ruby/RubyGems config to `AssemblyMode::SiblingMergePerIdentity`. Each distinct gemspec stays its own package; a single-gem directory (one gemspec + purl-less `Gemfile`/`Gemfile.lock` siblings) falls back to the one-package result unchanged.

## Issues

- Covers: Ruby multi-gemspec identity-collapse (the project-`.gemspec` case; the installed `specifications/*.gemspec` case was handled in #1172). Same defect class as Maven (#1159), BitBake (#1169), NuGet (#1170), wheelhouse (#1173).

## Scope and exclusions

- Included: mode change + a contract test (two distinct `.gemspec` in one dir → two packages). Single-gem fixtures (`Gemfile.lock`, `.gem` archive, extracted gem) are unchanged and still pass.

## How to verify

- CI covers ruby tests (80) + the 36 assembly goldens (unchanged). Beyond CI: scanning a flat multi-gem directory now reports one `pkg:gem` package per gemspec.

## Intentional differences from Python

- None material; surfaces the full set of gem identities.

## Expected-output fixture changes

- Files changed: none. Covered by the new contract test.
