### PR TITLE
perf(scanner): bound content-detection text to 10 MB (#1245)

### DIFF
--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -40,6 +40,20 @@ use std::time::{Duration, Instant};
 const LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES: usize = 128 * 1024;
 const LARGE_NON_SOURCE_JSON_MIN_PREFIX_LINES_TO_KEEP: usize = 256;
 
+/// Upper bound on the amount of extracted text handed to content detection
+/// (copyright, license, email, and URL). The license matcher already truncates
+/// its own input at this size (`license_detection::MAX_DETECTION_SIZE`); copyright
+/// and contact detection previously scanned the full file, so a multi-gigabyte
+/// data file (e.g. a 1.5 GB CSV) drove the whole scan past its timeout even
+/// though license detection ignored everything past the first 10 MB anyway.
+///
+/// Legal notices live in a file's header (or, rarely, its footer); a genuine
+/// notice does not first appear 10 MB deep in a data file. Bounding every content
+/// detector to the same prefix keeps detection consistent with the license
+/// matcher and makes huge non-legal data files finish quickly instead of timing
+/// out. Files at or below this size are completely unaffected.
+const MAX_CONTENT_DETECTION_BYTES: usize = 10 * 1024 * 1024;
+
 pub(super) fn process_file(
     path: &Path,
     metadata: &fs::Metadata,
@@ -299,6 +313,8 @@ fn extract_information_from_content(
         return Ok((is_generated, classification.is_source));
     }
 
+    let text_content = cap_content_detection_text(scan_diagnostics, text_content);
+
     if text_options.detect_copyrights {
         let copyrights_started = Instant::now();
         extract_copyright_information(
@@ -386,6 +402,29 @@ fn extract_information_from_content(
     }
 
     Ok((is_generated, classification.is_source))
+}
+
+/// Truncate the extracted detection text to `MAX_CONTENT_DETECTION_BYTES` so
+/// copyright, license, email, and URL detection never scan gigabytes of a large
+/// non-legal data file. Records an informational diagnostic (which does not count
+/// as an error or warning) so the truncation stays auditable in verbose output.
+fn cap_content_detection_text(
+    scan_diagnostics: &mut Vec<ScanDiagnostic>,
+    mut text_content: String,
+) -> String {
+    if text_content.len() <= MAX_CONTENT_DETECTION_BYTES {
+        return text_content;
+    }
+
+    let original_len = text_content.len();
+    let boundary = text_content.floor_char_boundary(MAX_CONTENT_DETECTION_BYTES);
+    text_content.truncate(boundary);
+    scan_diagnostics.push(ScanDiagnostic::info(format!(
+        "Content size {original_len} bytes exceeds the {MAX_CONTENT_DETECTION_BYTES}-byte \
+         detection limit; only the first {boundary} bytes were scanned for \
+         license, copyright, email, and URL detection"
+    )));
+    text_content
 }
 
 fn prepare_license_detection_text(

--- a/src/scanner/process/pipeline_test.rs
+++ b/src/scanner/process/pipeline_test.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES, cap_non_source_json_license_text,
+    LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES, MAX_CONTENT_DETECTION_BYTES,
+    cap_content_detection_text, cap_non_source_json_license_text,
     cap_non_source_text_dump_license_text, has_line_rich_json_prefix,
     maybe_record_processing_timeout, merge_parse_results, process_file,
 };
@@ -332,6 +333,37 @@ fn test_cap_non_source_text_dump_license_text_keeps_generic_large_plain_text() {
 
     assert!(large_text.len() > LARGE_NON_SOURCE_JSON_LICENSE_TEXT_BYTES);
     assert_eq!(capped.as_ref(), large_text);
+}
+
+#[test]
+fn test_cap_content_detection_text_keeps_small_text_untouched() {
+    let text = "Copyright (c) 2024 Acme Corp\nLicensed under the MIT License.\n".to_string();
+    let mut diagnostics = Vec::new();
+    let capped = cap_content_detection_text(&mut diagnostics, text.clone());
+
+    assert_eq!(capped, text);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn test_cap_content_detection_text_truncates_oversized_text_and_records_info() {
+    let header = "Copyright (c) 2024 Acme Corp\n";
+    let mut text = String::with_capacity(MAX_CONTENT_DETECTION_BYTES + header.len() + 4096);
+    text.push_str(header);
+    while text.len() <= MAX_CONTENT_DETECTION_BYTES + 2048 {
+        text.push_str("row_a,row_b,row_c,1234,5678\n");
+    }
+    let original_len = text.len();
+
+    let mut diagnostics = Vec::new();
+    let capped = cap_content_detection_text(&mut diagnostics, text);
+
+    assert!(capped.len() <= MAX_CONTENT_DETECTION_BYTES);
+    assert!(original_len > MAX_CONTENT_DETECTION_BYTES);
+    // The header (where notices live) is preserved for detection.
+    assert!(capped.starts_with(header));
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].severity, DiagnosticSeverity::Info);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Copyright, email, and URL detection scanned a file's entire decoded contents, and license detection re-tokenized the full text when rendering match spans. For a multi-gigabyte data file this drove the whole scan past its timeout — even though the license matcher already truncated its own input at 10 MB (`MAX_DETECTION_SIZE`), so anything past the first 10 MB could never yield a license anyway.
- This caps the shared extracted detection text at the same 10 MB bound (`cap_content_detection_text`) before it reaches any content detector, so copyright/email/URL are bounded consistently with license detection.
- Legal notices live in a file's header, so a huge non-legal data file now finishes in seconds instead of timing out, while notices in normal-sized files (and in the header of large files) are still detected. The truncation records a benign `Info` diagnostic so it stays auditable in verbose output. Files at or below 10 MB are completely unaffected.

## Issues

- Closes: #1245

## Scope and exclusions

- Included: a single shared cap on the extracted detection text in `src/scanner/process/pipeline.rs`, plus unit tests.
- Explicit exclusions: the pre-existing narrower license-only caps (non-source JSON at 128 KB, textual metadata dumps) are unchanged and still stack on top; no changes to the copyright/license detector internals.

## How to verify

Reproduced against the exact file from the issue (`HEU-101092696-CODECO-VRUMobility.csv`, 1.54 GB SUMO pedestrian-mobility telemetry):

- `provenant --copyright --license --info --strip-root --timeout 300 <file> --json out.json`
  - Before: times out at 300 s.
  - After: completes in ~5 s, exit 0.
- A full uncapped scan on the pre-fix binary (`--timeout 0`, 138 s) and the capped scan produce a **byte-identical** file-level result (0 copyrights / holders / authors / licenses / emails / urls). A scanner-independent `grep` over the whole 1.65 GB confirms the file contains zero `copyright`/`license`/`http`/`@`/non-ASCII markers anywhere — so nothing is dropped.
- Regression check: a >10 MB CSV whose first two lines are a `Copyright (c) 2024 … / MIT License` header still detects the copyright, holder, and MIT license (header is preserved).

## Follow-up work

- Created or intentionally deferred: none. If a larger detection margin is ever wanted, the bound could be raised or extended to also scan a trailing window; matching the license matcher's existing 10 MB was chosen for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)