### PR TITLE
fix(copyright): strip parenthesized "(see the CONTRIBUTORS file)" reference

### DIFF
--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -519,7 +519,7 @@ static CREDIT_FILE_REFERENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
     compile_static_regex(
         r"(?ix)
         ^(?P<prefix>.+?)
-        \s*\(?\s*
+        (?:\s+|\s*\(\s*)
         (?:see|refer\s+to|consult)\s+
         (?:the\s+)?
         (?:authors?|credits?|contributors?)\s+file

--- a/src/copyright/refiner/copyright.rs
+++ b/src/copyright/refiner/copyright.rs
@@ -512,33 +512,62 @@ pub(super) fn strip_trailing_heavily_based_clause(s: &str) -> String {
     s.to_string()
 }
 
+/// Trailing "see/refer to/consult (the) <authors|credits|contributors> file"
+/// reference, optionally parenthesized, e.g. `... and Contributors (see the
+/// CONTRIBUTORS file).`. Captures the statement prefix before the reference.
+static CREDIT_FILE_REFERENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    compile_static_regex(
+        r"(?ix)
+        ^(?P<prefix>.+?)
+        \s*\(?\s*
+        (?:see|refer\s+to|consult)\s+
+        (?:the\s+)?
+        (?:authors?|credits?|contributors?)\s+file
+        \s*\)?\.?\s*$
+        ",
+    )
+});
+
 pub(super) fn strip_trailing_credit_file_reference_clause(s: &str) -> String {
     let trimmed = s.trim();
     let lower = trimmed.to_ascii_lowercase();
     if !(lower.starts_with("copyright") || lower.starts_with("(c)")) {
         return s.to_string();
     }
-
-    for marker in [
-        " see authors file",
-        " see author file",
-        " see credits file",
-        " see credit file",
-        " refer to authors file",
-        " refer to credits file",
-        " consult authors file",
-        " consult credits file",
-    ] {
-        if let Some(index) = lower.find(marker) {
-            let prefix = trimmed[..index]
-                .trim_end_matches(&[',', ';', ':', ' '][..])
-                .trim();
-            if prefix.chars().any(|ch| ch.is_ascii_digit()) {
-                return prefix.to_string();
-            }
-        }
+    let Some(cap) = CREDIT_FILE_REFERENCE_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap
+        .name("prefix")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim_end_matches(&[',', ';', ':', ' '][..])
+        .trim();
+    if prefix.chars().any(|ch| ch.is_ascii_digit()) {
+        return prefix.to_string();
     }
+    s.to_string()
+}
 
+/// Holder-side counterpart of [`strip_trailing_credit_file_reference_clause`]:
+/// strips a trailing `(see the CONTRIBUTORS file)`-style reference from a holder
+/// such as `Audrius Butkevicius and Contributors (see the CONTRIBUTORS file)`.
+/// Guarded on the prefix looking like a real holder rather than a copyright
+/// statement, since a holder carries no `Copyright`/`(c)` marker.
+pub(super) fn strip_trailing_credit_file_reference_in_holder(s: &str) -> String {
+    let trimmed = s.trim();
+    let Some(cap) = CREDIT_FILE_REFERENCE_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap
+        .name("prefix")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim_end_matches(&[',', ';', ':', ' '][..])
+        .trim();
+    if !prefix.is_empty() && prefix_has_holder_words(prefix) {
+        return prefix.to_string();
+    }
     s.to_string()
 }
 

--- a/src/copyright/refiner/holder.rs
+++ b/src/copyright/refiner/holder.rs
@@ -153,6 +153,7 @@ pub(super) fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<
 
     h = remove_some_extra_words_and_punct(&h);
     h = strip_trailing_incomplete_as_represented_by(&h);
+    h = strip_trailing_credit_file_reference_in_holder(&h);
     h = strip_trailing_contributor_clause(&h);
     h = strip_trailing_contact_clause(&h);
     h = strip_trailing_holder_prose_clause(&h);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3139,6 +3139,12 @@ fn test_refine_copyright_strips_contributors_file_reference() {
         refine_copyright("Copyright (c) 2018 Foo Bar see authors file"),
         Some("Copyright (c) 2018 Foo Bar".to_string())
     );
+    // The `see` directive requires a real separator, so it never matches inside a
+    // holder word (`Tennessee`).
+    assert_eq!(
+        refine_copyright("Copyright 2024 Tennessee authors file"),
+        Some("Copyright 2024 Tennessee authors file".to_string())
+    );
 }
 
 #[test]

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3125,3 +3125,26 @@ fn test_refine_copyright_keeps_ofl_project_authors_contact() {
         Some("Copyright 2001, 2002 Foo".to_string())
     );
 }
+
+#[test]
+fn test_refine_copyright_strips_contributors_file_reference() {
+    assert_eq!(
+        refine_copyright(
+            "Copyright (C) 2015 Audrius Butkevicius and Contributors (see the CONTRIBUTORS file)."
+        ),
+        Some("Copyright (C) 2015 Audrius Butkevicius and Contributors".to_string())
+    );
+    // Existing unparenthesized AUTHORS/CREDITS references still strip.
+    assert_eq!(
+        refine_copyright("Copyright (c) 2018 Foo Bar see authors file"),
+        Some("Copyright (c) 2018 Foo Bar".to_string())
+    );
+}
+
+#[test]
+fn test_refine_holder_strips_contributors_file_reference() {
+    assert_eq!(
+        refine_holder("Audrius Butkevicius and Contributors (see the CONTRIBUTORS file)"),
+        Some("Audrius Butkevicius and Contributors".to_string())
+    );
+}


### PR DESCRIPTION
## Summary

- Many OSS headers write `Copyright (C) <year> <Holder> and Contributors (see the CONTRIBUTORS file).`. The trailing `(see the CONTRIBUTORS file)` is a pointer to a credits file, not part of the holder — ScanCode drops it.
- `strip_trailing_credit_file_reference_clause` only matched the unparenthesized `see authors/credits file` form, so the parenthesized, `the`-bearing, contributors-file variant leaked into both the copyright and the holder — surfaced verifying syncthing (`Audrius Butkevicius and Contributors (see the CONTRIBUTORS file)` across the strelay* sources).
- Generalizes the reference match to a regex covering `see`/`refer to`/`consult`, an optional `the`, `authors`/`credits`/`contributors`, and an optional wrapping paren; applies a holder-guarded variant in holder refinement. On syncthing this closes 11 copyright and 11 holder deltas against ScanCode.

## Issues

- Covers: credit-file-reference clause leak surfaced verifying syncthing/syncthing.

## Scope and exclusions

- Included: the generalized reference regex (copyright + holder paths) and copyright/holder unit tests; existing unparenthesized references still strip.
- Excluded: the source-faithful `copyright` field's retention of the raw notice, a dangling `see the` span-truncation variant, and an `aboutModalView.html` HTML included-software-list bleed remain documented residuals; the syncthing benchmark row lands separately after this merges.

## How to verify

- `cargo test --lib copyright::refiner::tests::test_refine_copyright_strips_contributors_file_reference`, `…test_refine_holder_strips_contributors_file_reference`.
- `cargo test --features golden-tests --test copyright_golden` — 36/36 (no golden churn).

## Expected-output fixture changes

- None — no golden fixtures change.
