### PR TITLE
feat(clojure): resolve dynamic defproject identity, ~def deps, discards, and deps.edn classifiers

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 238 of 238 recorded runs, with a **19.5× median speedup** and **19.4× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 239 of 239 recorded runs, with a **19.4× median speedup** and **19.4× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -556,6 +556,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-16 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `33.78s`; ScanCode `659.41s`
 - Broader Maven package coverage (`2969` vs `2518`) with richer dependency extraction (`2550` vs `2267`) from parent/module inheritance, `dependencyManagement`, and committed `.pom` fixtures, plus more specific classifier-bearing Maven identities where ScanCode flattens coordinates and quieter unresolved-placeholder handling that preserves Maven semantics without flooding the scan with property/cycle noise
+
+##### [clj-commons/aleph @ c930db6](https://github.com/clj-commons/aleph/tree/c930db61fe4a0f7b91e5eb20a13c221e86377a29) — **9.81× faster**
+
+- Files: 94
+- Run context: 2026-07-04 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.07s`; ScanCode `49.73s`
+- Direct Leiningen and tools.deps package identity (`2` vs `0` packages, `68` vs `0` dependencies) that ScanCode cannot model because it ships no `project.clj`/`deps.edn` parser: the root `pkg:maven/aleph/aleph` assembles its `project.clj` with the co-located generated `deps.edn`, resolving `def`-bound `~netty-version`/`~brotli-version` dependency versions and a runtime `(or (System/getenv …) …)` project version into concrete coordinates and normalizing tools.deps `artifact$classifier` deps into clean purls with classifier metadata, plus source-faithful `©` copyright recovery on `README.md` where ScanCode renders `(c)` and rejection of the `${…}`-templated CircleCI status URL ScanCode emits as a broken percent-encoded fragment
 
 ##### [elastic/elasticsearch @ a414f3d](https://github.com/elastic/elasticsearch/tree/a414f3d06c7ab59a5a0b350e80e5674bf9864688) — **38.84× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -200,6 +200,9 @@ ScanCode: 76.42s</title></rect>
     <rect x="402.83" y="447.10" width="8" height="8" fill="#d97706" rx="1.5"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 ScanCode: 45.99s</title></rect>
+    <rect x="405.07" y="443.41" width="8" height="8" fill="#d97706" rx="1.5"><title>clj-commons/aleph @ c930db6
+Files: 94
+ScanCode: 49.73s</title></rect>
     <rect x="406.52" y="444.93" width="8" height="8" fill="#d97706" rx="1.5"><title>goharbor/harbor-helm @ 7233a81
 Files: 96
 ScanCode: 48.15s</title></rect>
@@ -916,6 +919,9 @@ Provenant: 5.21s</title></circle>
     <circle cx="406.83" cy="557.98" r="4.5" fill="#2563eb"><title>sous-chefs/mysql @ 6b7110b
 Files: 91
 Provenant: 4.79s</title></circle>
+    <circle cx="409.07" cy="555.30" r="4.5" fill="#2563eb"><title>clj-commons/aleph @ c930db6
+Files: 94
+Provenant: 5.07s</title></circle>
     <circle cx="410.52" cy="544.58" r="4.5" fill="#2563eb"><title>goharbor/harbor-helm @ 7233a81
 Files: 96
 Provenant: 6.36s</title></circle>

--- a/src/parsers/clojure.rs
+++ b/src/parsers/clojure.rs
@@ -96,6 +96,8 @@ impl PackageParser for ClojureProjectCljParser {
             }
         };
 
+        let bindings = collect_def_bindings(&forms);
+
         let Some(form) = forms.into_iter().find(|form| {
             matches!(
                 form,
@@ -105,7 +107,7 @@ impl PackageParser for ClojureProjectCljParser {
             return vec![default_package_data(Some(DatasourceId::ClojureProjectClj))];
         };
 
-        match parse_project_clj_form(&form) {
+        match parse_project_clj_form(&form, &bindings) {
             Ok(package) => vec![package],
             Err(error) => {
                 warn!("Failed to parse project.clj at {:?}: {}", path, error);
@@ -125,7 +127,11 @@ enum Form {
     Vector(Vec<Form>),
     List(Vec<Form>),
     Map(Vec<(Form, Form)>),
-    Prefixed(Box<Form>),
+    /// A reader-macro-prefixed form. The `char` records which prefix was read
+    /// (`~` unquote, `'` quote, `` ` `` syntax-quote, `@` deref, or `#` for
+    /// `#'` var-quote), so consumers can distinguish an unquote — the only
+    /// prefix that means "evaluate this" — from quoting, which means "data".
+    Prefixed(char, Box<Form>),
 }
 
 struct Reader {
@@ -146,7 +152,11 @@ impl Reader {
     fn parse_all(mut self) -> Result<Vec<Form>, String> {
         let mut forms = Vec::new();
         let mut count = 0usize;
-        while self.skip_ws_and_comments() {
+        loop {
+            self.skip_discards()?;
+            if self.peek().is_none() {
+                break;
+            }
             count += 1;
             if count > MAX_ITERATION_COUNT {
                 warn!("Reached MAX_ITERATION_COUNT in parse_all, stopping early");
@@ -178,6 +188,23 @@ impl Reader {
         }
     }
 
+    /// Skip whitespace, comments, and any leading `#_ <form>` discards, leaving
+    /// the reader at the next real token (which may be a closing delimiter or
+    /// end of input). Handling discards at form-loop boundaries — rather than
+    /// only mid-sequence — tolerates a trailing `#_` before a closing bracket,
+    /// e.g. `[:a #_"skipme"]`, which is valid Clojure that real manifests use.
+    fn skip_discards(&mut self) -> Result<(), String> {
+        loop {
+            self.skip_ws_and_comments();
+            if self.peek() == Some('#') && self.chars.get(self.index + 1) == Some(&'_') {
+                self.index += 2;
+                let _ = self.parse_form()?;
+                continue;
+            }
+            return Ok(());
+        }
+    }
+
     fn parse_form(&mut self) -> Result<Form, String> {
         if self.guard.descend() {
             return Err("recursion depth exceeded".to_string());
@@ -196,11 +223,11 @@ impl Reader {
                 self.guard.ascend();
                 return result;
             }
-            Some('~') | Some('\'') | Some('`') | Some('@') => {
+            Some(prefix @ ('~' | '\'' | '`' | '@')) => {
                 self.index += 1;
                 let form = self.parse_form()?;
                 self.guard.ascend();
-                return Ok(Form::Prefixed(Box::new(form)));
+                return Ok(Form::Prefixed(prefix, Box::new(form)));
             }
             Some('#') => {
                 let result = self.parse_dispatch_form();
@@ -224,9 +251,10 @@ impl Reader {
             }
             Some('=') => Err("unsupported reader eval dispatch".to_string()),
             Some('\'') => {
+                // `#'` var-quote: data, not an unquote — tag with `#`.
                 self.index += 1;
                 let form = self.parse_form()?;
-                Ok(Form::Prefixed(Box::new(form)))
+                Ok(Form::Prefixed('#', Box::new(form)))
             }
             Some('"') => {
                 // Tolerate regex literals in ignored fields without implementing reader semantics.
@@ -308,7 +336,7 @@ impl Reader {
         let mut forms = Vec::new();
         let mut count = 0usize;
         loop {
-            self.skip_ws_and_comments();
+            self.skip_discards()?;
             if self.peek() == Some(close) {
                 self.index += 1;
                 return Ok(forms);
@@ -461,7 +489,10 @@ fn parse_deps_edn_form(form: &Form) -> Result<PackageData, String> {
     Ok(package)
 }
 
-fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
+fn parse_project_clj_form(
+    form: &Form,
+    bindings: &HashMap<String, String>,
+) -> Result<PackageData, String> {
     let Form::List(items) = form else {
         return Err("project.clj root is not a list".to_string());
     };
@@ -472,17 +503,27 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
     let Some((namespace, name)) = items.get(1).and_then(parse_lib_form) else {
         return Err("defproject missing project identifier".to_string());
     };
-    let Some(version) = items.get(2).and_then(form_as_string) else {
-        return Err("defproject missing project version".to_string());
+
+    // The version sits at position 2 unless it was omitted (options begin
+    // directly). A non-literal version (e.g. `(or (System/getenv ...) "1.2.3")`
+    // or a `~unquoted` `def`) is resolved statically where possible and left
+    // unset otherwise, so the package identity and dependencies are still
+    // recovered rather than discarding the whole manifest.
+    let (version, options_start) = match items.get(2) {
+        Some(form) if !matches!(form, Form::Keyword(_)) => {
+            (resolve_version(form, bindings, true), 3usize)
+        }
+        _ => (None, 2usize),
     };
 
     let mut package = default_package_data(Some(DatasourceId::ClojureProjectClj));
     package.namespace = namespace.clone().map(truncate_field);
     package.name = Some(truncate_field(name.clone()));
-    package.version = Some(truncate_field(version.to_string()));
-    package.purl = build_maven_purl(namespace.as_deref(), &name, Some(version)).map(truncate_field);
+    package.version = version.as_ref().map(|value| truncate_field(value.clone()));
+    package.purl =
+        build_maven_purl(namespace.as_deref(), &name, version.as_deref()).map(truncate_field);
 
-    let mut index = 3usize;
+    let mut index = options_start;
     while index + 1 < items.len() {
         let Some(key) = form_as_keyword(&items[index]) else {
             index += 1;
@@ -512,7 +553,7 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
                 if let Form::Vector(deps) = value {
                     package
                         .dependencies
-                        .extend(extract_project_dependencies(deps, None));
+                        .extend(extract_project_dependencies(deps, None, bindings));
                 }
             }
             "profiles" => {
@@ -527,9 +568,11 @@ fn parse_project_clj_form(form: &Form) -> Result<PackageData, String> {
                         if let Some(Form::Vector(deps)) =
                             map_get_keyword(profile_entries, "dependencies")
                         {
-                            package
-                                .dependencies
-                                .extend(extract_project_dependencies(deps, Some(&profile_name)));
+                            package.dependencies.extend(extract_project_dependencies(
+                                deps,
+                                Some(&profile_name),
+                                bindings,
+                            ));
                         }
                     }
                 }
@@ -561,8 +604,21 @@ fn build_deps_edn_dependency(
     scope: Option<&str>,
     runtime: bool,
 ) -> Option<Dependency> {
-    let (namespace, name) = parse_lib_form(lib)?;
+    let (namespace, raw_name) = parse_lib_form(lib)?;
+    // tools.deps encodes a Maven classifier in the lib symbol as
+    // `artifact$classifier` (e.g. `netty-transport-native-epoll$linux-x86_64`).
+    // Split it out so the purl carries the clean artifact and the classifier
+    // lands in `extra_data`, matching how `project.clj` `:classifier` is stored.
+    let (name, classifier) = match raw_name.split_once('$') {
+        Some((artifact, classifier)) if !artifact.is_empty() && !classifier.is_empty() => {
+            (artifact.to_string(), Some(classifier.to_string()))
+        }
+        _ => (raw_name, None),
+    };
     let mut extra_data = HashMap::new();
+    if let Some(classifier) = classifier {
+        extra_data.insert("classifier".to_string(), JsonValue::String(classifier));
+    }
     let mut requirement = None;
     let mut pinned = false;
 
@@ -606,7 +662,11 @@ fn build_deps_edn_dependency(
     })
 }
 
-fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<Dependency> {
+fn extract_project_dependencies(
+    entries: &[Form],
+    scope: Option<&str>,
+    bindings: &HashMap<String, String>,
+) -> Vec<Dependency> {
     let limit = capped_iteration_limit(entries.len(), "project.clj dependencies");
     entries
         .iter()
@@ -616,7 +676,9 @@ fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<De
                 return None;
             };
             let (namespace, name) = parse_lib_form(parts.first()?)?;
-            let version = form_as_string(parts.get(1)?)?;
+            // Dependency versions live in defproject's quoted body, so only a
+            // `~` unquote (not a bare or `'`-quoted symbol) names a `def` value.
+            let version = resolve_version(parts.get(1)?, bindings, false)?;
 
             let mut extra_data = HashMap::new();
             let mut index = 2usize;
@@ -641,20 +703,74 @@ fn extract_project_dependencies(entries: &[Form], scope: Option<&str>) -> Vec<De
                 purl: build_maven_purl(
                     namespace.as_deref(),
                     &name,
-                    Some(strip_exact_prefix(version)),
+                    Some(strip_exact_prefix(&version)),
                 )
                 .map(truncate_field),
-                extracted_requirement: Some(truncate_field(version.to_string())),
+                extracted_requirement: Some(truncate_field(version.clone())),
                 scope: scope.map(ToOwned::to_owned),
                 is_runtime: Some(is_runtime),
                 is_optional: Some(is_optional),
-                is_pinned: Some(is_exact_version(version)),
+                is_pinned: Some(is_exact_version(&version)),
                 is_direct: Some(true),
                 resolved_package: None,
                 extra_data: (!extra_data.is_empty()).then_some(extra_data),
             })
         })
         .collect()
+}
+
+/// Collect top-level `(def <symbol> "<string literal>")` bindings so that
+/// `~symbol` unquotes and bare-symbol version references elsewhere in the
+/// manifest can be resolved statically, without evaluating any Clojure.
+fn collect_def_bindings(forms: &[Form]) -> HashMap<String, String> {
+    let mut bindings = HashMap::new();
+    for form in forms {
+        let Form::List(items) = form else {
+            continue;
+        };
+        if items.len() != 3 {
+            continue;
+        }
+        if let (Some(Form::Symbol(head)), Some(Form::Symbol(name)), Some(Form::String(value))) =
+            (items.first(), items.get(1), items.get(2))
+            && head == "def"
+        {
+            bindings.insert(name.clone(), value.clone());
+        }
+    }
+    bindings
+}
+
+/// Resolve a version form to a literal string, statically following the simple
+/// indirections real `project.clj` manifests use, without evaluating Clojure.
+///
+/// `evaluated` distinguishes the two positions with different Leiningen
+/// semantics: the `defproject` version slot is evaluated (a bare `symbol` bound
+/// by a `def` resolves), while the quoted `:dependencies` body is not (only a
+/// `~symbol` unquote resolves; a bare or `'`-quoted symbol is literal data).
+/// `(or …)` resolves to its first statically-known argument — matching Clojure's
+/// short-circuit — treating unresolvable arguments (e.g. `(System/getenv …)`) as
+/// unknown and skipping them. Returns `None` when nothing resolves statically.
+fn resolve_version(
+    form: &Form,
+    bindings: &HashMap<String, String>,
+    evaluated: bool,
+) -> Option<String> {
+    match form {
+        Form::String(value) => Some(value.clone()),
+        // A bare symbol only names its `def` value in an evaluated position.
+        Form::Symbol(name) if evaluated => bindings.get(name).cloned(),
+        // `~` unquote forces evaluation of its inner form regardless of context;
+        // any other prefix (`'`, `` ` ``, `@`, `#'`) is quoting, i.e. data.
+        Form::Prefixed('~', inner) => resolve_version(inner, bindings, true),
+        Form::List(items) if matches!(items.first(), Some(Form::Symbol(head)) if head == "or") => {
+            items
+                .iter()
+                .skip(1)
+                .find_map(|arg| resolve_version(arg, bindings, evaluated))
+        }
+        _ => None,
+    }
 }
 
 fn parse_lib_form(form: &Form) -> Option<(Option<String>, String)> {
@@ -737,7 +853,7 @@ fn form_to_json(form: &Form, guard: &mut RecursionGuard<()>) -> Option<JsonValue
             }
             JsonValue::Object(map)
         }
-        Form::Prefixed(value) => form_to_json(value, guard)?,
+        Form::Prefixed(_, value) => form_to_json(value, guard)?,
     });
     guard.ascend();
     result

--- a/src/parsers/clojure_scan_test.rs
+++ b/src/parsers/clojure_scan_test.rs
@@ -125,4 +125,54 @@ mod tests {
             "project.clj dependencies should remain assigned to the owning package"
         );
     }
+
+    #[test]
+    fn test_dynamic_defproject_promotes_and_attaches_colocated_deps_edn() {
+        // A `project.clj` whose version is a runtime `(or …)` form and whose
+        // dependencies use `~`-unquoted `def` bindings must still promote to a
+        // package, which in turn lets the co-located `deps.edn` attach its deps.
+        let (files, result) = scan_and_assemble(std::path::Path::new(
+            "testdata/clojure-golden/assembly-dynamic",
+        ));
+
+        let package = result
+            .packages
+            .iter()
+            .find(|p| p.name.as_deref() == Some("dynamic-demo"))
+            .expect("dynamic-version project.clj should still promote to a package");
+        assert_eq!(
+            package.purl.as_deref(),
+            Some("pkg:maven/org.example/dynamic-demo@2.0.0")
+        );
+        assert!(
+            package
+                .datasource_ids
+                .contains(&DatasourceId::ClojureDepsEdn),
+            "co-located deps.edn should attach once the package promotes"
+        );
+
+        // The `~netty-version` dependency resolves from the file-local `def`.
+        let netty = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:maven/io.netty/netty-transport@4.1.135.Final"))
+            .expect("~def-resolved project.clj dependency should be present");
+        assert_eq!(netty.datasource_id, DatasourceId::ClojureProjectClj);
+        assert_eq!(netty.for_package_uid.as_ref(), Some(&package.package_uid));
+
+        // The co-located deps.edn dependency is now owned rather than orphaned.
+        let deps_file = files
+            .iter()
+            .find(|file| file.path.ends_with("/deps.edn"))
+            .expect("deps.edn should be scanned");
+        assert!(deps_file.for_packages.contains(&package.package_uid));
+
+        let transit = result
+            .dependencies
+            .iter()
+            .find(|d| d.purl.as_deref() == Some("pkg:maven/com.cognitect/transit-clj@1.0.333"))
+            .expect("deps.edn dependency should be visible");
+        assert_eq!(transit.datasource_id, DatasourceId::ClojureDepsEdn);
+        assert_eq!(transit.for_package_uid.as_ref(), Some(&package.package_uid));
+    }
 }

--- a/src/parsers/clojure_test.rs
+++ b/src/parsers/clojure_test.rs
@@ -165,6 +165,139 @@ mod tests {
     }
 
     #[test]
+    fn test_project_clj_resolves_dynamic_version_and_def_unquote_deps() {
+        let content = r#"
+(def netty-version "4.1.135.Final")
+
+(defproject aleph (or (System/getenv "PROJECT_VERSION") "0.9.9")
+  :description "Async communication"
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [io.netty/netty-transport ~netty-version]
+                 [io.netty/netty-handler ~netty-version :classifier "shaded"]])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let package_data = ClojureProjectCljParser::extract_first_package(&path);
+
+        // Bare-symbol name defaults its group; the `(or …)` version resolves to
+        // its string-literal fallback rather than discarding the manifest.
+        assert_eq!(package_data.namespace.as_deref(), Some("aleph"));
+        assert_eq!(package_data.name.as_deref(), Some("aleph"));
+        assert_eq!(package_data.version.as_deref(), Some("0.9.9"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:maven/aleph/aleph@0.9.9")
+        );
+        // `~netty-version` deps resolve from the file-local `def`.
+        assert_eq!(package_data.dependencies.len(), 3);
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref()
+                    == Some("pkg:maven/io.netty/netty-transport@4.1.135.Final"))
+        );
+        assert!(package_data.dependencies.iter().any(
+            |dep| dep.purl.as_deref() == Some("pkg:maven/io.netty/netty-handler@4.1.135.Final")
+        ));
+    }
+
+    #[test]
+    fn test_project_clj_or_version_prefers_first_statically_known_value() {
+        // `or` short-circuits to the first truthy value; an unresolvable
+        // `(System/getenv …)` is skipped, and a bare `def` symbol resolves in
+        // the evaluated version slot before any later literal fallback.
+        let content = r#"
+(def project-version "2.0.0")
+
+(defproject org.example/orfirst (or (System/getenv "VERSION") project-version "1.0.0")
+  :dependencies [[org.clojure/clojure "1.12.0"]])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let package_data = ClojureProjectCljParser::extract_first_package(&path);
+
+        assert_eq!(package_data.version.as_deref(), Some("2.0.0"));
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:maven/org.example/orfirst@2.0.0")
+        );
+    }
+
+    #[test]
+    fn test_project_clj_or_version_falls_through_to_first_literal() {
+        let content = r#"
+(defproject my/lib (or (System/getenv "VERSION") "1.0.0" "0.5.0")
+  :dependencies [[org.clojure/clojure "1.12.0"]])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let package_data = ClojureProjectCljParser::extract_first_package(&path);
+
+        assert_eq!(package_data.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_project_clj_quoted_and_bare_dep_versions_are_not_resolved() {
+        // Inside the quoted `:dependencies` body only a `~` unquote names a
+        // `def` value; a `'`-quoted or bare symbol is literal data, so those
+        // deps are dropped even though `(def dep-version …)` exists.
+        let content = r#"
+(def dep-version "1.2.3")
+
+(defproject org.example/quoted "1.0.0"
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [foo/bar 'dep-version]
+                 [baz/qux dep-version]
+                 [ok/unquoted ~dep-version]])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let package_data = ClojureProjectCljParser::extract_first_package(&path);
+
+        // clojure (literal) + ok/unquoted (~def) resolve; quoted/bare are dropped.
+        assert_eq!(package_data.dependencies.len(), 2);
+        assert!(
+            package_data
+                .dependencies
+                .iter()
+                .any(|dep| dep.purl.as_deref() == Some("pkg:maven/ok/unquoted@1.2.3"))
+        );
+        assert!(!package_data.dependencies.iter().any(|dep| {
+            (dep.purl.as_deref().unwrap_or_default()).contains("foo/bar")
+                || (dep.purl.as_deref().unwrap_or_default()).contains("baz/qux")
+        }));
+    }
+
+    #[test]
+    fn test_project_clj_unresolvable_version_degrades_without_dropping_manifest() {
+        // A version that cannot be resolved statically must not discard the
+        // recoverable name and dependencies; it is simply left unset.
+        let content = r#"
+(defproject org.example/degraded (str "1." (build-number))
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [foo/bar undefined-symbol]])
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let package_data = ClojureProjectCljParser::extract_first_package(&path);
+
+        assert_eq!(package_data.namespace.as_deref(), Some("org.example"));
+        assert_eq!(package_data.name.as_deref(), Some("degraded"));
+        assert!(package_data.version.is_none());
+        assert_eq!(
+            package_data.purl.as_deref(),
+            Some("pkg:maven/org.example/degraded")
+        );
+        // The literal dep is kept; the undefined-symbol version is still dropped.
+        assert_eq!(package_data.dependencies.len(), 1);
+        assert_eq!(
+            package_data.dependencies[0].purl.as_deref(),
+            Some("pkg:maven/org.clojure/clojure@1.11.1")
+        );
+    }
+
+    #[test]
     fn test_graceful_error_handling_for_invalid_forms() {
         let (_temp_dir, deps_path) = create_temp_file("deps.edn", "{:deps {foo/bar");
         let deps_package = ClojureDepsEdnParser::extract_first_package(&deps_path);
@@ -383,6 +516,64 @@ mod tests {
         assert_eq!(package_data.name.as_deref(), Some("var-quote"));
         assert_eq!(package_data.version.as_deref(), Some("1.0.0"));
         assert_eq!(package_data.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_project_clj_tolerates_discard_before_closing_delimiter() {
+        // A `#_` discard immediately before a closing bracket (as real manifests
+        // such as aleph's `:jvm-opts` use) must not fail the whole-file parse.
+        let content = r#"
+(defproject org.example/discard "1.0.0"
+  :dependencies [[org.clojure/clojure "1.12.0"]]
+  :jvm-opts ^:replace ["-server"
+                       "-Xmx2g"
+                       #_"-XX:+PrintCompilation"
+                       #_"-XX:+PrintInlining"]
+  :global-vars {*warn-on-reflection* true})
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("project.clj", content);
+        let result = capture_parser_diagnostics(
+            || ClojureProjectCljParser::extract_packages(&path),
+            "ClojureProjectCljParser",
+            &path,
+            None,
+        );
+
+        assert!(result.scan_diagnostics.is_empty());
+        assert_eq!(result.packages.len(), 1);
+
+        let package_data = &result.packages[0];
+        assert_eq!(package_data.namespace.as_deref(), Some("org.example"));
+        assert_eq!(package_data.name.as_deref(), Some("discard"));
+        assert_eq!(package_data.version.as_deref(), Some("1.0.0"));
+        assert_eq!(package_data.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_deps_edn_splits_classifier_suffix_into_extra_data() {
+        // tools.deps `artifact$classifier` syntax must yield a clean purl with
+        // the classifier captured in extra_data, not mangled into the artifact.
+        let content = r#"
+{:deps {io.netty/netty-transport-native-epoll$linux-x86_64 {:mvn/version "4.1.135.Final"}}}
+        "#;
+
+        let (_temp_dir, path) = create_temp_file("deps.edn", content);
+        let package_data = ClojureDepsEdnParser::extract_first_package(&path);
+
+        assert_eq!(package_data.dependencies.len(), 1);
+        let dep = &package_data.dependencies[0];
+        assert_eq!(
+            dep.purl.as_deref(),
+            Some("pkg:maven/io.netty/netty-transport-native-epoll@4.1.135.Final")
+        );
+        assert_eq!(
+            dep.extra_data
+                .as_ref()
+                .and_then(|data| data.get("classifier"))
+                .and_then(|value| value.as_str()),
+            Some("linux-x86_64")
+        );
     }
 
     #[test]

--- a/testdata/clojure-golden/assembly-dynamic/deps.edn
+++ b/testdata/clojure-golden/assembly-dynamic/deps.edn
@@ -1,0 +1,1 @@
+{:deps {com.cognitect/transit-clj {:mvn/version "1.0.333"}}}

--- a/testdata/clojure-golden/assembly-dynamic/project.clj
+++ b/testdata/clojure-golden/assembly-dynamic/project.clj
@@ -1,0 +1,5 @@
+(def netty-version "4.1.135.Final")
+
+(defproject org.example/dynamic-demo (or (System/getenv "PROJECT_VERSION") "2.0.0")
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [io.netty/netty-transport ~netty-version]])


### PR DESCRIPTION
## Summary

Make real-world Leiningen manifests parse statically so they promote to a package (which then lets the co-located `deps.edn` assembly pass from #1218 attach their dependencies). All resolution is static and bounded — no Clojure/Leiningen/`tools.deps` code is executed.

- Recover a `defproject` version from non-literal forms — a `~`/bare-symbol `def` reference or the string-literal fallback of an `(or …)` form such as `(or (System/getenv "V") "1.2.3")` — and degrade gracefully to an unset version instead of hard-failing the whole manifest.
- Resolve `~`-unquoted dependency versions via a bounded, file-local `(def x "literal")` symbol table (e.g. `[io.netty/netty-transport ~netty-version]`).
- Tolerate `#_ <form>` discards at form-loop boundaries, including immediately before a closing delimiter (`[… #_"skipme"]`), which previously failed the entire file parse.
- Normalize the `tools.deps` `deps.edn` `artifact$classifier` lib syntax (e.g. `netty-transport-native-epoll$linux-x86_64`) into a clean purl plus an `extra_data.classifier`, matching how `project.clj` `:classifier` is already stored.
- Records a `docs/BENCHMARKS.md` row for `clj-commons/aleph` from a `compare-outputs --profile common` run (see below).

Version resolution follows Leiningen semantics precisely: the `defproject` version slot is evaluated (a bare `def` symbol resolves), while the quoted `:dependencies` body is not (only a `~` unquote resolves; a `'`-quoted or bare symbol is literal data). `(or …)` resolves to its first statically-known argument.

## Issues

- Covers: #1220
- Closes: #1220

## Scope and exclusions

- Included: `project.clj` static parsing robustness for real-world dynamic manifests (version literal recovery, file-local `def` substitution for `~unquote`/bare-symbol versions, trailing `#_` discard tolerance); `deps.edn` `$classifier` normalization; parser unit tests and a scanner/assembly contract test.
- Explicit exclusions: no attempt to evaluate arbitrary version expressions (anything not reducible to a literal statically is left unset). No cross-datasource dependency dedup — see note below.

## Design note: no dependency dedup across `project.clj` and `deps.edn`

When a repo has both a `project.clj` and a co-located `deps.edn` declaring overlapping coordinates (aleph's `deps.edn` is auto-generated from its `project.clj`), the assembled package now carries a record from **each** datasource — e.g. `pkg:maven/io.netty/netty-transport@4.1.135.Final` appears once with `datasource_id: clojure_project_clj` and once with `clojure_deps_edn`. This is intentional and consistent with how Provenant records dependencies everywhere else (npm `package.json`+lock, cargo `Cargo.toml`+lock, …): dependencies are per-datafile with provenance, and there is no global cross-manifest dedup. Collapsing them would lose which file declared the dependency and would need a classifier/scope-aware key (the same purl legitimately covers distinct classifier artifacts). So this is left as-is by design, not deferred.

## How to verify

Beyond CI, verified end-to-end against the motivating repo. Scan a shallow clone of [`clj-commons/aleph`](https://github.com/clj-commons/aleph) (root `project.clj` with an `(or (System/getenv …) …)` version, `~netty-version`/`~brotli-version` deps, a `#_` before `]`, `$classifier` deps in the co-located `deps.edn`):

```sh
provenant path/to/aleph --package --json out.json
```

Before this change the root `project.clj` failed to parse (null identity, zero deps) and its `deps.edn` deps were all hoisted with `for_package_uid: null`. After it:

- the root promotes to `pkg:maven/aleph/aleph@0.9.9`;
- all 46 `project.clj` deps resolve (every `~netty-version`/`~brotli-version` → concrete version);
- all 22 co-located `deps.edn` deps are owned by that package (0 null) via the #1218 pass;
- `deps.edn` `$classifier` deps have clean purls with `extra_data.classifier` (e.g. `…/netty-transport-native-epoll@4.1.135.Final` + `classifier=linux-x86_64`); zero `$`-mangled purls remain.

### Benchmark verification (compare-outputs)

`compare-outputs --repo-url https://github.com/clj-commons/aleph.git --repo-ref c930db61… --profile common` (Apple M5 Pro, 4 proc): Provenant `5.07s` vs ScanCode `49.73s` (**9.81×**), over 94 files. Provenant surfaces `2` `pkg:maven` packages and `68` dependencies (46 from `project.clj` + 22 from the co-located `deps.edn`) that ScanCode leaves at `0` (no Leiningen/`tools.deps` parser). The only two ScanCode-favored file-metric deltas are both Provenant being *more correct*: source-faithful `©` on `README.md` (ScanCode renders `(c)`) and rejection of a `${…}`-templated CircleCI status URL ScanCode emits as a broken percent-encoded fragment. Recorded as a row in `docs/BENCHMARKS.md`.

## Intentional differences from Python

- Python ScanCode ships no production Leiningen `project.clj` package parser for this surface. This keeps Provenant's static Rust-only Clojure model and does not execute Clojure, Leiningen, or `tools.deps` code; non-literal versions are recovered only where a literal is statically present, otherwise left unset.

## Follow-up work

- None. Versions computable only at runtime (e.g. `(str "1." (build-number))`) are intentionally left unset rather than guessed; cross-datasource dedup is intentionally not done (see design note).

## Expected-output fixture changes

- Files changed: `docs/BENCHMARKS.md` (new `clj-commons/aleph` row) and `docs/scan-duration-vs-files.svg` + the headline summary line, both regenerated via `generate-benchmark-chart` from the new row. No scanner golden `.expected` files change.
- Adds scanner fixture inputs under `testdata/clojure-golden/assembly-dynamic/` (`project.clj` + co-located `deps.edn`), with behavior asserted by a contract test in `clojure_scan_test.rs` and parser unit tests in `clojure_test.rs`.
- Why the new expected output is correct: the dynamic-version `project.clj` promotes to `pkg:maven/org.example/dynamic-demo@2.0.0` owning its `~def`-resolved dependency, and the co-located `deps.edn` dependency is attached to that package rather than orphaned.
