### PR TITLE
feat(license): extend --fail-on gate to package/dependency declared licenses

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -569,7 +569,7 @@ For each scanned file, Provenant collects the license keys from its detected exp
 
 #### Failing CI on a policy violation
 
-Add `--fail-on <error|warning>` to turn the policy into a build gate. The scan exits with code **3** when any file matches a policy whose `compliance_alert` is at or above the given level (`warning` trips on warning and error; `error` trips only on error). The report is still written before the process exits, so the artifact is never lost. `--fail-on` requires `--license-policy`.
+Add `--fail-on <error|warning>` to turn the policy into a build gate. The scan exits with code **3** when a file's detected license — or a top-level package's or dependency's **declared** license — matches a policy whose `compliance_alert` is at or above the given level (`warning` trips on warning and error; `error` trips only on error). The report is still written before the process exits, so the artifact is never lost. `--fail-on` requires `--license-policy`.
 
 ```sh
 provenant scan --json-pp scan.json --license --license-policy policy.yml --fail-on error /path/to/project

--- a/docs/adr/0011-license-compliance-gating-and-sarif.md
+++ b/docs/adr/0011-license-compliance-gating-and-sarif.md
@@ -66,7 +66,7 @@ The action exposes `license-policy` and `fail-on` inputs that map to the CLI fla
 
 - **Positive**: CI can gate on license policy with a single flag; SARIF makes violations visible in pull requests and the code-scanning UI; the policy file gains a documented, machine-readable severity; all three features share one model and one source of truth. Non-gating, informational use is unchanged (severity is optional).
 - **Negative / cost**: a new output format and a new exit-code path to maintain and test; a small, Provenant-specific extension to the policy schema that ScanCode does not understand (harmless — ScanCode ignores unknown keys, and Provenant ignores the field when no gate/SARIF is requested).
-- **Scope boundary**: severity is evaluated against **file-level** detected license expressions (matching the existing `--license-policy` behavior). Extending gating to package/dependency declared licenses is a natural follow-up and is intentionally out of scope here.
+- **Scope boundary**: the `--fail-on` gate evaluates **file-level detected** licenses _and_ **package/dependency declared** licenses, so a disallowed dependency license fails CI too (SCA-style). SARIF results remain file-level (the most actionable inline surface); package/dependency violations surface through the gate and the `license_policy` output rather than SARIF.
 - Using the code-scanning UI for license findings is slightly off-label (it targets security), but it is an established pattern (Trivy/Grype upload license and misconfiguration findings the same way).
 
 ## Alternatives Considered

--- a/docs/adr/0011-license-compliance-gating-and-sarif.md
+++ b/docs/adr/0011-license-compliance-gating-and-sarif.md
@@ -66,7 +66,7 @@ The action exposes `license-policy` and `fail-on` inputs that map to the CLI fla
 
 - **Positive**: CI can gate on license policy with a single flag; SARIF makes violations visible in pull requests and the code-scanning UI; the policy file gains a documented, machine-readable severity; all three features share one model and one source of truth. Non-gating, informational use is unchanged (severity is optional).
 - **Negative / cost**: a new output format and a new exit-code path to maintain and test; a small, Provenant-specific extension to the policy schema that ScanCode does not understand (harmless — ScanCode ignores unknown keys, and Provenant ignores the field when no gate/SARIF is requested).
-- **Scope boundary**: the `--fail-on` gate evaluates **file-level detected** licenses _and_ **package/dependency declared** licenses, so a disallowed dependency license fails CI too (SCA-style). SARIF results remain file-level (the most actionable inline surface); package/dependency violations surface through the gate and the `license_policy` output rather than SARIF.
+- **Scope boundary**: the `--fail-on` gate evaluates **file-level detected** licenses _and_ **package/dependency declared** licenses, so a disallowed dependency license fails CI too (SCA-style). SARIF results remain file-level (the most actionable inline surface); package/dependency violations surface through the gate and logged summary rather than SARIF.
 - Using the code-scanning UI for license findings is slightly off-label (it targets security), but it is an established pattern (Trivy/Grype upload license and misconfiguration findings the same way).
 
 ## Alternatives Considered

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -135,12 +135,22 @@ pub fn run() -> Result<ExitCode> {
     );
 
     // License-policy gate: evaluated after the report is written so the artifact is
-    // never lost to a failing gate (ADR 0011).
+    // never lost to a failing gate (ADR 0011). Covers file-level detections plus
+    // package/dependency declared licenses.
     if let Some(threshold) = request.fail_on {
-        let violations = count_policy_violations(&output.files, threshold);
+        let file_violations = count_policy_violations(&output.files, threshold);
+        let declared_violations = request.license_policy.as_deref().map_or(0, |policy_path| {
+            crate::post_processing::count_declared_license_policy_violations(
+                Path::new(policy_path),
+                &output.packages,
+                &output.dependencies,
+                threshold,
+            )
+        });
+        let violations = file_violations + declared_violations;
         if violations > 0 {
             log::error!(
-                "License policy gate: {violations} file(s) match a policy at or above `{threshold:?}` severity; failing with exit code {POLICY_GATE_EXIT_CODE}."
+                "License policy gate: {file_violations} file(s) and {declared_violations} package/dependency license(s) match a policy at or above `{threshold:?}` severity; failing with exit code {POLICY_GATE_EXIT_CODE}."
             );
             return Ok(ExitCode::from(POLICY_GATE_EXIT_CODE));
         }

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -139,14 +139,17 @@ pub fn run() -> Result<ExitCode> {
     // package/dependency declared licenses.
     if let Some(threshold) = request.fail_on {
         let file_violations = count_policy_violations(&output.files, threshold);
-        let declared_violations = request.license_policy.as_deref().map_or(0, |policy_path| {
-            crate::post_processing::count_declared_license_policy_violations(
+        // Fail closed: propagate a policy re-evaluation failure instead of treating
+        // it as zero package/dependency violations.
+        let declared_violations = match request.license_policy.as_deref() {
+            Some(policy_path) => crate::post_processing::count_declared_license_policy_violations(
                 Path::new(policy_path),
                 &output.packages,
                 &output.dependencies,
                 threshold,
-            )
-        });
+            )?,
+            None => 0,
+        };
         let violations = file_violations + declared_violations;
         if violations > 0 {
             log::error!(

--- a/src/post_processing/license_policy.rs
+++ b/src/post_processing/license_policy.rs
@@ -139,10 +139,14 @@ pub(crate) fn count_declared_license_policy_violations(
     packages: &[Package],
     dependencies: &[TopLevelDependency],
     threshold: ComplianceAlert,
-) -> usize {
-    let policies = match load_license_policy(policy_path) {
-        Ok(PolicyFileStatus::Ready(policies)) => policies,
-        _ => return 0,
+) -> Result<usize> {
+    // Fail closed: a read/parse failure here (e.g. the policy file was replaced or
+    // removed mid-scan) propagates as an error rather than being treated as zero
+    // violations. A soft error (empty/duplicate keys) under `--fail-on` already
+    // failed the run in the pipeline, so treat it as no declared violations here.
+    let policies = match load_license_policy(policy_path)? {
+        PolicyFileStatus::Ready(policies) => policies,
+        PolicyFileStatus::SoftError(_) => return Ok(0),
     };
 
     let mut severity: BTreeMap<String, ComplianceAlert> = BTreeMap::new();
@@ -159,7 +163,7 @@ pub(crate) fn count_declared_license_policy_violations(
         }
     }
     if severity.is_empty() {
-        return 0;
+        return Ok(0);
     }
 
     let violates = |expression: &Option<String>| -> bool {
@@ -182,7 +186,7 @@ pub(crate) fn count_declared_license_policy_violations(
         })
         .count();
 
-    package_hits + dependency_hits
+    Ok(package_hits + dependency_hits)
 }
 
 /// True when any license key in `expression` maps to a severity at or above `threshold`.

--- a/src/post_processing/license_policy.rs
+++ b/src/post_processing/license_policy.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
@@ -12,7 +12,7 @@ use anyhow::{Result, anyhow};
 use serde::Deserialize;
 
 use crate::license_detection::expression::{LicenseExpression, parse_expression};
-use crate::models::{FileInfo, LicensePolicyEntry};
+use crate::models::{ComplianceAlert, FileInfo, LicensePolicyEntry, Package, TopLevelDependency};
 
 #[derive(Debug, Deserialize)]
 struct LicensePolicyFile {
@@ -128,10 +128,122 @@ fn collect_expression_keys(expression: &LicenseExpression, keys: &mut BTreeSet<S
     }
 }
 
+/// Count top-level packages and dependencies whose **declared** license matches a
+/// policy entry with a `compliance_alert` at or above `threshold`. This lets the
+/// `--fail-on` gate act on package/dependency licenses (SCA-style), not just
+/// file-level detections. Returns 0 if the policy carries no severities or cannot
+/// be loaded (file findings are gated separately, and an unevaluable policy under
+/// `--fail-on` already fails the run before this point).
+pub(crate) fn count_declared_license_policy_violations(
+    policy_path: &Path,
+    packages: &[Package],
+    dependencies: &[TopLevelDependency],
+    threshold: ComplianceAlert,
+) -> usize {
+    let policies = match load_license_policy(policy_path) {
+        Ok(PolicyFileStatus::Ready(policies)) => policies,
+        _ => return 0,
+    };
+
+    let mut severity: BTreeMap<String, ComplianceAlert> = BTreeMap::new();
+    for policy in &policies {
+        if let Some(alert) = policy.compliance_alert {
+            severity
+                .entry(policy.license_key.clone())
+                .and_modify(|current| {
+                    if alert > *current {
+                        *current = alert;
+                    }
+                })
+                .or_insert(alert);
+        }
+    }
+    if severity.is_empty() {
+        return 0;
+    }
+
+    let violates = |expression: &Option<String>| -> bool {
+        expression
+            .as_deref()
+            .is_some_and(|expr| declared_expression_violates(expr, &severity, threshold))
+    };
+
+    let package_hits = packages
+        .iter()
+        .filter(|package| violates(&package.declared_license_expression))
+        .count();
+    let dependency_hits = dependencies
+        .iter()
+        .filter(|dependency| {
+            dependency
+                .resolved_package
+                .as_ref()
+                .is_some_and(|resolved| violates(&resolved.declared_license_expression))
+        })
+        .count();
+
+    package_hits + dependency_hits
+}
+
+/// True when any license key in `expression` maps to a severity at or above `threshold`.
+fn declared_expression_violates(
+    expression: &str,
+    severity: &BTreeMap<String, ComplianceAlert>,
+    threshold: ComplianceAlert,
+) -> bool {
+    let mut keys = BTreeSet::new();
+    if collect_license_keys(expression, &mut keys).is_err() {
+        return false;
+    }
+    keys.iter()
+        .any(|key| severity.get(key).is_some_and(|alert| *alert >= threshold))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::apply_license_policy_from_file;
-    use crate::models::{FileInfo, FileType, LicenseDetection};
+    use super::{apply_license_policy_from_file, declared_expression_violates};
+    use crate::models::{ComplianceAlert, FileInfo, FileType, LicenseDetection};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn declared_expression_violates_respects_keys_and_threshold() {
+        let severity: BTreeMap<String, ComplianceAlert> = [
+            ("gpl-3.0".to_string(), ComplianceAlert::Error),
+            ("lgpl-2.1".to_string(), ComplianceAlert::Warning),
+        ]
+        .into_iter()
+        .collect();
+
+        // Error-severity key trips both thresholds.
+        assert!(declared_expression_violates(
+            "gpl-3.0",
+            &severity,
+            ComplianceAlert::Error
+        ));
+        // Present in a compound expression.
+        assert!(declared_expression_violates(
+            "mit OR gpl-3.0",
+            &severity,
+            ComplianceAlert::Error
+        ));
+        // Warning key trips `warning` but not `error`.
+        assert!(declared_expression_violates(
+            "lgpl-2.1",
+            &severity,
+            ComplianceAlert::Warning
+        ));
+        assert!(!declared_expression_violates(
+            "lgpl-2.1",
+            &severity,
+            ComplianceAlert::Error
+        ));
+        // Unlisted / approved license never violates.
+        assert!(!declared_expression_violates(
+            "mit",
+            &severity,
+            ComplianceAlert::Warning
+        ));
+    }
 
     #[test]
     fn apply_license_policy_populates_matching_file_entries() {

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -14,7 +14,9 @@ use glob::Pattern;
 use serde_json::{Map, Value};
 
 use self::classification::apply_file_classification;
-pub(crate) use self::license_policy::apply_license_policy_from_file;
+pub(crate) use self::license_policy::{
+    apply_license_policy_from_file, count_declared_license_policy_violations,
+};
 pub(crate) use self::license_references::collect_top_level_license_references;
 use self::output_indexes::{OutputIndexMode, OutputIndexes};
 use self::package_file_index::PackageFileIndex;


### PR DESCRIPTION
## Summary

- The `--fail-on` compliance gate previously evaluated only **file-level detected** licenses. It now also fails the build when a **top-level package's or dependency's declared** license expression matches a policy at or above the given severity — SCA-style gating ("does any dependency carry GPL?").
- Package/dependency evaluation runs in the gate against the assembled top-level `packages` and `dependencies` (declared license expressions), in addition to the existing file-level check. File-level SARIF is unchanged.
- Updates ADR 0011's scope note and the CLI guide.

## Scope and exclusions

- Included: `count_declared_license_policy_violations` in `license_policy.rs`, wired into the `cli/run` gate; ADR + CLI-guide updates; a unit test for the key/threshold matching.
- Excluded: no `license_policy` field added to the `Package`/`TopLevelDependency` **output** structs (43 construction sites; not worth the churn for gate-only value), so package/dependency violations surface via the **gate + logged summary**, not SARIF. SARIF stays file-level (the actionable inline surface).

## How to verify

Beyond CI:

```sh
printf '{ "name":"demo","version":"1.0.0","license":"GPL-3.0-only" }' > /tmp/pkg/package.json
printf 'license_policies:\n  - license_key: gpl-3.0\n    label: Prohibited\n    compliance_alert: error\n' > /tmp/policy.yml
provenant scan /tmp/pkg --package --license-policy /tmp/policy.yml --fail-on error --json-pp -; echo "exit=$?"   # => 3
# switch the manifest to "MIT" => exit 0
```

Verified locally: GPL-3.0 package → exit 3 (flags the manifest file *and* the assembled package); MIT → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)