### PR TITLE
perf(license): memoize referenced-filename tokenization on long-line files

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 239 of 239 recorded runs, with a **19.4× median speedup** and **19.4× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 240 of 240 recorded runs, with a **19.3× median speedup** and **19.3× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1719,6 +1719,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-14 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `8.76s`; ScanCode `42.90s`
 - Matched NSIS installer plus Windows PE package visibility (`2` vs `2` file-level package records), with a concrete `pkg:winexe/nsis-3.12-setup@3.12` identity on the executable metadata record and cleaner rejection of ScanCode's spurious `LicenseRef-scancode-unknown` license inferred only from the `LegalCopyright` URL
+
+##### [VS Code extensions extracted VSIX snapshot (Open VSX: esbenp.prettier-vscode 11.0.0, redhat.vscode-yaml 1.14.0, ms-python.python 2024.0.1)](https://open-vsx.org/) — **8.01× faster**
+
+- Files: 3,054
+- Run context: 2026-07-08 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `56.47s`; ScanCode `452.20s`
+- Broader package and dependency visibility across an extracted VS Code extension tree (`29` vs `3` packages, `487` vs `185` dependencies): dedicated `pkg:vscode-extension/<publisher>/<id>` identities for all three bundled extensions — carrying publisher, marketplace, source, and engine metadata from each `extension.vsixmanifest` — plus the npm and vendored-PyPI package metadata inside them that ScanCode's extension-tree model does not reach
 
 #### Generated dependency lock manifests
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -542,6 +542,9 @@ ScanCode: 157.23s</title></rect>
     <rect x="643.66" y="334.70" width="8" height="8" fill="#d97706" rx="1.5"><title>scipy/scipy @ 8a4633f
 Files: 2998
 ScanCode: 496.36s</title></rect>
+    <rect x="644.93" y="339.10" width="8" height="8" fill="#d97706" rx="1.5"><title>VS Code extensions extracted VSIX snapshot (Open VSX: esbenp.prettier-vscode 11.0.0, redhat.vscode-yaml 1.14.0, ms-python.python 2024.0.1)
+Files: 3054
+ScanCode: 452.20s</title></rect>
     <rect x="646.82" y="368.39" width="8" height="8" fill="#d97706" rx="1.5"><title>laravel/framework @ a3960e8
 Files: 3139
 ScanCode: 243.30s</title></rect>
@@ -1261,6 +1264,9 @@ Provenant: 5.81s</title></circle>
     <circle cx="647.66" cy="516.43" r="4.5" fill="#2563eb"><title>scipy/scipy @ 8a4633f
 Files: 2998
 Provenant: 11.54s</title></circle>
+    <circle cx="648.93" cy="441.40" r="4.5" fill="#2563eb"><title>VS Code extensions extracted VSIX snapshot (Open VSX: esbenp.prettier-vscode 11.0.0, redhat.vscode-yaml 1.14.0, ms-python.python 2024.0.1)
+Files: 3054
+Provenant: 56.47s</title></circle>
     <circle cx="650.82" cy="539.65" r="4.5" fill="#2563eb"><title>laravel/framework @ a3960e8
 Files: 3139
 Provenant: 7.06s</title></circle>

--- a/src/license_detection/match_refine/filter_low_quality.rs
+++ b/src/license_detection/match_refine/filter_low_quality.rs
@@ -14,6 +14,7 @@ use crate::license_detection::models::{LicenseMatch, MatcherKind};
 use crate::license_detection::position_set::PositionSet;
 use crate::license_detection::query::Query;
 use crate::license_detection::tokenize::tokenize_without_stopwords;
+use std::collections::HashMap;
 use std::path::Path;
 
 const INHERIT_LICENSE_FROM_PACKAGE_REFERENCE: &str = "INHERIT_LICENSE_FROM_PACKAGE";
@@ -154,12 +155,11 @@ pub(crate) fn filter_short_matches_scattered_on_too_many_lines(
 /// occur as a contiguous token run. This keeps the referenced-filename evidence guard
 /// intact — `COPYING` still requires a `copying` token — without discarding otherwise
 /// perfect matches over a `-` vs `_` difference.
-fn referenced_filename_tokens_present(matched_text: &str, name: &str) -> bool {
+fn referenced_filename_tokens_present(haystack: &[String], name: &str) -> bool {
     let needle = tokenize_without_stopwords(name);
     if needle.is_empty() {
         return false;
     }
-    let haystack = tokenize_without_stopwords(matched_text);
     haystack
         .windows(needle.len())
         .any(|w| w == needle.as_slice())
@@ -187,6 +187,10 @@ pub(crate) fn filter_matches_missing_required_phrases(
 
     let mut kept = Vec::new();
     let mut discarded = Vec::new();
+    // Cache of tokenized matched text keyed by (start_line, end_line); a match's
+    // referenced-filename haystack depends only on its line range, so many
+    // candidate matches over the same (often very long) line share one tokenization.
+    let mut haystack_token_cache: HashMap<(usize, usize), Vec<String>> = HashMap::new();
 
     for m in matches {
         let rid = m.rid;
@@ -237,13 +241,31 @@ pub(crate) fn filter_matches_missing_required_phrases(
                     && m.coverage() >= 50.0;
 
                 if !skip_referenced_filename_check {
-                    let matched_text = match &m.matched_text {
-                        Some(text) => text.clone(),
-                        None => query.matched_text(m.start_line.get(), m.end_line.get()),
+                    // The referenced-filename check tokenizes the match's text and
+                    // scans it for the filename token run. For files with very long
+                    // lines (minified JS) a single line can be megabytes, and a file
+                    // can produce thousands of candidate matches over the same line;
+                    // re-extracting and re-tokenizing that text per match is
+                    // quadratic. Tokenize each distinct line-range's matched text once
+                    // and reuse it across matches and referenced filenames — the token
+                    // result is a pure function of the line range, so this is
+                    // output-preserving.
+                    let owned_haystack;
+                    let haystack: &[String] = match &m.matched_text {
+                        Some(text) => {
+                            owned_haystack = tokenize_without_stopwords(text);
+                            &owned_haystack
+                        }
+                        None => {
+                            let key = (m.start_line.get(), m.end_line.get());
+                            haystack_token_cache.entry(key).or_insert_with(|| {
+                                tokenize_without_stopwords(&query.matched_text(key.0, key.1))
+                            })
+                        }
                     };
                     let has_referenced_filename =
                         concrete_referenced_filenames.iter().any(|filename| {
-                            if referenced_filename_tokens_present(&matched_text, filename) {
+                            if referenced_filename_tokens_present(haystack, filename) {
                                 return true;
                             }
 
@@ -256,7 +278,7 @@ pub(crate) fn filter_matches_missing_required_phrases(
 
                             is_path_like
                                 && basename.contains('.')
-                                && referenced_filename_tokens_present(&matched_text, basename)
+                                && referenced_filename_tokens_present(haystack, basename)
                         });
                     if !has_referenced_filename {
                         discarded.push(m.clone());
@@ -698,22 +720,23 @@ mod tests {
         // A rule referencing `LICENSE_MIT` is satisfied by the real-world hyphenated
         // and dotted spellings, and is case-insensitive, because filenames tokenize
         // identically regardless of separator punctuation.
+        let haystack = |text: &str| tokenize_without_stopwords(text);
         assert!(referenced_filename_tokens_present(
-            "licensed under the MIT license found in the LICENSE-MIT file",
+            &haystack("licensed under the MIT license found in the LICENSE-MIT file"),
             "LICENSE_MIT"
         ));
         assert!(referenced_filename_tokens_present(
-            "see the license.mit file",
+            &haystack("see the license.mit file"),
             "LICENSE_MIT"
         ));
         // The referenced name must still actually appear: a GPL notice that never
         // mentions COPYING does not satisfy a COPYING reference (the FP guard).
         assert!(!referenced_filename_tokens_present(
-            "under the terms of the GNU General Public License version 2 or later",
+            &haystack("under the terms of the GNU General Public License version 2 or later"),
             "COPYING"
         ));
         assert!(referenced_filename_tokens_present(
-            "see the file COPYING for details",
+            &haystack("see the file COPYING for details"),
             "COPYING"
         ));
     }


### PR DESCRIPTION
## Summary

- Stacked on #1237. Removes a quadratic license-detection hot path exposed while benchmarking the new VS Code extension parser on real extracted extensions, and records the resulting benchmark row.
- `filter_matches_missing_required_phrases` re-extracted and re-tokenized each candidate match's matched text once per match **and** per referenced filename. On files with very long lines (minified/generated JS, where one line is multiple MB), a single file produced thousands of candidate matches over the same line, so the same multi-MB text was re-tokenized thousands of times.
- Tokenize each distinct line-range's matched text once and reuse it across matches and referenced filenames. The token result is a pure function of the line range, so output is unchanged.

## Issues

- Covers: #356 (benchmark verification of the VS Code extension parser surfaced the hot path)

## Scope and exclusions

- Included: memoized referenced-filename haystack tokenization in the license required-phrase filter; one `docs/BENCHMARKS.md` row for the extracted VS Code extension tree.
- Explicit exclusions: no change to which matches are kept/discarded (byte-identical); no change to matched-text emitted in output; the pre-existing missed leading-banner MIT detection on minified `extension.js` is a separate detection gap (see Follow-up).

## How to verify

Beyond CI (which runs the license golden suite that gates byte-identical behavior):

- A/B on a minified target, byte-identical gate + median timing:
  ```
  cargo run --manifest-path xtask/Cargo.toml --bin perf-ab -- \
    --base codex/vscode-vsixmanifest-parser --head perf/license-referenced-filename-memo \
    --target-path <dir with a minified extension.js> --rounds 5 --check-output -- --license -n 1
  ```
  Observed: `check-output OK` (byte-identical), base median `26.509s` → head `4.978s` (5.325×). A single minified `extension.js`: `22.82s` → `1.65s` (~14×).
- Full extracted-extension tree compare (`--profile common`, 3,054 files): Provenant `56.47s` vs ScanCode `452.20s`; packages `29` vs `3`, dependencies `487` vs `185`, `0` packages missing vs ScanCode.

## Follow-up work

- Created or intentionally deferred: ScanCode detects `mit` on the minified `extension.js` leading banner where Provenant currently detects nothing — a separate minified-file leading-banner license-detection gap, deferred to its own investigation (not caused by this change; behavior here is byte-identical to before).

## Expected-output fixture changes

- Files changed: none. Output is byte-identical; the full license golden suite passes unchanged. The only doc change is the added `docs/BENCHMARKS.md` row (chart/summary regenerated via `generate-benchmark-chart`).
