### PR TITLE
ci(release): don't block the GitHub Release on crate/image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,11 +285,14 @@ jobs:
 
   create-release:
     name: Create Release
+    # Depends only on `build`: the GitHub Release publishes the built binaries and
+    # their provenance attestation, which do not depend on crates.io or GHCR. Gating
+    # this on `publish-crate`/`publish-image` meant a transient crates.io outage (even
+    # one that failed only the post-publish token revoke) skipped the Release entirely.
+    # Those jobs still run in parallel; their failures no longer block the binaries.
     if: github.repository == 'getprovenant/provenant'
     needs:
       - build
-      - publish-crate
-      - publish-image
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- `create-release` now depends only on `build` (was `[build, publish-crate, publish-image]`).
- The GitHub Release publishes the built binaries and their build-provenance attestation — neither depends on crates.io or GHCR. Gating it on `publish-crate` meant a **transient crates.io outage skipped the Release entirely**, even when the outage only failed the *post-publish token-revoke* step *after* the crate had already uploaded (exactly what happened cutting 0.2.4).
- `publish-crate` and `publish-image` still run in parallel; their failures no longer withhold the binaries/attestation.

## Issues

- Covers: the 0.2.4 release where the crate published but `create-release` was skipped on a crates.io `503` in the token-revoke step, so the GitHub Release had to be created by hand (and lost its attestation).

## Scope and exclusions

- Included: the one `needs:` change on `create-release` + rationale comment.
- Excluded: the crates.io token-revoke itself still fails the `publish-crate` job on a 503 (cosmetic — the crate publishes; the token expires on its own). Not worth special-casing the third-party auth action's post step.

## How to verify

Not exercisable without cutting a release. Reasoning: the release job graph is now `verify-release → build → {publish-crate ∥ publish-image ∥ create-release}`; `create-release` downloads the `build` artifacts and attests them independently, so a red `publish-crate`/`publish-image` no longer prevents the Release. `if:` repo guard and permissions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)