### PR TITLE
chore(deps): bump spin 0.9.8 -> 0.9.9 to clear yanked advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,9 +5669,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

`spin 0.9.8` was yanked upstream, so `cargo-deny` advisories fails in the **Code Quality** CI job for every open PR (it is a transitive dependency via `heapless` → `postcard` → `pagable`/`starlark_syntax`). `0.9.9` is a non-yanked patch release satisfying the same requirement.

Lockfile-only change via `cargo update -p spin`.

## Testing

- Pre-commit `dependency-policy` hook: `advisories ok, bans ok, licenses ok, sources ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)