### PR TITLE
fix(copyright): collapse padding inside angle-bracketed obfuscated emails

### DIFF
--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -179,6 +179,12 @@ fn render_raw_copyright_from_text(
     // are left untouched and still preserved natively.
     let rendered = normalize_html_copyright_entity(&rendered);
     let rendered = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Collapse padding immediately inside a `<...>` pair so a source-spaced
+    // contact such as `< florian.loitsch at inria dot fr >` renders as
+    // `<florian.loitsch at inria dot fr>`, matching the unspaced `<email>` form
+    // real notices normally use. Only balanced pairs are touched, so stray `<`
+    // and `>` comparison operators are left alone.
+    let rendered = collapse_angle_bracket_padding(&rendered);
 
     if rendered.is_empty() {
         fallback.to_string()
@@ -189,6 +195,29 @@ fn render_raw_copyright_from_text(
     } else {
         project_native_copyright_value(&rendered, fallback)
     }
+}
+
+/// Collapse whitespace immediately inside a balanced `<...>` pair, leaving the
+/// inner text otherwise intact. `< a b >` becomes `<a b>`; unbalanced `<` / `>`
+/// (comparison operators) are untouched because the pattern requires a closing
+/// `>` with no intervening angle bracket.
+fn collapse_angle_bracket_padding(text: &str) -> String {
+    static ANGLE_PADDING_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"<[ \t]+([^<>]*?)[ \t]*>|<([^<>]*?)[ \t]+>").expect("valid regex")
+    });
+    if !text.contains('<') {
+        return text.to_string();
+    }
+    ANGLE_PADDING_RE
+        .replace_all(text, |caps: &regex::Captures| {
+            let inner = caps
+                .get(1)
+                .or_else(|| caps.get(2))
+                .map(|m| m.as_str())
+                .unwrap_or("");
+            format!("<{inner}>")
+        })
+        .into_owned()
 }
 
 /// Render the raw source span backing a detection so it can be tested for

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    extract_comment_author_supplements, extract_copyright_information,
-    extract_patch_header_author_supplements, is_binary_garbage_party_value,
-    is_binary_string_copyright_candidate, is_font_metadata_label_copyright,
+    collapse_angle_bracket_padding, extract_comment_author_supplements,
+    extract_copyright_information, extract_patch_header_author_supplements,
+    is_binary_garbage_party_value, is_binary_string_copyright_candidate,
+    is_font_metadata_label_copyright,
 };
 use crate::copyright;
 use crate::models::{FileInfoBuilder, FileType};
@@ -1223,4 +1224,62 @@ fn test_html_copyright_entity_is_detected_not_treated_as_source_code() {
             .collect::<Vec<_>>(),
         vec!["Natural Earth"]
     );
+}
+
+#[test]
+fn test_collapse_angle_bracket_padding() {
+    // Padding on both sides, one side, and none.
+    assert_eq!(
+        collapse_angle_bracket_padding("Foo < a at b dot c > Bar"),
+        "Foo <a at b dot c> Bar"
+    );
+    assert_eq!(
+        collapse_angle_bracket_padding("Foo <a at b dot c > Bar"),
+        "Foo <a at b dot c> Bar"
+    );
+    assert_eq!(
+        collapse_angle_bracket_padding("Foo < a at b dot c> Bar"),
+        "Foo <a at b dot c> Bar"
+    );
+    assert_eq!(
+        collapse_angle_bracket_padding("Foo <a@b.c> Bar"),
+        "Foo <a@b.c> Bar"
+    );
+    // Unbalanced comparison operators are left alone.
+    assert_eq!(collapse_angle_bracket_padding("if a < b"), "if a < b");
+    assert_eq!(collapse_angle_bracket_padding("a > b and c"), "a > b and c");
+}
+
+#[test]
+fn test_extract_copyright_obfuscated_email_in_spaced_angle_brackets() {
+    // The fpconv/redis header form: an obfuscated email padded inside angle
+    // brackets. The email is retained and the brackets render without inner
+    // spaces, matching the unspaced `<email>` form real notices normally use.
+    let text = "/*\n * Copyright (c) 2009, Florian Loitsch < florian.loitsch at inria dot fr >\n * All rights reserved.\n */\n";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("fpconv.c"), text, 120.0, false);
+
+    let file = builder
+        .name("fpconv.c".to_string())
+        .base_name("fpconv".to_string())
+        .extension(".c".to_string())
+        .path("fpconv.c".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright (c) 2009, Florian Loitsch <florian.loitsch at inria dot fr> All rights reserved."
+    );
+    assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
+    assert_eq!(file.holders[0].holder, "Florian Loitsch");
 }


### PR DESCRIPTION
## Summary

- An obfuscated email padded inside angle brackets in source — e.g. the fpconv/redis header `Florian Loitsch < florian.loitsch at inria dot fr >` — rendered its copyright notice with the source spacing preserved verbatim: `... < florian.loitsch at inria dot fr > ...`.
- Since #1203 the obfuscated email is composed into a single leaf token and retained in the normalized value (an improvement over the pre-#1203 drop). But the normalized value carries no brackets, so it is not a verbatim substring of the raw span; native projection falls through to returning the raw span as-is, keeping the padded brackets.
- This collapses whitespace immediately inside a balanced `<...>` pair in the projected native notice, so the contact renders as `<florian.loitsch at inria dot fr>` — matching the unspaced `<email>` form real notices normally use, and closer to ScanCode which strips the brackets. Holder extraction was already correct (`Florian Loitsch`); this is purely the notice-string rendering.

## Scope and exclusions

- Included: `collapse_angle_bracket_padding` helper applied to the projected native copyright value in `render_raw_copyright_from_text`; only balanced `<...>` pairs are touched.
- Explicit exclusions: stray `<` / `>` comparison operators are left alone (the pattern requires a closing `>` with no intervening angle bracket). Brackets are not stripped — Provenant keeps the source-faithful bracketed form rather than adopting ScanCode's full strip.

## How to verify

- `printf '/*\n * Copyright (c) 2009, Florian Loitsch < florian.loitsch at inria dot fr >\n * All rights reserved.\n */\n' > /tmp/fpconv.c && provenant scan --copyright /tmp/fpconv.c --json-pp -` — the copyright renders `Copyright (c) 2009, Florian Loitsch <florian.loitsch at inria dot fr> All rights reserved.` (no inner-bracket spaces), holder `Florian Loitsch`.
- The spaced real-email form `< lf@elemental.net >` is likewise tidied to `<lf@elemental.net>`.

## Intentional differences from Python

- ScanCode strips the angle brackets entirely (`florian.loitsch at inria dot fr`); Provenant keeps the brackets for source fidelity but removes the cosmetic inner padding.

## Expected-output fixture changes

- Files changed: none. The `copyright_golden` suite passes unchanged — every existing golden `<email>` value is already unspaced, so nothing is perturbed. Added focused unit tests (`test_collapse_angle_bracket_padding`, `test_extract_copyright_obfuscated_email_in_spaced_angle_brackets`).
