### PR TITLE
ci: add per-OS cargo install verification workflow

### DIFF
--- a/.github/workflows/platform-verify.yml
+++ b/.github/workflows/platform-verify.yml
@@ -16,6 +16,11 @@ on:
         default: ""
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  # TEMPORARY: one-time PR validation trigger. Remove before this branch is
+  # merged/closed — the canonical entry points are workflow_dispatch + schedule.
+  pull_request:
+    branches: [main]
+    paths: [.github/workflows/platform-verify.yml]
 
 permissions:
   contents: read

--- a/.github/workflows/platform-verify.yml
+++ b/.github/workflows/platform-verify.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Post-release platform verification: installs the published crate on each OS and
+# runs it, so per-OS install/link/runtime regressions are caught outside the normal
+# PR matrix. Manual (workflow_dispatch) plus a weekly schedule.
+name: Platform Verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "provenant-cli version to install (blank = latest)"
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-install:
+    name: cargo install (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: cargo install provenant-cli
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            cargo install --locked provenant-cli --version "${{ inputs.version }}"
+          else
+            cargo install --locked provenant-cli
+          fi
+
+      - name: Run the installed binary
+        shell: bash
+        run: |
+          provenant --version
+          provenant scan --help >/dev/null
+          # A real scan of a tiny tree, exercising the installed binary end to end.
+          mkdir -p sample/src
+          printf '// SPDX-License-Identifier: MIT\n// Copyright (c) 2021 X\nint main(void){return 0;}\n' > sample/src/app.c
+          provenant scan sample --license --copyright --json-pp - | grep -q '"detected_license_expression_spdx": "MIT"'
+          echo "OK: installed provenant scans on ${{ matrix.os }}"

--- a/.github/workflows/platform-verify.yml
+++ b/.github/workflows/platform-verify.yml
@@ -37,9 +37,13 @@ jobs:
 
       - name: cargo install provenant-cli
         shell: bash
+        # Pass the dispatch input via the environment, never interpolated into the
+        # shell source, so a crafted `version` can't inject commands.
+        env:
+          PROVENANT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            cargo install --locked provenant-cli --version "${{ inputs.version }}"
+          if [ -n "${PROVENANT_VERSION}" ]; then
+            cargo install --locked provenant-cli --version "${PROVENANT_VERSION}"
           else
             cargo install --locked provenant-cli
           fi
@@ -50,7 +54,9 @@ jobs:
           provenant --version
           provenant scan --help >/dev/null
           # A real scan of a tiny tree, exercising the installed binary end to end.
+          # Write to a file so the scan's own exit status is checked, not grep's.
           mkdir -p sample/src
           printf '// SPDX-License-Identifier: MIT\n// Copyright (c) 2021 X\nint main(void){return 0;}\n' > sample/src/app.c
-          provenant scan sample --license --copyright --json-pp - | grep -q '"detected_license_expression_spdx": "MIT"'
-          echo "OK: installed provenant scans on ${{ matrix.os }}"
+          provenant scan sample --license --copyright --json-pp scan.json
+          grep -q '"detected_license_expression_spdx": "MIT"' scan.json
+          echo "OK: installed provenant scans"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/platform-verify.yml`: installs the **published** `provenant-cli` on **ubuntu / macOS / windows** and runs a real scan (`--version`, `scan --help`, and a tiny MIT scan asserting the detected SPDX expression).
- Catches per-OS **install / link / runtime** regressions in the actual published artifact — outside the normal PR matrix (which builds from source, not the packaged+published crate).
- Trigger: `workflow_dispatch` (with an optional `version` input) + a weekly cron.

## Scope

This is the first of three platform-verification items. The other two — **TLS trust in the musl/distroless container** and **Windows MAX_PATH/symlink behavior** — are scoped in the PR discussion; both need more setup (serve orchestration; Windows long-path/symlink privileges) and are proposed as follow-ups.

## How to verify

After merge: `gh workflow run platform-verify.yml -f version=0.2.4` and confirm all three OS jobs install + scan green. (Schedule keeps it running weekly against `latest`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)