### PR TITLE
feat(scan): exclude the --license-policy file from its own detection

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -575,6 +575,8 @@ Add `--fail-on <error|warning>` to turn the policy into a build gate. The scan e
 provenant scan --json-pp scan.json --license --license-policy policy.yml --fail-on error /path/to/project
 ```
 
+When scanning, the `--license-policy` file is automatically excluded from detection. It lists license keys (for example `gpl-3.0`), which the detector would otherwise report as licenses found _in that file_ and could self-trip the gate — so a policy file living inside the scanned tree is skipped for content detection. (With `--from-json`, the reshaped result's file set is taken as-is; nothing is re-scanned.)
+
 #### Surfacing violations in pull requests (SARIF)
 
 `--sarif <FILE>` writes the policy violations as SARIF 2.1.0, which GitHub can render as pull-request annotations and code-scanning alerts (upload it with `github/codeql-action/upload-sarif`). Each severity-carrying policy match becomes a result at the file's detection line; with no policy the run has zero results, so SARIF stays quiet unless you opt into a policy.

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -44,9 +44,9 @@ use crate::scan_result_shaping::{
     prepare_filter_clue_rule_lookup, trim_preloaded_assembly_to_files,
 };
 use crate::scanner::{
-    CollectionLimits, ProcessResult, collect_paths_with_limits, collect_selected_paths_with_limits,
-    process_collected_with_memory_limit, process_collected_with_memory_limit_sequential,
-    scan_options_fingerprint,
+    CollectedPaths, CollectionLimits, ProcessResult, collect_paths_with_limits,
+    collect_selected_paths_with_limits, process_collected_with_memory_limit,
+    process_collected_with_memory_limit_sequential, scan_options_fingerprint,
 };
 use crate::utils::hash::calculate_sha256;
 
@@ -556,6 +556,8 @@ fn load_native_scan_session(
             &collection_limits,
         )
     };
+    let policy_excluded_count =
+        exclude_license_policy_file(&mut collected, request.license_policy.as_deref());
     let user_excluded_count = apply_user_path_filters_to_collected(
         &mut collected,
         Path::new(&scan_path),
@@ -566,7 +568,7 @@ fn load_native_scan_session(
     let total_files = collected.file_count();
     let total_dirs = collected.directory_count();
     let total_size = collected.total_file_bytes;
-    let excluded_count = collected.excluded_count + user_excluded_count;
+    let excluded_count = collected.excluded_count + user_excluded_count + policy_excluded_count;
     let all_collected_files = collected.files.clone();
     let ordered_file_paths: Vec<PathBuf> = collected
         .files
@@ -941,6 +943,42 @@ fn normalize_relative_scan_path(path: &Path, scan_root: &Path) -> String {
         .replace('\\', "/")
 }
 
+/// Drop the `--license-policy` file itself from the collected set when it falls
+/// inside the scan tree. The policy file lists license keys (e.g. `gpl-3.0`),
+/// which the detector would otherwise report as licenses *in that file* — a
+/// self-inflicted match that can trip the `--fail-on` gate and pollute SARIF.
+/// Matched by canonical-path equality; canonicalization is only paid for files
+/// whose basename matches the policy file, so a scan of unrelated files is
+/// unaffected. Removing a file also decrements the collection's byte total so
+/// the discovery stats stay consistent. Returns the number of files removed
+/// (0 or 1). Applies to native scans only; `--from-json` takes its input file
+/// set as authoritative.
+fn exclude_license_policy_file(collected: &mut CollectedPaths, policy: Option<&str>) -> usize {
+    let Some(policy) = policy else {
+        return 0;
+    };
+    let Ok(policy_canonical) = std::fs::canonicalize(policy) else {
+        return 0;
+    };
+    let policy_name = Path::new(policy).file_name();
+    let before = collected.files.len();
+    let mut removed_bytes: u64 = 0;
+    collected.files.retain(|(path, metadata)| {
+        if path.file_name() != policy_name {
+            return true;
+        }
+        let keep = std::fs::canonicalize(path)
+            .map(|canonical| canonical != policy_canonical)
+            .unwrap_or(true);
+        if !keep {
+            removed_bytes = removed_bytes.saturating_add(metadata.len());
+        }
+        keep
+    });
+    collected.total_file_bytes = collected.total_file_bytes.saturating_sub(removed_bytes);
+    before - collected.files.len()
+}
+
 #[cfg(test)]
 mod incremental_manifest_tests {
     use std::collections::BTreeMap;
@@ -1177,5 +1215,87 @@ mod incremental_manifest_tests {
                 .expect("paranoid compare"),
             "after re-scan the manifest must stop flagging the unchanged file"
         );
+    }
+}
+
+#[cfg(test)]
+mod license_policy_exclusion_tests {
+    use super::*;
+
+    fn meta(path: &Path) -> std::fs::Metadata {
+        std::fs::metadata(path).expect("metadata")
+    }
+
+    fn collected_of(files: &[PathBuf]) -> CollectedPaths {
+        let entries: Vec<_> = files.iter().map(|p| (p.clone(), meta(p))).collect();
+        let total_file_bytes = entries.iter().map(|(_, m)| m.len()).sum();
+        CollectedPaths {
+            files: entries,
+            directories: Vec::new(),
+            excluded_count: 0,
+            total_file_bytes,
+            collection_errors: Vec::new(),
+            limit_reached: false,
+        }
+    }
+
+    #[test]
+    fn drops_only_the_policy_file_by_canonical_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = dir.path();
+        let policy = root.join("policy.yml");
+        std::fs::write(&policy, "license_policies: []\n").expect("write policy");
+        let src = root.join("app.c");
+        std::fs::write(&src, "int main(){return 0;}\n").expect("write src");
+        // Same basename, different file: must be kept (equality is by canonical path, not name).
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).expect("mkdir");
+        let other = sub.join("policy.yml");
+        std::fs::write(&other, "not the policy\n").expect("write other");
+
+        let mut collected = collected_of(&[policy.clone(), src.clone(), other.clone()]);
+        let total_before = collected.total_file_bytes;
+        let policy_size = meta(&policy).len();
+        let removed = exclude_license_policy_file(&mut collected, policy.to_str());
+
+        assert_eq!(removed, 1);
+        let kept: Vec<_> = collected.files.iter().map(|(p, _)| p.clone()).collect();
+        assert!(!kept.contains(&policy), "the policy file must be dropped");
+        assert!(kept.contains(&src), "source files are kept");
+        assert!(
+            kept.contains(&other),
+            "a same-named file elsewhere must be kept (canonical-path match, not basename)"
+        );
+        assert_eq!(
+            collected.total_file_bytes,
+            total_before - policy_size,
+            "the byte total must drop by exactly the removed policy file's size"
+        );
+    }
+
+    #[test]
+    fn no_policy_removes_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src = dir.path().join("app.c");
+        std::fs::write(&src, "x\n").expect("write");
+        let mut collected = collected_of(std::slice::from_ref(&src));
+        assert_eq!(exclude_license_policy_file(&mut collected, None), 0);
+        assert_eq!(collected.files.len(), 1);
+    }
+
+    #[test]
+    fn policy_outside_scan_set_removes_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src = dir.path().join("app.c");
+        std::fs::write(&src, "x\n").expect("write");
+        let policy = dir.path().join("elsewhere-policy.yml");
+        std::fs::write(&policy, "license_policies: []\n").expect("write");
+        // `policy` exists but is not among the collected files.
+        let mut collected = collected_of(std::slice::from_ref(&src));
+        assert_eq!(
+            exclude_license_policy_file(&mut collected, policy.to_str()),
+            0
+        );
+        assert_eq!(collected.files.len(), 1);
     }
 }

--- a/tests/progress_cli_integration.rs
+++ b/tests/progress_cli_integration.rs
@@ -2268,3 +2268,59 @@ fn exported_dataset_can_be_reused_via_license_dataset_path() {
         Some("custom-license-dataset")
     );
 }
+
+#[test]
+fn scan_excludes_the_license_policy_file_from_its_own_detection() {
+    // A policy file that lists an error-level license (gpl-3.0) and lives inside
+    // the scanned tree must not be scanned as source: otherwise the scanner
+    // detects "gpl-3.0" written in it and self-trips the --fail-on gate.
+    let temp = TempDir::new().expect("temp dir");
+    let root = temp.path().join("proj");
+    fs::create_dir_all(root.join(".provenant")).expect("mkdir");
+    fs::write(
+        root.join(".provenant/policy.yml"),
+        "license_policies:\n  - license_key: gpl-3.0\n    label: Prohibited\n    compliance_alert: error\n  - license_key: mit\n    label: OK\n    compliance_alert: warning\n",
+    )
+    .expect("write policy");
+    fs::write(
+        root.join("app.c"),
+        "// SPDX-License-Identifier: MIT\nint main(void){return 0;}\n",
+    )
+    .expect("write src");
+
+    let policy = root.join(".provenant/policy.yml");
+    let output = provenant_command()
+        .args([
+            "--license",
+            "--license-policy",
+            policy.to_str().unwrap(),
+            "--fail-on",
+            "error",
+            "--json-pp",
+            "-",
+            root.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run provenant policy scan");
+
+    assert!(
+        output.status.success(),
+        "the gate must not trip on the policy file's own license keys (stderr: {})",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
+    let files = json["files"].as_array().expect("files array");
+    assert!(
+        !files.iter().any(|f| f["path"]
+            .as_str()
+            .is_some_and(|p| p.ends_with("policy.yml"))),
+        "the --license-policy file must be excluded from the scan"
+    );
+    assert!(
+        !files.iter().any(|f| f["detected_license_expression_spdx"]
+            .as_str()
+            .is_some_and(|e| e.to_uppercase().contains("GPL"))),
+        "no scanned file should report GPL: the only GPL text was in the excluded policy file"
+    );
+}


### PR DESCRIPTION
## What & why

Found by running the GitHub Action live on a real repo: when a `--license-policy` file lives inside the scanned tree, the scanner detects the license keys written *in that file* (e.g. `gpl-3.0`) as licenses found in it — self-tripping the `--fail-on` gate and adding bogus SARIF results. No user expects their policy file to be scanned against itself.

## Fix

`exclude_license_policy_file` drops the policy file from the collected set by **canonical-path equality**. Canonicalization is only paid for files whose basename matches the policy file, so an ordinary scan of unrelated files costs nothing. It removes the file from detection, the gate, SARIF, and the inventory alike.

## Tests

- **Unit** (`license_policy_exclusion_tests`): drops only the exact policy file (a same-named file elsewhere is kept — proves canonical-path, not basename, matching); no-op when no policy / policy outside the collected set.
- **Wired CLI** (`scan_excludes_the_license_policy_file_from_its_own_detection`): a policy naming `gpl-3.0` inside the scan tree + `--fail-on error` → scan **succeeds** (gate not tripped), policy file absent from output, no GPL reported.

## How to verify

`cargo test --lib license_policy_exclusion_tests` and `cargo test --test progress_cli_integration scan_excludes_the_license_policy_file`. Documented in the CLI guide's policy section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)