### PR TITLE
chore(deps): ignore blocked quick-xml advisories, drop stale entry

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,9 +16,16 @@ yanked = "deny"
 unmaintained = "workspace"
 unsound = "workspace"
 ignore = [
-    # Still pulled transitively by pdf_oxide. Provenant no longer depends on
-    # ttf-parser directly; remove this once pdf_oxide migrates away.
-    "RUSTSEC-2026-0192",
+    # RUSTSEC-2026-0194 (quadratic duplicate-attribute check) and
+    # RUSTSEC-2026-0195 (unbounded namespace-declaration allocation) are both
+    # DoS advisories against quick-xml < 0.41.0. The fix is in quick-xml
+    # >= 0.41.0, but the vulnerable versions are held below it by transitive
+    # requirements we cannot resolve: office_oxide 0.1.2 (via pdf_oxide) pins
+    # quick-xml "0.40" and rusty-axml 0.2.1 pins "0.38", both of which exclude
+    # 0.41. No compatible fixed version is resolvable until those crates bump
+    # their quick-xml requirement. Remove once they do.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- Ignore `RUSTSEC-2026-0194` (quadratic duplicate-attribute check) and `RUSTSEC-2026-0195` (unbounded namespace-declaration allocation) — both DoS advisories against `quick-xml < 0.41.0`.
- The fix is in `quick-xml >= 0.41.0`, but the vulnerable versions are held below it by transitive requirements that cannot currently be resolved: `office_oxide 0.1.2` (via `pdf_oxide`) pins `quick-xml "0.40"` and `rusty-axml 0.2.1` pins `"0.38"`, both of which exclude `0.41`. `office_oxide 0.1.2` is the latest release, so there is no compatible fixed version resolvable yet.
- Drop the stale `RUSTSEC-2026-0192` ignore, which no longer matches any crate in the graph (`cargo deny` reported `advisory-not-detected`).

## Scope and exclusions

- Included: `deny.toml` advisory-policy update only.
- Explicit exclusions: no dependency version changes. Our direct `quick-xml = "0.40.1"` edge is left as-is because bumping it alone would not clear the advisories — the transitive `0.40.1` (`office_oxide`) and `0.38.4` (`rusty-axml`) copies remain in the tree regardless.

## How to verify

- `cargo deny check advisories` → `advisories ok`, with no `advisory-not-detected` warning for the removed entry.

## Follow-up work

- Deferred: remove these ignores once `office_oxide` and `rusty-axml` bump their `quick-xml` requirement to `>= 0.41.0`. Worth tracking/nudging upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)