### PR TITLE
fix(finder): skip SSH remotes and URL authorities in email detection

### DIFF
--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -32,6 +32,19 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
         let normalized_line = line.replace("\\r\\n", "\\n").replace("\\r", "\\n");
         for segment in normalized_line.split("\\n") {
             for matched in EMAILS_REGEX.find_iter(segment) {
+                // Skip SSH remotes such as `git@github.com:org/repo.git` and
+                // `user@host:port` URL authorities. Only a `:` followed by a
+                // path segment (contains `/`) or a bare numeric port qualifies —
+                // so structured text like `owner=admin@corp.com:active` keeps its
+                // email.
+                if let Some(after_colon) = segment[matched.end()..].strip_prefix(':') {
+                    let suffix = after_colon.split_whitespace().next().unwrap_or("");
+                    let is_ssh_path = suffix.contains('/');
+                    let is_port = !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit());
+                    if is_ssh_path || is_port {
+                        continue;
+                    }
+                }
                 let email = matched.as_str().to_lowercase();
                 if !is_good_email_domain(&email) {
                     continue;
@@ -66,4 +79,39 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
     }
 
     detections
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn emails(text: &str) -> Vec<String> {
+        find_emails(text, &DetectionConfig::default())
+            .into_iter()
+            .map(|d| d.email)
+            .collect()
+    }
+
+    #[test]
+    fn test_find_emails_skips_ssh_remote_and_authority() {
+        // `git@github.com:org/repo.git` SSH remote (colon + path) is not an email.
+        assert!(emails("clone: git clone git@github.com:tonsky/FiraCode.git").is_empty());
+        // `user@host:port` URL authority (colon + numeric port) is not an email.
+        assert!(emails("connect admin@dbhost.io:5432 now").is_empty());
+        // A real email followed by a colon + non-path text is still captured.
+        assert_eq!(
+            emails("owner=admin@corp.com:active"),
+            vec!["admin@corp.com"]
+        );
+        // A real email followed by a colon and a space is still captured.
+        assert_eq!(
+            emails("Contact real@corp.com: for help"),
+            vec!["real@corp.com"]
+        );
+        // Plain email untouched.
+        assert_eq!(
+            emails("mail jane@realcorp.io today"),
+            vec!["jane@realcorp.io"]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `git@github.com:org/repo.git` clone commands and `user@host:port` URL authorities were matched as emails (surfaced verifying FiraCode/syncthing). A real email is never immediately followed by a `:` and a **path segment** (contains `/`) or a **bare numeric port**, so skip those matches. Structured text like `owner=admin@corp.com:active` keeps its email.

## Issues

- Covers: SSH-remote / URL-authority email false positive.

## Scope and exclusions

- Included: the narrowed email-finder guard and a finder unit test (SSH path, numeric port, config `:value`, colon-space, plain email).
- **Note:** this PR was originally scoped to also drop DCO-placeholder authors on reserved (RFC 2606) documentation domains. That change was **pulled** — it conflicts with an established contract: the copyright author-list goldens and `test_extract_patch_header_author_supplements_collects_common_patch_headers` both intentionally keep `<...@example.com>` authors. Dropping reserved-domain authors is defensible but changes that contract, so it's deferred for a maintainer decision rather than forced through here.

## How to verify

- `cargo test --lib finder::emails::tests::test_find_emails_skips_ssh_remote_and_authority`
- `cargo test --features golden-tests --test finder_golden` (6/6) and `--test copyright_golden` (36/36) — both unchanged.

## Expected-output fixture changes

- None.
