### PR TITLE
feat(parsers): normalize npm slash-separated dual-license declared strings

### DIFF
--- a/resources/license_detection/declared_license_aliases.toml
+++ b/resources/license_detection/declared_license_aliases.toml
@@ -41,6 +41,11 @@ expression = "apache-2.0"
 reason = "SPDX deprecated the bare 'Apache' identifier in favor of Apache-2.0; a declared `license: \"Apache\"` is conventionally Apache-2.0, and ScanCode resolves it the same. Observed in apache/hadoop's hadoop-yarn-ui package.json."
 
 [[alias]]
+names = ["apache2", "apache-2"]
+expression = "apache-2.0"
+reason = "Informal spellings of Apache-2.0 used as operands in npm's legacy slash-separated dual-license convention (e.g. `license: \"MIT/Apache2\"`); npm packages historically wrote the Apache 2.0 license this way before SPDX expressions. Conventionally Apache-2.0 with no other meaning. Observed in bevy's .github/start-mobile-example/package.json (`\"license\": \"MIT/Apache2\"`). Declared-field-only, so it cannot misfire on file content."
+
+[[alias]]
 names = ["boost"]
 expression = "boost-1.0"
 reason = "Boost ships a single license, the Boost Software License 1.0 (SPDX BSL-1.0; ScanCode key boost-1.0); a declared 'Boost' has no other meaning. Observed in pyodide's bundled libboost conda metadata."

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -141,6 +141,86 @@ pub(crate) fn normalize_spdx_declared_license(
     )
 }
 
+/// Normalizes an npm package's declared `license` string, including the legacy
+/// informal slash-separated dual-license convention (e.g. `"MIT/Apache2"`,
+/// `"BSD/MIT"`, `"MIT/X11"`).
+///
+/// npm's `license` field historically allowed a `/`-separated list of license
+/// names to mean "dual licensed under either" before SPDX expressions were
+/// standardized. SPDX expression parsing does not understand `/` (it is not an
+/// SPDX operator), so these strings would otherwise fall through to an honest
+/// `null`. Here, scoped strictly to the bounded, trustworthy declared field,
+/// the `/` is treated as `OR`: each operand is normalized independently — via
+/// SPDX-expression normalization, then the declared-license key/alias table
+/// (which resolves informal single tokens such as `Apache2`) — and the results
+/// are joined with `OR`.
+///
+/// This never touches file-content detection, so a `/` appearing in arbitrary
+/// prose or a URL cannot trigger it. Statements that are already valid SPDX
+/// (including parenthesized forms like `"(MIT OR Apache-2.0)"`) normalize
+/// through the standard path first and never reach the slash handling. If any
+/// operand fails to resolve, the slash handling yields nothing so the field
+/// stays an honest `null` rather than a partial guess.
+pub(crate) fn normalize_npm_declared_license(
+    statement: Option<&str>,
+) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
+    let standard = normalize_spdx_declared_license(statement);
+    if standard.0.is_some() {
+        return standard;
+    }
+
+    let Some(statement) = statement.map(str::trim).filter(|value| !value.is_empty()) else {
+        return empty_declared_license_data();
+    };
+
+    let Some(normalized) = normalize_npm_slash_dual_license(statement) else {
+        return empty_declared_license_data();
+    };
+
+    build_declared_license_data(
+        normalized,
+        DeclaredLicenseMatchMetadata::single_line(statement),
+    )
+}
+
+/// Resolves the npm informal slash-separated dual-license convention into an
+/// `OR` expression, or `None` when the statement is not that form or any
+/// operand fails to resolve.
+fn normalize_npm_slash_dual_license(statement: &str) -> Option<NormalizedDeclaredLicense> {
+    // A `/` inside a URL (e.g. `http://x/y`) is not a license separator. Only
+    // treat the statement as a slash list when it is purely `/`-joined license
+    // names with no URL token.
+    if statement.contains("://") || !statement.contains('/') {
+        return None;
+    }
+
+    let mut operands = Vec::new();
+    for raw_operand in statement.split('/') {
+        let operand = raw_operand.trim();
+        if operand.is_empty() {
+            return None;
+        }
+        // Resolve each operand the same bounded, declared-field way the rest of
+        // this module does: try SPDX-expression normalization, then the
+        // key/alias table (informal single tokens such as `Apache2`), then
+        // declared free-text detection (which promotes a bare-name clue such as
+        // `BSD` to its conventional declared expression).
+        let normalized = normalize_spdx_expression(operand)
+            .or_else(|| normalize_declared_license_key(operand))
+            .or_else(|| detect_declared_license_name(operand))?;
+        operands.push(normalized);
+    }
+
+    // Only a genuine multi-operand list is the dual-license form. In practice this
+    // guard always holds: the `contains('/')` entry-check guarantees at least one
+    // separator, and every empty-operand path returns `None` above.
+    if operands.len() < 2 {
+        return None;
+    }
+
+    combine_normalized_licenses(operands, " OR ")
+}
+
 /// Resolve a declared license statement through the curated declared-license
 /// alias table (`resources/license_detection/declared_license_aliases.toml`).
 ///
@@ -1339,6 +1419,95 @@ mod tests {
         assert_eq!(declared.as_deref(), Some("mit"));
         assert_eq!(declared_spdx.as_deref(), Some("MIT"));
         assert_eq!(detections.len(), 1);
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_slash_dual_mit_apache2() {
+        let (declared, declared_spdx, detections) =
+            normalize_npm_declared_license(Some("MIT/Apache2"));
+
+        assert_eq!(declared.as_deref(), Some("apache-2.0 OR mit"));
+        assert_eq!(declared_spdx.as_deref(), Some("Apache-2.0 OR MIT"));
+        assert_eq!(detections.len(), 1);
+        assert_eq!(
+            detections[0].matches[0].matcher,
+            crate::license_detection::MatcherKind::Declared
+        );
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_slash_dual_forms() {
+        for statement in ["MIT/Apache-2.0", "MIT / Apache-2.0", "Apache2/MIT"] {
+            let (declared, declared_spdx, _) = normalize_npm_declared_license(Some(statement));
+            assert_eq!(
+                declared.as_deref(),
+                Some("apache-2.0 OR mit"),
+                "statement: {statement}"
+            );
+            assert_eq!(
+                declared_spdx.as_deref(),
+                Some("Apache-2.0 OR MIT"),
+                "statement: {statement}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_slash_dual_mit_x11() {
+        let (declared, declared_spdx, _) = normalize_npm_declared_license(Some("MIT/X11"));
+
+        // X11 normalizes to the ScanCode `x11-xconsortium` key (SPDX `X11`).
+        assert_eq!(declared.as_deref(), Some("mit OR x11-xconsortium"));
+        assert_eq!(declared_spdx.as_deref(), Some("MIT OR X11"));
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_slash_dual_bsd_mit() {
+        let (declared, declared_spdx, _) = normalize_npm_declared_license(Some("BSD/MIT"));
+
+        assert_eq!(declared.as_deref(), Some("bsd-new OR mit"));
+        assert_eq!(declared_spdx.as_deref(), Some("BSD-3-Clause OR MIT"));
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_parenthesized_spdx_uses_standard_path() {
+        // A valid SPDX expression (even parenthesized) must normalize through the
+        // standard SPDX path and never reach the slash handling.
+        let (declared, declared_spdx, _) =
+            normalize_npm_declared_license(Some("(MIT OR Apache-2.0)"));
+
+        assert_eq!(declared.as_deref(), Some("apache-2.0 OR mit"));
+        assert_eq!(declared_spdx.as_deref(), Some("Apache-2.0 OR MIT"));
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_plain_single_unaffected() {
+        let (declared, declared_spdx, _) = normalize_npm_declared_license(Some("MIT"));
+
+        assert_eq!(declared.as_deref(), Some("mit"));
+        assert_eq!(declared_spdx.as_deref(), Some("MIT"));
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_slash_with_unresolvable_operand_is_none() {
+        // If any operand fails to resolve, prefer an honest null over a partial guess.
+        let (declared, declared_spdx, detections) =
+            normalize_npm_declared_license(Some("MIT/NotARealLicenseXyz"));
+
+        assert_eq!(declared, None);
+        assert_eq!(declared_spdx, None);
+        assert!(detections.is_empty());
+    }
+
+    #[test]
+    fn test_normalize_npm_declared_license_url_slash_not_treated_as_dual() {
+        // A `/` inside a URL is not a license separator.
+        let (declared, _, _) = normalize_npm_declared_license(Some("https://example.com/LICENSE"));
+
+        assert!(
+            declared.as_deref() != Some("apache-2.0 OR mit"),
+            "URL slash must not be parsed as a dual-license list"
+        );
     }
 
     #[test]

--- a/src/parsers/npm.rs
+++ b/src/parsers/npm.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::PackageParser;
-use super::license_normalization::normalize_spdx_declared_license;
+use super::license_normalization::normalize_npm_declared_license;
 use super::metadata::ParserMetadata;
 
 const FIELD_NAME: &str = "name";
@@ -108,7 +108,7 @@ impl PackageParser for NpmParser {
 
         let extracted_license_statement = extract_license_statement(&json);
         let (declared_license_expression, declared_license_expression_spdx, license_detections) =
-            normalize_spdx_declared_license(extract_declared_license_candidate(&json).as_deref());
+            normalize_npm_declared_license(extract_declared_license_candidate(&json).as_deref());
         let peer_dependencies_meta = extract_peer_dependencies_meta(&json);
         let dependencies = extract_dependencies(&json, false);
         let dev_dependencies = extract_dependencies(&json, true);

--- a/src/parsers/npm_test.rs
+++ b/src/parsers/npm_test.rs
@@ -284,6 +284,51 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_slash_separated_dual_license() {
+        // npm's legacy informal slash convention: `MIT/Apache2` means dual
+        // licensed (MIT OR Apache-2.0), with `Apache2` an informal Apache-2.0.
+        let slash_dual_content = r#"
+{
+  "name": "start-mobile-example",
+  "version": "1.0.0",
+  "license": "MIT/Apache2"
+}
+"#;
+
+        let (_temp_file, path) = create_temp_package_json(slash_dual_content);
+        let package_data = NpmParser::extract_first_package(&path);
+
+        assert_eq!(
+            package_data.declared_license_expression.as_deref(),
+            Some("apache-2.0 OR mit")
+        );
+        assert_eq!(
+            package_data.declared_license_expression_spdx.as_deref(),
+            Some("Apache-2.0 OR MIT")
+        );
+        assert_eq!(package_data.license_detections.len(), 1);
+
+        // A plain single SPDX license is unaffected by the slash handling.
+        let single_content = r#"
+{
+  "name": "single-license",
+  "version": "1.0.0",
+  "license": "MIT"
+}
+"#;
+        let (_single_file, single_path) = create_temp_package_json(single_content);
+        let single_data = NpmParser::extract_first_package(&single_path);
+        assert_eq!(
+            single_data.declared_license_expression.as_deref(),
+            Some("mit")
+        );
+        assert_eq!(
+            single_data.declared_license_expression_spdx.as_deref(),
+            Some("MIT")
+        );
+    }
+
+    #[test]
     fn test_extract_repository_formats() {
         // Test repository as string
         let repo_string_content = r#"


### PR DESCRIPTION
## Summary

- npm's legacy informal `license` convention used a `/`-separated list to mean dual-licensed (e.g. `"MIT/Apache2"`, `"BSD/MIT"`, `"MIT/X11"`) before SPDX expressions were standardized. SPDX expression parsing does not understand `/`, so these strings fell through to an honest `null` declared license expression.
- Adds `normalize_npm_declared_license`, applied only to the bounded, trustworthy npm declared `license` field. It tries standard SPDX-expression normalization first (so valid forms, including parenthesized `"(MIT OR Apache-2.0)"`, are unchanged), then treats a `/`-joined list of license names as `OR`. Each operand is resolved via SPDX normalization, then the declared-license key/alias table, then declared free-text detection; if any operand fails to resolve, the field stays `null` rather than a partial guess.
- Adds `apache2`/`apache-2` declared-license aliases for the informal `Apache2` operand spelling.

## Issues

- Covers: bevy `.github/start-mobile-example/package.json` declaring `"license": "MIT/Apache2"`, which Provenant emitted as `declared_license_expression: null` (ScanCode emitted `mit`); the correct result is `MIT OR Apache-2.0`.

## Scope and exclusions

- Included: npm declared-license `/`-separated dual-license normalization; `apache2`/`apache-2` declared-license aliases; parser + normalizer unit tests.
- Explicit exclusions: file-content license detection is untouched — a `/` in prose or a URL never triggers this path (it is reached only from the npm declared field, and URL slashes `://` are explicitly excluded). No other ecosystems' declared-license handling is changed.

## How to verify

- Unit: `cargo test --lib parsers::license_normalization::tests::test_normalize_npm` and `cargo test --lib parsers::npm_test::tests::test_extract_slash_separated_dual_license`.
- Behavioral: a `package.json` with `"license": "MIT/Apache2"` now yields `declared_license_expression: "apache-2.0 OR mit"` / `_spdx: "Apache-2.0 OR MIT"`; a plain `"MIT"` is unchanged; an unresolvable operand (e.g. `"MIT/NotARealLicense"`) stays `null`.

## Intentional differences from Python

- For `MIT/Apache2`, ScanCode emits only `mit`; Provenant emits the more complete `MIT OR Apache-2.0`, which is the correct reading of the `/` dual-license convention with `Apache2` = Apache-2.0.

## Expected-output fixture changes

- Files changed: none. No npm golden fixture uses the slash form, so no `.expected` outputs change.
