### PR TITLE
fix(copyright): recover Javadoc @author names and drop bare XML tags

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -822,3 +822,28 @@ fn test_pulseaudio_ladspa_rfc_and_contact_fragments_do_not_emit_junk() {
         "holders: {holder_values:?}"
     );
 }
+
+#[test]
+fn test_xml_copyright_element_tag_is_not_detected_as_copyright() {
+    // Wayland protocol descriptions (glfw's vendored deps/wayland/*.xml) wrap
+    // notices in a `<copyright>` element. The bare tag opener must not itself be
+    // surfaced as a copyright/holder, while the real notices inside it are kept.
+    let input = concat!(
+        "  <copyright>\n",
+        "    Copyright \u{00a9} 2014 Jonas \u{00c5}dahl\n",
+        "  </copyright>\n",
+    );
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+    assert!(
+        !copyrights.iter().any(|c| c.copyright == "<copyright>"),
+        "bare XML tag leaked into copyrights: {copyrights:?}"
+    );
+    assert!(
+        !holders.iter().any(|h| h.holder == "<copyright>"),
+        "bare XML tag leaked into holders: {holders:?}"
+    );
+    assert!(
+        copyrights.iter().any(|c| c.copyright.contains("Jonas")),
+        "expected the real notice to survive: {copyrights:?}"
+    );
+}

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -847,3 +847,28 @@ fn test_xml_copyright_element_tag_is_not_detected_as_copyright() {
         "expected the real notice to survive: {copyrights:?}"
     );
 }
+
+#[test]
+fn test_javadoc_author_with_html_anchor_is_extracted() {
+    // Java Javadoc `@author` tags frequently wrap the name in an HTML anchor with
+    // an http(s) href (eclipse-vertx/vert.x uses
+    // `@author <a href="http://tfox.org">Tim Fox</a>` across hundreds of files).
+    // The href is a homepage link, not the name; the author resolves to the name.
+    for (text, expected) in [
+        (
+            " * @author <a href=\"http://tfox.org\">Tim Fox</a>",
+            "Tim Fox",
+        ),
+        (
+            " * @author <a href=\"https://github.com/cescoffier\">Clement Escoffier</a>",
+            "Clement Escoffier",
+        ),
+    ] {
+        let (_c, _h, authors) = detect_copyrights_from_text(text);
+        let vals: Vec<&String> = authors.iter().map(|a| &a.author).collect();
+        assert!(
+            vals.iter().any(|a| a.as_str() == expected),
+            "expected {expected:?} in {vals:?} for {text:?}"
+        );
+    }
+}

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -669,9 +669,7 @@ pub fn prepare_text_line(line: &str) -> String {
     // the marker and the name and break author extraction). Scoped to an author
     // marker and to http(s) hrefs so copyright anchors and mailto/email contact
     // anchors — which keep their address — are unaffected.
-    if AUTHOR_HTTP_ANCHOR_RE.is_match(&s) {
-        s = AUTHOR_HTTP_ANCHOR_RE.replace_all(&s, "$1$2 ").into_owned();
-    }
+    s = AUTHOR_HTTP_ANCHOR_RE.replace_all(&s, "$1$2 ").into_owned();
 
     s = HTTP_ANCHOR_RE.replace_all(&s, "$1 $2").into_owned();
 

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -222,6 +222,15 @@ static HTTP_ANCHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?is)<a\s+href=['\"](https?://[^'\"]+)['\"][^>]*>\s*([^<]+?)\s*</a>"#).unwrap()
 });
 
+/// A Javadoc `@author`/`@authors` tag whose name is wrapped in an HTML anchor
+/// with an http(s) href (`@author <a href="http://tfox.org">Tim Fox</a>`).
+/// Group 1 is the author marker, group 2 the link text (the name); the href is
+/// dropped as a homepage link, not part of the name.
+static AUTHOR_HTTP_ANCHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)(@?authors?[:\s]+)<a\s+href=['\"]https?://[^>]*>\s*([^<]+?)\s*</a>"#)
+        .unwrap()
+});
+
 static TAG_VALUE_ATTR_DQ_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?is)\bvalue\s*=\s*\"([^\"]+)\""#).unwrap());
 
@@ -652,6 +661,17 @@ pub fn prepare_text_line(line: &str) -> String {
     s = MAILTO_ANCHOR_RE.replace_all(&s, "$1 $2").into_owned();
 
     s = EMAIL_ANCHOR_RE.replace_all(&s, "$1 $2").into_owned();
+
+    // A Javadoc `@author <a href="http://tfox.org">Tim Fox</a>` names the author
+    // in the link text; the http(s) href is a homepage link, not the name. Drop
+    // the href so the author marker is immediately followed by the name (the
+    // generic http-anchor handling below would otherwise leave the URL between
+    // the marker and the name and break author extraction). Scoped to an author
+    // marker and to http(s) hrefs so copyright anchors and mailto/email contact
+    // anchors — which keep their address — are unaffected.
+    if AUTHOR_HTTP_ANCHOR_RE.is_match(&s) {
+        s = AUTHOR_HTTP_ANCHOR_RE.replace_all(&s, "$1$2 ").into_owned();
+    }
 
     s = HTTP_ANCHOR_RE.replace_all(&s, "$1 $2").into_owned();
 

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -225,7 +225,20 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_creative_commons_license_prose(s)
         || spans_prose_sentence_boundary(s)
         || contains_unicode_segmentation_markers(s)
+        || is_bare_markup_tag(s)
         || looks_like_source_code(s)
+}
+
+/// Return true if the whole candidate is a single markup tag such as the XML
+/// `<copyright>` element opener found in Wayland protocol descriptions and other
+/// schemas. The tag word (`copyright`) otherwise reaches the detector as a bare
+/// marker. Anchored to the full string and excluding `@`, so an angle-bracketed
+/// holder email (`<jane@example.com>`) — which carries an address, not a tag — is
+/// never matched.
+pub(super) fn is_bare_markup_tag(s: &str) -> bool {
+    static MARKUP_TAG_ONLY_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r"^\s*<[/!?]?[a-zA-Z][a-zA-Z0-9:_-]*\s*/?>\s*$"));
+    MARKUP_TAG_ONLY_RE.is_match(s)
 }
 
 /// Return true if a candidate carries Unicode segmentation-test markers — the
@@ -403,6 +416,7 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
         || looks_like_source_code(s)
         || starts_with_sentence_connective(s)
         || contains_unicode_segmentation_markers(s)
+        || is_bare_markup_tag(s)
         || s.eq_ignore_ascii_case("MIT")
 }
 


### PR DESCRIPTION
## Summary

Two copyright/author detector fixes, both surfaced by the benchmark round (`glfw/glfw`, `eclipse-vertx/vert.x`).

### 1. Javadoc `@author` with an HTML anchor (vert.x)

Java Javadoc author tags commonly wrap the name in an anchor whose href is a homepage link — `@author <a href="http://tfox.org">Tim Fox</a>` appears across **hundreds** of eclipse-vertx/vert.x files. The generic anchor unwrapping left the href URL *between* the `@author` marker and the name, so no author was extracted at all (257 files affected).

Drop the http(s) href from an author-marked anchor before the generic unwrap, so the marker is immediately followed by the link text. Scoped to an author marker and to http(s) hrefs, so copyright anchors and mailto/email contact anchors (which keep their address) are unaffected.

### 2. Bare `<copyright>` XML element tag (glfw)

Wayland protocol descriptions (glfw's vendored `deps/wayland/*.xml`) wrap notices in a `<copyright>` element; the bare tag opener reached the detector as a copyright marker and surfaced `<copyright>` as a copyright/holder. Classify a candidate that is a single markup tag as junk (anchored to the whole string, excluding `@` so an angle-bracketed holder email is never matched).

## Testing

- `cargo test --lib copyright::detector::tests_false_positives` — new coverage for the Javadoc anchor author and the XML tag.
- `cargo test --features golden-tests --test copyright_golden` — 36/36 pass.
- `cargo test --features golden-tests --test finder_golden` — 6/6 pass.
- `cargo test --lib copyright::prepare` — 103 pass.

## Compare evidence

- `eclipse-vertx/vert.x @ 78ade62`: recovers `Tim Fox`, `Clement Escoffier`, etc. from `@author` anchors across 257 files that previously produced no author.
- `glfw/glfw @ ed6452b`: the `<copyright>` tag no longer surfaces as a copyright/holder in vendored Wayland XML; the real `Copyright © 2014 Jonas Ådahl` notices (with `©` and accented names preserved) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)