### PR TITLE
docs(benchmarks): record terraform, superset, and godot verification rows

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 229 of 229 recorded runs, with a **19.1× median speedup** and **19.1× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.6×** on 10k+ file targets.
+> Provenant is faster on 232 of 232 recorded runs, with a **19.2× median speedup** and **19.2× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -128,6 +128,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-17 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `50.99s`; ScanCode `1158.57s`
 - Far broader Python/provider package coverage (`142` vs `1`) and dependency extraction (`7599` vs `1014`) from `uv.lock`, provider `pyproject.toml`, and committed `pnpm-lock.yaml` inputs, plus extra Docker and Helm package visibility, safer URL credential stripping, and cleaner copyright/author normalization across large documentation and kernel-style metadata blocks
+
+##### [apache/superset @ cd8ac41](https://github.com/apache/superset/tree/cd8ac41d169dfeced733b7db47b8146fe4667b3a) — **36.2× faster**
+
+- Files: 9,925
+- Run context: 2026-06-29 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `35.25s`; ScanCode `1276.89s`
+- Far broader Python/JS package and dependency extraction (`37` vs `1` packages, `8219` vs `171` dependencies) from `requirements/*.txt`, root and websocket `pyproject.toml`/`package.json`, `uv.lock`, multiple `yarn.lock`/`package-lock.json`, Docker, `.gitmodules` GitHub Actions, and Helm inputs — including Yarn `resolutions` and npm `overrides` surfaced as `is_pinned` dependencies ScanCode omits — with the assembled `pkg:pypi/apache-superset` package carrying the complete `apache-2.0 AND ofl-1.1` declared license from its `LICENSE.txt` where ScanCode reports only `apache-2.0`, plus rejection of the placeholder and binary-noise emails ScanCode emits such as the templated `GITHUB_ACTOR` actor address, the gettext `LL@li.org` placeholder, and `.parquet` byte-pairs
 
 ##### [astral-sh/uv @ 9581f2b](https://github.com/astral-sh/uv/tree/9581f2b0ea65550a3efe28bd7aabde19d98b39ba) — **28.81× faster**
 
@@ -804,6 +811,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `15.66s`; ScanCode `412.03s`
 - Broader package and dependency extraction from `flake.nix`, `flake.lock`, `Dockerfile`, and `uv.lock`, plus a correct root Go module identity on `go.mod` where ScanCode emits the malformed `pkg:golang/%28` package row, with remaining license deltas confined to generated `assets/go-licenses.json` inventory noise and README author prose
 
+##### [godotengine/godot @ d7c45b1](https://github.com/godotengine/godot/tree/d7c45b19ccf6ddadc73d1c8423cd2848f59de437) — **34.0× faster**
+
+- Files: 14,013
+- Run context: 2026-06-29 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `76.33s`; ScanCode `2591.46s`
+- Broader package and dependency extraction (`17` vs `1` packages, `214` vs `187` dependencies) across the `modules/mono` `.csproj` NuGet manifests ScanCode misses, with cleaner license accounting over the large `thirdparty/` tree: deduplicated, flattened compound expressions on multi-license registries such as `COPYRIGHT.txt`, `thirdparty/libjpeg-turbo/LICENSE.md`, and `glslang/LICENSE.txt` where ScanCode emits deeply nested duplicate groups; the more specific `(riverbank-sip OR gpl-2.0 OR gpl-3.0)` over ScanCode's vague `other-copyleft`; the more complete `info-zip-2009-01 AND zlib` on `minizip/unzip.c` where ScanCode reports only `zlib`; and rejection of ScanCode false positives such as `gpl-2.0 WITH universal-foss-exception-1.0` matched at 12.9% coverage against a BSD "see LICENSE" header and `ngpl` matched inside an ICU `.dat` binary
+
 ##### [goharbor/harbor @ eb944bb](https://github.com/goharbor/harbor/tree/eb944bb199211d6ac76fb207cd2ef1bf33ec0030) — **25.16× faster**
 
 - Files: 3,233
@@ -831,6 +845,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `13.06s`; ScanCode `428.07s`
 - Broader Debian source-package and dependency extraction (`23` vs `19` packages, `18` vs `0` dependencies) from the root multi-binary `debian/control` file plus committed `.dsc` fixtures, with explicit package visibility for `dpkg-dev`, `libdpkg-dev`, and `libdpkg-perl` and one extra top-level Autotools package on `configure.ac`
+
+##### [hashicorp/terraform @ e02391a](https://github.com/hashicorp/terraform/tree/e02391ad384c9c38f1d7f40b853c0d2297348094) — **35.6× faster**
+
+- Files: 5,425
+- Run context: 2026-06-29 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.96s`; ScanCode `354.17s`
+- Cleaner URL extraction that rejects `{account}`-templated host placeholders ScanCode emits as navigable URLs, and author capture that drops the README maintainer prose ScanCode records as a party, on otherwise matched Go module package, dependency, and declared-license coverage — the assembled `pkg:golang/github.com/hashicorp/terraform` resolves the repo-root `LICENSE` to the same `bsl-1.1 AND mpl-2.0` ScanCode reports
 
 ##### [kubernetes/autoscaler @ 9045d28](https://github.com/kubernetes/autoscaler/tree/9045d287a3458d6ea7440c3dcf921806bc994224) — **32.10× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -584,6 +584,9 @@ ScanCode: 476.87s</title></rect>
     <rect x="683.64" y="322.63" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/felix-dev @ 20aee77
 Files: 5356
 ScanCode: 640.75s</title></rect>
+    <rect x="684.52" y="350.65" width="8" height="8" fill="#d97706" rx="1.5"><title>hashicorp/terraform @ e02391a
+Files: 5425
+ScanCode: 354.17s</title></rect>
     <rect x="684.52" y="383.27" width="8" height="8" fill="#d97706" rx="1.5"><title>mesonbuild/meson @ b300d95
 Files: 5425
 ScanCode: 177.55s</title></rect>
@@ -650,6 +653,9 @@ ScanCode: 680.60s</title></rect>
     <rect x="725.29" y="281.69" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 ScanCode: 1524.08s</title></rect>
+    <rect x="726.15" y="290.05" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/superset @ cd8ac41
+Files: 9925
+ScanCode: 1276.89s</title></rect>
     <rect x="726.36" y="321.28" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/maven @ 459de76
 Files: 9955
 ScanCode: 659.41s</title></rect>
@@ -692,6 +698,9 @@ ScanCode: 1155.18s</title></rect>
     <rect x="748.21" y="346.54" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/vcpkg @ b21ff8f
 Files: 13670
 ScanCode: 386.36s</title></rect>
+    <rect x="749.92" y="256.61" width="8" height="8" fill="#d97706" rx="1.5"><title>godotengine/godot @ d7c45b1
+Files: 14013
+ScanCode: 2591.46s</title></rect>
     <rect x="751.78" y="274.80" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/vscode @ 0c1e100
 Files: 14398
 ScanCode: 1763.40s</title></rect>
@@ -1273,6 +1282,9 @@ Provenant: 11.06s</title></circle>
     <circle cx="687.64" cy="476.80" r="4.5" fill="#2563eb"><title>apache/felix-dev @ 20aee77
 Files: 5356
 Provenant: 26.70s</title></circle>
+    <circle cx="688.52" cy="523.39" r="4.5" fill="#2563eb"><title>hashicorp/terraform @ e02391a
+Files: 5425
+Provenant: 9.96s</title></circle>
     <circle cx="688.52" cy="525.87" r="4.5" fill="#2563eb"><title>mesonbuild/meson @ b300d95
 Files: 5425
 Provenant: 9.45s</title></circle>
@@ -1339,6 +1351,9 @@ Provenant: 26.73s</title></circle>
     <circle cx="729.29" cy="459.45" r="4.5" fill="#2563eb"><title>microsoft/onnxruntime @ 97e0a00
 Files: 9802
 Provenant: 38.54s</title></circle>
+    <circle cx="730.15" cy="463.67" r="4.5" fill="#2563eb"><title>apache/superset @ cd8ac41
+Files: 9925
+Provenant: 35.25s</title></circle>
     <circle cx="730.36" cy="465.68" r="4.5" fill="#2563eb"><title>apache/maven @ 459de76
 Files: 9955
 Provenant: 33.78s</title></circle>
@@ -1381,6 +1396,9 @@ Provenant: 33.43s</title></circle>
     <circle cx="752.21" cy="517.22" r="4.5" fill="#2563eb"><title>microsoft/vcpkg @ b21ff8f
 Files: 13670
 Provenant: 11.35s</title></circle>
+    <circle cx="753.92" cy="427.16" r="4.5" fill="#2563eb"><title>godotengine/godot @ d7c45b1
+Files: 14013
+Provenant: 76.33s</title></circle>
     <circle cx="755.78" cy="456.66" r="4.5" fill="#2563eb"><title>microsoft/vscode @ 0c1e100
 Files: 14398
 Provenant: 40.89s</title></circle>


### PR DESCRIPTION
## Summary

Records three new `compare-outputs` benchmark rows, verified on the current `main` after the campaign's fixes landed (#1181 npm resolutions/overrides, #1182 license clue-leak, #1183 PEP 621 license-file, #1184 ADR-0010 package-license-from-files, #1187 co-hosted-license key/SPDX form):

| Target | Files | Provenant | ScanCode | Speedup |
|---|---|---|---|---|
| [hashicorp/terraform @ e02391a](https://github.com/hashicorp/terraform/tree/e02391ad384c9c38f1d7f40b853c0d2297348094) | 5,425 | 9.96s | 354.17s | 35.6× |
| [apache/superset @ cd8ac41](https://github.com/apache/superset/tree/cd8ac41d169dfeced733b7db47b8146fe4667b3a) | 9,925 | 35.25s | 1276.89s | 36.2× |
| [godotengine/godot @ d7c45b1](https://github.com/godotengine/godot/tree/d7c45b19ccf6ddadc73d1c8423cd2848f59de437) | 14,013 | 76.33s | 2591.46s | 34.0× |

End-state highlights (Provenant vs ScanCode):

- **terraform** — assembled `pkg:golang/.../terraform` carries `bsl-1.1 AND mpl-2.0` from the repo-root LICENSE (`go.mod` declares none); EMQ use-grant boilerplate demoted to a clue; cleaner URL/author handling. Package/dep counts at parity.
- **superset** — far broader extraction (`37` vs `1` packages, `8219` vs `171` deps) incl. Yarn `resolutions`/npm `overrides` as pinned deps; main package `apache-2.0 AND ofl-1.1` (more complete than ScanCode's `apache-2.0`); gettext `.po` kept clean `apache-2.0`; placeholder/binary-noise emails rejected.
- **godot** — broader extraction (`17` vs `1` packages) from `modules/mono` csproj; cleaner license accounting over `thirdparty/` (deduped compound expressions, more specific classifications, ScanCode FP rejection like a 12.9%-coverage `gpl-2.0 WITH universal-foss-exception` on a BSD header).

## How to verify

- `docs/scan-duration-vs-files.svg` regenerated via `generate-benchmark-chart` (now 232 recorded runs, 19.2× median).
- `npm run check:docs` passes (markdownlint + prettier).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)