### PR TITLE
fix(release): ship static musl linux binaries with mimalloc

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -255,6 +255,48 @@ jobs:
           cargo run --quiet --locked --bin provenant -- serve --help > /dev/null
           cargo run --quiet --locked --bin provenant -- compare --help > /dev/null
 
+  linux-musl-build-smoke:
+    name: Linux musl Build Smoke Test (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          submodules: false
+          lfs: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
+        with:
+          cache: false
+          rustflags: ""
+          target: ${{ matrix.target }}
+
+      - name: Install musl build tools
+        run: sudo apt-get update && sudo apt-get install --assume-yes musl-tools
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-musl-build-smoke-${{ matrix.target }}
+
+      # Builds and runs the statically-linked musl binary, so a musl-specific
+      # allocator, bundled-C, linker, or startup failure surfaces here rather than
+      # only when a release tag publishes artifacts.
+      - name: Build and run static musl CLI smoke check
+        run: |
+          cargo run --quiet --locked --target ${{ matrix.target }} --bin provenant -- show-attribution > /dev/null
+          cargo run --quiet --locked --target ${{ matrix.target }} --bin provenant -- scan --help > /dev/null
+
   rust-sharded-tests:
     name: Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,17 +86,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          # Linux binaries target musl and link statically, so a single artifact runs on
+          # any glibc/musl distro (and in the distroless/static container). musl-tools
+          # provides musl-gcc for the bundled-SQLite C build.
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
             asset_name: provenant-linux-x86_64
             archive_format: tar.gz
-            packages: pkg-config libsqlite3-dev
+            packages: musl-tools
 
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
             asset_name: provenant-linux-aarch64
             archive_format: tar.gz
-            packages: pkg-config libsqlite3-dev
+            packages: musl-tools
 
           - target: x86_64-apple-darwin
             os: macos-15-intel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +2506,15 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -3434,6 +3452,7 @@ dependencies = [
  "liblzma",
  "log",
  "md-5",
+ "mimalloc",
  "mime_guess",
  "minijinja",
  "object",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,9 @@ yaml_serde = { workspace = true }
 zip = "8.6.0"
 zstd = { workspace = true }
 
+[target.'cfg(target_env = "musl")'.dependencies]
+mimalloc = "0.1.52"
+
 [build-dependencies]
 rkyv = { workspace = true }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,16 @@
 # published image ships the exact same binary as the GitHub release — no in-container
 # recompile, and multi-arch (amd64/arm64) needs no QEMU emulation (COPY only).
 #
-# The binary is self-contained: SQLite is statically linked (rusqlite "bundled"), TLS is
-# rustls (no OpenSSL), and the license index is embedded. So distroless/cc — glibc,
-# libgcc, and CA certificates — is all it needs at runtime.
+# The binary is fully static: SQLite is statically linked (rusqlite "bundled"), TLS is
+# rustls (no OpenSSL), libc is statically linked musl, and the license index is embedded.
+# So distroless/static — no libc, just CA certificates and /etc scaffolding — is all it
+# needs at runtime.
 #
-# To build locally, stage the binary for your arch first, e.g.:
-#   cargo build --release
-#   mkdir -p dist/amd64 && cp target/release/provenant dist/amd64/
-#   docker build --build-arg TARGETARCH=amd64 -t provenant .
-FROM gcr.io/distroless/cc-debian12@sha256:a90cf0f046efb32466b38b0972fef3a95e7c580e392e79ff1b7ac08c15fed0bc
+# To build locally, stage a statically-linked binary for your arch first, e.g.:
+#   cargo build --release --target aarch64-unknown-linux-musl
+#   mkdir -p dist/arm64 && cp target/aarch64-unknown-linux-musl/release/provenant dist/arm64/
+#   docker build --build-arg TARGETARCH=arm64 -t provenant .
+FROM gcr.io/distroless/static-debian12@sha256:22fd79fd75eab2372585b44517f8a094349938919dc613aafc37e4bdc9967c82
 
 # TARGETARCH is set automatically by BuildKit per target platform (amd64, arm64).
 ARG TARGETARCH

--- a/src/bin/provenant.rs
+++ b/src/bin/provenant.rs
@@ -1,6 +1,14 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// musl's default allocator serializes badly under the scanner's highly parallel
+// allocation, making static musl builds orders of magnitude slower. mimalloc restores
+// glibc-class throughput. Only the musl release binaries are affected; glibc, macOS, and
+// Windows builds keep the system allocator.
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     if let Err(err) = provenant::cli::run() {
         eprintln!("Error: {}", err);


### PR DESCRIPTION
## Summary

- The published linux release binaries were built on `ubuntu-24.04` (glibc 2.39) and dynamically linked, so they required **GLIBC_2.39** at runtime. The `v0.2.3` container (`distroless/cc-debian12`, glibc 2.36) **could not start at all**, and the standalone tarballs failed on Debian 12, Ubuntu 22.04, RHEL/Rocky 8–9, Amazon Linux 2, etc.
- Switch the linux release targets to `*-unknown-linux-musl` (fully **static**) and base the container on `distroless/static-debian12`. The binary now runs on any glibc/musl distro with no libc dependency.
- Add **mimalloc** as the global allocator **for musl builds only**. musl's default allocator serializes badly under the scanner's highly parallel allocation; mimalloc restores glibc-class throughput. glibc, macOS, and Windows builds are unaffected.

## Scope and exclusions

- Included: `.github/workflows/release.yml` (linux targets → musl, `musl-tools`), `Dockerfile` (base → `distroless/static`), `mimalloc` global allocator gated to `cfg(target_env = "musl")`.
- Explicit exclusions: no allocator change for glibc/macOS/Windows. Broadening mimalloc to all targets (a potential further speedup) is deliberately out of scope — it would need its own cross-platform benchmarking.

## How to verify

Beyond CI (which covers build/clippy/fmt/tests on the non-musl targets), the musl artifact + container were validated locally in an `aarch64-unknown-linux-musl` build:

- **Static binary**: `ldd` → `not a dynamic executable`; runs unchanged in `distroless/static`.
- **Container**: `docker build --build-arg TARGETARCH=arm64` on the new Dockerfile, then `docker run … --version` and a real `scan … --license --copyright` both succeed (embedded index initialises, JSON output written).
- **Allocator A/B** (9,355-file license corpus, 18 cores, same container, serial runs):
  - glibc: min **13.95s**, maxRSS ~2.14 GB
  - musl (default alloc): **>760s** for a single scan and still unfinished (~>50× slower) ⚠️
  - musl + mimalloc: min **13.38s**, maxRSS ~2.16 GB — parity with glibc, no regression.

The change takes effect on the next release tag; no throwaway release is needed to land it.

## Follow-up work

- Created or intentionally deferred: consider evaluating mimalloc (or jemalloc) as the global allocator on all targets as a possible general speedup — deferred pending cross-platform benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)