### PR TITLE
fix(output): make CycloneDX, SPDX, and Debian pass schema contracts

### DIFF
--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -4,13 +4,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::{self, Write};
 
 use serde_json::{Map, Value, json};
 use uuid::Uuid;
 
-use crate::output_schema::{Output, OutputPackage as Package};
+use crate::output_schema::{
+    Output, OutputPackage as Package, OutputTopLevelDependency as TopLevelDependency,
+};
 use crate::utils::time::{convert_header_timestamp_to_iso_utc, fallback_iso_utc_timestamp};
 
 use super::shared::{io_other, xml_escape};
@@ -28,6 +30,8 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
         .first()
         .and_then(|h| convert_header_timestamp_to_iso_utc(&h.end_timestamp))
         .unwrap_or_else(|| fallback_iso_utc_timestamp().to_string());
+    let component_refs = component_bom_refs(&output.packages);
+    let dependency_graph = build_dependency_graph(output, &component_refs);
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -50,10 +54,10 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
     for (idx, pkg) in output.packages.iter().enumerate() {
         let name = pkg.name.as_deref().unwrap_or("unknown");
         let version = pkg.version.as_deref().unwrap_or("unknown");
-        let bom_ref = cyclonedx_component_ref(pkg, idx);
+        let bom_ref = &component_refs[idx];
         xml.push_str(&format!(
             "    <component type=\"library\" bom-ref=\"{}\">\n",
-            xml_escape(&bom_ref)
+            xml_escape(bom_ref)
         ));
         xml.push_str("      <name>");
         xml.push_str(&xml_escape(name));
@@ -110,23 +114,17 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
     }
     xml.push_str("  </components>\n");
 
-    if !output.dependencies.is_empty() {
+    if !dependency_graph.is_empty() {
         xml.push_str("  <dependencies>\n");
-        for (idx, dep) in output.dependencies.iter().enumerate() {
-            let dep_ref = dep
-                .purl
-                .clone()
-                .unwrap_or_else(|| format!("dependency-{}", idx + 1));
+        for (dep_ref, depends_on) in &dependency_graph {
             xml.push_str(&format!(
                 "    <dependency ref=\"{}\">\n",
-                xml_escape(&dep_ref)
+                xml_escape(dep_ref)
             ));
-            if let Some(resolved) = &dep.resolved_package
-                && let Some(resolved_purl) = &resolved.purl
-            {
+            for child in depends_on {
                 xml.push_str(&format!(
                     "      <dependency ref=\"{}\"/>\n",
-                    xml_escape(resolved_purl)
+                    xml_escape(child)
                 ));
             }
             xml.push_str("    </dependency>\n");
@@ -144,6 +142,7 @@ fn build_cyclonedx_json(output: &Output) -> Value {
         .first()
         .and_then(|h| convert_header_timestamp_to_iso_utc(&h.end_timestamp))
         .unwrap_or_else(|| fallback_iso_utc_timestamp().to_string());
+    let component_refs = component_bom_refs(&output.packages);
 
     let components = output
         .packages
@@ -154,7 +153,7 @@ fn build_cyclonedx_json(output: &Output) -> Value {
             obj.insert("type".to_string(), Value::String("library".to_string()));
             obj.insert(
                 "bom-ref".to_string(),
-                Value::String(cyclonedx_component_ref(pkg, idx)),
+                Value::String(component_refs[idx].clone()),
             );
             obj.insert(
                 "name".to_string(),
@@ -204,24 +203,12 @@ fn build_cyclonedx_json(output: &Output) -> Value {
         })
         .collect::<Vec<_>>();
 
-    let dependencies = output
-        .dependencies
-        .iter()
-        .enumerate()
-        .map(|(idx, dep)| {
-            let reference = dep
-                .purl
-                .clone()
-                .unwrap_or_else(|| format!("dependency-{}", idx + 1));
-            let depends_on = dep
-                .resolved_package
-                .as_ref()
-                .and_then(|rp| rp.purl.clone())
-                .into_iter()
-                .collect::<Vec<_>>();
+    let dependencies = build_dependency_graph(output, &component_refs)
+        .into_iter()
+        .map(|(reference, depends_on)| {
             json!({
                 "ref": reference,
-                "dependsOn": depends_on,
+                "dependsOn": depends_on.into_iter().collect::<Vec<_>>(),
             })
         })
         .collect::<Vec<_>>();
@@ -255,10 +242,85 @@ fn build_cyclonedx_json(output: &Output) -> Value {
     }
 }
 
-fn cyclonedx_component_ref(pkg: &Package, idx: usize) -> String {
-    pkg.purl
+/// Assign a unique `bom-ref` per package. Prefer purl when it does not collide;
+/// fall back to `package_uid` (always unique) or a synthetic index-based ref.
+fn component_bom_refs(packages: &[Package]) -> Vec<String> {
+    let mut purl_counts: HashMap<&str, usize> = HashMap::new();
+    for pkg in packages {
+        if let Some(purl) = pkg.purl.as_deref() {
+            *purl_counts.entry(purl).or_default() += 1;
+        }
+    }
+
+    packages
+        .iter()
+        .enumerate()
+        .map(|(idx, pkg)| match pkg.purl.as_deref() {
+            Some(purl) if purl_counts.get(purl).copied().unwrap_or(0) == 1 => purl.to_string(),
+            Some(_) => pkg.package_uid.clone(),
+            None if !pkg.package_uid.is_empty() => pkg.package_uid.clone(),
+            None => format!("component-{}", idx + 1),
+        })
+        .collect()
+}
+
+/// Build a CycloneDX dependency graph: one unique entry per `ref`, with
+/// `dependsOn` listing the purls that package depends on.
+///
+/// Edges are owner → dependency (`for_package_uid` → package bom-ref, dependency
+/// purl as child). Self-edges are dropped. Components with no outgoing edges
+/// still get an empty `dependsOn` entry so the graph is complete.
+fn build_dependency_graph(
+    output: &Output,
+    component_refs: &[String],
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut uid_to_ref: HashMap<&str, &str> = HashMap::new();
+    for (pkg, bom_ref) in output.packages.iter().zip(component_refs.iter()) {
+        uid_to_ref.insert(pkg.package_uid.as_str(), bom_ref.as_str());
+    }
+
+    let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    // Every component appears in the graph (CycloneDX recommends empty nodes for
+    // leaves so the graph is explicit).
+    for bom_ref in component_refs {
+        graph.entry(bom_ref.clone()).or_default();
+    }
+
+    for dep in &output.dependencies {
+        let Some(dep_purl) = dependency_edge_purl(dep) else {
+            continue;
+        };
+
+        if let Some(owner_uid) = dep.for_package_uid.as_deref()
+            && let Some(owner_ref) = uid_to_ref.get(owner_uid).copied()
+        {
+            if owner_ref != dep_purl {
+                graph
+                    .entry(owner_ref.to_string())
+                    .or_default()
+                    .insert(dep_purl);
+            }
+            continue;
+        }
+
+        // Unowned / unknown-owner dependency: emit as a leaf node so its purl
+        // still appears once (no duplicate refs across hoisted rows).
+        graph.entry(dep_purl).or_default();
+    }
+
+    graph
+}
+
+fn dependency_edge_purl(dep: &TopLevelDependency) -> Option<String> {
+    dep.purl
         .clone()
-        .unwrap_or_else(|| format!("component-{}", idx + 1))
+        .or_else(|| {
+            dep.resolved_package
+                .as_ref()
+                .and_then(|resolved| resolved.purl.clone())
+        })
+        .filter(|purl| !purl.is_empty())
 }
 
 fn cyclonedx_license_expression(pkg: &Package) -> Option<String> {
@@ -311,4 +373,137 @@ fn component_external_references(pkg: &Package) -> Vec<(&'static str, String)> {
     push_ref("website", &pkg.repository_homepage_url);
     push_ref("vcs", &pkg.vcs_url);
     refs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::DatasourceId;
+    use crate::output_schema::OutputDatasourceId;
+
+    fn sample_package(name: &str, version: &str, uid: &str) -> Package {
+        Package {
+            package_type: None,
+            namespace: None,
+            name: Some(name.to_string()),
+            version: Some(version.to_string()),
+            qualifiers: None,
+            subpath: None,
+            primary_language: None,
+            description: None,
+            release_date: None,
+            parties: vec![],
+            keywords: vec![],
+            homepage_url: None,
+            download_url: None,
+            size: None,
+            sha1: None,
+            md5: None,
+            sha256: None,
+            sha512: None,
+            bug_tracking_url: None,
+            code_view_url: None,
+            vcs_url: None,
+            copyright: None,
+            holder: None,
+            declared_license_expression: None,
+            declared_license_expression_spdx: None,
+            license_detections: vec![],
+            other_license_expression: None,
+            other_license_expression_spdx: None,
+            other_license_detections: vec![],
+            extracted_license_statement: None,
+            notice_text: None,
+            source_packages: vec![],
+            is_private: false,
+            is_virtual: false,
+            extra_data: None,
+            repository_homepage_url: None,
+            repository_download_url: None,
+            api_data_url: None,
+            purl: Some(format!("pkg:hex/{name}@{version}")),
+            package_uid: uid.to_string(),
+            datafile_paths: vec![],
+            datasource_ids: vec![],
+        }
+    }
+
+    fn sample_dep(purl: &str, for_package_uid: Option<&str>) -> TopLevelDependency {
+        TopLevelDependency {
+            purl: Some(purl.to_string()),
+            extracted_requirement: None,
+            scope: None,
+            is_runtime: Some(true),
+            is_optional: Some(false),
+            is_pinned: Some(true),
+            is_direct: Some(true),
+            // Intentionally identical resolved purl: the old emitter turned this
+            // into a self-edge; the owner→dep graph must not.
+            resolved_package: None,
+            extra_data: None,
+            dependency_uid: format!("{purl}?uuid=dep"),
+            for_package_uid: for_package_uid.map(str::to_string),
+            datafile_path: "mix.lock".to_string(),
+            datasource_id: OutputDatasourceId::from(DatasourceId::HexMixLock),
+            namespace: None,
+        }
+    }
+
+    #[test]
+    fn dependency_graph_dedups_shared_deps_across_owners() {
+        let pkg_a = sample_package("a", "0.1.0", "uid-a");
+        let pkg_b = sample_package("b", "0.1.0", "uid-b");
+        let output = Output {
+            summary: None,
+            tallies: None,
+            tallies_of_key_files: None,
+            tallies_by_facet: None,
+            headers: vec![],
+            packages: vec![pkg_a, pkg_b],
+            dependencies: vec![
+                sample_dep("pkg:hex/jason@1.4.1", Some("uid-a")),
+                sample_dep("pkg:hex/jason@1.4.1", Some("uid-b")),
+                sample_dep("pkg:hex/plug@1.15.0", Some("uid-a")),
+                sample_dep("pkg:hex/plug@1.15.0", Some("uid-b")),
+            ],
+            license_detections: vec![],
+            files: vec![],
+            license_references: vec![],
+            license_rule_references: vec![],
+        };
+        let refs = component_bom_refs(&output.packages);
+        let graph = build_dependency_graph(&output, &refs);
+
+        assert_eq!(graph.len(), 2, "one unique entry per owner package");
+        assert_eq!(
+            graph["pkg:hex/a@0.1.0"],
+            BTreeSet::from([
+                "pkg:hex/jason@1.4.1".to_string(),
+                "pkg:hex/plug@1.15.0".to_string()
+            ])
+        );
+        assert_eq!(
+            graph["pkg:hex/b@0.1.0"],
+            BTreeSet::from([
+                "pkg:hex/jason@1.4.1".to_string(),
+                "pkg:hex/plug@1.15.0".to_string()
+            ])
+        );
+        // No self-edges and no duplicate refs.
+        for (r, deps) in &graph {
+            assert!(!deps.contains(r), "self-edge on {r}");
+        }
+    }
+
+    #[test]
+    fn component_bom_refs_disambiguate_duplicate_purls() {
+        let mut a = sample_package("shared", "1.0.0", "uid-1");
+        let mut b = sample_package("shared", "1.0.0", "uid-2");
+        a.purl = Some("pkg:hex/shared@1.0.0".to_string());
+        b.purl = Some("pkg:hex/shared@1.0.0".to_string());
+        let refs = component_bom_refs(&[a, b]);
+        assert_eq!(refs[0], "uid-1");
+        assert_eq!(refs[1], "uid-2");
+        assert_ne!(refs[0], refs[1]);
+    }
 }

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -265,10 +265,13 @@ fn component_bom_refs(packages: &[Package]) -> Vec<String> {
 }
 
 /// Build a CycloneDX dependency graph: one unique entry per `ref`, with
-/// `dependsOn` listing the purls that package depends on.
+/// `dependsOn` listing component `bom-ref`s (or dependency purls when the
+/// target is not itself a component).
 ///
-/// Edges are owner → dependency (`for_package_uid` → package bom-ref, dependency
-/// purl as child). Self-edges are dropped. Components with no outgoing edges
+/// Edges are owner → dependency (`for_package_uid` → package bom-ref). Child
+/// refs are resolved through [`resolve_depends_on_refs`] so a disambiguated
+/// `package_uid` bom-ref is used whenever the dependency purl maps to
+/// component(s). Self-edges are dropped. Components with no outgoing edges
 /// still get an empty `dependsOn` entry so the graph is complete.
 fn build_dependency_graph(
     output: &Output,
@@ -291,25 +294,55 @@ fn build_dependency_graph(
         let Some(dep_purl) = dependency_edge_purl(dep) else {
             continue;
         };
+        let child_refs = resolve_depends_on_refs(&dep_purl, &output.packages, component_refs);
 
         if let Some(owner_uid) = dep.for_package_uid.as_deref()
             && let Some(owner_ref) = uid_to_ref.get(owner_uid).copied()
         {
-            if owner_ref != dep_purl {
-                graph
-                    .entry(owner_ref.to_string())
-                    .or_default()
-                    .insert(dep_purl);
+            for child_ref in child_refs {
+                if owner_ref != child_ref {
+                    graph
+                        .entry(owner_ref.to_string())
+                        .or_default()
+                        .insert(child_ref);
+                }
             }
             continue;
         }
 
-        // Unowned / unknown-owner dependency: emit as a leaf node so its purl
+        // Unowned / unknown-owner dependency: emit as a leaf node so its ref
         // still appears once (no duplicate refs across hoisted rows).
-        graph.entry(dep_purl).or_default();
+        for child_ref in child_refs {
+            graph.entry(child_ref).or_default();
+        }
     }
 
     graph
+}
+
+/// Map a dependency purl onto component `bom-ref`s.
+///
+/// When the purl uniquely identifies a component, returns that component's
+/// bom-ref (purl or disambiguated `package_uid`). When several assembled
+/// packages share the purl, returns every matching bom-ref so `dependsOn`
+/// never points at a bare purl that no component owns. When no component
+/// matches, returns the purl itself (external / unresolved dependency).
+fn resolve_depends_on_refs(
+    dep_purl: &str,
+    packages: &[Package],
+    component_refs: &[String],
+) -> Vec<String> {
+    let matching: Vec<String> = packages
+        .iter()
+        .zip(component_refs.iter())
+        .filter(|(pkg, _)| pkg.purl.as_deref() == Some(dep_purl))
+        .map(|(_, bom_ref)| bom_ref.clone())
+        .collect();
+    if matching.is_empty() {
+        vec![dep_purl.to_string()]
+    } else {
+        matching
+    }
 }
 
 fn dependency_edge_purl(dep: &TopLevelDependency) -> Option<String> {
@@ -505,5 +538,62 @@ mod tests {
         assert_eq!(refs[0], "uid-1");
         assert_eq!(refs[1], "uid-2");
         assert_ne!(refs[0], refs[1]);
+    }
+
+    #[test]
+    fn depends_on_uses_component_bom_ref_when_target_purl_is_unique() {
+        let owner = sample_package("app", "1.0.0", "uid-app");
+        let mut lib = sample_package("lib", "2.0.0", "uid-lib");
+        lib.purl = Some("pkg:hex/lib@2.0.0".to_string());
+        let output = Output {
+            summary: None,
+            tallies: None,
+            tallies_of_key_files: None,
+            tallies_by_facet: None,
+            headers: vec![],
+            packages: vec![owner, lib],
+            dependencies: vec![sample_dep("pkg:hex/lib@2.0.0", Some("uid-app"))],
+            license_detections: vec![],
+            files: vec![],
+            license_references: vec![],
+            license_rule_references: vec![],
+        };
+        let refs = component_bom_refs(&output.packages);
+        let graph = build_dependency_graph(&output, &refs);
+        assert_eq!(
+            graph["pkg:hex/app@1.0.0"],
+            BTreeSet::from(["pkg:hex/lib@2.0.0".to_string()])
+        );
+    }
+
+    #[test]
+    fn depends_on_uses_disambiguated_bom_refs_when_target_purl_collides() {
+        let owner = sample_package("app", "1.0.0", "uid-app");
+        let mut shared_a = sample_package("shared", "1.0.0", "uid-shared-a");
+        let mut shared_b = sample_package("shared", "1.0.0", "uid-shared-b");
+        shared_a.purl = Some("pkg:hex/shared@1.0.0".to_string());
+        shared_b.purl = Some("pkg:hex/shared@1.0.0".to_string());
+        let output = Output {
+            summary: None,
+            tallies: None,
+            tallies_of_key_files: None,
+            tallies_by_facet: None,
+            headers: vec![],
+            packages: vec![owner, shared_a, shared_b],
+            dependencies: vec![sample_dep("pkg:hex/shared@1.0.0", Some("uid-app"))],
+            license_detections: vec![],
+            files: vec![],
+            license_references: vec![],
+            license_rule_references: vec![],
+        };
+        let refs = component_bom_refs(&output.packages);
+        assert_eq!(refs[1], "uid-shared-a");
+        assert_eq!(refs[2], "uid-shared-b");
+        let graph = build_dependency_graph(&output, &refs);
+        assert_eq!(
+            graph["pkg:hex/app@1.0.0"],
+            BTreeSet::from(["uid-shared-a".to_string(), "uid-shared-b".to_string()])
+        );
+        assert!(!graph["pkg:hex/app@1.0.0"].contains("pkg:hex/shared@1.0.0"));
     }
 }

--- a/src/output/debian.rs
+++ b/src/output/debian.rs
@@ -47,7 +47,10 @@ fn write_file_paragraph(writer: &mut dyn Write, file: &FileInfo) -> io::Result<(
         .iter()
         .map(|holder| holder.holder.as_str())
         .collect();
-    if !copyright_lines.is_empty() {
+    // DEP-5 Files paragraphs should carry Copyright; be explicit when unknown.
+    if copyright_lines.is_empty() {
+        write_multiline_field(writer, "Copyright", &["NOASSERTION"])?;
+    } else {
         write_multiline_field(writer, "Copyright", &copyright_lines)?;
     }
 
@@ -69,19 +72,10 @@ fn write_file_paragraph(writer: &mut dyn Write, file: &FileInfo) -> io::Result<(
     writer.write_all(b"\n")
 }
 
+/// Prefer SPDX short names for DEP-5 `License:` fields.
 fn detected_license_expression(file: &FileInfo) -> Option<String> {
-    let expressions: Vec<String> = file
-        .license_detections
-        .iter()
-        .map(|detection| detection.license_expression.clone())
-        .filter(|expression| !expression.is_empty())
-        .collect();
-
-    if !expressions.is_empty() {
-        return crate::utils::spdx::combine_license_expressions(expressions);
-    }
-
-    file.license_expression.clone()
+    file.detected_license_expression_spdx()
+        .or_else(|| file.detected_license_expression())
 }
 
 fn write_multiline_field(writer: &mut dyn Write, key: &str, lines: &[&str]) -> io::Result<()> {
@@ -176,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn detected_license_expression_prefers_non_spdx_detection_expression() {
+    fn detected_license_expression_prefers_spdx_short_name() {
         let internal = crate::models::FileInfo::new(
             "LICENSE".to_string(),
             "LICENSE".to_string(),
@@ -212,6 +206,6 @@ mod tests {
             identifier: None,
         }];
 
-        assert_eq!(detected_license_expression(&file).as_deref(), Some("mit"));
+        assert_eq!(detected_license_expression(&file).as_deref(), Some("MIT"));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -198,7 +198,7 @@ mod tests {
         assert!(rendered.contains("Comment: Generated with Provenant"));
         assert!(rendered.contains("Files: src/main.rs"));
         assert!(rendered.contains("Copyright: Example Org"));
-        assert!(rendered.contains("License: mit"));
+        assert!(rendered.contains("License: MIT"));
         assert!(rendered.contains(" Permission is hereby granted, free of charge"));
     }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -546,6 +546,18 @@ mod tests {
         let rendered = String::from_utf8(bytes).expect("spdx should be utf-8");
         assert!(rendered.contains("SPDXVersion: SPDX-2.2"));
         assert!(rendered.contains("FileName: ./src/main.rs"));
+        assert!(
+            rendered.contains("Creator: Tool: Provenant-"),
+            "SPDX TV must emit CreationInfo Creator for spdx-tools"
+        );
+        assert!(
+            rendered.contains("Created:"),
+            "SPDX TV must emit CreationInfo Created for spdx-tools"
+        );
+        assert!(
+            rendered.contains("Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001"),
+            "SPDX TV must describe the package from the document"
+        );
     }
 
     #[test]
@@ -568,6 +580,14 @@ mod tests {
         assert!(rendered.contains("<rdf:RDF"));
         assert!(rendered.contains("<spdx:SpdxDocument"));
         assert!(rendered.contains("<spdx:created>2026-01-01T00:00:00Z</spdx:created>"));
+        assert!(
+            rendered.contains("<spdx:creator>Tool: Provenant-"),
+            "SPDX RDF must emit a creator Actor for spdx-tools"
+        );
+        assert!(
+            rendered.contains("relationshipType_describes"),
+            "SPDX RDF must include Document DESCRIBES package"
+        );
     }
 
     #[test]
@@ -771,7 +791,7 @@ mod tests {
             "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/licenses/LicenseRef-scancode-unknown-license-reference\"/>"
         ));
         assert!(rdf_rendered.contains(
-            "<spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"#LicenseRef-scancode-unknown-license-reference\">"
+            "<spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"http://spdx.org/spdxdocs/scan#LicenseRef-scancode-unknown-license-reference\">"
         ));
         assert!(
             rdf_rendered.contains("<spdx:extractedText>Custom license text</spdx:extractedText>")

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -45,6 +45,8 @@ pub(crate) fn write_spdx_tag_value(
     let package_license_info_from_files = spdx_package_license_info_from_files(&files);
     let package_copyright_text = spdx_package_copyright_text(&files);
     let extracted_license_infos = spdx_extracted_license_infos(output, &files);
+    let created = spdx_created_timestamp(output);
+    let creator = spdx_creator();
 
     writeln!(writer, "## Document Information")?;
     writeln!(writer, "SPDXVersion: SPDX-2.2")?;
@@ -58,6 +60,8 @@ pub(crate) fn write_spdx_tag_value(
         SPDX_DOCUMENT_NOTICE
     )?;
     writeln!(writer, "## Creation Information")?;
+    writeln!(writer, "Creator: {}", creator)?;
+    writeln!(writer, "Created: {}", created)?;
     writeln!(writer, "## Package Information")?;
 
     writeln!(writer, "PackageName: {}", package_name)?;
@@ -77,13 +81,21 @@ pub(crate) fn write_spdx_tag_value(
         writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
     }
     writeln!(writer, "PackageLicenseDeclared: NOASSERTION")?;
-    writeln!(writer, "PackageCopyrightText: {}", package_copyright_text)?;
+    writeln!(
+        writer,
+        "PackageCopyrightText: {}",
+        format_spdx_text_field(&package_copyright_text)
+    )?;
     writeln!(writer, "## File Information")?;
 
     for (file_index, file) in (1usize..).zip(files) {
         let sha1 = file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX);
         let file_license_info = spdx_file_license_info(file);
-        writeln!(writer, "FileName: ./{}", file.path)?;
+        writeln!(
+            writer,
+            "FileName: {}",
+            spdx_relative_file_name(&file.path, config.scanned_path.as_deref())
+        )?;
         writeln!(writer, "SPDXID: SPDXRef-{}", file_index)?;
         writeln!(writer, "FileChecksum: SHA1: {}", sha1)?;
         writeln!(writer, "LicenseConcluded: NOASSERTION")?;
@@ -104,11 +116,21 @@ pub(crate) fn write_spdx_tag_value(
                 .map(|c| c.copyright.clone())
                 .collect::<Vec<_>>()
                 .join("\\n");
-            writeln!(writer, "FileCopyrightText: {}", text)?;
+            writeln!(
+                writer,
+                "FileCopyrightText: {}",
+                format_spdx_text_field(&text)
+            )?;
         }
 
         writeln!(writer)?;
     }
+
+    writeln!(writer, "## Relationships")?;
+    writeln!(
+        writer,
+        "Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001"
+    )?;
 
     if !extracted_license_infos.is_empty() {
         writeln!(writer, "## License Information")?;
@@ -143,22 +165,24 @@ pub(crate) fn write_spdx_rdf_xml(
     }
 
     let package_name = xml_escape(&package_name_raw);
+    let document_namespace = format!("http://spdx.org/spdxdocs/{}", package_name_raw);
+    let document_namespace_xml = xml_escape(&document_namespace);
     let package_verification_code = spdx_package_verification_code(&files);
     let package_license_info_from_files = spdx_package_license_info_from_files(&files);
     let package_copyright_text = xml_escape(&spdx_package_copyright_text(&files));
     let extracted_license_infos = spdx_extracted_license_infos(output, &files);
-    let created_raw = output
-        .headers
-        .first()
-        .and_then(|h| convert_header_timestamp_to_iso_utc(&h.start_timestamp))
-        .unwrap_or_else(|| fallback_iso_utc_timestamp().to_string());
-    let created = xml_escape(&created_raw);
+    let created = xml_escape(&spdx_created_timestamp(output));
+    let creator = xml_escape(&spdx_creator());
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     xml.push_str("<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:spdx=\"http://spdx.org/rdf/terms#\">\n");
 
-    xml.push_str("  <spdx:Package rdf:about=\"#SPDXRef-001\">\n");
+    // Absolute rdf:about URIs (namespace#SPDXRef-…) so RDF parsers do not resolve
+    // bare fragments against the on-disk file path.
+    xml.push_str("  <spdx:Package rdf:about=\"");
+    xml.push_str(&document_namespace_xml);
+    xml.push_str("#SPDXRef-001\">\n");
     xml.push_str("    <spdx:filesAnalyzed rdf:datatype=\"http://www.w3.org/2001/XMLSchema#boolean\">true</spdx:filesAnalyzed>\n");
     xml.push_str(
         "    <spdx:downloadLocation rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
@@ -189,7 +213,9 @@ pub(crate) fn write_spdx_rdf_xml(
         let file_license_info = spdx_file_license_info(file);
         xml.push_str("    <spdx:relationship><spdx:Relationship>");
         xml.push_str("<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_contains\"/>");
-        xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"#SPDXRef-");
+        xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"");
+        xml.push_str(&document_namespace_xml);
+        xml.push_str("#SPDXRef-");
         xml.push_str(&file_id.to_string());
         xml.push_str("\">");
         xml.push_str(
@@ -211,7 +237,10 @@ pub(crate) fn write_spdx_rdf_xml(
         xml.push_str(&xml_escape(file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX)));
         xml.push_str("</spdx:checksumValue></spdx:Checksum></spdx:checksum>");
         xml.push_str("<spdx:fileName>");
-        xml.push_str(&xml_escape(&format!("./{}", file.path)));
+        xml.push_str(&xml_escape(&spdx_relative_file_name(
+            &file.path,
+            config.scanned_path.as_deref(),
+        )));
         xml.push_str("</spdx:fileName>");
         xml.push_str("<spdx:copyrightText>");
         if file.copyrights.is_empty() {
@@ -240,15 +269,20 @@ pub(crate) fn write_spdx_rdf_xml(
     xml.push_str("</spdx:name>\n");
     xml.push_str("  </spdx:Package>\n");
 
-    xml.push_str("  <spdx:SpdxDocument rdf:about=\"#SPDXRef-DOCUMENT\">\n");
+    // spdx-tools expects SpdxDocument rdf:about = documentNamespace + "#SPDXRef-DOCUMENT".
+    xml.push_str("  <spdx:SpdxDocument rdf:about=\"");
+    xml.push_str(&document_namespace_xml);
+    xml.push_str("#SPDXRef-DOCUMENT\">\n");
     xml.push_str("    <spdx:dataLicense rdf:resource=\"http://spdx.org/licenses/CC0-1.0\"/>\n");
     xml.push_str("    <rdfs:comment>");
     xml.push_str(&xml_escape(SPDX_DOCUMENT_NOTICE));
     xml.push_str("</rdfs:comment>\n");
     for info in extracted_license_infos {
         xml.push_str(
-            "    <spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"#",
+            "    <spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"",
         );
+        xml.push_str(&document_namespace_xml);
+        xml.push('#');
         xml.push_str(&xml_escape(&info.license_id));
         xml.push_str("\">");
         xml.push_str("<spdx:licenseId>");
@@ -267,9 +301,22 @@ pub(crate) fn write_spdx_rdf_xml(
     }
     xml.push_str("    <spdx:name>SPDX Document created by Provenant</spdx:name>\n");
     xml.push_str("    <spdx:specVersion>SPDX-2.2</spdx:specVersion>\n");
-    xml.push_str("    <spdx:creationInfo><spdx:CreationInfo><spdx:created>");
+    xml.push_str("    <spdx:creationInfo><spdx:CreationInfo>");
+    xml.push_str("<spdx:creator>");
+    xml.push_str(&creator);
+    xml.push_str("</spdx:creator>");
+    xml.push_str("<spdx:created>");
     xml.push_str(&created);
-    xml.push_str("</spdx:created></spdx:CreationInfo></spdx:creationInfo>\n");
+    xml.push_str("</spdx:created>");
+    xml.push_str("</spdx:CreationInfo></spdx:creationInfo>\n");
+    xml.push_str("    <spdx:relationship><spdx:Relationship>");
+    xml.push_str(
+        "<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_describes\"/>",
+    );
+    xml.push_str("<spdx:relatedSpdxElement rdf:resource=\"");
+    xml.push_str(&document_namespace_xml);
+    xml.push_str("#SPDXRef-001\"/>");
+    xml.push_str("</spdx:Relationship></spdx:relationship>\n");
     xml.push_str("  </spdx:SpdxDocument>\n");
 
     xml.push_str("</rdf:RDF>\n");
@@ -338,7 +385,7 @@ fn spdx_package_verification_code(files: &[&FileInfo]) -> String {
 }
 
 fn spdx_file_license_info(file: &FileInfo) -> Vec<String> {
-    let mut license_ids = Vec::new();
+    let mut license_ids = BTreeSet::new();
 
     for detection in file.license_detections.iter().chain(
         file.package_data
@@ -365,7 +412,7 @@ fn spdx_file_license_info(file: &FileInfo) -> Vec<String> {
         }
     }
 
-    license_ids
+    license_ids.into_iter().collect()
 }
 
 fn spdx_package_license_info_from_files(files: &[&FileInfo]) -> Vec<String> {
@@ -482,7 +529,8 @@ fn spdx_ids_from_expression(expression: &str) -> Vec<String> {
     };
 
     for ch in expression.chars() {
-        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '.' | '+') {
+        // Keep underscores so LicenseRef- and SPDX ids that use them stay intact.
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '.' | '+' | '_') {
             token.push(ch);
         } else {
             flush(&mut token, &mut ids);
@@ -491,6 +539,46 @@ fn spdx_ids_from_expression(expression: &str) -> Vec<String> {
     flush(&mut token, &mut ids);
 
     ids
+}
+
+fn spdx_creator() -> String {
+    format!("Tool: Provenant-{}", crate::version::BUILD_VERSION)
+}
+
+fn spdx_created_timestamp(output: &Output) -> String {
+    output
+        .headers
+        .first()
+        .and_then(|h| convert_header_timestamp_to_iso_utc(&h.start_timestamp))
+        .unwrap_or_else(|| fallback_iso_utc_timestamp().to_string())
+}
+
+fn format_spdx_text_field(value: &str) -> String {
+    if value.contains('\n') {
+        format!("<text>{value}</text>")
+    } else {
+        value.to_string()
+    }
+}
+
+fn spdx_relative_file_name(path: &str, scanned_path: Option<&str>) -> String {
+    let trimmed = path.trim_start_matches("./");
+    let relative = if let Some(root) = scanned_path {
+        let root = root.trim_end_matches('/');
+        if let Some(rest) = trimmed.strip_prefix(root) {
+            rest.trim_start_matches('/')
+        } else {
+            trimmed
+        }
+    } else {
+        trimmed
+    };
+
+    if relative.is_empty() {
+        "./.".to_string()
+    } else {
+        format!("./{relative}")
+    }
 }
 
 #[cfg(test)]

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -622,9 +622,11 @@ fn format_spdx_text_field(value: &str) -> String {
 }
 
 fn spdx_relative_file_name(path: &str, scanned_path: Option<&str>) -> String {
-    let path = Path::new(path.trim_start_matches("./"));
+    // Normalize both sides the same way so a CLI root like `./proj` still
+    // strips against collected paths that lose the leading `./`.
+    let path = Path::new(trim_spdx_dot_slash(path));
     let relative = match scanned_path {
-        Some(root) => match path.strip_prefix(Path::new(root)) {
+        Some(root) => match path.strip_prefix(Path::new(trim_spdx_dot_slash(root))) {
             Ok(stripped) => stripped.to_string_lossy().into_owned(),
             Err(_) => path.to_string_lossy().into_owned(),
         },
@@ -639,6 +641,10 @@ fn spdx_relative_file_name(path: &str, scanned_path: Option<&str>) -> String {
     } else {
         format!("./{relative}")
     }
+}
+
+fn trim_spdx_dot_slash(path: &str) -> &str {
+    path.trim_start_matches("./")
 }
 
 /// Plan SPDX packages: one per assembled package (with owned files), plus a
@@ -738,6 +744,18 @@ mod tests {
         );
         assert_eq!(
             spdx_relative_file_name("/tmp/proj/src.rs", Some("/tmp/proj")),
+            "./src.rs"
+        );
+    }
+
+    #[test]
+    fn spdx_relative_file_name_strips_matching_dot_slash_roots() {
+        assert_eq!(
+            spdx_relative_file_name("./proj/src.rs", Some("./proj")),
+            "./src.rs"
+        );
+        assert_eq!(
+            spdx_relative_file_name("proj/src.rs", Some("./proj")),
             "./src.rs"
         );
     }

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -6,12 +6,12 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use sha1::{Digest, Sha1};
 
 use crate::output_schema::{
-    Output, OutputFileInfo as FileInfo, OutputFileType, OutputMatch as Match,
+    Output, OutputFileInfo as FileInfo, OutputFileType, OutputMatch as Match, OutputPackage,
 };
 use crate::utils::time::{convert_header_timestamp_to_iso_utc, fallback_iso_utc_timestamp};
 
@@ -27,26 +27,36 @@ struct ExtractedLicenseInfo {
     comment: String,
 }
 
+/// One SPDX Package to emit, with the files it owns.
+struct SpdxPackagePlan<'a> {
+    spdx_id: String,
+    name: String,
+    files: Vec<&'a FileInfo>,
+}
+
 pub(crate) fn write_spdx_tag_value(
     output: &Output,
     writer: &mut dyn Write,
     config: &OutputWriteConfig,
 ) -> io::Result<()> {
-    let package_name = primary_package_name(output, config);
-
     let files = spdx_files(output);
+    let fallback_name = primary_package_name(output, config);
     if files.is_empty() {
-        writeln!(writer, "# No results for package '{}'.", package_name)?;
+        writeln!(writer, "# No results for package '{}'.", fallback_name)?;
         return Ok(());
     }
 
-    let document_namespace = format!("http://spdx.org/spdxdocs/{}", package_name);
-    let package_verification_code = spdx_package_verification_code(&files);
-    let package_license_info_from_files = spdx_package_license_info_from_files(&files);
-    let package_copyright_text = spdx_package_copyright_text(&files);
+    let plans = plan_spdx_packages(output, &files, config);
+    let document_namespace = document_namespace_for(output, config);
     let extracted_license_infos = spdx_extracted_license_infos(output, &files);
     let created = spdx_created_timestamp(output);
     let creator = spdx_creator();
+
+    // Global file index → SPDXRef so CONTAINS relationships can point at files.
+    let mut file_spdx_ids: HashMap<&str, String> = HashMap::new();
+    for (file_index, file) in (1usize..).zip(files.iter()) {
+        file_spdx_ids.insert(file.path.as_str(), format!("SPDXRef-{file_index}"));
+    }
 
     writeln!(writer, "## Document Information")?;
     writeln!(writer, "SPDXVersion: SPDX-2.2")?;
@@ -57,38 +67,44 @@ pub(crate) fn write_spdx_tag_value(
     writeln!(
         writer,
         "DocumentComment: <text>{}</text>",
-        SPDX_DOCUMENT_NOTICE
+        sanitize_spdx_text_content(SPDX_DOCUMENT_NOTICE)
     )?;
     writeln!(writer, "## Creation Information")?;
     writeln!(writer, "Creator: {}", creator)?;
     writeln!(writer, "Created: {}", created)?;
-    writeln!(writer, "## Package Information")?;
 
-    writeln!(writer, "PackageName: {}", package_name)?;
-    writeln!(writer, "SPDXID: SPDXRef-001")?;
-    writeln!(writer, "PackageDownloadLocation: NOASSERTION")?;
-    writeln!(writer, "FilesAnalyzed: true")?;
-    writeln!(
-        writer,
-        "PackageVerificationCode: {}",
-        package_verification_code
-    )?;
-    writeln!(writer, "PackageLicenseConcluded: NOASSERTION")?;
-    for license_id in &package_license_info_from_files {
-        writeln!(writer, "PackageLicenseInfoFromFiles: {}", license_id)?;
+    for plan in &plans {
+        let package_verification_code = spdx_package_verification_code(&plan.files);
+        let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
+        let package_copyright_text = spdx_package_copyright_text(&plan.files);
+
+        writeln!(writer, "## Package Information")?;
+        writeln!(writer, "PackageName: {}", plan.name)?;
+        writeln!(writer, "SPDXID: {}", plan.spdx_id)?;
+        writeln!(writer, "PackageDownloadLocation: NOASSERTION")?;
+        writeln!(writer, "FilesAnalyzed: true")?;
+        writeln!(
+            writer,
+            "PackageVerificationCode: {}",
+            package_verification_code
+        )?;
+        writeln!(writer, "PackageLicenseConcluded: NOASSERTION")?;
+        for license_id in &package_license_info_from_files {
+            writeln!(writer, "PackageLicenseInfoFromFiles: {}", license_id)?;
+        }
+        if package_license_info_from_files.is_empty() {
+            writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
+        }
+        writeln!(writer, "PackageLicenseDeclared: NOASSERTION")?;
+        writeln!(
+            writer,
+            "PackageCopyrightText: {}",
+            format_spdx_text_field(&package_copyright_text)
+        )?;
     }
-    if package_license_info_from_files.is_empty() {
-        writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
-    }
-    writeln!(writer, "PackageLicenseDeclared: NOASSERTION")?;
-    writeln!(
-        writer,
-        "PackageCopyrightText: {}",
-        format_spdx_text_field(&package_copyright_text)
-    )?;
+
     writeln!(writer, "## File Information")?;
-
-    for (file_index, file) in (1usize..).zip(files) {
+    for (file_index, file) in (1usize..).zip(files.iter()) {
         let sha1 = file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX);
         let file_license_info = spdx_file_license_info(file);
         writeln!(
@@ -127,19 +143,39 @@ pub(crate) fn write_spdx_tag_value(
     }
 
     writeln!(writer, "## Relationships")?;
-    writeln!(
-        writer,
-        "Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001"
-    )?;
+    for plan in &plans {
+        writeln!(
+            writer,
+            "Relationship: SPDXRef-DOCUMENT DESCRIBES {}",
+            plan.spdx_id
+        )?;
+        for file in &plan.files {
+            if let Some(file_id) = file_spdx_ids.get(file.path.as_str()) {
+                writeln!(
+                    writer,
+                    "Relationship: {} CONTAINS {}",
+                    plan.spdx_id, file_id
+                )?;
+            }
+        }
+    }
 
     if !extracted_license_infos.is_empty() {
         writeln!(writer, "## License Information")?;
         for info in extracted_license_infos {
             writeln!(writer, "LicenseID: {}", info.license_id)?;
-            writeln!(writer, "ExtractedText: <text>{}", info.extracted_text)?;
+            writeln!(
+                writer,
+                "ExtractedText: <text>{}",
+                sanitize_spdx_text_content(&info.extracted_text)
+            )?;
             writeln!(writer, "</text>")?;
             writeln!(writer, "LicenseName: {}", info.name)?;
-            writeln!(writer, "LicenseComment: <text>{}", info.comment)?;
+            writeln!(
+                writer,
+                "LicenseComment: <text>{}",
+                sanitize_spdx_text_content(&info.comment)
+            )?;
             writeln!(writer, "</text>")?;
         }
     }
@@ -152,122 +188,132 @@ pub(crate) fn write_spdx_rdf_xml(
     writer: &mut dyn Write,
     config: &OutputWriteConfig,
 ) -> io::Result<()> {
-    let package_name_raw = primary_package_name(output, config);
-
+    let fallback_name = primary_package_name(output, config);
     let files = spdx_files(output);
     if files.is_empty() {
         writeln!(
             writer,
             "<!-- No results for package '{}'. -->",
-            package_name_raw
+            fallback_name
         )?;
         return Ok(());
     }
 
-    let package_name = xml_escape(&package_name_raw);
-    let document_namespace = format!("http://spdx.org/spdxdocs/{}", package_name_raw);
+    let plans = plan_spdx_packages(output, &files, config);
+    let document_namespace = document_namespace_for(output, config);
     let document_namespace_xml = xml_escape(&document_namespace);
-    let package_verification_code = spdx_package_verification_code(&files);
-    let package_license_info_from_files = spdx_package_license_info_from_files(&files);
-    let package_copyright_text = xml_escape(&spdx_package_copyright_text(&files));
     let extracted_license_infos = spdx_extracted_license_infos(output, &files);
     let created = xml_escape(&spdx_created_timestamp(output));
     let creator = xml_escape(&spdx_creator());
+
+    let mut file_spdx_ids: HashMap<&str, String> = HashMap::new();
+    for (file_index, file) in (1usize..).zip(files.iter()) {
+        file_spdx_ids.insert(file.path.as_str(), format!("SPDXRef-{file_index}"));
+    }
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     xml.push_str("<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:spdx=\"http://spdx.org/rdf/terms#\">\n");
 
-    // Absolute rdf:about URIs (namespace#SPDXRef-…) so RDF parsers do not resolve
-    // bare fragments against the on-disk file path.
-    xml.push_str("  <spdx:Package rdf:about=\"");
-    xml.push_str(&document_namespace_xml);
-    xml.push_str("#SPDXRef-001\">\n");
-    xml.push_str("    <spdx:filesAnalyzed rdf:datatype=\"http://www.w3.org/2001/XMLSchema#boolean\">true</spdx:filesAnalyzed>\n");
-    xml.push_str(
-        "    <spdx:downloadLocation rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
-    );
-    xml.push_str(
-        "    <spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
-    );
-    xml.push_str(
-        "    <spdx:licenseDeclared rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
-    );
-    if package_license_info_from_files.is_empty() {
-        xml.push_str(
-            "    <spdx:licenseInfoFromFiles rdf:resource=\"http://spdx.org/rdf/terms#none\"/>\n",
-        );
-    } else {
-        for license_id in &package_license_info_from_files {
-            xml.push_str("    <spdx:licenseInfoFromFiles rdf:resource=\"");
-            xml.push_str(&xml_escape(&spdx_license_rdf_resource(license_id)));
-            xml.push_str("\"/>\n");
-        }
-    }
-    xml.push_str("    <spdx:packageVerificationCode><spdx:PackageVerificationCode><spdx:packageVerificationCodeValue>");
-    xml.push_str(&package_verification_code);
-    xml.push_str("</spdx:packageVerificationCodeValue></spdx:PackageVerificationCode></spdx:packageVerificationCode>\n");
+    for plan in &plans {
+        let package_verification_code = spdx_package_verification_code(&plan.files);
+        let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
+        let package_copyright_text = xml_escape(&spdx_package_copyright_text(&plan.files));
+        let package_name = xml_escape(&plan.name);
 
-    for (idx, file) in files.iter().enumerate() {
-        let file_id = idx + 1usize;
-        let file_license_info = spdx_file_license_info(file);
-        xml.push_str("    <spdx:relationship><spdx:Relationship>");
-        xml.push_str("<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_contains\"/>");
-        xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"");
+        xml.push_str("  <spdx:Package rdf:about=\"");
         xml.push_str(&document_namespace_xml);
-        xml.push_str("#SPDXRef-");
-        xml.push_str(&file_id.to_string());
-        xml.push_str("\">");
+        xml.push('#');
+        xml.push_str(&xml_escape(&plan.spdx_id));
+        xml.push_str("\">\n");
+        xml.push_str("    <spdx:filesAnalyzed rdf:datatype=\"http://www.w3.org/2001/XMLSchema#boolean\">true</spdx:filesAnalyzed>\n");
         xml.push_str(
-            "<spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>",
+            "    <spdx:downloadLocation rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
         );
-        if file_license_info.is_empty() {
+        xml.push_str(
+            "    <spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
+        );
+        xml.push_str(
+            "    <spdx:licenseDeclared rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
+        );
+        if package_license_info_from_files.is_empty() {
             xml.push_str(
-                "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/rdf/terms#none\"/>",
+                "    <spdx:licenseInfoFromFiles rdf:resource=\"http://spdx.org/rdf/terms#none\"/>\n",
             );
         } else {
-            for license_id in file_license_info {
-                xml.push_str("<spdx:licenseInfoInFile rdf:resource=\"");
-                xml.push_str(&xml_escape(&spdx_license_rdf_resource(&license_id)));
-                xml.push_str("\"/>");
+            for license_id in &package_license_info_from_files {
+                xml.push_str("    <spdx:licenseInfoFromFiles rdf:resource=\"");
+                xml.push_str(&xml_escape(&spdx_license_rdf_resource(license_id)));
+                xml.push_str("\"/>\n");
             }
         }
-        xml.push_str("<spdx:checksum><spdx:Checksum><spdx:algorithm rdf:resource=\"http://spdx.org/rdf/terms#checksumAlgorithm_sha1\"/>");
-        xml.push_str("<spdx:checksumValue>");
-        xml.push_str(&xml_escape(file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX)));
-        xml.push_str("</spdx:checksumValue></spdx:Checksum></spdx:checksum>");
-        xml.push_str("<spdx:fileName>");
-        xml.push_str(&xml_escape(&spdx_relative_file_name(
-            &file.path,
-            config.scanned_path.as_deref(),
-        )));
-        xml.push_str("</spdx:fileName>");
-        xml.push_str("<spdx:copyrightText>");
-        if file.copyrights.is_empty() {
-            xml.push_str("NONE");
-        } else {
-            xml.push_str(&xml_escape(
-                &file
-                    .copyrights
-                    .iter()
-                    .map(|c| c.copyright.clone())
-                    .collect::<Vec<_>>()
-                    .join("\\n"),
-            ));
-        }
-        xml.push_str("</spdx:copyrightText>");
-        xml.push_str(
-            "</spdx:File></spdx:relatedSpdxElement></spdx:Relationship></spdx:relationship>\n",
-        );
-    }
+        xml.push_str("    <spdx:packageVerificationCode><spdx:PackageVerificationCode><spdx:packageVerificationCodeValue>");
+        xml.push_str(&package_verification_code);
+        xml.push_str("</spdx:packageVerificationCodeValue></spdx:PackageVerificationCode></spdx:packageVerificationCode>\n");
 
-    xml.push_str("    <spdx:copyrightText>");
-    xml.push_str(&package_copyright_text);
-    xml.push_str("</spdx:copyrightText>\n");
-    xml.push_str("    <spdx:name>");
-    xml.push_str(&package_name);
-    xml.push_str("</spdx:name>\n");
-    xml.push_str("  </spdx:Package>\n");
+        for file in &plan.files {
+            let Some(file_id) = file_spdx_ids.get(file.path.as_str()) else {
+                continue;
+            };
+            let file_license_info = spdx_file_license_info(file);
+            xml.push_str("    <spdx:relationship><spdx:Relationship>");
+            xml.push_str("<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_contains\"/>");
+            xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"");
+            xml.push_str(&document_namespace_xml);
+            xml.push('#');
+            xml.push_str(&xml_escape(file_id));
+            xml.push_str("\">");
+            xml.push_str(
+                "<spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>",
+            );
+            if file_license_info.is_empty() {
+                xml.push_str(
+                    "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/rdf/terms#none\"/>",
+                );
+            } else {
+                for license_id in file_license_info {
+                    xml.push_str("<spdx:licenseInfoInFile rdf:resource=\"");
+                    xml.push_str(&xml_escape(&spdx_license_rdf_resource(&license_id)));
+                    xml.push_str("\"/>");
+                }
+            }
+            xml.push_str("<spdx:checksum><spdx:Checksum><spdx:algorithm rdf:resource=\"http://spdx.org/rdf/terms#checksumAlgorithm_sha1\"/>");
+            xml.push_str("<spdx:checksumValue>");
+            xml.push_str(&xml_escape(file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX)));
+            xml.push_str("</spdx:checksumValue></spdx:Checksum></spdx:checksum>");
+            xml.push_str("<spdx:fileName>");
+            xml.push_str(&xml_escape(&spdx_relative_file_name(
+                &file.path,
+                config.scanned_path.as_deref(),
+            )));
+            xml.push_str("</spdx:fileName>");
+            xml.push_str("<spdx:copyrightText>");
+            if file.copyrights.is_empty() {
+                xml.push_str("NONE");
+            } else {
+                xml.push_str(&xml_escape(
+                    &file
+                        .copyrights
+                        .iter()
+                        .map(|c| c.copyright.clone())
+                        .collect::<Vec<_>>()
+                        .join("\\n"),
+                ));
+            }
+            xml.push_str("</spdx:copyrightText>");
+            xml.push_str(
+                "</spdx:File></spdx:relatedSpdxElement></spdx:Relationship></spdx:relationship>\n",
+            );
+        }
+
+        xml.push_str("    <spdx:copyrightText>");
+        xml.push_str(&package_copyright_text);
+        xml.push_str("</spdx:copyrightText>\n");
+        xml.push_str("    <spdx:name>");
+        xml.push_str(&package_name);
+        xml.push_str("</spdx:name>\n");
+        xml.push_str("  </spdx:Package>\n");
+    }
 
     // spdx-tools expects SpdxDocument rdf:about = documentNamespace + "#SPDXRef-DOCUMENT".
     xml.push_str("  <spdx:SpdxDocument rdf:about=\"");
@@ -309,14 +355,18 @@ pub(crate) fn write_spdx_rdf_xml(
     xml.push_str(&created);
     xml.push_str("</spdx:created>");
     xml.push_str("</spdx:CreationInfo></spdx:creationInfo>\n");
-    xml.push_str("    <spdx:relationship><spdx:Relationship>");
-    xml.push_str(
-        "<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_describes\"/>",
-    );
-    xml.push_str("<spdx:relatedSpdxElement rdf:resource=\"");
-    xml.push_str(&document_namespace_xml);
-    xml.push_str("#SPDXRef-001\"/>");
-    xml.push_str("</spdx:Relationship></spdx:relationship>\n");
+    for plan in &plans {
+        xml.push_str("    <spdx:relationship><spdx:Relationship>");
+        xml.push_str(
+            "<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_describes\"/>",
+        );
+        xml.push_str("<spdx:relatedSpdxElement rdf:resource=\"");
+        xml.push_str(&document_namespace_xml);
+        xml.push('#');
+        xml.push_str(&xml_escape(&plan.spdx_id));
+        xml.push_str("\"/>");
+        xml.push_str("</spdx:Relationship></spdx:relationship>\n");
+    }
     xml.push_str("  </spdx:SpdxDocument>\n");
 
     xml.push_str("</rdf:RDF>\n");
@@ -553,32 +603,121 @@ fn spdx_created_timestamp(output: &Output) -> String {
         .unwrap_or_else(|| fallback_iso_utc_timestamp().to_string())
 }
 
+fn sanitize_spdx_text_content(value: &str) -> String {
+    // SPDX tag-value `<text>` blocks end at the first `</text>`; neutralize
+    // embedded closers so source-derived copyright/license text cannot break
+    // the document. Fullwidth brackets keep the content readable.
+    value
+        .replace("</text>", "＜/text＞")
+        .replace("</TEXT>", "＜/TEXT＞")
+}
+
 fn format_spdx_text_field(value: &str) -> String {
-    if value.contains('\n') {
-        format!("<text>{value}</text>")
+    let sanitized = sanitize_spdx_text_content(value);
+    if sanitized.contains('\n') {
+        format!("<text>{sanitized}</text>")
     } else {
-        value.to_string()
+        sanitized
     }
 }
 
 fn spdx_relative_file_name(path: &str, scanned_path: Option<&str>) -> String {
-    let trimmed = path.trim_start_matches("./");
-    let relative = if let Some(root) = scanned_path {
-        let root = root.trim_end_matches('/');
-        if let Some(rest) = trimmed.strip_prefix(root) {
-            rest.trim_start_matches('/')
-        } else {
-            trimmed
-        }
-    } else {
-        trimmed
+    let path = Path::new(path.trim_start_matches("./"));
+    let relative = match scanned_path {
+        Some(root) => match path.strip_prefix(Path::new(root)) {
+            Ok(stripped) => stripped.to_string_lossy().into_owned(),
+            Err(_) => path.to_string_lossy().into_owned(),
+        },
+        None => path.to_string_lossy().into_owned(),
     };
 
     if relative.is_empty() {
         "./.".to_string()
+    } else if let Some(stripped) = relative.strip_prefix('/') {
+        // Absolute path that did not strip against scanned_path: keep one slash.
+        format!("./{stripped}")
     } else {
         format!("./{relative}")
     }
+}
+
+/// Plan SPDX packages: one per assembled package (with owned files), plus a
+/// scan-root fallback package for files that no assembled package claims.
+/// When there are no assembled packages, keep a single synthetic package
+/// (`SPDXRef-001`) owning every file — the historic no-package contract.
+fn plan_spdx_packages<'a>(
+    output: &'a Output,
+    files: &[&'a FileInfo],
+    config: &OutputWriteConfig,
+) -> Vec<SpdxPackagePlan<'a>> {
+    if output.packages.is_empty() {
+        return vec![SpdxPackagePlan {
+            spdx_id: "SPDXRef-001".to_string(),
+            name: primary_package_name(output, config),
+            files: files.to_vec(),
+        }];
+    }
+
+    let mut assigned_paths: HashSet<&str> = HashSet::new();
+    let mut plans = Vec::with_capacity(output.packages.len() + 1);
+
+    for (idx, package) in output.packages.iter().enumerate() {
+        let owned: Vec<&FileInfo> = files
+            .iter()
+            .copied()
+            .filter(|file| {
+                file.for_packages
+                    .iter()
+                    .any(|uid| uid == &package.package_uid)
+            })
+            .collect();
+        for file in &owned {
+            assigned_paths.insert(file.path.as_str());
+        }
+        plans.push(SpdxPackagePlan {
+            spdx_id: format!("SPDXRef-Package-{}", idx + 1),
+            name: spdx_assembled_package_name(package, idx),
+            files: owned,
+        });
+    }
+
+    let unassigned: Vec<&FileInfo> = files
+        .iter()
+        .copied()
+        .filter(|file| !assigned_paths.contains(file.path.as_str()))
+        .collect();
+    if !unassigned.is_empty() {
+        plans.push(SpdxPackagePlan {
+            spdx_id: "SPDXRef-Package-unassigned".to_string(),
+            name: primary_package_name(output, config),
+            files: unassigned,
+        });
+    }
+
+    plans
+}
+
+fn spdx_assembled_package_name(package: &OutputPackage, idx: usize) -> String {
+    package
+        .name
+        .as_deref()
+        .filter(|name| !name.is_empty())
+        .map(sanitize_spdx_package_name)
+        .unwrap_or_else(|| format!("package-{}", idx + 1))
+}
+
+fn document_namespace_for(output: &Output, config: &OutputWriteConfig) -> String {
+    let base = if output.packages.len() > 1 {
+        config
+            .scanned_path
+            .as_deref()
+            .and_then(|p| Path::new(p).file_name().and_then(|n| n.to_str()))
+            .map(sanitize_spdx_package_name)
+            .unwrap_or_else(|| "provenant-scan".to_string())
+    } else {
+        primary_package_name(output, config)
+    };
+    format!("http://spdx.org/spdxdocs/{base}")
 }
 
 #[cfg(test)]
@@ -588,6 +727,174 @@ mod tests {
     use crate::models::{
         FileType, LicenseDetection, LineNumber, MatchScore, PackageData, PackageType,
     };
+
+    #[test]
+    fn spdx_relative_file_name_uses_path_prefix_not_string_prefix() {
+        // Path::strip_prefix fails for /tmp/proj vs /tmp/project/..., so the
+        // original path is preserved (with ./ prefix), not truncated to ect/...
+        assert_eq!(
+            spdx_relative_file_name("/tmp/project/src.rs", Some("/tmp/proj")),
+            "./tmp/project/src.rs"
+        );
+        assert_eq!(
+            spdx_relative_file_name("/tmp/proj/src.rs", Some("/tmp/proj")),
+            "./src.rs"
+        );
+    }
+
+    #[test]
+    fn format_spdx_text_field_neutralizes_embedded_text_closers() {
+        let rendered = format_spdx_text_field("before</text>after\nline2");
+        assert!(rendered.starts_with("<text>"));
+        assert!(rendered.ends_with("</text>"));
+        assert!(!rendered.contains("before</text>after"));
+        assert!(rendered.contains("before＜/text＞after"));
+    }
+
+    #[test]
+    fn plan_spdx_packages_emits_one_package_per_assembled_package() {
+        let mut file_a = crate::models::FileInfo::new(
+            "a/mix.exs".to_string(),
+            "mix.exs".to_string(),
+            String::new(),
+            "a/mix.exs".to_string(),
+            FileType::File,
+            None,
+            None,
+            1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        file_a.for_packages = vec![crate::models::PackageUid::from_raw("uid-a".to_string())];
+        let mut file_b = crate::models::FileInfo::new(
+            "b/mix.exs".to_string(),
+            "mix.exs".to_string(),
+            String::new(),
+            "b/mix.exs".to_string(),
+            FileType::File,
+            None,
+            None,
+            1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        file_b.for_packages = vec![crate::models::PackageUid::from_raw("uid-b".to_string())];
+        let file_orphan = crate::models::FileInfo::new(
+            "README".to_string(),
+            "README".to_string(),
+            String::new(),
+            "README".to_string(),
+            FileType::File,
+            None,
+            None,
+            1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let pkg_a = {
+            let mut pkg = crate::models::Package::from_package_data(
+                &PackageData {
+                    package_type: Some(PackageType::Hex),
+                    name: Some("a".to_string()),
+                    version: Some("0.1.0".to_string()),
+                    purl: Some("pkg:hex/a@0.1.0".to_string()),
+                    ..Default::default()
+                },
+                "a/mix.exs".to_string(),
+            );
+            pkg.package_uid = crate::models::PackageUid::from_raw("uid-a".to_string());
+            pkg
+        };
+        let pkg_b = {
+            let mut pkg = crate::models::Package::from_package_data(
+                &PackageData {
+                    package_type: Some(PackageType::Hex),
+                    name: Some("b".to_string()),
+                    version: Some("0.1.0".to_string()),
+                    purl: Some("pkg:hex/b@0.1.0".to_string()),
+                    ..Default::default()
+                },
+                "b/mix.exs".to_string(),
+            );
+            pkg.package_uid = crate::models::PackageUid::from_raw("uid-b".to_string());
+            pkg
+        };
+
+        let output = crate::models::Output {
+            summary: None,
+            tallies: None,
+            tallies_of_key_files: None,
+            tallies_by_facet: None,
+            headers: vec![],
+            packages: vec![pkg_a, pkg_b],
+            dependencies: vec![],
+            license_detections: vec![],
+            files: vec![file_a, file_b, file_orphan],
+            license_references: vec![],
+            license_rule_references: vec![],
+        };
+        let schema = Output::from(&output);
+        let files = spdx_files(&schema);
+        let plans = plan_spdx_packages(
+            &schema,
+            &files,
+            &OutputWriteConfig {
+                format: crate::output::OutputFormat::SpdxTv,
+                custom_template: None,
+                scanned_path: Some("umbrella".to_string()),
+            },
+        );
+        assert_eq!(plans.len(), 3);
+        assert_eq!(plans[0].spdx_id, "SPDXRef-Package-1");
+        assert_eq!(plans[0].name, "a");
+        assert_eq!(plans[0].files.len(), 1);
+        assert_eq!(plans[1].spdx_id, "SPDXRef-Package-2");
+        assert_eq!(plans[2].spdx_id, "SPDXRef-Package-unassigned");
+        assert_eq!(plans[2].files.len(), 1);
+    }
 
     #[test]
     fn spdx_file_license_info_includes_manifest_package_data_detections() {

--- a/testdata/output-formats/cyclonedx-dependencies-expected.json
+++ b/testdata/output-formats/cyclonedx-dependencies-expected.json
@@ -12,15 +12,32 @@
       }
     ]
   },
-  "components": [],
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/root@1.0.0",
+      "name": "root",
+      "version": "1.0.0",
+      "scope": "required",
+      "purl": "pkg:npm/root@1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/other@1.0.0",
+      "name": "other",
+      "version": "1.0.0",
+      "scope": "required",
+      "purl": "pkg:npm/other@1.0.0"
+    }
+  ],
   "dependencies": [
     {
-      "ref": "pkg:npm/root@1.0.0",
+      "ref": "pkg:npm/other@1.0.0",
       "dependsOn": ["pkg:npm/dep@2.0.0"]
     },
     {
-      "ref": "dependency-2",
-      "dependsOn": []
+      "ref": "pkg:npm/root@1.0.0",
+      "dependsOn": ["pkg:npm/dep@2.0.0"]
     }
   ]
 }

--- a/testdata/output-formats/cyclonedx-dependencies-expected.xml
+++ b/testdata/output-formats/cyclonedx-dependencies-expected.xml
@@ -11,12 +11,25 @@
     </tools>
   </metadata>
   <components>
+    <component type="library" bom-ref="pkg:npm/root@1.0.0">
+      <name>root</name>
+      <version>1.0.0</version>
+      <scope>required</scope>
+      <purl>pkg:npm/root@1.0.0</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/other@1.0.0">
+      <name>other</name>
+      <version>1.0.0</version>
+      <scope>required</scope>
+      <purl>pkg:npm/other@1.0.0</purl>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/root@1.0.0">
+    <dependency ref="pkg:npm/other@1.0.0">
       <dependency ref="pkg:npm/dep@2.0.0"/>
     </dependency>
-    <dependency ref="dependency-2">
+    <dependency ref="pkg:npm/root@1.0.0">
+      <dependency ref="pkg:npm/dep@2.0.0"/>
     </dependency>
   </dependencies>
 </bom>

--- a/testdata/output-formats/cyclonedx-expected.json
+++ b/testdata/output-formats/cyclonedx-expected.json
@@ -61,5 +61,10 @@
       ]
     }
   ],
-  "dependencies": []
+  "dependencies": [
+    {
+      "ref": "pkg:npm/npm@2.13.5",
+      "dependsOn": []
+    }
+  ]
 }

--- a/testdata/output-formats/cyclonedx-expected.xml
+++ b/testdata/output-formats/cyclonedx-expected.xml
@@ -31,4 +31,8 @@
       </externalReferences>
     </component>
   </components>
+  <dependencies>
+    <dependency ref="pkg:npm/npm@2.13.5">
+    </dependency>
+  </dependencies>
 </bom>

--- a/testdata/output-formats/debian-basic-expected.copyright
+++ b/testdata/output-formats/debian-basic-expected.copyright
@@ -8,6 +8,6 @@ Comment: Generated with Provenant and provided on an "AS IS" BASIS, WITHOUT WARR
 
 Files: scan/src/main.rs
 Copyright: Example Org
-License: mit
+License: MIT
  Permission is hereby granted.
 

--- a/testdata/output-formats/spdx-simple-expected.rdf
+++ b/testdata/output-formats/spdx-simple-expected.rdf
@@ -17,7 +17,7 @@
       "spdx:licenseInfoFromFiles": {
         "@rdf:resource": "http://spdx.org/rdf/terms#none"
       },
-      "@rdf:about": "#SPDXRef-001",
+      "@rdf:about": "http://spdx.org/spdxdocs/simple#SPDXRef-001",
       "spdx:packageVerificationCode": {
         "spdx:PackageVerificationCode": {
           "spdx:packageVerificationCodeValue": "a83523bcfc10441aa94a575b88aa1d3269902485"
@@ -36,7 +36,7 @@
               "spdx:licenseInfoInFile": {
                 "@rdf:resource": "http://spdx.org/rdf/terms#none"
               },
-              "@rdf:about": "#SPDXRef-1",
+              "@rdf:about": "http://spdx.org/spdxdocs/simple#SPDXRef-1",
               "spdx:checksum": {
                 "spdx:Checksum": {
                   "spdx:algorithm": {
@@ -58,7 +58,7 @@
       "spdx:dataLicense": {
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
-      "@rdf:about": "#SPDXRef-DOCUMENT",
+      "@rdf:about": "http://spdx.org/spdxdocs/simple#SPDXRef-DOCUMENT",
       "rdfs:comment": "Generated with Provenant and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nProvenant should be considered or used as legal advice. Consult an attorney\nfor legal advice.\nProvenant is a free software code scanning tool.\nVisit https://github.com/getprovenant/provenant/ for support and download.\nSPDX License List: 3.27",
       "spdx:name": "SPDX Document created by Provenant",
       "spdx:specVersion": "SPDX-2.2"

--- a/testdata/output-formats/spdx-simple-expected.tv
+++ b/testdata/output-formats/spdx-simple-expected.tv
@@ -34,3 +34,4 @@ FileCopyrightText: NONE
 
 ## Relationships
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001
+Relationship: SPDXRef-001 CONTAINS SPDXRef-1

--- a/testdata/output-formats/spdx-simple-expected.tv
+++ b/testdata/output-formats/spdx-simple-expected.tv
@@ -12,6 +12,8 @@ Provenant is a free software code scanning tool.
 Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
+Creator: Tool: Provenant-0.0.5
+Created: 2026-01-01T00:00:00Z
 ## Package Information
 PackageName: simple
 SPDXID: SPDXRef-001
@@ -29,3 +31,6 @@ FileChecksum: SHA1: b8a793cce3c3a4cd3a4646ddbe86edd542ed0cd8
 LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NONE
 FileCopyrightText: NONE
+
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -683,6 +683,18 @@ fn test_spdx_simple_contract_matches_local_python_fixture_after_normalization() 
         .expect("fixture should be readable");
 
     assert_eq!(normalize_spdx_tv(&actual), normalize_spdx_tv(&expected));
+    assert!(
+        actual.contains("Creator: Tool: Provenant-"),
+        "SPDX TV golden path must keep CreationInfo Creator"
+    );
+    assert!(
+        actual.contains("Created:"),
+        "SPDX TV golden path must keep CreationInfo Created"
+    );
+    assert!(
+        actual.contains("Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-001"),
+        "SPDX TV golden path must keep DocumentDescribes"
+    );
 }
 
 #[test]
@@ -865,7 +877,10 @@ fn test_spdx_rdf_contract_contains_python_semantic_markers() {
     assert!(rendered.contains(&xml_escape_for_assert(expected_comment_prefix)));
     assert!(rendered.contains(expected_document_name));
     assert!(rendered.contains(expected_spec_version));
-    assert!(rendered.contains("<spdx:creationInfo><spdx:CreationInfo><spdx:created>"));
+    assert!(rendered.contains("<spdx:creationInfo><spdx:CreationInfo>"));
+    assert!(rendered.contains("<spdx:creator>Tool: Provenant-"));
+    assert!(rendered.contains("<spdx:created>"));
+    assert!(rendered.contains("relationshipType_describes"));
 }
 
 #[test]
@@ -1002,7 +1017,36 @@ fn test_cyclonedx_json_dependency_graph_matches_local_fixture_after_normalizatio
     let expected: Value = serde_json::from_str(&expected_text)
         .expect("cyclonedx dependency fixture should be valid json");
 
-    assert_eq!(normalize_cyclonedx(actual), normalize_cyclonedx(expected));
+    assert_eq!(
+        normalize_cyclonedx(actual.clone()),
+        normalize_cyclonedx(expected)
+    );
+
+    // Schema-guard: CycloneDX requires unique dependencies[].ref (uniqueItems).
+    let refs: Vec<&str> = actual["dependencies"]
+        .as_array()
+        .expect("dependencies array")
+        .iter()
+        .map(|d| d["ref"].as_str().expect("ref"))
+        .collect();
+    let unique: std::collections::BTreeSet<_> = refs.iter().copied().collect();
+    assert_eq!(
+        refs.len(),
+        unique.len(),
+        "duplicate CycloneDX dependency refs: {refs:?}"
+    );
+    let bom_refs: Vec<&str> = actual["components"]
+        .as_array()
+        .expect("components array")
+        .iter()
+        .map(|c| c["bom-ref"].as_str().expect("bom-ref"))
+        .collect();
+    let unique_bom: std::collections::BTreeSet<_> = bom_refs.iter().copied().collect();
+    assert_eq!(
+        bom_refs.len(),
+        unique_bom.len(),
+        "duplicate CycloneDX component bom-refs: {bom_refs:?}"
+    );
 }
 
 #[test]
@@ -1139,8 +1183,10 @@ fn normalize_html(html: &str) -> String {
 }
 
 fn normalize_spdx_tv(text: &str) -> String {
+    // Strip tool version / timestamp lines that vary across builds while keeping
+    // the rest of Creation Information (section header) and Relationships.
     text.lines()
-        .filter(|line| !line.starts_with("Creator:"))
+        .filter(|line| !line.starts_with("Creator:") && !line.starts_with("Created:"))
         .collect::<Vec<_>>()
         .join("\n")
         .trim()
@@ -1291,8 +1337,10 @@ fn extract_spdx_rdf_semantics(xml: &str) -> BTreeMap<String, String> {
         Regex::new(r#"<spdx:specVersion>([^<]+)</spdx:specVersion>"#).expect("spec version regex");
     let comment_re = Regex::new(r#"(?s)<rdfs:comment>(.*?)</rdfs:comment>"#)
         .expect("comment regex should compile");
-    let creation_info_re = Regex::new(r#"<spdx:creationInfo><spdx:CreationInfo><spdx:created>[^<]+</spdx:created></spdx:CreationInfo></spdx:creationInfo>"#)
-        .expect("creation info regex should compile");
+    let creation_info_re = Regex::new(
+        r#"<spdx:creationInfo><spdx:CreationInfo>(?:<spdx:creator>[^<]+</spdx:creator>)?<spdx:created>[^<]+</spdx:created></spdx:CreationInfo></spdx:creationInfo>"#,
+    )
+    .expect("creation info regex should compile");
     let package_license_values_re = Regex::new(
         r#"(?s)<spdx:Package[^>]*>.*?<spdx:licenseConcluded rdf:resource=\"([^\"]+)\"/>.*?<spdx:licenseDeclared rdf:resource=\"([^\"]+)\"/>.*?<spdx:licenseInfoFromFiles rdf:resource=\"([^\"]+)\"/>.*?<spdx:copyrightText>([^<]+)</spdx:copyrightText>.*?<spdx:name>[^<]+</spdx:name>"#,
     )
@@ -1907,9 +1955,27 @@ fn sample_cyclonedx_rich_output() -> Output {
 }
 
 fn sample_cyclonedx_dependency_output() -> Output {
-    let root_dep = TopLevelDependency {
-        purl: Some("pkg:npm/root@1.0.0".to_string()),
-        extracted_requirement: None,
+    let root_uid = PackageUid::from_raw(
+        "pkg:npm/root@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
+    );
+    let root_pkg = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("root".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/root@1.0.0".to_string()),
+                ..Default::default()
+            },
+            "scan/package.json".to_string(),
+        );
+        pkg.package_uid = root_uid.clone();
+        pkg
+    };
+
+    let owned_dep = TopLevelDependency {
+        purl: Some("pkg:npm/dep@2.0.0".to_string()),
+        extracted_requirement: Some("2.0.0".to_string()),
         scope: Some("dependencies".to_string()),
         is_runtime: Some(true),
         is_optional: Some(false),
@@ -1939,36 +2005,58 @@ fn sample_cyclonedx_dependency_output() -> Output {
         })),
         extra_data: None,
         dependency_uid: DependencyUid::from_raw(
-            "pkg:npm/root@1.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
+            "pkg:npm/dep@2.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
         ),
-        for_package_uid: Some(PackageUid::from_raw(
-            "pkg:npm/root-package@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
-        )),
+        for_package_uid: Some(root_uid.clone()),
         datafile_path: "scan/package-lock.json".to_string(),
         datasource_id: DatasourceId::NpmPackageLockJson,
         namespace: None,
     };
 
-    let fallback_dep = TopLevelDependency {
-        purl: None,
-        extracted_requirement: Some("^3.0.0".to_string()),
-        scope: Some("devDependencies".to_string()),
-        is_runtime: Some(false),
+    // Second owner of the same dep purl — must not duplicate CycloneDX refs.
+    let other_uid = PackageUid::from_raw(
+        "pkg:npm/other@1.0.0?uuid=00000000-0000-0000-0000-000000000010".to_string(),
+    );
+    let other_pkg = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("other".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/other@1.0.0".to_string()),
+                ..Default::default()
+            },
+            "scan/packages/other/package.json".to_string(),
+        );
+        pkg.package_uid = other_uid.clone();
+        pkg
+    };
+    let shared_dep = TopLevelDependency {
+        purl: Some("pkg:npm/dep@2.0.0".to_string()),
+        extracted_requirement: Some("2.0.0".to_string()),
+        scope: Some("dependencies".to_string()),
+        is_runtime: Some(true),
         is_optional: Some(false),
-        is_pinned: Some(false),
+        is_pinned: Some(true),
         is_direct: Some(true),
         resolved_package: None,
         extra_data: None,
-        dependency_uid: DependencyUid::empty(),
-        for_package_uid: Some(PackageUid::from_raw(
-            "pkg:npm/root-package@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
-        )),
-        datafile_path: "scan/package-lock.json".to_string(),
-        datasource_id: DatasourceId::NpmPackageLockJson,
+        dependency_uid: DependencyUid::from_raw(
+            "pkg:npm/dep@2.0.0?uuid=00000000-0000-0000-0000-000000000002".to_string(),
+        ),
+        for_package_uid: Some(other_uid),
+        datafile_path: "scan/packages/other/package.json".to_string(),
+        datasource_id: DatasourceId::NpmPackageJson,
         namespace: None,
     };
 
-    sample_output_with_sections(0, 0, vec![], vec![root_dep, fallback_dep], vec![])
+    sample_output_with_sections(
+        0,
+        0,
+        vec![root_pkg, other_pkg],
+        vec![owned_dep, shared_dep],
+        vec![],
+    )
 }
 
 fn empty_output() -> Output {


### PR DESCRIPTION
## Summary

- Rebuild CycloneDX dependency graphs as owner→dep with unique `ref`s; resolve `dependsOn` through component `bom-ref`s (including disambiguated `package_uid` when purls collide).
- Emit SPDX CreationInfo, multi-package DESCRIBES/CONTAINS topology, relative `FileName`s via `Path::strip_prefix`, safe `<text>` wrapping, and absolute RDF URIs so `spdx-tools` validates TV and RDF.
- Prefer SPDX short names in Debian copyright and always emit `Copyright` (with `NOASSERTION` when holders are unknown).
- Update output-format goldens and uniqueness / CreationInfo assertions so invalid documents cannot regress unnoticed.

## Issues

- Covers: #1288
- Closes: #1288, #1287

## Scope and exclusions

- Included: CycloneDX JSON/XML dependency graph + bom-ref uniqueness + dependsOn resolution; SPDX TV/RDF CreationInfo / multi-package topology / path and text hardening / RDF namespace URIs; Debian SPDX short names + Copyright completeness; schema-guarding goldens/tests.
- Explicit exclusions: custom-template schema validation (N/A); HTML formal schema; adding external validators to CI (follow-up).

## How to verify

- Scan an Elixir umbrella or npm workspace with `--cyclonedx out.json` and confirm `dependencies[].ref` values are unique and `dependsOn` targets match component `bom-ref`s; Dependency-Track / `cyclonedx-python-lib` JsonStrictValidator accepts the BOM.
- Scan a multi-package tree with `--spdx-tv` / `--spdx-rdf` and confirm `spdx-tools` parses with zero validation issues, plus one Package per assembled package with DESCRIBES/CONTAINS.
- Scan with `--debian` and confirm `License:` uses SPDX short names (e.g. `MIT`) and every Files paragraph has `Copyright:`.

## Intentional differences from Python

- CycloneDX graph groups by owning package (`for_package_uid`) and resolves `dependsOn` to component bom-refs instead of always using raw dependency purls.
- SPDX emits multi-package topology instead of collapsing to one synthetic package; RDF uses absolute `namespace#SPDXRef-…` URIs.
- Debian copyright prefers SPDX short names over ScanCode keys when available.

## Follow-up work

- Created or intentionally deferred: CI job that runs CycloneDX + SPDX external validators on fixtures.

## Expected-output fixture changes

- Files changed: `testdata/output-formats/cyclonedx-*.json|xml`, `spdx-simple-expected.tv|rdf`, `debian-basic-expected.copyright`
- Why the new expected output is correct: fixtures now encode schema-valid CycloneDX owner→dep graphs, SPDX CreationInfo / multi-package relationships / document namespace URIs, and DEP-5-friendly Debian SPDX names + Copyright fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)