### PR TITLE
docs(benchmarks): record Zlib, MPL-2.0, and EPL/Apache-dual targets

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 249 of 249 recorded runs, with a **19.6× median speedup** and **19.6× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
+> Provenant is faster on 252 of 252 recorded runs, with a **19.6× median speedup** and **19.6× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -571,6 +571,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `5.07s`; ScanCode `49.73s`
 - Direct Leiningen and tools.deps package identity (`2` vs `0` packages, `68` vs `0` dependencies) that ScanCode cannot model because it ships no `project.clj`/`deps.edn` parser: the root `pkg:maven/aleph/aleph` assembles its `project.clj` with the co-located generated `deps.edn`, resolving `def`-bound `~netty-version`/`~brotli-version` dependency versions and a runtime `(or (System/getenv …) …)` project version into concrete coordinates and normalizing tools.deps `artifact$classifier` deps into clean purls with classifier metadata, plus source-faithful `©` copyright recovery on `README.md` where ScanCode renders `(c)` and rejection of the `${…}`-templated CircleCI status URL ScanCode emits as a broken percent-encoded fragment
 
+##### [eclipse-vertx/vert.x @ 78ade62](https://github.com/eclipse-vertx/vert.x/tree/78ade6225ad1dc24f39496af6e109c1505ff9839) — **20.94× faster**
+
+- Files: 1,752
+- Run context: 2026-07-14 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `9.29s`; ScanCode `194.51s`
+- Classifies the `Apache-2.0 AND EPL-2.0` dual license on one more file than ScanCode and extracts the Java Javadoc `@author` contributor names wrapped in HTML homepage anchors (`Tim Fox`, `Clement Escoffier`) across hundreds of source files, while omitting ScanCode's `LicenseRef-scancode-unknown-license-reference` noise on the terms-of-service document
+
 ##### [elastic/elasticsearch @ a414f3d](https://github.com/elastic/elasticsearch/tree/a414f3d06c7ab59a5a0b350e80e5674bf9864688) — **38.84× faster**
 
 - Files: 40,293
@@ -846,6 +853,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `14.62s`; ScanCode `623.80s`
 - Broader package-adjacent Git metadata visibility on the tracked `.gitmodules` manifest (`1` vs `0` dependencies on that file), plus one extra top-level package row (`4` vs `3`) from treating the manifest as package metadata instead of leaving it scanner-silent
 
+##### [glfw/glfw @ ed6452b](https://github.com/glfw/glfw/tree/ed6452b13c76f7b4da216a9952bc7837aeb0f031) — **17.15× faster**
+
+- Files: 177
+- Run context: 2026-07-14 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `5.18s`; ScanCode `88.79s`
+- Copyright rendering in the vendored Wayland protocol descriptions preserves the literal `©` glyph and accented holder names (`Copyright © 2014 Jonas Ådahl`) where ScanCode normalizes the sign to `(c)` and folds the name to `Adahl`; both classify the repository `LICENSE.md` as `Zlib`, and a Doxygen build-config prose fragment (`doxygen. Using`) is kept out of the author list where ScanCode reports it
+
 ##### [go-gitea/gitea @ 47fdf3e2](https://github.com/go-gitea/gitea/tree/47fdf3e284308c6b648936b5c15e136b08f5e1da) — **26.3× faster**
 
 - Files: 5,201
@@ -1069,6 +1083,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-15 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `5.00s`; ScanCode `44.92s`
 - Matched Cargo workspace package and dependency coverage (`2` vs `2` packages, `190` vs `190` dependencies) while preserving the repository's dual-license README and manifest semantics, recovering SVG-linked URL evidence, and avoiding trailing-slash URL drift across the docs surfaces
+
+##### [mozilla/glean @ a4166fa](https://github.com/mozilla/glean/tree/a4166fa8816193c44d8b18a61e4457c7c430e44a) — **20.46× faster**
+
+- Files: 1,079
+- Run context: 2026-07-14 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `6.26s`; ScanCode `128.06s`
+- Detects `MPL-2.0` on one more file (`13` vs `12`) and rejects ScanCode's author false positives mined from config and documentation prose (`the Glean`, `cron task <url>`); the virtual `[workspace]` Cargo manifest and `Cargo.lock` report an empty declared license where ScanCode attributes `mpl-2.0` to files that declare none
 
 ##### [rust-lang/cargo @ b54fe55](https://github.com/rust-lang/cargo/tree/b54fe551a982d75d299e0d54daeac70cb854eef0) — **24.6× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -239,6 +239,9 @@ ScanCode: 125.87s</title></rect>
     <rect x="441.29" y="409.83" width="8" height="8" fill="#d97706" rx="1.5"><title>lodash/lodash @ cb0b9b9
 Files: 159
 ScanCode: 101.22s</title></rect>
+    <rect x="448.68" y="416.02" width="8" height="8" fill="#d97706" rx="1.5"><title>glfw/glfw @ ed6452b
+Files: 177
+ScanCode: 88.79s</title></rect>
     <rect x="450.98" y="426.44" width="8" height="8" fill="#d97706" rx="1.5"><title>Carthage/Carthage @ e33e133
 Files: 183
 ScanCode: 71.21s</title></rect>
@@ -413,6 +416,9 @@ ScanCode: 113.37s</title></rect>
     <rect x="572.02" y="412.37" width="8" height="8" fill="#d97706" rx="1.5"><title>commercialhaskell/stack @ cb6070f
 Files: 1060
 ScanCode: 95.91s</title></rect>
+    <rect x="573.24" y="398.71" width="8" height="8" fill="#d97706" rx="1.5"><title>mozilla/glean @ a4166fa
+Files: 1079
+ScanCode: 128.06s</title></rect>
     <rect x="573.49" y="377.40" width="8" height="8" fill="#d97706" rx="1.5"><title>jquery/jquery-ui @ eda7aa3
 Files: 1083
 ScanCode: 201.04s</title></rect>
@@ -470,6 +476,9 @@ ScanCode: 300.33s</title></rect>
     <rect x="603.42" y="377.17" width="8" height="8" fill="#d97706" rx="1.5"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 ScanCode: 202.03s</title></rect>
+    <rect x="606.64" y="378.96" width="8" height="8" fill="#d97706" rx="1.5"><title>eclipse-vertx/vert.x @ 78ade62
+Files: 1752
+ScanCode: 194.51s</title></rect>
     <rect x="607.19" y="341.69" width="8" height="8" fill="#d97706" rx="1.5"><title>guillemj/dpkg @ 0061122
 Files: 1766
 ScanCode: 428.07s</title></rect>
@@ -988,6 +997,9 @@ Provenant: 5.23s</title></circle>
     <circle cx="445.29" cy="556.81" r="4.5" fill="#2563eb"><title>lodash/lodash @ cb0b9b9
 Files: 159
 Provenant: 4.91s</title></circle>
+    <circle cx="452.68" cy="554.28" r="4.5" fill="#2563eb"><title>glfw/glfw @ ed6452b
+Files: 177
+Provenant: 5.18s</title></circle>
     <circle cx="454.98" cy="556.52" r="4.5" fill="#2563eb"><title>Carthage/Carthage @ e33e133
 Files: 183
 Provenant: 4.94s</title></circle>
@@ -1162,6 +1174,9 @@ Provenant: 6.40s</title></circle>
     <circle cx="576.02" cy="544.29" r="4.5" fill="#2563eb"><title>commercialhaskell/stack @ cb6070f
 Files: 1060
 Provenant: 6.40s</title></circle>
+    <circle cx="577.24" cy="545.33" r="4.5" fill="#2563eb"><title>mozilla/glean @ a4166fa
+Files: 1079
+Provenant: 6.26s</title></circle>
     <circle cx="577.49" cy="542.12" r="4.5" fill="#2563eb"><title>jquery/jquery-ui @ eda7aa3
 Files: 1083
 Provenant: 6.70s</title></circle>
@@ -1219,6 +1234,9 @@ Provenant: 9.99s</title></circle>
     <circle cx="607.42" cy="537.36" r="4.5" fill="#2563eb"><title>PX4/eigen @ 7cf1c01
 Files: 1672
 Provenant: 7.41s</title></circle>
+    <circle cx="610.64" cy="526.68" r="4.5" fill="#2563eb"><title>eclipse-vertx/vert.x @ 78ade62
+Files: 1752
+Provenant: 9.29s</title></circle>
     <circle cx="611.19" cy="510.59" r="4.5" fill="#2563eb"><title>guillemj/dpkg @ 0061122
 Files: 1766
 Provenant: 13.06s</title></circle>


### PR DESCRIPTION
## Summary

Records three `verify-benchmark-target` rows from this round, each stressing a distinct license family, measured on merged `main` with cached ScanCode baselines:

| Target | Family | Files | Provenant | ScanCode | Speedup |
| --- | --- | --- | --- | --- | --- |
| [glfw/glfw @ ed6452b](https://github.com/glfw/glfw/tree/ed6452b13c76f7b4da216a9952bc7837aeb0f031) | Zlib | 177 | 5.18s | 88.79s | 17.15× |
| [mozilla/glean @ a4166fa](https://github.com/mozilla/glean/tree/a4166fa8816193c44d8b18a61e4457c7c430e44a) | MPL-2.0 | 1,079 | 6.26s | 128.06s | 20.46× |
| [eclipse-vertx/vert.x @ 78ade62](https://github.com/eclipse-vertx/vert.x/tree/78ade6225ad1dc24f39496af6e109c1505ff9839) | EPL-2.0/Apache dual | 1,752 | 9.29s | 194.51s | 20.94× |

Corpus is now **252 of 252 runs faster, 19.6× median**. Chart (`scan-duration-vs-files.svg`) and the stats line regenerated via `generate-benchmark-chart`.

Detector fixes this round surfaced merged separately in #1281 (Javadoc `@author` HTML-anchor extraction; bare `<copyright>` XML-tag junk). Rows are written as present-tense Provenant-vs-ScanCode end-state differences.

## Deferred follow-ups (own PRs)

- **glean**: pyproject.toml PEP 621 `license = { file = "LICENSE" }` table form is detected at file level (`mpl-2.0`) but not propagated to the package's `declared_license_expression` — needs parser + file-reference/assembly wiring (like the existing `about.rs`/`podspec.rs`/rpm license-file precedent).
- **vert.x**: 4 files with `@author Name <a href=url>@handle</a>` (trailing handle-anchor) still miss the author.
- **glfw**: multi-line duplicate/merged holder from consecutive `©` copyright lines inside a `<copyright>` XML block (vendored Wayland deps).

## Testing

- markdown-lint + prettier via pre-commit hook: pass.
- Timings are same-host `compare-outputs --profile common --build-mode optimized` runs on merged `main`; ScanCode rows are cache hits from the original clean runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)