### PR TITLE
fix(output): emit known SPDX license fields instead of hardcoded NOASSERTION

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -788,7 +788,7 @@ mod tests {
             .expect("spdx rdf write should succeed");
         let rdf_rendered = String::from_utf8(rdf_bytes).expect("spdx rdf should be utf-8");
         assert!(rdf_rendered.contains(
-            "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/licenses/LicenseRef-scancode-unknown-license-reference\"/>"
+            "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/spdxdocs/scan#LicenseRef-scancode-unknown-license-reference\"/>"
         ));
         assert!(rdf_rendered.contains(
             "<spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"http://spdx.org/spdxdocs/scan#LicenseRef-scancode-unknown-license-reference\">"

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -254,11 +254,13 @@ pub(crate) fn write_spdx_rdf_xml(
         xml.push_str("    <spdx:licenseConcluded rdf:resource=\"");
         xml.push_str(&xml_escape(&spdx_rdf_license_resource(
             package_license_concluded.as_deref(),
+            &document_namespace,
         )));
         xml.push_str("\"/>\n");
         xml.push_str("    <spdx:licenseDeclared rdf:resource=\"");
         xml.push_str(&xml_escape(&spdx_rdf_license_resource(
             package_license_declared.as_deref(),
+            &document_namespace,
         )));
         xml.push_str("\"/>\n");
         if package_license_info_from_files.is_empty() {
@@ -268,7 +270,10 @@ pub(crate) fn write_spdx_rdf_xml(
         } else {
             for license_id in &package_license_info_from_files {
                 xml.push_str("    <spdx:licenseInfoFromFiles rdf:resource=\"");
-                xml.push_str(&xml_escape(&spdx_license_rdf_resource(license_id)));
+                xml.push_str(&xml_escape(&spdx_license_rdf_resource(
+                    license_id,
+                    &document_namespace,
+                )));
                 xml.push_str("\"/>\n");
             }
         }
@@ -292,6 +297,7 @@ pub(crate) fn write_spdx_rdf_xml(
             xml.push_str("<spdx:licenseConcluded rdf:resource=\"");
             xml.push_str(&xml_escape(&spdx_rdf_license_resource(
                 file_license_concluded.as_deref(),
+                &document_namespace,
             )));
             xml.push_str("\"/>");
             if file_license_info.is_empty() {
@@ -301,7 +307,10 @@ pub(crate) fn write_spdx_rdf_xml(
             } else {
                 for license_id in file_license_info {
                     xml.push_str("<spdx:licenseInfoInFile rdf:resource=\"");
-                    xml.push_str(&xml_escape(&spdx_license_rdf_resource(&license_id)));
+                    xml.push_str(&xml_escape(&spdx_license_rdf_resource(
+                        &license_id,
+                        &document_namespace,
+                    )));
                     xml.push_str("\"/>");
                 }
             }
@@ -511,8 +520,7 @@ fn spdx_package_license_info_from_files(files: &[&FileInfo]) -> Vec<String> {
 fn spdx_package_license_declared(package: Option<&OutputPackage>) -> Option<String> {
     package
         .and_then(|pkg| pkg.declared_license_expression_spdx.as_deref())
-        .filter(|expression| !expression.is_empty())
-        .map(str::to_string)
+        .and_then(spdx_validated_expression)
 }
 
 /// The best honest SPDX conclusion for the package: the declared expression
@@ -522,15 +530,28 @@ fn spdx_package_license_declared(package: Option<&OutputPackage>) -> Option<Stri
 /// `reference_following.rs`). Falls back to `None` (NOASSERTION) rather than
 /// inventing a conclusion from evidence the package itself doesn't carry.
 fn spdx_package_license_concluded(package: Option<&OutputPackage>) -> Option<String> {
-    fn non_empty(value: &Option<String>) -> Option<&str> {
-        value.as_deref().filter(|v| !v.is_empty())
+    package.and_then(|pkg| {
+        pkg.declared_license_expression_spdx
+            .as_deref()
+            .and_then(spdx_validated_expression)
+            .or_else(|| {
+                pkg.other_license_expression_spdx
+                    .as_deref()
+                    .and_then(spdx_validated_expression)
+            })
+    })
+}
+
+/// Re-parse an expression through the same strict SPDX combiner the file
+/// conclusion path uses, so malformed package fields (newlines, bad tokens)
+/// become `None` / NOASSERTION instead of broken tag-value output.
+fn spdx_validated_expression(expression: &str) -> Option<String> {
+    if expression.is_empty() {
+        return None;
     }
-    package
-        .and_then(|pkg| {
-            non_empty(&pkg.declared_license_expression_spdx)
-                .or_else(|| non_empty(&pkg.other_license_expression_spdx))
-        })
-        .map(str::to_string)
+    crate::utils::spdx::combine_license_expressions_preserving_structure_strict([
+        expression.to_string()
+    ])
 }
 
 /// The best honest SPDX conclusion for a file: reuses the same three-tier
@@ -555,9 +576,9 @@ fn spdx_tv_license_value(expression: Option<&str>) -> &str {
 /// not build, so it honestly falls back to NOASSERTION in RDF only (the
 /// tag-value form above keeps the full expression, since tag-value license
 /// fields accept SPDX expression syntax directly).
-fn spdx_rdf_license_resource(expression: Option<&str>) -> String {
+fn spdx_rdf_license_resource(expression: Option<&str>, document_namespace: &str) -> String {
     match expression.map(spdx_ids_from_expression) {
-        Some(ids) if ids.len() == 1 => spdx_license_rdf_resource(&ids[0]),
+        Some(ids) if ids.len() == 1 => spdx_license_rdf_resource(&ids[0], document_namespace),
         _ => "http://spdx.org/rdf/terms#noassertion".to_string(),
     }
 }
@@ -647,8 +668,16 @@ fn spdx_license_comment(detection_match: &Match) -> String {
     }
 }
 
-fn spdx_license_rdf_resource(license_id: &str) -> String {
-    format!("http://spdx.org/licenses/{}", license_id)
+/// Listed SPDX licenses use the canonical `spdx.org/licenses/` URI; document-
+/// scoped `LicenseRef-*` ids point at the matching `ExtractedLicensingInfo`
+/// node (`{documentNamespace}#{LicenseRef-…}`) instead of a non-existent
+/// listed-license URL.
+fn spdx_license_rdf_resource(license_id: &str, document_namespace: &str) -> String {
+    if license_id.starts_with("LicenseRef-") {
+        format!("{document_namespace}#{license_id}")
+    } else {
+        format!("http://spdx.org/licenses/{license_id}")
+    }
 }
 
 fn spdx_ids_from_expression(expression: &str) -> Vec<String> {
@@ -1098,6 +1127,47 @@ mod tests {
     }
 
     #[test]
+    fn spdx_package_license_helpers_reject_invalid_expressions() {
+        let malformed = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            declared_license_expression_spdx: Some("MIT\" or malformed".to_string()),
+            other_license_expression_spdx: Some("not a@@license".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(spdx_package_license_declared(Some(&malformed)), None);
+        assert_eq!(spdx_package_license_concluded(Some(&malformed)), None);
+
+        // Invalid declared must not poison a valid other-license fallback.
+        let declared_bad_other_ok = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            declared_license_expression_spdx: Some("MIT\" or malformed".to_string()),
+            other_license_expression_spdx: Some("Apache-2.0".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            spdx_package_license_concluded(Some(&declared_bad_other_ok)),
+            Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn spdx_license_rdf_resource_uses_document_namespace_for_license_refs() {
+        let ns = "http://spdx.org/spdxdocs/demo";
+        assert_eq!(
+            spdx_license_rdf_resource("MIT", ns),
+            "http://spdx.org/licenses/MIT"
+        );
+        assert_eq!(
+            spdx_license_rdf_resource("LicenseRef-Custom", ns),
+            "http://spdx.org/spdxdocs/demo#LicenseRef-Custom"
+        );
+        assert_eq!(
+            spdx_rdf_license_resource(Some("LicenseRef-Custom"), ns),
+            "http://spdx.org/spdxdocs/demo#LicenseRef-Custom"
+        );
+    }
+
+    #[test]
     fn spdx_package_license_concluded_prefers_declared_then_falls_back_to_other() {
         let declared = output_package_with(PackageData {
             package_type: Some(PackageType::Npm),
@@ -1178,18 +1248,19 @@ mod tests {
 
     #[test]
     fn spdx_rdf_license_resource_only_resolves_a_single_license_id() {
+        let ns = "http://spdx.org/spdxdocs/demo";
         assert_eq!(
-            spdx_rdf_license_resource(Some("MIT")),
+            spdx_rdf_license_resource(Some("MIT"), ns),
             "http://spdx.org/licenses/MIT"
         );
         // A compound expression would need a nested RDF license-set structure
         // this writer doesn't build, so it honestly reports NOASSERTION.
         assert_eq!(
-            spdx_rdf_license_resource(Some("MIT AND Apache-2.0")),
+            spdx_rdf_license_resource(Some("MIT AND Apache-2.0"), ns),
             "http://spdx.org/rdf/terms#noassertion"
         );
         assert_eq!(
-            spdx_rdf_license_resource(None),
+            spdx_rdf_license_resource(None, ns),
             "http://spdx.org/rdf/terms#noassertion"
         );
     }

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -32,6 +32,10 @@ struct SpdxPackagePlan<'a> {
     spdx_id: String,
     name: String,
     files: Vec<&'a FileInfo>,
+    /// The assembled package this plan was built from, when there is one.
+    /// `None` for the no-package synthetic plan and the unassigned-files
+    /// fallback bucket, which have no package-level license data to draw on.
+    package: Option<&'a OutputPackage>,
 }
 
 pub(crate) fn write_spdx_tag_value(
@@ -77,6 +81,8 @@ pub(crate) fn write_spdx_tag_value(
         let package_verification_code = spdx_package_verification_code(&plan.files);
         let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
         let package_copyright_text = spdx_package_copyright_text(&plan.files);
+        let package_license_concluded = spdx_package_license_concluded(plan.package);
+        let package_license_declared = spdx_package_license_declared(plan.package);
 
         writeln!(writer, "## Package Information")?;
         writeln!(writer, "PackageName: {}", plan.name)?;
@@ -88,14 +94,22 @@ pub(crate) fn write_spdx_tag_value(
             "PackageVerificationCode: {}",
             package_verification_code
         )?;
-        writeln!(writer, "PackageLicenseConcluded: NOASSERTION")?;
+        writeln!(
+            writer,
+            "PackageLicenseConcluded: {}",
+            spdx_tv_license_value(package_license_concluded.as_deref())
+        )?;
         for license_id in &package_license_info_from_files {
             writeln!(writer, "PackageLicenseInfoFromFiles: {}", license_id)?;
         }
         if package_license_info_from_files.is_empty() {
             writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
         }
-        writeln!(writer, "PackageLicenseDeclared: NOASSERTION")?;
+        writeln!(
+            writer,
+            "PackageLicenseDeclared: {}",
+            spdx_tv_license_value(package_license_declared.as_deref())
+        )?;
         writeln!(
             writer,
             "PackageCopyrightText: {}",
@@ -107,6 +121,7 @@ pub(crate) fn write_spdx_tag_value(
     for (file_index, file) in (1usize..).zip(files.iter()) {
         let sha1 = file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX);
         let file_license_info = spdx_file_license_info(file);
+        let file_license_concluded = spdx_file_license_concluded(file);
         writeln!(
             writer,
             "FileName: {}",
@@ -114,7 +129,11 @@ pub(crate) fn write_spdx_tag_value(
         )?;
         writeln!(writer, "SPDXID: SPDXRef-{}", file_index)?;
         writeln!(writer, "FileChecksum: SHA1: {}", sha1)?;
-        writeln!(writer, "LicenseConcluded: NOASSERTION")?;
+        writeln!(
+            writer,
+            "LicenseConcluded: {}",
+            spdx_tv_license_value(file_license_concluded.as_deref())
+        )?;
         if file_license_info.is_empty() {
             writeln!(writer, "LicenseInfoInFile: NONE")?;
         } else {
@@ -220,6 +239,8 @@ pub(crate) fn write_spdx_rdf_xml(
         let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
         let package_copyright_text = xml_escape(&spdx_package_copyright_text(&plan.files));
         let package_name = xml_escape(&plan.name);
+        let package_license_concluded = spdx_package_license_concluded(plan.package);
+        let package_license_declared = spdx_package_license_declared(plan.package);
 
         xml.push_str("  <spdx:Package rdf:about=\"");
         xml.push_str(&document_namespace_xml);
@@ -230,12 +251,16 @@ pub(crate) fn write_spdx_rdf_xml(
         xml.push_str(
             "    <spdx:downloadLocation rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
         );
-        xml.push_str(
-            "    <spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
-        );
-        xml.push_str(
-            "    <spdx:licenseDeclared rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>\n",
-        );
+        xml.push_str("    <spdx:licenseConcluded rdf:resource=\"");
+        xml.push_str(&xml_escape(&spdx_rdf_license_resource(
+            package_license_concluded.as_deref(),
+        )));
+        xml.push_str("\"/>\n");
+        xml.push_str("    <spdx:licenseDeclared rdf:resource=\"");
+        xml.push_str(&xml_escape(&spdx_rdf_license_resource(
+            package_license_declared.as_deref(),
+        )));
+        xml.push_str("\"/>\n");
         if package_license_info_from_files.is_empty() {
             xml.push_str(
                 "    <spdx:licenseInfoFromFiles rdf:resource=\"http://spdx.org/rdf/terms#none\"/>\n",
@@ -256,6 +281,7 @@ pub(crate) fn write_spdx_rdf_xml(
                 continue;
             };
             let file_license_info = spdx_file_license_info(file);
+            let file_license_concluded = spdx_file_license_concluded(file);
             xml.push_str("    <spdx:relationship><spdx:Relationship>");
             xml.push_str("<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_contains\"/>");
             xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"");
@@ -263,9 +289,11 @@ pub(crate) fn write_spdx_rdf_xml(
             xml.push('#');
             xml.push_str(&xml_escape(file_id));
             xml.push_str("\">");
-            xml.push_str(
-                "<spdx:licenseConcluded rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>",
-            );
+            xml.push_str("<spdx:licenseConcluded rdf:resource=\"");
+            xml.push_str(&xml_escape(&spdx_rdf_license_resource(
+                file_license_concluded.as_deref(),
+            )));
+            xml.push_str("\"/>");
             if file_license_info.is_empty() {
                 xml.push_str(
                     "<spdx:licenseInfoInFile rdf:resource=\"http://spdx.org/rdf/terms#none\"/>",
@@ -475,6 +503,65 @@ fn spdx_package_license_info_from_files(files: &[&FileInfo]) -> Vec<String> {
     unique.into_iter().collect()
 }
 
+/// The package's own declared SPDX expression, straight from parser/assembly
+/// -normalized manifest data. `None` (rendered as NOASSERTION) when the
+/// package declares nothing we could resolve to a valid SPDX expression; this
+/// never falls back to detected evidence, since "declared" specifically means
+/// what the package's producer stated.
+fn spdx_package_license_declared(package: Option<&OutputPackage>) -> Option<String> {
+    package
+        .and_then(|pkg| pkg.declared_license_expression_spdx.as_deref())
+        .filter(|expression| !expression.is_empty())
+        .map(str::to_string)
+}
+
+/// The best honest SPDX conclusion for the package: the declared expression
+/// when present (the single most authoritative source we have), otherwise
+/// `other_license_expression_spdx` — license text assembly detected in the
+/// package's own files that was not folded into the declared expression (see
+/// `reference_following.rs`). Falls back to `None` (NOASSERTION) rather than
+/// inventing a conclusion from evidence the package itself doesn't carry.
+fn spdx_package_license_concluded(package: Option<&OutputPackage>) -> Option<String> {
+    fn non_empty(value: &Option<String>) -> Option<&str> {
+        value.as_deref().filter(|v| !v.is_empty())
+    }
+    package
+        .and_then(|pkg| {
+            non_empty(&pkg.declared_license_expression_spdx)
+                .or_else(|| non_empty(&pkg.other_license_expression_spdx))
+        })
+        .map(str::to_string)
+}
+
+/// The best honest SPDX conclusion for a file: reuses the same three-tier
+/// fallback the JSON `detected_license_expression_spdx` field already applies
+/// (own detections, then owning package-data detections, then the carried
+/// expression). `None` (rendered as NOASSERTION) when nothing was detected.
+fn spdx_file_license_concluded(file: &FileInfo) -> Option<String> {
+    file.detected_license_expression_spdx()
+}
+
+/// Renders an already-resolved SPDX expression for a tag-value field, or the
+/// NOASSERTION placeholder when nothing is known.
+fn spdx_tv_license_value(expression: Option<&str>) -> &str {
+    expression.unwrap_or("NOASSERTION")
+}
+
+/// Renders an already-resolved SPDX expression as an RDF resource. Only a
+/// single license id (no `AND`/`OR`/`WITH` operators) can be expressed as the
+/// simple `rdf:resource` link this writer uses elsewhere (see
+/// `spdx_license_rdf_resource`); a compound expression would need a nested
+/// `ConjunctiveLicenseSet`/`DisjunctiveLicenseSet` structure this writer does
+/// not build, so it honestly falls back to NOASSERTION in RDF only (the
+/// tag-value form above keeps the full expression, since tag-value license
+/// fields accept SPDX expression syntax directly).
+fn spdx_rdf_license_resource(expression: Option<&str>) -> String {
+    match expression.map(spdx_ids_from_expression) {
+        Some(ids) if ids.len() == 1 => spdx_license_rdf_resource(&ids[0]),
+        _ => "http://spdx.org/rdf/terms#noassertion".to_string(),
+    }
+}
+
 fn spdx_package_copyright_text(files: &[&FileInfo]) -> String {
     let copyrights: BTreeSet<String> = files
         .iter()
@@ -661,6 +748,7 @@ fn plan_spdx_packages<'a>(
             spdx_id: "SPDXRef-001".to_string(),
             name: primary_package_name(output, config),
             files: files.to_vec(),
+            package: None,
         }];
     }
 
@@ -684,6 +772,7 @@ fn plan_spdx_packages<'a>(
             spdx_id: format!("SPDXRef-Package-{}", idx + 1),
             name: spdx_assembled_package_name(package, idx),
             files: owned,
+            package: Some(package),
         });
     }
 
@@ -697,6 +786,7 @@ fn plan_spdx_packages<'a>(
             spdx_id: "SPDXRef-Package-unassigned".to_string(),
             name: primary_package_name(output, config),
             files: unassigned,
+            package: None,
         });
     }
 
@@ -974,6 +1064,133 @@ mod tests {
         assert_eq!(
             spdx_file_license_info(&schema_file),
             vec!["MIT".to_string()]
+        );
+    }
+
+    fn output_package_with(package_data: PackageData) -> crate::output_schema::OutputPackage {
+        let package =
+            crate::models::Package::from_package_data(&package_data, "package.json".to_string());
+        crate::output_schema::OutputPackage::from(&package)
+    }
+
+    #[test]
+    fn spdx_package_license_declared_uses_only_the_declared_spdx_expression() {
+        let declared = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            declared_license_expression_spdx: Some("MIT".to_string()),
+            other_license_expression_spdx: Some("Apache-2.0".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            spdx_package_license_declared(Some(&declared)),
+            Some("MIT".to_string())
+        );
+
+        // Never falls back to detected-but-undeclared evidence, and no package
+        // (the synthetic/unassigned SPDX plans) means nothing was declared.
+        let undeclared = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            other_license_expression_spdx: Some("Apache-2.0".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(spdx_package_license_declared(Some(&undeclared)), None);
+        assert_eq!(spdx_package_license_declared(None), None);
+    }
+
+    #[test]
+    fn spdx_package_license_concluded_prefers_declared_then_falls_back_to_other() {
+        let declared = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            declared_license_expression_spdx: Some("MIT".to_string()),
+            other_license_expression_spdx: Some("Apache-2.0".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            spdx_package_license_concluded(Some(&declared)),
+            Some("MIT".to_string())
+        );
+
+        let other_only = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            other_license_expression_spdx: Some("Apache-2.0".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            spdx_package_license_concluded(Some(&other_only)),
+            Some("Apache-2.0".to_string())
+        );
+
+        let unknown = output_package_with(PackageData {
+            package_type: Some(PackageType::Npm),
+            ..Default::default()
+        });
+        assert_eq!(spdx_package_license_concluded(Some(&unknown)), None);
+        assert_eq!(spdx_package_license_concluded(None), None);
+    }
+
+    #[test]
+    fn spdx_file_license_concluded_reuses_the_detected_spdx_expression() {
+        let mut file = crate::models::FileInfo::new(
+            "notice.c".to_string(),
+            "notice".to_string(),
+            ".c".to_string(),
+            "project/notice.c".to_string(),
+            FileType::File,
+            None,
+            None,
+            1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        file.license_detections = vec![LicenseDetection {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            matches: vec![],
+            detection_log: vec![],
+            identifier: String::new(),
+        }];
+
+        let schema_file = crate::output_schema::OutputFileInfo::from(&file);
+        assert_eq!(
+            spdx_file_license_concluded(&schema_file),
+            Some("MIT".to_string())
+        );
+
+        let mut undetected = file;
+        undetected.license_detections = vec![];
+        let schema_undetected = crate::output_schema::OutputFileInfo::from(&undetected);
+        assert_eq!(spdx_file_license_concluded(&schema_undetected), None);
+    }
+
+    #[test]
+    fn spdx_rdf_license_resource_only_resolves_a_single_license_id() {
+        assert_eq!(
+            spdx_rdf_license_resource(Some("MIT")),
+            "http://spdx.org/licenses/MIT"
+        );
+        // A compound expression would need a nested RDF license-set structure
+        // this writer doesn't build, so it honestly reports NOASSERTION.
+        assert_eq!(
+            spdx_rdf_license_resource(Some("MIT AND Apache-2.0")),
+            "http://spdx.org/rdf/terms#noassertion"
+        );
+        assert_eq!(
+            spdx_rdf_license_resource(None),
+            "http://spdx.org/rdf/terms#noassertion"
         );
     }
 }

--- a/testdata/output-formats/spdx-licensed-expected.tv
+++ b/testdata/output-formats/spdx-licensed-expected.tv
@@ -1,0 +1,56 @@
+## Document Information
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: SPDX Document created by Provenant
+DocumentNamespace: http://spdx.org/spdxdocs/licensed
+DocumentComment: <text>Generated with Provenant and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+Provenant should be considered or used as legal advice. Consult an attorney
+for legal advice.
+Provenant is a free software code scanning tool.
+Visit https://github.com/getprovenant/provenant/ for support and download.
+SPDX License List: 3.27</text>
+## Creation Information
+Creator: Tool: Provenant-0.0.0
+Created: 2026-01-01T00:00:00Z
+## Package Information
+PackageName: widget-mit
+SPDXID: SPDXRef-Package-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: 0a05a9e69e5757ac71c75a50418622624f042c97
+PackageLicenseConcluded: MIT
+PackageLicenseInfoFromFiles: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NONE
+## Package Information
+PackageName: widget-other
+SPDXID: SPDXRef-Package-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: 4ef6c88cdec9dbcc9bd8b7fa0fdfe4cc43bfed4f
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseInfoFromFiles: NONE
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## File Information
+FileName: ./widget-mit/package.json
+SPDXID: SPDXRef-1
+FileChecksum: SHA1: 1111111111111111111111111111111111111111
+LicenseConcluded: MIT
+LicenseInfoInFile: MIT
+FileCopyrightText: NONE
+
+FileName: ./widget-other/package.json
+SPDXID: SPDXRef-2
+FileChecksum: SHA1: 2222222222222222222222222222222222222222
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: NONE
+
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
+Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-1
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-2
+Relationship: SPDXRef-Package-2 CONTAINS SPDXRef-2

--- a/testdata/output-formats/spdx-multi-package-expected.tv
+++ b/testdata/output-formats/spdx-multi-package-expected.tv
@@ -55,7 +55,7 @@ FileCopyrightText: Copyright 2024 Umbrella Maintainers
 FileName: ./packages/widget-a/package.json
 SPDXID: SPDXRef-2
 FileChecksum: SHA1: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-LicenseConcluded: NOASSERTION
+LicenseConcluded: MIT
 LicenseInfoInFile: MIT
 FileCopyrightText: Copyright 2024 Widget A Contributors
 
@@ -69,7 +69,7 @@ FileCopyrightText: NONE
 FileName: ./packages/widget-b/package.json
 SPDXID: SPDXRef-4
 FileChecksum: SHA1: cccccccccccccccccccccccccccccccccccccccc
-LicenseConcluded: NOASSERTION
+LicenseConcluded: Apache-2.0
 LicenseInfoInFile: Apache-2.0
 FileCopyrightText: Copyright 2024 Widget B Contributors
 

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -884,6 +884,70 @@ fn test_spdx_rdf_contract_contains_python_semantic_markers() {
 }
 
 #[test]
+fn test_spdx_licensed_tv_matches_local_golden_fixture() {
+    let output = sample_spdx_licensed_output();
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::SpdxTv)
+        .write(
+            &schema_output,
+            &mut bytes,
+            &OutputWriteConfig {
+                format: OutputFormat::SpdxTv,
+                custom_template: None,
+                scanned_path: Some("licensed".to_string()),
+            },
+        )
+        .expect("spdx output should be generated");
+
+    let actual = String::from_utf8(bytes).expect("spdx output should be utf-8");
+    let expected = fs::read_to_string("testdata/output-formats/spdx-licensed-expected.tv")
+        .expect("golden fixture should be readable");
+
+    assert_eq!(normalize_spdx_tv(&actual), normalize_spdx_tv(&expected));
+}
+
+#[test]
+fn test_spdx_licensed_rdf_fills_known_license_fields() {
+    let output = sample_spdx_licensed_output();
+    let mut bytes = Vec::new();
+    let schema_output = OutputSchemaOutput::from(&output);
+    writer_for_format(OutputFormat::SpdxRdf)
+        .write(
+            &schema_output,
+            &mut bytes,
+            &OutputWriteConfig {
+                format: OutputFormat::SpdxRdf,
+                custom_template: None,
+                scanned_path: Some("licensed".to_string()),
+            },
+        )
+        .expect("spdx rdf output should be generated");
+
+    let rendered = String::from_utf8(bytes).expect("spdx rdf should be utf-8");
+
+    // widget-mit declares MIT: PackageLicenseDeclared and PackageLicenseConcluded
+    // both resolve to the declared expression (the single most authoritative
+    // source), and its manifest file's own MIT detection fills LicenseConcluded.
+    assert!(rendered.contains(
+        "<spdx:Package rdf:about=\"http://spdx.org/spdxdocs/licensed#SPDXRef-Package-1\">"
+    ));
+    assert!(rendered.contains(
+        "<spdx:licenseConcluded rdf:resource=\"http://spdx.org/licenses/MIT\"/>\n    <spdx:licenseDeclared rdf:resource=\"http://spdx.org/licenses/MIT\"/>"
+    ));
+
+    // widget-other declares nothing but carries other_license_expression_spdx
+    // (detected-but-undeclared evidence): PackageLicenseConcluded falls back to
+    // it while PackageLicenseDeclared honestly stays NOASSERTION.
+    assert!(rendered.contains(
+        "<spdx:Package rdf:about=\"http://spdx.org/spdxdocs/licensed#SPDXRef-Package-2\">"
+    ));
+    assert!(rendered.contains(
+        "<spdx:licenseConcluded rdf:resource=\"http://spdx.org/licenses/Apache-2.0\"/>\n    <spdx:licenseDeclared rdf:resource=\"http://spdx.org/rdf/terms#noassertion\"/>"
+    ));
+}
+
+#[test]
 fn test_spdx_rdf_semantics_match_fixture_map() {
     let output = sample_spdx_simple_output();
     let mut bytes = Vec::new();
@@ -2173,6 +2237,108 @@ fn sample_spdx_multi_package_output() -> Output {
         vec![pkg_a, pkg_b],
         vec![],
         vec![manifest_a, source_a, manifest_b, source_b, readme],
+    )
+}
+
+/// Two assembled packages exercising the two honest SPDX license rules:
+/// `widget-mit` has a declared SPDX expression (used for both
+/// `PackageLicenseDeclared` and `PackageLicenseConcluded`, and its manifest's
+/// own detection fills the file's `LicenseConcluded`); `widget-other` has no
+/// declared expression but carries `other_license_expression_spdx` (detected
+/// evidence assembly found in its own files), which only backs
+/// `PackageLicenseConcluded` — `PackageLicenseDeclared` stays NOASSERTION
+/// since nothing was actually declared.
+fn sample_spdx_licensed_output() -> Output {
+    let mit_uid = PackageUid::from_raw(
+        "pkg:npm/widget-mit@1.0.0?uuid=00000000-0000-0000-0000-00000000m1".to_string(),
+    );
+    let mit_package = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("widget-mit".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/widget-mit@1.0.0".to_string()),
+                declared_license_expression_spdx: Some("MIT".to_string()),
+                ..Default::default()
+            },
+            "widget-mit/package.json".to_string(),
+        );
+        pkg.package_uid = mit_uid.clone();
+        pkg
+    };
+
+    let other_uid = PackageUid::from_raw(
+        "pkg:npm/widget-other@1.0.0?uuid=00000000-0000-0000-0000-00000000o1".to_string(),
+    );
+    let other_package = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("widget-other".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/widget-other@1.0.0".to_string()),
+                other_license_expression_spdx: Some("Apache-2.0".to_string()),
+                ..Default::default()
+            },
+            "widget-other/package.json".to_string(),
+        );
+        pkg.package_uid = other_uid.clone();
+        pkg
+    };
+
+    let mut manifest_mit = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "widget-mit/package.json",
+        20,
+        "1111111111111111111111111111111111111111",
+        vec![],
+    );
+    manifest_mit.for_packages = vec![mit_uid];
+    manifest_mit.detected_license_expression = Some("MIT".to_string());
+    manifest_mit.license_detections = vec![provenant::models::LicenseDetection {
+        license_expression: "mit".to_string(),
+        license_expression_spdx: "MIT".to_string(),
+        matches: vec![provenant::models::Match {
+            license_expression: "mit".to_string(),
+            license_expression_spdx: "MIT".to_string(),
+            from_file: Some("widget-mit/package.json".to_string()),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+            matcher: MatcherKind::Declared,
+            score: MatchScore::MAX,
+            matched_length: Some(1),
+            match_coverage: Some(100.0),
+            rule_relevance: Some(100),
+            rule_identifier: "mit_1.RULE".to_string(),
+            rule_url: None,
+            matched_text: Some("MIT".to_string()),
+            referenced_filenames: None,
+            matched_text_diagnostics: None,
+        }],
+        detection_log: vec![],
+        identifier: String::new(),
+    }];
+
+    let mut manifest_other = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "widget-other/package.json",
+        20,
+        "2222222222222222222222222222222222222222",
+        vec![],
+    );
+    manifest_other.for_packages = vec![other_uid];
+
+    sample_output_with_sections(
+        2,
+        0,
+        vec![mit_package, other_package],
+        vec![],
+        vec![manifest_mit, manifest_other],
     )
 }
 


### PR DESCRIPTION
## Summary

- `PackageLicenseDeclared`, `PackageLicenseConcluded`, and file `LicenseConcluded` in the SPDX writer were hardcoded to `NOASSERTION` even when a package's declared SPDX expression or a file's detected SPDX expression was already known from assembled scan data. This fills those fields from that data, falling back to `NOASSERTION` only when nothing is actually known.

## Issues

- Covers: SPDX output understating licensing for compliance consumers when Provenant already knows the answer.
- Closes: <!-- none -->

## Scope and exclusions

- Included:
  - `PackageLicenseDeclared`: the package's own `declared_license_expression_spdx`, or `NOASSERTION` when the package declares nothing.
  - `PackageLicenseConcluded`: prefers the declared expression (the single most authoritative source); otherwise falls back to `other_license_expression_spdx` (detected-but-undeclared evidence assembly already attached to the package); otherwise `NOASSERTION`.
  - File `LicenseConcluded`: reuses the existing `detected_license_expression_spdx()` three-tier fallback already used for the JSON `detected_license_expression_spdx` field (own detections, then owning package-data detections, then the carried expression).
  - RDF/XML: only renders a concluded/declared license as a plain `rdf:resource` link when the resolved expression is a single license id; a compound `AND`/`OR`/`WITH` expression would need a nested RDF license-set structure this writer doesn't build, so RDF honestly falls back to NOASSERTION for those (the tag-value writer keeps the full expression text, since tag-value license fields accept SPDX expression syntax directly).
- Explicit exclusions:
  - No multi-package topology, CycloneDX, or Debian changes.
  - No new CI/external SPDX validators.
  - No new inference: nothing is derived from evidence the package/file doesn't already carry in assembled scan data (e.g. no smearing a directory's license across unrelated files).

## How to verify

- `cargo test --lib output::spdx --test output_format_golden` covers the new behavior, including a new fixture (`spdx-licensed-expected.tv`) with one package that declares MIT (both `PackageLicenseDeclared`/`PackageLicenseConcluded` fill to `MIT`, and its manifest file's own detection fills `LicenseConcluded`) and one package with only `other_license_expression_spdx` set (`PackageLicenseConcluded` falls back to `Apache-2.0` while `PackageLicenseDeclared` correctly stays `NOASSERTION`).
- To see it end to end: scan a project with a clearly declared manifest license (e.g. an npm package with `"license": "MIT"`) with `--license --package --output-spdx-tv -` and check `PackageLicenseDeclared`/`PackageLicenseConcluded` are no longer `NOASSERTION`.

## Intentional differences from Python

- ScanCode's own `output_spdx.py` hardcodes `NOASSERTION` for all three fields unconditionally, even though it computes `license_info_from_files` from the same detections. Per `AGENTS.md`, ScanCode's choice here is a compatibility signal, not an automatically-correct target: Provenant already carries a normalized, honest SPDX expression for declared and detected licenses, so surfacing it (with strict "no invented conclusions" rules) is a more useful, still-honest result for compliance consumers than always saying "no assertion."

## Follow-up work

- Created or intentionally deferred: a full RDF `ConjunctiveLicenseSet`/`DisjunctiveLicenseSet` representation for compound license expressions in `PackageLicenseConcluded`/`PackageLicenseDeclared`/`LicenseConcluded` is deferred; RDF currently reports `NOASSERTION` for those rather than guessing a simplified structure.

## Expected-output fixture changes

- Files changed: `testdata/output-formats/spdx-licensed-expected.tv` (new).
- Why the new expected output is correct: it was generated by running the new golden test against the implementation and reviewed by hand against the two rules described above (declared-first for both declared/concluded; `other_license_expression_spdx` fallback only for concluded).

Made with [Cursor](https://cursor.com)