### PR TITLE
fix(copyright): trim prose bleed in copyright, holder, and author extraction

### DIFF
--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -262,7 +262,7 @@ pub fn extract_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span {
+                if !skip_holder_from_span && span_has_strong_holder_or_year(&filtered) {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()
@@ -512,7 +512,7 @@ pub fn extract_copyrights_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span {
+                if !skip_holder_from_span && span_has_strong_holder_or_year(&filtered) {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -38,6 +38,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_trailing_website_url_clause(&a);
     a = truncate_trailing_clause_after_contact(&a);
     a = strip_trailing_comma_and(&a);
+    a = strip_trailing_role_qualifier(&a);
     a = truncate_bug_reports_clause(&a);
     a = truncate_caller_specificaly_clause(&a);
     a = truncate_json_metadata_tail(&a);
@@ -814,6 +815,32 @@ fn truncate_bug_reports_clause(s: &str) -> String {
     }
 
     s.to_string()
+}
+
+/// Strip a trailing `, <role qualifier>` left dangling after the author keyword
+/// was removed, e.g. `Rich Felker, primary` (from "modified by Rich Felker,
+/// primary author and maintainer of ..."). Only a fixed allowlist of role words
+/// that follow "author"/"maintainer"/"contributor" is stripped, so ordinary
+/// `Last, First` names and name particles are untouched.
+fn strip_trailing_role_qualifier(s: &str) -> String {
+    static TRAILING_ROLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)^(?P<prefix>.+?),\s+
+              (?:primary|secondary|principal|lead|main|original|current|former|
+                 corresponding|sole|chief|additional|initial|co)
+              \s*$",
+        )
+        .unwrap()
+    });
+    let trimmed = s.trim();
+    let Some(cap) = TRAILING_ROLE_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str().trim()).unwrap_or("");
+    if prefix.is_empty() || !prefix.chars().any(|c| c.is_ascii_uppercase()) {
+        return s.to_string();
+    }
+    prefix.to_string()
 }
 
 fn strip_trailing_comma_and(s: &str) -> String {

--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -39,6 +39,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = normalize_b_dot_angle_emails(&c);
     c = strip_nickname_quotes(&c);
     c = strip_leading_author_label_in_copyright(&c);
+    c = strip_leading_prose_clause_before_copyright(&c);
     c = strip_leading_duplicate_phrase_before_embedded_copyright(&c);
     c = strip_leading_licensed_material_of(&c);
     c = strip_leading_version_number_before_c(&c);
@@ -88,6 +89,7 @@ pub fn refine_copyright(s: &str) -> Option<String> {
     c = strip_trailing_paren_at_without_domain(&c);
     c = strip_trailing_inc_after_today_year_placeholder(&c);
     c = truncate_trailing_boilerplate(&c);
+    c = strip_trailing_dangling_pronoun(&c);
     c = strip_trailing_everyone_is_permitted_to_copy_clause(&c);
     c = strip_trailing_all_rights_reserved_clause(&c);
     c = strip_trailing_reserved_font_name_clause(&c);

--- a/src/copyright/refiner/copyright_clauses.rs
+++ b/src/copyright/refiner/copyright_clauses.rs
@@ -103,6 +103,78 @@ pub(super) fn strip_leading_version_number_before_c(s: &str) -> String {
     }
 }
 
+/// Strip a trailing dangling pronoun left after a copyright/holder span ran one
+/// token into the following sentence, e.g. `Copyright © 1994 David Burren. It`
+/// or a holder `David Burren. It` (from "... David Burren. It is licensed ...",
+/// where the node stopped at the pronoun). Only a subject pronoun sitting at the
+/// very end after a sentence period is removed — no holder ends in a bare
+/// pronoun — so determiner/proper-noun continuations that ScanCode keeps
+/// (`Copyright (c) 1994-1999. The MITRE Corporation`) are untouched.
+pub(super) fn strip_trailing_dangling_pronoun(s: &str) -> String {
+    static DANGLING_PRONOUN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?x)
+            ^(?P<prefix>.+?)\.\s+
+            (?:It|Its|This|These|Those|They|We|You|He|She|Their)
+            \s*$
+            ",
+        )
+    });
+    let trimmed = s.trim();
+    let Some(cap) = DANGLING_PRONOUN_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap.name("prefix").map(|m| m.as_str().trim()).unwrap_or("");
+    if prefix.is_empty() {
+        return s.to_string();
+    }
+    prefix.to_string()
+}
+
+/// Strip a leading file/component descriptor that ends in a linking verb
+/// immediately before the copyright marker, e.g.
+/// `The ARM memcpy code (src/string/arm/memcpy.S) is Copyright (c) 2008 ...`
+/// or `src/regex/tre*) is Copyright (c) 2001-2008 Ville Laurikari`.
+///
+/// A holder name never ends in `is`/`was`/`are`, so anchoring the statement at
+/// the copyright marker mirrors ScanCode, whose grammar never folds a run of
+/// common-noun prose ahead of `<COPY>`. Two guards keep it narrow: the discarded
+/// lead must not itself contain a copyright marker, and it must carry a
+/// path/parenthetical descriptor (`(`, `)`, `/`, `*`). The path requirement is
+/// what distinguishes musl's `The <component> (<path>) is Copyright ...` from a
+/// standard notice preamble such as MPL's `Portions created by the Initial
+/// Developer are Copyright ...`, which ScanCode keeps verbatim and which has no
+/// such descriptor.
+pub(super) fn strip_leading_prose_clause_before_copyright(s: &str) -> String {
+    static LEADING_PROSE_BEFORE_COPY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?ix)
+            ^(?P<lead>.+?\b(?:is|was|are))\s+
+            (?P<copy>(?:copyright|copr\.?|\u{00a9}|\(c\))\b.*)$
+            ",
+        )
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = LEADING_PROSE_BEFORE_COPY_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let lead = cap.name("lead").map(|m| m.as_str()).unwrap_or("");
+    let copy = cap.name("copy").map(|m| m.as_str()).unwrap_or("").trim();
+    let lead_lower = lead.to_ascii_lowercase();
+    let lead_has_path_descriptor = lead.contains(['(', ')', '/', '*']);
+    if copy.is_empty()
+        || !lead_has_path_descriptor
+        || lead_lower.contains("copyright")
+        || lead_lower.contains("copr")
+        || lead.contains("(c)")
+        || lead.contains('\u{00a9}')
+    {
+        return s.to_string();
+    }
+    copy.to_string()
+}
+
 pub(super) fn strip_trailing_authors_clause(s: &str) -> String {
     static AUTHORS_CLAUSE_RE: LazyLock<Regex> =
         LazyLock::new(|| compile_static_regex(r"^(?P<prefix>.+?)\s+Authors?\b\s+(?P<rest>.+)$"));
@@ -618,6 +690,7 @@ pub(super) fn truncate_trailing_boilerplate(s: &str) -> String {
             r"(?i)\bDublin\s+\d\b",
             r"(?i)\band\s+Bob\s+Dougherty\b",
             r"(?i)\band\s+is\s+licensed\s+under\b",
+            r"(?i)\band\s+it\s+is\s+hereby\s+released\b",
             r"(?i)\bBEGIN\s+LICENSE\s+BLOCK\b",
             r"(?i)^NOTICE,\s*DISCLAIMER,\s*and\s*LICENSE\b",
             r"(?i)\bIn\s+the\s+event\s+of\b",

--- a/src/copyright/refiner/copyright_clauses.rs
+++ b/src/copyright/refiner/copyright_clauses.rs
@@ -150,7 +150,7 @@ pub(super) fn strip_leading_prose_clause_before_copyright(s: &str) -> String {
         compile_static_regex(
             r"(?ix)
             ^(?P<lead>.+?\b(?:is|was|are))\s+
-            (?P<copy>(?:copyright|copr\.?|\u{00a9}|\(c\))\b.*)$
+            (?P<copy>(?:(?:copyright|copr\.?)\b|\u{00a9}|\(c\)).*)$
             ",
         )
     });

--- a/src/copyright/refiner/holder.rs
+++ b/src/copyright/refiner/holder.rs
@@ -125,6 +125,7 @@ pub(super) fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<
     h = strip_trailing_x509_dn_fields_from_holder(&h);
     h = strip_leading_js_project_version(&h);
     h = truncate_trailing_boilerplate(&h);
+    h = strip_trailing_dangling_pronoun(&h);
     h = strip_trailing_isc_after_inc(&h);
     h = strip_trailing_caps_after_company_suffix(&h);
     h = strip_trailing_javadoc_tags(&h);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3035,6 +3035,17 @@ fn test_refine_copyright_strips_leading_component_descriptor_before_marker() {
         ),
         Some("Copyright (c) 2011 Lynn Ochs".to_string())
     );
+    // Bare sign markers (`©` / `(c)`) without the spelled-out word are also
+    // anchored — the marker is followed by whitespace, which a trailing `\b`
+    // on the alternation could not match.
+    assert_eq!(
+        refine_copyright("The component (src/foo.c) is \u{00a9} 2024 Acme Corp"),
+        Some("\u{00a9} 2024 Acme Corp".to_string())
+    );
+    assert_eq!(
+        refine_copyright("The widget (lib/bar.c) is (c) 2024 Acme Corp"),
+        Some("(c) 2024 Acme Corp".to_string())
+    );
 }
 
 #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3019,3 +3019,78 @@ fn test_refine_copyright_rejects_source_code() {
         Some("Copyright (c) 2020 Acme, Inc.".to_string())
     );
 }
+
+#[test]
+fn test_refine_copyright_strips_leading_component_descriptor_before_marker() {
+    // musl COPYRIGHT third-party notices: `The <component> (<path>) is Copyright`.
+    assert_eq!(
+        refine_copyright(
+            "The ARM memcpy code (src/string/arm/memcpy.S) is Copyright (c) 2008 The Android Open Source Project"
+        ),
+        Some("Copyright (c) 2008 The Android Open Source Project".to_string())
+    );
+    assert_eq!(
+        refine_copyright(
+            "The smoothsort implementation (src/stdlib/qsort.c) is Copyright (c) 2011 Lynn Ochs"
+        ),
+        Some("Copyright (c) 2011 Lynn Ochs".to_string())
+    );
+}
+
+#[test]
+fn test_refine_copyright_leading_strip_preserves_notice_preamble_without_path() {
+    // The MPL preamble ends in `are` before `Copyright` but carries no path
+    // descriptor, so it must be kept verbatim (ScanCode parity).
+    assert_eq!(
+        refine_copyright(
+            "Portions created by the Initial Developer are Copyright (c) 1998 the Initial Developer"
+        ),
+        Some(
+            "Portions created by the Initial Developer are Copyright (c) 1998 the Initial Developer"
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn test_refine_copyright_strips_dangling_trailing_pronoun() {
+    assert_eq!(
+        refine_copyright("Copyright (c) 1994 David Burren. It"),
+        Some("Copyright (c) 1994 David Burren".to_string())
+    );
+    // A determiner-led proper-noun continuation is a second holder, not prose,
+    // and is kept (ScanCode parity).
+    assert_eq!(
+        refine_copyright("Copyright (c) 1994-1999. The MITRE Corporation"),
+        Some("Copyright (c) 1994-1999. The MITRE Corporation".to_string())
+    );
+}
+
+#[test]
+fn test_refine_copyright_truncates_hereby_released_prose() {
+    assert_eq!(
+        refine_copyright("Copyright (c) 1998-2014 Solar Designer and it is hereby released to the"),
+        Some("Copyright (c) 1998-2014 Solar Designer".to_string())
+    );
+}
+
+#[test]
+fn test_refine_holder_strips_dangling_trailing_pronoun() {
+    assert_eq!(
+        refine_holder("David Burren. It"),
+        Some("David Burren".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_strips_trailing_role_qualifier() {
+    assert_eq!(
+        refine_author("Rich Felker, primary"),
+        Some("Rich Felker".to_string())
+    );
+    // A genuine `Last, First` name is untouched.
+    assert_eq!(
+        refine_author("Felker, Rich"),
+        Some("Felker, Rich".to_string())
+    );
+}

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -374,6 +374,17 @@ fn project_native_copyright_value(rendered: &str, fallback: &str) -> String {
     let rendered_lower = rendered.to_ascii_lowercase();
     let fallback_lower = fallback.to_ascii_lowercase();
     let Some(start) = rendered_lower.find(&fallback_lower) else {
+        // The normalized notice differs from the source only in how the
+        // copyright sign is written — the refiner emits `(c)` while the source
+        // carries a literal `©` (or vice versa). Relocate the notice
+        // sign-insensitively and project the source-faithful raw slice, so the
+        // leading/trailing prose the refiner already trimmed is not re-attached
+        // by falling back to the whole raw line.
+        if let Some((s, len)) = locate_ignoring_copyright_sign(&rendered_lower, &fallback_lower) {
+            let base = rendered[s..s + len].trim().to_string();
+            let native_suffix = rendered[s + len..].trim();
+            return join_native_suffix(&base, native_suffix);
+        }
         if refine_copyright(rendered).as_deref() == Some(fallback) {
             return preserve_native_suffix_for_semantic_match(rendered, fallback);
         }
@@ -390,21 +401,53 @@ fn project_native_copyright_value(rendered: &str, fallback: &str) -> String {
     };
     let end = start + fallback.len();
     let suffix = rendered[end..].trim();
-    let Some(native_suffix) = normalize_native_suffix(suffix) else {
-        return fallback.to_string();
-    };
+    join_native_suffix(fallback, suffix)
+}
 
+/// Append a source-faithful trailing suffix to a projected copyright `base`,
+/// keeping only the suffix shapes `normalize_native_suffix` sanctions (bare
+/// punctuation, an `All rights reserved` tail, a confidentiality note). Any
+/// other trailing text — ordinary prose the refiner already trimmed — is
+/// dropped, so `base` is returned unchanged.
+fn join_native_suffix(base: &str, suffix: &str) -> String {
+    let Some(native_suffix) = normalize_native_suffix(suffix) else {
+        return base.to_string();
+    };
     if native_suffix.is_empty() {
-        fallback.to_string()
+        base.to_string()
     } else if native_suffix
         .chars()
         .next()
         .is_some_and(|ch| matches!(ch, '.' | ',' | ';' | ':'))
     {
-        format!("{fallback}{native_suffix}")
+        format!("{base}{native_suffix}")
     } else {
-        format!("{fallback} {native_suffix}")
+        format!("{base} {native_suffix}")
     }
+}
+
+/// Locate `fallback_lower` inside `rendered_lower` when the two differ only in
+/// how the copyright sign is spelled — the refiner emits `(c)` while the source
+/// may carry a literal `©` (or the reverse). Returns the byte offset and length
+/// of the match **within `rendered_lower`** (whose offsets align with the
+/// original mixed-case `rendered`, since ASCII case folding and the `©` glyph
+/// are byte-length preserving), so the caller can slice the source-faithful
+/// span. Returns `None` when no sign substitution locates the notice.
+fn locate_ignoring_copyright_sign(
+    rendered_lower: &str,
+    fallback_lower: &str,
+) -> Option<(usize, usize)> {
+    for candidate in [
+        fallback_lower.replace("(c)", "\u{00a9}"),
+        fallback_lower.replace('\u{00a9}', "(c)"),
+    ] {
+        if candidate != fallback_lower
+            && let Some(index) = rendered_lower.find(&candidate)
+        {
+            return Some((index, candidate.len()));
+        }
+    }
+    None
 }
 
 fn preserve_native_suffix_for_semantic_match(rendered: &str, fallback: &str) -> String {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -230,6 +230,72 @@ fn test_extract_copyright_information_keeps_raw_notice_and_holder_for_no_year_c_
 }
 
 #[test]
+fn test_extract_copyright_projects_source_faithful_slice_without_prose_bleed() {
+    // musl COPYRIGHT third-party notice: a `©` sign, a leading file/component
+    // descriptor, and a trailing prose sentence. The projected `copyright` must
+    // be the clean source-faithful slice (the literal `©` preserved) with the
+    // leading descriptor and trailing sentence dropped.
+    let text = "The TRE implementation (src/regex/tre.c) is Copyright \u{00a9} 2001-2008 Ville Laurikari and licensed under a 2-clause BSD license.\n";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("COPYRIGHT"), text, 120.0, false);
+
+    let file = builder
+        .name("COPYRIGHT".to_string())
+        .base_name("COPYRIGHT".to_string())
+        .extension(String::new())
+        .path("COPYRIGHT".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert_eq!(
+        file.copyrights.len(),
+        1,
+        "copyrights: {:?}",
+        file.copyrights
+    );
+    assert_eq!(
+        file.copyrights[0].copyright,
+        "Copyright \u{00a9} 2001-2008 Ville Laurikari"
+    );
+    assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
+    assert_eq!(file.holders[0].holder, "Ville Laurikari");
+}
+
+#[test]
+fn test_extract_copyright_skips_c_variable_control_flow_as_holder() {
+    // `if (c) goto ilseq;` tags the C variable `(c)` as a copyright marker; the
+    // following lowercase identifier must not be manufactured into a holder.
+    let text = "\tif (c) goto ilseq;\n\tif (c) return 0;\n";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("mbrtowc.c"), text, 120.0, false);
+
+    let file = builder
+        .name("mbrtowc.c".to_string())
+        .base_name("mbrtowc".to_string())
+        .extension(".c".to_string())
+        .path("mbrtowc.c".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(
+        file.holders.is_empty(),
+        "expected no holders from C control flow, got: {:?}",
+        file.holders
+    );
+    assert!(
+        file.copyrights.is_empty(),
+        "expected no copyrights from C control flow, got: {:?}",
+        file.copyrights
+    );
+}
+
+#[test]
 fn test_extract_copyright_information_uses_embedded_sourcemap_sources_for_parties() {
     let text = r#"{"version":3,"comment":"Copyright 1999 Wrong Corp.","sourcesContent":["/* Copyright 2024 Example Corp. */\n"]}"#;
     let mut builder = FileInfoBuilder::default();

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/lib/decompress_unlzma.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/lib/decompress_unlzma.c.yml
@@ -10,5 +10,4 @@ holders:
   - Alain
   - Aurelien Jacobs
   - Igor Pavlov
-  - the parts
 authors: []

--- a/testdata/copyright-golden/copyrights/misco4/to_improve/junk-copyright-44.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco4/to_improve/junk-copyright-44.txt.yml
@@ -3,6 +3,5 @@ what:
   - holders
   - authors
 copyrights: []
-holders:
-  - ?A$?I1/4Pedegi$?I
+holders: []
 authors: []


### PR DESCRIPTION
## Summary

- Closes a general copyright/holder/author **over-capture (prose bleed)** class surfaced while verifying musl for the benchmark set. ScanCode stays clean because its grammar anchors every statement at the copyright marker and never folds bare common-noun prose in; Provenant reconstructed values from whole spans/lines and then re-expanded them during source-faithful projection.
- **Projection** (`render_raw_copyright_from_text`): when the refined value and the source differed only in copyright-sign spelling (`(c)` vs `©`), the raw-slice projection failed to locate the notice and fell back to the entire raw line, re-attaching the leading/trailing prose the refiner had already trimmed. It now relocates the notice sign-insensitively and projects only its source-faithful slice (the literal `©` preserved).
- **Refiner**: anchors a leading `The <component> (<path>) is Copyright ...` descriptor at the copyright marker (guarded to a path/parenthetical lead, so the MPL `Portions created by ... are Copyright` preamble is kept verbatim); trims a dangling trailing subject pronoun (`... David Burren. It`) and an `and it is hereby released ...` tail; strips a trailing `, <role>` author qualifier (`Rich Felker, primary`).
- **Flat-span holder fallback**: now requires the same strong holder/year anchor the span's copyright build already demands, so `if (c) goto ilseq;` C control flow no longer manufactures a holder from the `(c)` variable.

## Issues

- Covers: copyright/holder/author prose-bleed reduction identified during musl benchmark verification. No linked issue.

## Scope and exclusions

- Included: the projection fix, four narrow, guarded refiner rules, and the span-holder anchor; refiner unit tests and scanner projection/guard tests.
- Explicit exclusions: the benchmark row for musl lands in a separate follow-up after this merges and a clean optimized re-scan. Two residual musl deltas are left as documented, defensible differences — a merged `by`-chain author (`Richard Pennington, and later ... John Spencer`) that needs a detector-level author *split* rather than bleed-trimming, and `©`-vs-`(c)` copyright rendering (the intended Provenant source-faithful advantage).

## How to verify

- `cargo test --features golden-tests --test copyright_golden` — 36/36 (100%).
- `cargo test --lib copyright:: scanner::process::copyright` — refiner + scanner projection/guard tests.
- Behavioral: scanning musl's `COPYRIGHT` and `src/crypt/*`, `src/multibyte/mbrtowc.c` at the pinned SHA shows clean, anchored copyright/holder/author values with no leading/trailing prose bleed and no `goto ilseq` holder.

## Expected-output fixture changes

- Two curated copyright goldens are synced (`--sync-actual`): `misco4/linux-copyrights/lib/decompress_unlzma.c` drops the junk holder `the parts` (from source `Copyrights of the parts`; the three real holders remain), and `misco4/to_improve/junk-copyright-44.txt` drops a mojibake holder string. Both are ScanCode-parity noise removed by the strong-holder span anchor — a junk-reduction improvement, not a parity regression.
