### PR TITLE
docs(benchmarks): record musl copyright/holder/author verification target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 243 of 243 recorded runs, with a **19.4× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 244 of 244 recorded runs, with a **19.5× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -887,6 +887,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-29 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `9.96s`; ScanCode `354.17s`
 - Cleaner URL extraction that rejects `{account}`-templated host placeholders ScanCode emits as navigable URLs, and author capture that drops the README maintainer prose ScanCode records as a party, on otherwise matched Go module package, dependency, and declared-license coverage — the assembled `pkg:golang/github.com/hashicorp/terraform` resolves the repo-root `LICENSE` to the same `bsl-1.1 AND mpl-2.0` ScanCode reports
+
+##### [ifduyue/musl @ b306b16](https://github.com/ifduyue/musl/tree/b306b16af15c89a04d8e0c55cac2dadbeb39c083) — **19.65× faster**
+
+- Files: 2,660
+- Run context: 2026-07-12 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.12s`; ScanCode `100.58s`
+- Clean copyright, holder, and author extraction across musl's `COPYRIGHT` third-party-notice roster: statements anchor at the copyright marker with no leading file-descriptor (`Copyright (c) 2008 The Android Open Source Project`, not `The ARM memcpy code (…) is Copyright …`) or trailing license-prose bleed, the source `©` glyph is preserved (`Copyright © 1994 David Burren`), and C control flow such as `if (c) goto ilseq;` no longer manufactures a holder — holders match exactly (`148` vs `148`) and the bare word `BSD` surfaces as a `bsd-new` clue rather than a detection, with no spurious `pkg:autotools/input` package invented from the hand-written `configure` script; ScanCode keeps a marginal author edge (`13` vs `12`) from one multi-contributor `by`-chain that Provenant reports as a single merged attribution
 
 ##### [ImageMagick/ImageMagick @ 55e52c4](https://github.com/ImageMagick/ImageMagick/tree/55e52c44752eec35d893f4edbf7f7fa2dbe247ce) — **37.07× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -527,6 +527,9 @@ ScanCode: 686.99s</title></rect>
     <rect x="634.05" y="342.72" width="8" height="8" fill="#d97706" rx="1.5"><title>pandas-dev/pandas @ c385d01
 Files: 2608
 ScanCode: 418.88s</title></rect>
+    <rect x="635.41" y="410.13" width="8" height="8" fill="#d97706" rx="1.5"><title>ifduyue/musl @ b306b16
+Files: 2660
+ScanCode: 100.58s</title></rect>
     <rect x="638.16" y="373.05" width="8" height="8" fill="#d97706" rx="1.5"><title>jgm/pandoc @ d9838eb
 Files: 2768
 ScanCode: 220.43s</title></rect>
@@ -1258,6 +1261,9 @@ Provenant: 25.48s</title></circle>
     <circle cx="638.05" cy="510.48" r="4.5" fill="#2563eb"><title>pandas-dev/pandas @ c385d01
 Files: 2608
 Provenant: 13.09s</title></circle>
+    <circle cx="639.41" cy="554.83" r="4.5" fill="#2563eb"><title>ifduyue/musl @ b306b16
+Files: 2660
+Provenant: 5.12s</title></circle>
     <circle cx="642.16" cy="524.25" r="4.5" fill="#2563eb"><title>jgm/pandoc @ d9838eb
 Files: 2768
 Provenant: 9.78s</title></circle>


### PR DESCRIPTION
## Summary

- Records **ifduyue/musl @ b306b16** (`19.65×`) in `docs/BENCHMARKS.md`, scanned on merged `main` after #1270, with ScanCode reused from cache for same-host timing (Provenant `5.12s`; ScanCode `100.58s`, 2,660 files).
- musl's `COPYRIGHT` third-party-notice roster is a copyright/holder/author stress target. On merged main the notices anchor cleanly at the copyright marker (no leading file-descriptor or trailing license-prose bleed), the source `©` glyph is preserved, `if (c) goto ilseq;` C control flow no longer manufactures a holder, holders match ScanCode exactly (`148` vs `148`), the bare word `BSD` surfaces as a `bsd-new` clue rather than a detection, and no degenerate `pkg:autotools/input` package is invented from the hand-written `configure` script.
- Regenerates `docs/scan-duration-vs-files.svg`; the corpus is now **244 of 244 runs faster** (19.5× median).

## Issues

- Covers: benchmark verification of musl (copyright/holder/author extraction) following `docs/BENCHMARKS.md`.

## Scope and exclusions

- Included: one new row in the "Rust / Go / native / infrastructure" section (alphabetically placed) and the regenerated chart + auto-updated stats line.
- Explicit exclusions: no scanner code changes — the extraction improvements this row depends on shipped in #1270 (copyright/holder/author prose-bleed reduction). One documented residual: ScanCode keeps a marginal author edge (`13` vs `12`) from a multi-contributor `by`-chain that Provenant reports as a single merged attribution; a proper split is a detector-level enhancement tracked for follow-up.

## How to verify

- Reproducible via `compare-outputs --repo-url https://github.com/ifduyue/musl.git --repo-ref b306b16af15c89a04d8e0c55cac2dadbeb39c083 --profile common`; ScanCode is a cache hit so the timing is same-host. Nothing beyond reading the row is needed in CI.

## Expected-output fixture changes

- Files changed: `docs/BENCHMARKS.md` (one row + auto-updated stats line), `docs/scan-duration-vs-files.svg` (regenerated).
