### PR TITLE
fix(license): make match from_file the repo-relative scan path

### DIFF
--- a/src/scanner/process/pipeline.rs
+++ b/src/scanner/process/pipeline.rs
@@ -368,7 +368,9 @@ fn extract_information_from_content(
             file_info_builder,
             scan_diagnostics,
             LicenseExtractionInput {
-                path: &filesystem_path,
+                // Relative scan path (matches the resource `path`) so match `from_file`
+                // is repo-relative, not an absolute host path (better parity + SARIF).
+                path,
                 text_content: text_content_for_license_detection.clone(),
                 license_engine,
                 license_options,
@@ -383,7 +385,9 @@ fn extract_information_from_content(
             file_info_builder,
             scan_diagnostics,
             LicenseExtractionInput {
-                path: &filesystem_path,
+                // Relative scan path (matches the resource `path`) so match `from_file`
+                // is repo-relative, not an absolute host path (better parity + SARIF).
+                path,
                 text_content: text_content_for_license_detection,
                 license_engine,
                 license_options,


### PR DESCRIPTION
## Summary

- License-detection matches set `from_file` from the **absolute** filesystem path (`current_dir()` joined with the scan path), so scan output — and SARIF `artifactLocation.uri` — leaked the host workspace path (`/home/runner/work/…`, `/Users/…`) and diverged from the resource `path` field and from ScanCode's relative form.
- Fix: pass the **relative** scan path (the same value used for the resource `path`) as the detection source, so `from_file` is repo-relative and identical to `path`.
- Bonus: SARIF locations are now repo-relative, which is what GitHub code scanning actually resolves to source files.

## Scope and exclusions

- One-line source-of-truth change in `process_file`; no schema change. `from_file` was already relative in every golden (the harness expected relative), so this aligns the emitted value with what goldens assert.

## How to verify

Beyond CI (assembly + license-detection golden suites pass unchanged, 36 + 22):

```sh
provenant scan testdata/smoke --license --json-pp - | jq -r '.files[].license_detections[]?.matches[]?.from_file' | sort -u
# => testdata/smoke/LICENSE, testdata/smoke/src/app.c  (relative, == resource path; previously absolute)
```

## Expected-output fixture changes

- None. Goldens already stored relative `from_file`; this makes the scanner emit that directly instead of relying on absolute-path normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)