### PR TITLE
fix(license): don't apply prose-context pruning to minified long lines

### DIFF
--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -26,6 +26,13 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
+/// Maximum source-line length for which the contextual short-reference prune
+/// applies its prose heuristics. Lines longer than this are treated as
+/// minified/generated content rather than prose, so a stray phrase elsewhere on
+/// a very long line cannot prune a genuine short license reference. See
+/// [`should_prune_contextual_short_reference_match`].
+const MAX_CONTEXTUAL_PRUNE_LINE_LEN: usize = 1_000;
+
 const MAX_OUTPUT_MATCHED_TEXT_LINE_LENGTH: usize = 10_000;
 const MAX_OUTPUT_MATCHED_TEXT_BYTES: usize = 128 * 1024;
 const MATCHED_TEXT_TRUNCATION_MARKER: &str = "… [truncated]";
@@ -890,8 +897,19 @@ fn should_prune_contextual_short_reference_match(
     }
 
     (start_line..=end_line).any(|line_number| {
+        let line = source_lines[line_number - 1];
+        // These heuristics recognize human-authored prose context (README license
+        // tables, comparative "unlike X"/"no restriction" sentences). On minified
+        // or generated files a single line can be megabytes long, so an unrelated
+        // phrase anywhere on that line would misclassify the whole line as prose
+        // and prune a genuine short license reference elsewhere on it. Real prose,
+        // table, and comment lines are far shorter than this bound, so lines above
+        // it are not prose context and are left untouched.
+        if line.len() > MAX_CONTEXTUAL_PRUNE_LINE_LEN {
+            return false;
+        }
         is_markdown_license_table_row(line_number, source_lines)
-            || is_negative_or_comparative_license_mention_line(source_lines[line_number - 1])
+            || is_negative_or_comparative_license_mention_line(line)
     })
 }
 

--- a/src/scanner/process/license_test.rs
+++ b/src/scanner/process/license_test.rs
@@ -689,6 +689,40 @@ fn test_prune_contextual_short_reference_matches_drops_negative_policy_lines() {
 }
 
 #[test]
+fn test_prune_contextual_short_reference_matches_keeps_short_reference_on_minified_long_line() {
+    // A minified/generated single line (megabytes in the wild) that happens to
+    // contain a stray standalone `no`, a `/`, and uppercase letters trips the
+    // negated-shorthand prose heuristic used to prune comparative mentions. Such
+    // a line is far too long to be prose, so a genuine short MIT reference on it
+    // (here an inlined dependency's `"license":"MIT"`) must be kept, not pruned.
+    let text = format!(
+        "var a={{no:1}};var B=x/y;{}\"license\":\"MIT\";{}\n",
+        "z".repeat(1100),
+        "q".repeat(64),
+    );
+    let mut detections = vec![make_public_detection_with_matches(
+        "mit",
+        "MIT",
+        vec![make_public_match("mit", "MIT", 1, 1, 2, "mit_30.RULE")],
+    )];
+    let mut clues = Vec::new();
+
+    prune_contextual_short_reference_matches(
+        Path::new("extension.js"),
+        &text,
+        false,
+        &mut detections,
+        &mut clues,
+    );
+
+    assert_eq!(
+        detections.len(),
+        1,
+        "short MIT reference on a minified long line must be kept: {detections:#?}"
+    );
+}
+
+#[test]
 fn test_prune_contextual_short_reference_matches_keeps_dual_license_choice_but_drops_comparative_suffix()
  {
     let text = "Dual-licensed under MIT or Apache-2.0 at your option. Unlike AGPL-licensed alternatives, this project is permissive.\n";


### PR DESCRIPTION
## Summary

- Fixes the follow-up flagged in #1238/#1239: on minified/generated files, a genuine short license reference could be silently dropped.
- The contextual short-reference prune (`should_prune_contextual_short_reference_match`) inspects the whole source line for prose signals (README license tables; negative/comparative mentions like "unlike AGPL-licensed alternatives" or "no GPL/AGPL"). On a minified single line — which can be megabytes — an unrelated phrase anywhere on the line misclassifies the entire line as prose. A stray standalone `no` + a `/` + an uppercase letter (ubiquitous in minified JS) trips the negated-shorthand heuristic and prunes a legitimate, score-100 short reference elsewhere on the same line.
- Fix: skip the prose-context heuristics for lines longer than a prose-plausible bound (1,000 chars). Such lines are minified/generated content, not prose. Generic — no license-specific logic.

## Issues

- Covers: #356 (VS Code extension benchmark surfaced this on webpack bundles)

## Scope and exclusions

- Included: length guard in the contextual short-reference prune + a regression unit test.
- Explicit exclusions: no change to the prose heuristics themselves; short prose lines (README tables, comparative sentences) behave exactly as before.

## How to verify

Beyond CI:

- Root cause was bisected on a real webpack bundle (`ms-python.python`'s `extension.js`): it carries an inlined `"license":"MIT"` dependency fragment. Before this change the file's `detected_license_expression` was `null`; the reference was pruned only once enough surrounding minified code accumulated a standalone `no` token. After the change it is `mit`, matching ScanCode.
- The full license golden suite is unchanged (22/22) — real prose fixtures are far below the length bound, so their pruning is unaffected. The change only restores references on minified/generated long lines.

## Follow-up work

- Created or intentionally deferred: none.
