### PR TITLE
fix(assembly): hoist purl-less records' dependencies and refresh affected benchmark rows

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -299,21 +299,21 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 305
 - Run context: 2026-06-06 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `6.53s`; ScanCode `57.19s`
-- Direct Hex dependency extraction (`367` vs `0` dependencies) from the root `mix.lock`'s legacy 7-element hex tuples that ScanCode does not parse, defaulting `hexpm` as the repository for tuples that omit it, with MIT license detection preserved across the Elixir source tree
+- Broader Hex package and dependency extraction (`6` vs `0` packages, `399` vs `0` dependencies): one `pkg:hex` package per `mix.exs` (the root `distillery` app plus five `test/fixtures/*` apps), each merging its sibling `mix.lock` for locked identities, parsing the root lockfile's legacy 7-element hex tuples ScanCode does not read and defaulting `hexpm` as the repository for tuples that omit it, with MIT license detection preserved across the Elixir source tree
 
 ##### [elixir-ecto/ecto @ 28d9282](https://github.com/elixir-ecto/ecto/tree/28d928267388018d5b0bb1f83e04368b7e8cae50) — **13.56× faster**
 
 - Files: 156
 - Run context: 2026-06-15 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `4.85s`; ScanCode `65.75s`
-- Broader Hex dependency extraction (`19` vs `0`) from the repo-root `mix.lock` plus `examples/friends/mix.lock`, with direct locked package identities for entries such as `ecto_sql`, `postgrex`, and `telemetry` that ScanCode leaves dependency-blind
+- Broader Hex package and dependency extraction (`2` vs `0` packages, `27` vs `0` dependencies): a `pkg:hex/ecto` package and an `examples/friends` app, each pairing `mix.exs` identity with `mix.lock` locked dependencies such as `ecto_sql`, `postgrex`, and `telemetry` that ScanCode leaves dependency-blind
 
 ##### [elixir-plug/plug @ 47649aa](https://github.com/elixir-plug/plug/tree/47649aa7bb910f481b66cc3e98c14b2c3b761c3c) — **10.51× faster**
 
 - Files: 104
 - Run context: 2026-06-15 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `4.88s`; ScanCode `51.28s`
-- Locked Hex dependency extraction (`9` vs `0`) for `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
+- Direct Hex package and dependency extraction (`1` vs `0` packages, `13` vs `0` dependencies): a `pkg:hex/plug` package from `mix.exs` carrying locked `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins from `mix.lock` that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
 
 ##### [erlang/otp @ 264def5](https://github.com/erlang/otp/tree/264def545b8214ea7100bfede1a4629c676ff1c0) — **33.91× faster**
 
@@ -334,7 +334,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 476
 - Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.49s`; ScanCode `78.97s`
-- Direct Hex package visibility on the repo-root, `installer/mix.lock`, and `integration_test/mix.lock` surfaces (`3` vs `0` file-level package records), while preserving top-level package and dependency parity elsewhere and preserving structured npm party metadata
+- Direct Hex package visibility (`3` vs `0` file-level package records) on the repo-root, `installer/`, and `integration_test/` `mix.exs`/`mix.lock` surfaces — each `pkg:hex` package versioned from its `mix.exs` (`phoenix@1.8.5`, `phx_new@1.8.5`) and merged with its sibling lockfile — while preserving top-level package and dependency parity elsewhere and structured party metadata on the bundled `pkg:npm/phoenix` asset package
 
 ##### [processone/ejabberd @ 87475d8](https://github.com/processone/ejabberd/tree/87475d813b974492f338720eab5c9c3d4646a4ce) — **15.15× faster**
 
@@ -1233,7 +1233,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 13,670
 - Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `11.35s`; ScanCode `386.36s`
-- Far broader vcpkg registry package and dependency extraction (`2` vs `1` packages, `13653` vs `39` dependencies) from many committed `ports/*/vcpkg.json` manifests with host, feature, and platform-qualified dependencies, plus standalone Debian copyright package rows on `ports/*/copyright` and explicit vcpkg package identities where ScanCode stays largely manifest-blind
+- Far broader vcpkg registry package and dependency extraction (`2942` vs `1` packages, `13653` vs `39` dependencies): `2940` top-level `pkg:generic/vcpkg` packages, one per committed `ports/*/vcpkg.json` manifest, each owning its host, feature, and platform-qualified dependencies, plus standalone Debian copyright package rows on `ports/*/copyright` where ScanCode stays largely manifest-blind
 
 ##### [OrchardCMS/OrchardCore @ 01386f3](https://github.com/OrchardCMS/OrchardCore/tree/01386f38ee3fef620a93934f05ba1363ff05c291) — **51.92× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -320,7 +320,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 11,749
 - Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `59.99s`; ScanCode `2034.56s`
-- Direct OTP application package visibility (`41` vs `0`): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable and preserves the same non-stdlib runtime dependency inventory ScanCode finds
+- Broader OTP package visibility (`51` vs `0` packages): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src` (`41`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable) alongside `10` `pkg:autotools` packages from per-application `configure.ac` build manifests, preserving the same non-stdlib runtime dependency inventory ScanCode finds
 
 ##### [livebook-dev/livebook @ 77cbcd9](https://github.com/livebook-dev/livebook/tree/77cbcd98df133045f5a4adf7273e4cd077307714) — **17.14× faster**
 
@@ -341,7 +341,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 623
 - Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `8.01s`; ScanCode `121.38s`
-- Broader Erlang/Rebar package and dependency extraction (`2` vs `1` packages, `43` vs `3` dependencies) from the root `rebar.config`, `rebar.lock`, nested `_checkouts/configure_deps` manifests, and committed Dockerfiles, with the bundled `priv/mod_invites/copyright` notice kept as clue-level license evidence instead of being overstated as Debian package metadata
+- Broader Erlang package and dependency extraction (`3` vs `1` packages, `43` vs `3` dependencies): `pkg:hex` and `pkg:autotools` identities from the `_checkouts/configure_deps` app and root `configure.ac` alongside the `pkg:npm` project, with rebar dependencies recovered from the root `rebar.config`/`rebar.lock` and committed Dockerfiles, plus the bundled `priv/mod_invites/copyright` notice kept as clue-level license evidence instead of being overstated as Debian package metadata
 
 ##### [vernemq/vernemq @ 4681e54](https://github.com/vernemq/vernemq/tree/4681e5490cc42e6cc26a504bb4b3c5413315c21f) — **14.07× faster**
 
@@ -1219,7 +1219,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 3,625
 - Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `9.93s`; ScanCode `304.40s`
-- Broader mixed-package extraction (`15` vs `2` packages, `40` vs `0` dependencies) from the root `vcpkg.json`, overlay-port `dep/vcpkg-overlay-ports/*/vcpkg.json`, and committed `packages.config` files, with explicit vcpkg package identities where ScanCode reports none
+- Broader mixed-package extraction (`17` vs `2` packages, `40` vs `0` dependencies) from the root `vcpkg.json`, overlay-port `dep/vcpkg-overlay-ports/*/vcpkg.json`, and committed `packages.config` files, with explicit `pkg:generic/vcpkg` and `pkg:nuget` package identities where ScanCode reports none
 
 ##### [microsoft/vcpkg @ 0bf3923](https://github.com/microsoft/vcpkg/tree/0bf3923f9fab4001c00f0f429682a0853b5749e0) — **31.18× faster**
 
@@ -1412,14 +1412,14 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 2,120
 - Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `10.87s`; ScanCode `348.59s`
-- Direct opam package visibility (`1` vs `0` packages) with broader dependency extraction (`27` vs `24`) from the repo-root `merlin*.opam`, `dot-merlin-reader.opam`, `ocaml-index.opam`, and `flake.lock` surfaces, plus Unicode-preserving copyright normalization across the Merlin source tree
+- Broader opam and Nix package visibility (`5` vs `0` packages) with broader dependency extraction (`27` vs `24`): one `pkg:opam` package per repo-root `merlin*.opam`, `dot-merlin-reader.opam`, and `ocaml-index.opam` manifest (`4`) plus the `flake.lock` package, with Unicode-preserving copyright normalization across the Merlin source tree
 
 ##### [ocaml/ocaml-lsp @ 788ff73](https://github.com/ocaml/ocaml-lsp/tree/788ff738991189537141776bfa07652547bff9c4) — **17.13× faster**
 
 - Files: 546
 - Run context: 2026-06-20 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.79s`; ScanCode `99.19s`
-- Broader opam package visibility (`3` vs `1` packages) with slightly richer dependency extraction (`380` vs `376`) from the root and submodule `.opam` manifests plus `flake.lock`, with cleaner maintainer and email recovery on opam metadata and Unicode-preserving copyright normalization
+- Broader package visibility (`11` vs `1` packages) with richer dependency extraction (`380` vs `376`): one `pkg:opam` package per root and submodule `.opam` manifest (`8`) alongside the `flake.lock`, `package.json`, and vendored-submodule `configure.ac` packages, with cleaner maintainer and email recovery on opam metadata and Unicode-preserving copyright normalization
 
 ##### [openfl/openfl @ 74d8f72](https://github.com/openfl/openfl/tree/74d8f72890b9ae70bba589d034ea35b86588e548) — **13.61× faster**
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -320,7 +320,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 11,749
 - Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `59.99s`; ScanCode `2034.56s`
-- Direct OTP application package visibility (`11` vs `0`) across committed `lib/*/src/*.app.src` templates, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable and preserves the same non-stdlib runtime dependency inventory ScanCode finds
+- Direct OTP application package visibility (`41` vs `0`): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable and preserves the same non-stdlib runtime dependency inventory ScanCode finds
 
 ##### [livebook-dev/livebook @ 77cbcd9](https://github.com/livebook-dev/livebook/tree/77cbcd98df133045f5a4adf7273e4cd077307714) — **17.14× faster**
 
@@ -506,7 +506,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 4,623
 - Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `10.57s`; ScanCode `425.90s`
-- Matched top-level SBT package coverage (`7` vs `7`) with broader dependency extraction (`49` vs `40`) from the root `build.sbt`, sample applications, and native-image test manifests, plus cleaner rejection of weak actor-name author noise such as `the ActorSystem` and `the ReceiveBuilder`
+- Broader top-level package coverage (`11` vs `7`): each `build.sbt` project is its own `pkg:maven` package (`4` sbt projects) alongside the `7` Maven POM packages ScanCode also finds, with broader dependency extraction (`49` vs `40`) from the root `build.sbt`, sample applications, and native-image test manifests owned by their projects, plus cleaner rejection of weak actor-name author noise such as `the ActorSystem` and `the ReceiveBuilder`
 
 ##### [apache/ant-ivy @ dc35d51](https://github.com/apache/ant-ivy/tree/dc35d510d281ab2ab8fb4486e517e838c72a64d2) — **25.5× faster**
 
@@ -1226,7 +1226,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 5,536
 - Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `7.83s`; ScanCode `244.13s`
-- Far broader classic vcpkg registry package and dependency extraction (`1531` vs `9` package_data records, `4677` vs `0` dependencies) from 1444 committed `ports/*/CONTROL` files plus early `ports/*/vcpkg.json` manifests, with `Build-Depends` dependency visibility including feature and platform qualifiers, named Debian copyright package identities where ScanCode emits nameless standalone copyright rows, and URL normalization that preserves complete CMake variable expressions instead of truncating at `${...` braces
+- Far broader classic vcpkg registry coverage: `1521` top-level `pkg:generic/vcpkg` packages — one per committed `ports/*/CONTROL` (1444) and early `ports/*/vcpkg.json` manifest — each owning its `Build-Depends` (`4677` dependencies, with feature and platform qualifiers) where ScanCode surfaces only `9` file-level records and no dependencies, plus named Debian copyright package identities where ScanCode emits nameless standalone copyright rows, and URL normalization that preserves complete CMake variable expressions instead of truncating at `${...` braces
 
 ##### [microsoft/vcpkg @ b21ff8f](https://github.com/microsoft/vcpkg/tree/b21ff8f3cadbd8e0b175b49be2dd9202f1f208f4) — **34.04× faster**
 
@@ -1405,7 +1405,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 7,751
 - Run context: 2026-06-21 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `7.58s`; ScanCode `272.90s`
-- Broader opam and Nix package visibility (`4` vs `2` packages, `130` vs `116` dependencies) from the generated `opam/*.opam` manifests and `flake.lock`, with structured opam description, maintainer, and dependency recovery instead of ScanCode's field-bleeding author text on those manifests
+- Far broader opam and Nix package visibility (`257` vs `2` packages, `130` vs `116` dependencies): one `pkg:opam/<name>` package per `opam/*.opam` manifest (`256`, named from the filename when the manifest omits `name:`) plus the `flake.lock` package, with structured opam description, maintainer, and dependency recovery instead of ScanCode's field-bleeding author text on those manifests
 
 ##### [ocaml/merlin @ 30b4f24](https://github.com/ocaml/merlin/tree/30b4f24fdd76fdbf32685aac73de7fd4a6ff7470) — **32.07× faster**
 

--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -3772,6 +3772,59 @@ mod tests {
     }
 
     #[test]
+    fn test_one_per_package_data_hoists_purlless_record_dependencies() {
+        // A purl-less manifest under OnePerPackageData cannot become a package,
+        // but its dependencies must still be hoisted (unowned) rather than
+        // dropped — the visibility they had before the datasource was assembled.
+        let mut files = vec![
+            create_test_file_info(
+                "proj/meson.build",
+                DatasourceId::MesonBuild,
+                Some("pkg:meson/proj@1.0"),
+                Some("proj"),
+                Some("1.0"),
+                vec![create_test_dependency("pkg:generic/meson/zlib", None, None)],
+            ),
+            create_test_file_info(
+                "proj/sub/meson.build",
+                DatasourceId::MesonBuild,
+                None,
+                None,
+                None,
+                vec![create_test_dependency(
+                    "pkg:generic/meson/openssl",
+                    None,
+                    None,
+                )],
+            ),
+        ];
+
+        let result = assemble(&mut files);
+
+        let proj = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("proj"))
+            .expect("project()-bearing meson.build should promote to a package");
+        assert!(
+            result.dependencies.iter().any(|d| {
+                d.purl.as_deref() == Some("pkg:generic/meson/zlib")
+                    && d.for_package_uid.as_ref() == Some(&proj.package_uid)
+            }),
+            "the named project must own its dependency"
+        );
+        let hoisted = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:generic/meson/openssl"))
+            .expect("a purl-less record's dependency must be hoisted, not dropped");
+        assert!(
+            hoisted.for_package_uid.is_none(),
+            "the hoisted dependency has no owning package"
+        );
+    }
+
+    #[test]
     fn test_assemble_python_standalone_wheel_creates_top_level_package() {
         let mut files = vec![create_test_file_info(
             "dist/construct-2.10.68-py3-none-any.whl",

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -143,10 +143,7 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
                     apply_directory_merge_results(files, &mut packages, &mut dependencies, results);
                 }
                 AssemblyMode::OnePerPackageData => {
-                    let results = assemble_one_per_package_data(config, files, file_indices)
-                        .into_iter()
-                        .map(|(pkg, deps, affected_idx)| (Some(pkg), deps, vec![affected_idx]))
-                        .collect();
+                    let results = assemble_one_per_package_data(config, files, file_indices);
                     apply_directory_merge_results(files, &mut packages, &mut dependencies, results);
                 }
             }
@@ -322,7 +319,7 @@ fn assemble_one_per_package_data(
     config: &AssemblerConfig,
     files: &[FileInfo],
     file_indices: &[usize],
-) -> Vec<(Package, Vec<TopLevelDependency>, usize)> {
+) -> Vec<DirectoryMergeOutput> {
     let mut results = Vec::new();
 
     for &idx in file_indices {
@@ -332,17 +329,28 @@ fn assemble_one_per_package_data(
                 .datasource_id
                 .is_some_and(|dsid| config.datasource_ids.contains(&dsid));
 
-            if !dsid_matches
-                || pkg_data.purl.is_none()
-                || should_skip_placeholder_only_cocoapods_podspec(pkg_data)
-            {
+            if !dsid_matches || should_skip_placeholder_only_cocoapods_podspec(pkg_data) {
                 continue;
             }
 
+            let Some(datasource_id) = pkg_data.datasource_id else {
+                continue;
+            };
             let datafile_path = file.path.clone();
-            let datasource_id = pkg_data.datasource_id.expect("datasource_id must be Some");
-            let pkg = Package::from_package_data(pkg_data, datafile_path.clone());
-            let for_package_uid = Some(pkg.package_uid.clone());
+
+            // A record carrying an identity becomes its own package that owns its
+            // dependencies. A purl-less record cannot be a package, but its
+            // dependencies are still hoisted (unowned) rather than dropped — the
+            // same visibility they had before this datasource was assembled.
+            let (package, affected) = if pkg_data.purl.is_some() {
+                (
+                    Some(Package::from_package_data(pkg_data, datafile_path.clone())),
+                    vec![idx],
+                )
+            } else {
+                (None, Vec::new())
+            };
+            let for_package_uid = package.as_ref().map(|pkg| pkg.package_uid.clone());
 
             let deps: Vec<TopLevelDependency> = pkg_data
                 .dependencies
@@ -358,7 +366,11 @@ fn assemble_one_per_package_data(
                 })
                 .collect();
 
-            results.push((pkg, deps, idx));
+            if package.is_none() && deps.is_empty() {
+                continue;
+            }
+
+            results.push((package, deps, affected));
         }
     }
 

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -262,6 +262,27 @@ pub(super) fn assemble_siblings_per_identity(
         ));
     }
 
+    // Handled files with no purl cannot join a specific identity in a
+    // multi-identity directory, but their dependencies are still hoisted
+    // (unowned) rather than dropped — the same visibility they had before the
+    // directory was split per identity.
+    let mut orphan_pending: Vec<PendingDependency> = Vec::new();
+    for &idx in file_indices {
+        for pkg_data in &files[idx].package_data {
+            if !is_handled_by(pkg_data, config) || pkg_data.purl.is_some() {
+                continue;
+            }
+            orphan_pending.extend(collect_pending_dependencies(pkg_data, &files[idx].path));
+        }
+    }
+    if !orphan_pending.is_empty() {
+        results.push(build_directory_merge_output(
+            None,
+            orphan_pending,
+            Vec::new(),
+        ));
+    }
+
     results
 }
 


### PR DESCRIPTION
## Summary

- **Fix (assembly):** the `OnePerPackageData` and `SiblingMergePerIdentity` promotions dropped the dependencies of any record that carried no resolvable purl (e.g. a `build.sbt` with `libraryDependencies` but no `organization`/`version`, or a purl-less `packages.config` in a multi-project dir). This regressed against the prior `UNASSEMBLED` behavior, which hoisted those deps as orphaned (unowned but visible). Both paths now emit such deps as hoisted (`for_package_uid: null`) instead of dropping them. Purl-bearing records still become packages that own their deps.
- **Refresh (docs):** PV-only re-scan of every promotion-affected `docs/BENCHMARKS.md` row with the fix in place (and, after #1179 merged, the `mix.exs` parser), recording current package/dependency counts. Provenant-side counts re-measured at each row's pinned ref; ScanCode-side numbers and recorded timings are unchanged (those targets are parity gaps precisely because ScanCode does not parse these manifests, and the ScanCode side did not change).

### Fix evidence

| Row | Deps before fix | Deps after fix |
|---|---|---|
| playframework | 3 (4 purl-less `build.sbt` dropped) | **7** |
| microsoft/terminal | 35 (purl-less `packages.config` dropped) | **40** |

### Rows refreshed

| Row | Change |
|---|---|
| akka/akka | 11 vs 7 packages, 49 vs 40 deps |
| erlang/otp | **51 vs 0** packages (41 `pkg:hex` `.app.src` + 10 `pkg:autotools` `configure.ac`) |
| ocaml/dune | 257 vs 2 packages, 130 vs 116 deps |
| microsoft/vcpkg @0bf3923 | 1521 `pkg:generic/vcpkg` packages, 4677 deps |
| microsoft/vcpkg @b21ff8f | **2942 vs 1** packages (recorded 2 predated the port promotion) |
| processone/ejabberd | **3 vs 1** packages (hex/autotools/npm) |
| ocaml/merlin | **5 vs 0** packages (one `pkg:opam` per manifest + `flake.lock`) |
| ocaml/ocaml-lsp | **11 vs 1** packages (one `pkg:opam` per manifest + `flake.lock`/npm/autotools) |
| microsoft/terminal | **17 vs 2** packages, 40 vs 0 deps |
| bitwalker/distillery | **6 vs 0** packages, 399 vs 0 deps (one `pkg:hex` per `mix.exs`) |
| elixir-ecto/ecto | **2 vs 0** packages, 27 vs 0 deps |
| elixir-plug/plug | **1 vs 0** packages, 13 vs 0 deps |
| phoenixframework/phoenix | hex packages now versioned from `mix.exs`, merged with lockfiles |
| leiningen, vernemq, scalatest, arch grep, arch pacman, playframework | re-scan identical to recorded counts |

## Issues

- Covers: dependency-hoisting regression from the package-promotion campaign, plus refreshing the affected benchmark rows.

## Scope and exclusions

- Included: the assembly hoisting fix, a focused assembly contract test, and the affected outcome-bullet text in `docs/BENCHMARKS.md`.
- Excluded: timings (kept as recorded — PV-only refresh does not re-time) and the scan-duration chart (unchanged — no timing change here).

## How to verify

- `cargo test --lib assembly` and `cargo test --features golden-tests --test assembly_golden`.
- New test `test_one_per_package_data_hoists_purlless_record_dependencies` proves a purl-less manifest under a promotion keeps its dependency as hoisted rather than dropped.
- Benchmark counts taken from re-scans of each pinned ref with the current optimized binary; ScanCode counts carried from the recorded runs.

## Expected-output fixture changes

- None (the fix adds previously-dropped hoisted dependencies; existing assembly goldens pass unchanged).
