### PR TITLE
ci: attest build provenance for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
@@ -236,6 +238,13 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -R artifacts
+
+      - name: Attest build provenance for release binaries
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            artifacts/*/*.tar.gz
+            artifacts/*/*.zip
 
       - name: Create Release with all assets
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd


### PR DESCRIPTION
## Summary

- Add `actions/attest-build-provenance` to the `create-release` job so every release archive (`.tar.gz` / `.zip`) gets a **signed, verifiable build-provenance attestation** tying the artifact to this workflow, repository, and commit SHA.
- Grants the job `id-token: write` + `attestations: write` (it already had `contents: write`). Uses OIDC — no secrets, consistent with the existing crates.io trusted publishing.
- Complements the existing sha256 checksums: checksums prove **integrity**, attestation proves **authenticity/origin**. Fitting for a provenance tool to ship its own provenance.

## Issues

- Covers: the remaining Phase A (pre-1.0) gap — release artifacts had checksums but no provenance attestation.

## Scope and exclusions

- Included: the attest step + the two added permissions on `create-release`. Action pinned by SHA (`# v4.1.1`), matching repo convention.
- Excluded: no change to build, checksums, crate publish, or release upload.

## How to verify

- On the next tagged release, consumers can run `gh attestation verify provenant-linux-x86_64.tar.gz --repo <org>/provenant` and see it was built by this workflow at the released commit. The attestation is also visible under the repo's **Attestations**.
- Note: this only exercises on a real tag push (the `Release` workflow is tag-triggered), so it won't run on this PR's CI.

## Intentional differences from Python

- N/A