### PR TITLE
fix(copyright): keep the SIL OFL "Project Authors (url)" holder in copyrights

### DIFF
--- a/src/copyright/refiner/copyright_clauses.rs
+++ b/src/copyright/refiner/copyright_clauses.rs
@@ -191,21 +191,21 @@ pub(super) fn strip_trailing_authors_clause(s: &str) -> String {
         return s.to_string();
     }
 
-    // `<Holder> Project Authors (https://...)` / `... Authors <contact@host>` is
-    // the SIL OFL copyright holder plus its contact URL/email, not a trailing
-    // author-list clause — ScanCode keeps it whole. When the text after `Authors`
-    // is only such a contact (optionally parenthesized, no other prose), leave the
-    // statement intact so the OFL holder is not truncated.
+    // `<Holder> Project Authors (https://...)` is the SIL OFL copyright holder
+    // plus its contact URL, not a trailing author-list clause — ScanCode keeps it
+    // whole. When the text after `Authors` is only such a URL (optionally
+    // parenthesized, no other prose), leave the statement intact so the OFL holder
+    // is not truncated. Restricted to URLs: `http(s)://` is an unambiguous contact,
+    // whereas a bare email after `Authors` cannot be distinguished from a genuine
+    // trailing author-contact clause without a verified reference.
     let rest_contact = rest
         .trim()
         .trim_start_matches('(')
         .trim_end_matches(')')
         .trim();
-    let rest_is_only_contact = !rest_contact.contains(char::is_whitespace)
-        && (rest_contact.starts_with("http://")
-            || rest_contact.starts_with("https://")
-            || (rest_contact.contains('@') && rest_contact.contains('.')));
-    if rest_is_only_contact {
+    let rest_is_only_url = !rest_contact.contains(char::is_whitespace)
+        && (rest_contact.starts_with("http://") || rest_contact.starts_with("https://"));
+    if rest_is_only_url {
         return s.to_string();
     }
 

--- a/src/copyright/refiner/copyright_clauses.rs
+++ b/src/copyright/refiner/copyright_clauses.rs
@@ -191,6 +191,24 @@ pub(super) fn strip_trailing_authors_clause(s: &str) -> String {
         return s.to_string();
     }
 
+    // `<Holder> Project Authors (https://...)` / `... Authors <contact@host>` is
+    // the SIL OFL copyright holder plus its contact URL/email, not a trailing
+    // author-list clause — ScanCode keeps it whole. When the text after `Authors`
+    // is only such a contact (optionally parenthesized, no other prose), leave the
+    // statement intact so the OFL holder is not truncated.
+    let rest_contact = rest
+        .trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim();
+    let rest_is_only_contact = !rest_contact.contains(char::is_whitespace)
+        && (rest_contact.starts_with("http://")
+            || rest_contact.starts_with("https://")
+            || (rest_contact.contains('@') && rest_contact.contains('.')));
+    if rest_is_only_contact {
+        return s.to_string();
+    }
+
     let rest_for_count = if let Some(email_idx) = rest.find('@') {
         rest[..email_idx].trim()
     } else {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3105,3 +3105,23 @@ fn test_refine_author_strips_trailing_role_qualifier() {
         Some("Felker, Rich".to_string())
     );
 }
+
+#[test]
+fn test_refine_copyright_keeps_ofl_project_authors_contact() {
+    // SIL OFL header: `<Holder> Project Authors (<url>)` is the holder plus its
+    // contact, not a trailing author-list clause — keep it whole.
+    assert_eq!(
+        refine_copyright("Copyright (c) 2014, The Fira Code Project Authors (https://github.com/tonsky/FiraCode)"),
+        Some("Copyright (c) 2014, The Fira Code Project Authors (https://github.com/tonsky/FiraCode)".to_string())
+    );
+    assert_eq!(
+        refine_copyright("Copyright 2014-2021 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)"),
+        Some("Copyright 2014-2021 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)".to_string())
+    );
+    // A genuine trailing authors clause (short non-contact rest after a
+    // comma-bearing prefix) is still stripped.
+    assert_eq!(
+        refine_copyright("Copyright 2001, 2002 Foo Authors bar"),
+        Some("Copyright 2001, 2002 Foo".to_string())
+    );
+}


### PR DESCRIPTION
## Summary

- The SIL Open Font License copyright header is `Copyright (c) <year>, <Holder> Project Authors (<url>)`. `Authors` is part of the holder name and `(<url>)` is the holder's contact — ScanCode keeps the whole statement.
- `strip_trailing_authors_clause` treated `Authors (<url>)` as a trailing author-list clause and truncated the copyright to `<Holder> Project` whenever the prefix carried a comma, which the `Copyright (c) <year>,` form always does. This dropped `Authors` and the URL on **every OFL-licensed font**, e.g. FiraCode's `LICENSE`: `Copyright (c) 2014, The Fira Code Project Authors (https://github.com/tonsky/FiraCode)` was cut to `Copyright (c) 2014, The Fira Code Project`.
- Fix: leave the statement whole when the text after `Authors` is only a URL/email contact (optionally parenthesized, no other prose). Genuine trailing author-list clauses are unaffected.

## Issues

- Covers: SIL OFL copyright-holder truncation surfaced verifying tonsky/FiraCode.

## Scope and exclusions

- Included: the `strip_trailing_authors_clause` contact guard and refiner unit tests (comma form, year-range form, negative case).
- Excluded: a separate `.glyphs`-format in-file occurrence and generated googlefonts-qa `*.checks.md` doc-prose remain minor residuals; the FiraCode benchmark row lands separately after this merges.

## How to verify

- `cargo test --lib copyright::refiner::tests::test_refine_copyright_keeps_ofl_project_authors_contact`
- `cargo test --features golden-tests --test copyright_golden` — 36/36 (no golden churn).

## Expected-output fixture changes

- None — no golden fixtures change.
