### PR TITLE
fix(copyright): recover multi-author "by" chains and texinfo comment authors

### DIFF
--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -407,20 +407,40 @@ fn is_noncopyright_at_directive_line(prepared: &str) -> bool {
         && !hints::has_year(trimmed)
         && !trimmed.contains("://")
         && !has_copyright_indicators(trimmed)
-        && !has_author_attribution(trimmed)
+        && !is_authorship_directive_line(trimmed)
+}
+
+/// Whether an `@`-directive line is itself an authorship directive whose content
+/// must survive the structural-directive skip in
+/// [`is_noncopyright_at_directive_line`].
+///
+/// Only the `@author` directive and a texinfo comment directive (`@c` /
+/// `@comment`) carrying an attribution phrase qualify — e.g. the texinfo
+/// `@c Written by <name>`. A structural directive such as
+/// `@param formatter Developed by John Smith` merely *mentions* an attribution
+/// phrase in its prose and must stay filtered, so the phrase check is gated on
+/// the directive being a comment/author directive rather than applied to any
+/// `@` line.
+fn is_authorship_directive_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if contains_ascii_ci(trimmed.as_bytes(), b"@author") {
+        return true;
+    }
+    let directive: String = trimmed
+        .strip_prefix('@')
+        .unwrap_or("")
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect();
+    (directive.eq_ignore_ascii_case("c") || directive.eq_ignore_ascii_case("comment"))
+        && has_author_attribution(trimmed)
 }
 
 /// Detect an explicit authorship attribution phrase (`written by`, `authored
-/// by`, `maintained by`, `developed by`, `contributed by`, `@author`).
-///
-/// Texinfo comment directives such as `@c Written by <name>` carry real author
-/// attribution and must survive the `@directive` skip in
-/// [`is_noncopyright_at_directive_line`], unlike structural directives
-/// (`@node`, `@chapter`, ...).
+/// by`, `maintained by`, `developed by`, `contributed by`).
 fn has_author_attribution(line: &str) -> bool {
     let bytes = line.as_bytes();
-    contains_ascii_ci(bytes, b"@author")
-        || contains_ascii_ci(bytes, b"written by")
+    contains_ascii_ci(bytes, b"written by")
         || contains_ascii_ci(bytes, b"authored by")
         || contains_ascii_ci(bytes, b"maintained by")
         || contains_ascii_ci(bytes, b"developed by")

--- a/src/copyright/candidates.rs
+++ b/src/copyright/candidates.rs
@@ -407,6 +407,24 @@ fn is_noncopyright_at_directive_line(prepared: &str) -> bool {
         && !hints::has_year(trimmed)
         && !trimmed.contains("://")
         && !has_copyright_indicators(trimmed)
+        && !has_author_attribution(trimmed)
+}
+
+/// Detect an explicit authorship attribution phrase (`written by`, `authored
+/// by`, `maintained by`, `developed by`, `contributed by`, `@author`).
+///
+/// Texinfo comment directives such as `@c Written by <name>` carry real author
+/// attribution and must survive the `@directive` skip in
+/// [`is_noncopyright_at_directive_line`], unlike structural directives
+/// (`@node`, `@chapter`, ...).
+fn has_author_attribution(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    contains_ascii_ci(bytes, b"@author")
+        || contains_ascii_ci(bytes, b"written by")
+        || contains_ascii_ci(bytes, b"authored by")
+        || contains_ascii_ci(bytes, b"maintained by")
+        || contains_ascii_ci(bytes, b"developed by")
+        || contains_ascii_ci(bytes, b"contributed by")
 }
 
 /// A numbered line: (1-based line number, prepared text).

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -76,6 +76,19 @@ fn test_texinfo_comment_written_by_is_candidate_author() {
 }
 
 #[test]
+fn test_structural_at_directive_mentioning_by_phrase_is_not_author() {
+    // A structural directive (`@param`, `@brief`, ...) that merely mentions an
+    // attribution phrase in its prose must stay filtered — only the `@c`/
+    // `@comment` texinfo directive and `@author` carry real authorship.
+    let input = "@param formatter Developed by John Smith";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    assert!(
+        authors.is_empty(),
+        "structural @param directive leaked an author: {authors:?}"
+    );
+}
+
+#[test]
 fn test_camelcase_provider_not_author_false_positive() {
     let input = "A meter implementation is created by a MeterProvider in this system.\nA trace implementation is created by a TracerProvider in this system.";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -4,6 +4,78 @@
 use super::*;
 
 #[test]
+fn test_multi_author_by_chain_recovers_all_and_does_not_bleed() {
+    // coreutils src/tail.c header: each contribution line is "<phrase> by
+    // <Name> <email>.". All four authors must be recovered, and the first must
+    // not absorb the leading word of the next line ("Extensions").
+    let input = "\
+   Original version by Paul Rubin <phr@ocf.berkeley.edu>.
+   Extensions by David MacKenzie <djm@gnu.ai.mit.edu>.
+   tail -f for multiple files by Ian Lance Taylor <ian@airs.com>.
+   inotify back-end by Giuseppe Scrivano <gscrivano@gnu.org>.  */";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let authors: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        authors.contains(&"Paul Rubin <phr@ocf.berkeley.edu>"),
+        "first author bled or missing: {authors:?}"
+    );
+    assert!(
+        authors.contains(&"David MacKenzie <djm@gnu.ai.mit.edu>"),
+        "single-word-lead-in author dropped: {authors:?}"
+    );
+    assert!(
+        authors.contains(&"Ian Lance Taylor <ian@airs.com>"),
+        "authors: {authors:?}"
+    );
+    assert!(
+        authors.contains(&"Giuseppe Scrivano <gscrivano@gnu.org>"),
+        "authors: {authors:?}"
+    );
+    assert!(
+        !authors.iter().any(|a| a.contains("Extensions")),
+        "cross-line bleed into author name: {authors:?}"
+    );
+}
+
+#[test]
+fn test_by_name_with_trailing_comma_email_recovers_author() {
+    // coreutils src/cksum_crc.c: "<phrase> by <Name>, <bare-email>." The email
+    // trails the name as a sibling token rather than being folded into the name.
+    let input = "/* Written by Q. Frank Xia, qx@math.columbia.edu.\n   Cosmetic changes and reorganization by David MacKenzie, djm@gnu.ai.mit.edu.  */";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    assert!(
+        authors.iter().any(|a| a.author.contains("David MacKenzie")),
+        "trailing-comma-email author dropped: {authors:?}"
+    );
+}
+
+#[test]
+fn test_line_initial_by_name_email_is_not_an_author() {
+    // A bare, line-initial "by <Name> <email>" with no contribution phrase in
+    // front is intentionally left out (matches curated behavior for isolated
+    // mid-comment attributions such as posix-timers "by George Anzinger ...").
+    let input = "by George Anzinger <george@mvista.com>";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    assert!(
+        authors.is_empty(),
+        "line-initial bare `by` should not yield an author: {authors:?}"
+    );
+}
+
+#[test]
+fn test_texinfo_comment_written_by_is_candidate_author() {
+    // doc/sort-version.texi: a `@c` texinfo comment carrying "Written by <name>"
+    // must survive the `@directive` skip and yield the author.
+    let input = "@c Written by Assaf Gordon";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    assert!(
+        authors.iter().any(|a| a.author == "Assaf Gordon"),
+        "texinfo `@c Written by` author missed: {authors:?}"
+    );
+}
+
+#[test]
 fn test_camelcase_provider_not_author_false_positive() {
     let input = "A meter implementation is created by a MeterProvider in this system.\nA trace implementation is created by a TracerProvider in this system.";
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/src/copyright/detector/tree_walk/author.rs
+++ b/src/copyright/detector/tree_walk/author.rs
@@ -271,27 +271,22 @@ pub(super) fn try_extract_by_name_email_author(
         _ => return None,
     };
 
+    // Require a "<contribution phrase> by ..." lead-in on the same line (e.g.
+    // "Extensions by", "inotify back-end by"). A bare line-initial "by <name>"
+    // with nothing before it is left out, matching the curated expectation that
+    // isolated mid-comment attributions are not authors.
     let by_line = by_token.start_line;
-
-    let mut same_line_preceding = 0;
-    for j in (0..idx).rev() {
-        let leaves = detector::token_utils::collect_all_leaves(&tree[j]);
-        for leaf in &leaves {
-            if leaf.start_line == by_line {
-                same_line_preceding += 1;
-            }
-        }
-    }
-    if same_line_preceding < 2 {
+    let same_line_preceding = tree[..idx]
+        .iter()
+        .flat_map(detector::collect_all_leaves)
+        .filter(|leaf| leaf.start_line == by_line)
+        .count();
+    if same_line_preceding < 1 {
         return None;
     }
 
     let name_idx = idx + 1;
-    if name_idx >= tree.len() {
-        return None;
-    }
-
-    let name_node = &tree[name_idx];
+    let name_node = tree.get(name_idx)?;
     match name_node.label() {
         Some(
             TreeLabel::NameYear | TreeLabel::NameEmail | TreeLabel::Name | TreeLabel::NameCaps,
@@ -299,20 +294,55 @@ pub(super) fn try_extract_by_name_email_author(
         _ => return None,
     }
 
-    let all_leaves = detector::token_utils::collect_all_leaves(name_node);
-    let has_email = all_leaves.iter().any(|t| t.tag == PosTag::Email);
-    if !has_email {
-        return None;
-    }
+    let name_line = detector::token_utils::collect_all_leaves(name_node)
+        .first()
+        .map(|t| t.start_line)?;
 
-    let author_tokens: Vec<&Token> = detector::token_utils::collect_filtered_leaves(
+    let mut author_tokens: Vec<&Token> = detector::token_utils::collect_filtered_leaves(
         name_node,
         &[TreeLabel::YrRange, TreeLabel::YrAnd],
         detector::NON_AUTHOR_POS_TAGS,
     );
+    let mut last_consumed = name_idx;
+
+    match author_tokens.iter().position(|t| t.tag == PosTag::Email) {
+        // A personal name ends at its email address, so drop any trailing proper
+        // nouns the grammar over-merged from the following clause (this is the
+        // cross-line "<name> <email>. <NextWord> by ..." bleed).
+        Some(pos) => author_tokens.truncate(pos + 1),
+        // `<name>, <email>` shape: the email trails the name as a sibling leaf
+        // rather than being folded into the NAME node.
+        None => {
+            let mut j = name_idx + 1;
+            while let Some(ParseNode::Leaf(tok)) = tree.get(j) {
+                if tok.start_line != name_line {
+                    break;
+                }
+                match tok.tag {
+                    PosTag::Cc if tok.value == "," => {
+                        last_consumed = j;
+                        j += 1;
+                    }
+                    PosTag::Email => {
+                        author_tokens.push(tok);
+                        last_consumed = j;
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+
+    // Require an email as the strong authorship signal, mirroring ScanCode's
+    // `AUTHOR: {<BY> <NAME-EMAIL>+}` / `AUTHOR: {<BY> <EMAIL>}` productions. The
+    // email keeps this bare `by <name>` extraction from firing on ordinary prose.
+    if !author_tokens.iter().any(|t| t.tag == PosTag::Email) {
+        return None;
+    }
 
     let det = detector::token_utils::build_author_from_tokens(&author_tokens)?;
-    Some((det, 1))
+    Some((det, last_consumed - idx))
 }
 
 pub(super) fn build_author_with_trailing(


### PR DESCRIPTION
## Summary

- Recover trailing authors in multi-author `<contribution> by <Name> <email>` chains and stop the first author absorbing the next line's leading word (coreutils `src/tail.c`, `src/cksum_crc.c`).
- Detect author attribution inside texinfo `@c` comment lines (`@c Written by <name>`), previously skipped as a structural `@`-directive (coreutils `doc/sort-version.texi`).
- Scoped entirely to the copyright engine (`src/copyright/`). No golden expected values changed; the full copyright/holder/ICS golden suite stays green.

Both gaps were found by verifying the coreutils source tree against ScanCode. A third, HTML-embedded gap (Doxygen `*_source.html`) is investigated and **intentionally deferred** — see Follow-up work.

### Before / after (author extraction)

`src/tail.c` header (`Original version by Paul Rubin ... / Extensions by David MacKenzie ... / ... by Ian Lance Taylor ... / ... by Giuseppe Scrivano ...`):

- Before: `["Paul Rubin <phr@ocf.berkeley.edu> Extensions", "Ian Lance Taylor <ian@airs.com>", "Giuseppe Scrivano <gscrivano@gnu.org>"]` — first author malformed (bled the next line's word), David MacKenzie dropped.
- After: `["Paul Rubin <phr@ocf.berkeley.edu>", "David MacKenzie <djm@gnu.ai.mit.edu>", "Ian Lance Taylor <ian@airs.com>", "Giuseppe Scrivano <gscrivano@gnu.org>"]`.

`src/cksum_crc.c` (`... reorganization by David MacKenzie, djm@gnu.ai.mit.edu.`):

- Before: `["Q. Frank Xia, qx@math.columbia.edu"]` — MacKenzie dropped.
- After: adds `David MacKenzie djm@gnu.ai.mit.edu`.

`doc/sort-version.texi` (`@c Written by Assaf Gordon`):

- Before: `[]`.
- After: `["Assaf Gordon"]`.

## Issues

- Covers: copyright-engine author-detection gaps surfaced by coreutils verification.

## Scope and exclusions

- Included: `src/copyright/detector/tree_walk/author.rs` (`try_extract_by_name_email_author`), `src/copyright/candidates.rs` (texinfo `@c` comment attribution), focused unit tests.
- Explicit exclusions: no changes to license detection, parsers, grammar rules, or the scanner. No golden fixtures edited.

### Root cause

**`by` chains.** `try_extract_by_name_email_author` required ≥2 leading tokens before `by` on the line (dropping single-word lead-ins like `Extensions by ...`), required the email to sit *inside* the NAME node (dropping the `<Name>, <bare-email>` shape), and emitted the whole NAME node — so a grammar over-merge (`NAME: {<NAME> <NNP>}`, ScanCode rule #75) that appended the next line's first proper noun after the email leaked into the author. The extractor now keys off an email as the authorship signal (mirroring ScanCode `AUTHOR: {<BY> <NAME-EMAIL>+}` / `{<BY> <EMAIL>}`), accepts a single-word contribution lead-in, truncates the name at its email (a personal name ends there), and consumes a trailing `, <bare-email>` sibling. A bare line-initial `by <Name> <email>` with nothing before it is deliberately still excluded, matching the curated expectation that isolated mid-comment attributions (e.g. Linux `posix-timers.c` "by George Anzinger") are not authors.

**texinfo `@c`.** `is_noncopyright_at_directive_line` skipped every lowercase `@directive` line. A texinfo comment (`@c ...`) is a real comment, so lines carrying an author-attribution phrase (`written by`, `@author`, `maintained by`, ...) are now kept while structural directives (`@node`, `@chapter`) are still skipped.

## How to verify

Beyond the CI-covered unit + golden suites, exercise the coreutils fixtures directly:

- `printf '   Original version by Paul Rubin <phr@ocf.berkeley.edu>.\n   Extensions by David MacKenzie <djm@gnu.ai.mit.edu>.\n' > /tmp/tail_snip.c` then `provenant --copyright --json-pp - /tmp/tail_snip.c` — expect both Paul Rubin (clean, no trailing "Extensions") and David MacKenzie as authors.
- New focused tests live in `src/copyright/detector/tests_author_pipeline.rs` (`test_multi_author_by_chain_*`, `test_by_name_with_trailing_comma_email_*`, `test_line_initial_by_name_email_is_not_an_author`, `test_texinfo_comment_written_by_*`).

## Intentional differences from Python

- ScanCode extracts *every* mid-comment `by <Name> <email>` (e.g. Linux `raid1.c` "Various fixes by Neil Brown"); Provenant's curated goldens deliberately exclude those isolated attributions. This change keeps that curation (line-initial / no-lead-in `by` is not an author) while still recovering the contribution-chain authors that carry a lead-in phrase.

## Follow-up work

- **Deferred: copyrights in Doxygen-generated HTML source pages** (e.g. ImageMagick `www/api/Magick++/Blob_8cpp_source.html`). Root cause: Doxygen collapses the whole source listing onto a handful of multi-thousand-character physical lines (each source line wrapped in `<div class="line">`), and the bounded grammar parser (fixed fixpoint budget, `parser.rs`) cannot chunk a single line carrying thousands of tokens, so every notice past the leading boilerplate is dropped. A correct fix must re-split the listing at the scanner's `detection_text` seam (so copyright detection and the scanner's raw-span rendering / `detection_is_source_code` guard share one line map — splitting only inside `detect_copyrights` desyncs the line numbers and the notices get reclassified as source and dropped), plus `&#160;` decoding, Doxygen line-number stripping, and multiline-bleed cleanup. That crosses out of the copyright engine and risks the global `prepare` goldens, so it is left for a dedicated PR.

## Expected-output fixture changes

- None. No golden or `.expected` files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
