### PR TITLE
feat(cli): show per-phase timing breakdown only under --verbose

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -609,7 +609,7 @@ Centralized `ScanProgress` struct manages mode-aware progress output via `indica
 2. **SPDX load phase**: Startup message and timing capture around license DB load.
 3. **Scan phase**: Main progress bar (default mode, TTY only) with ETA, elapsed time, and `{per_sec}` throughput; verbose mode keeps file-by-file paths on TTY and degrades to bounded scan lifecycle messages plus per-file warning/error context when stderr is not a TTY.
 4. **Assembly and output phases**: Phase messages/spinners with timing capture.
-5. **Scan summary**: Files/sec, bytes/sec, error count, initial/final counts (including sizes), package assembly counts, and per-phase timings.
+5. **Scan summary**: Files/sec, bytes/sec, error count, initial/final counts (including sizes), package assembly counts, ScanCode-style scan timestamps, and total wall time; the full per-phase timing breakdown is shown only under `--verbose`.
 
 Verbosity behavior is implemented in `src/progress.rs` and wired through `src/main.rs`: quiet suppresses stderr output, default shows progress/summary, and verbose stays detailed without flooding redirected logs by limiting successful per-file path output to TTY runs while still surfacing per-file warnings/errors in non-TTY environments.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -313,6 +313,7 @@ pub struct ScanArgs {
     #[arg(short, long, conflicts_with = "verbose")]
     pub quiet: bool,
 
+    /// Emit verbose diagnostics, including the per-phase timing breakdown and, on a TTY, per-file scan detail.
     #[arg(short, long, conflicts_with = "quiet")]
     pub verbose: bool,
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -397,7 +397,12 @@ impl ScanProgress {
         } else if stats.warning_count > 0 {
             self.message("Some files reported recoverable scan warnings:");
         }
-        for line in build_summary_messages(&stats, scan_start, scan_end) {
+        for line in build_summary_messages(
+            &stats,
+            scan_start,
+            scan_end,
+            self.mode == ProgressMode::Verbose,
+        ) {
             self.message(&line);
         }
         if stats.incremental_reused > 0 {
@@ -643,7 +648,12 @@ fn supports_color(stderr_is_tty: bool) -> bool {
     !matches!(env::var("TERM"), Ok(term) if term == "dumb")
 }
 
-fn build_summary_messages(stats: &ScanStats, scan_start: &str, scan_end: &str) -> Vec<String> {
+fn build_summary_messages(
+    stats: &ScanStats,
+    scan_start: &str,
+    scan_end: &str,
+    verbose: bool,
+) -> Vec<String> {
     let total = stats
         .top_level_timings
         .iter()
@@ -708,30 +718,35 @@ fn build_summary_messages(stats: &ScanStats, scan_start: &str, scan_end: &str) -
         format!("  scan_end:   {scan_end}"),
     ];
 
-    for (name, value) in &stats.top_level_timings {
-        lines.push(format!("  {name}: {value:.2}s"));
+    // The per-phase breakdown is developer-facing diagnostic detail; keep the
+    // default summary compact (counts, ScanCode-style timestamps, and total) and
+    // surface the full tree only under --verbose.
+    if verbose {
+        for (name, value) in &stats.top_level_timings {
+            lines.push(format!("  {name}: {value:.2}s"));
 
-        let detail_timings = stats
-            .detail_timings
-            .iter()
-            .filter(|(detail_name, _)| detail_parent_phase(detail_name) == Some(name.as_str()));
+            let detail_timings = stats
+                .detail_timings
+                .iter()
+                .filter(|(detail_name, _)| detail_parent_phase(detail_name) == Some(name.as_str()));
 
-        if name == "scan" {
-            let scan_breakdown: Vec<_> = detail_timings.collect();
-            if !scan_breakdown.is_empty() {
-                lines.push("  scan breakdown (cumulative worker time):".to_string());
-                lines.extend(
-                    scan_breakdown
-                        .into_iter()
-                        .map(|(detail_name, detail_value)| {
-                            format!("    {detail_name}: {detail_value:.2}s")
-                        }),
-                );
+            if name == "scan" {
+                let scan_breakdown: Vec<_> = detail_timings.collect();
+                if !scan_breakdown.is_empty() {
+                    lines.push("  scan breakdown (cumulative worker time):".to_string());
+                    lines.extend(
+                        scan_breakdown
+                            .into_iter()
+                            .map(|(detail_name, detail_value)| {
+                                format!("    {detail_name}: {detail_value:.2}s")
+                            }),
+                    );
+                }
+            } else {
+                lines.extend(detail_timings.map(|(detail_name, detail_value)| {
+                    format!("    {detail_name}: {detail_value:.2}s")
+                }));
             }
-        } else {
-            lines.extend(detail_timings.map(|(detail_name, detail_value)| {
-                format!("    {detail_name}: {detail_value:.2}s")
-            }));
         }
     }
     lines.push(format!("  total: {total:.2}s"));
@@ -838,7 +853,7 @@ mod tests {
             ],
         };
 
-        let lines = build_summary_messages(&stats, "start", "end");
+        let lines = build_summary_messages(&stats, "start", "end", true);
         let line_index = |needle: &str| {
             lines
                 .iter()
@@ -875,9 +890,33 @@ mod tests {
             ..ScanStats::default()
         };
 
-        let lines = build_summary_messages(&stats, "start", "end");
+        let lines = build_summary_messages(&stats, "start", "end", false);
 
         assert!(lines.contains(&"Scan Speed:     5.00 files/sec. 512 Bytes/sec.".to_string()));
+    }
+
+    #[test]
+    fn default_summary_keeps_total_but_omits_phase_breakdown() {
+        let stats = ScanStats {
+            final_files: 10,
+            total_bytes_scanned: 800,
+            top_level_timings: vec![("setup".to_string(), 1.0), ("scan".to_string(), 3.0)],
+            detail_timings: vec![("scan:packages".to_string(), 1.25)],
+            ..ScanStats::default()
+        };
+
+        let lines = build_summary_messages(&stats, "start", "end", false);
+
+        // Compact default: counts, ScanCode-style timestamps, and total wall time.
+        assert!(lines.contains(&"Timings:".to_string()));
+        assert!(lines.contains(&"  scan_start: start".to_string()));
+        assert!(lines.contains(&"  scan_end:   end".to_string()));
+        assert!(lines.contains(&"  total: 4.00s".to_string()));
+        // No per-phase breakdown without --verbose.
+        assert!(!lines.contains(&"  setup: 1.00s".to_string()));
+        assert!(!lines.contains(&"  scan: 3.00s".to_string()));
+        assert!(!lines.iter().any(|line| line.contains("scan breakdown")));
+        assert!(!lines.contains(&"    scan:packages: 1.25s".to_string()));
     }
 
     #[test]

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -1347,7 +1347,7 @@ fn default_mode_emits_summary_to_stderr() {
 }
 
 #[test]
-fn default_mode_emits_hierarchical_timing_summary() {
+fn verbose_mode_emits_hierarchical_timing_summary() {
     let (temp, scan_dir) = create_scan_fixture();
     let output_file = temp.path().join("out.json");
 
@@ -1355,6 +1355,7 @@ fn default_mode_emits_hierarchical_timing_summary() {
         .args([
             "--json-pp",
             output_file.to_str().expect("utf8 output path"),
+            "--verbose",
             "--only-findings",
             "--package",
             &scan_dir,
@@ -1374,6 +1375,34 @@ fn default_mode_emits_hierarchical_timing_summary() {
     assert!(stderr.contains("  total:"));
     assert!(stderr.contains("    scan:packages:"));
     assert!(stderr.contains("    output-filter:only-findings:"));
+}
+
+#[test]
+fn default_mode_summary_keeps_total_but_omits_phase_breakdown() {
+    let (temp, scan_dir) = create_scan_fixture();
+    let output_file = temp.path().join("out.json");
+
+    let output = provenant_command()
+        .args([
+            "--json-pp",
+            output_file.to_str().expect("utf8 output path"),
+            "--package",
+            &scan_dir,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Compact default summary: header, ScanCode-style timestamps, and total wall time.
+    assert!(stderr.contains("Timings:"));
+    assert!(stderr.contains("  scan_start:"));
+    assert!(stderr.contains("  scan_end:"));
+    assert!(stderr.contains("  total:"));
+    // The per-phase breakdown is verbose-only.
+    assert!(!stderr.contains("  setup:"));
+    assert!(!stderr.contains("scan breakdown"));
+    assert!(!stderr.contains("    scan:packages:"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- The default scan summary printed a ~20-line per-phase timing tree (setup/inventory/scan/post-scan/assembly/finalize/output, plus indented detail timings and the scan breakdown) on every run. It's developer-facing diagnostic detail that dominates the terminal.
- Keep the default summary **compact** — counts, ScanCode-style `scan_start`/`scan_end` timestamps, and total wall time — and surface the full per-phase breakdown only under `--verbose`.
- Update the `--verbose` help text, progress unit + CLI integration tests, and the architecture doc to match.

## Issues

- Covers: CLI output-noise reduction (basis for stacked README demo work).
- Closes:

## Scope and exclusions

- Included: default vs `--verbose` terminal timing output, its tests, `--verbose` help text, architecture-doc note.
- Explicit exclusions: no change to JSON/SPDX/CycloneDX output; no change to counts, Scan Speed, timestamps, or total; `--quiet` behavior unchanged.

## How to verify

- `provenant scan --json-pp /dev/null --license --package <dir>` — default summary shows `Timings:` + `scan_start`/`scan_end` + `total:` only (no per-phase tree).
- Add `--verbose` — full per-phase breakdown returns.
- Covered by `default_mode_summary_keeps_total_but_omits_phase_breakdown` and `verbose_mode_emits_hierarchical_timing_summary`.

## Intentional differences from Python

- The full per-phase breakdown becomes `--verbose`-only; the default summary still emits the ScanCode-style timestamps and totals users rely on.

## Follow-up work

- README scan-demo PR stacks on this branch.