### PR TITLE
test(output): add multi-package SPDX TV/RDF format-level goldens

### DIFF
--- a/testdata/output-formats/spdx-multi-package-expected.tv
+++ b/testdata/output-formats/spdx-multi-package-expected.tv
@@ -1,0 +1,91 @@
+## Document Information
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: SPDX Document created by Provenant
+DocumentNamespace: http://spdx.org/spdxdocs/workspace
+DocumentComment: <text>Generated with Provenant and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+Provenant should be considered or used as legal advice. Consult an attorney
+for legal advice.
+Provenant is a free software code scanning tool.
+Visit https://github.com/getprovenant/provenant/ for support and download.
+SPDX License List: 3.27</text>
+## Creation Information
+Creator: Tool: Provenant-0.2.7-0-g75a53ba7-dirty
+Created: 2026-01-01T00:00:00Z
+## Package Information
+PackageName: widget-a
+SPDXID: SPDXRef-Package-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: c361e706434ebcd03e8857c6c8dd2786adaeb3ef
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseInfoFromFiles: MIT
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: Copyright 2024 Widget A Contributors
+## Package Information
+PackageName: widget-b
+SPDXID: SPDXRef-Package-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: 8fe04df3f4570c5b3840493e6159d69afa80ed7d
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: Copyright 2024 Widget B Contributors
+## Package Information
+PackageName: workspace
+SPDXID: SPDXRef-Package-unassigned
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: e5db70953280561f48271f9a71eb2dd9d6e07b9b
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseInfoFromFiles: NONE
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: Copyright 2024 Umbrella Maintainers
+## File Information
+FileName: ./README.md
+SPDXID: SPDXRef-1
+FileChecksum: SHA1: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: Copyright 2024 Umbrella Maintainers
+
+FileName: ./packages/widget-a/package.json
+SPDXID: SPDXRef-2
+FileChecksum: SHA1: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: MIT
+FileCopyrightText: Copyright 2024 Widget A Contributors
+
+FileName: ./packages/widget-a/src/index.js
+SPDXID: SPDXRef-3
+FileChecksum: SHA1: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: NONE
+
+FileName: ./packages/widget-b/package.json
+SPDXID: SPDXRef-4
+FileChecksum: SHA1: cccccccccccccccccccccccccccccccccccccccc
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: Copyright 2024 Widget B Contributors
+
+FileName: ./packages/widget-b/src/index.js
+SPDXID: SPDXRef-5
+FileChecksum: SHA1: dddddddddddddddddddddddddddddddddddddddd
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: NONE
+
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
+Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-2
+Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-3
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-2
+Relationship: SPDXRef-Package-2 CONTAINS SPDXRef-4
+Relationship: SPDXRef-Package-2 CONTAINS SPDXRef-5
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-unassigned
+Relationship: SPDXRef-Package-unassigned CONTAINS SPDXRef-1

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -912,6 +912,105 @@ fn test_spdx_rdf_semantics_match_fixture_map() {
 }
 
 #[test]
+fn test_spdx_multi_package_tv_matches_local_golden_fixture() {
+    let output = sample_spdx_multi_package_output();
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::SpdxTv)
+        .write(
+            &schema_output,
+            &mut bytes,
+            &OutputWriteConfig {
+                format: OutputFormat::SpdxTv,
+                custom_template: None,
+                scanned_path: Some("workspace".to_string()),
+            },
+        )
+        .expect("spdx output should be generated");
+
+    let actual = String::from_utf8(bytes).expect("spdx output should be utf-8");
+    let expected = fs::read_to_string("testdata/output-formats/spdx-multi-package-expected.tv")
+        .expect("golden fixture should be readable");
+
+    assert_eq!(normalize_spdx_tv(&actual), normalize_spdx_tv(&expected));
+
+    // Two assembled packages plus the unassigned fallback bucket, each DESCRIBES'd
+    // from the document and CONTAINS'ing only the files that belong to it.
+    assert!(actual.contains("Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1"));
+    assert!(actual.contains("Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-2"));
+    assert!(actual.contains("Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-unassigned"));
+    assert!(actual.contains("Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-2"));
+    assert!(actual.contains("Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-3"));
+    assert!(actual.contains("Relationship: SPDXRef-Package-2 CONTAINS SPDXRef-4"));
+    assert!(actual.contains("Relationship: SPDXRef-Package-2 CONTAINS SPDXRef-5"));
+    assert!(actual.contains("Relationship: SPDXRef-Package-unassigned CONTAINS SPDXRef-1"));
+    assert!(actual.contains("PackageName: widget-a"));
+    assert!(actual.contains("PackageName: widget-b"));
+    assert!(actual.contains("PackageName: workspace"));
+}
+
+#[test]
+fn test_spdx_multi_package_rdf_contains_one_package_element_per_plan() {
+    let output = sample_spdx_multi_package_output();
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::SpdxRdf)
+        .write(
+            &schema_output,
+            &mut bytes,
+            &OutputWriteConfig {
+                format: OutputFormat::SpdxRdf,
+                custom_template: None,
+                scanned_path: Some("workspace".to_string()),
+            },
+        )
+        .expect("spdx rdf output should be generated");
+
+    let rendered = String::from_utf8(bytes).expect("spdx rdf should be utf-8");
+
+    // One <spdx:Package> per plan: widget-a, widget-b, and the unassigned bucket.
+    let package_open_count = rendered.matches("<spdx:Package rdf:about=\"").count();
+    assert_eq!(
+        package_open_count, 3,
+        "expected 3 SPDX RDF packages: {rendered}"
+    );
+    assert!(rendered.contains("http://spdx.org/spdxdocs/workspace#SPDXRef-Package-1\">"));
+    assert!(rendered.contains("http://spdx.org/spdxdocs/workspace#SPDXRef-Package-2\">"));
+    assert!(rendered.contains("http://spdx.org/spdxdocs/workspace#SPDXRef-Package-unassigned\">"));
+    assert!(rendered.contains("<spdx:name>widget-a</spdx:name>"));
+    assert!(rendered.contains("<spdx:name>widget-b</spdx:name>"));
+    assert!(rendered.contains("<spdx:name>workspace</spdx:name>"));
+
+    // One DESCRIBES relationship per plan, from the document.
+    let describes_count = rendered.matches("relationshipType_describes").count();
+    assert_eq!(describes_count, 3);
+
+    // Five CONTAINS relationships total: two files per assembled package, one
+    // orphaned file rolled up into the unassigned fallback package.
+    let contains_count = rendered.matches("relationshipType_contains").count();
+    assert_eq!(contains_count, 5);
+
+    for file_id in [
+        "SPDXRef-1",
+        "SPDXRef-2",
+        "SPDXRef-3",
+        "SPDXRef-4",
+        "SPDXRef-5",
+    ] {
+        assert!(
+            rendered.contains(&format!("http://spdx.org/spdxdocs/workspace#{file_id}\">")),
+            "expected RDF to contain a File element for {file_id}"
+        );
+    }
+
+    assert!(rendered.contains("<spdx:fileName>./packages/widget-a/package.json</spdx:fileName>"));
+    assert!(rendered.contains("<spdx:fileName>./packages/widget-a/src/index.js</spdx:fileName>"));
+    assert!(rendered.contains("<spdx:fileName>./packages/widget-b/package.json</spdx:fileName>"));
+    assert!(rendered.contains("<spdx:fileName>./packages/widget-b/src/index.js</spdx:fileName>"));
+    assert!(rendered.contains("<spdx:fileName>./README.md</spdx:fileName>"));
+}
+
+#[test]
 fn test_cyclonedx_rich_output_contains_enriched_fields_json_and_xml() {
     let output = sample_cyclonedx_rich_output();
     let schema_output = OutputSchemaOutput::from(&output);
@@ -1912,6 +2011,168 @@ fn sample_spdx_simple_output() -> Output {
             "b8a793cce3c3a4cd3a4646ddbe86edd542ed0cd8",
             vec![],
         )],
+    )
+}
+
+/// A small umbrella/workspace-style fixture: two assembled packages each
+/// owning a manifest + source file, plus one top-level file no package
+/// claims. Exercises multi-package DESCRIBES/CONTAINS and the
+/// `SPDXRef-Package-unassigned` fallback bucket that `spdx-simple-*` and
+/// `spdx-empty-*` (single-package / no-package) goldens cannot cover.
+fn sample_spdx_multi_package_output() -> Output {
+    let pkg_a_uid = PackageUid::from_raw(
+        "pkg:npm/widget-a@1.0.0?uuid=00000000-0000-0000-0000-0000000000a1".to_string(),
+    );
+    let pkg_a = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("widget-a".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/widget-a@1.0.0".to_string()),
+                ..Default::default()
+            },
+            "packages/widget-a/package.json".to_string(),
+        );
+        pkg.package_uid = pkg_a_uid.clone();
+        pkg
+    };
+
+    let pkg_b_uid = PackageUid::from_raw(
+        "pkg:npm/widget-b@2.0.0?uuid=00000000-0000-0000-0000-0000000000b1".to_string(),
+    );
+    let pkg_b = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("widget-b".to_string()),
+                version: Some("2.0.0".to_string()),
+                purl: Some("pkg:npm/widget-b@2.0.0".to_string()),
+                ..Default::default()
+            },
+            "packages/widget-b/package.json".to_string(),
+        );
+        pkg.package_uid = pkg_b_uid.clone();
+        pkg
+    };
+
+    let license_detection =
+        |key: &str, spdx: &str, rule: &str, from_file: &str| provenant::models::LicenseDetection {
+            license_expression: key.to_string(),
+            license_expression_spdx: spdx.to_string(),
+            matches: vec![provenant::models::Match {
+                license_expression: key.to_string(),
+                license_expression_spdx: spdx.to_string(),
+                from_file: Some(from_file.to_string()),
+                start_line: LineNumber::ONE,
+                end_line: LineNumber::ONE,
+                matcher: MatcherKind::Declared,
+                score: MatchScore::MAX,
+                matched_length: Some(1),
+                match_coverage: Some(100.0),
+                rule_relevance: Some(100),
+                rule_identifier: rule.to_string(),
+                rule_url: None,
+                matched_text: Some(spdx.to_string()),
+                referenced_filenames: None,
+                matched_text_diagnostics: None,
+            }],
+            detection_log: vec![],
+            identifier: String::new(),
+        };
+
+    let mut manifest_a = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "packages/widget-a/package.json",
+        30,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        vec![],
+    );
+    manifest_a.detected_license_expression = Some("MIT".to_string());
+    manifest_a.license_detections = vec![license_detection(
+        "mit",
+        "MIT",
+        "mit_1.RULE",
+        "packages/widget-a/package.json",
+    )];
+    manifest_a.copyrights = vec![Copyright {
+        copyright: "Copyright 2024 Widget A Contributors".to_string(),
+        normalized_copyright: None,
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+    manifest_a.for_packages = vec![pkg_a_uid.clone()];
+
+    let mut source_a = sample_plain_text_file(
+        "index.js",
+        "index",
+        ".js",
+        "packages/widget-a/src/index.js",
+        12,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        vec![],
+    );
+    source_a.for_packages = vec![pkg_a_uid.clone()];
+
+    let mut manifest_b = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "packages/widget-b/package.json",
+        30,
+        "cccccccccccccccccccccccccccccccccccccccc",
+        vec![],
+    );
+    manifest_b.detected_license_expression = Some("Apache-2.0".to_string());
+    manifest_b.license_detections = vec![license_detection(
+        "apache-2.0",
+        "Apache-2.0",
+        "apache-2.0_1.RULE",
+        "packages/widget-b/package.json",
+    )];
+    manifest_b.copyrights = vec![Copyright {
+        copyright: "Copyright 2024 Widget B Contributors".to_string(),
+        normalized_copyright: None,
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+    manifest_b.for_packages = vec![pkg_b_uid.clone()];
+
+    let mut source_b = sample_plain_text_file(
+        "index.js",
+        "index",
+        ".js",
+        "packages/widget-b/src/index.js",
+        12,
+        "dddddddddddddddddddddddddddddddddddddddd",
+        vec![],
+    );
+    source_b.for_packages = vec![pkg_b_uid.clone()];
+
+    let mut readme = sample_plain_text_file(
+        "README.md",
+        "README",
+        ".md",
+        "README.md",
+        8,
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        vec![],
+    );
+    readme.copyrights = vec![Copyright {
+        copyright: "Copyright 2024 Umbrella Maintainers".to_string(),
+        normalized_copyright: None,
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    sample_output_with_sections(
+        5,
+        0,
+        vec![pkg_a, pkg_b],
+        vec![],
+        vec![manifest_a, source_a, manifest_b, source_b, readme],
     )
 }
 


### PR DESCRIPTION
## Summary

- `plan_spdx_packages` only had unit coverage in `src/output/spdx.rs`; `testdata/output-formats/` only exercised single-package (`spdx-simple-*`) and no-package (`spdx-empty-*`) scans, so an umbrella/workspace multi-package regression in the SPDX TV/RDF writers could slip past the format-level golden suite.
- Added a synthetic two-package fixture in `tests/output_format_golden.rs` (`sample_spdx_multi_package_output`): two npm-style packages (`widget-a`, `widget-b`), each owning a manifest + source file, plus one orphaned top-level `README.md` that no package claims.
- Wired it into two new tests: a byte-level SPDX tag-value golden compared against a checked-in fixture, and SPDX RDF structural assertions (package/relationship counts, DESCRIBES/CONTAINS wiring, file names).

## Issues

- Covers: multi-package SPDX format-level regression coverage requested for the SPDX multi-package planner added in #1289.
- Closes: <!-- none -->

## Scope and exclusions

- Included:
  - New `testdata/output-formats/spdx-multi-package-expected.tv` golden fixture.
  - `test_spdx_multi_package_tv_matches_local_golden_fixture`: full-byte SPDX tag-value comparison (Creator/Created lines normalized out, matching the existing `spdx-simple` pattern), plus explicit DESCRIBES/CONTAINS relationship assertions.
  - `test_spdx_multi_package_rdf_contains_one_package_element_per_plan`: SPDX RDF structural assertions (3 `<spdx:Package>` elements, 3 DESCRIBES, 5 CONTAINS, correct `SPDXRef-Package-*` ids and file names) — no byte-for-byte RDF fixture was added since the existing RDF goldens use marker/semantic assertions rather than full-document comparison for the same reason (Rust XML formatting doesn't byte-match the historic Python-rendered fixture).
- Explicit exclusions:
  - No changes to SPDX emission semantics in `src/output/spdx.rs` — `plan_spdx_packages` already produces correct output; this PR is fixtures/tests only.
  - No CycloneDX multi-owner golden added (a CycloneDX dependency-graph golden with multiple owning packages already exists via `sample_cyclonedx_dependency_output` / `test_cyclonedx_json_dependency_graph_matches_local_fixture_after_normalization`).
  - No CI external SPDX/RDF validators added.

## How to verify

- `cargo test --test output_format_golden` covers both new tests plus the full existing suite (23 tests, all passing).
- Beyond CI: `cargo test --lib output::spdx` confirms the existing `plan_spdx_packages` unit test still agrees with the new format-level fixture's relationship/ID structure.

## Intentional differences from Python

- None — this is a test-only addition; no output behavior changed.

## Follow-up work

- Created or intentionally deferred: a byte-level SPDX RDF multi-package golden was deferred as impractical (see Scope and exclusions); the existing single-package RDF goldens already use the same marker-based approach rather than full-document comparison.

## Expected-output fixture changes

- Files changed: `testdata/output-formats/spdx-multi-package-expected.tv` (new).
- Why the new expected output is correct: generated directly from `write_spdx_tag_value` for the new synthetic fixture and verified line-by-line (package plans, `SPDXRef-Package-1`/`-2`/`-unassigned` ids, per-package `PackageVerificationCode`/`PackageLicenseInfoFromFiles`/`PackageCopyrightText`, and the `DESCRIBES`/`CONTAINS` relationship graph) before being checked in as the golden.

Made with [Cursor](https://cursor.com)