### PR TITLE
fix(copyright): reduce holder/copyright false positives (article prose + Unicode data)

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -27,6 +27,46 @@ fn test_prose_copyright_word_without_proper_holder_is_not_detected() {
 }
 
 #[test]
+fn test_prose_copyright_spanning_a_sentence_boundary_is_not_detected() {
+    // Article prose that discusses copyright (github/opensource.guide legal.md and
+    // its translations) has a bare `copyright` token sweep the rest of the
+    // sentence — and across the sentence period into the next one — into a
+    // copyright/holder. ScanCode emits nothing. A real notice never crosses a
+    // sentence boundary (`... by default. That is ...`).
+    for prose in [
+        "that work is under exclusive copyright by default. That is, the law assumes you have a say.",
+        "who holds copyright can get complicated and confusing very quickly. Switching to a new license.",
+        "you aren't the sole copyright holder. If you're the sole contributor you own it.",
+        "hai una licenza copyright esclusivo per impostazione predefinita. Cioè, la legge presuppone.",
+        "non puoi semplicemente cambiare la licenza del tuo progetto MIT. In sostanza vale questo.",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(prose);
+        assert!(
+            copyrights.is_empty(),
+            "prose produced copyrights: {copyrights:?} for {prose:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "prose produced holders: {holders:?} for {prose:?}"
+        );
+    }
+}
+
+#[test]
+fn test_notice_with_trailing_email_tld_and_second_copyright_is_kept() {
+    // A period after an email TLD that precedes a second `Copyright` clause is not
+    // a prose sentence boundary; the whole notice must survive.
+    let text = "Pascal Andre, andre@chimay.via.ecp.fr. Copyright (c) 1995, Pascal Andre";
+    let (copyrights, _holders, _authors) = detect_copyrights_from_text(text);
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright.contains("Pascal Andre")),
+        "expected the Pascal Andre notice to survive: {copyrights:?}"
+    );
+}
+
+#[test]
 fn test_lowercase_copyright_with_proper_holder_still_detected() {
     // The span guard must not suppress legitimate lowercase notices that carry a
     // real holder: proper noun, company, "by <name>", or an all-caps acronym.

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -90,6 +90,41 @@ fn test_lowercase_copyright_with_proper_holder_still_detected() {
 }
 
 #[test]
+fn test_unicode_break_test_data_lines_do_not_produce_holders() {
+    // Unicode Character Database segmentation-test data (unicode-org/icu4x
+    // WordBreakTest.txt / GraphemeBreakTest.txt) embeds the copyright codepoint
+    // `00A9`/`©` as literal test input on lines dense with the break markers
+    // `÷`/`×`. The genuine file header notice is kept; the data lines are not
+    // turned into holders/copyrights.
+    let input = concat!(
+        "# \u{00a9} 2025 Unicode\u{00ae}, Inc.\n",
+        "\u{00f7} 0009 \u{00d7} 0308 \u{00f7} 00A9 \u{00f7} # \u{00f7} [0.2] SIGN (ExtPict) \u{00d7} [9.0] COMBINING DIAERESIS\n",
+        "\u{00f7} 000D \u{00f7} 00A9 \u{00f7} # \u{00f7} [0.2] (CR) \u{00f7} [3.1] COPYRIGHT SIGN (ExtPict)\n",
+    );
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    // The real header notice survives.
+    assert!(
+        holders.iter().any(|h| h.holder.contains("Unicode")),
+        "expected the header holder to survive: {holders:?}"
+    );
+    // No break-test data line becomes a holder or copyright.
+    assert!(
+        !holders
+            .iter()
+            .any(|h| h.holder.contains('\u{00f7}') || h.holder.contains('\u{00d7}')),
+        "segmentation data leaked into holders: {holders:?}"
+    );
+    assert!(
+        !copyrights
+            .iter()
+            .any(|c| c.copyright.contains('\u{00f7}') || c.copyright.contains('\u{00d7}')),
+        "segmentation data leaked into copyrights: {copyrights:?}"
+    );
+}
+
+#[test]
 fn test_bpe_tokenizer_data_lines_do_not_produce_copyrights_or_holders() {
     // Hugging Face subword-tokenizer artifacts: merges.txt BPE pairs and
     // vocab.json token:id entries embed the `©` symbol and the literal

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -53,6 +53,29 @@ fn test_prose_copyright_spanning_a_sentence_boundary_is_not_detected() {
 }
 
 #[test]
+fn test_notices_before_a_following_sentence_are_kept() {
+    // The sentence-boundary junk rule must keep genuine notices whose holder is
+    // named before the boundary: a year-range notice (`1994-1999. The MITRE ...`),
+    // and a lowercase collective-agent holder (`by the original authors. ...`).
+    for (text, expected) in [
+        (
+            "Copyright (c) 1994-1999. The MITRE Corporation makes no representations.",
+            "MITRE",
+        ),
+        (
+            "Copyright by the original authors. Redistribution is permitted.",
+            "original authors",
+        ),
+    ] {
+        let (copyrights, _holders, _authors) = detect_copyrights_from_text(text);
+        assert!(
+            copyrights.iter().any(|c| c.copyright.contains(expected)),
+            "expected {expected:?} kept in {copyrights:?} for {text:?}"
+        );
+    }
+}
+
+#[test]
 fn test_notice_with_trailing_email_tld_and_second_copyright_is_kept() {
     // A period after an email TLD that precedes a second `Copyright` clause is not
     // a prose sentence boundary; the whole notice must survive.

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -143,6 +143,51 @@ pub(crate) fn hf_tokenizer_merges_line_span(content: &str) -> Option<(usize, usi
     None
 }
 
+/// Return true if a candidate is running article prose that a bare `copyright`
+/// token swept across a sentence boundary: a lowercase word closed by a period
+/// and followed by a capitalized word (`... by default. That is ...`).
+///
+/// A genuine multi-clause notice names a proper-noun holder *before* that first
+/// sentence boundary (`(c) Example Corp. and affiliates. Confidential ...`);
+/// article prose that merely discusses copyright does not (`copyright by
+/// default. That is ...`). Only the latter is treated as junk. The
+/// leading-whitespace requirement also keeps email/URL TLDs
+/// (`...ecp.fr. Copyright`) and company/initial abbreviations (`Inc.`, `A.`)
+/// out of scope, since those are not whitespace-delimited all-lowercase words.
+pub(super) fn spans_prose_sentence_boundary(s: &str) -> bool {
+    // The word closing the sentence is either an all-lowercase prose word
+    // (`... by default. That ...`) or an all-caps acronym (`... to MIT. In ...`,
+    // `... MIT). Ma ...`). The following prefix-holder check is what keeps a
+    // genuine multi-clause notice — which names a proper noun before this point —
+    // from being classified as prose.
+    static SENTENCE_BOUNDARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(r"(?:^|\s)(?:\p{Ll}[\p{Ll}']+|\p{Lu}{2,})\)?\.\s+\p{Lu}")
+    });
+    let Some(m) = SENTENCE_BOUNDARY_RE.find(s) else {
+        return false;
+    };
+    !prefix_names_holder(&s[..m.start()])
+}
+
+/// Whether the text before the first sentence boundary names a proper-noun
+/// holder — any capitalized word once the leading copyright-marker words are
+/// removed. Marker words are excluded so a leading `Copyright`/`Portions` does
+/// not masquerade as the holder.
+fn prefix_names_holder(prefix: &str) -> bool {
+    prefix
+        .split_whitespace()
+        .filter(|w| {
+            let lw = w
+                .trim_matches(|c: char| !c.is_alphanumeric())
+                .to_ascii_lowercase();
+            !matches!(
+                lw.as_str(),
+                "copyright" | "copyrighted" | "copr" | "copyrights" | "c" | "portions" | "portion"
+            )
+        })
+        .any(|w| w.chars().next().is_some_and(|c| c.is_uppercase()))
+}
+
 /// Return true if `s` matches any known junk copyright pattern.
 pub fn is_junk_copyright(s: &str) -> bool {
     if looks_like_structured_copyright_notice_with_year(s) {
@@ -155,6 +200,7 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_junk_copyright_symbol_garbage(s)
         || is_junk_c_sign_path_fragment(s)
         || is_creative_commons_license_prose(s)
+        || spans_prose_sentence_boundary(s)
         || looks_like_source_code(s)
 }
 
@@ -320,7 +366,50 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
         || is_junk_holder_symbol_garbage(s)
         || is_creative_commons_license_prose(s)
         || looks_like_source_code(s)
+        || starts_with_sentence_connective(s)
         || s.eq_ignore_ascii_case("MIT")
+}
+
+/// Whether a holder opens with a subordinating conjunction or clause pronoun
+/// (`If you're the sole`, `When the ...`, `This is ...`). These begin a sentence
+/// clause, never a party name, so a holder that starts with one is running prose
+/// the copyright marker swept in. Determiners that legitimately open real
+/// holders (`The Regents`, `A. Person`) are deliberately excluded.
+fn starts_with_sentence_connective(s: &str) -> bool {
+    const CONNECTIVES: &[&str] = &[
+        "if",
+        "when",
+        "while",
+        "because",
+        "although",
+        "though",
+        "since",
+        "whether",
+        "unless",
+        "however",
+        "therefore",
+        "thus",
+        "hence",
+        "moreover",
+        "furthermore",
+        "otherwise",
+        "nevertheless",
+        "this",
+        "that",
+        "these",
+        "those",
+    ];
+    let Some(first) = s.split_whitespace().next() else {
+        return false;
+    };
+    let word = first.trim_matches(|c: char| !c.is_alphanumeric());
+    // A single capitalized connective word is not itself a holder; require a
+    // following word so `This`/`That` used as a real (rare) token is still safe.
+    if s.split_whitespace().count() < 2 {
+        return false;
+    }
+    CONNECTIVES.contains(&word.to_ascii_lowercase().as_str())
+        && word.chars().next().is_some_and(|c| c.is_uppercase())
 }
 
 pub(super) fn is_junk_holder_code_fragment(s: &str) -> bool {

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -161,31 +161,54 @@ pub(super) fn spans_prose_sentence_boundary(s: &str) -> bool {
     // genuine multi-clause notice — which names a proper noun before this point —
     // from being classified as prose.
     static SENTENCE_BOUNDARY_RE: LazyLock<Regex> = LazyLock::new(|| {
-        compile_static_regex(r"(?:^|\s)(?:\p{Ll}[\p{Ll}']+|\p{Lu}{2,})\)?\.\s+\p{Lu}")
+        compile_static_regex(r"(?:^|\s)(?P<word>\p{Ll}[\p{Ll}']+|\p{Lu}{2,})\)?\.\s+\p{Lu}")
     });
-    let Some(m) = SENTENCE_BOUNDARY_RE.find(s) else {
+    let Some(caps) = SENTENCE_BOUNDARY_RE.captures(s) else {
         return false;
     };
-    !prefix_names_holder(&s[..m.start()])
+    // Check the text up to and including the sentence-closing word, so a
+    // collective-agent holder that is itself that word (`... the original
+    // authors. Redistribution ...`) still counts as a named holder.
+    let word_end = caps.name("word").expect("word group").end();
+    !prefix_names_holder(&s[..word_end])
 }
 
-/// Whether the text before the first sentence boundary names a proper-noun
-/// holder — any capitalized word once the leading copyright-marker words are
-/// removed. Marker words are excluded so a leading `Copyright`/`Portions` does
-/// not masquerade as the holder.
+/// Whether the text before the first sentence boundary names a holder: a
+/// capitalized proper noun, or a lowercase collective-agent word (`authors`,
+/// `contributors`, ...). The leading copyright-marker words are excluded so a
+/// bare `Copyright`/`Portions` does not masquerade as the holder. The collective
+/// clause keeps a real lowercase notice — `Copyright by the original authors.
+/// Redistribution is permitted.` — from being classified as prose, mirroring the
+/// `allow_single_word_contributors` holder rule. `holders` is deliberately not a
+/// collective agent: `copyright holders. If you're the sole ...` is prose.
 fn prefix_names_holder(prefix: &str) -> bool {
+    const COLLECTIVE_AGENTS: &[&str] = &[
+        "authors",
+        "contributors",
+        "developers",
+        "maintainers",
+        "committers",
+        "team",
+        "project",
+        "community",
+        "foundation",
+    ];
     prefix
         .split_whitespace()
-        .filter(|w| {
+        .filter_map(|w| {
             let lw = w
                 .trim_matches(|c: char| !c.is_alphanumeric())
                 .to_ascii_lowercase();
-            !matches!(
+            (!matches!(
                 lw.as_str(),
                 "copyright" | "copyrighted" | "copr" | "copyrights" | "c" | "portions" | "portion"
-            )
+            ))
+            .then_some((w, lw))
         })
-        .any(|w| w.chars().next().is_some_and(|c| c.is_uppercase()))
+        .any(|(w, lw)| {
+            w.chars().next().is_some_and(|c| c.is_uppercase())
+                || COLLECTIVE_AGENTS.contains(&lw.as_str())
+        })
 }
 
 /// Return true if `s` matches any known junk copyright pattern.

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -201,7 +201,19 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_junk_c_sign_path_fragment(s)
         || is_creative_commons_license_prose(s)
         || spans_prose_sentence_boundary(s)
+        || contains_unicode_segmentation_markers(s)
         || looks_like_source_code(s)
+}
+
+/// Return true if a candidate carries Unicode segmentation-test markers — the
+/// division sign `÷` (U+00F7) or multiplication sign `×` (U+00D7). Unicode
+/// Character Database break-test data (`WordBreakTest.txt`,
+/// `GraphemeBreakTest.txt`) embeds the copyright codepoint `00A9`/`©` as literal
+/// test input on lines dense with these break markers; the detector otherwise
+/// manufactures a holder from the surrounding data. These markers never occur in
+/// a real copyright notice, so their presence alone identifies the data line.
+pub(super) fn contains_unicode_segmentation_markers(s: &str) -> bool {
+    s.contains('\u{00f7}') || s.contains('\u{00d7}')
 }
 
 /// Return true if `s` is a fragment of Creative Commons (or cited treaty)
@@ -367,6 +379,7 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
         || is_creative_commons_license_prose(s)
         || looks_like_source_code(s)
         || starts_with_sentence_connective(s)
+        || contains_unicode_segmentation_markers(s)
         || s.eq_ignore_ascii_case("MIT")
 }
 

--- a/testdata/copyright-golden/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
+++ b/testdata/copyright-golden/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
@@ -4,16 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 2000 Sun Microsystems, Inc.
-  - copyright et distribue avec des licences qui en restreignent l'utilisation, la copie, la distribution, et la de'compilation. Ce documention associe n peut
   - copyright et licencie par des fournisseurs de Sun
 holders:
   - Sun Microsystems, Inc.
-  - et distribue avec des licences qui en restreignent l'utilisation, la copie, la distribution, et la de'compilation. Ce documention associe n peut
   - et licencie par des fournisseurs de Sun
 holders_summary:
   - value: Sun Microsystems
-    count: 1
-  - value: et distribue avec des licences qui en restreignent l'utilisation, la copie, la distribution, et la de'compilation. Ce documention associe n peut
     count: 1
   - value: et licencie par des fournisseurs de Sun
     count: 1


### PR DESCRIPTION
## Summary

Two copyright/holder false-positive reductions in the detector's junk filter, both surfaced by the benchmark round (`github/opensource.guide`, `unicode-org/icu4x`).

### 1. Article prose crossing a sentence boundary

Documentation prose that *discusses* copyright ("...under exclusive copyright by default. That is, the law assumes...") had a bare `copyright` marker sweep the surrounding sentence — and across the sentence period into the next one — into a copyright/holder. ScanCode emits nothing for such text.

A candidate is junk when it crosses a sentence boundary (a lowercase word or all-caps acronym closed by a period, followed by a capitalized word) **and names no proper-noun holder before that boundary**. Also dropped: a holder that opens with a subordinating conjunction/clause pronoun (`If you're the sole`).

Kept intact: multi-clause notices that name their holder up front (`(c) Example Corp. and affiliates. Confidential and proprietary`), email/URL TLDs before a second clause (`...ecp.fr. Copyright ...`), abbreviations (`Inc.`, `A.`), and lowercase `copyright by the original`-style holders.

### 2. Unicode break-test data lines

Unicode Character Database segmentation-test data (`WordBreakTest.txt`, `GraphemeBreakTest.txt`) embeds the copyright codepoint `00A9`/`©` as literal test input on lines dense with the break markers `÷` (U+00F7) / `×` (U+00D7). The detector fired on the data-embedded `©` and manufactured 100+ junk holders per file. A candidate carrying either break marker — which never appears in a real notice — is now junk; the file's real header (`© 2025 Unicode, Inc.`) is preserved.

## Testing

- `cargo test --lib copyright::detector::tests_false_positives` — new coverage for prose sentence-boundary (English + Italian), email-TLD keep, and Unicode break-test data.
- `cargo test --features golden-tests --test copyright_golden` — 36/36 pass.
- `cargo test --features golden-tests --test finder_golden` — 6/6 pass.
- `cargo test --lib copyright::` — 1134 pass.

## Golden changes

- `testdata/copyright-golden/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml`: removed a French license paragraph (no holder) that spanned a sentence. The real `Copyright (c) 2000 Sun Microsystems, Inc.` notice in the same file is unchanged.

## Compare evidence

- `github/opensource.guide @ 38d739c8`: copyright FPs on the `legal.md` family dropped 28 → 0; holders 26 → 0. Remaining copyright deltas are font-embedded notices ScanCode does not read (Provenant advantage). ~6.9s vs ~117s.
- `unicode-org/icu4x @ 98270524`: junk holders from Unicode break-test data files dropped by ~160+. ~36s vs ~1364s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)