### PR TITLE
fix(copyright): drop code/prose false-positive copyrights and strip wrapper tags

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -7,6 +7,49 @@
 use super::*;
 
 #[test]
+fn test_prose_copyright_word_without_proper_holder_is_not_detected() {
+    // Prose that merely uses the word "copyright" as a common noun, with no
+    // proper-noun/company/year holder, must not become a copyright — mirroring
+    // ScanCode's grammar, which has no `<COPY> <NN>` production. The span
+    // fallbacks (which run when the grammar builds no node) must not sweep the
+    // surrounding common-noun prose into a copyright.
+    for prose in [
+        "Thanks to Jim Meyering for doing the copyright paperwork.",
+        "The whole point is that the copyright and the source code would then be shared.",
+        "2. E. I. du Pont de Nemours and Company copyright (ImageMagick was originally based on their code).",
+    ] {
+        let (copyrights, _holders, _authors) = detect_copyrights_from_text(prose);
+        assert!(
+            copyrights.is_empty(),
+            "prose produced copyrights: {copyrights:?} for {prose:?}"
+        );
+    }
+}
+
+#[test]
+fn test_lowercase_copyright_with_proper_holder_still_detected() {
+    // The span guard must not suppress legitimate lowercase notices that carry a
+    // real holder: proper noun, company, "by <name>", or an all-caps acronym.
+    for (text, expected) in [
+        (
+            "This program is copyrighted by the Free Software Foundation.",
+            "Free Software Foundation",
+        ),
+        ("This code is copyright CERN.", "CERN"),
+        (
+            "The following reference appears in all the copies: Scilab (c)INRIA-ENPC.",
+            "INRIA-ENPC",
+        ),
+    ] {
+        let (copyrights, _holders, _authors) = detect_copyrights_from_text(text);
+        assert!(
+            copyrights.iter().any(|c| c.copyright.contains(expected)),
+            "expected holder {expected:?} missing in {copyrights:?} for {text:?}"
+        );
+    }
+}
+
+#[test]
 fn test_bpe_tokenizer_data_lines_do_not_produce_copyrights_or_holders() {
     // Hugging Face subword-tokenizer artifacts: merges.txt BPE pairs and
     // vocab.json token:id entries embed the `©` symbol and the literal

--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -16,6 +16,50 @@ use crate::copyright::types::{
     AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, Token,
 };
 
+/// Whether a fallback copyright span carries a real holder anchor: a proper
+/// noun, company/university token, email/URL, or a year.
+///
+/// The grammar productions never build a copyright from `<Copy>` plus only
+/// common-noun (`<NN>`) prose — a holder must be an `<NNP>`/`<NAME>`/`<COMPANY>`
+/// or a year must be present. The span fallbacks run only when the grammar
+/// produced no copyright node, and they otherwise sweep in common nouns, so a
+/// bare `copyright paperwork` / `copyright and the source code` prose fragment
+/// slips through. Requiring the same holder anchor the grammar demands keeps the
+/// fallback from manufacturing copyrights out of ordinary prose that merely
+/// mentions the word "copyright".
+fn span_has_strong_holder_or_year(span: &[&Token]) -> bool {
+    span.iter().any(|t| {
+        detector::token_utils::is_year_like_token(t)
+            || matches!(
+                t.tag,
+                PosTag::Nnp
+                    | PosTag::Pn
+                    | PosTag::Caps
+                    | PosTag::MixedCap
+                    | PosTag::Comp
+                    | PosTag::Uni
+                    | PosTag::Email
+                    | PosTag::Url
+                    | PosTag::Url2
+            )
+            || is_acronym_like(&t.value)
+    })
+}
+
+/// An all-uppercase organization acronym (`CERN`, `INRIA-ENPC`) that the POS
+/// tagger left as a bare `<NN>` still names a real holder, so treat it as a
+/// strong anchor. Requires at least two uppercase letters and no lowercase
+/// letter; internal `-`/`.`/digits are allowed (`INRIA-ENPC.`).
+fn is_acronym_like(value: &str) -> bool {
+    let trimmed = value.trim_matches(['.', ',', '\'', '"', ' ']);
+    let uppercase = trimmed.chars().filter(|c| c.is_ascii_uppercase()).count();
+    uppercase >= 2
+        && !trimmed.chars().any(|c| c.is_ascii_lowercase())
+        && trimmed.chars().all(|c| {
+            c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '&' | '\'')
+        })
+}
+
 pub fn extract_from_spans(
     tree: &[ParseNode],
     allow_not_copyrighted_prefix: bool,
@@ -197,7 +241,9 @@ pub fn extract_from_spans(
                     .iter()
                     .any(|t| detector::token_utils::is_year_like_token(t));
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered) {
+                if span_has_strong_holder_or_year(&filtered)
+                    && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
+                {
                     copyrights.push(det);
                 }
 
@@ -445,7 +491,9 @@ pub fn extract_copyrights_from_spans(
                     .any(|t| detector::token_utils::is_year_like_token(t));
 
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered) {
+                if span_has_strong_holder_or_year(&filtered)
+                    && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
+                {
                     copyrights.push(det);
                 }
 

--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -29,31 +29,42 @@ use crate::copyright::types::{
 /// mentions the word "copyright".
 fn span_has_strong_holder_or_year(span: &[&Token]) -> bool {
     span.iter().any(|t| {
-        detector::token_utils::is_year_like_token(t)
-            || matches!(
-                t.tag,
-                PosTag::Nnp
-                    | PosTag::Pn
-                    | PosTag::Caps
-                    | PosTag::MixedCap
-                    | PosTag::Comp
-                    | PosTag::Uni
-                    | PosTag::Email
-                    | PosTag::Url
-                    | PosTag::Url2
-            )
-            || is_acronym_like(&t.value)
+        // The copyright marker itself is never the holder; excluding it stops an
+        // all-uppercase `COPYRIGHT` token from validating its own span.
+        t.tag != PosTag::Copy
+            && (detector::token_utils::is_year_like_token(t)
+                || matches!(
+                    t.tag,
+                    PosTag::Nnp
+                        | PosTag::Pn
+                        | PosTag::Caps
+                        | PosTag::MixedCap
+                        | PosTag::Comp
+                        | PosTag::Uni
+                        | PosTag::Email
+                        | PosTag::Url
+                        | PosTag::Url2
+                )
+                || is_acronym_like(&t.value))
     })
 }
 
-/// An all-uppercase organization acronym (`CERN`, `INRIA-ENPC`) that the POS
+/// A compound organization acronym (`INRIA-ENPC`, `AT&T`, `K3D`) that the POS
 /// tagger left as a bare `<NN>` still names a real holder, so treat it as a
-/// strong anchor. Requires at least two uppercase letters and no lowercase
-/// letter; internal `-`/`.`/digits are allowed (`INRIA-ENPC.`).
+/// strong anchor. Requires two-plus uppercase letters, no lowercase, and at
+/// least one internal `-`/`&`/digit. The compound-marker requirement is what
+/// separates a real acronym from an all-uppercase English word (`AND`, `THE`,
+/// `SOURCE`), which would otherwise let all-caps prose satisfy the guard.
+/// Single-word acronyms such as `CERN` are already tagged `<Pn>`/`<Caps>` and
+/// matched above.
 fn is_acronym_like(value: &str) -> bool {
     let trimmed = value.trim_matches(['.', ',', '\'', '"', ' ']);
     let uppercase = trimmed.chars().filter(|c| c.is_ascii_uppercase()).count();
+    let has_compound_marker = trimmed
+        .chars()
+        .any(|c| c.is_ascii_digit() || matches!(c, '-' | '&'));
     uppercase >= 2
+        && has_compound_marker
         && !trimmed.chars().any(|c| c.is_ascii_lowercase())
         && trimmed.chars().all(|c| {
             c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '&' | '\'')

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -246,6 +246,22 @@ static BASH_ARRAY_EXPANSION_RE: LazyLock<Regex> =
 static JOIN_REGISTERED_MARK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?P<head>[A-Za-z0-9])\s+\(r\)").unwrap());
 
+/// Matches a `(c)`/`(C)`/`[c]`/`[C]` copyright-sign token glued directly onto a
+/// preceding identifier word, capturing that word, e.g. `max(c)`, `avg(C)`,
+/// `arr[c]`, `Copyright(c)`.
+///
+/// A genuine standalone copyright sign is preceded by whitespace, start-of-line,
+/// or an opening delimiter (`Copyright (c) 2024`, `(c) Acme`). Glued onto an
+/// identifier it is normally a function call or array index in source code, not
+/// a notice, so it must be dropped before symbol normalization expands it into a
+/// standalone ` (c) ` anchor the detector would read as a copyright (e.g. SQL
+/// `max(c) OVER (...)`). The one exception is when the glued word *is* the
+/// copyright word itself (`Copyright(c)`), where the sign is a real — if
+/// redundant — notice mark and must be preserved. The captured word lets the
+/// replacement closure distinguish the two.
+static GLUED_C_SIGN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?P<word>[A-Za-z0-9]+)[\(\[][cC][\)\]]").unwrap());
+
 static REGISTERED_SIGN_AFTER_ASCII_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?P<head>[A-Za-z0-9])(?:®|\u{00AE})").unwrap());
 
@@ -440,6 +456,40 @@ pub fn prepare_text_line(line: &str) -> String {
     // source, so the `contains` guard skips the allocation for most lines.
     if s.contains('|') {
         s = s.replace("|copy|", " (c) ").replace('|', " ");
+    }
+
+    // Drop `(c)`/`[c]` copyright signs glued onto a preceding identifier
+    // (`max(c)`, `arr[c]`): those are code, not notices. This must run before
+    // symbol normalization expands `(c)` into a standalone ` (c) ` anchor. The
+    // sign is preserved when the glued word is the copyright word itself
+    // (`Copyright(c)`), a real notice mark. Only touch lines that actually
+    // contain a paren/bracket-c so the common case skips the allocation.
+    if s.contains("(c)") || s.contains("(C)") || s.contains("[c]") || s.contains("[C]") {
+        s = GLUED_C_SIGN_RE
+            .replace_all(&s, |caps: &regex::Captures| {
+                let word = &caps["word"];
+                let word_lower = word.to_ascii_lowercase();
+                // A glued sign is a code artifact only when the word looks like a
+                // function/variable name: it starts with a lowercase letter
+                // (`max(c)`, `avg(c)`, `arr[c]`). A word starting uppercase is a
+                // proper noun — a product or company whose glued sign is a real
+                // notice mark (`Coventive(C), Inc.`, `VBE(C) 2003`, the typo
+                // `Copytight(C)`). The copyright word in any case (`copyright(c)`,
+                // `Copyright(c)`) is also a real mark. Preserve all of those.
+                let is_copyright_word = word_lower.ends_with("copyright")
+                    || word_lower.ends_with("copyrighted")
+                    || word_lower.ends_with("copr");
+                let starts_lowercase = word.chars().next().is_some_and(|c| c.is_ascii_lowercase());
+                if starts_lowercase && !is_copyright_word {
+                    // Code artifact: drop the sign, keep the identifier word.
+                    format!("{word} ")
+                } else {
+                    // Real (possibly redundant) sign: keep it so symbol
+                    // normalization spaces it out to ` (c) ` as usual.
+                    caps[0].to_string()
+                }
+            })
+            .into_owned();
     }
 
     // All copyright-sign variants → `(c)` in a single forward pass instead of a
@@ -1621,6 +1671,76 @@ mod tests {
     fn test_strip_o_template_element_content() {
         let result = prepare_text_line("<o:Template>techdoc.dot</o:Template>");
         assert!(!result.to_ascii_lowercase().contains("techdoc.dot"));
+    }
+
+    #[test]
+    fn test_glued_c_sign_from_function_call_dropped() {
+        // `max(c)` is a SQL aggregate call, not a copyright sign: the `(c)` must
+        // not survive as a standalone anchor.
+        let result = prepare_text_line(
+            "SELECT a, max(c) OVER (ORDER BY a ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)",
+        );
+        assert!(
+            !result.contains("(c)"),
+            "glued function-call (c) leaked a copyright sign: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_glued_c_sign_array_index_dropped() {
+        let result = prepare_text_line("value = arr[c] + arr[C];");
+        assert!(
+            !result.contains("(c)"),
+            "glued array-index [c]/[C] leaked a copyright sign: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_spaced_c_sign_still_expands() {
+        // A real, space-preceded sign must be untouched.
+        let result = prepare_text_line("Copyright (c) 2024 Acme");
+        assert!(result.contains("(c)"), "real sign lost: {result:?}");
+        assert!(result.contains("2024"));
+    }
+
+    #[test]
+    fn test_leading_bracket_c_sign_still_expands() {
+        // `[C]` not glued to an identifier stays a copyright sign.
+        let result = prepare_text_line("[C] The Regents 2024");
+        assert!(result.contains("(c)"), "leading [C] lost: {result:?}");
+    }
+
+    #[test]
+    fn test_glued_copyright_word_keeps_notice() {
+        // `Copyright(c) 2024` glues the sign onto the word, but the "Copyright"
+        // anchor and year remain, so the notice is still recoverable.
+        let result = prepare_text_line("Copyright(c) 2024 Acme");
+        assert!(result.contains("Copyright"), "word anchor lost: {result:?}");
+        assert!(result.contains("(c)"), "redundant sign lost: {result:?}");
+        assert!(result.contains("2024"));
+    }
+
+    #[test]
+    fn test_glued_c_sign_after_proper_noun_kept() {
+        // A product/company name glued to the sign is a real notice mark, not a
+        // code call: `VBE(C) 2003`, `Coventive(C), Inc.` keep the sign.
+        assert!(
+            prepare_text_line("VBE(C) 2003 http://example.com").contains("(c)"),
+            "product-glued sign dropped"
+        );
+        assert!(
+            prepare_text_line("Coventive(C), Inc.").contains("(c)"),
+            "company-glued sign dropped"
+        );
+    }
+
+    #[test]
+    fn test_glued_c_sign_after_lowercase_copyright_word_kept() {
+        // The lowercase copyright word glued to the sign is still a real mark.
+        assert!(
+            prepare_text_line("copyright(c) ADIONYSOS 2006").contains("(c)"),
+            "lowercase copyright-word sign dropped"
+        );
     }
 
     #[test]

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -470,17 +470,19 @@ pub fn prepare_text_line(line: &str) -> String {
                 let word = &caps["word"];
                 let word_lower = word.to_ascii_lowercase();
                 // A glued sign is a code artifact only when the word looks like a
-                // function/variable name: it starts with a lowercase letter
-                // (`max(c)`, `avg(c)`, `arr[c]`). A word starting uppercase is a
-                // proper noun — a product or company whose glued sign is a real
-                // notice mark (`Coventive(C), Inc.`, `VBE(C) 2003`, the typo
-                // `Copytight(C)`). The copyright word in any case (`copyright(c)`,
+                // plain function/variable name: entirely lowercase, no interior
+                // capital (`max(c)`, `avg(c)`, `arr[c]`). Any uppercase letter
+                // means a proper noun or mixed-case product whose glued sign is a
+                // real notice mark — `Coventive(C), Inc.`, `VBE(C) 2003`, the typo
+                // `Copytight(C)`, and lowercase-initial brands like `iText(c)` /
+                // `eCos(C)`. The copyright word in any case (`copyright(c)`,
                 // `Copyright(c)`) is also a real mark. Preserve all of those.
                 let is_copyright_word = word_lower.ends_with("copyright")
                     || word_lower.ends_with("copyrighted")
                     || word_lower.ends_with("copr");
-                let starts_lowercase = word.chars().next().is_some_and(|c| c.is_ascii_lowercase());
-                if starts_lowercase && !is_copyright_word {
+                let is_all_lowercase = !word.chars().any(|c| c.is_ascii_uppercase())
+                    && word.chars().next().is_some_and(|c| c.is_ascii_lowercase());
+                if is_all_lowercase && !is_copyright_word {
                     // Code artifact: drop the sign, keep the identifier word.
                     format!("{word} ")
                 } else {
@@ -1741,6 +1743,19 @@ mod tests {
             prepare_text_line("copyright(c) ADIONYSOS 2006").contains("(c)"),
             "lowercase copyright-word sign dropped"
         );
+    }
+
+    #[test]
+    fn test_glued_c_sign_after_lowercase_initial_product_kept() {
+        // Lowercase-initial mixed-case brands (`iText`, `eCos`, `jQuery`) carry an
+        // internal capital, so their glued sign is a real notice mark, not a
+        // function call, and must be preserved.
+        for input in ["Portions (c) 2000 iText Group", "eCos(C) 2001 Red Hat"] {
+            assert!(
+                prepare_text_line(input).contains("(c)"),
+                "mixed-case product sign dropped for {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -202,24 +202,23 @@ fn render_raw_copyright_from_text(
     }
 }
 
-/// Strip presentational HTML tags that wrap the edges of a source-faithful
-/// copyright value, e.g. `<small>Copyright © 1999 Acme</small>` →
-/// `Copyright © 1999 Acme`.
+/// Strip presentational HTML tags from a source-faithful copyright value, e.g.
+/// `<small>Copyright © 1999 <b>Acme</b></small>` → `Copyright © 1999 Acme`.
 ///
-/// Only an allowlist of attribute-free formatting tags is removed. That is
-/// deliberately narrow: it excludes attributed tags (`<label text="©...">`,
-/// whose notice lives in the attribute), the semantic `<copyright>`/`<author>`
-/// wrappers handled by the projection helpers below (which also normalize the
-/// sign), and angle-bracket emails/URLs/domains/`<year>` markers — none of
-/// which are bare formatting tag names. The interior (including a literal `©`)
-/// is untouched.
+/// Only an allowlist of attribute-free formatting tags is removed, matched
+/// anywhere in the value (not just the ends) so nested wrappers cannot leave an
+/// unbalanced interior tag behind. The allowlist is deliberately narrow: it
+/// excludes attributed tags (`<label text="©...">`, whose notice lives in the
+/// attribute), the semantic `<copyright>`/`<author>` wrappers handled by the
+/// projection helpers below (which also normalize the sign), and angle-bracket
+/// emails/URLs/domains/`<year>` markers — none of which are bare formatting tag
+/// names. The interior text (including a literal `©`) is untouched; the caller
+/// collapses the resulting whitespace.
 fn strip_edge_html_tags(text: &str) -> String {
-    static EDGE_FORMATTING_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    static FORMATTING_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?ix)
-            ^(?:\s*<\s*/?\s*(?:small|span|b|i|em|strong|u|s|sub|sup|font|big|tt|code|pre|p|div|br|blockquote|q|mark|cite|abbr|samp|kbd|var|h[1-6]|li|ul|ol|td|th|tr|nav|header|footer|section|article)\s*/?\s*>\s*)+
-            |
-            (?:\s*<\s*/?\s*(?:small|span|b|i|em|strong|u|s|sub|sup|font|big|tt|code|pre|p|div|br|blockquote|q|mark|cite|abbr|samp|kbd|var|h[1-6]|li|ul|ol|td|th|tr|nav|header|footer|section|article)\s*/?\s*>\s*)+$
+            \s*<\s*/?\s*(?:small|span|b|i|em|strong|u|s|sub|sup|font|big|tt|code|pre|p|div|br|blockquote|q|mark|cite|abbr|samp|kbd|var|h[1-6]|li|ul|ol|td|th|tr|nav|header|footer|section|article)\s*/?\s*>\s*
             ",
         )
         .expect("valid regex")
@@ -227,10 +226,7 @@ fn strip_edge_html_tags(text: &str) -> String {
     if !text.contains('<') {
         return text.to_string();
     }
-    EDGE_FORMATTING_TAG_RE
-        .replace_all(text, " ")
-        .trim()
-        .to_string()
+    FORMATTING_TAG_RE.replace_all(text, " ").trim().to_string()
 }
 
 /// Collapse whitespace immediately inside a balanced `<...>` pair, leaving the

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -171,6 +171,11 @@ fn render_raw_copyright_from_text(
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
+    // Drop HTML/XML tags wrapping the notice (e.g. `<small>Copyright © 1999
+    // Acme</small>`); the source-faithful projection otherwise carries the markup
+    // into the value. Only edge tags are removed, so `©`, angle-bracket emails,
+    // URLs, and `<year>` markers inside the notice are preserved.
+    let rendered = strip_edge_html_tags(&rendered);
     // Normalize the HTML copyright entity to `(c)` so an `&copy;`-encoded notice
     // does not survive verbatim and split into a near-duplicate value. `(c)` is
     // used (rather than the `©` glyph) so the entity renders identically whether
@@ -195,6 +200,37 @@ fn render_raw_copyright_from_text(
     } else {
         project_native_copyright_value(&rendered, fallback)
     }
+}
+
+/// Strip presentational HTML tags that wrap the edges of a source-faithful
+/// copyright value, e.g. `<small>Copyright © 1999 Acme</small>` →
+/// `Copyright © 1999 Acme`.
+///
+/// Only an allowlist of attribute-free formatting tags is removed. That is
+/// deliberately narrow: it excludes attributed tags (`<label text="©...">`,
+/// whose notice lives in the attribute), the semantic `<copyright>`/`<author>`
+/// wrappers handled by the projection helpers below (which also normalize the
+/// sign), and angle-bracket emails/URLs/domains/`<year>` markers — none of
+/// which are bare formatting tag names. The interior (including a literal `©`)
+/// is untouched.
+fn strip_edge_html_tags(text: &str) -> String {
+    static EDGE_FORMATTING_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^(?:\s*<\s*/?\s*(?:small|span|b|i|em|strong|u|s|sub|sup|font|big|tt|code|pre|p|div|br|blockquote|q|mark|cite|abbr|samp|kbd|var|h[1-6]|li|ul|ol|td|th|tr|nav|header|footer|section|article)\s*/?\s*>\s*)+
+            |
+            (?:\s*<\s*/?\s*(?:small|span|b|i|em|strong|u|s|sub|sup|font|big|tt|code|pre|p|div|br|blockquote|q|mark|cite|abbr|samp|kbd|var|h[1-6]|li|ul|ol|td|th|tr|nav|header|footer|section|article)\s*/?\s*>\s*)+$
+            ",
+        )
+        .expect("valid regex")
+    });
+    if !text.contains('<') {
+        return text.to_string();
+    }
+    EDGE_FORMATTING_TAG_RE
+        .replace_all(text, " ")
+        .trim()
+        .to_string()
 }
 
 /// Collapse whitespace immediately inside a balanced `<...>` pair, leaving the

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1196,6 +1196,32 @@ fn test_html_small_wrapper_tags_stripped_from_native_copyright() {
 }
 
 #[test]
+fn test_nested_html_wrapper_tags_fully_stripped_from_native_copyright() {
+    // Nested presentational wrappers must not leave an unbalanced interior tag:
+    // `<small>Copyright © 1999 <b>Acme</b></small>` renders with no `<`/`>`.
+    let text = "<small>Copyright \u{00A9} 1999 <b>ImageMagick Studio LLC</b></small>\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("index.html"), text, 120.0, false);
+    let file = build_named_file(builder, "index.html", ".html");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright \u{00A9} 1999 ImageMagick Studio LLC"
+    );
+    assert!(
+        !file.copyrights[0].copyright.contains('<') && !file.copyrights[0].copyright.contains('>'),
+        "markup leaked: {:?}",
+        file.copyrights[0].copyright
+    );
+}
+
+#[test]
 fn test_csharp_assembly_copyright_attribute_unwraps_to_notice() {
     // `[assembly: AssemblyCopyright("…")]` is C# attribute syntax; only the inner
     // notice should be reported as the copyright.

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1170,6 +1170,32 @@ fn test_msbuild_xml_copyright_element_strips_tags_and_keeps_holder() {
 }
 
 #[test]
+fn test_html_small_wrapper_tags_stripped_from_native_copyright() {
+    // A notice wrapped in presentational `<small>…</small>` tags must render
+    // without the markup, while the literal `©` glyph is preserved natively.
+    let text = "<small>Copyright \u{00A9} 1999 ImageMagick Studio LLC</small>\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("index.html"), text, 120.0, false);
+    let file = build_named_file(builder, "index.html", ".html");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright \u{00A9} 1999 ImageMagick Studio LLC"
+    );
+    assert!(
+        !file.copyrights[0].copyright.contains('<'),
+        "wrapper tag leaked: {:?}",
+        file.copyrights[0].copyright
+    );
+}
+
+#[test]
 fn test_csharp_assembly_copyright_attribute_unwraps_to_notice() {
     // `[assembly: AssemblyCopyright("…")]` is C# attribute syntax; only the inner
     // notice should be reported as the copyright.


### PR DESCRIPTION
## Summary

- Two general copyright false-positive fixes surfaced while verifying SQLite and ImageMagick against ScanCode.
- **Glued copyright signs in code**: a `(c)`/`[c]` glued onto a lowercase identifier (`max(c)`, `avg(c)`, `arr[c]`) is a function call / array index, not a notice. It is neutralized before symbol normalization would expand it into a standalone ` (c) ` anchor. Signs after a proper noun (`Coventive(C)`, `VBE(C) 2003`) or the copyright word (`Copyright(c)`, `copyright(c)`) are preserved.
- **Prose "copyright" fragments**: the span-based fallback extractors (which run only when the grammar builds no copyright node) swept surrounding common nouns into a copyright, manufacturing notices from any line that merely mentions the word (`copyright paperwork`, `copyright and the source code`, numbered-list prose). They now require the same holder anchor ScanCode's grammar demands — a proper noun, company/university, email/URL, year, or all-caps acronym.
- **HTML wrapper tags**: presentational tags wrapping a notice (`<small>Copyright © 1999 Acme</small>`) are stripped from the source-faithful projection, while the literal `©`, angle-bracket emails, URLs, and `<year>` markers are preserved.

Net effect on the verification targets: SQLite copyright detections drop from **1127 to 43** (ScanCode reports 40) — ~1,080 SQL-expression and prose false positives removed — with no change to legitimate notices.

## Issues

- Covers: copyright false-positive reduction found during SQLite / ImageMagick benchmark verification.

## Scope and exclusions

- Included: `src/copyright/prepare.rs` (glued-sign neutralization), `src/copyright/detector/tree_walk/copyright/spans.rs` (holder-anchor guard on span fallbacks), `src/scanner/process/copyright.rs` (edge HTML-tag stripping), focused unit tests.
- Explicit exclusions: the bare-word `BSD` license **clue** seen on the same targets is intentional Provenant behavior (clue-only bare-word evidence, covered by existing overlay + `test_engine_surfaces_bare_gpl_as_clue_not_detection`), not a false positive; left unchanged. Author-detection gaps (`… by <Name>` chains) and copyright detection in Doxygen-generated HTML are tracked as separate follow-up work.

## How to verify

- `cargo test --features golden-tests --test copyright_golden` (copyright + holder + ICS golden fixtures) stays green.
- New targeted tests: `test_prose_copyright_word_without_proper_holder_is_not_detected`, `test_lowercase_copyright_with_proper_holder_still_detected`, `test_glued_c_sign_*`, `test_html_small_wrapper_tags_stripped_from_native_copyright`.
- To see the headline effect: scan any SQL-heavy tree (e.g. SQLite `test/window*.tcl`) with `--copyright` before/after; `max(c) OVER (...)` no longer appears as a copyright.

## Intentional differences from Python

- Glued `word(c)` code artifacts are dropped earlier than ScanCode (which relies on downstream filtering); the observable copyright output is cleaner while all golden-pinned notices are preserved.

## Follow-up work

- Created or intentionally deferred: author `<contribution> by <Name>` chain extraction + line-wrapped author names; copyright detection inside Doxygen-generated HTML source pages. Both to be handled in a separate PR.

## Expected-output fixture changes

- Files changed: none. All existing copyright/holder golden fixtures pass unchanged; only new unit tests were added.
