### PR TITLE
docs(benchmarks): add FiraCode row, reword musl row to end-state differences

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 244 of 244 recorded runs, with a **19.5× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 245 of 245 recorded runs, with a **19.5× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -893,7 +893,7 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Files: 2,660
 - Run context: 2026-07-12 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.12s`; ScanCode `100.58s`
-- Clean copyright, holder, and author extraction across musl's `COPYRIGHT` third-party-notice roster: statements anchor at the copyright marker with no leading file-descriptor (`Copyright (c) 2008 The Android Open Source Project`, not `The ARM memcpy code (…) is Copyright …`) or trailing license-prose bleed, the source `©` glyph is preserved (`Copyright © 1994 David Burren`), and C control flow such as `if (c) goto ilseq;` no longer manufactures a holder — holders match exactly (`148` vs `148`) and the bare word `BSD` surfaces as a `bsd-new` clue rather than a detection, with no spurious `pkg:autotools/input` package invented from the hand-written `configure` script; ScanCode keeps a marginal author edge (`13` vs `12`) from one multi-contributor `by`-chain that Provenant reports as a single merged attribution
+- Copyright rendering preserves the literal `©` glyph (`Copyright © 1994 David Burren`) where ScanCode normalizes it to `(c)`; the bare word `BSD` in musl's `COPYRIGHT` roster is reported as a `bsd-new` license clue where ScanCode emits none; and the hand-written `configure` script yields no package where ScanCode names a degenerate `pkg:autotools/input` after the scan-root directory. ScanCode holds a marginal author edge (`13` vs `12`) from one multi-contributor `by`-chain Provenant reports as a single merged attribution
 
 ##### [ImageMagick/ImageMagick @ 55e52c4](https://github.com/ImageMagick/ImageMagick/tree/55e52c44752eec35d893f4edbf7f7fa2dbe247ce) — **37.07× faster**
 
@@ -1125,6 +1125,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-14 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.55s`; ScanCode `103.73s`
 - Matched Cargo workspace package and dependency coverage (`12` vs `12` packages, `83` vs `83` dependencies) while preserving collective manifest-author names like `Tokio Contributors <team@tokio.rs>`, plus cleaner rejection of ScanCode's weak `(c)`-plus-URL copyright and holder noise and normalized docs.rs URL variants
+
+##### [tonsky/FiraCode @ 727682c](https://github.com/tonsky/FiraCode/tree/727682c24c33fb0bbc7ab0ed9b7a8d0d9745a198) — **20.41× faster**
+
+- Files: 234
+- Run context: 2026-07-12 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.65s`; ScanCode `94.92s`
+- Author extraction reports only the real author (`Nikita Prokopov <niki@tonsky.me>`) against ScanCode's `30`, which include OpenType glyph and feature names (`greater_equal_end.seq`, `greater_greater_hyphen_start.seq`, …) and a `package.json` author value with the manifest's `license`/`bugs`/`url` fields bled in; package extraction is broader (`5` vs `3` file-level `package_data`, `6` more dependencies) and the SIL OFL holder keeps its `Authors (https://…)` contact in the repo-root `LICENSE`. ScanCode reports cleaner copyright holders in a `.glyphs`-internal OFL notice and the generated `googlefonts-qa/*.checks.md` QA reports, where Provenant retains a `Project Authors (git url) …` prose fragment
 
 ##### [xiph/opus @ 22244de](https://github.com/xiph/opus/tree/22244de5a79bd1d6d623c32e72bf1954b56235be) — **15.24× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -248,6 +248,9 @@ ScanCode: 54.22s</title></rect>
     <rect x="462.40" y="443.56" width="8" height="8" fill="#d97706" rx="1.5"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 ScanCode: 49.57s</title></rect>
+    <rect x="467.92" y="412.86" width="8" height="8" fill="#d97706" rx="1.5"><title>tonsky/FiraCode @ 727682c
+Files: 234
+ScanCode: 94.92s</title></rect>
     <rect x="469.95" y="423.83" width="8" height="8" fill="#d97706" rx="1.5"><title>boostorg/boost @ 4f1cbeb
 Files: 241
 ScanCode: 75.26s</title></rect>
@@ -982,6 +985,9 @@ Provenant: 5.17s</title></circle>
     <circle cx="466.40" cy="559.28" r="4.5" fill="#2563eb"><title>ReactiveCocoa/ReactiveCocoa @ f2d9bd5
 Files: 216
 Provenant: 4.66s</title></circle>
+    <circle cx="471.92" cy="559.38" r="4.5" fill="#2563eb"><title>tonsky/FiraCode @ 727682c
+Files: 234
+Provenant: 4.65s</title></circle>
     <circle cx="473.95" cy="554.10" r="4.5" fill="#2563eb"><title>boostorg/boost @ 4f1cbeb
 Files: 241
 Provenant: 5.20s</title></circle>


### PR DESCRIPTION
## Summary

- Records **tonsky/FiraCode @ 727682c** (`20.41×`) in the native/infrastructure section, scanned on merged `main` after #1272 (Provenant `4.65s`; ScanCode `94.92s`, 234 files, ScanCode reused from cache for same-host timing).
- FiraCode is an OFL-1.1 font project. The end-state difference is author precision: Provenant reports the single real author (`Nikita Prokopov <niki@tonsky.me>`) against ScanCode's `30`, which include OpenType glyph/feature names (`greater_equal_end.seq`, …) and a `package.json` author value with the manifest's `license`/`bugs`/`url` fields bled in; package extraction is broader (`5` vs `3` file-level `package_data`, `6` more dependencies) and the SIL OFL holder keeps its `Authors (https://…)` contact in the repo-root `LICENSE`. ScanCode reports cleaner holders in a `.glyphs`-internal OFL notice and generated `googlefonts-qa/*.checks.md` QA reports (a documented residual).
- Also rewrites the **musl** row to state only actual Provenant-vs-ScanCode end-state differences (source `©` vs `(c)`, bare-word `bsd-new` clue, declined degenerate `pkg:autotools/input`, ScanCode's 13-vs-12 author edge) rather than narrating how the fix reached parity.
- Regenerates `docs/scan-duration-vs-files.svg`; the corpus is now **245 of 245 runs faster** (19.5× median).

## Issues

- Covers: benchmark verification of FiraCode (OFL-1.1 font project) plus a wording correction to the musl row.

## Scope and exclusions

- Included: one new FiraCode row, the musl row reword, and the regenerated chart + stats line.
- Excluded: no scanner code changes — the OFL holder-contact fix this row depends on shipped in #1272. Documented FiraCode residuals: a `.glyphs`-internal OFL notice and generated googlefonts-qa `*.checks.md` doc-prose where Provenant's copyright/holder retain a `Project Authors (git url)` fragment.

## How to verify

- Reproducible via `compare-outputs --repo-url https://github.com/tonsky/FiraCode.git --repo-ref 727682c24c33fb0bbc7ab0ed9b7a8d0d9745a198 --profile common`; ScanCode is a cache hit so timing is same-host.

## Expected-output fixture changes

- Files changed: `docs/BENCHMARKS.md` (one new row, musl row reword, auto-updated stats line), `docs/scan-duration-vs-files.svg` (regenerated).
