### PR TITLE
test(scanner): verify CRLF files report correct detection line spans

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # file sizes, hashes, and detection line spans, desyncing the smoke golden. The
 # fixture is meant to test scanner behavior, not git's EOL handling.
 testdata/smoke/** text eol=lf
+
+# CRLF line-span test fixture: preserve exact bytes (do not normalize EOL).
+testdata/crlf/** -text

--- a/docs/OUTPUT_FIELD_REFERENCE.md
+++ b/docs/OUTPUT_FIELD_REFERENCE.md
@@ -211,23 +211,23 @@ File-level holder evidence record.
 
 Match record used for clue output, grouped detections, and top-level representative references.
 
-| JSON field                 | Value shape             | Key presence                 | Meaning                                                            |
-| -------------------------- | ----------------------- | ---------------------------- | ------------------------------------------------------------------ |
-| `license_expression`       | `string`                | Always emitted.              | License expression assigned to this individual match.              |
-| `license_expression_spdx`  | `string`                | Always emitted.              | SPDX-form expression assigned to this individual match.            |
-| `from_file`                | `string \| null`        | Always emitted.              | Origin file path associated with the match record.                 |
-| `start_line`               | `integer`               | Always emitted.              | First line covered by the match.                                   |
-| `end_line`                 | `integer`               | Always emitted.              | Last line covered by the match.                                    |
-| `matcher`                  | `string \| null`        | Emitted only when available. | Matcher kind that produced the match.                              |
-| `score`                    | `number`                | Always emitted.              | Match score on the public output scale.                            |
-| `matched_length`           | `integer \| null`       | Emitted only when available. | Matched token/text length when tracked.                            |
-| `match_coverage`           | `number \| null`        | Emitted only when available. | Coverage ratio for the match when tracked.                         |
-| `rule_relevance`           | `integer \| null`       | Emitted only when available. | Rule relevance score when tracked.                                 |
-| `rule_identifier`          | `string \| null`        | Emitted only when available. | Identifier of the matched rule when available.                     |
-| `rule_url`                 | `string \| null`        | Always emitted.              | Rule URL when available.                                           |
-| `matched_text`             | `string \| null`        | Emitted only when available. | Matched text payload when text output is enabled.                  |
-| `matched_text_diagnostics` | `string \| null`        | Emitted only when available. | Diagnostic rendering of the matched text when enabled.             |
-| `referenced_filenames`     | `array<string> \| null` | Emitted only when available. | Referenced filenames captured on the matched rule when applicable. |
+| JSON field                 | Value shape             | Key presence                 | Meaning                                                                                 |
+| -------------------------- | ----------------------- | ---------------------------- | --------------------------------------------------------------------------------------- |
+| `license_expression`       | `string`                | Always emitted.              | License expression assigned to this individual match.                                   |
+| `license_expression_spdx`  | `string`                | Always emitted.              | SPDX-form expression assigned to this individual match.                                 |
+| `from_file`                | `string \| null`        | Always emitted.              | Repo-relative path of the file the match came from (same value as the resource `path`). |
+| `start_line`               | `integer`               | Always emitted.              | First line covered by the match.                                                        |
+| `end_line`                 | `integer`               | Always emitted.              | Last line covered by the match.                                                         |
+| `matcher`                  | `string \| null`        | Emitted only when available. | Matcher kind that produced the match.                                                   |
+| `score`                    | `number`                | Always emitted.              | Match score on the public output scale.                                                 |
+| `matched_length`           | `integer \| null`       | Emitted only when available. | Matched token/text length when tracked.                                                 |
+| `match_coverage`           | `number \| null`        | Emitted only when available. | Coverage ratio for the match when tracked.                                              |
+| `rule_relevance`           | `integer \| null`       | Emitted only when available. | Rule relevance score when tracked.                                                      |
+| `rule_identifier`          | `string \| null`        | Emitted only when available. | Identifier of the matched rule when available.                                          |
+| `rule_url`                 | `string \| null`        | Always emitted.              | Rule URL when available.                                                                |
+| `matched_text`             | `string \| null`        | Emitted only when available. | Matched text payload when text output is enabled.                                       |
+| `matched_text_diagnostics` | `string \| null`        | Emitted only when available. | Diagnostic rendering of the matched text when enabled.                                  |
+| `referenced_filenames`     | `array<string> \| null` | Emitted only when available. | Referenced filenames captured on the matched rule when applicable.                      |
 
 ## `OutputLicenseDetection`
 

--- a/src/output_schema/metadata/license.rs
+++ b/src/output_schema/metadata/license.rs
@@ -108,7 +108,7 @@ pub(super) const MATCH_FIELDS: &[OutputFieldDoc] = &[
         rust_field: "from_file",
         value_shape: "string | null",
         presence: "Always emitted.",
-        meaning: "Origin file path associated with the match record.",
+        meaning: "Repo-relative path of the file the match came from (same value as the resource `path`).",
     },
     OutputFieldDoc {
         json_name: "start_line",

--- a/testdata/crlf/app.c
+++ b/testdata/crlf/app.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// Copyright (c) 2021 CRLF Example, Inc.
+
+int main(void) {
+    return 0;
+}

--- a/tests/scanner_integration.rs
+++ b/tests/scanner_integration.rs
@@ -1353,3 +1353,54 @@ fn test_scanner_respects_email_url_thresholds() {
     assert_eq!(file.emails.len(), 2);
     assert_eq!(file.urls.len(), 2);
 }
+
+#[test]
+fn crlf_files_report_correct_line_spans() {
+    // testdata/crlf/app.c uses CRLF line endings (byte-pinned via .gitattributes):
+    // the SPDX license is on line 1 and the copyright on line 3. Guards against
+    // miscounting CRLF lines when computing detection line spans.
+    let patterns: Vec<Pattern> = vec![];
+    let engine = create_license_detection_engine();
+    let options = TextDetectionOptions {
+        collect_info: false,
+        detect_packages: false,
+        detect_application_packages: false,
+        detect_system_packages: false,
+        detect_packages_in_compiled: false,
+        detect_copyrights: true,
+        detect_generated: false,
+        detect_emails: false,
+        detect_urls: false,
+        max_emails: 50,
+        max_urls: 50,
+        timeout_seconds: 120.0,
+    };
+
+    let result = scan(
+        "testdata/crlf",
+        10,
+        &patterns,
+        engine,
+        false,
+        Some(&options),
+    );
+    let file = result
+        .files
+        .iter()
+        .find(|f| f.file_type == FileType::File && f.path.ends_with("app.c"))
+        .expect("should find the CRLF fixture file");
+
+    // Copyright is on the third CRLF line.
+    assert_eq!(file.copyrights.len(), 1);
+    assert_eq!(file.copyrights[0].start_line, LineNumber::new(3).unwrap());
+    assert_eq!(file.copyrights[0].end_line, LineNumber::new(3).unwrap());
+
+    // SPDX MIT identifier is on the first line.
+    let mit_match = file
+        .license_detections
+        .iter()
+        .flat_map(|detection| detection.matches.iter())
+        .find(|m| m.license_expression == "mit")
+        .expect("should detect MIT on the CRLF file");
+    assert_eq!(mit_match.start_line, LineNumber::ONE);
+}


### PR DESCRIPTION
## Summary

- Adds a **byte-pinned CRLF fixture** (`testdata/crlf/app.c`, pinned with `.gitattributes` `-text` so the CRLF bytes survive checkout on every OS) — SPDX license on line 1, copyright on line 3 — plus an integration test asserting the detected line spans.
- Closes the CRLF gap deferred from the cross-platform smoke test (whose fixture is LF-pinned): this guards against miscounting CRLF lines when computing detection `start_line`/`end_line`.
- Also sharpens the `from_file` output-field doc to state it is the repo-relative path equal to the resource `path` (matching #1254) and regenerates `OUTPUT_FIELD_REFERENCE.md`.

## How to verify

`cargo test --test scanner_integration crlf_files_report_correct_line_spans` — asserts copyright at line 3 and MIT at line 1 on the CRLF file. (Verified: the committed blob retains 7 CRs.)

## Expected-output fixture changes

- New `testdata/crlf/app.c` (fixture, not a golden) + a one-line `OUTPUT_FIELD_REFERENCE.md` description refresh. No golden output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)