### PR TITLE
fix(copyright): compose obfuscated emails so multi-holder notices chain past them

### DIFF
--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -2278,3 +2278,48 @@ fn test_notice_file_multiple_copyrights() {
         cr_texts
     );
 }
+
+#[test]
+fn test_multiholder_with_obfuscated_emails_keeps_all_holders() {
+    // hiredis.c header: two comma-separated holders, each followed by an
+    // obfuscated email. The continuation must not stop at the first email +
+    // comma; both holders and both emails belong to the copyright.
+    let text = "Copyright (c) 2015, Matt Stancliff <matt at genges dot com>, Jan-Erik Rediger <janerik at fnordig dot com>";
+    let (c, h, _a) = detect_copyrights_from_text(text);
+    assert_eq!(c.len(), 1, "one copyright statement: {c:?}");
+    let cr = c[0].copyright.as_str();
+    assert!(cr.contains("Matt Stancliff"), "first holder kept: {cr}");
+    assert!(
+        cr.contains("matt at genges dot com"),
+        "first obfuscated email kept: {cr}"
+    );
+    assert!(
+        cr.contains("Jan-Erik Rediger"),
+        "second holder must not be dropped: {cr}"
+    );
+    assert!(
+        cr.contains("janerik at fnordig dot com"),
+        "second obfuscated email kept: {cr}"
+    );
+    let holders: Vec<&str> = h.iter().map(|x| x.holder.as_str()).collect();
+    assert!(
+        holders.iter().any(|x| x.contains("Matt Stancliff"))
+            && holders.iter().any(|x| x.contains("Jan-Erik Rediger")),
+        "both holders captured: {holders:?}"
+    );
+}
+
+#[test]
+fn test_single_holder_obfuscated_email_kept_in_copyright() {
+    // dict.c header: the obfuscated email must stay in the copyright statement
+    // rather than being truncated at the holder name.
+    let text = "Copyright (c) 2006-2010, Salvatore Sanfilippo antirez at gmail dot com";
+    let (c, h, _a) = detect_copyrights_from_text(text);
+    assert_eq!(c.len(), 1, "{c:?}");
+    assert_eq!(
+        c[0].copyright,
+        "Copyright (c) 2006-2010, Salvatore Sanfilippo antirez at gmail dot com"
+    );
+    assert_eq!(h.len(), 1);
+    assert_eq!(h[0].holder, "Salvatore Sanfilippo");
+}

--- a/src/copyright/lexer.rs
+++ b/src/copyright/lexer.rs
@@ -115,8 +115,79 @@ pub fn get_tokens(numbered_lines: &[(usize, String)]) -> Vec<Token> {
     }
 
     retag_camel_case_junk_before_company_suffix_in_copyright_context(&mut tokens);
+    compose_obfuscated_emails(&mut tokens);
 
     tokens
+}
+
+/// Collapse a space-separated obfuscated email such as
+/// `matt at genges dot com` into a single [`PosTag::Email`] token.
+///
+/// Mirrors the ScanCode `EMAIL` grammar rules for obfuscated forms
+/// (`copyrights.py` rules `# foo at bat dot com` and `#350.3`): a word, the
+/// literal connector `at`, a word, the literal `dot`, and a final word. The
+/// connector tokenizes as either [`PosTag::At`] (from `AT`) or [`PosTag::Cc`]
+/// (from lowercase `at`); the separator tokenizes as [`PosTag::Dot`]. Composing
+/// in the token stream — rather than as grammar rules — keeps `Email` a leaf
+/// tag, so the existing `NAME`/`NAME-EMAIL` rules chain holders across the
+/// obfuscated email and the trailing comma instead of stopping at it.
+fn compose_obfuscated_emails(tokens: &mut Vec<Token>) {
+    if tokens.len() < 5 {
+        return;
+    }
+
+    // A local/domain word of the obfuscated-email pattern. `PosTag::Pn` (dotted
+    // initials such as `j.` or `DMTF.`) is intentionally excluded: a dotted
+    // local-part like `j.doe at example dot com` is vanishingly rare in real
+    // copyright headers and not worth the over-composition risk.
+    let is_word = |t: &Token| {
+        matches!(
+            t.tag,
+            PosTag::Nn | PosTag::Nnp | PosTag::Caps | PosTag::MixedCap
+        )
+    };
+    let is_at_connector = |t: &Token| {
+        t.tag == PosTag::At || (t.tag == PosTag::Cc && t.value.eq_ignore_ascii_case("at"))
+    };
+
+    let mut i = 0;
+    while i + 5 <= tokens.len() {
+        // A parenthesis-wrapped obfuscated email such as `(pdimov at gmail dot
+        // com)` is left to the existing single-token bracket pattern and stays
+        // inline in the holder, matching ScanCode. Only the angle-bracketed and
+        // bare forms (whose brackets were already stripped upstream) compose
+        // here, where ScanCode also lifts the email out of the holder.
+        // Checking only the first and last token's line is sufficient: a blank
+        // line between tokens injects an `EmptyLine` token (which fails `is_word`
+        // /`is_at_connector` below), and a gapless continuation is treated as one
+        // logical line — so the three inner tokens cannot straddle lines here.
+        let has_paren_boundary =
+            tokens[i].value.starts_with('(') || tokens[i + 4].value.ends_with(')');
+        if !has_paren_boundary
+            && tokens[i].start_line == tokens[i + 4].start_line
+            && is_word(&tokens[i])
+            && is_at_connector(&tokens[i + 1])
+            && is_word(&tokens[i + 2])
+            && tokens[i + 3].tag == PosTag::Dot
+            && is_word(&tokens[i + 4])
+        {
+            let value = tokens[i..i + 5]
+                .iter()
+                .map(|t| t.value.as_str())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let start_line = tokens[i].start_line;
+            tokens.splice(
+                i..i + 5,
+                std::iter::once(Token {
+                    value,
+                    tag: PosTag::Email,
+                    start_line,
+                }),
+            );
+        }
+        i += 1;
+    }
 }
 
 fn retag_camel_case_junk_before_company_suffix_in_copyright_context(tokens: &mut [Token]) {

--- a/src/copyright/lexer_test.rs
+++ b/src/copyright/lexer_test.rs
@@ -218,3 +218,43 @@ fn test_quoted_plain_key_is_junk_for_structured_literals() {
         .expect("data token should exist");
     assert_eq!(token.tag, PosTag::Junk, "tokens: {tokens:?}");
 }
+
+#[test]
+fn test_composes_lowercase_obfuscated_email_into_single_token() {
+    // `matt at genges dot com` tokenizes as Nnp Cc(at) Nn Dot(dot) Nn; it must
+    // collapse to one Email leaf so downstream NAME rules chain past it.
+    let lines = vec![(1, "Matt Stancliff matt at genges dot com".to_string())];
+    let tokens = get_tokens(&lines);
+    let email = tokens
+        .iter()
+        .find(|t| t.tag == PosTag::Email)
+        .expect("obfuscated email should compose to an Email token");
+    assert_eq!(email.value, "matt at genges dot com", "tokens: {tokens:?}");
+    assert!(
+        !tokens.iter().any(|t| t.tag == PosTag::Dot),
+        "the `dot` separator must be consumed into the Email token: {tokens:?}"
+    );
+}
+
+#[test]
+fn test_composes_uppercase_at_obfuscated_email() {
+    // `joe AT foo DOT com` uses At/Dot tags (uppercase connectors).
+    let lines = vec![(1, "Jane Doe joe AT foo DOT com".to_string())];
+    let tokens = get_tokens(&lines);
+    let email = tokens
+        .iter()
+        .find(|t| t.tag == PosTag::Email)
+        .expect("uppercase AT/DOT obfuscated email should compose");
+    assert_eq!(email.value, "joe AT foo DOT com", "tokens: {tokens:?}");
+}
+
+#[test]
+fn test_does_not_compose_plain_prose_without_dot_separator() {
+    // No obfuscated `dot` separator: ordinary prose must not collapse to an email.
+    let lines = vec![(1, "the cat sat at the mat".to_string())];
+    let tokens = get_tokens(&lines);
+    assert!(
+        !tokens.iter().any(|t| t.tag == PosTag::Email),
+        "plain prose must not compose into an email: {tokens:?}"
+    );
+}

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -316,6 +316,15 @@ fn project_native_copyright_value(rendered: &str, fallback: &str) -> String {
         if refine_copyright(rendered).as_deref() == Some(fallback) {
             return preserve_native_suffix_for_semantic_match(rendered, fallback);
         }
+        // The normalized notice was not found verbatim (e.g. punctuation differs)
+        // and the span does not refine to it. A faithful raw projection stays
+        // close in length to the normalized value; a span dramatically longer is
+        // the notice embedded in a run-on blob — common in font name-table records
+        // that pack a whole licence onto one line — so prefer the trustworthy
+        // normalized value rather than emitting the blob.
+        if rendered.len() > fallback.len().saturating_mul(2) + 64 {
+            return fallback.to_string();
+        }
         return rendered.to_string();
     };
     let end = start + fallback.len();

--- a/testdata/copyright-golden/ics/ppp-pppd-plugins/winbind.c.yml
+++ b/testdata/copyright-golden/ics/ppp-pppd-plugins/winbind.c.yml
@@ -10,7 +10,7 @@ copyrights:
   - Copyright (c) 1997, Miguel A.L. Paraz @iphil.net
   - Copyright (c) 2002 Roaring Penguin Software Inc.
   - Copyright (c) 2003 Andrew Bartlet <abartlet@samba.org>
-  - Copyright (c) 2003, Sean E. Millichamp
+  - Copyright (c) 2003, Sean E. Millichamp sean at bruenor dot org
   - Copyright (c) Andrew Tridgell 1992-2001
   - Copyright (c) Martin Pool 2003
   - Copyright (c) Simo Sorce 2001-2002


### PR DESCRIPTION
## Summary

- A space-separated obfuscated email (e.g. `matt at genges dot com`) broke holder chaining: the NAME-EMAIL grammar stopped at it, **truncating a multi-holder copyright**. On redis `deps/hiredis/hiredis.c`, source `Copyright (c) 2015, Matt Stancliff <matt at genges dot com>, Jan-Erik Rediger <...>` captured only Matt Stancliff and dropped Jan-Erik; ScanCode kept both.
- `compose_obfuscated_emails` collapses such forms into a single `Email` leaf token **before** the grammar runs, so holders chain across the email + trailing comma and **all holders are captured** (matching ScanCode), with the obfuscated email consistently retained rather than inconsistently dropped. Parenthesis-wrapped forms (`(pdimov at gmail dot com)`) stay inline, as before.
- Also guards `project_native_copyright_value` against emitting a run-on blob far longer than the normalized notice (e.g. font `name`-table records packing a whole licence onto one line).

## Tests / verification
- New: `test_multiholder_with_obfuscated_emails_keeps_all_holders` (the redis shape), lexer composition tests (lowercase `at` and uppercase `AT`), single-holder email-retention. All existing obfuscated-email tests still pass (1134 copyright lib tests, 0 failed).
- Copyright golden suite: **36/36 pass**; one fixture updated (`ics/ppp-pppd-plugins/winbind.c`) where the obfuscated email is now retained on the holder — more complete, matching ScanCode. No other golden affected.

Found via benchmark verification of redis/redis (with the font-name-table guard motivated by bevy font assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)