### PR TITLE
perf(cli): speed up license-dataset export ~65x and add logging to all subcommands

### DIFF
--- a/src/cache/io.rs
+++ b/src/cache/io.rs
@@ -60,6 +60,30 @@ pub fn write_bytes_atomically(path: &Path, payload: &[u8]) -> io::Result<()> {
     result
 }
 
+/// Write `payload` to `path`, creating the file owner-only (`0600`) on Unix,
+/// **without** the fsync + temp-file-rename durability of
+/// [`write_bytes_atomically`].
+///
+/// Intended for bulk one-shot writes such as dataset export, where the target
+/// directory is freshly created/empty and per-file durability is unnecessary:
+/// if the process is interrupted the caller simply re-runs the export. Skipping
+/// the per-file `fsync` (which is an `F_FULLFSYNC` media barrier on macOS)
+/// turns a multi-minute export of tens of thousands of small files into a
+/// few-second operation. The resulting file permissions match
+/// `write_bytes_atomically`, so this is purely a durability/atomicity tradeoff.
+pub fn write_bytes_owner_only(path: &Path, payload: &[u8]) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(payload)?;
+    Ok(())
+}
+
 fn write_bytes_to_temp(temp_path: &Path, payload: &[u8]) -> io::Result<()> {
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -16,7 +16,7 @@ pub use incremental::{
     load_incremental_manifest, manifest_entry_matches_path, metadata_fingerprint,
     write_incremental_manifest,
 };
-pub(crate) use io::{create_dir_all_private, write_bytes_atomically};
+pub(crate) use io::{create_dir_all_private, write_bytes_atomically, write_bytes_owner_only};
 
 pub fn build_collection_exclude_patterns(scan_root: &Path, cache_root: &Path) -> Vec<Pattern> {
     let mut patterns = Vec::new();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -159,6 +159,54 @@ pub enum Command {
     ExportLicenseDataset(ExportLicenseDatasetArgs),
 }
 
+/// Requested output verbosity for a subcommand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Verbosity {
+    /// Warnings and errors only.
+    Quiet,
+    /// Progress and informational output (the default).
+    #[default]
+    Normal,
+    /// Everything, including debug-level diagnostics.
+    Verbose,
+}
+
+impl Verbosity {
+    /// Default global log level for this verbosity. `RUST_LOG` still overrides.
+    pub fn log_level(self) -> log::LevelFilter {
+        match self {
+            Self::Quiet => log::LevelFilter::Warn,
+            Self::Normal => log::LevelFilter::Info,
+            Self::Verbose => log::LevelFilter::Debug,
+        }
+    }
+}
+
+/// Reusable `-q/-v` verbosity flags, flattened into subcommands other than
+/// `scan` (which has its own richer progress modes tied to its output header).
+#[derive(Args, Debug, Clone, Default)]
+pub struct VerbosityFlags {
+    /// Suppress progress and informational output; show warnings and errors only.
+    #[arg(short = 'q', long = "quiet", conflicts_with = "verbose")]
+    pub quiet: bool,
+
+    /// Emit verbose diagnostics, including debug-level logging.
+    #[arg(short = 'v', long = "verbose", conflicts_with = "quiet")]
+    pub verbose: bool,
+}
+
+impl VerbosityFlags {
+    pub fn verbosity(&self) -> Verbosity {
+        if self.quiet {
+            Verbosity::Quiet
+        } else if self.verbose {
+            Verbosity::Verbose
+        } else {
+            Verbosity::Normal
+        }
+    }
+}
+
 #[derive(Args, Debug, Clone)]
 pub struct CompareArgs {
     /// Path to an existing ScanCode JSON output file.
@@ -172,12 +220,18 @@ pub struct CompareArgs {
     /// Directory where comparison artifacts should be written. Defaults to a timestamped directory in the current working directory.
     #[arg(long = "artifact-dir", value_name = "DIR")]
     pub artifact_dir: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub verbosity: VerbosityFlags,
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct ExportLicenseDatasetArgs {
     #[arg(value_name = "DIR")]
     pub dir: String,
+
+    #[command(flatten)]
+    pub verbosity: VerbosityFlags,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -205,6 +259,9 @@ pub struct ServeArgs {
     /// Allow paths, URL, and repository inputs when bound beyond localhost.
     #[arg(long = "allow-privileged-inputs")]
     pub allow_privileged_inputs: bool,
+
+    #[command(flatten)]
+    pub verbosity: VerbosityFlags,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -7,7 +7,7 @@ use crate::cli::{Cli, Command, ScanArgs};
 use crate::compare::compare_json_files;
 use crate::license_detection::dataset::export_embedded_license_dataset;
 use crate::output::{OutputWriteConfig, write_output_file};
-use crate::progress::ScanProgress;
+use crate::progress::{ScanProgress, init_cli_logger};
 use crate::serve::run as run_serve_shell;
 use crate::time::format_scancode_timestamp;
 use anyhow::{Result, anyhow};
@@ -21,6 +21,20 @@ pub fn run() -> Result<()> {
     touch_license_golden_symbols();
 
     let cli = Cli::parse();
+
+    // Every subcommand except `scan` installs a plain global logger here so its
+    // `log::*` diagnostics are actually emitted (respecting `-q`/`-v`). `scan`
+    // installs an indicatif-aware bridge later, once its progress system exists.
+    match &cli.command {
+        Command::Scan(_) => {}
+        Command::Serve(args) => init_cli_logger(args.verbosity.verbosity().log_level()),
+        Command::Compare(args) => init_cli_logger(args.verbosity.verbosity().log_level()),
+        Command::ExportLicenseDataset(args) => {
+            init_cli_logger(args.verbosity.verbosity().log_level())
+        }
+        Command::ShowAttribution => init_cli_logger(crate::cli::Verbosity::Normal.log_level()),
+    }
+
     match &cli.command {
         Command::ShowAttribution => {
             print!("{}", include_str!("../../../NOTICE"));
@@ -30,6 +44,11 @@ pub fn run() -> Result<()> {
             return run_serve_shell(args);
         }
         Command::Compare(args) => {
+            log::info!(
+                "Comparing ScanCode JSON {} against Provenant JSON {}...",
+                args.scancode_json.display(),
+                args.provenant_json.display()
+            );
             let result = compare_json_files(
                 &args.scancode_json,
                 &args.provenant_json,
@@ -47,7 +66,19 @@ pub fn run() -> Result<()> {
             return Ok(());
         }
         Command::ExportLicenseDataset(args) => {
-            export_embedded_license_dataset(Path::new(&args.dir))?;
+            let dir = Path::new(&args.dir);
+            log::info!("Exporting built-in license dataset to {}...", dir.display());
+
+            let started = Instant::now();
+            let outcome = export_embedded_license_dataset(dir)?;
+
+            log::info!(
+                "Exported {} license dataset files to {} in {:.1}s (SPDX list {})",
+                outcome.files_written,
+                dir.display(),
+                started.elapsed().as_secs_f64(),
+                outcome.manifest.spdx_license_list_version
+            );
             return Ok(());
         }
         Command::Scan(_) => {}

--- a/src/license_detection/dataset.rs
+++ b/src/license_detection/dataset.rs
@@ -5,9 +5,10 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::cache::write_bytes_atomically;
+use crate::cache::{create_dir_all_private, write_bytes_atomically, write_bytes_owner_only};
 use crate::license_detection::embedded::index::load_loader_snapshot_from_bytes;
 use crate::license_detection::embedded::schema::EmbeddedArtifactMetadata;
 use crate::license_detection::license_cache::compute_rules_fingerprint;
@@ -39,7 +40,15 @@ pub struct LoadedLicenseDataset {
     pub licenses: Vec<LoadedLicense>,
 }
 
-pub fn export_embedded_license_dataset(target_root: &Path) -> Result<LicenseDatasetManifest> {
+/// Result of a dataset export: the manifest plus the number of `.RULE`/`.LICENSE`
+/// files written (excluding the manifest and README), for a caller's summary.
+#[derive(Debug, Clone)]
+pub struct ExportOutcome {
+    pub manifest: LicenseDatasetManifest,
+    pub files_written: usize,
+}
+
+pub fn export_embedded_license_dataset(target_root: &Path) -> Result<ExportOutcome> {
     let artifact_bytes = include_bytes!("../../resources/license_detection/license_index.zst");
     let snapshot = load_loader_snapshot_from_bytes(artifact_bytes)
         .map_err(|error| anyhow!("Failed to load embedded license dataset: {}", error))?;
@@ -57,8 +66,12 @@ pub fn export_license_dataset_to_root(
     rules: &[LoadedRule],
     licenses: &[LoadedLicense],
     metadata: &EmbeddedArtifactMetadata,
-) -> Result<LicenseDatasetManifest> {
+) -> Result<ExportOutcome> {
     ensure_export_target_is_empty(target_root)?;
+    // Reject duplicate output names up front: the parallel writers would
+    // otherwise race two workers onto the same path (truncate-and-write), and a
+    // dataset with colliding rule identifiers / license keys is malformed anyway.
+    ensure_unique_export_names(rules, licenses)?;
 
     let manifest = LicenseDatasetManifest {
         schema_version: LICENSE_DATASET_SCHEMA_VERSION,
@@ -68,12 +81,41 @@ pub fn export_license_dataset_to_root(
         exported_by_version: BUILD_VERSION.to_string(),
     };
 
-    write_dataset_manifest(target_root, &manifest)?;
-    write_dataset_readme(target_root, &manifest)?;
     write_rule_files(target_root, rules)?;
     write_license_files(target_root, licenses)?;
+    write_dataset_readme(target_root, &manifest)?;
+    // Write the manifest last: the loader requires `manifest.json`, so its
+    // presence marks a complete export. If the process is interrupted mid-write
+    // the manifest is absent and the loader rejects the partial directory rather
+    // than silently loading an incomplete license index.
+    write_dataset_manifest(target_root, &manifest)?;
 
-    Ok(manifest)
+    Ok(ExportOutcome {
+        manifest,
+        files_written: rules.len() + licenses.len(),
+    })
+}
+
+fn ensure_unique_export_names(rules: &[LoadedRule], licenses: &[LoadedLicense]) -> Result<()> {
+    let mut rule_ids = std::collections::HashSet::with_capacity(rules.len());
+    for rule in rules {
+        if !rule_ids.insert(rule.identifier.as_str()) {
+            return Err(anyhow!(
+                "Duplicate rule identifier in license dataset export: {}",
+                rule.identifier
+            ));
+        }
+    }
+    let mut license_keys = std::collections::HashSet::with_capacity(licenses.len());
+    for license in licenses {
+        if !license_keys.insert(license.key.as_str()) {
+            return Err(anyhow!(
+                "Duplicate license key in license dataset export: {}",
+                license.key
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub fn load_license_dataset_from_root(root: &Path) -> Result<LoadedLicenseDataset> {
@@ -180,35 +222,32 @@ fn write_dataset_readme(root: &Path, manifest: &LicenseDatasetManifest) -> Resul
 }
 
 fn write_rule_files(root: &Path, rules: &[LoadedRule]) -> Result<()> {
-    let mut sorted = rules.iter().collect::<Vec<_>>();
-    sorted.sort_by_key(|rule| &rule.identifier);
+    // Create the target directory once, then write files directly (no per-file
+    // fsync/temp-rename): the target is a freshly emptied export dir, so per-file
+    // durability is unnecessary and its fsync cost dominates at this file count.
+    let rules_dir = root.join(LICENSE_DATASET_RULES_DIR);
+    create_dir_all_private(&rules_dir)?;
 
-    for rule in sorted {
+    rules.par_iter().try_for_each(|rule| -> Result<()> {
         validate_dataset_filename_component(&rule.identifier, "rule identifier")?;
         let rendered = render_rule(rule)?;
-        let output_path = root.join(LICENSE_DATASET_RULES_DIR).join(&rule.identifier);
-        write_bytes_atomically(&output_path, rendered.as_bytes())
-            .with_context(|| format!("Write rule dataset file {}", output_path.display()))?;
-    }
-
-    Ok(())
+        let output_path = rules_dir.join(&rule.identifier);
+        write_bytes_owner_only(&output_path, rendered.as_bytes())
+            .with_context(|| format!("Write rule dataset file {}", output_path.display()))
+    })
 }
 
 fn write_license_files(root: &Path, licenses: &[LoadedLicense]) -> Result<()> {
-    let mut sorted = licenses.iter().collect::<Vec<_>>();
-    sorted.sort_by_key(|license| &license.key);
+    let licenses_dir = root.join(LICENSE_DATASET_LICENSES_DIR);
+    create_dir_all_private(&licenses_dir)?;
 
-    for license in sorted {
+    licenses.par_iter().try_for_each(|license| -> Result<()> {
         validate_dataset_filename_component(&license.key, "license key")?;
         let rendered = render_license(license)?;
-        let output_path = root
-            .join(LICENSE_DATASET_LICENSES_DIR)
-            .join(format!("{}.LICENSE", license.key));
-        write_bytes_atomically(&output_path, rendered.as_bytes())
-            .with_context(|| format!("Write license dataset file {}", output_path.display()))?;
-    }
-
-    Ok(())
+        let output_path = licenses_dir.join(format!("{}.LICENSE", license.key));
+        write_bytes_owner_only(&output_path, rendered.as_bytes())
+            .with_context(|| format!("Write license dataset file {}", output_path.display()))
+    })
 }
 
 fn load_strict_loaded_rules_from_directory(dir: &Path) -> Result<Vec<LoadedRule>> {
@@ -617,6 +656,75 @@ mod tests {
             error
                 .to_string()
                 .contains("Invalid rule identifier for exported license dataset")
+        );
+    }
+
+    #[test]
+    fn export_reports_file_count_and_roundtrips() {
+        let metadata = EmbeddedArtifactMetadata {
+            spdx_license_list_version: "3.27".to_string(),
+            license_index_provenance: crate::models::LicenseIndexProvenance {
+                source: "embedded-artifact".to_string(),
+                dataset_fingerprint: "abc123".to_string(),
+                ignored_rules: vec![],
+                ignored_licenses: vec![],
+                ignored_rules_due_to_licenses: vec![],
+                added_rules: vec![],
+                replaced_rules: vec![],
+                added_licenses: vec![],
+                replaced_licenses: vec![],
+            },
+        };
+        let rules = vec![
+            LoadedRule {
+                identifier: "first.RULE".to_string(),
+                ..create_loaded_rule()
+            },
+            LoadedRule {
+                identifier: "second.RULE".to_string(),
+                ..create_loaded_rule()
+            },
+        ];
+        let licenses = vec![create_loaded_license()];
+        let temp = TempDir::new().expect("temp dir");
+
+        let outcome = export_license_dataset_to_root(temp.path(), &rules, &licenses, &metadata)
+            .expect("export should succeed");
+
+        // Counts the rule and license files written (manifest/README excluded).
+        assert_eq!(outcome.files_written, 3);
+
+        // The written tree must reload through the dataset loader unchanged.
+        let reloaded =
+            load_license_dataset_from_root(temp.path()).expect("reload exported dataset");
+        assert_eq!(reloaded.rules.len(), 2);
+        assert_eq!(reloaded.licenses.len(), 1);
+    }
+
+    #[test]
+    fn export_rejects_duplicate_rule_identifiers() {
+        let metadata = EmbeddedArtifactMetadata {
+            spdx_license_list_version: "3.27".to_string(),
+            license_index_provenance: crate::models::LicenseIndexProvenance {
+                source: "embedded-artifact".to_string(),
+                dataset_fingerprint: "abc123".to_string(),
+                ignored_rules: vec![],
+                ignored_licenses: vec![],
+                ignored_rules_due_to_licenses: vec![],
+                added_rules: vec![],
+                replaced_rules: vec![],
+                added_licenses: vec![],
+                replaced_licenses: vec![],
+            },
+        };
+        let rules = vec![create_loaded_rule(), create_loaded_rule()];
+        let temp = TempDir::new().expect("temp dir");
+
+        let error = export_license_dataset_to_root(temp.path(), &rules, &[], &metadata)
+            .expect_err("duplicate rule identifiers should be rejected before any parallel write");
+        assert!(
+            error.to_string().contains("Duplicate rule identifier"),
+            "unexpected error: {error}"
         );
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -521,6 +521,42 @@ fn build_env_logger() -> env_logger::Logger {
     builder.build()
 }
 
+/// Install a plain global logger for CLI subcommands other than `scan`.
+///
+/// `scan` installs an indicatif-aware bridge via [`ScanProgress::init_logging_bridge`]
+/// so log lines never corrupt its progress bars; the other subcommands have no
+/// bars and use this simpler logger. `default_level` sets the baseline filter
+/// (derived from `-q`/`-v`); an explicit `RUST_LOG` still overrides it. Safe to
+/// call at most once — a second call, or a call after a bridge is installed, is
+/// a no-op.
+pub fn init_cli_logger(default_level: LevelFilter) {
+    let default_filter = match default_level {
+        LevelFilter::Off => "off",
+        LevelFilter::Error => "error",
+        LevelFilter::Warn => "warn",
+        LevelFilter::Info => "info",
+        LevelFilter::Debug => "debug",
+        LevelFilter::Trace => "trace",
+    };
+    let mut builder =
+        env_logger::Builder::from_env(Env::default().default_filter_or(default_filter));
+    apply_default_log_filters(&mut builder);
+    // Concise CLI-facing format: informational lines print bare, warnings and
+    // errors carry a prefix, and debug/trace keep their module target.
+    builder.format(|buf, record| {
+        use std::io::Write as _;
+        match record.level() {
+            log::Level::Error => writeln!(buf, "error: {}", record.args()),
+            log::Level::Warn => writeln!(buf, "warning: {}", record.args()),
+            log::Level::Info => writeln!(buf, "{}", record.args()),
+            log::Level::Debug | log::Level::Trace => {
+                writeln!(buf, "[{}] {}", record.target(), record.args())
+            }
+        }
+    });
+    let _ = builder.try_init();
+}
+
 fn apply_default_log_filters(builder: &mut env_logger::Builder) {
     apply_default_log_filters_from(builder, env::var("RUST_LOG").ok().as_deref());
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -230,12 +230,11 @@ pub(crate) fn run(args: &ServeArgs) -> Result<()> {
         .map_err(|e| anyhow!("Failed to bind provenant serve to {}: {e}", config.bind))?;
     let local_addr = server.server_addr();
 
-    eprintln!(
-        "Starting provenant serve on http://{} (api {API_VERSION})",
-        local_addr
-    );
+    log::info!("Starting provenant serve on http://{local_addr} (api {API_VERSION})");
     if !config.ingest_policy.privileged_inputs_allowed() {
-        eprintln!(
+        // Warn (not info) so this security-boundary notice still surfaces under
+        // `serve --quiet`, which raises the log level to warn.
+        log::warn!(
             "Privileged serve inputs (paths, url, repository) are disabled for this non-loopback bind; use --allow-privileged-inputs only for trusted deployments."
         );
     }
@@ -252,7 +251,7 @@ fn serve_forever(server: Server, state: ServeState) -> Result<()> {
     let dispatcher = RequestDispatcher::start(state, RequestWorkerConfig::default());
     for request in server.incoming_requests() {
         if let Err(error) = dispatcher.dispatch(request) {
-            eprintln!("serve request dispatch error: {error}");
+            log::error!("serve request dispatch error: {error}");
         }
     }
 
@@ -342,7 +341,7 @@ fn request_worker_loop(
         match request {
             Ok(request) => {
                 if let Err(error) = handle_request(request, &state) {
-                    eprintln!("serve {label} worker {index} request handling error: {error}");
+                    log::error!("serve {label} worker {index} request handling error: {error}");
                 }
             }
             Err(_) => break,
@@ -650,11 +649,11 @@ fn spawn_dispatches(
 
             let outcome = match result {
                 Ok(result_body) => {
-                    eprintln!("serve async job {} succeeded", dispatched.job_id);
+                    log::info!("serve async job {} succeeded", dispatched.job_id);
                     JobOutcome::Succeeded { result_body }
                 }
                 Err(error) => {
-                    eprintln!("serve async job {} failed: {error}", dispatched.job_id);
+                    log::error!("serve async job {} failed: {error}", dispatched.job_id);
                     JobOutcome::Failed {
                         message: "async scan job failed".to_string(),
                         status_code: error.http_status_code().0,
@@ -771,6 +770,7 @@ mod tests {
         let args = ServeArgs {
             bind: String::new(),
             allow_privileged_inputs: false,
+            verbosity: crate::cli::VerbosityFlags::default(),
         };
 
         let error = ServeConfig::try_from(&args).expect_err("empty bind should fail");
@@ -782,6 +782,7 @@ mod tests {
         let args = ServeArgs {
             bind: "127.0.0.1:8080".to_string(),
             allow_privileged_inputs: false,
+            verbosity: crate::cli::VerbosityFlags::default(),
         };
 
         let config = ServeConfig::try_from(&args).expect("loopback bind should configure");
@@ -793,6 +794,7 @@ mod tests {
         let args = ServeArgs {
             bind: "localhost:8080".to_string(),
             allow_privileged_inputs: false,
+            verbosity: crate::cli::VerbosityFlags::default(),
         };
 
         let config = ServeConfig::try_from(&args).expect("localhost bind should configure");
@@ -804,6 +806,7 @@ mod tests {
         let args = ServeArgs {
             bind: "0.0.0.0:8080".to_string(),
             allow_privileged_inputs: false,
+            verbosity: crate::cli::VerbosityFlags::default(),
         };
 
         let config = ServeConfig::try_from(&args).expect("non-loopback bind should configure");
@@ -815,6 +818,7 @@ mod tests {
         let args = ServeArgs {
             bind: "0.0.0.0:8080".to_string(),
             allow_privileged_inputs: true,
+            verbosity: crate::cli::VerbosityFlags::default(),
         };
 
         let config = ServeConfig::try_from(&args).expect("non-loopback bind should configure");


### PR DESCRIPTION
## Summary

Two related CLI robustness/UX gaps surfaced while investigating why `export-license-dataset` appeared to hang.

**1. `export-license-dataset` was ~65× slower than it needed to be, with zero feedback.** It wrote its ~39k `.RULE`/`.LICENSE` files via `write_bytes_atomically`, which `fsync`s every file (an `F_FULLFSYNC` media barrier on macOS) and re-runs `create_dir_all` per file. A full export took **~160s of almost pure I/O wait** (`user 0.22s, sys 8.38s, real 159s`) and printed nothing — indistinguishable from a hang. Per-file durability is pointless here: the target is a freshly emptied directory and the user just re-runs on interruption. Export now creates the two directories once and writes files **in parallel (rayon)** via a new `write_bytes_owner_only` helper (same `0600`/`0700` perms, no fsync/temp-rename). Measured end to end: **~160s → ~2.5s**, byte-identical output that still round-trips through the dataset loader.

Two robustness guards come with the rewrite:
- The **manifest is written last**, so its presence marks a complete export. An export interrupted mid-write leaves no `manifest.json` and is rejected by the loader rather than silently loaded as an incomplete license index.
- **Duplicate rule identifiers / license keys are rejected up front**, so the parallel writers can never race two workers onto the same path (and a colliding dataset is malformed anyway).

**2. Only `scan` initialized a logger**, so `log::*` calls in every other subcommand were silently dropped (which is why `serve` had resorted to raw `eprintln!`). This adds a plain global logger (`init_cli_logger`) for all non-scan subcommands — `scan` keeps its indicatif-aware bridge untouched — and a reusable `-q/-v` `VerbosityFlags` (quiet=warn, normal=info, verbose=debug) flattened into `serve`, `compare`, and `export-license-dataset`.

Resulting UX:
- **export**: a start line and a completion summary (`Exported 39220 … files … in 2.0s`); silent under `--quiet`. (No progress bar — the operation is short and disk-bound; the two lines bracket it.)
- **serve**: startup / request-error / async-job lines now go through `log` at appropriate levels instead of ad-hoc `eprintln!`. The non-loopback privileged-inputs boundary notice is logged at **warn** so it still surfaces under `serve --quiet`.
- **compare**: a `log::info!` start line; its result summary still prints as before.

`scan` is deliberately left 100% untouched — its `--quiet`/`--verbose` are entangled with the parity-sensitive output-header options block, so this PR does not fold them into the shared flags.

## How to verify

```
DIR=$(mktemp -d); rm -rf "$DIR"
# Fast + informative (was ~160s and silent):
time provenant export-license-dataset "$DIR"
#   Exporting built-in license dataset to <DIR>...
#   Exported 39220 license dataset files to <DIR> in ~2.5s (SPDX list 3.28)
provenant export-license-dataset -q "$DIR2"          # silent
# Round-trips as a custom dataset:
provenant scan <path> --license --license-dataset-path "$DIR" --json-pp -
# A partial export (files but no manifest) is now rejected, not loaded:
mkdir -p "$DIR3/rules" "$DIR3/licenses"
provenant scan <path> --license --license-dataset-path "$DIR3" --json-pp -   # errors: missing manifest.json
# serve logs via the log framework; boundary notice survives --quiet:
provenant serve --bind 127.0.0.1:0                   # "Starting provenant serve on http://…"
provenant serve --quiet --bind 0.0.0.0:0             # still prints the privileged-inputs warning
```

Verified: export 160s→2.5s (~65×), 39,222 files, `0600` perms preserved, reloads via `--license-dataset-path`; partial export rejected; scan output unchanged. New unit tests cover the export file-count + round-trip and the duplicate-identifier rejection.

## Intentional differences from Python

- N/A (Provenant-specific CLI tooling and progress/logging UX).

## Follow-up work

- Optionally unify `scan`'s verbosity onto the shared `VerbosityFlags` (deferred: touches the parity-sensitive output-header options block).