### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- `crossbeam-epoch 0.9.18` is flagged by **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`), which is failing `cargo-deny` advisories on **main** (and therefore on every open PR).
- Bump it to the fixed **0.9.20** via a transitive `Cargo.lock` update (`cargo update -p crossbeam-epoch`). No `Cargo.toml` or source change.

## Issues

- Covers: unblocking `Code Quality` (dependency policy / advisories) across the repo.

## Scope and exclusions

- Included: `Cargo.lock` only (crossbeam-epoch 0.9.18 → 0.9.20).
- Excluded: everything else. `bans`/`licenses`/`sources` were already ok.

## How to verify

- `cargo deny check advisories` → `advisories ok` (verified locally).

## Intentional differences from Python

- N/A