### PR TITLE
fix(license): stop clue and low-coverage partial matches leaking into detected license expression

### DIFF
--- a/src/license_detection/detection/analysis_test.rs
+++ b/src/license_detection/detection/analysis_test.rs
@@ -1630,3 +1630,27 @@ fn test_is_license_reference_local_file_false_none() {
     let m = create_test_match(100.0, "mit.RULE");
     assert!(!is_license_reference_local_file(&m));
 }
+
+#[test]
+fn analyze_detection_classifies_sub_threshold_exception_partial_as_low_quality() {
+    // A ~38% partial match of an `is_exception` license sharing generic
+    // boilerplate (e.g. emq-use-grant-for-bsl-1.1 inside a BSL-1.1 LICENSE)
+    // is a low-quality fragment, not a license assertion. ScanCode keeps it as
+    // a clue.
+    let m = create_test_match_full(
+        "emq-use-grant-for-bsl-1.1",
+        "3-seq",
+        1,
+        12,
+        MatchScore::from_percentage(38.01),
+        65,
+        171,
+        38.01,
+        100,
+        "emq-use-grant-for-bsl-1.1.LICENSE",
+    );
+    assert_eq!(
+        analyze_detection(std::slice::from_ref(&m), false),
+        "low-quality-match-fragments"
+    );
+}

--- a/src/post_processing/output_test/reference_following_local_test.rs
+++ b/src/post_processing/output_test/reference_following_local_test.rs
@@ -691,15 +691,16 @@ fn apply_local_file_reference_following_does_not_reuse_followed_license_as_secon
         .iter()
         .find(|file| file.path == "project/ncat/ncat_core.h")
         .expect("source file should exist");
+    // The reference must not resolve to the already-followed license; with no
+    // resolvable target the bare `See LICENSE` reference is a clue, not a
+    // detected license.
+    assert_eq!(source.detected_license_expression, None);
+    assert!(source.license_detections.is_empty());
+    assert_eq!(source.license_clues.len(), 1);
     assert_eq!(
-        source.detected_license_expression.as_deref(),
-        Some("unknown-license-reference")
+        source.license_clues[0].license_expression,
+        "unknown-license-reference"
     );
-    assert_eq!(
-        source.license_detections[0].detection_log,
-        Vec::<String>::new()
-    );
-    assert_eq!(source.license_detections[0].matches.len(), 1);
 }
 
 #[test]
@@ -764,11 +765,12 @@ fn apply_local_file_reference_following_requires_exact_filename_match() {
         .iter()
         .find(|file| file.path == "project/src/notice.js")
         .expect("notice file should exist");
-    assert_eq!(
-        notice.detected_license_expression.as_deref(),
-        Some("unknown-license-reference")
-    );
-    assert_eq!(notice.license_detections[0].matches.len(), 1);
+    // `LICENSE.txt` does not match the sibling `LICENSE`, so the reference does
+    // not resolve and the bare reference stays a clue rather than asserting a
+    // license.
+    assert_eq!(notice.detected_license_expression, None);
+    assert!(notice.license_detections.is_empty());
+    assert_eq!(notice.license_clues.len(), 1);
 }
 
 #[test]
@@ -833,12 +835,11 @@ fn apply_local_file_reference_following_does_not_search_unrelated_top_level_dire
         .iter()
         .find(|file| file.path == "docs/3rd-party-licenses.txt")
         .expect("notice file should exist");
-    assert_eq!(
-        notice.detected_license_expression.as_deref(),
-        Some("unknown-license-reference")
-    );
-    assert_eq!(notice.license_detections[0].matches.len(), 1);
-    assert!(notice.license_detections[0].detection_log.is_empty());
+    // The unrelated top-level `libssh2/COPYING` must not be searched, so the
+    // reference does not resolve and the bare reference stays a clue.
+    assert_eq!(notice.detected_license_expression, None);
+    assert!(notice.license_detections.is_empty());
+    assert_eq!(notice.license_clues.len(), 1);
 }
 
 #[test]

--- a/src/post_processing/output_test/reference_following_package_test.rs
+++ b/src/post_processing/output_test/reference_following_package_test.rs
@@ -815,12 +815,16 @@ fn apply_package_reference_following_leaves_ambiguous_multi_package_file_unresol
         .iter()
         .find(|file| file.path == "project/shared/locale.po")
         .expect("shared file should exist");
+    // The reference is ambiguous across two packages and does not resolve, so
+    // the bare `free-unknown` reference stays a clue rather than asserting a
+    // license.
+    assert_eq!(shared_file.detected_license_expression, None);
+    assert!(shared_file.license_detections.is_empty());
+    assert_eq!(shared_file.license_clues.len(), 1);
     assert_eq!(
-        shared_file.detected_license_expression.as_deref(),
-        Some("free-unknown")
+        shared_file.license_clues[0].license_expression,
+        "free-unknown"
     );
-    assert_eq!(shared_file.license_detections[0].matches.len(), 1);
-    assert!(shared_file.license_detections[0].detection_log.is_empty());
 }
 
 #[test]

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -82,6 +82,71 @@ pub(crate) fn apply_package_reference_following(files: &mut [FileInfo], packages
             break;
         }
     }
+
+    for file in files
+        .iter_mut()
+        .filter(|file| file.file_type == FileType::File)
+    {
+        demote_unresolved_reference_detections_to_clues(file);
+    }
+}
+
+/// True if a detection still carries a bare, unresolved reference placeholder
+/// expression (a "See the license in COPYING" / "distributed under the same
+/// license as the X project" match whose referenced license was never
+/// resolved). These are clues, not assertions: ScanCode reports an unresolved
+/// `unknown-file-reference-local` group as `license_clues` (no combined
+/// expression) at detection time, and only promotes it to a real detection
+/// once reference following resolves the referenced license. After the
+/// reference-following passes above have run, any file-level detection still
+/// carrying one of these placeholder expressions failed to resolve and must
+/// not leak into `detected_license_expression` / `license_detections`.
+fn is_unresolved_reference_placeholder_detection(detection: &LicenseDetection) -> bool {
+    matches!(
+        detection.license_expression.as_str(),
+        "unknown-license-reference" | "free-unknown"
+    ) && detection
+        .matches
+        .iter()
+        .all(is_unknown_reference_like_match_public)
+}
+
+fn is_unknown_reference_like_match_public(match_item: &Match) -> bool {
+    matches!(
+        match_item.license_expression.as_str(),
+        "unknown-license-reference" | "free-unknown"
+    )
+}
+
+/// Move unresolved reference-placeholder detections out of `license_detections`
+/// and into `license_clues`, then recompute the file-level
+/// `detected_license_expression` from the surviving real detections. This keeps
+/// the placeholder matches visible as weak evidence (matching ScanCode's
+/// `license_clues`) while ensuring they no longer assert a license.
+fn demote_unresolved_reference_detections_to_clues(file: &mut FileInfo) {
+    if !file
+        .license_detections
+        .iter()
+        .any(is_unresolved_reference_placeholder_detection)
+    {
+        return;
+    }
+
+    let mut surviving = Vec::with_capacity(file.license_detections.len());
+    for detection in std::mem::take(&mut file.license_detections) {
+        if is_unresolved_reference_placeholder_detection(&detection) {
+            file.license_clues.extend(detection.matches);
+        } else {
+            surviving.push(detection);
+        }
+    }
+    file.license_detections = surviving;
+
+    file.detected_license_expression = combine_license_expressions(
+        file.license_detections
+            .iter()
+            .map(|detection| detection.license_expression.clone()),
+    );
 }
 
 fn collect_referenced_file_paths(files: &[FileInfo]) -> HashSet<String> {
@@ -1767,5 +1832,106 @@ mod tests {
             font.license_detections[0].matches[0].from_file.as_deref(),
             Some("fonts/OFL.txt")
         );
+    }
+
+    fn placeholder_reference_match(expression: &str, rule_identifier: &str) -> Match {
+        Match {
+            license_expression: expression.to_string(),
+            license_expression_spdx: format!("LicenseRef-scancode-{expression}"),
+            from_file: None,
+            start_line: LineNumber::new(10).unwrap(),
+            end_line: LineNumber::new(10).unwrap(),
+            matcher: MatcherKind::Aho,
+            score: MatchScore::MAX,
+            matched_length: Some(8),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: rule_identifier.to_string(),
+            rule_url: None,
+            matched_text: None,
+            referenced_filenames: Some(vec!["INHERIT_LICENSE_FROM_PACKAGE".to_string()]),
+            matched_text_diagnostics: None,
+        }
+    }
+
+    #[test]
+    fn apply_package_reference_following_demotes_unresolved_free_unknown_to_clue() {
+        // A `.po` file with a "distributed under the same license as the X
+        // project" free-unknown reference and no resolvable package context.
+        // The reference can't resolve, so it must become a clue rather than
+        // leaking `free-unknown` into the detected expression.
+        let mut po = file("project/locale/messages.po");
+        po.license_detections = vec![crate::models::LicenseDetection {
+            license_expression: "free-unknown".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+            matches: vec![placeholder_reference_match(
+                "free-unknown",
+                "free-unknown-package_4.RULE",
+            )],
+            detection_log: vec!["unknown-reference-to-local-file".to_string()],
+            identifier: "free-unknown-id".to_string(),
+        }];
+        po.detected_license_expression = Some("free-unknown".to_string());
+
+        let mut files = vec![po];
+        apply_package_reference_following(&mut files, &mut []);
+        let po = files.remove(0);
+
+        assert!(po.license_detections.is_empty());
+        assert_eq!(po.license_clues.len(), 1);
+        assert_eq!(po.license_clues[0].license_expression, "free-unknown");
+        assert_eq!(po.detected_license_expression, None);
+    }
+
+    #[test]
+    fn apply_package_reference_following_keeps_unresolved_placeholder_alongside_real_detection() {
+        // A real detection in the same file must survive; only the unresolved
+        // placeholder is demoted, and the file expression keeps the real key.
+        let mut f = file("project/locale/messages.po");
+        f.license_detections = vec![
+            crate::models::LicenseDetection {
+                license_expression: "apache-2.0".to_string(),
+                license_expression_spdx: "Apache-2.0".to_string(),
+                matches: vec![Match {
+                    license_expression: "apache-2.0".to_string(),
+                    license_expression_spdx: "Apache-2.0".to_string(),
+                    from_file: Some("project/locale/messages.po".to_string()),
+                    start_line: LineNumber::new(20).unwrap(),
+                    end_line: LineNumber::new(40).unwrap(),
+                    matcher: MatcherKind::Seq,
+                    score: MatchScore::from_percentage(73.0),
+                    matched_length: Some(60),
+                    match_coverage: Some(73.0),
+                    rule_relevance: Some(100),
+                    rule_identifier: "apache-2.0_932.RULE".to_string(),
+                    rule_url: None,
+                    matched_text: None,
+                    referenced_filenames: None,
+                    matched_text_diagnostics: None,
+                }],
+                detection_log: vec![],
+                identifier: "apache-id".to_string(),
+            },
+            crate::models::LicenseDetection {
+                license_expression: "free-unknown".to_string(),
+                license_expression_spdx: "LicenseRef-scancode-free-unknown".to_string(),
+                matches: vec![placeholder_reference_match(
+                    "free-unknown",
+                    "free-unknown-package_4.RULE",
+                )],
+                detection_log: vec!["unknown-reference-to-local-file".to_string()],
+                identifier: "free-unknown-id".to_string(),
+            },
+        ];
+        f.detected_license_expression = Some("apache-2.0 AND free-unknown".to_string());
+
+        let mut files = vec![f];
+        apply_package_reference_following(&mut files, &mut []);
+        let f = files.remove(0);
+
+        assert_eq!(f.license_detections.len(), 1);
+        assert_eq!(f.license_detections[0].license_expression, "apache-2.0");
+        assert_eq!(f.license_clues.len(), 1);
+        assert_eq!(f.detected_license_expression.as_deref(), Some("apache-2.0"));
     }
 }

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -667,6 +667,21 @@ fn promote_legal_notice_low_quality_detections(
             continue;
         }
 
+        // Only recover fragments that lost quality to extra words, not ones
+        // whose match coverage is itself below the clue threshold. A genuine
+        // notice fragment (e.g. a lightly modified Apache notice) still covers
+        // most of its rule; a sub-threshold partial match is a clue, not an
+        // assertion. Promoting those would re-introduce false positives such as
+        // a BSL-1.1 LICENSE partially matching the shared boilerplate of an
+        // unrelated `is_exception` license at ~38% coverage. ScanCode keeps
+        // those as `license_clues`.
+        if detection.matches.iter().any(|license_match| {
+            license_match.coverage()
+                < crate::license_detection::detection::analysis::CLUES_MATCH_COVERAGE_THR
+        }) {
+            continue;
+        }
+
         let Some(license_expression) =
             crate::utils::spdx::combine_license_expressions_preserving_structure(
                 detection

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -440,10 +440,14 @@ fn test_promote_legal_notice_low_quality_detections_promotes_apache_notice_fragm
         detection_log: Vec::new(),
         identifier: None,
     };
+    // A genuine notice fragment that lost quality to extra words still covers
+    // most of its rule (coverage at/above the clue threshold).
+    let mut fragment = make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8);
+    fragment.match_coverage = 88.0;
     let low_quality = InternalLicenseDetection {
         license_expression: None,
         license_expression_spdx: None,
-        matches: vec![make_internal_notice_match("apache-2.0", "Apache-2.0", 7, 8)],
+        matches: vec![fragment],
         detection_log: vec!["low-quality-match-fragments".to_string()],
         identifier: None,
     };
@@ -512,6 +516,43 @@ fn test_promote_legal_notice_low_quality_detections_ignores_true_clue_rules() {
     promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("NOTICE"));
 
     assert!(detections[1].license_expression.is_none());
+}
+
+#[test]
+fn test_promote_legal_notice_low_quality_detections_keeps_sub_threshold_partial_as_clue() {
+    // A BSL-1.1 LICENSE partially matches the shared boilerplate of an unrelated
+    // `is_exception` license at sub-threshold coverage. That is a clue, not a
+    // license assertion, and must not be promoted even in a LICENSE file.
+    let concrete = InternalLicenseDetection {
+        license_expression: Some("bsl-1.1".to_string()),
+        license_expression_spdx: Some("BUSL-1.1".to_string()),
+        matches: vec![make_internal_notice_match("bsl-1.1", "BUSL-1.1", 20, 40)],
+        detection_log: Vec::new(),
+        identifier: None,
+    };
+    let mut partial = make_internal_notice_match(
+        "emq-use-grant-for-bsl-1.1",
+        "LicenseRef-scancode-emq-use-grant-for-bsl-1.1",
+        1,
+        12,
+    );
+    partial.match_coverage = 38.01;
+    partial.rule_identifier = "emq-use-grant-for-bsl-1.1.LICENSE".to_string();
+    let low_quality = InternalLicenseDetection {
+        license_expression: None,
+        license_expression_spdx: None,
+        matches: vec![partial],
+        detection_log: vec!["low-quality-match-fragments".to_string()],
+        identifier: None,
+    };
+    let mut detections = vec![concrete, low_quality];
+
+    promote_legal_notice_low_quality_detections(&mut detections, std::path::Path::new("LICENSE"));
+
+    assert!(
+        detections[1].license_expression.is_none(),
+        "sub-threshold partial must stay a clue: {detections:#?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Stop clue / low-coverage partial license matches leaking into a file's `detected_license_expression` and `license_detections`, matching ScanCode's clue semantics. Two distinct file-content false-positive assertions found via compare-outputs vs ScanCode.
- **Instance C (gettext / `free-unknown`):** a `.po` file whose only license-bearing line is "This file is distributed under the same license as the X project" matches `free-unknown-package_4.RULE` (`is_license_clue`, `referenced_filenames: INHERIT_LICENSE_FROM_PACKAGE`). ScanCode classifies this `unknown-file-reference-local` group with no combined expression at detection time (a `license_clue`), and only promotes it once reference following resolves the referenced license. Provenant deliberately keeps the placeholder detection through reference following (more aggressive package/file inheritance, exercised by existing goldens), but never demoted the ones that fail to resolve — so `free-unknown` leaked into the file expression. Added a final pass in `apply_package_reference_following` that demotes any file-level detection still carrying a bare, unresolved `free-unknown` / `unknown-license-reference` placeholder (all matches placeholder-like) into `license_clues` and recomputes the file expression. Resolved references are untouched.
- **Instance A (BSL / emq partial):** a BSL-1.1 `LICENSE` partially matches the shared boilerplate of the unrelated `is_exception` license `emq-use-grant-for-bsl-1.1` at ~38% coverage. `analyze_detection` already classifies that as `low-quality-match-fragments`, but `promote_legal_notice_low_quality_detections` then promoted it back in any legal-notice-like file regardless of coverage. Gated that promotion to fragments at or above the clue coverage threshold, so genuine notice fragments that lost quality to extra words are still recovered while sub-threshold boilerplate overlaps stay clues.

## Issues

- Covers: benchmark-verification campaign findings (apache/superset gettext `.po` files; hashicorp/terraform `LICENSE`).

## Scope and exclusions

- Included: file-content license detection only — the demotion pass and the legal-notice promotion gate.
- Explicit exclusions: package declared-license detections (`package_license=true`) are untouched; `unknown-license-reference` in package `license_detections` is still preserved for assembly. Reference-following resolution behaviour (file-to-package, root fallback, beside-manifest) is unchanged.

## How to verify

- `cargo test --features golden-tests --test post_processing_golden` and `--test license_detection_golden` (reference-following and raw-detection goldens, both green, no expected-file changes).
- Targeted units: `cargo test --lib post_processing::reference_following`, `cargo test --lib scanner::process::license`, `cargo test --lib license_detection::detection::analysis`.
- Manual: scan a directory containing a `.po` file with the line `# This file is distributed under the same license as the X project.` and no resolvable package — observe `free-unknown` now appears under `license_clues`, not `detected_license_expression`.

## Intentional differences from Python

- Provenant continues to follow `free-unknown` / `unknown-license-reference` references into packages and sibling/root LICENSE files more aggressively than ScanCode (a documented product-quality divergence). This PR only adds the ScanCode-faithful behaviour for the unresolved case (demote to clue) without weakening the resolvable path.

## Expected-output fixture changes

- None. No golden expected files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
