### PR TITLE
perf(xtask): scope golden-tests feature to the two bins that need it

### DIFF
--- a/.agents/skills/verify-benchmark-target/SKILL.md
+++ b/.agents/skills/verify-benchmark-target/SKILL.md
@@ -216,9 +216,9 @@ Keep validation tightly scoped. Prefer the narrowest useful owning test target/f
    For license golden YAML fixtures, first do a parity precheck, then choose the update mode that matches the intent:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --list-mismatches --show-diff --filter <pattern>
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --filter <pattern> --write
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --sync-actual --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --sync-actual --filter <pattern> --write
    ```
 
    Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.
@@ -226,9 +226,9 @@ Keep validation tightly scoped. Prefer the narrowest useful owning test target/f
    For copyright golden YAML fixtures, use the same precheck-then-update flow:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --list-mismatches --show-diff --filter <pattern>
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --filter <pattern> --write
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
    ```
 
    Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.

--- a/.claude/skills/verify-benchmark-target/SKILL.md
+++ b/.claude/skills/verify-benchmark-target/SKILL.md
@@ -216,9 +216,9 @@ Keep validation tightly scoped. Prefer the narrowest useful owning test target/f
    For license golden YAML fixtures, first do a parity precheck, then choose the update mode that matches the intent:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --list-mismatches --show-diff --filter <pattern>
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --filter <pattern> --write
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --sync-actual --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --sync-actual --filter <pattern> --write
    ```
 
    Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.
@@ -226,9 +226,9 @@ Keep validation tightly scoped. Prefer the narrowest useful owning test target/f
    For copyright golden YAML fixtures, use the same precheck-then-update flow:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --list-mismatches --show-diff --filter <pattern>
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --filter <pattern> --write
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --list-mismatches --show-diff --filter <pattern>
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
    ```
 
    Use plain `--write` for parity-safe syncs from the Python reference. Use `--sync-actual --write` only when the Rust-owned expectation is intentionally diverging.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,6 +116,13 @@ jobs:
       - name: Check compilation
         run: cargo check --all --verbose
 
+      # `cargo check --all` uses default features, which excludes xtask bins gated
+      # behind the non-default `golden` feature (update-license-golden,
+      # update-copyright-golden). Check xtask with all features so those bins stay
+      # compile-checked.
+      - name: Check xtask (all features)
+        run: cargo check --manifest-path xtask/Cargo.toml --all-targets --all-features --verbose
+
       - name: Check dependency policy
         uses: EmbarkStudios/cargo-deny-action@44db170f6a7d12a6e90340e9e0fca1f650d34b14
         with:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/bin/update_parser_golden.rs"
 [[bin]]
 name = "update-copyright-golden"
 path = "src/bin/update_copyright_golden.rs"
+required-features = ["golden"]
 
 [[bin]]
 name = "validate-urls"
@@ -24,6 +25,7 @@ path = "src/bin/generate_supported_formats.rs"
 [[bin]]
 name = "update-license-golden"
 path = "src/bin/update_license_golden.rs"
+required-features = ["golden"]
 
 [[bin]]
 name = "generate-index-artifact"
@@ -65,13 +67,19 @@ path = "src/bin/generate_legalese_artifact/main.rs"
 name = "classify-rule-overmatch"
 path = "src/bin/classify_rule_overmatch.rs"
 
+[features]
+# Only the golden-fixture update tools need the provenant `golden-tests` API.
+# Scoping it here (instead of enabling it on the dependency crate-wide) lets the
+# other xtask bins — notably generate-index-artifact — build provenant-cli with
+# the same default feature set as the main workspace, so they share compiled
+# artifacts instead of triggering a separate feature-configured rebuild.
+golden = ["provenant/golden-tests"]
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
 postcard = { workspace = true }
-provenant = { path = "..", package = "provenant-cli", features = [
-    "golden-tests",
-] }
+provenant = { path = "..", package = "provenant-cli" }
 rayon = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -369,10 +369,14 @@ Always review the resulting diff before committing.
 
 `update-copyright-golden` syncs and updates copyright golden YAML fixtures (authors / ics / copyrights).
 
+> This tool and `update-license-golden` require the `golden` feature (they use the
+> `provenant` `golden-tests` API), so their commands pass `--features golden`. The other
+> xtask bins do not, which lets them share the main workspace's compiled `provenant-cli`.
+
 Show CLI help:
 
 ```bash
-cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- --help
+cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- --help
 ```
 
 CLI arguments:
@@ -393,19 +397,19 @@ Expected workflow:
 1. Check Python-reference parity impact first:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --list-mismatches --show-diff
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --list-mismatches --show-diff
    ```
 
 2. If parity is acceptable for a fixture, sync from Python reference:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --filter <pattern> --write
    ```
 
 3. If divergence is intentional or Rust-specific, update to Rust actuals:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-copyright-golden -- copyrights --sync-actual --filter <pattern> --write
    ```
 
 ## `update-license-golden`
@@ -415,7 +419,7 @@ Expected workflow:
 Show CLI help:
 
 ```bash
-cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --help
+cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --help
 ```
 
 CLI arguments:
@@ -432,19 +436,19 @@ Expected workflow:
 1. Check Python-reference parity impact first:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --list-mismatches --show-diff
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --list-mismatches --show-diff
    ```
 
 2. If parity is acceptable for a fixture, sync from Python reference:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --suite lic1 --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --suite lic1 --filter <pattern> --write
    ```
 
 3. If divergence is intentional or Rust-specific, update to Rust actuals:
 
    ```bash
-   cargo run --manifest-path xtask/Cargo.toml --bin update-license-golden -- --sync-actual --suite unknown --filter <pattern> --write
+   cargo run --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden -- --sync-actual --suite unknown --filter <pattern> --write
    ```
 
 ## `validate-urls`


### PR DESCRIPTION
## Summary

- `xtask` enabled `provenant-cli`'s `golden-tests` feature on the dependency **crate-wide**, so every xtask bin — including `generate-index-artifact` — built a *separate* feature-configured variant of `provenant-cli`. That variant can't share compiled artifacts with the default workspace build, so editing library source and then running an xtask generator paid two full `provenant-cli` compiles instead of one.
- Only `update-license-golden` and `update-copyright-golden` actually use the `golden-tests` API. This moves the feature behind a **non-default** xtask `golden` feature and gates those two bins with `required-features = ["golden"]`.
- The remaining xtask bins now build `provenant-cli` with the same default feature set as the main workspace and reuse its artifacts. Locally, a warm `generate-index-artifact` build after `cargo build --bin provenant` drops from a full `provenant-cli` recompile (~20s debug) to **~0.2s** (no recompile).

## Issues

- Covers: follow-up from the maintainer-workflow performance investigation on #1230 (artifact generation felt slow; root cause was cold/variant recompiles, not the command runtime).
- Closes:

## Scope and exclusions

- Included: `xtask/Cargo.toml` feature gating, a CI step to keep the gated bins compile-checked, and doc updates for the two golden-update tools.
- Explicit exclusions: no change to the `provenant-cli` `golden-tests` feature itself or to the golden test suites (`cargo test --features golden-tests` is unchanged).

## How to verify

```bash
# Non-golden bins share the default provenant-cli build (no recompile):
cargo build --bin provenant
cargo build --manifest-path xtask/Cargo.toml --bin generate-index-artifact   # Finishes in ~0.2s, no "Compiling provenant-cli"

# Golden bins still build with the feature:
cargo build --manifest-path xtask/Cargo.toml --features golden --bin update-license-golden

# And are correctly gated without it:
cargo build --manifest-path xtask/Cargo.toml --bin update-license-golden      # errors: requires the features: golden
```

CI's `cargo check --all` uses default features and would skip the two gated bins, so a new "Check xtask (all features)" step keeps them compile-checked.

## Intentional differences from Python

- N/A (build-system change).

## Follow-up work

- None.

## Expected-output fixture changes

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
