### PR TITLE
fix(post-processing): prefer LICENSE over NOTICE when co-hosted legal files disagree

### DIFF
--- a/docs/adr/0010-package-license-from-cohosted-files.md
+++ b/docs/adr/0010-package-license-from-cohosted-files.md
@@ -98,11 +98,24 @@ guards:
   the `for_packages` association that copyright/holder promotion relies on, because
   that link is only populated by ecosystem-specific resource-assign passes and is
   empty for exactly the formats this pass targets (Go, autotools, Swift, Bazel).
+- **`LICENSE` over `NOTICE` precedence**: when the co-located legal files
+  _disagree_, prefer the canonically-named license file(s) — the
+  `LICENSE`/`LICENCE`/`COPYING` family (including `LICENSE.txt`, `LICENSE.md`, and
+  the `LICENSE-*`/`COPYING-*` variants) — over `NOTICE`/`COPYRIGHT`/`AUTHORS` files,
+  and promote from that license-family subset. A `NOTICE` typically enumerates the
+  licenses of _bundled third-party_ code, not the package's own declared license, so
+  it must not drive (or block) the package's declared expression. The full legal set
+  is used only when no canonical license file is present, preserving the prior
+  `NOTICE`/`COPYING`-only behavior. See
+  [LICENSE-over-NOTICE precedence](#license-over-notice-precedence).
 - **Single legal file, or agreeing files**: promote when all the promoted
   detections originate from a _single_ legal file, or when _multiple_ legal files
   resolve to one shared expression. Abstain only when _multiple separate_ legal
   files resolve to _differing_ expressions (e.g. dual `LICENSE-APACHE` +
-  `LICENSE-MIT`) rather than guessing an `AND`/`OR` combination. See
+  `LICENSE-MIT`) rather than guessing an `AND`/`OR` combination. When the
+  `LICENSE`-over-`NOTICE` precedence above applies, this single-file / agreeing-files
+  test runs against the chosen license-family subset, so a genuine dual-license pair
+  of `LICENSE-*` files still abstains. See
   [Single legal file with a compound license vs. multiple disagreeing files](#single-legal-file-with-a-compound-license-vs-multiple-disagreeing-files)
   for why a single compound file is promoted but disagreeing separate files are not.
 - **Preserve provenance**: the promoted `license_detections` retain each match's
@@ -135,6 +148,14 @@ parsers.
   `LICENSE-APACHE`/`LICENSE-MIT` still abstains), and `promotes_when_multiple_files_agree`
   (separate agreeing files still promote), plus the end-to-end
   `create_output_promotes_single_file_compound_license_from_cohosted_legal_file`.
+- ✅ LICENSE-over-NOTICE precedence coverage:
+  `prefers_license_over_disagreeing_notice` (prometheus shape — `LICENSE` →
+  `apache-2.0` wins over a bundled-attribution `NOTICE` →
+  `mit AND apache-2.0 AND bsd-new`),
+  `license_family_precedence_does_not_override_dual_license_files` (dual `LICENSE-*`
+  still abstains even with a co-located `NOTICE`), and
+  `promotes_from_notice_when_no_license_family_file_present` (a `NOTICE`-only
+  directory is unchanged).
 
 ### Scope note: assembled packages only, not file-level `package_data`
 
@@ -253,6 +274,60 @@ assembled-`Package` pass, and the file-level remainder is all false-positive ris
 - No code change ships from this decision; the existing
   `promote_package_declared_license_from_legal_files` pass and its
   assembled-package-only scope are retained verbatim.
+
+### LICENSE-over-NOTICE precedence
+
+The original abstain-on-disagreement guard treated every `is_legal_file` match in a
+package's directory as equally authoritative. That conflates two semantically
+different kinds of legal file:
+
+- A **canonical license file** — `LICENSE`, `LICENSE.txt`, `LICENSE.md`, `LICENCE`,
+  `COPYING`, and their `LICENSE-*`/`COPYING-*` variants — states _the package's own_
+  license.
+- A **`NOTICE`** (and, by the same reasoning, `COPYRIGHT`/`AUTHORS`) file most often
+  enumerates the licenses of _bundled or third-party_ code that the package
+  redistributes. This is the standard Apache-style `NOTICE`: attribution for
+  dependencies, not a declaration of the package's own license.
+
+When both are present and they **disagree**, blindly abstaining throws away a
+high-confidence signal. The motivating case is `prometheus/prometheus`: its repo-root
+`LICENSE` detects `apache-2.0` (the project's real license), while its `NOTICE`
+detects `mit AND apache-2.0 AND bsd-new` (the licenses of vendored third-party code).
+The two disagree, so the original pass abstained and left
+`pkg:golang/github.com/prometheus/prometheus` with `declared_license_expression:
+null`. ScanCode, conversely, over-aggregates both files into a noisy
+`apache-2.0 AND bsd-new AND mit`. Neither is the right answer: the package's declared
+license is `apache-2.0`, taken from the canonical `LICENSE`.
+
+**Decision: prefer the license-family subset.** When the co-located legal files
+disagree, the pass now promotes from the canonical `LICENSE`/`LICENCE`/`COPYING`
+family alone, ignoring `NOTICE`/`COPYRIGHT`/`AUTHORS` for the purpose of the declared
+license. This makes Provenant **more correct than ScanCode** on the ubiquitous
+`LICENSE` + `NOTICE` pattern: it reports the package's own license and does not smear
+bundled-dependency licenses into the declared expression.
+
+Preserved behaviors:
+
+- **Dual-license `LICENSE-*` files still abstain.** The license-family subset can
+  itself be genuinely ambiguous — `LICENSE-APACHE` (`apache-2.0`) + `LICENSE-MIT`
+  (`mit`) are both canonical license files and they disagree. The single-file /
+  agreeing-files test runs _within_ the chosen subset, so this dual-license case is
+  unchanged and still left unset. A co-located `NOTICE` does not break the tie.
+- **`NOTICE`/`COPYRIGHT`-only directories are unchanged.** If a directory has _no_
+  canonical license-family file, the pass falls back to the full legal set, so a sole
+  `NOTICE` (or `COPYRIGHT`/`AUTHORS`) still promotes exactly as before. (`COPYING` is
+  itself in the license family, so a `COPYING`-only directory takes the license-family
+  path, not this fallback.) The precedence only re-prioritizes; it never removes a
+  previously-available signal.
+- **A single canonical `LICENSE` still promotes**, and a directory whose legal files
+  already agree is unaffected (the subset filter is a no-op when there is no
+  disagreement to resolve).
+
+The classifier is `is_license_family_file` in
+`src/post_processing/classification.rs`; it matches the `LICENSE`/`LICENCE`/`COPYING`
+family by name and deliberately excludes `NOTICE`/`COPYRIGHT`/`AUTHORS`/`LEGAL`/
+`EULA`/`PATENT`. (`copying` cannot match `copyright`: `copyright` neither starts nor
+ends with `copying`.)
 
 ### Single legal file with a compound license vs. multiple disagreeing files
 

--- a/src/post_processing/classification.rs
+++ b/src/post_processing/classification.rs
@@ -40,6 +40,15 @@ const LEGAL_STARTS_ENDS: &[&str] = &[
     "patents",
 ];
 
+/// The canonically-named license-file family within the broader legal set: a
+/// `LICENSE`/`LICENCE`/`COPYING` file (including `LICENSE.txt`, `LICENSE.md`, and
+/// the `LICENSE-*`/`COPYING-*` variants). Deliberately excludes `NOTICE`,
+/// `COPYRIGHT`, `AUTHORS`, `LEGAL`, `EULA`, and `PATENT(S)`: those carry bundled
+/// third-party attribution or related metadata, not the package's *own* declared
+/// license (see ADR 0010). `copying` cannot match `copyright` because `copyright`
+/// neither starts nor ends with `copying`.
+const LICENSE_FAMILY_STARTS_ENDS: &[&str] = &["license", "licence", "copying"];
+
 const MANIFEST_ENDS: &[&str] = &[
     ".about",
     "/bower.json",
@@ -110,6 +119,14 @@ fn name_or_base_name_matches(file: &FileInfo, patterns: &[&str]) -> bool {
 
 pub(super) fn is_legal_file(file: &FileInfo) -> bool {
     name_or_base_name_matches(file, LEGAL_STARTS_ENDS)
+}
+
+/// Whether `file` is a canonically-named license file (`LICENSE`/`LICENCE`/`COPYING`
+/// family), as opposed to a `NOTICE`/`COPYRIGHT`/`AUTHORS` attribution file. Used to
+/// give the package's own license file precedence over a `NOTICE` (which lists
+/// bundled third-party licenses) when co-located legal files disagree — see ADR 0010.
+pub(super) fn is_license_family_file(file: &FileInfo) -> bool {
+    name_or_base_name_matches(file, LICENSE_FAMILY_STARTS_ENDS)
 }
 
 pub(super) fn is_manifest_file(path: &str) -> bool {

--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -11,7 +11,7 @@ use crate::utils::path::parent_dir;
 use crate::utils::spdx::combine_license_expressions;
 
 use super::PackageIx;
-use super::classification::is_legal_file;
+use super::classification::{is_legal_file, is_license_family_file};
 use super::license_expression_render::{detection_token_maps, render_license_expression};
 use super::output_indexes::OutputIndexes;
 use super::summary_helpers::unique;
@@ -93,16 +93,26 @@ pub(super) fn promote_package_metadata_from_key_files(
 ///   down into nested sub-packages. (`for_packages` is not used here: it is only
 ///   populated by ecosystem-specific resource-assign passes, so it is empty for
 ///   exactly the formats this pass targets — Go, autotools, Swift, Bazel.)
-/// - **Single legal file, or agreeing files**: promoted from a *single* legal file —
-///   which may legitimately carry a compound license (e.g. a repo-root `LICENSE`
-///   detecting `mpl-2.0 AND bsl-1.1`) — or when *multiple* legal files resolve to one
-///   shared expression. The promoted expression is built from the file's own
-///   `license_detections` (whose `license_expression`/`_spdx` are reliably key and
-///   SPDX form), not from the file's `detected_license_expression` string, which can
-///   already be SPDX-rendered when this pass runs. *Multiple* legal files that resolve
-///   to *differing* expressions (e.g. dual `LICENSE-APACHE` + `LICENSE-MIT`) are left
-///   unset rather than guessing an `AND`/`OR` combination. See ADR 0010 "Single legal
-///   file with a compound license vs. multiple disagreeing files".
+/// - **`LICENSE` over `NOTICE` precedence**: when the co-located legal files
+///   disagree, the canonically-named license file(s) (`LICENSE`/`LICENCE`/`COPYING`
+///   family) take precedence over `NOTICE`/`COPYRIGHT`/`AUTHORS` files, and promotion
+///   runs against that license-family subset. A `NOTICE` commonly lists the licenses
+///   of *bundled third-party* code (e.g. prometheus's `NOTICE` →
+///   `mit AND apache-2.0 AND bsd-new`), which is not the package's own declared
+///   license (its `LICENSE` → `apache-2.0`). The full legal set is used only when no
+///   canonical license file is present, preserving the prior `NOTICE`/`COPYING`-only
+///   behavior. See ADR 0010 "LICENSE-over-NOTICE precedence".
+/// - **Single legal file, or agreeing files**: within the chosen subset, promoted
+///   from a *single* legal file — which may legitimately carry a compound license
+///   (e.g. a repo-root `LICENSE` detecting `mpl-2.0 AND bsl-1.1`) — or when *multiple*
+///   legal files resolve to one shared expression. The promoted expression is built
+///   from the file's own `license_detections` (whose `license_expression`/`_spdx` are
+///   reliably key and SPDX form), not from the file's `detected_license_expression`
+///   string, which can already be SPDX-rendered when this pass runs. *Multiple* legal
+///   files that resolve to *differing* expressions (e.g. dual `LICENSE-APACHE` +
+///   `LICENSE-MIT`) are left unset rather than guessing an `AND`/`OR` combination. See
+///   ADR 0010 "Single legal file with a compound license vs. multiple disagreeing
+///   files".
 /// - **Provenance preserved**: the legal file's `license_detections` are copied
 ///   onto the package, keeping each detection's `from_file` so consumers can tell a
 ///   co-hosted-file-derived license from a manifest-declared one.
@@ -148,22 +158,34 @@ pub(super) fn promote_package_declared_license_from_legal_files(
             continue;
         }
 
-        let source_legal_files: Vec<&FileInfo> = package_anchor_dirs(package)
+        let colocated_legal_files: Vec<&FileInfo> = package_anchor_dirs(package)
             .into_iter()
             .filter(|dir| packages_per_dir.get(dir).copied() == Some(1))
             .filter_map(|dir| legal_files_by_dir.get(&dir))
             .flatten()
             .copied()
             .collect();
-        if source_legal_files.is_empty() {
+        if colocated_legal_files.is_empty() {
             continue;
         }
 
         // The legal files' agreed expression carries the authoritative operator
         // structure — crucially an `OR` choice, which must not be tightened to `AND`.
-        // Abstain when separate legal files disagree (e.g. dual `LICENSE-APACHE` +
-        // `LICENSE-MIT`).
-        let Some(file_expression) = single_declared_expression(&source_legal_files) else {
+        //
+        // When the co-located legal files *disagree*, prefer the canonically-named
+        // license file(s) (`LICENSE`/`LICENCE`/`COPYING` family) over `NOTICE`/
+        // `COPYRIGHT`/`AUTHORS` and resolve against that subset. A `NOTICE` typically
+        // enumerates the licenses of *bundled third-party* code (e.g. prometheus's
+        // `NOTICE` → `mit AND apache-2.0 AND bsd-new`), which must not drive (or block)
+        // the package's own declared license (its `LICENSE` → `apache-2.0`). The
+        // narrowing applies only on disagreement, and only when a canonical license
+        // file is actually present, so an agreeing set (including its `NOTICE`
+        // detections) and a `NOTICE`/`COPYRIGHT`/`AUTHORS`-only directory keep their
+        // prior behavior. A subset that *still* disagrees (e.g. dual `LICENSE-APACHE` +
+        // `LICENSE-MIT`) abstains. See ADR 0010 "LICENSE-over-NOTICE precedence".
+        let Some((source_legal_files, file_expression)) =
+            select_legal_files_and_expression(colocated_legal_files)
+        else {
             continue;
         };
 
@@ -214,6 +236,36 @@ fn single_declared_expression(legal_files: &[&FileInfo]) -> Option<String> {
         return None;
     };
     Some(expression.clone())
+}
+
+/// Chooses the legal files to promote from and their agreed expression, applying the
+/// `LICENSE`-over-`NOTICE` precedence (ADR 0010).
+///
+/// - If the full co-located set already agrees on one expression, it is used as-is
+///   (its `NOTICE`/`COPYRIGHT`/`AUTHORS` detections included).
+/// - If the set disagrees, the canonical `LICENSE`/`LICENCE`/`COPYING` family takes
+///   precedence and the agreement test is re-run on that subset; a subset that still
+///   disagrees (dual `LICENSE-*`) abstains.
+/// - If no canonical license file is present, the full set is kept, so a sole
+///   `NOTICE` (or `COPYRIGHT`/`AUTHORS`) still promotes as before.
+///
+/// Returns `None` (abstain) when the chosen set has no single agreed expression.
+fn select_legal_files_and_expression(
+    colocated_legal_files: Vec<&FileInfo>,
+) -> Option<(Vec<&FileInfo>, String)> {
+    if let Some(expression) = single_declared_expression(&colocated_legal_files) {
+        return Some((colocated_legal_files, expression));
+    }
+    let license_family_files: Vec<&FileInfo> = colocated_legal_files
+        .iter()
+        .copied()
+        .filter(|file| is_license_family_file(file))
+        .collect();
+    if license_family_files.is_empty() {
+        return None;
+    }
+    let expression = single_declared_expression(&license_family_files)?;
+    Some((license_family_files, expression))
 }
 
 /// The distinct directories a package is anchored in (the parent directory of each
@@ -592,6 +644,102 @@ mod tests {
         assert_eq!(
             packages[0].declared_license_expression.as_deref(),
             Some("apache-2.0")
+        );
+    }
+
+    #[test]
+    fn promotes_when_license_and_notice_agree() {
+        // Agreeing-path branch: a `LICENSE` and a `NOTICE` that resolve to the *same*
+        // expression are not ambiguous, so the full set is used as-is (no narrowing)
+        // and both detections are promoted. Guards the `Some(_)` arm of the selection
+        // for a mixed license-family + attribution set.
+        let files = vec![
+            legal("LICENSE", "apache-2.0", "Apache-2.0"),
+            legal("NOTICE", "apache-2.0", "Apache-2.0"),
+        ];
+        let mut packages = vec![pkg("a", "go.mod")];
+
+        promote_package_declared_license_from_legal_files(&files, &mut packages);
+
+        assert_eq!(
+            packages[0].declared_license_expression.as_deref(),
+            Some("apache-2.0")
+        );
+        assert_eq!(
+            packages[0].license_detections.len(),
+            2,
+            "an agreeing LICENSE+NOTICE set keeps both detections (no narrowing)"
+        );
+    }
+
+    #[test]
+    fn prefers_license_over_disagreeing_notice() {
+        // prometheus shape: the canonical `LICENSE` carries the project's own license
+        // (`apache-2.0`) while `NOTICE` enumerates bundled third-party licenses
+        // (`mit AND apache-2.0 AND bsd-new`). The two disagree; the package's declared
+        // license must come from `LICENSE`, never the bundled-attribution `NOTICE`.
+        let files = vec![
+            legal("LICENSE", "apache-2.0", "Apache-2.0"),
+            legal(
+                "NOTICE",
+                "mit AND apache-2.0 AND bsd-new",
+                "MIT AND Apache-2.0 AND BSD-3-Clause",
+            ),
+        ];
+        let mut packages = vec![pkg("a", "go.mod")];
+
+        promote_package_declared_license_from_legal_files(&files, &mut packages);
+
+        assert_eq!(
+            packages[0].declared_license_expression.as_deref(),
+            Some("apache-2.0"),
+            "the canonical LICENSE wins over a bundled-attribution NOTICE"
+        );
+        assert_eq!(
+            packages[0].declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0")
+        );
+        assert_eq!(
+            packages[0].license_detections.len(),
+            1,
+            "only the LICENSE detection is promoted, not the NOTICE detections"
+        );
+    }
+
+    #[test]
+    fn license_family_precedence_does_not_override_dual_license_files() {
+        // Precedence operates within the license-family subset: genuine dual-licensing
+        // expressed as separate `LICENSE-APACHE` + `LICENSE-MIT` files (both in the
+        // license family) still disagrees, so the dual-license guard still abstains.
+        let files = vec![
+            legal("LICENSE-APACHE", "apache-2.0", "Apache-2.0"),
+            legal("LICENSE-MIT", "mit", "MIT"),
+            legal("NOTICE", "apache-2.0", "Apache-2.0"),
+        ];
+        let mut packages = vec![pkg("a", "go.mod")];
+
+        promote_package_declared_license_from_legal_files(&files, &mut packages);
+
+        assert_eq!(
+            packages[0].declared_license_expression, None,
+            "two disagreeing LICENSE-* files stay ambiguous; NOTICE does not break the tie"
+        );
+    }
+
+    #[test]
+    fn promotes_from_notice_when_no_license_family_file_present() {
+        // No canonical LICENSE-family file: the full legal set is used, so a sole
+        // `NOTICE` (or `COPYRIGHT`/`AUTHORS`) still promotes as before. This preserves
+        // the prior behavior for directories that carry only a NOTICE.
+        let files = vec![legal("NOTICE", "apache-2.0", "Apache-2.0")];
+        let mut packages = vec![pkg("a", "go.mod")];
+
+        promote_package_declared_license_from_legal_files(&files, &mut packages);
+
+        assert_eq!(
+            packages[0].declared_license_expression.as_deref(),
+            Some("apache-2.0"),
+            "a NOTICE-only directory still promotes when no LICENSE family file exists"
         );
     }
 


### PR DESCRIPTION
## Summary

- When a package's co-located legal files disagree, ADR 0010's `promote_package_declared_license_from_legal_files` abstained and left `declared_license_expression` null. The ubiquitous Apache-style `LICENSE` + `NOTICE` pattern hit this: a canonical `LICENSE` states the package's own license while the `NOTICE` enumerates *bundled third-party* licenses, so the two disagree.
- This PR prefers the canonically-named license-family files (`LICENSE`/`LICENCE`/`COPYING` and their `LICENSE-*`/`COPYING-*` variants) over `NOTICE`/`COPYRIGHT`/`AUTHORS` on disagreement, and promotes from that subset. A `NOTICE` listing bundled-dependency licenses no longer drives or blocks the package's declared license.
- Makes Provenant **more correct than ScanCode**, which over-aggregates both files into a noisy `apache-2.0 AND bsd-new AND mit`.

## Scope and exclusions

- Included: new `is_license_family_file` classifier; LICENSE-over-NOTICE precedence in the ADR 0010 promotion pass; unit tests; ADR 0010 amendment documenting the precedence + rationale.
- Explicit exclusions: no change to file-level `package_data` stamping (still rejected per ADR 0010); all other ADR 0010 guards (genuine-absence, same-dir/sole-package, provenance, single/agreeing-file, resolved-dependency) are unchanged. The narrowing applies **only on disagreement and only when a canonical license file is present**, so agreeing sets and `NOTICE`/`COPYING`-only directories keep prior behavior.

## How to verify

- Scan a repo with a root `LICENSE` (the project license) and a root `NOTICE` listing bundled third-party licenses (e.g. `prometheus/prometheus@351447a4`) with `--package --license`. Confirm the assembled `pkg:golang/github.com/prometheus/prometheus` now reports `declared_license_expression: apache-2.0` sourced only from `LICENSE`, where it was previously `null`. Confirmed locally on that ref.
- Edge cases covered by unit tests in `package_metadata_promotion.rs`: dual `LICENSE-APACHE` + `LICENSE-MIT` still abstains even with a co-located agreeing `NOTICE`; a `NOTICE`-only directory still promotes from `NOTICE`.

## Intentional differences from Python

- ScanCode over-aggregates `LICENSE` + `NOTICE` into a combined expression; Provenant promotes only the package's own `LICENSE` license and treats `NOTICE` as bundled-attribution. Documented in ADR 0010 "LICENSE-over-NOTICE precedence".

🤖 Generated with [Claude Code](https://claude.com/claude-code)