### PR TITLE
fix(copyright): drop SSPL "copyright, or other" prose false positive

### DIFF
--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -73,6 +73,7 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright\s*,\s*patents?\s*,\s*trade secrets?\s*$",
         r"(?i)^copyright\s*,\s*patents?\s+or\b",
         r"(?i)^copyright\s*,\s*patents?\s*$",
+        r"(?i)^copyright\s*,\s*or\s+other\b",
         r"(?i)^copyright\s*,\s*patents?\s*,\s*trade secrets?\b",
         r"(?i)^copyright\s*,\s*including\b",
         r"(?i)^copyright\s*,\s*patent\s*,\s*or trademark\b",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -627,6 +627,15 @@ fn test_is_junk_copyright_trade_secrets_fragments() {
 }
 
 #[test]
+fn test_is_junk_copyright_sspl_licensing_copyright_or_other_notices() {
+    // SSPL/Elastic-style prose "any licensing, copyright, or other notices"
+    // leaves the bare fragment "copyright, or other" after refinement; it is
+    // license-body prose, not a real copyright statement.
+    assert!(is_junk_copyright("copyright, or other"));
+    assert!(is_junk_copyright("COPYRIGHT, OR OTHER"));
+}
+
+#[test]
 fn test_is_junk_copyright_all_caps_placeholders() {
     assert!(is_junk_copyright(
         "Copyright (c) 1999-2008 MODULEAUTHOR endif"

--- a/testdata/copyright-golden/non-detection-boilerplate/sspl_licensing_copyright_or_other_notices.txt
+++ b/testdata/copyright-golden/non-detection-boilerplate/sspl_licensing_copyright_or_other_notices.txt
@@ -1,0 +1,2 @@
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the Licensor in the Software.

--- a/testdata/copyright-golden/non-detection-boilerplate/sspl_licensing_copyright_or_other_notices.txt.yml
+++ b/testdata/copyright-golden/non-detection-boilerplate/sspl_licensing_copyright_or_other_notices.txt.yml
@@ -1,0 +1,4 @@
+what:
+  - holders
+  - copyrights
+  - authors


### PR DESCRIPTION
## Summary

- Fixes a pre-existing copyright-detection false positive: SSPL/Elastic-style license prose `You may not alter, remove, or obscure any licensing, copyright, or other notices of the Licensor` (present in redis `LICENSE.txt`) was mis-detected as a copyright statement, surfacing the bare fragment `copyright, or other`. It is license-body prose, not a real copyright notice; ScanCode does not report it.
- Adds a tightly anchored junk pattern to `COPYRIGHTS_JUNK_PATTERNS` (`^copyright\s*,\s*or\s+other\b`), placed alongside the existing `^copyright, patents ...` fragment cluster. The `^`/`\b` anchoring prevents misfiring on genuine notices such as `Copyright (c) 2020 Foo`.

## Scope and exclusions

- Included: one junk regex, one refiner unit test, one synthetic non-detection golden fixture.
- Explicit exclusions: no grammar/engine changes; no ScanCode-parity lane changes.

## How to verify

- CI golden + unit suites fully cover this. Nothing extra to try beyond `cargo test --features golden-tests --test copyright_golden` and `cargo test --lib copyright::`.

## Expected-output fixture changes

- Files changed: added `testdata/copyright-golden/non-detection-boilerplate/sspl_licensing_copyright_or_other_notices.txt` and its `.txt.yml` (synthetic 2-line SSPL snippet, `what` lists copyrights/holders/authors with no expected detections).
- Why the new expected output is correct: the snippet is pure license-body prose; the correct result is zero copyright/holder/author detections, matching ScanCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)