### PR TITLE
fix(copyright): detect open-ended year ranges ending in "now"

### DIFF
--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -82,6 +82,28 @@ fn test_standalone_c_holder_year_range_with_trailing_period_is_extracted() {
 }
 
 #[test]
+fn test_open_ended_now_year_range_is_extracted() {
+    // scancode-toolkit#5220: an open-ended year range ending in "NOW" must not
+    // drop the entire copyright statement.
+    let input = "Copyright (c) 2013-NOW Jinzhu <wosmvp@gmail.com>";
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright (c) 2013-NOW Jinzhu <wosmvp@gmail.com>"),
+        "copyrights: {:?}",
+        copyrights.iter().map(|c| &c.copyright).collect::<Vec<_>>()
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Jinzhu"),
+        "holders: {:?}",
+        holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_obfuscated_angle_email_is_kept_in_copyright() {
     let input = "(C)opyright MMIV-MMV Anselm R. Garbe <garbeam at gmail dot com>";
 

--- a/src/copyright/patterns.rs
+++ b/src/copyright/patterns.rs
@@ -93,7 +93,10 @@ fn build_pattern_list() -> Vec<(String, PosTag)> {
     let year_short_punct = &format!("{}{}", year_short, punct);
     let year_or_year_year = &format!("({}|{})", year_punct, year_year_punct);
     let year_then_short = &format!("({}({})*)", year_or_year_year, year_short_punct);
-    let year_dash_present = &format!(r"{}[\-~]? ?[Pp]resent\.?,?", year);
+    // Provenant extension: also accept "now" as an open-ended range end, e.g.
+    // "2013-NOW". ScanCode only handles "present" here; "now" is commonly
+    // uppercase in the wild, so match it case-insensitively.
+    let year_dash_present = &format!(r"{}[\-~]? ?([Pp]resent|(?i:now))\.?,?", year);
 
     let mut patterns: Vec<(String, PosTag)> = Vec::with_capacity(1200);
 

--- a/src/copyright/patterns_test.rs
+++ b/src/copyright/patterns_test.rs
@@ -195,6 +195,14 @@ fn test_year_ranges() {
     assert_eq!(p.match_token("2010-202x"), PosTag::Yr);
     assert_eq!(p.match_token("1999,2000"), PosTag::Yr);
     assert_eq!(p.match_token("2020-present"), PosTag::Yr);
+    // Open-ended range ending in "now" (scancode-toolkit#5220), including the
+    // common uppercase form.
+    assert_eq!(p.match_token("2013-NOW"), PosTag::Yr);
+    assert_eq!(p.match_token("2013-now"), PosTag::Yr);
+    assert_eq!(p.match_token("2013now"), PosTag::Yr);
+    // A year attached to an unrelated word must NOT become a year range.
+    assert_ne!(p.match_token("2013-final"), PosTag::Yr);
+    assert_ne!(p.match_token("2020-Jinzhu"), PosTag::Yr);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- A copyright line whose year range ends in `now` (e.g. `Copyright (c) 2013-NOW Jinzhu <wosmvp@gmail.com>`) was dropped entirely. The `2013-NOW` token matched no year pattern and tagged as a common noun (`Nn`), so the grammar never built a copyright tree.
- Extends the existing year-dash-present POS pattern (derived from ScanCode's `_YEAR_DASH_PRESENT`) to also accept `now`, matched case-insensitively since it is commonly uppercase in the wild.
- The match stays anchored to a real year in the same token, so standalone `now` and unrelated attached tokens (`2013-final`, `2020-Name`) are not treated as years.

## Issues

- Covers: aboutcode-org/scancode-toolkit#5220 (Provenant inherited the identical `_YEAR_DASH_PRESENT` pattern; the upstream issue is still open).

## Scope and exclusions

- Included: `now` as an open-ended range terminator alongside the existing `present`.
- Explicit exclusions: the maintainer discussion floated a much wider `[0-9]* - [a-zA-Z0-9]*` pattern. Deliberately not adopted — it would tag `2013-final`, `2020-rc1`, or `2013-SomeName` as year ranges, a false-positive surface that violates bounded-parsing / honest-unknowns guardrails. Also excluded: the spaced form `2013 - NOW` (tokenizes separately; matches ScanCode's same-token-only `present` behavior) and unfilled `<end_year>` template placeholders.

## How to verify

```
printf "Copyright (c) 2013-NOW Jinzhu <wosmvp@gmail.com>\n" > /tmp/LICENSE
cargo run -- scan --copyright /tmp/LICENSE --json-pp -
```

Observe a `copyrights` entry `Copyright (c) 2013-NOW Jinzhu <wosmvp@gmail.com>` and holder `Jinzhu`. On `main` both arrays are empty. Automated coverage is added at the pattern level (`patterns_test.rs`, including negative cases) and end-to-end (`detector/tests.rs`).

## Intentional differences from Python

- ScanCode only handles `present` here and does not detect `year-NOW` (the open upstream issue). This PR additionally detects `now`.

## Follow-up work

- If real-world `today` / `current` open-ended terminators surface, the terminator set is trivial to extend.

## Expected-output fixture changes

- None. Full copyright unit suite (1100 tests) and the copyright golden suite (36 tests, `--features golden-tests`) pass with no fixture shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)