### PR TITLE
feat(output): refine the HTML report mark to match the org logo

### DIFF
--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -206,7 +206,7 @@ const HTML_REPORT_TEMPLATE: &str = r##"<!doctype html>
   <head>
     <meta charset="utf-8" />
     <title>Provenant HTML Report</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAgMTIwIj48cmVjdCB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iIzE3MUIyNCIvPjxnIHN0cm9rZT0iI0YxRUNFNCIgc3Ryb2tlLXdpZHRoPSI3LjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTYwIDgyIFY2MyIvPjxwYXRoIGQ9Ik02MCA2MyBMNDAgNDEiLz48cGF0aCBkPSJNNjAgNjMgTDgwIDQxIi8+PHBhdGggZD0iTTYwIDYzIFYzOSIvPjwvZz48Y2lyY2xlIGN4PSI0MCIgY3k9IjM3IiByPSI4IiBmaWxsPSIjRjFFQ0U0Ii8+PGNpcmNsZSBjeD0iODAiIGN5PSIzNyIgcj0iOCIgZmlsbD0iI0YxRUNFNCIvPjxjaXJjbGUgY3g9IjYwIiBjeT0iMzUiIHI9IjgiIGZpbGw9IiNGMUVDRTQiLz48Y2lyY2xlIGN4PSI2MCIgY3k9Ijg2IiByPSI5LjUiIGZpbGw9IiNFMDhBM0MiLz48L3N2Zz4=" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Crect width='120' height='120' fill='%23171b24'/%3E%3Cg stroke='%23f1ece4' stroke-width='8' stroke-linecap='round' fill='none'%3E%3Cpath d='M60 86 V32'/%3E%3Cpath d='M60 58 L35 32'/%3E%3Cpath d='M60 58 L85 32'/%3E%3C/g%3E%3Ccircle cx='35' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='60' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='85' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='60' cy='86' r='10' fill='%23e08a3c'/%3E%3C/svg%3E" />
     <style type="text/css">
       table {
         border-collapse: collapse;
@@ -268,16 +268,15 @@ const HTML_REPORT_TEMPLATE: &str = r##"<!doctype html>
     <header class="report-header">
       <svg class="brand-mark" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <rect width="120" height="120" rx="26" fill="#171b24" />
-        <g stroke="#f1ece4" stroke-width="7.5" stroke-linecap="round" fill="none">
-          <path d="M60 82 V63" />
-          <path d="M60 63 L40 41" />
-          <path d="M60 63 L80 41" />
-          <path d="M60 63 V39" />
+        <g stroke="#f1ece4" stroke-width="8" stroke-linecap="round" fill="none">
+          <path d="M60 86 V32" />
+          <path d="M60 58 L35 32" />
+          <path d="M60 58 L85 32" />
         </g>
-        <circle cx="40" cy="37" r="8" fill="#f1ece4" />
-        <circle cx="80" cy="37" r="8" fill="#f1ece4" />
-        <circle cx="60" cy="35" r="8" fill="#f1ece4" />
-        <circle cx="60" cy="86" r="9.5" fill="#e08a3c" />
+        <circle cx="35" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="60" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="85" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="60" cy="86" r="10" fill="#e08a3c" />
       </svg>
       <div class="brand-text">
         <div class="brand-name">Provenant</div>

--- a/testdata/output-formats/html-templated-simple-expected.html
+++ b/testdata/output-formats/html-templated-simple-expected.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Provenant HTML Report</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAgMTIwIj48cmVjdCB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iIzE3MUIyNCIvPjxnIHN0cm9rZT0iI0YxRUNFNCIgc3Ryb2tlLXdpZHRoPSI3LjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTYwIDgyIFY2MyIvPjxwYXRoIGQ9Ik02MCA2MyBMNDAgNDEiLz48cGF0aCBkPSJNNjAgNjMgTDgwIDQxIi8+PHBhdGggZD0iTTYwIDYzIFYzOSIvPjwvZz48Y2lyY2xlIGN4PSI0MCIgY3k9IjM3IiByPSI4IiBmaWxsPSIjRjFFQ0U0Ii8+PGNpcmNsZSBjeD0iODAiIGN5PSIzNyIgcj0iOCIgZmlsbD0iI0YxRUNFNCIvPjxjaXJjbGUgY3g9IjYwIiBjeT0iMzUiIHI9IjgiIGZpbGw9IiNGMUVDRTQiLz48Y2lyY2xlIGN4PSI2MCIgY3k9Ijg2IiByPSI5LjUiIGZpbGw9IiNFMDhBM0MiLz48L3N2Zz4=" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Crect width='120' height='120' fill='%23171b24'/%3E%3Cg stroke='%23f1ece4' stroke-width='8' stroke-linecap='round' fill='none'%3E%3Cpath d='M60 86 V32'/%3E%3Cpath d='M60 58 L35 32'/%3E%3Cpath d='M60 58 L85 32'/%3E%3C/g%3E%3Ccircle cx='35' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='60' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='85' cy='32' r='8' fill='%23f1ece4'/%3E%3Ccircle cx='60' cy='86' r='10' fill='%23e08a3c'/%3E%3C/svg%3E" />
     <style type="text/css">
       table {
         border-collapse: collapse;
@@ -66,16 +66,15 @@
     <header class="report-header">
       <svg class="brand-mark" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <rect width="120" height="120" rx="26" fill="#171b24" />
-        <g stroke="#f1ece4" stroke-width="7.5" stroke-linecap="round" fill="none">
-          <path d="M60 82 V63" />
-          <path d="M60 63 L40 41" />
-          <path d="M60 63 L80 41" />
-          <path d="M60 63 V39" />
+        <g stroke="#f1ece4" stroke-width="8" stroke-linecap="round" fill="none">
+          <path d="M60 86 V32" />
+          <path d="M60 58 L35 32" />
+          <path d="M60 58 L85 32" />
         </g>
-        <circle cx="40" cy="37" r="8" fill="#f1ece4" />
-        <circle cx="80" cy="37" r="8" fill="#f1ece4" />
-        <circle cx="60" cy="35" r="8" fill="#f1ece4" />
-        <circle cx="60" cy="86" r="9.5" fill="#e08a3c" />
+        <circle cx="35" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="60" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="85" cy="32" r="8" fill="#f1ece4" />
+        <circle cx="60" cy="86" r="10" fill="#e08a3c" />
       </svg>
       <div class="brand-text">
         <div class="brand-name">Provenant</div>


### PR DESCRIPTION
## Summary

- Update the HTML report's **favicon** and **header mark** to the refined lineage geometry — level top nodes, a single continuous spine (origin → center node), symmetric branches, and a slightly bolder stroke — matching the `getprovenant` org avatar.
- Golden fixture updated in lockstep. The file-type cell (and all table data) is unchanged; the diff is mark geometry only.

## Issues

- Covers: keep the HTML report's embedded mark consistent with the finalized org logo (follow-up to #1243).

## Scope and exclusions

- Included: favicon data-URI + header `<svg>` geometry in `src/output/html.rs`, and the matching bytes in the golden fixture.
- Excluded: no data/table/section changes; no other output formats.

## How to verify

- `provenant scan --html report.html --license --package <dir>` — the tab favicon and report header show the refined mark. Covered by the two HTML tests in `output_format_golden.rs`.

## Intentional differences from Python

- N/A