### PR TITLE
chore(renovate): pin dependency versions to fix artifact update failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
   "gitIgnoredAuthors": ["github-actions[bot] <github-actions[bot]@users.noreply.github.com>"],
   "prConcurrentLimit": 5,
   "prCreation": "not-pending",
-  "rangeStrategy": "bump",
+  "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Change `rangeStrategy` from `bump` to `pin` in `renovate.json` to eliminate recurring `renovate/artifacts` failures on Cargo dependency-update PRs.
- `provenant-cli` is `publish = false` (an application, not a published library), so exact version pins carry no downstream-consumer cost.

## Root cause

With `rangeStrategy: "bump"`, Renovate rewrites a manifest caret range (e.g. `indicatif = "0.18.4"`) to the release-age-approved target (`"0.18.5"`) but leaves it a caret range. It then runs `cargo update`, and cargo resolves the lockfile to the *newest* compatible version — which can be a still-pending release (e.g. `0.18.6` inside the `minimumReleaseAge` window). Renovate rejects that pending version and aborts the artifact step, producing the `renovate/artifacts` FAILURE. Renovate cannot pass `cargo update --precise` to force the aged version ([renovatebot/renovate#41624](https://github.com/renovatebot/renovate/issues/41624)).

Pinning exact versions removes the range cargo could drift within, so the lockfile always matches the release-aged target. This is the fix Renovate's own error message recommends for apps. See PR #1213 for a live instance of the failure.

## Scope and exclusions

- Included: single-line `rangeStrategy` config change.
- Explicit exclusions: no dependency version changes here. The first Renovate run after merge will open a (large) PR pinning current dependencies to exact versions; that is expected one-time churn.

## How to verify

- Config-only change; nothing for CI to build. After merge, confirm the next Renovate run opens a pinning PR and that subsequent Cargo update PRs no longer show `renovate/artifacts` failures.
