### PR TITLE
fix(post-processing): mirror reference-following SPDX fields on key structure

### DIFF
--- a/.license-headers.toml
+++ b/.license-headers.toml
@@ -197,6 +197,7 @@ derived = [
   "src/parsers/windows_executable.rs",
   "src/parsers/yarn_lock.rs",
   "src/post_processing/classification.rs",
+  "src/post_processing/license_expression_render.rs",
   "src/post_processing/license_policy.rs",
   "src/post_processing/license_references.rs",
   "src/post_processing/mod.rs",

--- a/src/post_processing/license_expression_render.rs
+++ b/src/post_processing/license_expression_render.rs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: nexB Inc. and others
+// ScanCode is a trademark of nexB Inc.
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+// Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
+
+//! Rendering a license expression's SPDX form so it *mirrors* an already-combined
+//! key (scancode-key) expression's `AND`/`OR`/`WITH` structure, rather than
+//! independently re-combining the per-detection `license_expression_spdx` strings.
+//!
+//! The latter loses structure: AND-combining individual SPDX operands tightens a
+//! file-level `OR` into an `AND`, and skipping detections that lack an SPDX id can
+//! leak scancode-key text into the SPDX field. Deriving the SPDX form from the key
+//! expression via a per-detection key<->SPDX token correspondence keeps the exact
+//! operator structure and yields an absent field (never key-form text) when any
+//! operand has no SPDX id.
+
+use std::collections::HashMap;
+
+use crate::models::LicenseDetection;
+
+/// Renders the SPDX form of `key_expression` by mapping each license-key token through
+/// the key->SPDX correspondence built from `detections`, preserving the key
+/// expression's `AND`/`OR`/`WITH` structure. Returns `None` (an absent SPDX field,
+/// never key-form text) when any operand lacks an SPDX id — e.g. a custom/unmapped
+/// license — matching the strict rendering used by declared-license promotion.
+pub(super) fn spdx_expression_mirroring_key(
+    key_expression: &str,
+    detections: &[LicenseDetection],
+) -> Option<String> {
+    let (_, token_to_spdx) = detection_token_maps(detections);
+    render_license_expression(key_expression, &token_to_spdx, true)
+}
+
+/// Builds case-insensitive token maps from a set of detections: license-key token →
+/// canonical key form, and license-key token → SPDX id. Each detection's
+/// `license_expression` and `license_expression_spdx` share the same operator
+/// structure, so their license tokens align positionally. Both the key and the SPDX
+/// spelling of every token are indexed, so an expression in *either* form resolves.
+pub(super) fn detection_token_maps(
+    detections: &[LicenseDetection],
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut token_to_key: HashMap<String, String> = HashMap::new();
+    let mut token_to_spdx: HashMap<String, String> = HashMap::new();
+    for detection in detections {
+        let pairs = std::iter::once((
+            detection.license_expression.as_str(),
+            detection.license_expression_spdx.as_str(),
+        ))
+        .chain(detection.matches.iter().map(|match_item| {
+            (
+                match_item.license_expression.as_str(),
+                match_item.license_expression_spdx.as_str(),
+            )
+        }));
+        for (key_expression, spdx_expression) in pairs {
+            let keys = license_tokens(key_expression);
+            let spdxes = license_tokens(spdx_expression);
+            if keys.len() != spdxes.len() {
+                continue;
+            }
+            for (key, spdx) in keys.into_iter().zip(spdxes) {
+                if key.is_empty() || spdx.is_empty() {
+                    continue;
+                }
+                token_to_key
+                    .entry(key.to_ascii_lowercase())
+                    .or_insert_with(|| key.to_string());
+                token_to_key
+                    .entry(spdx.to_ascii_lowercase())
+                    .or_insert_with(|| key.to_string());
+                token_to_spdx
+                    .entry(key.to_ascii_lowercase())
+                    .or_insert_with(|| spdx.to_string());
+                token_to_spdx
+                    .entry(spdx.to_ascii_lowercase())
+                    .or_insert_with(|| spdx.to_string());
+            }
+        }
+    }
+    (token_to_key, token_to_spdx)
+}
+
+/// Re-renders a license expression by mapping each license-key token (case-insensitively)
+/// through `token_map`, leaving `AND`/`OR`/`WITH` operators and parentheses untouched so
+/// the operator structure is preserved. With `strict`, returns `None` if any license
+/// token is unmapped — so an SPDX rendering that cannot fully resolve yields an absent
+/// field rather than leaking key-form text. Without `strict`, an unmapped token passes
+/// through unchanged.
+pub(super) fn render_license_expression(
+    expression: &str,
+    token_map: &HashMap<String, String>,
+    strict: bool,
+) -> Option<String> {
+    let mut rendered = String::with_capacity(expression.len());
+    for token in tokenize_license_expression(expression) {
+        match token {
+            ExpressionToken::Operator(text) => rendered.push_str(text),
+            ExpressionToken::License(key) => match token_map.get(&key.to_ascii_lowercase()) {
+                Some(mapped) => rendered.push_str(mapped),
+                None if strict => return None,
+                None => rendered.push_str(key),
+            },
+        }
+    }
+    Some(rendered)
+}
+
+enum ExpressionToken<'a> {
+    /// Operators, parentheses, and whitespace — emitted verbatim.
+    Operator(&'a str),
+    /// A license-key token to be mapped through a token map.
+    License(&'a str),
+}
+
+/// Splits a license expression into license-key tokens and the operator/punctuation
+/// runs between them, preserving every character so the input can be reconstructed.
+fn tokenize_license_expression(expression: &str) -> Vec<ExpressionToken<'_>> {
+    let is_license_char = |c: char| c.is_alphanumeric() || matches!(c, '-' | '.' | '_' | '+' | ':');
+    let mut tokens = Vec::new();
+    let mut rest = expression;
+    while !rest.is_empty() {
+        let boundary = rest.find(is_license_char).unwrap_or(rest.len());
+        if boundary > 0 {
+            tokens.push(ExpressionToken::Operator(&rest[..boundary]));
+            rest = &rest[boundary..];
+            continue;
+        }
+        let end = rest
+            .find(|c: char| !is_license_char(c))
+            .unwrap_or(rest.len());
+        let word = &rest[..end];
+        if is_expression_operator(word) {
+            tokens.push(ExpressionToken::Operator(word));
+        } else {
+            tokens.push(ExpressionToken::License(word));
+        }
+        rest = &rest[end..];
+    }
+    tokens
+}
+
+fn is_expression_operator(word: &str) -> bool {
+    matches!(word.to_ascii_uppercase().as_str(), "AND" | "OR" | "WITH")
+}
+
+/// The license-key tokens of an expression in order, dropping operators and punctuation.
+fn license_tokens(expression: &str) -> Vec<&str> {
+    tokenize_license_expression(expression)
+        .into_iter()
+        .filter_map(|token| match token {
+            ExpressionToken::License(license) => Some(license),
+            ExpressionToken::Operator(_) => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detection(key: &str, spdx: &str) -> LicenseDetection {
+        LicenseDetection {
+            license_expression: key.to_string(),
+            license_expression_spdx: spdx.to_string(),
+            matches: Vec::new(),
+            detection_log: Vec::new(),
+            identifier: String::new(),
+        }
+    }
+
+    #[test]
+    fn mirrors_or_choice_without_collapsing_to_and() {
+        let detections = vec![detection("mit OR apache-2.0", "MIT OR Apache-2.0")];
+        assert_eq!(
+            spdx_expression_mirroring_key("mit OR apache-2.0", &detections).as_deref(),
+            Some("MIT OR Apache-2.0"),
+        );
+    }
+
+    #[test]
+    fn mirrors_key_structure_when_combined_from_separate_detections() {
+        let detections = vec![
+            detection("mit OR apache-2.0", "MIT OR Apache-2.0"),
+            detection("bsd-new", "BSD-3-Clause"),
+        ];
+        assert_eq!(
+            spdx_expression_mirroring_key("(mit OR apache-2.0) AND bsd-new", &detections)
+                .as_deref(),
+            Some("(MIT OR Apache-2.0) AND BSD-3-Clause"),
+        );
+    }
+
+    #[test]
+    fn yields_absent_field_rather_than_leaking_key_form_text() {
+        // `proprietary-license` is a scancode key with no SPDX id (its detection carries
+        // an empty SPDX form). Strict rendering must abstain — never emit the key token
+        // into the SPDX field.
+        let detections = vec![
+            detection("mit", "MIT"),
+            detection("proprietary-license", ""),
+        ];
+        assert_eq!(
+            spdx_expression_mirroring_key("mit AND proprietary-license", &detections),
+            None,
+        );
+    }
+
+    #[test]
+    fn resolves_a_key_already_spelled_in_spdx_form() {
+        // The `detected_license_expression` fallback can hand this helper a key argument
+        // that is itself SPDX-spelled; the token map indexes both spellings so it resolves.
+        let detections = vec![detection("bsl-1.1 AND mpl-2.0", "BUSL-1.1 AND MPL-2.0")];
+        assert_eq!(
+            spdx_expression_mirroring_key("BUSL-1.1 AND MPL-2.0", &detections).as_deref(),
+            Some("BUSL-1.1 AND MPL-2.0"),
+        );
+    }
+}

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -64,6 +64,7 @@ mod font_policy;
 mod generated_test;
 #[cfg(feature = "golden-tests")]
 pub mod golden_helpers;
+mod license_expression_render;
 mod license_policy;
 mod license_references;
 mod output_indexes;

--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -12,6 +12,7 @@ use crate::utils::spdx::combine_license_expressions;
 
 use super::PackageIx;
 use super::classification::is_legal_file;
+use super::license_expression_render::{detection_token_maps, render_license_expression};
 use super::output_indexes::OutputIndexes;
 use super::summary_helpers::unique;
 
@@ -214,129 +215,6 @@ fn single_declared_expression(legal_files: &[&FileInfo]) -> Option<String> {
         return None;
     };
     Some(expression.clone())
-}
-
-/// Builds case-insensitive token maps from a set of detections: license-key token →
-/// canonical key form, and license-key token → SPDX id. Each detection's
-/// `license_expression` and `license_expression_spdx` share the same operator
-/// structure, so their license tokens align positionally. Both the key and the SPDX
-/// spelling of every token are indexed, so an expression in *either* form resolves.
-fn detection_token_maps(
-    detections: &[LicenseDetection],
-) -> (HashMap<String, String>, HashMap<String, String>) {
-    let mut token_to_key: HashMap<String, String> = HashMap::new();
-    let mut token_to_spdx: HashMap<String, String> = HashMap::new();
-    for detection in detections {
-        let pairs = std::iter::once((
-            detection.license_expression.as_str(),
-            detection.license_expression_spdx.as_str(),
-        ))
-        .chain(detection.matches.iter().map(|match_item| {
-            (
-                match_item.license_expression.as_str(),
-                match_item.license_expression_spdx.as_str(),
-            )
-        }));
-        for (key_expression, spdx_expression) in pairs {
-            let keys = license_tokens(key_expression);
-            let spdxes = license_tokens(spdx_expression);
-            if keys.len() != spdxes.len() {
-                continue;
-            }
-            for (key, spdx) in keys.into_iter().zip(spdxes) {
-                if key.is_empty() || spdx.is_empty() {
-                    continue;
-                }
-                token_to_key
-                    .entry(key.to_ascii_lowercase())
-                    .or_insert_with(|| key.to_string());
-                token_to_key
-                    .entry(spdx.to_ascii_lowercase())
-                    .or_insert_with(|| key.to_string());
-                token_to_spdx
-                    .entry(key.to_ascii_lowercase())
-                    .or_insert_with(|| spdx.to_string());
-                token_to_spdx
-                    .entry(spdx.to_ascii_lowercase())
-                    .or_insert_with(|| spdx.to_string());
-            }
-        }
-    }
-    (token_to_key, token_to_spdx)
-}
-
-/// Re-renders a license expression by mapping each license-key token (case-insensitively)
-/// through `token_map`, leaving `AND`/`OR`/`WITH` operators and parentheses untouched so
-/// the operator structure is preserved. With `strict`, returns `None` if any license
-/// token is unmapped — so an SPDX rendering that cannot fully resolve yields an absent
-/// field rather than leaking key-form text. Without `strict`, an unmapped token passes
-/// through unchanged.
-fn render_license_expression(
-    expression: &str,
-    token_map: &HashMap<String, String>,
-    strict: bool,
-) -> Option<String> {
-    let mut rendered = String::with_capacity(expression.len());
-    for token in tokenize_license_expression(expression) {
-        match token {
-            ExpressionToken::Operator(text) => rendered.push_str(text),
-            ExpressionToken::License(key) => match token_map.get(&key.to_ascii_lowercase()) {
-                Some(mapped) => rendered.push_str(mapped),
-                None if strict => return None,
-                None => rendered.push_str(key),
-            },
-        }
-    }
-    Some(rendered)
-}
-
-enum ExpressionToken<'a> {
-    /// Operators, parentheses, and whitespace — emitted verbatim.
-    Operator(&'a str),
-    /// A license-key token to be mapped through a token map.
-    License(&'a str),
-}
-
-/// Splits a license expression into license-key tokens and the operator/punctuation
-/// runs between them, preserving every character so the input can be reconstructed.
-fn tokenize_license_expression(expression: &str) -> Vec<ExpressionToken<'_>> {
-    let is_license_char = |c: char| c.is_alphanumeric() || matches!(c, '-' | '.' | '_' | '+' | ':');
-    let mut tokens = Vec::new();
-    let mut rest = expression;
-    while !rest.is_empty() {
-        let boundary = rest.find(is_license_char).unwrap_or(rest.len());
-        if boundary > 0 {
-            tokens.push(ExpressionToken::Operator(&rest[..boundary]));
-            rest = &rest[boundary..];
-            continue;
-        }
-        let end = rest
-            .find(|c: char| !is_license_char(c))
-            .unwrap_or(rest.len());
-        let word = &rest[..end];
-        if is_expression_operator(word) {
-            tokens.push(ExpressionToken::Operator(word));
-        } else {
-            tokens.push(ExpressionToken::License(word));
-        }
-        rest = &rest[end..];
-    }
-    tokens
-}
-
-fn is_expression_operator(word: &str) -> bool {
-    matches!(word.to_ascii_uppercase().as_str(), "AND" | "OR" | "WITH")
-}
-
-/// The license-key tokens of an expression in order, dropping operators and punctuation.
-fn license_tokens(expression: &str) -> Vec<&str> {
-    tokenize_license_expression(expression)
-        .into_iter()
-        .filter_map(|token| match token {
-            ExpressionToken::License(license) => Some(license),
-            ExpressionToken::Operator(_) => None,
-        })
-        .collect()
 }
 
 /// The distinct directories a package is anchored in (the parent directory of each

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -22,6 +22,7 @@ use crate::utils::spdx::{
 };
 
 use super::classification::is_legal_file;
+use super::license_expression_render::spdx_expression_mirroring_key;
 use super::package_file_index::PackageFileIndex;
 
 const INHERIT_LICENSE_FROM_PACKAGE_REFERENCE: &str = "INHERIT_LICENSE_FROM_PACKAGE";
@@ -631,26 +632,28 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
                     .iter()
                     .map(|detection| detection.license_expression.clone()),
             );
-            package_data.declared_license_expression_spdx = combine_license_expressions(
-                package_data
-                    .license_detections
-                    .iter()
-                    .filter(|detection| !detection.license_expression_spdx.is_empty())
-                    .map(|detection| detection.license_expression_spdx.clone()),
-            );
+            // Mirror the SPDX field on the key expression's structure rather than
+            // independently AND-combining each detection's `license_expression_spdx`,
+            // which would tighten a detection's own `OR`/`WITH` into `AND` and could
+            // leak key-form text when an operand has no SPDX id (see #1187).
+            package_data.declared_license_expression_spdx = package_data
+                .declared_license_expression
+                .as_deref()
+                .and_then(|key| {
+                    spdx_expression_mirroring_key(key, &package_data.license_detections)
+                });
             package_data.other_license_expression = combine_license_expressions(
                 package_data
                     .other_license_detections
                     .iter()
                     .map(|detection| detection.license_expression.clone()),
             );
-            package_data.other_license_expression_spdx = combine_license_expressions(
-                package_data
-                    .other_license_detections
-                    .iter()
-                    .filter(|detection| !detection.license_expression_spdx.is_empty())
-                    .map(|detection| detection.license_expression_spdx.clone()),
-            );
+            package_data.other_license_expression_spdx = package_data
+                .other_license_expression
+                .as_deref()
+                .and_then(|key| {
+                    spdx_expression_mirroring_key(key, &package_data.other_license_detections)
+                });
         }
     }
 
@@ -674,12 +677,12 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
                     .iter()
                     .map(|detection| detection.license_expression.clone()),
             );
-            package_data.declared_license_expression_spdx = combine_license_expressions(
-                own_detections
-                    .iter()
-                    .filter(|detection| !detection.license_expression_spdx.is_empty())
-                    .map(|detection| detection.license_expression_spdx.clone()),
-            );
+            // Render the SPDX field to mirror the key expression's structure (see #1187),
+            // not by independently combining each detection's SPDX form.
+            package_data.declared_license_expression_spdx = package_data
+                .declared_license_expression
+                .as_deref()
+                .and_then(|key| spdx_expression_mirroring_key(key, &own_detections));
             package_data.license_detections = own_detections;
             modified = true;
         }
@@ -896,12 +899,12 @@ fn sync_packages_from_followed_package_data(
                             .iter()
                             .map(|detection| detection.license_expression.clone()),
                     );
-                    next_declared_license_expression_spdx = combine_license_expressions(
-                        merged_detections
-                            .iter()
-                            .filter(|detection| !detection.license_expression_spdx.is_empty())
-                            .map(|detection| detection.license_expression_spdx.clone()),
-                    );
+                    // Mirror the SPDX field on the merged key expression's structure
+                    // rather than independently AND-combining each target's SPDX form,
+                    // which would lose an `OR`/`WITH` operand or leak key-form text (#1187).
+                    next_declared_license_expression_spdx = next_declared_license_expression
+                        .as_deref()
+                        .and_then(|key| spdx_expression_mirroring_key(key, &merged_detections));
                     next_license_detections = merged_detections;
                 }
                 if !merged_other_detections.is_empty() {
@@ -910,12 +913,10 @@ fn sync_packages_from_followed_package_data(
                             .iter()
                             .map(|detection| detection.license_expression.clone()),
                     );
-                    next_other_license_expression_spdx = combine_license_expressions(
-                        merged_other_detections
-                            .iter()
-                            .filter(|detection| !detection.license_expression_spdx.is_empty())
-                            .map(|detection| detection.license_expression_spdx.clone()),
-                    );
+                    next_other_license_expression_spdx =
+                        next_other_license_expression.as_deref().and_then(|key| {
+                            spdx_expression_mirroring_key(key, &merged_other_detections)
+                        });
                     next_other_license_detections = merged_other_detections;
                 }
             }
@@ -955,13 +956,15 @@ fn sync_packages_from_followed_package_data(
                     .or_else(|| manifest_file.detected_license_expression.clone());
                 }
                 if next_declared_license_expression_spdx.is_none() {
-                    next_declared_license_expression_spdx = combine_license_expressions(
-                        manifest_file
-                            .license_detections
-                            .iter()
-                            .filter(|detection| !detection.license_expression_spdx.is_empty())
-                            .map(|detection| detection.license_expression_spdx.clone()),
-                    );
+                    // Mirror the SPDX field on the adopted key expression's structure
+                    // (see #1187). The key may itself carry an `OR`/`WITH`, so independently
+                    // AND-combining each detection's SPDX form would lose it; the token map
+                    // also resolves a key already spelled in SPDX form (the
+                    // `detected_license_expression` fallback above).
+                    next_declared_license_expression_spdx =
+                        next_declared_license_expression.as_deref().and_then(|key| {
+                            spdx_expression_mirroring_key(key, &manifest_file.license_detections)
+                        });
                 }
             }
 
@@ -2335,5 +2338,149 @@ mod tests {
         // file's OWN file-level detections; the pyproject here has none, so the
         // package stays null — proving the multi-datafile step did not fire.
         assert_eq!(packages[0].declared_license_expression, None);
+    }
+
+    /// A package_data with no purl and no detections on a single-package manifest
+    /// file whose own file-level detection is an `OR` choice. The reference-following
+    /// per-file enrichment (the `file.package_data.len() == 1` branch) adopts that
+    /// detection. The `_spdx` field must mirror the key expression's `OR`, not collapse
+    /// it to `AND`.
+    #[test]
+    fn file_package_data_adopt_preserves_or_structure_in_spdx() {
+        let mut manifest = file("proj/build.gradle");
+        manifest.license_detections = vec![detection(
+            "mit OR apache-2.0",
+            "MIT OR Apache-2.0",
+            "proj/build.gradle",
+        )];
+        manifest.detected_license_expression = Some("mit OR apache-2.0".to_string());
+        manifest.package_data = vec![crate::models::PackageData {
+            package_type: Some(crate::models::PackageType::Maven),
+            datasource_id: Some(crate::models::DatasourceId::BuildGradle),
+            ..Default::default()
+        }];
+
+        let mut files = vec![manifest];
+        let mut packages: Vec<crate::models::Package> = vec![];
+        apply_package_reference_following(&mut files, &mut packages);
+
+        let package_data = &files[0].package_data[0];
+        // `combine_license_expressions` canonically reorders OR operands; the point of
+        // the assertion is that the OR survives and the SPDX field mirrors it operand
+        // for operand, not the operand order.
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT"),
+            "the package_data SPDX field must keep the OR choice, never `AND`"
+        );
+    }
+
+    /// The single-datafile manifest-adopt path in `sync_packages_from_followed_package_data`:
+    /// a package with no detections adopts its manifest file's own `OR`-shaped detection.
+    /// The promoted `_spdx` must mirror the key `OR`, not an AND-join of the operands.
+    #[test]
+    fn sync_manifest_adopt_preserves_or_structure_in_spdx() {
+        let mut manifest = file("proj/go.mod");
+        manifest.license_detections = vec![detection(
+            "mit OR apache-2.0",
+            "MIT OR Apache-2.0",
+            "proj/go.mod",
+        )];
+        manifest.detected_license_expression = Some("mit OR apache-2.0".to_string());
+        manifest.package_data = vec![crate::models::PackageData {
+            package_type: Some(crate::models::PackageType::Golang),
+            datasource_id: Some(crate::models::DatasourceId::GoMod),
+            name: Some("tfx".to_string()),
+            ..Default::default()
+        }];
+
+        let mut pkg = package("pkg:golang/example/tfx?uuid=1", "proj/go.mod");
+        pkg.package_type = Some(crate::models::PackageType::Golang);
+        pkg.name = Some("tfx".to_string());
+        pkg.purl = None;
+        pkg.declared_license_expression = None;
+        pkg.declared_license_expression_spdx = None;
+        pkg.license_detections = vec![];
+        pkg.datafile_paths = vec!["proj/go.mod".to_string()];
+
+        let mut files = vec![manifest];
+        let mut packages = vec![pkg];
+        apply_package_reference_following(&mut files, &mut packages);
+
+        let pkg = &packages[0];
+        assert_eq!(
+            pkg.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            pkg.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT"),
+            "the adopted package SPDX field must preserve the OR choice"
+        );
+    }
+
+    /// The Bazel/Buck multi-target merge path: a directory's BUILD targets are
+    /// collapsed into one component and their resolved licenses are unioned. When one
+    /// target carries an `OR` choice, the merged `_spdx` must keep that `OR` rather than
+    /// AND-joining every operand of every target.
+    #[test]
+    fn bazel_merge_preserves_or_structure_in_spdx() {
+        let mut build = file("proj/BUILD");
+        build.package_data = vec![
+            crate::models::PackageData {
+                package_type: Some(crate::models::PackageType::Bazel),
+                datasource_id: Some(crate::models::DatasourceId::BazelBuild),
+                name: Some("lib_a".to_string()),
+                declared_license_expression: Some("mit OR apache-2.0".to_string()),
+                declared_license_expression_spdx: Some("MIT OR Apache-2.0".to_string()),
+                license_detections: vec![detection(
+                    "mit OR apache-2.0",
+                    "MIT OR Apache-2.0",
+                    "proj/BUILD",
+                )],
+                ..Default::default()
+            },
+            crate::models::PackageData {
+                package_type: Some(crate::models::PackageType::Bazel),
+                datasource_id: Some(crate::models::DatasourceId::BazelBuild),
+                name: Some("lib_b".to_string()),
+                declared_license_expression: Some("bsd-new".to_string()),
+                declared_license_expression_spdx: Some("BSD-3-Clause".to_string()),
+                license_detections: vec![detection("bsd-new", "BSD-3-Clause", "proj/BUILD")],
+                ..Default::default()
+            },
+        ];
+
+        let mut pkg = package("pkg:bazel/lib?uuid=1", "proj/BUILD");
+        pkg.package_type = Some(crate::models::PackageType::Bazel);
+        pkg.purl = None;
+        pkg.declared_license_expression = None;
+        pkg.declared_license_expression_spdx = None;
+        pkg.license_detections = vec![];
+        pkg.datafile_paths = vec!["proj/BUILD".to_string()];
+
+        let mut files = vec![build];
+        let mut packages = vec![pkg];
+        apply_package_reference_following(&mut files, &mut packages);
+
+        let spdx = packages[0].declared_license_expression_spdx.as_deref();
+        assert_eq!(
+            packages[0].declared_license_expression.as_deref(),
+            Some("(apache-2.0 OR mit) AND bsd-new")
+        );
+        assert_eq!(
+            spdx,
+            Some("(Apache-2.0 OR MIT) AND BSD-3-Clause"),
+            "the merged SPDX must keep lib_a's OR choice instead of flattening to all-AND"
+        );
+        let spdx = spdx.unwrap_or_default();
+        assert!(
+            spdx.contains(" OR "),
+            "the OR operator must survive the Bazel target merge in the SPDX field"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- A latent OR→AND structure-loss bug remained in `reference_following.rs` after #1187 fixed the same class in the declared-license promotion pass. Six sites built each package(_data) `*_license_expression_spdx` field by AND-combining the individual detections' `license_expression_spdx` values via `combine_license_expressions(...)`. That tightens a detection's own `OR`/`WITH` choice into `AND` and, by skipping detections whose SPDX form is empty, can leak scancode-key text into the SPDX field.
- Fix: render each SPDX field to **mirror the already-combined key expression's** `AND`/`OR`/`WITH` structure via a per-detection key↔SPDX token correspondence, rendered strictly (an absent field — never key-form text — when any operand lacks an SPDX id). This is exactly #1187's approach, reused.
- The token-map + render helpers introduced in #1187 are extracted from `package_metadata_promotion.rs` into a shared `post_processing::license_expression_render` module so both passes share one implementation (no behavior change to the promotion pass; its 16 tests pass unchanged).

## Scope and exclusions

- Included — the six listed sites in `reference_following.rs`:
  - `sync_packages_from_followed_package_data`: the file-level `package_data.declared_license_expression_spdx` and `package_data.other_license_expression_spdx` (per-detection reference-following block);
  - the single-package no-purl manifest adopt (`file.package_data.len() == 1` branch);
  - the Bazel/Buck target-merge `next_declared_license_expression_spdx` and `next_other_license_expression_spdx`;
  - the `sync_packages_from_followed_package_data` manifest-adopt `next_declared_license_expression_spdx`.
- All six were genuinely buggy (each can carry an `OR`/`WITH` operand); none were left unchanged.
- Explicit exclusion: `adopt_license_file_from_origin_manifest` (added in #1184/#1187) is **not** changed. It already uses `combine_license_expressions_preserving_structure` for both key and SPDX, so it does not exhibit the OR→AND structure-loss bug. Its per-detection "fall back to key form when SPDX is empty" path is a separate, much smaller key-into-SPDX-leak concern that the existing code comment explicitly documents as intentional; harmonizing it is left out to keep this PR scoped to the structure-loss class.

## How to verify

- New unit tests cover an `OR`-shaped expression flowing through each fixed path; `cargo test --lib reference_following` and `cargo test --lib license_expression_render`.
- Manual: scan a Go module whose co-hosted `LICENSE` carries a compound license (e.g. terraform's BUSL `LICENSE` next to a `go.mod`) with `--package --license`; the assembled `pkg:golang/...` package keeps `declared = bsl-1.1 AND mpl-2.0` / `BUSL-1.1 AND MPL-2.0`. To exercise the `OR` path, a file/manifest whose detection is `a OR b` must keep the `OR` in both key and `_spdx` fields rather than collapsing to `AND`.

## Follow-up work — ITEM 3 root cause (deferred, no code change here)

Investigated the transient SPDX-form `detected_license_expression` that motivated #1187's workaround. Root cause, confirmed empirically with debug tracing (prints removed):

- The internal `FileInfo.detected_license_expression` field is populated at the **scanner** stage (`src/scanner/process/license.rs:513-534`) from the detections' **SPDX** expressions (`license_expression_spdx`), so its in-memory value is SPDX-form (e.g. `MPL-2.0 AND BUSL-1.1`).
- `promote_package_declared_license_from_legal_files` reads that same SPDX-form value. There is **no later pass that "restores" key form**: the key-form `mpl-2.0 AND bsl-1.1` seen in final JSON is computed independently by the output-schema accessor (`src/output_schema/file_info.rs:129`) from each detection's key `license_expression`. The internal field is, by design at the scanner stage, an SPDX-form string whose name is misleading.
- This is exactly why #1187 (and this PR) cannot trust `file.detected_license_expression` as key form and must re-render via the token map.

Proposed fix (deferred — larger/architectural, not forced here per the investigation brief): make the scanner store the **key** form in `detected_license_expression` and the SPDX form in `detected_license_expression_spdx`, so the internal field matches its name and the output accessor / promotion passes can read it directly. This touches a hot scanner path and changes the meaning of a field consumed by tallies/summary/clarity (`tallies.rs`, `summary/mod.rs`, `license_references.rs`); `canonicalize_summary_expression` lowercases but does not translate SPDX→key, so a fallback path could shift `busl-1.1` vs `bsl-1.1` in aggregates. It is best done as its own change with the full golden matrix, not bundled with this structure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
