### PR TITLE
feat(parsers): record PEP 621 license-file reference from pyproject

### DIFF
--- a/src/parsers/python/pyproject.rs
+++ b/src/parsers/python/pyproject.rs
@@ -154,6 +154,18 @@ pub(super) fn extract(path: &Path) -> Vec<PackageData> {
     }
 
     let mut extra_data = extract_pyproject_extra_data(&toml_content).unwrap_or_default();
+    // Skip the file form when `[project].dynamic` declares `license`: per PEP 621 a
+    // dynamic field's static value is a build-time placeholder, so a stale
+    // `license = { file = "..." }` must not become an authoritative license-file
+    // reference that resolves onto the package.
+    if !project_declares_dynamic_license(project_metadata)
+        && let Some(license_file) = extract_license_file_reference(selected_metadata)
+    {
+        extra_data.insert(
+            "license_file".to_string(),
+            JsonValue::String(license_file.to_string()),
+        );
+    }
     let urls = extract_urls(
         project_metadata,
         poetry_metadata,
@@ -264,6 +276,42 @@ fn extract_raw_license_string(project: &TomlMap<String, TomlValue>) -> Option<St
                         .map(|expr| expr.to_string())
                 }),
             _ => None,
+        })
+}
+
+/// Extract a PEP 621 license-file reference from the `license = { file = "X" }`
+/// table form.
+///
+/// PEP 621 lets a project point its license field at a license file instead of
+/// inlining an expression. The referenced filename is recorded in
+/// `extra_data["license_file"]` (matching ScanCode and the existing convention
+/// honored by `finalize_package_declared_license_references`), so the package
+/// reference-following pass resolves the sibling file's detected license onto
+/// this package's declared license. The parser stays file-local and never reads
+/// the referenced file itself.
+fn extract_license_file_reference(project: &TomlMap<String, TomlValue>) -> Option<&str> {
+    match project.get(FIELD_LICENSE) {
+        Some(TomlValue::Table(license_table)) => license_table
+            .get("file")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        _ => None,
+    }
+}
+
+/// Returns whether the PEP 621 `[project]` table lists `license` in its
+/// `dynamic` array, in which case any static `license` value is a build-time
+/// placeholder that must not be treated as authoritative.
+fn project_declares_dynamic_license(project: Option<&TomlMap<String, TomlValue>>) -> bool {
+    project
+        .and_then(|table| table.get("dynamic"))
+        .and_then(|value| value.as_array())
+        .is_some_and(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.as_str())
+                .any(|entry| entry == FIELD_LICENSE)
         })
 }
 

--- a/src/parsers/python/scan_test.rs
+++ b/src/parsers/python/scan_test.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::models::{DatasourceId, PackageType};
     use crate::parsers::scan_test_utils::{
         assert_dependency_present, assert_file_links_to_package, scan_and_assemble,
+        scan_assemble_and_follow_references,
     };
     use serde_json::Value as JsonValue;
 
@@ -647,5 +648,72 @@ pytest-github-actions-annotate-failures = "^0.1.7"
         assert_eq!(gha.scope.as_deref(), Some("github-actions"));
         assert_eq!(gha.is_runtime, Some(false));
         assert_eq!(gha.is_optional, Some(true));
+    }
+
+    /// Layer-3 contract: a single-datafile PEP 621 `license = { file = "LICENSE.txt" }`
+    /// manifest leaves the parser with no inline expression, yet the sibling
+    /// LICENSE.txt's detected license resolves onto the assembled package's
+    /// declared license through the reference-following pass. This guards the
+    /// common single-manifest case end to end and confirms recording the file
+    /// form in `extra_data["license_file"]` does not disturb that resolution.
+    #[test]
+    fn test_pep621_license_file_resolves_sibling_license_onto_package() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let project = temp_dir.path();
+
+        fs::write(
+            project.join("pyproject.toml"),
+            r#"[project]
+name = "demo"
+version = "1.0.0"
+license = { file = "LICENSE.txt" }
+"#,
+        )
+        .expect("write pyproject.toml");
+
+        let apache_text = fs::read_to_string(
+            "testdata/summarycode-golden/score/no_license_ambiguity/LICENSE-APACHE",
+        )
+        .expect("read apache license fixture");
+        fs::write(project.join("LICENSE.txt"), apache_text).expect("write LICENSE.txt");
+
+        let (files, result) = scan_assemble_and_follow_references(project);
+
+        let package = result
+            .packages
+            .iter()
+            .find(|package| package.name.as_deref() == Some("demo"))
+            .expect("demo package should be assembled");
+
+        assert_eq!(
+            package.declared_license_expression.as_deref(),
+            Some("apache-2.0"),
+            "the referenced LICENSE.txt should resolve onto the package declared license"
+        );
+
+        let license_file = files
+            .iter()
+            .find(|file| file.path.ends_with("LICENSE.txt"))
+            .expect("LICENSE.txt should be scanned");
+        assert!(
+            license_file.is_referenced,
+            "the resolved license file should be marked as referenced"
+        );
+
+        // The resolved package detection should carry a match sourced from the
+        // referenced LICENSE.txt, not only the manifest's own reference clue.
+        let resolved_from_license_file = package
+            .license_detections
+            .iter()
+            .flat_map(|detection| detection.matches.iter())
+            .any(|m| {
+                m.from_file
+                    .as_deref()
+                    .is_some_and(|f| f.ends_with("LICENSE.txt"))
+            });
+        assert!(
+            resolved_from_license_file,
+            "the package license detection should include a match from the referenced LICENSE.txt"
+        );
     }
 }

--- a/src/parsers/python/test.rs
+++ b/src/parsers/python/test.rs
@@ -215,6 +215,131 @@ numpy = ">=1.20.0"
     }
 
     #[test]
+    fn test_pep621_license_string_form() {
+        let content = r#"
+[project]
+name = "demo"
+version = "1.0.0"
+license = "MIT"
+"#;
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("MIT")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("mit")
+        );
+        assert!(
+            package_data
+                .extra_data
+                .as_ref()
+                .map(|extra| !extra.contains_key("license_file"))
+                .unwrap_or(true)
+        );
+    }
+
+    #[test]
+    fn test_pep621_license_text_form() {
+        let content = r#"
+[project]
+name = "demo"
+version = "1.0.0"
+license = { text = "Apache-2.0" }
+"#;
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("Apache-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0")
+        );
+    }
+
+    #[test]
+    fn test_pep621_license_expression_form() {
+        let content = r#"
+[project]
+name = "demo"
+version = "1.0.0"
+license = { expression = "MIT OR Apache-2.0" }
+"#;
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        assert_eq!(
+            package_data.extracted_license_statement.as_deref(),
+            Some("MIT OR Apache-2.0")
+        );
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+    }
+
+    #[test]
+    fn test_pep621_license_file_form_records_license_file_reference() {
+        let content = r#"
+[project]
+name = "demo"
+version = "1.0.0"
+license = { file = "LICENSE.txt" }
+"#;
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        // The PEP 621 file form is recorded as a license-file reference in
+        // extra_data, matching ScanCode. The parser stays file-local and does not
+        // inline any expression for the file form, so the declared expression
+        // stays an honest null here; the cross-file reference-following pass
+        // resolves the referenced file's detected license downstream.
+        let extra_data = package_data
+            .extra_data
+            .as_ref()
+            .expect("extra_data should be present");
+        assert_eq!(
+            extra_data.get("license_file").and_then(|v| v.as_str()),
+            Some("LICENSE.txt")
+        );
+        assert_eq!(package_data.declared_license_expression, None);
+        assert_eq!(package_data.extracted_license_statement, None);
+    }
+
+    #[test]
+    fn test_pep621_dynamic_license_skips_stale_license_file_reference() {
+        // `license` is declared dynamic, so the static `{ file = ... }` value is a
+        // build-time placeholder and must not be recorded as an authoritative
+        // license-file reference.
+        let content = r#"
+[project]
+name = "demo"
+version = "1.0.0"
+dynamic = ["license"]
+license = { file = "OLD.txt" }
+"#;
+        let (_temp_file, file_path) = create_temp_file(content, "pyproject.toml");
+        let package_data = PythonParser::extract_first_package(&file_path);
+
+        let has_license_file = package_data
+            .extra_data
+            .as_ref()
+            .map(|extra| extra.contains_key("license_file"))
+            .unwrap_or(false);
+        assert!(
+            !has_license_file,
+            "a dynamic license must not record a stale license_file reference"
+        );
+        assert_eq!(package_data.declared_license_expression, None);
+    }
+
+    #[test]
     fn test_extract_from_pyproject_toml_with_pep621_tables_and_labeled_urls() {
         let content = r#"
 [project]

--- a/src/parsers/scan_test_utils.rs
+++ b/src/parsers/scan_test_utils.rs
@@ -37,6 +37,48 @@ pub(crate) fn scan_and_assemble(path: &Path) -> (Vec<FileInfo>, assembly::Assemb
     (files, assembly_result)
 }
 
+/// Like [`scan_and_assemble`], but runs file-content license detection with the
+/// embedded engine and then applies the package reference-following pass, so a
+/// manifest's license-file reference resolves the sibling file's detected
+/// license onto the assembled package's declared license. Use for Layer-3
+/// contract tests where that cross-file resolution is the behavior under test.
+pub(crate) fn scan_assemble_and_follow_references(
+    path: &Path,
+) -> (Vec<FileInfo>, assembly::AssemblyResult) {
+    let progress = Arc::new(ScanProgress::new(ProgressMode::Quiet));
+    let collected = collect_paths(
+        path,
+        0,
+        &build_collection_exclude_patterns(path, &path.join(DEFAULT_CACHE_DIR_NAME)),
+    );
+    let engine = Arc::new(
+        crate::license_detection::LicenseDetectionEngine::from_embedded()
+            .expect("embedded license engine should initialize"),
+    );
+    let result = process_collected(
+        &collected,
+        progress,
+        Some(engine),
+        LicenseScanOptions::default(),
+        &TextDetectionOptions {
+            collect_info: true,
+            detect_packages: true,
+            detect_application_packages: true,
+            detect_system_packages: true,
+            detect_packages_in_compiled: false,
+            ..TextDetectionOptions::default()
+        },
+    );
+
+    let mut files = result.files;
+    let mut assembly_result = assembly::assemble(&mut files);
+    crate::post_processing::apply_package_reference_following(
+        &mut files,
+        &mut assembly_result.packages,
+    );
+    (files, assembly_result)
+}
+
 pub(crate) fn scan_and_assemble_with_stripped_root(
     path: &Path,
 ) -> (Vec<FileInfo>, assembly::AssemblyResult) {


### PR DESCRIPTION
## Summary

- The pyproject parser dropped the PEP 621 license-file form (`license = { file = "LICENSE.txt" }`), recording nothing for it. It now records the referenced filename in `extra_data["license_file"]`, matching ScanCode and the existing convention consumed by `finalize_package_declared_license_references` and the cross-file reference-following pass.
- The parser stays file-local (never reads the referenced file). For the common single-manifest case, the post-assembly reference-following pass resolves the sibling LICENSE's detected license onto the package's declared license.

## Issues

- Covers: benchmark-verification gap B' (apache/superset PEP 621 `license = { file = "LICENSE.txt" }` left `declared_license_expression: null`).

## Scope and exclusions

- Included: PEP 621 `{ file = ... }` extraction into `extra_data["license_file"]`; parser unit tests for all four license forms (string/text/expression/file); a Layer-3 scanner+assembly contract test for the single-datafile file form.
- Explicit exclusions: the two assembly-level resolution gaps below are deliberately deferred (boundary-crossing → ADR-first per repo norms). No production assembly behavior is changed by this PR.

## How to verify

- `cargo test --lib parsers::python` and `cargo test --lib license_normalization` — the new parser unit tests and the Layer-3 contract test pass.
- CI covers the rest (clippy, fmt, golden, doc tests). Parser/post-processing golden suites show zero drift (322 + 22 unchanged).

## Intentional differences from Python

- None in observable output. This PR brings the recorded `extra_data["license_file"]` to parity with ScanCode for the file form.

## Follow-up work

Two assembly-level gaps block full declared-license resolution for the file form and are intentionally deferred to an ADR (they change a deliberately-bounded enrichment pass with regression history — see ADR 0002/0010 and #1077/#1081):

1. **Multi-datafile manifest-adopt (the actual superset case).** `apache/superset`'s top-level `pkg:pypi/apache-superset` aggregates 8 datafiles (pyproject.toml, requirements/*, setup.py). The reference-following manifest-adopt enrichment (`sync_packages_from_followed_package_data`) only adopts a manifest file's resolved file-level detection when `package.datafile_paths.len() == 1`, so a license referenced by one of several manifests is never adopted. Note: Provenant already detects `apache-2.0 AND ofl-1.1` at the pyproject **file** level via the `unknown-license-reference_see_license_at_manifest` rule — it just isn't synced onto the multi-datafile package. Relaxing this guard safely (adopt only from the specific resolved datafile, without smearing) needs an ADR.

2. **Synthesized vs file-content reference detection (non-rule filenames).** For referenced filenames without a dedicated `see license at manifest` file-content rule (e.g. `COPYING`, `LICENSE.md`), resolution would require `finalize_package_declared_license_references` to synthesize a package-level `unknown-license-reference` detection carrying the referenced filename. Prototyping this regressed the cargo `manifest_origin_local_file` golden: for `LICENSE`/`LICENSE.txt`, the manifest's file-content `see_license_at_manifest` detection already resolves, so the synthesized package detection produces a duplicate top-level detection. Doing this cleanly needs dedup between the two resolution paths — also an ADR-tracked assembly change.

- Also deferred: gap **B** (hashicorp/terraform Go package, no declared license at all, resolved by ScanCode from the repo-root LICENSE). Go declares no license field, so this is the ADR-0010 `promote_package_declared_license_from_legal_files` territory rather than a parser fix; it needs the same multi-datafile / co-hosted-legal-file assembly work and is out of scope here.

## Expected-output fixture changes

- None. No golden/expected fixtures changed; the parser-only change records metadata and does not alter any covered fixture's output.
