### PR TITLE
chore: move repository to the getprovenant organization

### DIFF
--- a/.agents/skills/pr-lifecycle/SKILL.md
+++ b/.agents/skills/pr-lifecycle/SKILL.md
@@ -16,7 +16,7 @@ This skill owns only the operational loop and the non-obvious `gh`/GraphQL mecha
 - `.github/pull_request_template.md` — required PR body structure.
 - `ci-failure-triage` skill — map any red CI check to its owning surface and local reproduction.
 
-The repo is `mstykow/provenant`; use that owner/name in every `gh api` and GraphQL call below.
+The repo is `getprovenant/provenant`; use that owner/name in every `gh api` and GraphQL call below.
 
 ## 1. Open the PR
 
@@ -39,18 +39,18 @@ Opening a PR does **not** obligate you to block on CI or review — it is fine t
 ## 3. Fetch Comments
 
 ```bash
-gh api repos/mstykow/provenant/issues/<num>/comments   # summary + human top-level
-gh api repos/mstykow/provenant/pulls/<num>/comments    # inline review comments
-gh api repos/mstykow/provenant/pulls/<num>/reviews     # review bodies/state
+gh api repos/getprovenant/provenant/issues/<num>/comments   # summary + human top-level
+gh api repos/getprovenant/provenant/pulls/<num>/comments    # inline review comments
+gh api repos/getprovenant/provenant/pulls/<num>/reviews     # review bodies/state
 ```
 
 **CRITICAL — distinguish FRESH from STALE.** The inline-comments API returns ALL comments ever made, including ones from earlier reviews that GitHub carried forward onto the new commit. A comment is current only if it targets the PR head; treat the rest as stale.
 
 ```bash
-head=$(gh api repos/mstykow/provenant/pulls/<num> --jq '.head.sha')
+head=$(gh api repos/getprovenant/provenant/pulls/<num> --jq '.head.sha')
 # Only comments on the PR head are current; the rest were carried forward and are stale.
 # `gh api --jq` uses gojq (no `--arg`), so inject the value via the environment (env.HEAD).
-HEAD="$head" gh api repos/mstykow/provenant/pulls/<num>/comments \
+HEAD="$head" gh api repos/getprovenant/provenant/pulls/<num>/comments \
   --jq '.[] | select(.commit_id == env.HEAD) | {id, path, line, commit: .commit_id, body}'
 ```
 
@@ -74,7 +74,7 @@ git push --force-with-lease origin <branch>
 - **Always reply to every actionable thread — Greptile's included — with a short comment** saying what you changed (cite the commit) or, if you disagree, why. The reply is the transparency record that the feedback was considered; never address feedback silently. Post a threaded reply:
 
 ```bash
-gh api repos/mstykow/provenant/pulls/<num>/comments \
+gh api repos/getprovenant/provenant/pulls/<num>/comments \
   -f body='Addressed in <sha>: <what changed>.' -F in_reply_to=<comment_id>
 ```
 

--- a/.claude/skills/pr-lifecycle/SKILL.md
+++ b/.claude/skills/pr-lifecycle/SKILL.md
@@ -16,7 +16,7 @@ This skill owns only the operational loop and the non-obvious `gh`/GraphQL mecha
 - `.github/pull_request_template.md` — required PR body structure.
 - `ci-failure-triage` skill — map any red CI check to its owning surface and local reproduction.
 
-The repo is `mstykow/provenant`; use that owner/name in every `gh api` and GraphQL call below.
+The repo is `getprovenant/provenant`; use that owner/name in every `gh api` and GraphQL call below.
 
 ## 1. Open the PR
 
@@ -39,18 +39,18 @@ Opening a PR does **not** obligate you to block on CI or review — it is fine t
 ## 3. Fetch Comments
 
 ```bash
-gh api repos/mstykow/provenant/issues/<num>/comments   # summary + human top-level
-gh api repos/mstykow/provenant/pulls/<num>/comments    # inline review comments
-gh api repos/mstykow/provenant/pulls/<num>/reviews     # review bodies/state
+gh api repos/getprovenant/provenant/issues/<num>/comments   # summary + human top-level
+gh api repos/getprovenant/provenant/pulls/<num>/comments    # inline review comments
+gh api repos/getprovenant/provenant/pulls/<num>/reviews     # review bodies/state
 ```
 
 **CRITICAL — distinguish FRESH from STALE.** The inline-comments API returns ALL comments ever made, including ones from earlier reviews that GitHub carried forward onto the new commit. A comment is current only if it targets the PR head; treat the rest as stale.
 
 ```bash
-head=$(gh api repos/mstykow/provenant/pulls/<num> --jq '.head.sha')
+head=$(gh api repos/getprovenant/provenant/pulls/<num> --jq '.head.sha')
 # Only comments on the PR head are current; the rest were carried forward and are stale.
 # `gh api --jq` uses gojq (no `--arg`), so inject the value via the environment (env.HEAD).
-HEAD="$head" gh api repos/mstykow/provenant/pulls/<num>/comments \
+HEAD="$head" gh api repos/getprovenant/provenant/pulls/<num>/comments \
   --jq '.[] | select(.commit_id == env.HEAD) | {id, path, line, commit: .commit_id, body}'
 ```
 
@@ -74,7 +74,7 @@ git push --force-with-lease origin <branch>
 - **Always reply to every actionable thread — Greptile's included — with a short comment** saying what you changed (cite the commit) or, if you disagree, why. The reply is the transparency record that the feedback was considered; never address feedback silently. Post a threaded reply:
 
 ```bash
-gh api repos/mstykow/provenant/pulls/<num>/comments \
+gh api repos/getprovenant/provenant/pulls/<num>/comments \
   -f body='Addressed in <sha>: <what changed>.' -F in_reply_to=<comment_id>
 ```
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
   publish-crate:
     name: Publish crate
     needs: build
-    if: github.repository == 'mstykow/provenant'
+    if: github.repository == 'getprovenant/provenant'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -219,12 +219,74 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
+  publish-image:
+    name: Publish container image
+    needs: build
+    if: github.repository == 'getprovenant/provenant'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          submodules: false
+          lfs: false
+
+      - name: Download linux build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        with:
+          pattern: provenant-linux-*
+          path: artifacts
+
+      # Package the exact released binaries into a tiny build context so the multi-arch
+      # image is a COPY-only build (no in-container recompile, no QEMU emulation).
+      - name: Stage release binaries into the build context
+        run: |
+          mkdir -p docker-context/dist/amd64 docker-context/dist/arm64
+          cp Dockerfile docker-context/Dockerfile
+          tar xzf artifacts/provenant-linux-x86_64/provenant-linux-x86_64.tar.gz -C docker-context/dist/amd64 provenant
+          tar xzf artifacts/provenant-linux-aarch64/provenant-linux-aarch64.tar.gz -C docker-context/dist/arm64 provenant
+          chmod +x docker-context/dist/amd64/provenant docker-context/dist/arm64/provenant
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/getprovenant/provenant
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=${{ !contains(github.ref, '-') }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker-context
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   create-release:
     name: Create Release
-    if: github.repository == 'mstykow/provenant'
+    if: github.repository == 'getprovenant/provenant'
     needs:
       - build
       - publish-crate
+      - publish-image
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ title: "Provenant"
 version: "0.2.2"
 type: software
 license: Apache-2.0
-repository-code: "https://github.com/mstykow/provenant"
-url: "https://github.com/mstykow/provenant"
+repository-code: "https://github.com/getprovenant/provenant"
+url: "https://github.com/getprovenant/provenant"
 authors:
   - name: "The Provenant contributors"
 abstract: >-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Before running the bootstrap flow, install:
 A typical local setup on Linux, macOS, or WSL is:
 
 ```sh
-git clone https://github.com/mstykow/provenant.git
+git clone https://github.com/getprovenant/provenant.git
 cd provenant
 npm run setup
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 # scripts/check_release_version_sync.sh. Do not edit by hand.
 rust-version = "1.96"
 autobins = false
-repository = "https://github.com/mstykow/provenant"
-homepage = "https://github.com/mstykow/provenant"
-documentation = "https://github.com/mstykow/provenant/blob/main/docs/DOCUMENTATION_INDEX.md"
+repository = "https://github.com/getprovenant/provenant"
+homepage = "https://github.com/getprovenant/provenant"
+documentation = "https://github.com/getprovenant/provenant/blob/main/docs/DOCUMENTATION_INDEX.md"
 description = "Fast Rust scanner for licenses, copyrights, package metadata, SBOMs, and provenance data."
 license = "Apache-2.0"
 keywords = ["sbom", "license", "copyright", "provenance", "compliance"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal runtime image that packages a pre-built provenant release binary.
+#
+# Built by .github/workflows/release.yml from the linux release artifacts, so the
+# published image ships the exact same binary as the GitHub release — no in-container
+# recompile, and multi-arch (amd64/arm64) needs no QEMU emulation (COPY only).
+#
+# The binary is self-contained: SQLite is statically linked (rusqlite "bundled"), TLS is
+# rustls (no OpenSSL), and the license index is embedded. So distroless/cc — glibc,
+# libgcc, and CA certificates — is all it needs at runtime.
+#
+# To build locally, stage the binary for your arch first, e.g.:
+#   cargo build --release
+#   mkdir -p dist/amd64 && cp target/release/provenant dist/amd64/
+#   docker build --build-arg TARGETARCH=amd64 -t provenant .
+FROM gcr.io/distroless/cc-debian12@sha256:a90cf0f046efb32466b38b0972fef3a95e7c580e392e79ff1b7ac08c15fed0bc
+
+# TARGETARCH is set automatically by BuildKit per target platform (amd64, arm64).
+ARG TARGETARCH
+COPY dist/${TARGETARCH}/provenant /usr/local/bin/provenant
+
+ENTRYPOINT ["/usr/local/bin/provenant"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [Why Provenant?](#why-provenant) · [Choose a Workflow](#choose-a-workflow) · [Install](#install) · [CLI Guide](docs/CLI_GUIDE.md) · [Benchmarks](docs/BENCHMARKS.md) · [Supported Formats](docs/SUPPORTED_FORMATS.md) · [Architecture](docs/ARCHITECTURE.md)
 
-[![Latest Release](https://img.shields.io/github/v/release/mstykow/provenant?display_name=tag)](https://github.com/mstykow/provenant/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/getprovenant/provenant?display_name=tag)](https://github.com/getprovenant/provenant/releases/latest)
 [![Crates.io](https://img.shields.io/crates/v/provenant-cli.svg)](https://crates.io/crates/provenant-cli)
-[![CI](https://github.com/mstykow/provenant/actions/workflows/check.yml/badge.svg?branch=main)](https://github.com/mstykow/provenant/actions/workflows/check.yml)
+[![CI](https://github.com/getprovenant/provenant/actions/workflows/check.yml/badge.svg?branch=main)](https://github.com/getprovenant/provenant/actions/workflows/check.yml)
 [![License](https://img.shields.io/crates/l/provenant-cli.svg)](LICENSE)
 
 Provenant is a fast, Rust-based code scanner for licenses, copyrights, package metadata, file metadata, and related provenance data, focused on correctness, safe static parsing, and native execution.
@@ -26,7 +26,7 @@ cargo install provenant-cli
 provenant scan --json-pp - --license --package /path/to/repo
 ```
 
-Prefer release binaries? Download precompiled archives from [GitHub Releases](https://github.com/mstykow/provenant/releases).
+Prefer release binaries? Download precompiled archives from [GitHub Releases](https://github.com/getprovenant/provenant/releases).
 
 ## Why Provenant?
 
@@ -75,7 +75,7 @@ This installs the `provenant` command-line binary.
 
 ### Download Precompiled Binary
 
-Download the release archive for your platform from the [GitHub Releases](https://github.com/mstykow/provenant/releases) page.
+Download the release archive for your platform from the [GitHub Releases](https://github.com/getprovenant/provenant/releases) page.
 
 Extract the archive and place the binary somewhere on your `PATH`.
 
@@ -93,7 +93,7 @@ On Windows, extract the `.zip` release and add `provenant.exe` to your `PATH`.
 For a normal source build, you only need the Rust toolchain:
 
 ```sh
-git clone https://github.com/mstykow/provenant.git
+git clone https://github.com/getprovenant/provenant.git
 cd provenant
 cargo build --release
 ```

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -38,7 +38,7 @@ This index helps you find the right documentation for your needs.
 
 - **[RELEASING.md](RELEASING.md)** - Release prerequisites, workflow, and verification steps
 - **[BENCHMARKS.md](BENCHMARKS.md)** - Maintained verification records and recorded package-detection compare runs
-- **[Package-detection issue tracker](https://github.com/mstykow/provenant/issues?q=is%3Aissue%20state%3Aopen%20label%3Apackage-parsing)** - Open future package-detection work
+- **[Package-detection issue tracker](https://github.com/getprovenant/provenant/issues?q=is%3Aissue%20state%3Aopen%20label%3Apackage-parsing)** - Open future package-detection work
 - **[../xtask/README.md](../xtask/README.md)** - Maintainer commands for compare runs, golden maintenance, and generated artifacts
 
 ### Document Organization
@@ -77,7 +77,7 @@ docs/
 → [HOW_TO_ADD_A_PARSER.md](HOW_TO_ADD_A_PARSER.md)
 
 **...see future package-detection work**
-→ [Package-detection issue tracker](https://github.com/mstykow/provenant/issues?q=is%3Aissue%20state%3Aopen%20label%3Apackage-parsing)
+→ [Package-detection issue tracker](https://github.com/getprovenant/provenant/issues?q=is%3Aissue%20state%3Aopen%20label%3Apackage-parsing)
 
 **...understand testing strategy**
 → [TESTING_STRATEGY.md](TESTING_STRATEGY.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,7 +86,7 @@ If the tag contains `-`, GitHub marks the release as a prerelease.
 
 ## After Starting the Release
 
-Monitor the [GitHub Actions release workflow](https://github.com/mstykow/provenant/actions) and the resulting [GitHub Releases page](https://github.com/mstykow/provenant/releases).
+Monitor the [GitHub Actions release workflow](https://github.com/getprovenant/provenant/actions) and the resulting [GitHub Releases page](https://github.com/getprovenant/provenant/releases).
 
 Verify:
 

--- a/src/output/debian.rs
+++ b/src/output/debian.rs
@@ -17,7 +17,7 @@ const DEBIAN_DOCUMENT_NOTICE: &[&str] = &[
     "Provenant should be considered or used as legal advice. Consult an attorney",
     "for legal advice.",
     "Provenant is a free software code scanning tool.",
-    "Visit https://github.com/mstykow/provenant/ for support and download.",
+    "Visit https://github.com/getprovenant/provenant/ for support and download.",
 ];
 
 pub(crate) fn write_debian_copyright(output: &Output, writer: &mut dyn Write) -> io::Result<()> {

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -472,7 +472,7 @@ const HTML_REPORT_TEMPLATE: &str = r##"<!doctype html>
       ANY KIND, either express or implied. No content created from Provenant should be considered or
       used as legal advice. Consult an attorney for legal advice. Provenant is a free software code
       scanning tool. Visit
-      <a href="https://github.com/mstykow/provenant/">https://github.com/mstykow/provenant/</a>
+      <a href="https://github.com/getprovenant/provenant/">https://github.com/getprovenant/provenant/</a>
       for support and download.
     </p>
   </footer>

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -18,7 +18,7 @@ mod shared;
 mod spdx;
 mod template;
 
-pub(crate) const SPDX_DOCUMENT_NOTICE: &str = "Generated with Provenant and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nProvenant should be considered or used as legal advice. Consult an attorney\nfor legal advice.\nProvenant is a free software code scanning tool.\nVisit https://github.com/mstykow/provenant/ for support and download.\nSPDX License List: 3.27";
+pub(crate) const SPDX_DOCUMENT_NOTICE: &str = "Generated with Provenant and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nProvenant should be considered or used as legal advice. Consult an attorney\nfor legal advice.\nProvenant is a free software code scanning tool.\nVisit https://github.com/getprovenant/provenant/ for support and download.\nSPDX License List: 3.27";
 const OUTPUT_BUFFER_SIZE: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/testdata/output-formats/debian-basic-expected.copyright
+++ b/testdata/output-formats/debian-basic-expected.copyright
@@ -4,7 +4,7 @@ Comment: Generated with Provenant and provided on an "AS IS" BASIS, WITHOUT WARR
          Provenant should be considered or used as legal advice. Consult an attorney
          for legal advice.
          Provenant is a free software code scanning tool.
-         Visit https://github.com/mstykow/provenant/ for support and download.
+         Visit https://github.com/getprovenant/provenant/ for support and download.
 
 Files: scan/src/main.rs
 Copyright: Example Org

--- a/testdata/output-formats/html-templated-simple-expected.html
+++ b/testdata/output-formats/html-templated-simple-expected.html
@@ -259,7 +259,7 @@
       ANY KIND, either express or implied. No content created from Provenant should be considered or
       used as legal advice. Consult an attorney for legal advice. Provenant is a free software code
       scanning tool. Visit
-      <a href="https://github.com/mstykow/provenant/">https://github.com/mstykow/provenant/</a>
+      <a href="https://github.com/getprovenant/provenant/">https://github.com/getprovenant/provenant/</a>
       for support and download.
     </p>
   </footer>

--- a/testdata/output-formats/spdx-simple-expected.rdf
+++ b/testdata/output-formats/spdx-simple-expected.rdf
@@ -59,7 +59,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with Provenant and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nProvenant should be considered or used as legal advice. Consult an attorney\nfor legal advice.\nProvenant is a free software code scanning tool.\nVisit https://github.com/mstykow/provenant/ for support and download.\nSPDX License List: 3.27",
+      "rdfs:comment": "Generated with Provenant and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nProvenant should be considered or used as legal advice. Consult an attorney\nfor legal advice.\nProvenant is a free software code scanning tool.\nVisit https://github.com/getprovenant/provenant/ for support and download.\nSPDX License List: 3.27",
       "spdx:name": "SPDX Document created by Provenant",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/testdata/output-formats/spdx-simple-expected.tv
+++ b/testdata/output-formats/spdx-simple-expected.tv
@@ -9,7 +9,7 @@ OR CONDITIONS OF ANY KIND, either express or implied. No content created from
 Provenant should be considered or used as legal advice. Consult an attorney
 for legal advice.
 Provenant is a free software code scanning tool.
-Visit https://github.com/mstykow/provenant/ for support and download.
+Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
 ## Package Information


### PR DESCRIPTION
> [!WARNING]
> **Draft — merge only AFTER transferring the repo to `getprovenant`.** The release-workflow guards target `getprovenant/provenant`, so merging while the repo is still under `mstykow` would make the crate/release/image jobs skip on the next tag.

## Summary

Repoints everything from `mstykow/provenant` → `getprovenant/provenant` ahead of the org transfer:

- **`release.yml`**: flip the `publish-crate` / `create-release` repository guards, and add a **`publish-image`** job that builds and pushes a **multi-arch (amd64/arm64)** image to **`ghcr.io/getprovenant/provenant`** using `GITHUB_TOKEN` (`packages: write`). Reuses a distroless, COPY-only `Dockerfile` (no recompile, no QEMU).
- **Metadata/docs**: `Cargo.toml` (repository/homepage/documentation), `CITATION.cff`, README badges + links, `CONTRIBUTING.md`, and docs URLs.
- **Scan-output notices**: the repo URL embedded in SPDX, Debian-copyright, and HTML-report output (`src/output/{mod,debian,html}.rs`) + their four golden fixtures — otherwise every generated scan result would point users at the emptied old repo.
- **`pr-lifecycle` skill docs** (both `.agents/` and `.claude/` copies).

## Scope and exclusions

- Included: all `mstykow/provenant` → `getprovenant/provenant` references + the GHCR publish job + `Dockerfile`.
- Excluded: no scanner logic changes; the `Dockerfile`/image path was validated separately.

## How to verify

- Golden tests (`output_format_golden`) pass — output URLs and fixtures moved in lockstep.
- On the first post-transfer tag: `docker run --rm ghcr.io/getprovenant/provenant --version` and `docker manifest inspect ghcr.io/getprovenant/provenant:<version>` should show amd64 + arm64. The release/crate jobs run because `github.repository == getprovenant/provenant`.

## Follow-up

- After transfer: leave `mstykow/provenant` empty (keeps redirects), repoint local remotes, and confirm the GHCR package is public.