### PR TITLE
feat(license): compliance severity, --fail-on gate, and SARIF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,16 @@ Prefer release binaries? Download precompiled archives from [GitHub Releases](ht
 
 ## Choose a Workflow
 
-| If you need to...                                     | Start here                                                         | Next doc                                                                                   |
-| ----------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| Run a one-off CLI scan                                | `provenant scan --json-pp - --license --package /path/to/repo`     | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
-| Scan explicit changed files in CI or automation       | Use `--paths-file` with one native scan root                       | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
-| Run a scan in a container                             | `docker run ghcr.io/getprovenant/provenant scan ...`               | [Container Image](#container-image)                                                        |
-| Run a scan from a GitHub Actions workflow             | `uses: getprovenant/provenant-action@v1`                           | [provenant-action](https://github.com/getprovenant/provenant-action)                       |
-| Reuse a warm process through HTTP                     | `provenant serve --help`                                           | [Serve API Guide](docs/SERVE_API_GUIDE.md)                                                 |
-| Embed Provenant in a Rust application                 | Use the `provenant` library target from `provenant-cli`            | [Library Guide](docs/LIBRARY_GUIDE.md)                                                     |
-| Evaluate Provenant with an existing ScanCode workflow | Start from Provenant's compatibility and workflow-difference notes | [Evaluating Provenant with ScanCode workflows](docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md) |
+| If you need to...                                      | Start here                                                         | Next doc                                                                                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Run a one-off CLI scan                                 | `provenant scan --json-pp - --license --package /path/to/repo`     | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
+| Scan explicit changed files in CI or automation        | Use `--paths-file` with one native scan root                       | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
+| Run a scan in a container                              | `docker run ghcr.io/getprovenant/provenant scan ...`               | [Container Image](#container-image)                                                        |
+| Run a scan from a GitHub Actions workflow              | `uses: getprovenant/provenant-action@v1`                           | [provenant-action](https://github.com/getprovenant/provenant-action)                       |
+| Gate CI on disallowed licenses (fail the build, SARIF) | `--license-policy policy.yml --fail-on error`                      | [CLI Guide](docs/CLI_GUIDE.md#17-i-want-policy-aware-license-review)                       |
+| Reuse a warm process through HTTP                      | `provenant serve --help`                                           | [Serve API Guide](docs/SERVE_API_GUIDE.md)                                                 |
+| Embed Provenant in a Rust application                  | Use the `provenant` library target from `provenant-cli`            | [Library Guide](docs/LIBRARY_GUIDE.md)                                                     |
+| Evaluate Provenant with an existing ScanCode workflow  | Start from Provenant's compatibility and workflow-difference notes | [Evaluating Provenant with ScanCode workflows](docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md) |
 
 ## Relationship to ScanCode
 
@@ -149,18 +150,6 @@ Multiple output flags can be used in a single run.
 When using `--from-json`, you can pass multiple JSON inputs. Native directory scans also support multiple input paths using common-prefix behavior.
 For guided workflows, flag combinations, cache controls, and stdin-driven file lists, see the [CLI Guide](docs/CLI_GUIDE.md).
 
-### HTTP Service
-
-For the current service shell surface, run:
-
-```sh
-provenant serve --help
-```
-
-`provenant serve` runs Provenant as a long-lived HTTP service with warm process reuse, synchronous and asynchronous scan endpoints, and job polling for automation-friendly integrations.
-
-For the HTTP request/response contract and examples, see the [Serve API Guide](docs/SERVE_API_GUIDE.md).
-
 ### GitHub Action
 
 To run Provenant from a GitHub Actions workflow, use the
@@ -172,7 +161,19 @@ action, which wraps the published container image:
 - uses: getprovenant/provenant-action@v1
 ```
 
-See the [action README](https://github.com/getprovenant/provenant-action) for inputs and examples.
+It can also **gate CI on a license policy** (`fail-on`) and upload **SARIF** findings to the code-scanning UI. See the [action README](https://github.com/getprovenant/provenant-action) for inputs and examples.
+
+### HTTP Service
+
+For the current service shell surface, run:
+
+```sh
+provenant serve --help
+```
+
+`provenant serve` runs Provenant as a long-lived HTTP service with warm process reuse, synchronous and asynchronous scan endpoints, and job polling for automation-friendly integrations.
+
+For the HTTP request/response contract and examples, see the [Serve API Guide](docs/SERVE_API_GUIDE.md).
 
 ### Rust Library
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -105,6 +105,7 @@ Use other outputs when you need a specific consumer or review format:
 - `--html` for a browsable report
 - `--spdx-tv`, `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml` for downstream compliance or SBOM workflows
 - `--debian` for a machine-readable Debian copyright file
+- `--sarif` for SARIF 2.1.0 output of license-policy violations, for pull-request checks and the code-scanning UI (see [policy-aware license review](#17-i-want-policy-aware-license-review))
 - `--custom-output` with `--custom-template` for custom report generation
 
 You can write more than one output format in the same run. For example:
@@ -547,6 +548,41 @@ Why it is useful:
 
 This workflow is also useful with `--from-json` when you want to reshape an existing scan instead of rescanning the original inputs.
 
+#### The license policy file
+
+`--license-policy` takes a YAML file with a top-level `license_policies:` list. Each entry maps a license key to display metadata (`label`, `color_code`, `icon`, all optional) and, as a Provenant extension, an optional `compliance_alert` severity of `error` or `warning`:
+
+```yaml
+license_policies:
+  - license_key: gpl-3.0
+    label: Prohibited License
+    compliance_alert: error
+  - license_key: gpl-2.0
+    label: Copyleft License
+    compliance_alert: warning
+  - license_key: mit
+    label: Approved License
+    # no compliance_alert => informational only
+```
+
+For each scanned file, Provenant collects the license keys from its detected expressions, matches them against the policy, and attaches the matching entries (including `compliance_alert`) to that file's `license_policy` output field. Entries without a `compliance_alert` are informational and never fail a build.
+
+#### Failing CI on a policy violation
+
+Add `--fail-on <error|warning>` to turn the policy into a build gate. The scan exits with code **3** when any file matches a policy whose `compliance_alert` is at or above the given level (`warning` trips on warning and error; `error` trips only on error). The report is still written before the process exits, so the artifact is never lost. `--fail-on` requires `--license-policy`.
+
+```sh
+provenant scan --json-pp scan.json --license --license-policy policy.yml --fail-on error /path/to/project
+```
+
+#### Surfacing violations in pull requests (SARIF)
+
+`--sarif <FILE>` writes the policy violations as SARIF 2.1.0, which GitHub can render as pull-request annotations and code-scanning alerts (upload it with `github/codeql-action/upload-sarif`). Each severity-carrying policy match becomes a result at the file's detection line; with no policy the run has zero results, so SARIF stays quiet unless you opt into a policy.
+
+```sh
+provenant scan --sarif provenant.sarif --license --license-policy policy.yml /path/to/project
+```
+
 ### 18. "I want tallies, facets, or clarity scoring"
 
 ```sh
@@ -644,6 +680,8 @@ These are worth learning early because they change what the output means:
 - `--tallies-key-files` requires `--tallies` and `--classify`
 - `--tallies-by-facet` requires `--facet` and `--tallies`
 - `--debian <FILE>` requires `--license`, `--copyright`, and `--license-text`
+- `--fail-on <LEVEL>` requires `--license-policy`; a violation exits with code 3
+- `--sarif <FILE>` only emits results for `--license-policy` entries that carry a `compliance_alert`
 - `--paths-file <FILE>` requires exactly one native scan root and is currently native-scan only (no `--from-json`)
 - `--reindex` only matters when the license engine is initialized (`--license` and some `--from-json` reference-recompute flows)
 - `--no-license-index-cache` only matters when the license engine is initialized
@@ -675,7 +713,7 @@ If you are not sure where to start, use this rule of thumb:
 - Want a narrower file-level package-data pass across application and installed-package inputs without normal top-level assembly? → `--package-only`
 - Want SBOM-oriented output? → add `--cyclonedx` or `--spdx-*`, usually with `--package`
 - Want browser-friendly review? → `--html`
-- Want policy-aware license review? → add `--license-references`, `--filter-clues`, and optionally `--license-policy`
+- Want policy-aware license review? → add `--license-references`, `--filter-clues`, and `--license-policy` (add `--fail-on` to gate CI, `--sarif` for pull-request alerts)
 - Want summary/tally/facet review? → add `--classify`, `--summary`, and optionally `--tallies*` / `--facet`
 - Want glob-style file filtering inside one scan root? → add one or more `--include` patterns
 - Want an explicit rooted list of files/directories? → use `--paths-file`

--- a/docs/OUTPUT_FIELD_REFERENCE.md
+++ b/docs/OUTPUT_FIELD_REFERENCE.md
@@ -249,12 +249,13 @@ Grouped license detection record used on file, package_data, package, and resolv
 
 Policy decoration entry attached to file-level license-policy output.
 
-| JSON field    | Value shape | Key presence    | Meaning                                              |
-| ------------- | ----------- | --------------- | ---------------------------------------------------- |
-| `license_key` | `string`    | Always emitted. | License key this policy entry applies to.            |
-| `label`       | `string`    | Always emitted. | Human-facing policy label for the license.           |
-| `color_code`  | `string`    | Always emitted. | Color code used by policy-aware outputs or UIs.      |
-| `icon`        | `string`    | Always emitted. | Icon identifier used by policy-aware outputs or UIs. |
+| JSON field         | Value shape                     | Key presence                                                   | Meaning                                                                    |
+| ------------------ | ------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `license_key`      | `string`                        | Always emitted.                                                | License key this policy entry applies to.                                  |
+| `label`            | `string`                        | Always emitted.                                                | Human-facing policy label for the license.                                 |
+| `color_code`       | `string`                        | Always emitted.                                                | Color code used by policy-aware outputs or UIs.                            |
+| `icon`             | `string`                        | Always emitted.                                                | Icon identifier used by policy-aware outputs or UIs.                       |
+| `compliance_alert` | `string ("error" \| "warning")` | Emitted only when the policy entry sets a compliance severity. | Provenant compliance severity driving the --fail-on gate and SARIF output. |
 
 ## `OutputPackageData`
 

--- a/docs/adr/0011-license-compliance-gating-and-sarif.md
+++ b/docs/adr/0011-license-compliance-gating-and-sarif.md
@@ -1,0 +1,77 @@
+# ADR 0011: License Compliance Gating and SARIF Output
+
+**Status**: Accepted
+**Authors**: Provenant team
+**Supersedes**: None
+
+> **Current contract owner**: [`../CLI_GUIDE.md`](../CLI_GUIDE.md) owns the live flag and policy-file documentation; [`../OUTPUT_FIELD_REFERENCE.md`](../OUTPUT_FIELD_REFERENCE.md) owns the output-field contract. This ADR records why compliance severity, build gating, and SARIF output were added and how they fit together.
+
+## Context
+
+Provenant is increasingly run in CI (directly, in containers, and via the GitHub Action). A scan that only emits a JSON/SBOM report is useful as an audit artifact, but it does not, by itself, act as a guardrail: nothing decides whether a result is acceptable, and nobody reads a JSON artifact on every run. The two behaviors teams actually want from license scanning in CI are:
+
+1. **Gating** — fail the build when a disallowed license appears (for example copyleft in a proprietary product).
+2. **Inline surfacing** — show violations where reviewers already look (pull-request checks and the code-scanning UI), via SARIF.
+
+The existing `--license-policy` feature (ported from ScanCode) attaches policy entries `{license_key, label, color_code, icon}` to each file. `label` is free text, so there is **no machine-readable severity**: the output cannot drive a gate or a SARIF level. ScanCode has no severity concept here either, so there is no compatibility contract to preserve — we are free to define one.
+
+The blocker for SARIF was never lines of code (a serializer is comparable in size to the existing CycloneDX emitter). It was semantics: emitting every license detection as a SARIF result produces thousands of informational alerts (alert fatigue) and is worse than no SARIF. Meaningful SARIF requires a notion of which findings are violations and at what level — the same severity a gate needs. Gating, SARIF, and severity are therefore one decision, not three.
+
+## Decision
+
+**Introduce a Provenant-defined compliance severity on license-policy entries, and build both the CI gate and SARIF output on top of it.**
+
+### 1. Policy severity (`compliance_alert`)
+
+Extend the policy-file entry with an optional `compliance_alert` field:
+
+```yaml
+license_policies:
+  - license_key: gpl-3.0
+    label: Prohibited License
+    compliance_alert: error
+  - license_key: gpl-2.0
+    label: Copyleft License
+    compliance_alert: warning
+  - license_key: mit
+    label: Approved License
+    # no compliance_alert => informational only
+```
+
+- Allowed values: `error`, `warning`, or absent (informational).
+- The field is optional and additive: existing ScanCode-style policy files keep working unchanged and simply carry no severity.
+- Severity ordering: `error` > `warning` > none.
+- `compliance_alert` is surfaced on each file's `license_policy` entries in the output, so downstream tooling can read it without re-deriving anything.
+
+### 2. Build gate (`--fail-on <LEVEL>`)
+
+`--fail-on <error|warning>` makes a scan exit non-zero when any scanned file matches a policy whose `compliance_alert` is at or above `LEVEL` (`warning` fails on warning and error; `error` fails only on error). It requires `--license-policy` (nothing to evaluate otherwise).
+
+- A policy violation exits with a **dedicated exit code (3)**, distinct from a scan/runtime error (1), so CI can tell "policy failed" from "the tool broke."
+- Output is still written first: the report (and SARIF, if requested) is produced, then the process exits non-zero. The artifact is never lost to the gate.
+
+### 3. SARIF output (`--sarif <FILE>`)
+
+A SARIF 2.1.0 emitter (`src/output/sarif.rs`, wired like the other output formats) turns policy-flagged findings into code-scanning results:
+
+- One SARIF rule per policy license key that carries a `compliance_alert`; `ruleId` is the license key, description is the `label`.
+- One result per file whose detected license matches such a policy; `level` maps `error -> error`, `warning -> warning`; the location is the file path plus the matching detection's line region when available.
+- With no policy (or no severities) the run has zero results — no noise by default. SARIF is therefore meaningful only alongside `--license-policy`, which the docs state explicitly.
+
+### 4. GitHub Action surface
+
+The action exposes `license-policy` and `fail-on` inputs that map to the CLI flags, so the gate and SARIF are reachable from a workflow without hand-writing `args`.
+
+## Consequences
+
+- **Positive**: CI can gate on license policy with a single flag; SARIF makes violations visible in pull requests and the code-scanning UI; the policy file gains a documented, machine-readable severity; all three features share one model and one source of truth. Non-gating, informational use is unchanged (severity is optional).
+- **Negative / cost**: a new output format and a new exit-code path to maintain and test; a small, Provenant-specific extension to the policy schema that ScanCode does not understand (harmless — ScanCode ignores unknown keys, and Provenant ignores the field when no gate/SARIF is requested).
+- **Scope boundary**: severity is evaluated against **file-level** detected license expressions (matching the existing `--license-policy` behavior). Extending gating to package/dependency declared licenses is a natural follow-up and is intentionally out of scope here.
+- Using the code-scanning UI for license findings is slightly off-label (it targets security), but it is an established pattern (Trivy/Grype upload license and misconfiguration findings the same way).
+
+## Alternatives Considered
+
+- **Action-only gate (parse JSON in the wrapper).** Rejected as the primary mechanism: it hides the decision in shell, only helps Action users, and duplicates policy semantics outside the engine. The CLI gate is reusable everywhere; the Action just forwards to it.
+- **SARIF of every detection.** Rejected: informational-level noise that buries real violations. SARIF is scoped to severity-carrying policy matches.
+- **Deriving severity from the free-text `label`.** Rejected as brittle and locale-dependent; an explicit `compliance_alert` field is unambiguous.
+- **A separate policy engine / config format.** Rejected: extending the existing, already-shipped policy file keeps one concept and preserves ScanCode-file compatibility.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Each ADR follows a consistent structure:
 | [0008](0008-output-schema-separation.md)                 | Output Schema Type Separation                         | Accepted | 2026-04-10 |
 | [0009](0009-parser-submodule-structure.md)               | Parser Submodule Structure for Large Ecosystems       | Accepted | 2026-04-17 |
 | [0010](0010-package-license-from-cohosted-files.md)      | Package Declared License From Co-hosted License Files | Accepted | 2026-06-25 |
+| [0011](0011-license-compliance-gating-and-sarif.md)      | License Compliance Gating and SARIF Output            | Accepted | 2026-07-11 |
 
 ## When to Create a New ADR
 

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -69,6 +69,8 @@ pub(crate) struct ScanRequest {
     pub(crate) license_clarity_score: bool,
     pub(crate) license_references: bool,
     pub(crate) license_policy: Option<String>,
+    /// Minimum compliance severity that fails the run (`--fail-on`); `None` disables gating.
+    pub(crate) fail_on: Option<crate::models::ComplianceAlert>,
     pub(crate) tallies: bool,
     pub(crate) tallies_key_files: bool,
     pub(crate) tallies_with_details: bool,

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -270,6 +270,14 @@ pub(crate) fn build_output_model(
                     Path::new(policy_path),
                 )
             })?;
+        // Fail closed: if a gate was requested but the policy could not be
+        // evaluated (empty file, duplicate keys), refuse to pass silently.
+        if request.fail_on.is_some() && !license_policy_errors.is_empty() {
+            return Err(anyhow!(
+                "--fail-on was requested but the license policy could not be evaluated: {}",
+                license_policy_errors.join("; ")
+            ));
+        }
         for err in &license_policy_errors {
             progress.record_additional_error(err);
         }

--- a/src/bin/provenant.rs
+++ b/src/bin/provenant.rs
@@ -9,9 +9,12 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-fn main() {
-    if let Err(err) = provenant::cli::run() {
-        eprintln!("Error: {}", err);
-        std::process::exit(1);
+fn main() -> std::process::ExitCode {
+    match provenant::cli::run() {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            std::process::ExitCode::from(1)
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -234,6 +234,23 @@ pub struct ExportLicenseDatasetArgs {
     pub verbosity: VerbosityFlags,
 }
 
+/// Minimum license-policy compliance severity that fails the build (`--fail-on`).
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailOn {
+    Warning,
+    Error,
+}
+
+impl FailOn {
+    /// Lowest `ComplianceAlert` severity that should trip the gate.
+    pub fn threshold(self) -> crate::models::ComplianceAlert {
+        match self {
+            Self::Warning => crate::models::ComplianceAlert::Warning,
+            Self::Error => crate::models::ComplianceAlert::Error,
+        }
+    }
+}
+
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompatibilityMode {
     #[default]
@@ -339,6 +356,10 @@ pub struct ScanArgs {
         allow_hyphen_values = true
     )]
     pub output_cyclonedx_xml: Option<String>,
+
+    /// Write license-policy violations as SARIF 2.1.0 to FILE (needs --license-policy)
+    #[arg(long = "sarif", value_name = "FILE", allow_hyphen_values = true)]
+    pub output_sarif: Option<String>,
 
     /// Write scan output to FILE formatted with the custom template
     #[arg(
@@ -556,6 +577,11 @@ pub struct ScanArgs {
     )]
     pub license_policy: Option<String>,
 
+    /// Exit non-zero (code 3) when a scanned file matches a license policy whose
+    /// compliance_alert is at or above this level. Requires --license-policy.
+    #[arg(long = "fail-on", value_enum, requires = "license_policy")]
+    pub fail_on: Option<FailOn>,
+
     #[arg(long)]
     pub tallies: bool,
 
@@ -760,6 +786,14 @@ impl ScanArgs {
         if let Some(file) = &self.output_cyclonedx_xml {
             targets.push(OutputTarget {
                 format: OutputFormat::CycloneDxXml,
+                file: file.clone(),
+                custom_template: None,
+            });
+        }
+
+        if let Some(file) = &self.output_sarif {
+            targets.push(OutputTarget {
+                format: OutputFormat::Sarif,
                 file: file.clone(),
                 custom_template: None,
             });
@@ -1007,6 +1041,7 @@ impl From<&ScanArgs> for ScanRequest {
             license_clarity_score: cli.license_clarity_score,
             license_references: cli.license_references,
             license_policy: cli.license_policy.clone(),
+            fail_on: cli.fail_on.map(FailOn::threshold),
             tallies: cli.tallies,
             tallies_key_files: cli.tallies_key_files,
             tallies_with_details: cli.tallies_with_details,

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -13,10 +13,15 @@ use crate::time::format_scancode_timestamp;
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 use std::path::Path;
+use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Instant;
 
-pub fn run() -> Result<()> {
+/// Exit code returned when the `--fail-on` license-policy gate trips, distinct from
+/// the code used for scan/runtime errors (see ADR 0011).
+const POLICY_GATE_EXIT_CODE: u8 = 3;
+
+pub fn run() -> Result<ExitCode> {
     #[cfg(feature = "golden-tests")]
     touch_license_golden_symbols();
 
@@ -38,10 +43,10 @@ pub fn run() -> Result<()> {
     match &cli.command {
         Command::ShowAttribution => {
             print!("{}", include_str!("../../../NOTICE"));
-            return Ok(());
+            return Ok(ExitCode::SUCCESS);
         }
         Command::Serve(args) => {
-            return run_serve_shell(args);
+            return run_serve_shell(args).map(|()| ExitCode::SUCCESS);
         }
         Command::Compare(args) => {
             log::info!(
@@ -63,7 +68,7 @@ pub fn run() -> Result<()> {
             println!("  Summary JSON:       {}", result.summary_json.display());
             println!("  Summary TSV:        {}", result.summary_tsv.display());
             println!("  Sample artifacts:   {}", result.samples_dir.display());
-            return Ok(());
+            return Ok(ExitCode::SUCCESS);
         }
         Command::ExportLicenseDataset(args) => {
             let dir = Path::new(&args.dir);
@@ -79,7 +84,7 @@ pub fn run() -> Result<()> {
                 started.elapsed().as_secs_f64(),
                 outcome.manifest.spdx_license_list_version
             );
-            return Ok(());
+            return Ok(ExitCode::SUCCESS);
         }
         Command::Scan(_) => {}
     }
@@ -129,7 +134,38 @@ pub fn run() -> Result<()> {
         &format_scancode_timestamp(&summary_end),
     );
 
-    Ok(())
+    // License-policy gate: evaluated after the report is written so the artifact is
+    // never lost to a failing gate (ADR 0011).
+    if let Some(threshold) = request.fail_on {
+        let violations = count_policy_violations(&output.files, threshold);
+        if violations > 0 {
+            log::error!(
+                "License policy gate: {violations} file(s) match a policy at or above `{threshold:?}` severity; failing with exit code {POLICY_GATE_EXIT_CODE}."
+            );
+            return Ok(ExitCode::from(POLICY_GATE_EXIT_CODE));
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Count files whose license policy carries a `compliance_alert` at or above `threshold`.
+fn count_policy_violations(
+    files: &[crate::models::FileInfo],
+    threshold: crate::models::ComplianceAlert,
+) -> usize {
+    files
+        .iter()
+        .filter(|file| {
+            file.license_policy.as_ref().is_some_and(|entries| {
+                entries.iter().any(|entry| {
+                    entry
+                        .compliance_alert
+                        .is_some_and(|alert| alert >= threshold)
+                })
+            })
+        })
+        .count()
 }
 
 #[cfg(feature = "golden-tests")]

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1600,9 +1600,25 @@ pub struct OutputURL {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct LicensePolicyEntry {
     pub license_key: String,
+    #[serde(default)]
     pub label: String,
+    #[serde(default)]
     pub color_code: String,
+    #[serde(default)]
     pub icon: String,
+    /// Provenant extension: optional machine-readable compliance severity used by
+    /// the `--fail-on` build gate and SARIF output. Absent means informational.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compliance_alert: Option<ComplianceAlert>,
+}
+
+/// Severity attached to a license policy entry. Ordered `Error` > `Warning`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum ComplianceAlert {
+    // Ordering matters: derived Ord ranks later variants higher, so Warning < Error.
+    Warning,
+    Error,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -22,9 +22,9 @@ pub use diagnostic::{
 };
 pub use digest::{GitSha1, Md5Digest, Sha1Digest, Sha256Digest, Sha512Digest};
 pub use file_info::{
-    Author, Copyright, Dependency, FileInfo, FileInfoBuilder, FileReference, FileType, Holder,
-    LicenseDetection, LicensePolicyEntry, Match, OutputEmail, OutputURL, Package, PackageData,
-    Party, PartyType, ResolvedPackage, TopLevelDependency,
+    Author, ComplianceAlert, Copyright, Dependency, FileInfo, FileInfoBuilder, FileReference,
+    FileType, Holder, LicenseDetection, LicensePolicyEntry, Match, OutputEmail, OutputURL, Package,
+    PackageData, Party, PartyType, ResolvedPackage, TopLevelDependency,
 };
 pub use line_number::LineNumber;
 pub use match_score::MatchScore;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -14,6 +14,7 @@ mod debian;
 mod html;
 mod jsonl;
 mod public_serialize;
+mod sarif;
 mod shared;
 mod spdx;
 mod template;
@@ -35,6 +36,7 @@ pub enum OutputFormat {
     SpdxRdf,
     CycloneDxJson,
     CycloneDxXml,
+    Sarif,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -88,6 +90,7 @@ impl OutputWriter for FormatWriter {
             OutputFormat::SpdxRdf => spdx::write_spdx_rdf_xml(output, writer, config),
             OutputFormat::CycloneDxJson => cyclonedx::write_cyclonedx_json(output, writer),
             OutputFormat::CycloneDxXml => cyclonedx::write_cyclonedx_xml(output, writer),
+            OutputFormat::Sarif => sarif::write_sarif(output, writer),
         }
     }
 }

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -63,7 +63,7 @@ fn build_sarif(output: &Output) -> Value {
                 .or_insert((entry.label.clone(), alert));
 
             let mut physical_location = json!({
-                "artifactLocation": { "uri": file.path }
+                "artifactLocation": { "uri": path_to_uri(&file.path) }
             });
             if let Some((start_line, end_line)) = region_for_key(file, &entry.license_key) {
                 physical_location["region"] = json!({
@@ -115,6 +115,22 @@ fn build_sarif(output: &Output) -> Value {
 
 fn display_label<'a>(label: &'a str, license_key: &'a str) -> &'a str {
     if label.is_empty() { license_key } else { label }
+}
+
+/// Percent-encode a scan path into a valid SARIF `artifactLocation.uri` reference.
+/// Paths are already POSIX (`/`-separated), so `/` and RFC 3986 unreserved bytes are
+/// kept and everything else (spaces, `#`, `?`, `%`, non-ASCII) is `%`-escaped.
+fn path_to_uri(path: &str) -> String {
+    let mut uri = String::with_capacity(path.len());
+    for &byte in path.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                uri.push(byte as char);
+            }
+            _ => uri.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    uri
 }
 
 /// Find a line region to anchor a policy result: the first license-detection match

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// SARIF 2.1.0 output. Results come from license-policy entries that carry a
+// `compliance_alert` severity (see ADR 0011): each such policy match on a file
+// becomes a code-scanning result. With no policy (or no severities) the run has
+// zero results, so SARIF stays quiet unless the user opts into policy gating.
+
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+
+use serde_json::{Value, json};
+
+use crate::models::ComplianceAlert;
+use crate::output_schema::{Output, OutputFileInfo};
+
+use super::shared::io_other;
+
+const SARIF_SCHEMA: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+const INFORMATION_URI: &str = "https://github.com/getprovenant/provenant";
+
+pub(crate) fn write_sarif(output: &Output, writer: &mut dyn Write) -> io::Result<()> {
+    let sarif = build_sarif(output);
+    serde_json::to_writer_pretty(&mut *writer, &sarif).map_err(io_other)?;
+    writer.write_all(b"\n")
+}
+
+fn level_str(alert: ComplianceAlert) -> &'static str {
+    match alert {
+        ComplianceAlert::Error => "error",
+        ComplianceAlert::Warning => "warning",
+    }
+}
+
+fn build_sarif(output: &Output) -> Value {
+    let tool_version = output
+        .headers
+        .first()
+        .map(|header| header.tool_version.clone())
+        .unwrap_or_default();
+
+    // license_key -> (label, highest severity seen), kept sorted for stable output.
+    let mut rule_map: BTreeMap<String, (String, ComplianceAlert)> = BTreeMap::new();
+    let mut results: Vec<Value> = Vec::new();
+
+    for file in &output.files {
+        let Some(policy_entries) = &file.license_policy else {
+            continue;
+        };
+        for entry in policy_entries {
+            let Some(alert) = entry.compliance_alert else {
+                continue;
+            };
+
+            rule_map
+                .entry(entry.license_key.clone())
+                .and_modify(|(_, level)| {
+                    if alert > *level {
+                        *level = alert;
+                    }
+                })
+                .or_insert((entry.label.clone(), alert));
+
+            let mut physical_location = json!({
+                "artifactLocation": { "uri": file.path }
+            });
+            if let Some((start_line, end_line)) = region_for_key(file, &entry.license_key) {
+                physical_location["region"] = json!({
+                    "startLine": start_line,
+                    "endLine": end_line,
+                });
+            }
+
+            let label = display_label(&entry.label, &entry.license_key);
+            results.push(json!({
+                "ruleId": entry.license_key,
+                "level": level_str(alert),
+                "message": {
+                    "text": format!("{label}: license `{}` detected in {}", entry.license_key, file.path)
+                },
+                "locations": [ { "physicalLocation": physical_location } ]
+            }));
+        }
+    }
+
+    let rules: Vec<Value> = rule_map
+        .iter()
+        .map(|(key, (label, level))| {
+            json!({
+                "id": key,
+                "name": key,
+                "shortDescription": { "text": display_label(label, key) },
+                "defaultConfiguration": { "level": level_str(*level) }
+            })
+        })
+        .collect();
+
+    json!({
+        "$schema": SARIF_SCHEMA,
+        "version": "2.1.0",
+        "runs": [ {
+            "tool": {
+                "driver": {
+                    "name": "Provenant",
+                    "informationUri": INFORMATION_URI,
+                    "version": tool_version,
+                    "rules": rules
+                }
+            },
+            "results": results
+        } ]
+    })
+}
+
+fn display_label<'a>(label: &'a str, license_key: &'a str) -> &'a str {
+    if label.is_empty() { license_key } else { label }
+}
+
+/// Find a line region to anchor a policy result: the first license-detection match
+/// on the file whose expression contains this exact license key. Tokenizing avoids
+/// substring false positives (e.g. `gpl-3.0` inside `lgpl-3.0`).
+fn region_for_key(file: &OutputFileInfo, license_key: &str) -> Option<(u64, u64)> {
+    for detection in &file.license_detections {
+        for license_match in &detection.matches {
+            if expression_has_key(&license_match.license_expression, license_key) {
+                return Some((license_match.start_line, license_match.end_line));
+            }
+        }
+    }
+    None
+}
+
+fn expression_has_key(expression: &str, license_key: &str) -> bool {
+    expression
+        .split(|character: char| character.is_whitespace() || character == '(' || character == ')')
+        .any(|token| token == license_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expression_has_key;
+
+    #[test]
+    fn expression_has_key_matches_whole_tokens_only() {
+        assert!(expression_has_key("gpl-3.0", "gpl-3.0"));
+        assert!(expression_has_key("gpl-3.0 OR mit", "mit"));
+        assert!(expression_has_key("(apache-2.0 AND gpl-3.0)", "gpl-3.0"));
+        assert!(expression_has_key(
+            "gpl-2.0 WITH classpath-exception-2.0",
+            "gpl-2.0"
+        ));
+        // Must not match a substring of a different key.
+        assert!(!expression_has_key("lgpl-3.0", "gpl-3.0"));
+        assert!(!expression_has_key("mit OR apache-2.0", "gpl-3.0"));
+    }
+}

--- a/src/output_schema/license_policy_entry.rs
+++ b/src/output_schema/license_policy_entry.rs
@@ -3,12 +3,16 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::models::ComplianceAlert;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct OutputLicensePolicyEntry {
     pub license_key: String,
     pub label: String,
     pub color_code: String,
     pub icon: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compliance_alert: Option<ComplianceAlert>,
 }
 
 impl From<&crate::models::LicensePolicyEntry> for OutputLicensePolicyEntry {
@@ -18,6 +22,7 @@ impl From<&crate::models::LicensePolicyEntry> for OutputLicensePolicyEntry {
             label: value.label.clone(),
             color_code: value.color_code.clone(),
             icon: value.icon.clone(),
+            compliance_alert: value.compliance_alert,
         }
     }
 }
@@ -30,6 +35,7 @@ impl TryFrom<&OutputLicensePolicyEntry> for crate::models::LicensePolicyEntry {
             label: value.label.clone(),
             color_code: value.color_code.clone(),
             icon: value.icon.clone(),
+            compliance_alert: value.compliance_alert,
         })
     }
 }

--- a/src/output_schema/metadata/license.rs
+++ b/src/output_schema/metadata/license.rs
@@ -623,4 +623,11 @@ pub(super) const LICENSE_POLICY_ENTRY_FIELDS: &[OutputFieldDoc] = &[
         presence: "Always emitted.",
         meaning: "Icon identifier used by policy-aware outputs or UIs.",
     },
+    OutputFieldDoc {
+        json_name: "compliance_alert",
+        rust_field: "compliance_alert",
+        value_shape: "string (\"error\" | \"warning\")",
+        presence: "Emitted only when the policy entry sets a compliance severity.",
+        meaning: "Provenant compliance severity driving the --fail-on gate and SARIF output.",
+    },
 ];

--- a/src/output_schema/metadata/mod.rs
+++ b/src/output_schema/metadata/mod.rs
@@ -395,6 +395,7 @@ mod tests {
             label: "Allowed".to_string(),
             color_code: "#00ff00".to_string(),
             icon: "check".to_string(),
+            compliance_alert: None,
         }
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -309,6 +309,7 @@ fn request_for_native_paths(input_paths: Vec<String>, options: &ScanOptions) -> 
             .license_policy
             .as_ref()
             .map(|path| path.to_string_lossy().to_string()),
+        fail_on: None,
         tallies: options.tallies,
         tallies_key_files: options.tallies_key_files,
         tallies_with_details: options.tallies_with_details,


### PR DESCRIPTION
## Summary

- Turns `--license-policy` from an annotation-only feature into a CI guardrail. See [ADR 0011](docs/adr/0011-license-compliance-gating-and-sarif.md).
- Adds an optional **`compliance_alert`** (`error` | `warning`) to policy entries — the machine-readable severity that was missing (`label` was free text). ScanCode-style policy files keep working; the field is additive.
- **`--fail-on <error|warning>`**: exits with a dedicated code **3** when any scanned file matches a policy at or above that severity. The report is written *before* the gate exits, so the artifact is never lost. Requires `--license-policy`.
- **`--sarif <FILE>`**: SARIF 2.1.0 output of policy violations for pull-request checks / the code-scanning UI. Empty when no policy carries a severity, so there's no noise by default.
- Documents the license-policy file format in the CLI guide (it was previously undocumented) and surfaces `compliance_alert` in the public output schema.

## Issues

- Covers: the CI-gating and inline-surfacing gaps discussed for compliance workflows.

## Scope and exclusions

- Included: `compliance_alert` model + public-schema field, `--fail-on` gate (exit 3), `--sarif` emitter, CLI-guide policy-format docs, ADR 0011.
- Explicit exclusions: gating is evaluated against **file-level** detected licenses (matching existing `--license-policy` behavior); extending to package/dependency declared licenses is a deliberate follow-up. The GitHub Action inputs and README updates are handled separately.

## How to verify

Beyond CI:

```sh
cat > policy.yml <<'YAML'
license_policies:
  - license_key: mit
    label: Prohibited License
    compliance_alert: error
YAML
# gate: exits 3, writes both reports first
provenant scan testdata/smoke --license --license-policy policy.yml \
  --sarif out.sarif --json-pp out.json --fail-on error; echo "exit=$?"   # => 3
jq '.runs[0].results | length' out.sarif                                 # => 2 (mit flagged, with line regions)
jq -r '.files[].license_policy[]?.compliance_alert' out.json | sort -u   # => error
# no --fail-on => exit 0; --sarif with no policy => 0 results; --fail-on without --license-policy => clap error (exit 2)
```

## Expected-output fixture changes

- No golden fixtures changed. `compliance_alert` is `skip_serializing_if = None`, so existing outputs are byte-identical unless a policy sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)