### PR TITLE
docs(benchmarks): record prometheus, redis, and bevy comparison runs

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 232 of 232 recorded runs, with a **19.2× median speedup** and **19.2× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 235 of 235 recorded runs, with a **19.4× median speedup** and **19.4× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -657,6 +657,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `7.29s`; ScanCode `136.34s`
 - Far broader Bazel module coverage (`29` vs `5` `pkg:bazel/*` packages, `1362` vs `736` dependencies) from the repo's `MODULE.bazel` bzlmod manifests, `WORKSPACE`, and `BUILD` files across the example and test trees that ScanCode largely leaves unmodeled, with the assembled `pkg:bazel/py_toolchains` carrying both `apache-2.0` declared licensing and the `The Bazel Authors` holder where ScanCode attaches neither to its top-level package, plus extension-qualified installed-wheel PURLs and clean canonical PyPI dependency identities where ScanCode appends `file_name` archive qualifiers
 
+##### [bevyengine/bevy @ d227783](https://github.com/bevyengine/bevy/tree/d22778325fd1fdec484109d0c0074b70524ab0f9) — **47.5× faster**
+
+- Files: 2,897
+- Run context: 2026-07-01 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `7.64s`; ScanCode `362.89s`
+- Structure-preserving dual-license identity across the Cargo workspace — the `pkg:cargo/bevy*` crates carry `apache-2.0 OR mit` with the `OR` intact — plus normalization of the informal npm `"MIT/Apache2"` declared string to `apache-2.0 OR mit` where ScanCode reports only `mit`, and source-faithful URL extraction that preserves author-written trailing slashes (for example `https://bevy.org/donate/`) that ScanCode strips inconsistently, on matched package and dependency coverage (`94` packages, `1679` dependencies)
+
 ##### [boostorg/boost @ 4f1cbeb](https://github.com/boostorg/boost/tree/4f1cbeb724d9f3c08a826fbcee5a3db2f5480441) — **14.47× faster**
 
 - Files: 241
@@ -944,6 +951,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `21.79s`; ScanCode `841.78s`
 - Broader package and dependency visibility (`1` vs `0` packages, `41` vs `0` dependencies) from bundled `external/perl/Text-Template-1.56` CPAN metadata plus committed `.gitmodules` and `test/quic-openssl-docker/Dockerfile` surfaces, with stronger `Written by ...` author recovery on OpenSSL-style comment headers and cleaner rejection of weak CPAL or MIT overcalls on standard OpenSSL license footers
 
+##### [prometheus/prometheus @ 351447a](https://github.com/prometheus/prometheus/tree/351447a44b0887c959b74996d2d3367f31293cba) — **30.1× faster**
+
+- Files: 1,637
+- Run context: 2026-07-01 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.99s`; ScanCode `300.33s`
+- Broader Go package and dependency extraction (`9` vs `7` packages, `3995` vs `2324` dependencies) across the workspace `go.mod`/`go.sum`/`go.work` and nested module manifests, with the assembled `pkg:golang/github.com/prometheus/prometheus` carrying a clean `apache-2.0` declared license from the repo-root `LICENSE` where ScanCode conflates the sibling `NOTICE`'s bundled-dependency licensing into an `apache-2.0 AND mit AND bsd-new AND (apache-2.0 AND unknown-license-reference)` aggregate, plus author capture that rejects the README prose and Go test-code fragments ScanCode records as parties
+
 ##### [pulseaudio/pulseaudio @ b096704](https://github.com/pulseaudio/pulseaudio/tree/b096704c0d42c5e784deb781a07b23cfb5286a82) — **29.70× faster**
 
 - Files: 867
@@ -964,6 +978,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `32.26s`; ScanCode `1488.40s`
 - Broader Meson and package-adjacent dependency extraction (`22` vs `21` packages, `260` vs `176` dependencies) from the root `.gitmodules`, `python/tests/minreqs.txt`, and many committed `subprojects/**/meson.build` manifests, with the real `pkg:autotools/qemu` root identity instead of ScanCode's generic input placeholder
+
+##### [redis/redis @ 5b5c326](https://github.com/redis/redis/tree/5b5c32663b09e5e5c6d8918207d35d82d79ab0a5) — **24.4× faster**
+
+- Files: 1,803
+- Run context: 2026-07-01 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `11.16s`; ScanCode `272.71s`
+- Direct `pkg:autotools/jemalloc` package identity (`bsd-simplified`) assembled from the vendored `deps/jemalloc` build manifests where ScanCode surfaces no package at all, cleaner per-file license expressions — the vendored `deps/jemalloc/test` SFMT sources resolve to a clean `bsd-new` where ScanCode bolts on the whole repo-license blob (`bsd-new AND (bsd-new AND generic-cla AND mongodb-sspl-1.0 AND agpl-3.0 AND unknown-license-reference …)`) — and source-faithful copyright capture that keeps complete multi-holder notices and their obfuscated-email contacts across the vendored `deps/hiredis` and `deps/fpconv` sources where ScanCode truncates to a single holder
 
 ##### [restic/restic @ 29446b0](https://github.com/restic/restic/tree/29446b0fd853b7765f652584ff90e817890ee389) — **8.47× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -446,6 +446,9 @@ ScanCode: 186.47s</title></rect>
     <rect x="596.63" y="389.66" width="8" height="8" fill="#d97706" rx="1.5"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 ScanCode: 155.12s</title></rect>
+    <rect x="601.96" y="358.44" width="8" height="8" fill="#d97706" rx="1.5"><title>prometheus/prometheus @ 351447a
+Files: 1637
+ScanCode: 300.33s</title></rect>
     <rect x="603.42" y="377.17" width="8" height="8" fill="#d97706" rx="1.5"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 ScanCode: 202.03s</title></rect>
@@ -455,6 +458,9 @@ ScanCode: 428.07s</title></rect>
     <rect x="607.89" y="371.18" width="8" height="8" fill="#d97706" rx="1.5"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 ScanCode: 229.36s</title></rect>
+    <rect x="608.62" y="363.00" width="8" height="8" fill="#d97706" rx="1.5"><title>redis/redis @ 5b5c326
+Files: 1803
+ScanCode: 272.71s</title></rect>
     <rect x="610.17" y="432.56" width="8" height="8" fill="#d97706" rx="1.5"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
 Files: 1844
 ScanCode: 62.57s</title></rect>
@@ -515,6 +521,9 @@ ScanCode: 205.19s</title></rect>
     <rect x="641.06" y="367.52" width="8" height="8" fill="#d97706" rx="1.5"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 ScanCode: 247.80s</title></rect>
+    <rect x="641.30" y="349.50" width="8" height="8" fill="#d97706" rx="1.5"><title>bevyengine/bevy @ d227783
+Files: 2897
+ScanCode: 362.89s</title></rect>
     <rect x="641.37" y="349.55" width="8" height="8" fill="#d97706" rx="1.5"><title>facebook/fresco @ c991a69
 Files: 2900
 ScanCode: 362.51s</title></rect>
@@ -1144,6 +1153,9 @@ Provenant: 7.95s</title></circle>
     <circle cx="600.63" cy="529.89" r="4.5" fill="#2563eb"><title>aosp-mirror/platform_build @ 045a3d6
 Files: 1515
 Provenant: 8.68s</title></circle>
+    <circle cx="605.96" cy="523.25" r="4.5" fill="#2563eb"><title>prometheus/prometheus @ 351447a
+Files: 1637
+Provenant: 9.99s</title></circle>
     <circle cx="607.42" cy="537.36" r="4.5" fill="#2563eb"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 Provenant: 7.41s</title></circle>
@@ -1153,6 +1165,9 @@ Provenant: 13.06s</title></circle>
     <circle cx="611.89" cy="535.86" r="4.5" fill="#2563eb"><title>ValveSoftware/eigen @ e9c4315
 Files: 1784
 Provenant: 7.65s</title></circle>
+    <circle cx="612.62" cy="518.01" r="4.5" fill="#2563eb"><title>redis/redis @ 5b5c326
+Files: 1803
+Provenant: 11.16s</title></circle>
     <circle cx="614.17" cy="538.33" r="4.5" fill="#2563eb"><title>Azure Linux distroless/minimal 3.0 linux/amd64 @ sha256:0c64ab9
 Files: 1844
 Provenant: 7.26s</title></circle>
@@ -1213,6 +1228,9 @@ Provenant: 8.34s</title></circle>
     <circle cx="645.06" cy="537.94" r="4.5" fill="#2563eb"><title>pnpm/pnpm @ 2a1ffe1
 Files: 2887
 Provenant: 7.32s</title></circle>
+    <circle cx="645.30" cy="535.92" r="4.5" fill="#2563eb"><title>bevyengine/bevy @ d227783
+Files: 2897
+Provenant: 7.64s</title></circle>
     <circle cx="645.37" cy="524.20" r="4.5" fill="#2563eb"><title>facebook/fresco @ c991a69
 Files: 2900
 Provenant: 9.79s</title></circle>


### PR DESCRIPTION
## Summary

Records three new real-world comparison-run benchmark rows in `docs/BENCHMARKS.md` and regenerates the scan-duration-vs-files chart (now 235 runs). These targets were chosen to both validate recently merged fixes in the wild and gather confidence in provenance correctness against ScanCode.

- **prometheus/prometheus @351447a** — 30.1× faster. Assembled `pkg:golang/…/prometheus` carries a clean `apache-2.0` from the repo-root `LICENSE` where ScanCode conflates the sibling `NOTICE` into `apache-2.0 AND mit AND bsd-new AND (apache-2.0 AND unknown-license-reference)`; broader Go package/dependency extraction (9 vs 7 packages, 3995 vs 2324 deps). Validates ADR-0010 co-hosted LICENSE promotion.
- **redis/redis @5b5c326** — 24.4× faster. Direct `pkg:autotools/jemalloc` (`bsd-simplified`) where ScanCode surfaces no package; cleaner per-file expressions (jemalloc SFMT sources → clean `bsd-new` vs ScanCode's bolted-on SSPL/AGPL/unknown blob); source-faithful multi-holder copyright capture across `deps/hiredis` and `deps/fpconv`. Validates the multi-holder copyright fix (#1203).
- **bevyengine/bevy @d227783** — 47.5× faster. Structure-preserving `apache-2.0 OR mit` across 76 cargo crates; informal npm `\"MIT/Apache2\"` normalized to `apache-2.0 OR mit` where ScanCode reports only `mit`; trailing-slash URL fidelity — on matched package/dependency coverage. Validates the npm slash-separated dual-license fix (#1195).

## Testing

- `npm run check:docs` — markdownlint + prettier pass (0 errors).
- All row facts (license expressions, package identities, URL forms, timings) verified against the raw `provenant.json` / `scancode.json` from the clean-`main` re-scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)