### PR TITLE
ci: publish provenant Docker image to Docker Hub on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,65 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
+  publish-docker:
+    name: Publish Docker image
+    needs: build
+    if: github.repository == 'mstykow/provenant'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          submodules: false
+          lfs: false
+
+      - name: Download linux build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        with:
+          pattern: provenant-linux-*
+          path: artifacts
+
+      # Package the exact released binaries into a tiny build context so the multi-arch
+      # image is a COPY-only build (no in-container recompile, no QEMU emulation).
+      - name: Stage release binaries into the build context
+        run: |
+          mkdir -p docker-context/dist/amd64 docker-context/dist/arm64
+          cp Dockerfile docker-context/Dockerfile
+          tar xzf artifacts/provenant-linux-x86_64/provenant-linux-x86_64.tar.gz -C docker-context/dist/amd64 provenant
+          tar xzf artifacts/provenant-linux-aarch64/provenant-linux-aarch64.tar.gz -C docker-context/dist/arm64 provenant
+          chmod +x docker-context/dist/amd64/provenant docker-context/dist/arm64/provenant
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: provenant/provenant
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=${{ !contains(github.ref, '-') }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker-context
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   create-release:
     name: Create Release
     if: github.repository == 'mstykow/provenant'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal runtime image that packages a pre-built provenant release binary.
+#
+# Built by .github/workflows/release.yml from the linux release artifacts, so the
+# published image ships the exact same binary as the GitHub release — no in-container
+# recompile, and multi-arch (amd64/arm64) needs no QEMU emulation (COPY only).
+#
+# The binary is self-contained: SQLite is statically linked (rusqlite "bundled"), TLS is
+# rustls (no OpenSSL), and the license index is embedded. So distroless/cc — glibc,
+# libgcc, and CA certificates — is all it needs at runtime.
+#
+# To build locally, stage the binary for your arch first, e.g.:
+#   cargo build --release
+#   mkdir -p dist/amd64 && cp target/release/provenant dist/amd64/
+#   docker build --build-arg TARGETARCH=amd64 -t provenant .
+FROM gcr.io/distroless/cc-debian12@sha256:a90cf0f046efb32466b38b0972fef3a95e7c580e392e79ff1b7ac08c15fed0bc
+
+# TARGETARCH is set automatically by BuildKit per target platform (amd64, arm64).
+ARG TARGETARCH
+COPY dist/${TARGETARCH}/provenant /usr/local/bin/provenant
+
+ENTRYPOINT ["/usr/local/bin/provenant"]


### PR DESCRIPTION
## Summary

- Add a **`publish-docker`** job to the release workflow: builds a **multi-arch (linux/amd64 + linux/arm64)** image and pushes `provenant/provenant:<version>`, `:<major>.<minor>`, and `:latest` (latest skipped for prereleases, via `docker/metadata-action`).
- Add a **`Dockerfile`** that packages the *exact* linux release binaries into `distroless/cc` (digest-pinned). Because the binary is self-contained — SQLite is statically linked (`rusqlite` `bundled`), TLS is rustls (no OpenSSL), license index embedded — the runtime only needs glibc + libgcc + CA certs, which distroless/cc provides.
- The image is a **COPY-only build from the already-built release artifacts**, so: same binary as the GitHub release (no in-container recompile) and multi-arch needs **no QEMU emulation**.

## Issues

- Covers: Phase B distribution — Docker image on release. First distribution channel toward 1.0.

## Scope and exclusions

- Included: `Dockerfile` + `publish-docker` job. Actions and base image are SHA/digest-pinned per repo convention.
- Excluded: no change to the binary build, checksums, crate publish, or GitHub release. Image-level provenance attestation left as a follow-up.

## Required setup (maintainer, outside this PR)

This job stays inert until:
1. A **Docker Hub org `provenant`** exists (I verified the name is free on Docker Hub).
2. Repo secrets **`DOCKERHUB_USERNAME`** and **`DOCKERHUB_TOKEN`** (a Docker Hub access token with push access to the org) are set.

Without those the job would fail at login, so add them before the next tagged release (or the job can be temporarily disabled).

## How to verify

- Runs only on a tag push (the workflow is tag-triggered), so it won't exercise on this PR's CI. On the next release: `docker run --rm provenant/provenant --version`, and `docker manifest inspect provenant/provenant:<version>` should show amd64 + arm64.
- Dockerfile structurally validated locally (`docker build` succeeds; ~48 MB image).

## Follow-up

- After the eventual org move, update the `github.repository == 'mstykow/provenant'` guard (same as the other publish jobs).
- Optional: add image-level build-provenance attestation, and Docker rows to the README Install section once the first image is live.

## Intentional differences from Python

- N/A