### PR TITLE
fix(copyright): split coordinated second `by` clauses into separate authors

### DIFF
--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -928,3 +928,63 @@ fn test_markup_authors_section_collective_author_detected() {
         "authors: {authors:?}"
     );
 }
+
+#[test]
+fn test_second_by_chain_splits_into_separate_author() {
+    // musl COPYRIGHT: a single coordinated sentence with two `by` clauses.
+    // ScanCode makes each distinct `by` clause its own author, so both names
+    // must be recovered as separate authors (previously John Spencer was
+    // dropped when the second clause was left unattached).
+    let input = "The powerpc port was also originally written by Richard \
+Pennington, and later supplemented and integrated by John Spencer. It is \
+licensed under the standard MIT terms.\n";
+
+    let (_c, _h, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        values.contains(&"Richard Pennington"),
+        "first by-clause author missing: {values:?}"
+    );
+    assert!(
+        values.contains(&"John Spencer"),
+        "second by-clause author missing: {values:?}"
+    );
+}
+
+#[test]
+fn test_second_by_chain_splits_across_wrapped_lines() {
+    // Same coordination as above but line-wrapped mid-name, as in the real
+    // musl COPYRIGHT file.
+    let input = "The powerpc port was also originally written by Richard\n\
+Pennington, and later supplemented and integrated by John Spencer. It is licensed\n\
+under the standard MIT terms.\n";
+
+    let (_c, _h, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        values.contains(&"Richard Pennington") && values.contains(&"John Spencer"),
+        "wrapped two-author split failed: {values:?}"
+    );
+}
+
+#[test]
+fn test_single_by_conjoined_name_list_stays_one_author() {
+    // A single `by` clause with a conjoined name list must remain one author
+    // string (matching the curated multi-name author expectations); only a
+    // *second* `by` clause introduces a new author.
+    let input = "/* Written by David Ihnat, David MacKenzie, and Jim Meyering.  */\n";
+
+    let (_c, _h, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        !values.contains(&"David MacKenzie") && !values.contains(&"Jim Meyering"),
+        "single-by conjoined list was wrongly split: {values:?}"
+    );
+    assert!(
+        values.iter().any(|a| a.contains("David Ihnat")),
+        "primary author missing: {values:?}"
+    );
+}

--- a/src/copyright/detector/tree_walk/author.rs
+++ b/src/copyright/detector/tree_walk/author.rs
@@ -262,6 +262,92 @@ fn is_author_tail_preposition(token: &Token) -> bool {
         )
 }
 
+/// Capture additional coordinated `by <Name>` chains that follow a `by`-style
+/// AUTHOR node on the same physical line, e.g. musl's
+/// "written by Richard Pennington, and later ... integrated by John Spencer".
+///
+/// This mirrors ScanCode's `AUTHOR: {<BY> <NAME-EMAIL>+}`, which makes each
+/// distinct `by` clause its own author. It deliberately fires only on a *second*
+/// `by` clause introduced by a coordinating conjunction (`,`/`and`) so that a
+/// single-`by` conjoined name list ("by A, B and C") is left as one author
+/// string, matching the curated multi-name author expectations. Returns the new
+/// authors plus the number of trailing sibling nodes consumed (relative to
+/// `author_idx`).
+pub(super) fn extract_conjoined_by_authors(
+    tree: &[ParseNode],
+    author_idx: usize,
+) -> (Vec<AuthorDetection>, usize) {
+    let node = &tree[author_idx];
+    let node_leaves = detector::token_utils::collect_all_leaves(node);
+    // Only extend genuine `by`-style author clauses, and anchor to the line of
+    // the author node's last leaf so the whole coordination stays one sentence.
+    if !node_leaves.iter().any(|t| t.tag == PosTag::By) {
+        return (Vec::new(), 0);
+    }
+    let Some(anchor_line) = node_leaves.last().map(|t| t.start_line) else {
+        return (Vec::new(), 0);
+    };
+
+    let mut authors: Vec<AuthorDetection> = Vec::new();
+    let mut consumed = 0usize;
+    let mut seen_conjunction = false;
+
+    let mut j = author_idx + 1;
+    while j < tree.len() {
+        match &tree[j] {
+            ParseNode::Leaf(tok) if tok.start_line == anchor_line => match tok.tag {
+                PosTag::Cc => {
+                    if tok.value == "and" || tok.value == "," {
+                        seen_conjunction = true;
+                    }
+                    consumed = j - author_idx;
+                    j += 1;
+                }
+                // Connective prose inside the coordinated clause
+                // ("later supplemented and integrated").
+                PosTag::Nn | PosTag::Junk | PosTag::To => {
+                    consumed = j - author_idx;
+                    j += 1;
+                }
+                PosTag::By => {
+                    if !seen_conjunction {
+                        break;
+                    }
+                    let name_idx = j + 1;
+                    match tree.get(name_idx).and_then(|n| n.label()) {
+                        Some(
+                            TreeLabel::Name
+                            | TreeLabel::NameEmail
+                            | TreeLabel::NameYear
+                            | TreeLabel::NameCaps,
+                        ) => {
+                            let name_leaves = detector::token_utils::collect_filtered_leaves(
+                                &tree[name_idx],
+                                &[TreeLabel::YrRange, TreeLabel::YrAnd],
+                                detector::NON_AUTHOR_POS_TAGS,
+                            );
+                            if let Some(det) =
+                                detector::token_utils::build_author_from_tokens(&name_leaves)
+                            {
+                                authors.push(det);
+                            }
+                            // A further chain needs its own coordinating conjunction.
+                            seen_conjunction = false;
+                            consumed = name_idx - author_idx;
+                            j = name_idx + 1;
+                        }
+                        _ => break,
+                    }
+                }
+                _ => break,
+            },
+            _ => break,
+        }
+    }
+
+    (authors, consumed)
+}
+
 pub(super) fn try_extract_by_name_email_author(
     tree: &[ParseNode],
     idx: usize,

--- a/src/copyright/detector/tree_walk/copyright/tree_nodes.rs
+++ b/src/copyright/detector/tree_walk/copyright/tree_nodes.rs
@@ -730,6 +730,11 @@ pub fn extract_from_tree_nodes(
                 i += skip;
             } else if let Some(det) = detector::token_utils::build_author_from_node(node) {
                 authors.push(det);
+                let (extra, extra_skip) = author::extract_conjoined_by_authors(tree, i);
+                if !extra.is_empty() {
+                    authors.extend(extra);
+                    i += extra_skip;
+                }
             }
         } else if let ParseNode::Leaf(token) = node
             && token.tag == PosTag::Copy


### PR DESCRIPTION
## Summary

- A multi-author `by`-chain such as musl's `COPYRIGHT` line "The powerpc port was ... written by Richard Pennington, and later supplemented and integrated by John Spencer" was captured as a **single merged author**. ScanCode's `AUTHOR: {<BY> <NAME-EMAIL>+}` makes each distinct `by` clause its own author.
- After a `by`-style author node, the walk now scans the trailing siblings on the same physical line and, when a coordinating conjunction (`,`/`and`) introduces a **second** `by` clause, extracts its name as a separate author. Result: `Richard Pennington` + `John Spencer`.

## Issues

- Covers: the merged `by`-chain author residual documented for the musl benchmark target.

## Scope and exclusions

- **Deliberately narrow guard:** it fires only on a *second* `by`. A single-`by` conjoined name list ("Written by A, B, and C") stays one author — the exact case a prior attempt regressed (it split curated multi-name author expectations). The extractor also requires the coordination to stay on one physical line and to follow a genuine `by`-style author node, structurally excluding the entangled Linux headers (raid1, posix-timers) that caused the earlier regression.
- Implemented in an isolated worktree under a hard golden-gate and independently re-verified on a clean branch.

## How to verify

- `cargo test --lib copyright::detector::tests_author_pipeline` — includes the one-line split, the wrapped-line split, and the single-`by` name-list non-split.
- `cargo test --features golden-tests --test copyright_golden` — **36/36, unchanged** (no golden churn); clippy clean.

## Expected-output fixture changes

- None — no golden fixtures change.
