### PR TITLE
ci(release): auto-bump the Homebrew tap on stable releases

### DIFF
--- a/.github/homebrew/provenant.rb.tmpl
+++ b/.github/homebrew/provenant.rb.tmpl
@@ -1,0 +1,37 @@
+class Provenant < Formula
+  desc "Fast Rust code scanner for licenses, copyrights, and package provenance"
+  homepage "https://github.com/getprovenant/provenant"
+  version "@@VERSION@@"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/getprovenant/provenant/releases/download/@@TAG@@/provenant-macos-aarch64.tar.gz"
+      sha256 "@@SHA_MACOS_ARM@@"
+    end
+    on_intel do
+      url "https://github.com/getprovenant/provenant/releases/download/@@TAG@@/provenant-macos-x86_64.tar.gz"
+      sha256 "@@SHA_MACOS_INTEL@@"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/getprovenant/provenant/releases/download/@@TAG@@/provenant-linux-aarch64.tar.gz"
+      sha256 "@@SHA_LINUX_ARM@@"
+    end
+    on_intel do
+      url "https://github.com/getprovenant/provenant/releases/download/@@TAG@@/provenant-linux-x86_64.tar.gz"
+      sha256 "@@SHA_LINUX_INTEL@@"
+    end
+  end
+
+  def install
+    bin.install "provenant"
+    prefix.install "LICENSE", "NOTICE", "THIRD-PARTY-NOTICES.md"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/provenant --version")
+  end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,8 @@ jobs:
               --pattern "provenant-${arch}.tar.gz.sha256" --dir shas
           done
           sha() { awk '{print $1}' "shas/provenant-$1.tar.gz.sha256"; }
+          # Render to a temp file (not into the tap checkout): the push step
+          # re-syncs the tap on each attempt and re-applies this rendered formula.
           sed \
             -e "s|@@VERSION@@|${version}|g" \
             -e "s|@@TAG@@|${TAG}|g" \
@@ -394,26 +396,54 @@ jobs:
             -e "s|@@SHA_MACOS_INTEL@@|$(sha macos-x86_64)|" \
             -e "s|@@SHA_LINUX_ARM@@|$(sha linux-aarch64)|" \
             -e "s|@@SHA_LINUX_INTEL@@|$(sha linux-x86_64)|" \
-            .github/homebrew/provenant.rb.tmpl > tap/Formula/provenant.rb
+            .github/homebrew/provenant.rb.tmpl > "${RUNNER_TEMP}/provenant.rb"
           # Fail before pushing if the rendered formula is not valid Ruby or still
           # carries an unresolved placeholder.
-          ruby -c tap/Formula/provenant.rb
-          if grep -q '@@' tap/Formula/provenant.rb; then
+          ruby -c "${RUNNER_TEMP}/provenant.rb"
+          if grep -q '@@' "${RUNNER_TEMP}/provenant.rb"; then
             echo "Unresolved placeholder in rendered formula:" >&2
-            grep -n '@@' tap/Formula/provenant.rb >&2
+            grep -n '@@' "${RUNNER_TEMP}/provenant.rb" >&2
             exit 1
           fi
 
       - name: Commit and push to the tap
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          version="${TAG#v}"
           cd tap
-          if git diff --quiet -- Formula/provenant.rb; then
-            echo "Formula already at ${GITHUB_REF_NAME#v}; nothing to push."
-            exit 0
-          fi
           git config user.name "provenant-release-bot[bot]"
           git config user.email "provenant-release-bot[bot]@users.noreply.github.com"
-          git add Formula/provenant.rb
-          git commit -m "provenant ${GITHUB_REF_NAME#v}"
-          git push
+          formula="Formula/provenant.rb"
+          # Concurrent stable releases push to the same branch. Re-sync and retry on
+          # a rejected (non-fast-forward) push, and never downgrade the formula: if
+          # the tap already carries a newer version (another release won the race),
+          # skip instead of clobbering it.
+          for attempt in 1 2 3 4 5; do
+            git fetch --quiet origin main
+            git reset --quiet --hard origin/main
+            current="$(sed -nE 's/^  version "([^"]+)"/\1/p' "$formula" | head -1)"
+            if [ -n "$current" ] && [ "$current" != "$version" ]; then
+              newest="$(printf '%s\n%s\n' "$current" "$version" | sort -V | tail -1)"
+              if [ "$newest" = "$current" ]; then
+                echo "Tap already at $current (newer than $version); leaving it."
+                exit 0
+              fi
+            fi
+            cp "${RUNNER_TEMP}/provenant.rb" "$formula"
+            if git diff --quiet -- "$formula"; then
+              echo "Tap already at $version; nothing to push."
+              exit 0
+            fi
+            git add "$formula"
+            git commit --quiet -m "provenant ${version}"
+            if git push; then
+              echo "Bumped tap to $version."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); re-syncing and retrying." >&2
+            sleep 3
+          done
+          echo "Failed to push formula bump after retries." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,3 +338,82 @@ jobs:
           artifactErrorsFailBuild: true
           generateReleaseNotes: true
           prerelease: ${{ contains(github.ref, '-') }}
+
+  bump-homebrew:
+    name: Bump Homebrew formula
+    # Runs after the release exists (needs its assets + checksums). Stable tags
+    # only: the tap tracks releases, not prereleases. Skipped on forks.
+    needs: create-release
+    if: github.repository == 'getprovenant/provenant' && !contains(github.ref, '-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out provenant (for the formula template)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          submodules: false
+          lfs: false
+
+      # Least-privilege, short-lived token scoped to the tap repo only. Requires
+      # the provenant-release-bot GitHub App (RELEASE_BOT_APP_ID /
+      # RELEASE_BOT_PRIVATE_KEY secrets) installed on getprovenant/homebrew-tap.
+      - name: Mint a token for the tap repository
+        id: tap_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: getprovenant
+          repositories: homebrew-tap
+
+      - name: Check out the tap
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: getprovenant/homebrew-tap
+          token: ${{ steps.tap_token.outputs.token }}
+          path: tap
+
+      - name: Render the formula for this release
+        env:
+          # The app token is scoped to the tap; fetch the release checksums with
+          # the workflow's own repo token instead.
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          mkdir -p shas
+          for arch in macos-aarch64 macos-x86_64 linux-aarch64 linux-x86_64; do
+            gh release download "$TAG" --repo "${{ github.repository }}" \
+              --pattern "provenant-${arch}.tar.gz.sha256" --dir shas
+          done
+          sha() { awk '{print $1}' "shas/provenant-$1.tar.gz.sha256"; }
+          sed \
+            -e "s|@@VERSION@@|${version}|g" \
+            -e "s|@@TAG@@|${TAG}|g" \
+            -e "s|@@SHA_MACOS_ARM@@|$(sha macos-aarch64)|" \
+            -e "s|@@SHA_MACOS_INTEL@@|$(sha macos-x86_64)|" \
+            -e "s|@@SHA_LINUX_ARM@@|$(sha linux-aarch64)|" \
+            -e "s|@@SHA_LINUX_INTEL@@|$(sha linux-x86_64)|" \
+            .github/homebrew/provenant.rb.tmpl > tap/Formula/provenant.rb
+          # Fail before pushing if the rendered formula is not valid Ruby or still
+          # carries an unresolved placeholder.
+          ruby -c tap/Formula/provenant.rb
+          if grep -q '@@' tap/Formula/provenant.rb; then
+            echo "Unresolved placeholder in rendered formula:" >&2
+            grep -n '@@' tap/Formula/provenant.rb >&2
+            exit 1
+          fi
+
+      - name: Commit and push to the tap
+        run: |
+          set -euo pipefail
+          cd tap
+          if git diff --quiet -- Formula/provenant.rb; then
+            echo "Formula already at ${GITHUB_REF_NAME#v}; nothing to push."
+            exit 0
+          fi
+          git config user.name "provenant-release-bot[bot]"
+          git config user.email "provenant-release-bot[bot]@users.noreply.github.com"
+          git add Formula/provenant.rb
+          git commit -m "provenant ${GITHUB_REF_NAME#v}"
+          git push

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo install provenant-cli
 provenant scan --json-pp - --license --package /path/to/repo
 ```
 
-Prefer release binaries? Download precompiled archives from [GitHub Releases](https://github.com/getprovenant/provenant/releases).
+On macOS or Linux you can also `brew install getprovenant/tap/provenant`. Prefer release binaries? Download precompiled archives from [GitHub Releases](https://github.com/getprovenant/provenant/releases).
 
 ## Why Provenant?
 
@@ -63,6 +63,14 @@ Provenant is an independent project and is not affiliated with, endorsed by, or 
 | Evaluation path    | For teams evaluating Provenant against existing compatible workflows, see the [evaluation guide](docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md) for notes and differences |
 
 ## Install
+
+### Homebrew (macOS and Linux)
+
+```sh
+brew install getprovenant/tap/provenant
+```
+
+Installs a prebuilt `provenant` binary from the [Provenant tap](https://github.com/getprovenant/homebrew-tap); covers macOS (Apple Silicon and Intel) and Linux (arm64 and x86_64).
 
 ### From Crates.io
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,11 +81,14 @@ That workflow:
 - Generates SHA256 checksum files
 - Creates a GitHub Release, attaches SLSA build-provenance attestation for the release archives, and uploads all generated assets
 - Publishes `provenant-cli` to crates.io via trusted publishing
-- Publishes a multi-arch container image to `ghcr.io/getprovenant/provenant`
+- Publishes a multi-arch container image to `ghcr.io/getprovenant/provenant`, with its own SLSA build-provenance attestation
+- On a stable (non-prerelease) tag, bumps the Homebrew formula in [`getprovenant/homebrew-tap`](https://github.com/getprovenant/homebrew-tap) to the new version and checksums
 
 The GitHub Release (binaries + attestation) is produced independently of the crates.io and GHCR publishes: those jobs run in parallel and depend only on the build, so a crates.io or GHCR outage does not fail or skip the Release.
 
 If the tag contains `-`, GitHub marks the release as a prerelease.
+
+The Homebrew bump renders [`.github/homebrew/provenant.rb.tmpl`](../.github/homebrew/provenant.rb.tmpl) with the release version and per-arch checksums, validates it, and commits it directly to the tap. It authenticates with the `provenant-release-bot` GitHub App (via the `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` repository secrets); the app is installed on the tap repo with only `contents: write`.
 
 ## After Starting the Release
 


### PR DESCRIPTION
## What & why

Completes the Homebrew tap plan. The tap repo [`getprovenant/homebrew-tap`](https://github.com/getprovenant/homebrew-tap) is already live (`brew install getprovenant/tap/provenant` installs 0.2.5). This wires the release pipeline to keep it current automatically.

- **`.github/homebrew/provenant.rb.tmpl`** — the prebuilt-binary formula (macOS + Linux × arm64/x86_64) with `@@VERSION@@` / `@@TAG@@` / per-arch `@@SHA_*@@` placeholders.
- **`bump-homebrew` job** in `release.yml` (after `create-release`, **stable tags only**, skipped on forks): fetches the release checksums, renders the template, **validates** (`ruby -c` + fails on any unresolved placeholder), and **direct-commits** to the tap.
- **Auth**: `provenant-release-bot` GitHub App → a short-lived token scoped to `homebrew-tap` with only `contents: write` (`RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` secrets, already set).
- **Docs**: `brew install` in the README; bump flow in RELEASING.

## How to verify

The bump job can only run on a real release, so it's exercised on the **next** stable tag. Pre-merge validation done locally:
- `release.yml` YAML parses; `ruby -c` on the rendered formula passes.
- The render step reproduces the current tap formula **byte-for-byte** (`diff` clean) — and that formula already passed `brew audit --strict --online` + `brew install` + `brew test` and is published.
- App secrets are configured; the app is installed on the tap with `contents: write`.

After the next release: `git log` on the tap shows a `provenant-release-bot[bot]` bump commit, and `brew upgrade provenant` fetches the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)