### PR TITLE
docs(readme): make the container quick-start runnable, fix image-tag wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ On macOS or Linux you can also `brew install getprovenant/tap/provenant`. Prefer
 
 ## Choose a Workflow
 
-| If you need to...                                      | Start here                                                         | Next doc                                                                                   |
-| ------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| Run a one-off CLI scan                                 | `provenant scan --json-pp - --license --package /path/to/repo`     | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
-| Scan explicit changed files in CI or automation        | Use `--paths-file` with one native scan root                       | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
-| Run a scan in a container                              | `docker run ghcr.io/getprovenant/provenant scan ...`               | [Container Image](#container-image)                                                        |
-| Run a scan from a GitHub Actions workflow              | `uses: getprovenant/provenant-action@v1`                           | [provenant-action](https://github.com/getprovenant/provenant-action)                       |
-| Gate CI on disallowed licenses (fail the build, SARIF) | `--license-policy policy.yml --fail-on error`                      | [CLI Guide](docs/CLI_GUIDE.md#17-i-want-policy-aware-license-review)                       |
-| Reuse a warm process through HTTP                      | `provenant serve --help`                                           | [Serve API Guide](docs/SERVE_API_GUIDE.md)                                                 |
-| Embed Provenant in a Rust application                  | Use the `provenant` library target from `provenant-cli`            | [Library Guide](docs/LIBRARY_GUIDE.md)                                                     |
-| Evaluate Provenant with an existing ScanCode workflow  | Start from Provenant's compatibility and workflow-difference notes | [Evaluating Provenant with ScanCode workflows](docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md) |
+| If you need to...                                      | Start here                                                                       | Next doc                                                                                   |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Run a one-off CLI scan                                 | `provenant scan --json-pp - --license --package /path/to/repo`                   | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
+| Scan explicit changed files in CI or automation        | Use `--paths-file` with one native scan root                                     | [CLI Guide](docs/CLI_GUIDE.md)                                                             |
+| Run a scan in a container                              | `docker run -v "$PWD:/src" ghcr.io/getprovenant/provenant scan /src --json-pp -` | [Container Image](#container-image)                                                        |
+| Run a scan from a GitHub Actions workflow              | `uses: getprovenant/provenant-action@v1`                                         | [provenant-action](https://github.com/getprovenant/provenant-action)                       |
+| Gate CI on disallowed licenses (fail the build, SARIF) | `--license-policy policy.yml --fail-on error`                                    | [CLI Guide](docs/CLI_GUIDE.md#17-i-want-policy-aware-license-review)                       |
+| Reuse a warm process through HTTP                      | `provenant serve --help`                                                         | [Serve API Guide](docs/SERVE_API_GUIDE.md)                                                 |
+| Embed Provenant in a Rust application                  | Use the `provenant` library target from `provenant-cli`                          | [Library Guide](docs/LIBRARY_GUIDE.md)                                                     |
+| Evaluate Provenant with an existing ScanCode workflow  | Start from Provenant's compatibility and workflow-difference notes               | [Evaluating Provenant with ScanCode workflows](docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md) |
 
 ## Relationship to ScanCode
 
@@ -99,7 +99,7 @@ On Windows, extract the `.zip` release and add `provenant.exe` to your `PATH`.
 
 ### Container Image
 
-Prebuilt, statically linked multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry as [`ghcr.io/getprovenant/provenant`](https://github.com/getprovenant/provenant/pkgs/container/provenant), tagged by release version (major and major.minor) and `latest`:
+Prebuilt, statically linked multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry as [`ghcr.io/getprovenant/provenant`](https://github.com/getprovenant/provenant/pkgs/container/provenant), tagged with the full version (e.g. `0.2.5`), the `major.minor` series (e.g. `0.2`), and `latest`:
 
 ```sh
 docker run --rm -v "$PWD:/src" ghcr.io/getprovenant/provenant:latest \


### PR DESCRIPTION
## What & why

Accuracy pass on the README (and the org profile README, fixed separately in `getprovenant/.github`).

- **Container quick-start was broken.** The "Run a scan in a container" cell was `docker run … scan ...`, and the org profile README literally had `docker run … scan .`. A bare `scan .` **fails** — a scan requires an explicit output flag (`test_requires_at_least_one_output_option`; the CLI errors with `required arguments were not provided: <--json|--json-pp|…>`), and with no `-v` mount there's nothing to scan. Replaced with a command I verified runs: `docker run -v "$PWD:/src" ghcr.io/getprovenant/provenant scan /src --json-pp -`.
- **Image-tag wording was wrong.** Said "release version (major and major.minor)". The workflow tags the **full version** (`0.2.5`) and **major.minor** (`0.2`) plus `latest` — never a bare major. Corrected.

Rest of the README was checked and is accurate: the output-formats list matches the CLI's actual output flags, all other scan examples include an output flag, org/URLs are `getprovenant`, and Homebrew is documented.

## How to verify

`npm run check:docs` passes. I ran the new container command against the published image: valid JSON, exit 0. The old `scan .` exits 2 with the missing-output-flag error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)