### PR TITLE
ci(release): use client-id for the tap-token GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,13 +354,13 @@ jobs:
           lfs: false
 
       # Least-privilege, short-lived token scoped to the tap repo only. Requires
-      # the provenant-release-bot GitHub App (RELEASE_BOT_APP_ID /
+      # the provenant-release-bot GitHub App (RELEASE_BOT_CLIENT_ID /
       # RELEASE_BOT_PRIVATE_KEY secrets) installed on getprovenant/homebrew-tap.
       - name: Mint a token for the tap repository
         id: tap_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: getprovenant
           repositories: homebrew-tap


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id`; the v0.2.6 release run surfaced this as a warning on the **Bump Homebrew formula** job.
- Switch the tap-token step in `release.yml` to pass the GitHub App's **Client ID** via the new `RELEASE_BOT_CLIENT_ID` secret, and update the neighboring comment to match.

## Scope and exclusions

- Included: the single tap-token step in the `bump-homebrew` job.
- Explicit exclusions: no other action inputs or jobs changed. The `RELEASE_BOT_CLIENT_ID` secret has already been provisioned by the maintainer.

## How to verify

- Config-only change to a release-gated job. It cannot run on this PR (the `bump-homebrew` job only fires on stable tag pushes to `getprovenant/provenant`), so the real signal is the next stable release: the `app-id` deprecation warning should be gone and the tap-token step should still mint a valid token.

## Follow-up work

- The remaining v0.2.6 release warnings are non-actionable: the macOS `aws/tap` trust notices are runner-image noise, and the container-image `artifact-metadata`/`no artifacts found` warning is a benign message from the latest `attest-build-provenance` when attesting an OCI image (the attestation itself succeeds).
