### PR TITLE
docs(benchmarks): record syncthing MPL-2.0 verification target

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 245 of 245 recorded runs, with a **19.5× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
+> Provenant is faster on 246 of 246 recorded runs, with a **19.5× median speedup** and **19.5× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **36.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -1090,6 +1090,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-07-12 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `10.34s`; ScanCode `688.10s`
 - Clean copyright output on the SQL-heavy public-domain tree — `(c)` tokens inside expressions such as `max(c) OVER (...)` and `avg(c) FILTER (...)` are treated as code rather than notices, yielding `43` copyrights against ScanCode's `40` — with richer author capture (`19` vs `13`), rejection of ScanCode's own grammar and fuzz/binary copyright noise (`(c) JOIN` in `parse.y`, byte runs in `fuzzdata2.db`), and a deduplicated `public-domain AND blessing AND bsd-new` expression on `LICENSE.md` more compact than ScanCode's repeated form
+
+##### [syncthing/syncthing @ 5277033](https://github.com/syncthing/syncthing/tree/527703390608d743788f464ada8d422bfa933993) — **22.41× faster**
+
+- Files: 1,132
+- Run context: 2026-07-12 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.90s`; ScanCode `154.60s`
+- Author extraction captures the project's full `AUTHORS` contributor roster (`279` authors against ScanCode's `7`), and `OFL-1.1` is detected in the vendored fork-awesome fonts — the `LICENSE.txt` plus the `.woff`/`.ttf`/`.eot`/`.svg` binaries — that ScanCode leaves as bare license clues; copyright rendering preserves the source `©`/`(C)` where ScanCode normalizes to `(c)`, over a slightly larger dependency set (`355` vs `352`). ScanCode reports cleaner holders in the `gui/default/syncthing/core/aboutModalView.html` "included software" credits list, where Provenant retains adjacent-entry fragments (`Alec Thomas. beorn7/perks`)
 
 ##### [systemd/systemd @ 89d705a](https://github.com/systemd/systemd/tree/89d705a892b3476de14e548f3f9b0af96207d4b0) — **42.92× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -422,6 +422,9 @@ ScanCode: 85.71s</title></rect>
     <rect x="575.87" y="395.19" width="8" height="8" fill="#d97706" rx="1.5"><title>microsoft/regorus @ 7f42115
 Files: 1121
 ScanCode: 137.98s</title></rect>
+    <rect x="576.54" y="389.81" width="8" height="8" fill="#d97706" rx="1.5"><title>syncthing/syncthing @ 5277033
+Files: 1132
+ScanCode: 154.60s</title></rect>
     <rect x="577.87" y="402.80" width="8" height="8" fill="#d97706" rx="1.5"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 ScanCode: 117.46s</title></rect>
@@ -1159,6 +1162,9 @@ Provenant: 5.17s</title></circle>
     <circle cx="579.87" cy="543.92" r="4.5" fill="#2563eb"><title>microsoft/regorus @ 7f42115
 Files: 1121
 Provenant: 6.45s</title></circle>
+    <circle cx="580.54" cy="540.73" r="4.5" fill="#2563eb"><title>syncthing/syncthing @ 5277033
+Files: 1132
+Provenant: 6.90s</title></circle>
     <circle cx="581.87" cy="542.91" r="4.5" fill="#2563eb"><title>tidyverse/ggplot2 @ 7d79c95
 Files: 1154
 Provenant: 6.59s</title></circle>


### PR DESCRIPTION
## Summary

- Records **syncthing/syncthing @ 5277033** (`22.41×`) in the native/infrastructure section, scanned on merged `main` after #1274 (Provenant `6.90s`; ScanCode `154.60s`, 1,132 files, ScanCode reused from cache for same-host timing).
- syncthing is an MPL-2.0 Go codebase with per-file headers. The end-state differences are authorship and license coverage: Provenant captures the full `AUTHORS` contributor roster (`279` authors vs ScanCode's `7`) and detects `OFL-1.1` in the vendored fork-awesome fonts (`LICENSE.txt` + `.woff`/`.ttf`/`.eot`/`.svg`) that ScanCode leaves as bare license clues; copyright rendering preserves the source `©`/`(C)` where ScanCode normalizes to `(c)`, over a slightly larger dependency set (`355` vs `352`).
- Documented residual: ScanCode reports cleaner holders in the `aboutModalView.html` "included software" credits list, where Provenant retains adjacent-entry fragments.
- Regenerates `docs/scan-duration-vs-files.svg`; the corpus is now **246 of 246 runs faster** (19.5× median).

## Issues

- Covers: benchmark verification of syncthing (MPL-2.0 Go codebase) following `docs/BENCHMARKS.md`.

## Scope and exclusions

- Included: one new row in the "Rust / Go / native / infrastructure" section (alphabetically placed) and the regenerated chart + stats line.
- Excluded: no scanner code changes — the `(see the CONTRIBUTORS file)` credit-reference fix this row depends on shipped in #1274. Documented residual: the `aboutModalView.html` HTML credits-list holder bleed.

## How to verify

- Reproducible via `compare-outputs --repo-url https://github.com/syncthing/syncthing.git --repo-ref 527703390608d743788f464ada8d422bfa933993 --profile common`; ScanCode is a cache hit so timing is same-host.

## Expected-output fixture changes

- Files changed: `docs/BENCHMARKS.md` (one row + auto-updated stats line), `docs/scan-duration-vs-files.svg` (regenerated).
