### PR TITLE
fix(output): emit POSIX resource paths on Windows + add cross-platform smoke test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Pin the cross-platform smoke fixture to LF so it checks out byte-identical on
+# every OS. Without this, Windows autocrlf would rewrite line endings and change
+# file sizes, hashes, and detection line spans, desyncing the smoke golden. The
+# fixture is meant to test scanner behavior, not git's EOL handling.
+testdata/smoke/** text eol=lf

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -225,6 +225,12 @@ jobs:
           cargo run --quiet --locked --bin provenant -- serve --help | Out-Null
           cargo run --quiet --locked --bin provenant -- compare --help | Out-Null
 
+      # Real scan + golden diff, so Windows-specific output behavior (path
+      # separators, file_type, detection line spans) is verified, not just startup.
+      - name: Cross-platform scan smoke check
+        shell: bash
+        run: ./scripts/smoke_scan_check.sh
+
   intel-macos-build-smoke:
     name: Intel macOS Build Smoke Test
     runs-on: macos-15-intel
@@ -254,6 +260,11 @@ jobs:
           cargo run --quiet --locked --bin provenant -- scan --help > /dev/null
           cargo run --quiet --locked --bin provenant -- serve --help > /dev/null
           cargo run --quiet --locked --bin provenant -- compare --help > /dev/null
+
+      # Real scan + golden diff, so macOS-specific output behavior (path separators,
+      # file_type, detection line spans) is verified, not just startup.
+      - name: Cross-platform scan smoke check
+        run: ./scripts/smoke_scan_check.sh
 
   linux-musl-build-smoke:
     name: Linux musl Build Smoke Test (${{ matrix.target }})
@@ -296,6 +307,11 @@ jobs:
         run: |
           cargo run --quiet --locked --target ${{ matrix.target }} --bin provenant -- show-attribution > /dev/null
           cargo run --quiet --locked --target ${{ matrix.target }} --bin provenant -- scan --help > /dev/null
+
+      # Real scan + golden diff against the shipped static musl binary, so its
+      # output behavior (not just startup) is verified before a release ships it.
+      - name: Cross-platform scan smoke check
+        run: ./scripts/smoke_scan_check.sh ${{ matrix.target }}
 
   rust-sharded-tests:
     name: Tests (${{ matrix.shard }})

--- a/scripts/smoke_scan_check.sh
+++ b/scripts/smoke_scan_check.sh
@@ -64,11 +64,19 @@ if [ "${UPDATE_GOLDEN:-}" = "1" ]; then
     exit 0
 fi
 
-# Highest-value invariant, checked explicitly for a clear failure message: output
-# paths must use POSIX '/', never a Windows backslash.
-if jq -r '.files[].path' "$got" | grep -q '\\'; then
-    echo "FAIL: scan output paths contain backslashes; expected POSIX '/' separators:"
-    jq -r '.files[].path' "$got"
+# Highest-value invariant, checked explicitly for a clear failure message: every
+# path-bearing string must use POSIX '/', never a Windows backslash. This covers the
+# resource path AND each license match's `from_file` (a distinct, absolute-path
+# emission site the golden projection can't pin because it embeds the workspace path).
+path_fields="$(jq -r '
+    [ .files[].path ]
+    + [ .files[].license_detections[]?.matches[]?.from_file // empty ]
+    + [ .files[].license_clues[]?.matches[]?.from_file // empty ]
+    + [ .license_detections[]?.reference_matches[]?.from_file // empty ]
+    | .[]' "$raw")"
+if printf '%s\n' "$path_fields" | grep -q '\\'; then
+    echo "FAIL: output path fields contain backslashes; expected POSIX '/' separators:"
+    printf '%s\n' "$path_fields" | grep '\\'
     exit 1
 fi
 

--- a/scripts/smoke_scan_check.sh
+++ b/scripts/smoke_scan_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Cross-platform behavioral smoke check.
+#
+# Scans a tiny, EOL-pinned fixture and diffs a normalized projection of the scan
+# output against a committed golden. This runs in the Windows, macOS, and static
+# musl CI smoke jobs so platform-specific behavior differences — output path
+# separators, file_type/mime detection, and copyright/license line spans — surface
+# in CI instead of only when a release ships. The build is already paid for by the
+# surrounding smoke job, so this adds only a few seconds.
+#
+# The projection drops volatile fields (headers with tool version/timings, and the
+# per-file mtime `date`) and keeps the deterministic, platform-sensitive ones. The
+# fixture is pinned to LF via .gitattributes so sizes/hashes/line spans are identical
+# on every OS.
+#
+# jq and diff are preinstalled on all GitHub-hosted runners.
+#
+# Usage:
+#   scripts/smoke_scan_check.sh [TARGET_TRIPLE]   # verify against the golden
+#   UPDATE_GOLDEN=1 scripts/smoke_scan_check.sh   # regenerate the golden
+set -euo pipefail
+
+target_arg=()
+if [ "${1:-}" != "" ]; then
+    target_arg=(--target "$1")
+fi
+
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+fixture="testdata/smoke"
+golden="testdata/smoke-expected.json"
+# Workspace-relative paths (under gitignored target/): a leading-slash absolute
+# path would be mangled by Git Bash's MSYS path translation before a native
+# Windows provenant.exe sees it.
+raw="target/smoke-raw.json"
+got="target/smoke-got.json"
+mkdir -p target
+trap 'rm -f "$raw" "$got"' EXIT
+
+cargo run --quiet --locked ${target_arg[@]+"${target_arg[@]}"} --bin provenant -- \
+    scan "$fixture" --license --copyright --info --json-pp "$raw" >/dev/null
+
+# Allowlist projection: deterministic, platform-sensitive fields only.
+jq_prog='{files: [.files[] | {
+    path, type, name, extension, size, sha1, mime_type, file_type,
+    programming_language, is_binary, is_text, is_source, is_script,
+    detected_license_expression, detected_license_expression_spdx,
+    percentage_of_license_text,
+    copyrights: [.copyrights[]? | {copyright, start_line, end_line}],
+    holders: [.holders[]? | {holder, start_line, end_line}],
+    scan_errors
+}] | sort_by(.path)}'
+
+jq -S "$jq_prog" "$raw" > "$got"
+
+if [ "${UPDATE_GOLDEN:-}" = "1" ]; then
+    cp "$got" "$golden"
+    echo "Updated golden: $golden"
+    exit 0
+fi
+
+# Highest-value invariant, checked explicitly for a clear failure message: output
+# paths must use POSIX '/', never a Windows backslash.
+if jq -r '.files[].path' "$got" | grep -q '\\'; then
+    echo "FAIL: scan output paths contain backslashes; expected POSIX '/' separators:"
+    jq -r '.files[].path' "$got"
+    exit 1
+fi
+
+if ! diff -u "$golden" "$got"; then
+    echo "FAIL: scan projection differs from the golden ($golden)."
+    echo "If this change is intentional, regenerate with: UPDATE_GOLDEN=1 scripts/smoke_scan_check.sh"
+    exit 1
+fi
+
+echo "OK: cross-platform scan smoke check passed."

--- a/src/scanner/process/license.rs
+++ b/src/scanner/process/license.rs
@@ -72,7 +72,7 @@ pub(super) fn extract_license_information(
                 &text_content,
                 license_options.unknown_licenses,
                 from_binary_strings,
-                &path.to_string_lossy(),
+                &crate::utils::path::to_posix_string(path),
                 license_options.enable_sequence_matching,
                 deadline,
             )
@@ -87,7 +87,10 @@ pub(super) fn extract_license_information(
                     deadline,
                 )
                 .map(|mut detections| {
-                    attach_source_path_to_detections(&mut detections, &path.to_string_lossy());
+                    attach_source_path_to_detections(
+                        &mut detections,
+                        &crate::utils::path::to_posix_string(path),
+                    );
                     detections
                 })
         };
@@ -125,7 +128,7 @@ pub(super) fn extract_license_information(
                 &text_content,
                 license_options.unknown_licenses,
                 from_binary_strings,
-                &path.to_string_lossy(),
+                &crate::utils::path::to_posix_string(path),
                 license_options.enable_sequence_matching,
             )
         } else {
@@ -133,7 +136,7 @@ pub(super) fn extract_license_information(
                 &text_content,
                 license_options.unknown_licenses,
                 from_binary_strings,
-                &path.to_string_lossy(),
+                &crate::utils::path::to_posix_string(path),
                 license_options.enable_sequence_matching,
                 f32::from(license_options.min_score),
             )
@@ -876,7 +879,7 @@ fn refresh_public_detection_after_context_prune(
     }
     crate::models::file_info::enrich_license_detection_provenance(
         detection,
-        &path.to_string_lossy(),
+        &crate::utils::path::to_posix_string(path),
     );
 }
 

--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -103,7 +103,7 @@ pub(super) fn process_file(
             path.extension()
                 .map_or("".to_string(), |ext| format!(".{}", ext.to_string_lossy())),
         )
-        .path(path.to_string_lossy().to_string())
+        .path(crate::utils::path::to_posix_string(path))
         .file_type(FileType::File)
         .size(metadata.len())
         .date(

--- a/src/scanner/process/special_cases.rs
+++ b/src/scanner/process/special_cases.rs
@@ -74,7 +74,7 @@ pub(super) fn process_directory(
         name,
         base_name,
         extension: "".to_string(),
-        path: path.to_string_lossy().to_string(),
+        path: crate::utils::path::to_posix_string(path),
         file_type: FileType::Directory,
         mime_type: None,
         file_type_label: None,

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -1,6 +1,17 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::{MAIN_SEPARATOR, Path};
+
+/// Render a filesystem path as a POSIX-style string with `/` separators.
+///
+/// Scan output must use `/` on every platform (ScanCode does, downstream tooling
+/// expects it, and the internal path helpers here split on `/`). On Unix this is
+/// just `to_string_lossy`; on Windows it rewrites the `\` separators the OS uses.
+pub(crate) fn to_posix_string(path: &Path) -> String {
+    path.to_string_lossy().replace(MAIN_SEPARATOR, "/")
+}
+
 pub(crate) fn parent_dir(path: &str) -> &str {
     path.rsplit_once('/').map_or("", |(parent, _)| parent)
 }
@@ -15,7 +26,15 @@ pub(crate) fn parent_dir_for_lookup(path: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parent_dir, parent_dir_for_lookup};
+    use super::{parent_dir, parent_dir_for_lookup, to_posix_string};
+
+    #[test]
+    fn to_posix_string_uses_forward_slashes() {
+        // Built from components so it uses the platform separator (\ on Windows,
+        // / on Unix); the result must be POSIX on both.
+        let path: std::path::PathBuf = ["packages", "app", "index.js"].iter().collect();
+        assert_eq!(to_posix_string(&path), "packages/app/index.js");
+    }
 
     #[test]
     fn parent_dir_handles_top_level_paths() {

--- a/testdata/smoke-expected.json
+++ b/testdata/smoke-expected.json
@@ -1,0 +1,112 @@
+{
+  "files": [
+    {
+      "copyrights": [],
+      "detected_license_expression": null,
+      "detected_license_expression_spdx": null,
+      "extension": "",
+      "file_type": null,
+      "holders": [],
+      "is_binary": false,
+      "is_script": false,
+      "is_source": false,
+      "is_text": false,
+      "mime_type": null,
+      "name": "smoke",
+      "path": "testdata/smoke",
+      "percentage_of_license_text": 0.0,
+      "programming_language": null,
+      "scan_errors": [],
+      "sha1": null,
+      "size": 0,
+      "type": "directory"
+    },
+    {
+      "copyrights": [
+        {
+          "copyright": "Copyright (c) 2021 Example Corp.",
+          "end_line": 3,
+          "start_line": 3
+        }
+      ],
+      "detected_license_expression": "mit",
+      "detected_license_expression_spdx": "MIT",
+      "extension": "",
+      "file_type": "UTF-8 Unicode text",
+      "holders": [
+        {
+          "end_line": 3,
+          "holder": "Example Corp.",
+          "start_line": 3
+        }
+      ],
+      "is_binary": false,
+      "is_script": false,
+      "is_source": false,
+      "is_text": true,
+      "mime_type": "text/plain",
+      "name": "LICENSE",
+      "path": "testdata/smoke/LICENSE",
+      "percentage_of_license_text": 0.0,
+      "programming_language": null,
+      "scan_errors": [],
+      "sha1": "26d7c7a90da16ec93ff023113ad7dedead2d5d70",
+      "size": 1070,
+      "type": "file"
+    },
+    {
+      "copyrights": [],
+      "detected_license_expression": null,
+      "detected_license_expression_spdx": null,
+      "extension": "",
+      "file_type": null,
+      "holders": [],
+      "is_binary": false,
+      "is_script": false,
+      "is_source": false,
+      "is_text": false,
+      "mime_type": null,
+      "name": "src",
+      "path": "testdata/smoke/src",
+      "percentage_of_license_text": 0.0,
+      "programming_language": null,
+      "scan_errors": [],
+      "sha1": null,
+      "size": 0,
+      "type": "directory"
+    },
+    {
+      "copyrights": [
+        {
+          "copyright": "Copyright (c) 2021 Example Corp.",
+          "end_line": 2,
+          "start_line": 2
+        }
+      ],
+      "detected_license_expression": "mit",
+      "detected_license_expression_spdx": "MIT",
+      "extension": ".c",
+      "file_type": "C source, UTF-8 Unicode text",
+      "holders": [
+        {
+          "end_line": 2,
+          "holder": "Example Corp.",
+          "start_line": 2
+        }
+      ],
+      "is_binary": false,
+      "is_script": false,
+      "is_source": true,
+      "is_text": true,
+      "mime_type": "text/plain",
+      "name": "app.c",
+      "path": "testdata/smoke/src/app.c",
+      "percentage_of_license_text": 0.0,
+      "programming_language": "C",
+      "scan_errors": [],
+      "sha1": "aa048030d15c660cd547bc482632446c8e8c347e",
+      "size": 102,
+      "type": "file"
+    }
+  ]
+}

--- a/testdata/smoke/LICENSE
+++ b/testdata/smoke/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Example Corp.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testdata/smoke/src/app.c
+++ b/testdata/smoke/src/app.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 Example Corp.
+
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- The Windows and Intel-macOS smoke jobs only exercised `--help`/`show-attribution`, and no behavioral test ran on any non-Linux target. All golden/integration coverage runs on x86_64 Linux, so platform-specific **output** differences — path separators, `file_type` detection, copyright/license line spans — were invisible until a release shipped. (The musl allocator bug was this same "untested platform" pattern.)
- Adds a tiny EOL-pinned fixture (`testdata/smoke`) and a portable `scripts/smoke_scan_check.sh` that scans it and diffs a normalized, volatile-field-stripped projection against a committed golden (`testdata/smoke-expected.json`).
- Wires the check into the **Windows**, **Intel-macOS**, and **static-musl** smoke jobs (one shared script, run under `bash` on every OS — Git Bash on Windows). The `cargo build` these jobs already run dominates their runtime, so the added scan costs only a few seconds.

## Scope and exclusions

- Included: cross-platform behavioral verification for the three non-primary targets, focused on the highest-impact invariants (POSIX `/` paths, `file_type`/detection determinism, line spans).
- Explicit exclusions: an explicit **CRLF** fixture (the fixture is pinned to LF so the golden is deterministic; CRLF-offset behavior is a worthwhile follow-up). Not adding a full golden suite on every OS — the projection is deliberately small to stay fast.

## How to verify

Beyond CI:
- `scripts/smoke_scan_check.sh` locally → prints `OK: cross-platform scan smoke check passed.`
- To see the guard bite, imagine a Windows `\` path: the script asserts no backslashes in output paths and fails loudly, and the golden diff catches any `file_type`/detection/line-span drift.
- Regenerate the golden intentionally with `UPDATE_GOLDEN=1 scripts/smoke_scan_check.sh`.

The real proof is this PR's own CI: the Windows / Intel-macOS / musl smoke jobs now run the behavioral check.

## Expected-output fixture changes

- Files changed: adds `testdata/smoke-expected.json` (new golden) and the `testdata/smoke` fixture.
- Why the new expected output is correct: generated directly from a real scan of the fixture; MIT is detected in both `LICENSE` and `src/app.c` with the expected copyright/holder line numbers, and all paths use `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)