### PR TITLE
fix(copyright): strip trailing "Website: <url>" bleed from authors

### DIFF
--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -35,6 +35,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_version(&a);
     a = strip_trailing_comma_email_matching_name(&a);
     a = truncate_trailing_from_clause_after_angle_contact(&a);
+    a = truncate_trailing_website_url_clause(&a);
     a = truncate_trailing_clause_after_contact(&a);
     a = strip_trailing_comma_and(&a);
     a = truncate_bug_reports_clause(&a);
@@ -1207,6 +1208,37 @@ fn truncate_trailing_clause_after_contact(s: &str) -> String {
         return prefix.to_string();
     }
 
+    s.to_string()
+}
+
+/// Truncate a trailing website/homepage label followed by a URL.
+///
+/// Structured file headers such as
+/// ```text
+/// Author: Valerii Hiora <valerii.hiora@gmail.com>
+/// Contributors: Angel G. Olloqui <angelgarcia.mail@gmail.com>, ...
+/// Website: https://developer.apple.com/documentation/objectivec
+/// ```
+/// let the following `Website: <url>` line bleed into the collected author. The
+/// label word plus an explicit `http(s)://` URL is unambiguous metadata, never
+/// part of a person or organization name, so drop it.
+fn truncate_trailing_website_url_clause(s: &str) -> String {
+    static WEBSITE_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        // `[\s:]+` tolerates the colon-preserved header form (`Website: https://`,
+        // `Website:https://`) as well as the colon-stripped `Website https://`.
+        Regex::new(
+            r"(?i)^(?P<prefix>.+?)\s+(?:Website|Homepage|Web\s?site|URL)[\s:]+https?://\S+\s*$",
+        )
+        .expect("valid trailing website-url clause regex")
+    });
+
+    let trimmed = s.trim();
+    if let Some(cap) = WEBSITE_URL_RE.captures(trimmed) {
+        let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
+        if !prefix.is_empty() {
+            return prefix.to_string();
+        }
+    }
     s.to_string()
 }
 

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -87,6 +87,41 @@ fn test_refine_author_discards_laboriously_took_the_trouble_junk() {
 }
 
 #[test]
+fn test_refine_author_strips_trailing_website_url_clause() {
+    // A `Website: <url>` header line following an `Author:`/`Contributors:`
+    // line bleeds into the collected author; the label + URL is dropped.
+    assert_eq!(
+        refine_author(
+            "Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com> Website https://developer.apple.com/documentation/objectivec"
+        ),
+        Some(
+            "Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com>"
+                .to_string()
+        )
+    );
+    // `Homepage`/`URL` label variants are handled too.
+    assert_eq!(
+        refine_author("Jane Doe <jane@example.com> Homepage https://example.com/"),
+        Some("Jane Doe <jane@example.com>".to_string())
+    );
+    // The colon-preserved header form (label punctuation not stripped) is also
+    // truncated, including when an email contact is present.
+    assert_eq!(
+        refine_author("Jane Doe <jane@example.com> Website: https://example.com/"),
+        Some("Jane Doe <jane@example.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("Jane Doe <jane@example.com> Website:https://example.com/"),
+        Some("Jane Doe <jane@example.com>".to_string())
+    );
+    // A bare name that merely contains the word "Website" (no URL) is preserved.
+    assert_eq!(
+        refine_author("Acme Website Team"),
+        Some("Acme Website Team".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_strips_xcode_on_date_suffix() {
     // Xcode/IDE headers `Created by <Name> on M/D/YY` yield a date-suffixed
     // author variant; the suffix is stripped so it dedupes to the bare name.

--- a/testdata/copyright-golden/copyrights/objectivec_hljs_js-objectivec_js.js
+++ b/testdata/copyright-golden/copyrights/objectivec_hljs_js-objectivec_js.js
@@ -1,0 +1,7 @@
+/*
+Language: Objective-C
+Author: Valerii Hiora <valerii.hiora@gmail.com>
+Contributors: Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com>, Andrew Farmer <ahfarmer@gmail.com>, Minh Nguyễn <mxn@1ec5.org>
+Website: https://developer.apple.com/documentation/objectivec
+Category: common
+*/

--- a/testdata/copyright-golden/copyrights/objectivec_hljs_js-objectivec_js.js.yml
+++ b/testdata/copyright-golden/copyrights/objectivec_hljs_js-objectivec_js.js.yml
@@ -1,0 +1,5 @@
+what:
+  - authors
+authors:
+  - Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com>, Andrew Farmer <ahfarmer@gmail.com>, Minh Nguyễn <mxn@1ec5.org>
+  - Valerii Hiora <valerii.hiora@gmail.com>


### PR DESCRIPTION
## Summary

- File-content author detection bled a trailing `Website: <url>` header line into the collected author. For highlight.js language definitions and similar structured headers, the author came out as `... Minh Nguyễn <mxn@1ec5.org> Website https://developer.apple.com/documentation/objectivec`.
- Adds `truncate_trailing_website_url_clause` to the author refiner: a `Website`/`Homepage`/`URL` label immediately followed by an explicit `http(s)://` URL is unambiguous metadata (never part of a person/org name) and is truncated. A bare name that merely contains the word "Website" without a URL is preserved.

## Issues

- Covers: aboutcode-org/scancode-toolkit#5138 (the `objectivec.js` case). Found while triaging recent upstream ScanCode issues for ones that also affect Provenant.

## Scope and exclusions

- Included: the trailing `Website: <url>` bleed in file-content author detection, plus a truncated golden fixture.
- Explicit exclusions: splitting the comma-separated `Contributors:` list into separate authors. That output (`Angel G. Olloqui <…>, Matt Diephouse <…>, …`) matches ScanCode and is a larger, higher-risk grammar change (commas also appear inside names/orgs); left as potential follow-up. The other #5138 fixtures already behave correctly in Provenant — the npm parser splits `package.json` contributors into separate parties, and the govalidator README produces no junk author.

## How to verify

- `printf 'Contributors: A <a@x.com>, B <b@x.com>\nWebsite: https://example.com/docs\n' | provenant --copyright --json-pp - <file>` — the author no longer contains `Website https://…`.
- Unit test `copyright::refiner::tests::test_refine_author_strips_trailing_website_url_clause` and golden fixture `objectivec_hljs_js-objectivec_js.js` (covered by the golden shard).

## Intentional differences from Python

- ScanCode ships `# (r'^Website', 'NN'),` commented out and therefore reproduces this bleed. Provenant deliberately strips the metadata tail instead.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/objectivec_hljs_js-objectivec_js.js{,.yml}` (new; truncated header block).
- Why the new expected output is correct: the two authors are the file's real `Author:` and `Contributors:` values; the `Website:` metadata line is correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
