### PR TITLE
fix(cli): make license-index startup messaging honest and quiet

### DIFF
--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -390,13 +390,16 @@ pub(crate) fn build_output_model(
                 && !session.preloaded_license_references.is_empty()));
 
     if should_recompute_license_references && session.active_license_engine.is_none() {
+        let cache_config = session
+            .shared_cache_config
+            .as_ref()
+            .expect("cache config should be prepared before license engine init");
         progress.start_license_detection_engine_creation();
+        let notify_cold_build = || progress.notify_license_index_cold_build();
         session.active_license_engine = Some(init_license_engine(
-            session
-                .shared_cache_config
-                .as_ref()
-                .expect("cache config should be prepared before license engine init"),
+            cache_config,
             request,
+            Some(&notify_cold_build),
         )?);
         progress.finish_license_detection_engine_creation("finalize:license-engine-creation");
     }
@@ -580,13 +583,12 @@ fn load_native_scan_session(
 
     let license_engine = if request.license {
         progress.start_setup();
+        let cache_config = shared_cache_config
+            .as_ref()
+            .expect("cache config should be prepared before license engine init");
         progress.start_license_detection_engine_creation();
-        let engine = init_license_engine(
-            shared_cache_config
-                .as_ref()
-                .expect("cache config should be prepared before license engine init"),
-            request,
-        )?;
+        let notify_cold_build = || progress.notify_license_index_cold_build();
+        let engine = init_license_engine(cache_config, request, Some(&notify_cold_build))?;
         progress.finish_license_detection_engine_creation("setup_scan:licenses");
         progress.finish_setup();
         progress.output_written(&describe_license_engine_source(

--- a/src/app/scan_runtime.rs
+++ b/src/app/scan_runtime.rs
@@ -11,8 +11,8 @@ use anyhow::{Result, anyhow};
 
 use crate::app::request::ScanRequest;
 use crate::cache::{CACHE_DIR_ENV_VAR, CacheConfig};
-use crate::license_detection::LicenseDetectionEngine;
 use crate::license_detection::license_cache::LicenseCacheConfig;
+use crate::license_detection::{ColdBuildNotify, LicenseDetectionEngine};
 use crate::scan_result_shaping::{
     SelectedPath, resolve_native_scan_inputs, resolve_paths_file_entries,
 };
@@ -110,6 +110,7 @@ pub(crate) fn build_license_cache_config(
 pub(crate) fn init_license_engine(
     cache_root: &CacheConfig,
     request: &ScanRequest,
+    on_cold_build: Option<ColdBuildNotify<'_>>,
 ) -> Result<Arc<LicenseDetectionEngine>> {
     let cache_config = build_license_cache_config(cache_root, request);
 
@@ -119,11 +120,16 @@ pub(crate) fn init_license_engine(
             if !path.exists() {
                 return Err(anyhow!("License dataset path does not exist: {:?}", path));
             }
-            let engine = LicenseDetectionEngine::from_directory_with_cache(&path, &cache_config)?;
+            let engine = LicenseDetectionEngine::from_directory_with_cache(
+                &path,
+                &cache_config,
+                on_cold_build,
+            )?;
             Ok(Arc::new(engine))
         }
         None => {
-            let engine = LicenseDetectionEngine::from_embedded_with_cache(&cache_config)?;
+            let engine =
+                LicenseDetectionEngine::from_embedded_with_cache(&cache_config, on_cold_build)?;
             Ok(Arc::new(engine))
         }
     }

--- a/src/license_detection/mod.rs
+++ b/src/license_detection/mod.rs
@@ -554,6 +554,12 @@ fn collect_regular_seq_matches(
     ))
 }
 
+/// Callback invoked once when engine initialization begins a cold index build
+/// (cache miss, `--reindex`, or an invalidated cache) rather than loading the
+/// rkyv cache. Lets the caller surface a one-time latency notice at exactly the
+/// right moment without the detection layer depending on the CLI progress type.
+pub type ColdBuildNotify<'a> = &'a dyn Fn();
+
 impl LicenseDetectionEngine {
     /// Create a new license detection engine from a pre-built license index.
     ///
@@ -597,7 +603,7 @@ impl LicenseDetectionEngine {
     pub fn from_embedded() -> Result<Self> {
         let cache_config =
             LicenseCacheConfig::new(LicenseCacheConfig::default_root_dir(), false, true);
-        Self::from_embedded_with_cache(&cache_config)
+        Self::from_embedded_with_cache(&cache_config, None)
     }
 
     /// Create a new license detection engine from the embedded license index.
@@ -611,10 +617,15 @@ impl LicenseDetectionEngine {
     ///
     /// # Arguments
     /// * `cache_config` - Cache configuration (directory and reindex flag)
+    /// * `on_cold_build` - Optional callback fired once if the index is rebuilt
+    ///   from scratch instead of loaded from cache (see [`ColdBuildNotify`])
     ///
     /// # Returns
     /// A Result containing the engine or an error
-    pub fn from_embedded_with_cache(cache_config: &LicenseCacheConfig) -> Result<Self> {
+    pub fn from_embedded_with_cache(
+        cache_config: &LicenseCacheConfig,
+        on_cold_build: Option<ColdBuildNotify<'_>>,
+    ) -> Result<Self> {
         let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
         let fingerprint = compute_artifact_fingerprint(artifact_bytes);
         let artifact_metadata = load_embedded_artifact_metadata_from_bytes(artifact_bytes)
@@ -633,7 +644,7 @@ impl LicenseDetectionEngine {
             if let Some(cached) =
                 load_cached_index(cache_config, LicenseCacheNamespace::Embedded, &fingerprint)?
             {
-                eprintln!(
+                log::debug!(
                     "License index loaded from rkyv cache in {:.2}s",
                     start.elapsed().as_secs_f64()
                 );
@@ -643,6 +654,11 @@ impl LicenseDetectionEngine {
             delete_cache(cache_config, LicenseCacheNamespace::Embedded, &fingerprint)?;
         }
 
+        // Cache miss (or forced reindex): a cold build is about to happen.
+        if let Some(notify) = on_cold_build {
+            notify();
+        }
+
         let snapshot = load_loader_snapshot_from_bytes(artifact_bytes)
             .map_err(|e| anyhow::anyhow!("Failed to load embedded license index: {}", e))?;
         let spdx_version = Some(snapshot.metadata.spdx_license_list_version.clone());
@@ -650,7 +666,7 @@ impl LicenseDetectionEngine {
 
         let start = Instant::now();
         let index = build_index_from_loaded(snapshot.rules, snapshot.licenses, false);
-        eprintln!(
+        log::debug!(
             "License index built from embedded artifact in {:.2}s",
             start.elapsed().as_secs_f64()
         );
@@ -663,11 +679,11 @@ impl LicenseDetectionEngine {
             &index,
             &fingerprint,
         ) {
-            eprintln!("Warning: failed to save license index cache: {}", e);
+            log::warn!("Failed to save license index cache: {e}");
         } else if let Some(size) =
             cache_file_size(cache_config, LicenseCacheNamespace::Embedded, &fingerprint)
         {
-            eprintln!(
+            log::debug!(
                 "License index cache saved ({:.1} MB)",
                 size as f64 / 1_048_576.0
             );
@@ -683,7 +699,7 @@ impl LicenseDetectionEngine {
     pub fn from_directory(rules_path: &Path) -> Result<Self> {
         let cache_config =
             LicenseCacheConfig::new(LicenseCacheConfig::default_root_dir(), false, true);
-        Self::from_directory_with_cache(rules_path, &cache_config)
+        Self::from_directory_with_cache(rules_path, &cache_config, None)
     }
 
     /// Create a new license detection engine from a directory of license rules.
@@ -694,12 +710,15 @@ impl LicenseDetectionEngine {
     /// # Arguments
     /// * `rules_path` - Path to dataset root containing rules/ and licenses/
     /// * `cache_config` - Cache configuration (directory and reindex flag)
+    /// * `on_cold_build` - Optional callback fired once if the index is rebuilt
+    ///   from scratch instead of loaded from cache (see [`ColdBuildNotify`])
     ///
     /// # Returns
     /// A Result containing the engine or an error
     pub fn from_directory_with_cache(
         rules_path: &Path,
         cache_config: &LicenseCacheConfig,
+        on_cold_build: Option<ColdBuildNotify<'_>>,
     ) -> Result<Self> {
         let LoadedLicenseDataset {
             manifest,
@@ -724,13 +743,13 @@ impl LicenseDetectionEngine {
         });
 
         if !cache_config.reindex {
+            let start = Instant::now();
             if let Some(cached) = load_cached_index(
                 cache_config,
                 LicenseCacheNamespace::CustomRules,
                 &fingerprint,
             )? {
-                let start = Instant::now();
-                eprintln!(
+                log::debug!(
                     "License index loaded from rkyv cache in {:.2}s",
                     start.elapsed().as_secs_f64()
                 );
@@ -748,9 +767,14 @@ impl LicenseDetectionEngine {
             )?;
         }
 
+        // Cache miss (or forced reindex): a cold build is about to happen.
+        if let Some(notify) = on_cold_build {
+            notify();
+        }
+
         let start = Instant::now();
         let index = build_index_from_loaded(loaded_rules, loaded_licenses, false);
-        eprintln!(
+        log::debug!(
             "License index built from custom dataset in {:.2}s",
             start.elapsed().as_secs_f64()
         );
@@ -761,13 +785,13 @@ impl LicenseDetectionEngine {
             &index,
             &fingerprint,
         ) {
-            eprintln!("Warning: failed to save license index cache: {}", e);
+            log::warn!("Failed to save license index cache: {e}");
         } else if let Some(size) = cache_file_size(
             cache_config,
             LicenseCacheNamespace::CustomRules,
             &fingerprint,
         ) {
-            eprintln!(
+            log::debug!(
                 "License index cache saved ({:.1} MB)",
                 size as f64 / 1_048_576.0
             );

--- a/src/parsers/license_normalization.rs
+++ b/src/parsers/license_normalization.rs
@@ -30,7 +30,7 @@ pub(crate) const PARSER_DECLARED_MATCHER: &str = "parser-declared-license";
 static PARSER_LICENSE_ENGINE: LazyLock<Option<Arc<LicenseDetectionEngine>>> = LazyLock::new(|| {
     let cache_config =
         LicenseCacheConfig::new(LicenseCacheConfig::default_root_dir(), false, false);
-    match LicenseDetectionEngine::from_embedded_with_cache(&cache_config) {
+    match LicenseDetectionEngine::from_embedded_with_cache(&cache_config, None) {
         Ok(engine) => Some(Arc::new(engine)),
         Err(error) => {
             warn!(

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -154,7 +154,14 @@ impl ScanProgress {
 
     pub fn start_license_detection_engine_creation(&self) {
         self.start_phase("license_detection_engine_creation");
-        self.message("Loading SPDX data, this may take a while...");
+    }
+
+    /// Surface the one-time cold-build latency notice. Invoked by the engine
+    /// initializer only when it actually rebuilds the index (cache miss,
+    /// `--reindex`, or an invalidated cache); the common warm path loads the
+    /// rkyv cache in a fraction of a second and stays silent.
+    pub fn notify_license_index_cold_build(&self) {
+        self.message("Building license index (first run may take a few seconds)...");
     }
 
     pub fn finish_license_detection_engine_creation(&self, detail_name: impl Into<String>) {

--- a/src/scan_result_shaping/mod.rs
+++ b/src/scan_result_shaping/mod.rs
@@ -267,11 +267,11 @@ pub(crate) fn prepare_filter_clue_rule_lookup(
 
     let fallback_engine = match (rules_path, license_cache_config) {
         (Some(path), Some(cache_config)) => {
-            LicenseDetectionEngine::from_directory_with_cache(Path::new(path), cache_config)?
+            LicenseDetectionEngine::from_directory_with_cache(Path::new(path), cache_config, None)?
         }
         (Some(path), None) => LicenseDetectionEngine::from_directory(Path::new(path))?,
         (None, Some(cache_config)) => {
-            LicenseDetectionEngine::from_embedded_with_cache(cache_config)?
+            LicenseDetectionEngine::from_embedded_with_cache(cache_config, None)?
         }
         (None, None) => LicenseDetectionEngine::from_embedded()?,
     };


### PR DESCRIPTION
## Summary

- The scan pipeline unconditionally printed `Loading SPDX data, this may take a while...` at the start of license-engine creation, before it knew whether the run would hit the cache. Measured on a release build (single-file `--license` scan, M-series Mac): the warm path loads the rkyv cache in **~0.3s**, while only the cold path (first run, `--reindex`, or an invalidated cache) pays the **~4.4s** build cost. So on the overwhelmingly common warm run the notice was pure noise.
- The wording was also inaccurate — nothing loads SPDX data; the *embedded license index* is built or loaded (routine scans use the embedded index, per `AGENTS.md`).
- The notice is now driven from the engine initializer itself via an optional `ColdBuildNotify` callback: `from_embedded_with_cache` / `from_directory_with_cache` invoke it once, exactly when they fall through to a cold rebuild instead of loading the cache. The pipeline passes a closure that emits `Building license index (first run may take a few seconds)...`. This makes the notice correct for **both** the embedded and custom-dataset (`--license-dataset-path`) paths — a warm custom-dataset scan no longer prints the warning, which a cheap pre-check could not have predicted without loading the whole dataset.
- Additionally route the **sibling** license-index diagnostics through `log` instead of raw `eprintln!`. They previously printed on every scan regardless of `--quiet` — e.g. `License index loaded from rkyv cache in 0.30s` on every warm run. The per-scan timing lines become `log::debug!` (the per-phase timing is already surfaced under `--verbose`), and the cache-save failure becomes `log::warn!` so it stays visible at the default level.

## Scope and exclusions

- Included: `progress.rs` notice split (timing vs. one-shot notice); the `ColdBuildNotify` callback threaded through `init_license_engine` and both engine constructors; both engine-creation call sites; conversion of the `eprintln!` diagnostics to `log` macros; a fix to the custom-dataset cache-load timer (the `Instant` was started after the load, so it always read ~0s — now started before, mirroring the embedded branch).
- Explicit exclusions: none of note.

## How to verify

```
CACHE=$(mktemp -d); TGT=$(mktemp -d); echo "SPDX-License-Identifier: MIT" > "$TGT/f.txt"
# Embedded — cold prints the notice, warm is silent, quiet is always silent:
provenant scan "$TGT" --license --json-pp - --cache-dir "$CACHE" 2>&1 >/dev/null   # notice
provenant scan "$TGT" --license --json-pp - --cache-dir "$CACHE" 2>&1 >/dev/null   # silent
# Custom dataset (the reviewed case) — warm no longer warns:
DS=$(mktemp -d); provenant export-license-dataset "$DS"
provenant scan "$TGT" --license --license-dataset-path "$DS" --json-pp - --cache-dir "$CACHE"  # cold: notice
provenant scan "$TGT" --license --license-dataset-path "$DS" --json-pp - --cache-dir "$CACHE"  # warm: silent
# Timing details are opt-in:
RUST_LOG=debug provenant scan "$TGT" --license --json-pp - --cache-dir "$CACHE" 2>&1 >/dev/null | grep "rkyv cache"
```

Verified: embedded cold/warm/reindex/quiet = notice/silent/notice/silent; custom-dataset cold/warm = notice/silent (was notice/notice before this change).

## Intentional differences from Python

- N/A (CLI progress messaging, not detection behavior).