### PR TITLE
docs: fix stale references found in a docs-wide audit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,7 +548,7 @@ Provenant separates internal domain types from the ScanCode-compatible JSON outp
 
 - **Internal types** (`src/models/`) carry domain invariants (e.g., `LineNumber` wraps `NonZeroUsize`, `Sha1Digest` validates hex length). They retain serde only for cache round-tripping and `--from-json` deserialization.
 - **Output schema types** (`src/output_schema/`) are dedicated serde-enabled types that define the public JSON schema: field renames, conditional omission, type widening (`LineNumber` → `u64`, digests → `Option<String>`), and the `FileInfo` info-surface gating logic.
-- **Conversion boundary** in `main.rs` converts `models::Output` → `output_schema::Output` before serialization. The `--from-json` path deserializes into output schema types and converts back via `TryFrom`.
+- **Conversion boundary** in `src/cli/run/mod.rs` converts `models::Output` → `output_schema::Output` before serialization. The `--from-json` path deserializes into output schema types and converts back via `TryFrom`.
 
 See [ADR 0008: Output Schema Type Separation](adr/0008-output-schema-separation.md) for the full decision record.
 
@@ -611,7 +611,7 @@ Centralized `ScanProgress` struct manages mode-aware progress output via `indica
 4. **Assembly and output phases**: Phase messages/spinners with timing capture.
 5. **Scan summary**: Files/sec, bytes/sec, error count, initial/final counts (including sizes), package assembly counts, ScanCode-style scan timestamps, and total wall time; the full per-phase timing breakdown is shown only under `--verbose`.
 
-Verbosity behavior is implemented in `src/progress.rs` and wired through `src/main.rs`: quiet suppresses stderr output, default shows progress/summary, and verbose stays detailed without flooding redirected logs by limiting successful per-file path output to TTY runs while still surfacing per-file warnings/errors in non-TTY environments.
+Verbosity behavior is implemented in `src/progress.rs` and wired through `src/cli/run/mod.rs`: quiet suppresses stderr output, default shows progress/summary, and verbose stays detailed without flooding redirected logs by limiting successful per-file path output to TTY runs while still surfacing per-file warnings/errors in non-TTY environments.
 
 Logging integration uses `indicatif-log-bridge` for startup and global warnings, while parser and other file-scoped scan failures are attached to `FileInfo.scan_diagnostics` in the scanner process pipeline under `src/scanner/process/` (primarily `pipeline.rs`). That keeps serialized output, CI logs, and the quiet/default/verbose progress modes aligned: default mode shows concise failing paths, verbose mode shows the underlying per-file error details.
 
@@ -636,7 +636,7 @@ The binary ships with a built-in license index embedded at compile time. This el
 - **Embedded artifact**: `resources/license_detection/license_index.zst`
 - **Embedded build policy**: compile-time-bundled from `resources/license_detection/index_build_policy.toml`
 - **Embedded overlay files**: compile-time-bundled from `resources/license_detection/overlay/`
-- **Format**: MessagePack-serialized, zstd-compressed `EmbeddedLoaderSnapshot` data
+- **Format**: postcard-serialized, zstd-compressed `EmbeddedLoaderSnapshot` data
 - **Contents**: Sorted `LoadedRule` and `LoadedLicense` values derived from the ScanCode rules dataset
 - **Structured provenance surface**: `headers[0].extra_data.license_index_provenance`
 - **Exported custom dataset root**: `manifest.json` + `rules/` + `licenses/`

--- a/docs/LICENSE_DETECTION_ARCHITECTURE.md
+++ b/docs/LICENSE_DETECTION_ARCHITECTURE.md
@@ -102,7 +102,7 @@ verify the target key resolves in the index).
 ### Initialization Flow
 
 ```text
-main.rs::init_license_engine()
+scan_runtime::init_license_engine()
     │
     ├── No --license-dataset-path specified (default)
     │       ↓
@@ -112,7 +112,7 @@ main.rs::init_license_engine()
     │       ├── Yes → Load CachedLicenseIndex from rkyv cache
     │       │         → Convert to LicenseIndex
     │       └── No  → Decompress embedded artifact (zstd)
-    │                 → Deserialize LoadedRule/LoadedLicense (MessagePack)
+    │                 → Deserialize LoadedRule/LoadedLicense (postcard)
     │                 → Build LicenseIndex
     │                 → Save rkyv cache with fingerprint prefix
     │
@@ -140,7 +140,7 @@ main.rs::init_license_engine()
 The binary includes a pre-built license index embedded at compile time:
 
 - **Location**: `resources/license_detection/license_index.zst`
-- **Format**: MessagePack serialization, zstd compression
+- **Format**: postcard serialization, zstd compression
 - **Contents**: sorted `LoadedRule` and `LoadedLicense` values derived from the ScanCode rules dataset
 
 ### Loader/Build Stage Separation
@@ -156,7 +156,7 @@ The loading process is split into two distinct stages:
 - Fail fast if an ignore id no longer exists upstream, an overlay-reason entry is stale or missing, or an overlay file becomes identical to upstream data
 - Canonicalize `LicenseRef-scancode-*` SPDX keys so each mirrors its license key (see the `LicenseRef-*` namespace convention above)
 - Sort embedded rules and licenses deterministically
-- Serialize the embedded loader snapshot with MessagePack
+- Serialize the embedded loader snapshot with postcard
 - Compress the serialized bytes with zstd
 
 **Build Stage** (runtime):
@@ -212,25 +212,28 @@ The orchestrator that coordinates the detection pipeline. Its durable responsibi
 
 Pre-computed data structures for efficient matching:
 
-| Field                   | Purpose                                      |
-| ----------------------- | -------------------------------------------- |
-| `dictionary`            | Token → ID mapping                           |
-| `len_legalese`          | Count of high-value legalese tokens          |
-| `digit_only_tids`       | Set of digit-only token IDs                  |
-| `rules_by_rid`          | Rules indexed by ID                          |
-| `tids_by_rid`           | Token ID sequences per rule                  |
-| `rid_by_hash`           | SHA1 hash → rule ID (exact match)            |
-| `rules_automaton`       | Aho-Corasick automaton for all rules         |
-| `unknown_automaton`     | Automaton for unknown license detection      |
-| `sets_by_rid`           | Unique token sets per rule                   |
-| `msets_by_rid`          | Token frequency maps per rule                |
-| `high_postings_by_rid`  | Inverted index for candidate selection       |
-| `regular_rids`          | Set of regular (non-false-positive) rule IDs |
-| `false_positive_rids`   | Set of false-positive rule IDs               |
-| `approx_matchable_rids` | Set of approx-matchable rule IDs             |
-| `licenses_by_key`       | ScanCode key → License mapping               |
-| `rid_by_spdx_key`       | SPDX license key → rule ID                   |
-| `unknown_spdx_rid`      | Rule ID for unknown-spdx fallback            |
+Representative fields (see the `LicenseIndex` struct for the full set):
+
+| Field                         | Purpose                                            |
+| ----------------------------- | -------------------------------------------------- |
+| `dictionary`                  | Token → ID mapping                                 |
+| `len_legalese`                | Count of high-value legalese tokens                |
+| `rules_by_rid`                | Rules indexed by ID                                |
+| `tids_by_rid`                 | Token ID sequences per rule                        |
+| `rid_by_hash`                 | SHA1 hash → rule ID (exact match)                  |
+| `rules_automaton`             | Aho-Corasick automaton for all rules               |
+| `unknown_automaton`           | Automaton for unknown license detection            |
+| `sets_by_rid`                 | Unique token sets per rule                         |
+| `msets_by_rid`                | Token frequency maps per rule                      |
+| `high_sets_by_rid`            | High/legalese-token sets per rule                  |
+| `high_bitsets_by_rid`         | Bitset form of the high-token sets per rule        |
+| `high_postings_by_rid`        | Inverted index for candidate selection             |
+| `rids_by_high_tid`            | Rules containing each high token                   |
+| `rule_metadata_by_identifier` | Rule metadata keyed by rule identifier             |
+| `licenses_by_key`             | ScanCode key → License mapping                     |
+| `rid_by_spdx_key`             | SPDX license key → rule ID                         |
+| `unknown_spdx_rid`            | Rule ID for unknown-spdx fallback                  |
+| `spdx_license_list_version`   | SPDX license-list version the index was built from |
 
 ### Query
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,7 +7,7 @@ This guide documents the maintainer release flow for `provenant`.
 Releases are split into two phases:
 
 1. local release preparation with `release.sh`, which refreshes the embedded license data, runs the release-time sync checks, prepares the release commit, and pushes the release tag
-2. tag-triggered GitHub Actions publication, which publishes `provenant-cli` to crates.io via trusted publishing and creates the GitHub Release assets
+2. tag-triggered GitHub Actions publication, which creates the GitHub Release assets, publishes `provenant-cli` to crates.io via trusted publishing, and pushes a container image to GHCR
 
 The published crate name is `provenant-cli`, while the installed binary and product name remain `provenant` / Provenant.
 
@@ -75,12 +75,15 @@ Pushing the `vX.Y.Z` tag triggers `.github/workflows/release.yml`.
 That workflow:
 
 - verifies release invariants on the tagged commit, including version/tag alignment and crates.io dry-run packaging
-- Builds release binaries for Linux, macOS (Intel and Apple Silicon), and Windows
-- publishes `provenant-cli` to crates.io via trusted publishing
 - Re-runs embedded license index verification as a final release-time safeguard before building artifacts
+- Builds release binaries for Linux, macOS (Intel and Apple Silicon), and Windows
 - Packages each build under the `provenant-<platform>-<arch>` naming scheme
 - Generates SHA256 checksum files
-- Creates a GitHub Release and uploads all generated assets
+- Creates a GitHub Release, attaches SLSA build-provenance attestation for the release archives, and uploads all generated assets
+- Publishes `provenant-cli` to crates.io via trusted publishing
+- Publishes a multi-arch container image to `ghcr.io/getprovenant/provenant`
+
+The GitHub Release (binaries + attestation) is produced independently of the crates.io and GHCR publishes: those jobs run in parallel and depend only on the build, so a crates.io or GHCR outage does not fail or skip the Release.
 
 If the tag contains `-`, GitHub marks the release as a prerelease.
 
@@ -90,11 +93,11 @@ Monitor the [GitHub Actions release workflow](https://github.com/getprovenant/pr
 
 Verify:
 
-- The crates.io publish job in the GitHub Actions release workflow succeeded
 - The tag and release commit are present on the remote
 - The GitHub Release contains all expected Linux, macOS (Intel and Apple Silicon), and Windows archives and checksum files
+- The crates.io publish job succeeded and the container image was pushed to GHCR
 
-If the GitHub Release asset step fails after crates.io publish has already succeeded, rerun only the failed downstream jobs. Do not rerun the successful crates.io publish job for the same version.
+The crates.io and GHCR publish jobs are independent of the GitHub Release: if one fails, rerun only that failed job for the same version. The Release itself does not depend on them, so a publish failure never requires re-cutting the Release.
 
 ## Common Failure Points
 

--- a/docs/adr/0005-auto-generated-docs.md
+++ b/docs/adr/0005-auto-generated-docs.md
@@ -183,7 +183,7 @@ The generator iterates the registered parser metadata, renders a normalized Mark
 3. **Rust Doc Comments Required**
    - Contributors must write `///` comments
    - More verbose than Python docstrings
-   - **Acceptable**: Standard Rust practice, enforced by `#![deny(missing_docs)]`
+   - **Acceptable**: Standard Rust practice, kept as a contributor convention
 
 ## Alternatives Considered
 

--- a/docs/adr/0008-output-schema-separation.md
+++ b/docs/adr/0008-output-schema-separation.md
@@ -32,7 +32,7 @@ Separate the ScanCode-compatible output schema from internal types:
 
 2. **Internal types** (`src/models/`) retain serde for cache round-tripping and `--from-json` deserialization. Output-specific attributes (`skip_serializing_if`, `serialize_with`, custom `Serialize` impls) are removed from internal types.
 
-3. **Conversion boundary** — `From<&InternalType>` converts internal → output at the serialization boundary in `main.rs`. `TryFrom<&OutputType>` converts output → internal for the `--from-json` path, with validation at the conversion boundary.
+3. **Conversion boundary** — `From<&InternalType>` converts internal → output at the serialization boundary in `src/cli/run/mod.rs`. `TryFrom<&OutputType>` converts output → internal for the `--from-json` path, with validation at the conversion boundary.
 
 4. **Shared enums** (`FileType`, `DatasourceId`, `PackageType`) are reused directly in output types — not widened to `String`. These enums have their own serde impls that are shared between internal and output contexts.
 
@@ -49,7 +49,7 @@ Separate the ScanCode-compatible output schema from internal types:
 
 ### Scope boundaries
 
-- License detection internal types (`src/license_detection/`) still have serde for the embedded index artifact (MessagePack). That is a separate serialization concern and is out of scope for this ADR.
+- License detection internal types (`src/license_detection/`) still have serde for the embedded index artifact (postcard). That is a separate serialization concern and is out of scope for this ADR.
 - Parser-private deserialization types are out of scope — they parse external file formats, not the Provenant output schema.
 
 ## Consequences
@@ -89,6 +89,6 @@ Would ensure schema consistency but adds a build-time code generation step and m
 ## References
 
 - Output schema module: `src/output_schema/`
-- Conversion boundary: `src/main.rs` (where `models::Output` → `output_schema::Output`)
+- Conversion boundary: `src/cli/run/mod.rs` (where `models::Output` → `output_schema::Output`)
 - `--from-json` deserialization: `src/scan_result_shaping/json_input.rs`
 - Cache serialization: `src/cache/incremental.rs`

--- a/docs/adr/0010-package-license-from-cohosted-files.md
+++ b/docs/adr/0010-package-license-from-cohosted-files.md
@@ -24,13 +24,13 @@ ScanCode `apache-2.0` from the repo's root `LICENSE`; Provenant `null`). It is
   that co-located key-file promotion "promotes only copyright/holder, never the
   declared license."
 - The post-assembly pass `apply_package_reference_following`
-  (`src/post_processing/reference_following.rs:856-899`) **does** adopt a license
+  (`src/post_processing/reference_following.rs`) **does** adopt a license
   into the package declared expression, but only the manifest's **own** file-level
   detection or a file the manifest **references** (e.g. a `license-file` / "see
   LICENSE" pointer). Its comment is explicit: it "never adopts arbitrary
   co-located files."
 - `promote_package_metadata_from_key_files`
-  (`src/post_processing/package_metadata_promotion.rs:28-61`) already promotes
+  (`src/post_processing/package_metadata_promotion.rs`) already promotes
   `copyright` and `holder` from co-located key files when the package lacks them —
   but intentionally **not** the declared license.
 
@@ -439,9 +439,9 @@ the assembled `pkg:golang/.../terraform` package gains `bsl-1.1 AND mpl-2.0`.
 
 ## References
 
-- `src/post_processing/reference_following.rs:856-899` — existing manifest-referenced
+- `src/post_processing/reference_following.rs` — existing manifest-referenced
   license adoption ("never adopts arbitrary co-located files").
-- `src/post_processing/package_metadata_promotion.rs:28-61` — co-located key-file
+- `src/post_processing/package_metadata_promotion.rs` — co-located key-file
   promotion of copyright/holder (excludes declared license).
 - `src/parsers/go.rs`, `src/parsers/autotools.rs`, `src/parsers/swift_manifest_json.rs`,
   `src/parsers/bazel.rs` — formats with no declared-license field.


### PR DESCRIPTION
## What & why

A docs-wide staleness audit (verifying concrete doc claims against current code) turned up a handful of references that drifted from the code. This corrects them. Docs-only; no behavior change.

| Doc | Fix |
|-----|-----|
| ARCHITECTURE.md, ADR 0008 | Conversion/verbosity boundary is in `src/cli/run/mod.rs` — there is no `src/main.rs` (binary is `src/bin/provenant.rs`). |
| LICENSE_DETECTION_ARCHITECTURE.md, ARCHITECTURE.md, ADR 0008 | Embedded license-index artifact is serialized with **postcard**, not MessagePack; init entry point is `scan_runtime::init_license_engine()`. |
| LICENSE_DETECTION_ARCHITECTURE.md | `LicenseIndex` field table listed 4 fields that no longer exist (`digit_only_tids`, `regular_rids`, `false_positive_rids`, `approx_matchable_rids`) → replaced with current representative fields. |
| ADR 0005 | Doc comments are a contributor convention, not enforced by `#![deny(missing_docs)]` (that lint is set nowhere). |
| ADR 0010 | Dropped drifted line-span citations in favor of function-name references. |
| RELEASING.md | GitHub Release is now independent of crate/image publishing (#1253); documented the GHCR image publish and the build-provenance attestation (#1241). |

`SERVE_API_GUIDE.md` staleness from the same audit is handled in #1260.

Docs audited and found clean (no changes): CLI_GUIDE, LIBRARY_GUIDE, OUTPUT_FIELD_REFERENCE (regenerates to zero diff), SUPPORTED_FORMATS (in sync), EVALUATING_WITH_SCANCODE_WORKFLOWS, DOCUMENTATION_INDEX, BENCHMARKS, TESTING_STRATEGY, HOW_TO_ADD_A_PARSER, and ADRs 0001–0004/0006/0007/0009/0011.

## How to verify

`npm run check:docs` passes. Every corrected reference was checked against the current source (e.g. no `src/main.rs`; `postcard` in `xtask/src/bin/generate_index_artifact.rs` + `src/license_detection/embedded/index.rs`; the `LicenseIndex` struct in `src/license_detection/index/mod.rs`; `create-release` `needs: [build]` only in `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)