### PR TITLE
fix(post-processing): prefer LICENSE over NOTICE when co-hosted legal files disagree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "provenant",
       "version": "0.1.0",
       "devDependencies": {
-        "lefthook": "2.1.8",
+        "lefthook": "2.1.9",
         "markdownlint-cli2": "0.22.1",
         "prettier": "3.9.0"
       },
@@ -482,9 +482,9 @@
       }
     },
     "node_modules/lefthook": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.8.tgz",
-      "integrity": "sha512-tJIoVpFF52PuU8YPJI9bRprGwzI6FR2GNeBbpMnXdRjjfJHyOR4VRLXilzoQ6lbhKVHfTohXhrQgLpU41bKITg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.9.tgz",
+      "integrity": "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -492,22 +492,22 @@
         "lefthook": "bin/index.js"
       },
       "optionalDependencies": {
-        "lefthook-darwin-arm64": "2.1.8",
-        "lefthook-darwin-x64": "2.1.8",
-        "lefthook-freebsd-arm64": "2.1.8",
-        "lefthook-freebsd-x64": "2.1.8",
-        "lefthook-linux-arm64": "2.1.8",
-        "lefthook-linux-x64": "2.1.8",
-        "lefthook-openbsd-arm64": "2.1.8",
-        "lefthook-openbsd-x64": "2.1.8",
-        "lefthook-windows-arm64": "2.1.8",
-        "lefthook-windows-x64": "2.1.8"
+        "lefthook-darwin-arm64": "2.1.9",
+        "lefthook-darwin-x64": "2.1.9",
+        "lefthook-freebsd-arm64": "2.1.9",
+        "lefthook-freebsd-x64": "2.1.9",
+        "lefthook-linux-arm64": "2.1.9",
+        "lefthook-linux-x64": "2.1.9",
+        "lefthook-openbsd-arm64": "2.1.9",
+        "lefthook-openbsd-x64": "2.1.9",
+        "lefthook-windows-arm64": "2.1.9",
+        "lefthook-windows-x64": "2.1.9"
       }
     },
     "node_modules/lefthook-darwin-arm64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.8.tgz",
-      "integrity": "sha512-6dZr2QUdJOOvy9FjQHZoFVfPjgxb9IH5f9DeU0OBYMQ0cUGvb5YjHnkUkRrWIlASmwFm1bk3OPwhqKU7pTsICw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.9.tgz",
+      "integrity": "sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==",
       "cpu": [
         "arm64"
       ],
@@ -519,9 +519,9 @@
       ]
     },
     "node_modules/lefthook-darwin-x64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.8.tgz",
-      "integrity": "sha512-DW1yc+W5RBHdwaPJ94/mwFNROmNHI8Osu0iziIeJFXJIdkQ2P+KHfoxBWejYd2QA2Eu5W9i+gBssTDkJ4kX2kA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.9.tgz",
+      "integrity": "sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==",
       "cpu": [
         "x64"
       ],
@@ -533,9 +533,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-arm64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.8.tgz",
-      "integrity": "sha512-rmWVdImTihY/V1bLSb3zeDxEHjRBQtudnkKKsoph934enIWPwzIap5zVHHAj8q9mzp0wpn5r1ybX55aO2wM61A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.9.tgz",
+      "integrity": "sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==",
       "cpu": [
         "arm64"
       ],
@@ -547,9 +547,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-x64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.8.tgz",
-      "integrity": "sha512-o1AG4CpmgESxLqZWzkXhne+PhLhLFV0GHVAIJCmieOwq4q2+rDYAudGhtot/NrgSpyMCo84qVSQmI8Dgnu1XJw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.9.tgz",
+      "integrity": "sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==",
       "cpu": [
         "x64"
       ],
@@ -561,9 +561,9 @@
       ]
     },
     "node_modules/lefthook-linux-arm64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.8.tgz",
-      "integrity": "sha512-er3zTjx2DMxojPJ1LZv0G3ug9Th+mAapqWrt5ZZhQNcXWW28pfvo2fCqBs6Fz14GMn4xassmwOpGovutSh1UtA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.9.tgz",
+      "integrity": "sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==",
       "cpu": [
         "arm64"
       ],
@@ -575,9 +575,9 @@
       ]
     },
     "node_modules/lefthook-linux-x64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.8.tgz",
-      "integrity": "sha512-3yGx0VFbPcaKiIir313ETNcyq34CfAwkIU+Ry3WMGDjrsRNuA/YlDxm0BHKLcum7u+rpVfT4Uz6r8gHdaHXolg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.9.tgz",
+      "integrity": "sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==",
       "cpu": [
         "x64"
       ],
@@ -589,9 +589,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-arm64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.8.tgz",
-      "integrity": "sha512-Dq+GJdJdclOwxt4NneTFHjLSA4v8tI7XUZq40KUVtpUQDpZcYhXSdkTytB0uLmD52tbFKt9Kx0VbB6uvxPvLvw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.9.tgz",
+      "integrity": "sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==",
       "cpu": [
         "arm64"
       ],
@@ -603,9 +603,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-x64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.8.tgz",
-      "integrity": "sha512-/Gv2EdlzyiDoK+9fDWIn+EeTgrNeVncQsSeAF47X2Abe5LGxuFjZbBXxEIkY1BU79OQNNLnkx0gFHbrr5mmd9Q==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.9.tgz",
+      "integrity": "sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==",
       "cpu": [
         "x64"
       ],
@@ -617,9 +617,9 @@
       ]
     },
     "node_modules/lefthook-windows-arm64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.8.tgz",
-      "integrity": "sha512-S+/pBBj/7hMQOl9pLBS4Ut8+U0feQbzmD7iN0ifNth4r/uqW8UFFAHwERbclfsVnni4ceHpt7lFr7sXsu0RU8g==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.9.tgz",
+      "integrity": "sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==",
       "cpu": [
         "arm64"
       ],
@@ -631,9 +631,9 @@
       ]
     },
     "node_modules/lefthook-windows-x64": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.8.tgz",
-      "integrity": "sha512-MpdgKMU/JLLCsEpTqJ9jWlxngSdDh3EknvUHveWePrIms7G11y6R3oZBNRSqZ+zx/PGNl/HKvqEtbwtw8Hz3gw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.9.tgz",
+      "integrity": "sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=24.0.0"
   },
   "devDependencies": {
-    "lefthook": "2.1.8",
+    "lefthook": "2.1.9",
     "markdownlint-cli2": "0.22.1",
     "prettier": "3.9.0"
   }

--- a/src/post_processing/package_metadata_promotion.rs
+++ b/src/post_processing/package_metadata_promotion.rs
@@ -246,8 +246,10 @@ fn single_declared_expression(legal_files: &[&FileInfo]) -> Option<String> {
 /// - If the set disagrees, the canonical `LICENSE`/`LICENCE`/`COPYING` family takes
 ///   precedence and the agreement test is re-run on that subset; a subset that still
 ///   disagrees (dual `LICENSE-*`) abstains.
-/// - If no canonical license file is present, the full set is kept, so a sole
-///   `NOTICE` (or `COPYRIGHT`/`AUTHORS`) still promotes as before.
+/// - A *sole* or *agreeing* `NOTICE`/`COPYRIGHT`/`AUTHORS` set still promotes via the
+///   first branch. Only a *disagreeing* set with no canonical license file abstains
+///   (returns `None`) — matching prior behavior, where a `NOTICE`-vs-`COPYRIGHT`
+///   disagreement was never promoted either.
 ///
 /// Returns `None` (abstain) when the chosen set has no single agreed expression.
 fn select_legal_files_and_expression(


### PR DESCRIPTION
## Summary

- ADR-0010's `promote_package_declared_license_from_legal_files` previously **abstained** when a package's co-located legal files disagreed, leaving `declared_license_expression` null. The ubiquitous Apache-style **LICENSE + NOTICE** pattern hits this: the canonical `LICENSE` states the package's own license while `NOTICE` enumerates *bundled third-party* licenses, so the two disagree.
- Now prefer canonically-named license-family files (`LICENSE`/`LICENCE`/`COPYING`, `LICENSE-*`/`COPYING-*`) over `NOTICE`/`COPYRIGHT`/`AUTHORS` on disagreement, promoting from that subset. This makes Provenant **more correct than ScanCode**, which over-aggregates both files (e.g. prometheus `apache-2.0 AND bsd-new AND mit`).

## Preserved guards
- Dual `LICENSE-APACHE` + `LICENSE-MIT` still **abstains** (disagreement test runs within the license-family subset).
- `NOTICE`/`COPYING`-only dirs keep prior behavior via fallback. Other ADR-0010 guards unchanged.

## Tests / verification
- Unit tests: agree; prefer-LICENSE-over-disagreeing-NOTICE (prometheus shape); dual-license abstains; NOTICE-only fallback. ADR-0010 amended.
- Verified on prometheus@351447a4: `pkg:golang/.../prometheus` declared = `apache-2.0` (was null).

Found via benchmark verification of prometheus/prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)