### PR TITLE
ci: validate output-format fixtures against official CycloneDX/SPDX tooling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -366,6 +366,30 @@ jobs:
         if: matrix.shard == 'integration'
         run: cargo test --test output_format_golden --profile ci-release --verbose
 
+      # The progress-CLI suite above already builds `provenant` at
+      # `target/ci-release/provenant` (it exercises `CARGO_BIN_EXE_provenant`),
+      # so this reuses that binary instead of paying for a second CLI build in
+      # a standalone job. Official/reference validators for each spec: the
+      # CycloneDX JSON-Schema + XSD (via cyclonedx-python-lib) and the SPDX
+      # tag-value/RDF parser and full document validator (via spdx-tools'
+      # pyspdxtools). Catches schema regressions goldens alone can miss, like
+      # https://github.com/getprovenant/provenant/issues/1288.
+      - name: Set up Python
+        if: matrix.shard == 'integration'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements-output-format-validators.txt
+
+      - name: Install CycloneDX/SPDX validator tooling
+        if: matrix.shard == 'integration'
+        run: pip install -r scripts/requirements-output-format-validators.txt
+
+      - name: Validate output-format fixtures against official external validators
+        if: matrix.shard == 'integration'
+        run: python3 scripts/validate_output_format_fixtures.py --provenant-bin target/ci-release/provenant
+
   golden-tests:
     name: Golden Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -181,6 +181,17 @@ and the resulting package data shape.
 - Validate CLI/runtime behavior and graceful degradation
 - Test output-format and fixture-backed contracts that matter to end users
 
+`tests/output_format_golden.rs` proves output _stability_ against checked-in fixtures. The
+`rust-sharded-tests` integration shard's external-validator step
+(`scripts/validate_output_format_fixtures.py`) is a complementary, narrower check that proves spec
+_conformance_: it runs the official CycloneDX JSON-Schema/XSD validators and the SPDX
+`pyspdxtools` document validator against those same fixtures (plus a tiny live scan for SPDX RDF,
+which has no genuine checked-in RDF/XML fixture). It runs in that shard rather than a standalone
+job because the shard's progress-CLI suite already builds the `provenant` binary it needs, so the
+check adds only a Python install + short script run instead of a second CLI build. A
+change that keeps a golden green by drifting the fixture and the writer together in the same wrong
+direction can still fail this job.
+
 **When to Write**:
 
 - After major scanner changes

--- a/scripts/requirements-output-format-validators.txt
+++ b/scripts/requirements-output-format-validators.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pinned Python dependencies for scripts/validate_output_format_fixtures.py.
+# Bump deliberately; these packages provide the official/reference validators
+# (CycloneDX JSON-Schema/XSD, SPDX tag-value/RDF parsing + spec validation)
+# that catch schema regressions our own goldens can miss.
+cyclonedx-python-lib[validation]==11.11.0
+spdx-tools==0.8.5

--- a/scripts/validate_output_format_fixtures.py
+++ b/scripts/validate_output_format_fixtures.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Provenant contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Validate Provenant's SBOM/SPDX output against official external validators.
+
+Provenant's own golden tests (tests/output_format_golden.rs) compare emitted
+CycloneDX/SPDX output against checked-in fixtures byte-for-byte (after light
+normalization). That proves *stability*, not *spec conformance*: a bug that
+changes both the writer and the golden fixture in the same wrong way (element
+order, a missing required field, a duplicate id that violates `uniqueItems`,
+...) can slip through goldens alone. See https://github.com/getprovenant/provenant/issues/1288.
+
+This script instead runs the actual reference tooling from each spec:
+
+- CycloneDX JSON/XML fixtures are validated against the official CycloneDX
+  1.3 JSON Schema / XSD, via the `cyclonedx-python-lib` validators.
+- SPDX tag-value fixtures are validated with `pyspdxtools` (spdx-tools),
+  which parses and runs full SPDX-2.2/2.3 document validation.
+
+Most checked-in `testdata/output-formats/` fixtures are validated directly.
+SPDX RDF has no genuine checked-in RDF/XML fixture (the `.rdf` golden is a
+JSON-shaped semantic projection used for internal comparisons, see
+tests/output_format_golden.rs), so RDF -- and, as a cheap extra check, the
+other formats too -- are also validated end-to-end from a tiny live scan of
+testdata/smoke when `--provenant-bin` is given.
+
+Usage:
+    python3 scripts/validate_output_format_fixtures.py [--provenant-bin PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = ROOT / "testdata" / "output-formats"
+SMOKE_SCAN_ROOT = ROOT / "testdata" / "smoke"
+
+# Real, complete CycloneDX documents. `cyclonedx-expected-without-packages.json`
+# is intentionally excluded: it is a partial fixture with `metadata`/
+# `serialNumber` normalized away for a narrow unit-test comparison, not a
+# realistic full document.
+CYCLONEDX_JSON_FIXTURES = [
+    "cyclonedx-expected.json",
+    "cyclonedx-dependencies-expected.json",
+]
+CYCLONEDX_XML_FIXTURES = [
+    "cyclonedx-expected.xml",
+    "cyclonedx-dependencies-expected.xml",
+]
+
+# `spdx-empty-expected.tv` is intentionally excluded: Provenant emits a
+# `# No results for package '...'.` placeholder comment (not a full SPDX
+# document) when a scan finds no files, so it is out of scope for spec
+# validation.
+SPDX_TAGVALUE_FIXTURES = [
+    "spdx-simple-expected.tv",
+]
+
+CYCLONEDX_SPEC_VERSION = "1.3"
+
+
+def report_ok(label: str) -> None:
+    print(f"OK   {label}")
+
+
+def report_fail(errors: list[str], label: str, detail: str) -> None:
+    message = f"{label}: {detail}"
+    errors.append(message)
+    print(f"FAIL {message}", file=sys.stderr)
+
+
+def cyclonedx_error_detail(error) -> str:
+    return str(getattr(error.data, "message", error.data))
+
+
+def validate_cyclonedx_json(path: Path, errors: list[str], label: str) -> None:
+    from cyclonedx.schema import OutputFormat, SchemaVersion
+    from cyclonedx.validation import make_schemabased_validator
+
+    validator = make_schemabased_validator(OutputFormat.JSON, SchemaVersion.V1_3)
+    error = validator.validate_str(path.read_text())
+    if error is None:
+        report_ok(label)
+    else:
+        report_fail(errors, label, cyclonedx_error_detail(error))
+
+
+def validate_cyclonedx_xml(path: Path, errors: list[str], label: str) -> None:
+    from cyclonedx.schema import OutputFormat, SchemaVersion
+    from cyclonedx.validation import make_schemabased_validator
+
+    validator = make_schemabased_validator(OutputFormat.XML, SchemaVersion.V1_3)
+    error = validator.validate_str(path.read_text())
+    if error is None:
+        report_ok(label)
+    else:
+        report_fail(errors, label, cyclonedx_error_detail(error))
+
+
+def validate_spdx_tagvalue(path: Path, errors: list[str], label: str, tmp_dir: Path) -> None:
+    # pyspdxtools infers the format from the file extension; copy to a
+    # recognized `.spdx` name so the real tag-value parser + validator run.
+    staged = tmp_dir / f"{path.stem}.spdx"
+    shutil.copy(path, staged)
+    result = subprocess.run(
+        ["pyspdxtools", "-i", str(staged)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        report_ok(label)
+    else:
+        detail = (result.stderr or result.stdout).strip().replace("\n", " | ")
+        report_fail(errors, label, detail)
+
+
+def validate_spdx_rdf(path: Path, errors: list[str], label: str) -> None:
+    # `.rdf` is already a recognized pyspdxtools extension.
+    result = subprocess.run(
+        ["pyspdxtools", "-i", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        report_ok(label)
+    else:
+        detail = (result.stderr or result.stdout).strip().replace("\n", " | ")
+        report_fail(errors, label, detail)
+
+
+def validate_static_fixtures(errors: list[str], tmp_dir: Path) -> None:
+    for name in CYCLONEDX_JSON_FIXTURES:
+        validate_cyclonedx_json(FIXTURES_DIR / name, errors, f"testdata/output-formats/{name}")
+    for name in CYCLONEDX_XML_FIXTURES:
+        validate_cyclonedx_xml(FIXTURES_DIR / name, errors, f"testdata/output-formats/{name}")
+    for name in SPDX_TAGVALUE_FIXTURES:
+        validate_spdx_tagvalue(
+            FIXTURES_DIR / name, errors, f"testdata/output-formats/{name}", tmp_dir
+        )
+
+
+def validate_generated_scan(errors: list[str], provenant_bin: Path, tmp_dir: Path) -> None:
+    tv_out = tmp_dir / "generated-scan.spdx.tag"
+    rdf_out = tmp_dir / "generated-scan.spdx.rdf"
+    json_out = tmp_dir / "generated-scan.cdx.json"
+    xml_out = tmp_dir / "generated-scan.cdx.xml"
+
+    subprocess.run(
+        [
+            str(provenant_bin),
+            "scan",
+            str(SMOKE_SCAN_ROOT),
+            "--license",
+            "--copyright",
+            "--package",
+            "--info",
+            "--spdx-tv",
+            str(tv_out),
+            "--spdx-rdf",
+            str(rdf_out),
+            "--cyclonedx",
+            str(json_out),
+            "--cyclonedx-xml",
+            str(xml_out),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    validate_spdx_tagvalue(tv_out, errors, "generated scan: SPDX tag-value", tmp_dir)
+    validate_spdx_rdf(rdf_out, errors, "generated scan: SPDX RDF/XML")
+    validate_cyclonedx_json(json_out, errors, "generated scan: CycloneDX JSON")
+    validate_cyclonedx_xml(xml_out, errors, "generated scan: CycloneDX XML")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provenant-bin",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a built `provenant` binary. When given, also runs a tiny live "
+            f"scan of {SMOKE_SCAN_ROOT.relative_to(ROOT)} and validates its SPDX/"
+            "CycloneDX output, which is the only way to exercise the SPDX RDF "
+            "writer against a real validator (no genuine RDF/XML fixture is "
+            "checked in)."
+        ),
+    )
+    args = parser.parse_args()
+
+    print(f"Validating checked-in CycloneDX {CYCLONEDX_SPEC_VERSION} / SPDX fixtures...")
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="provenant-output-format-validators-") as tmp:
+        tmp_dir = Path(tmp)
+        validate_static_fixtures(errors, tmp_dir)
+        if args.provenant_bin is not None:
+            validate_generated_scan(errors, args.provenant_bin, tmp_dir)
+
+    if errors:
+        print(
+            f"\n{len(errors)} output-format check(s) failed external schema/spec validation.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll output-format fixtures passed external schema/spec validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/output/cyclonedx.rs
+++ b/src/output/cyclonedx.rs
@@ -59,6 +59,14 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
             "    <component type=\"library\" bom-ref=\"{}\">\n",
             xml_escape(bom_ref)
         ));
+        // CycloneDX 1.3 XSD requires this element order within <component>:
+        // author precedes name/version, which precede description, which
+        // precedes scope.
+        if let Some(author) = package_author(pkg) {
+            xml.push_str("      <author>");
+            xml.push_str(&xml_escape(&author));
+            xml.push_str("</author>\n");
+        }
         xml.push_str("      <name>");
         xml.push_str(&xml_escape(name));
         xml.push_str("</name>\n");
@@ -70,17 +78,7 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
             xml.push_str(&xml_escape(description));
             xml.push_str("</description>\n");
         }
-        if let Some(author) = package_author(pkg) {
-            xml.push_str("      <author>");
-            xml.push_str(&xml_escape(&author));
-            xml.push_str("</author>\n");
-        }
         xml.push_str("      <scope>required</scope>\n");
-        if let Some(purl) = &pkg.purl {
-            xml.push_str("      <purl>");
-            xml.push_str(&xml_escape(purl));
-            xml.push_str("</purl>\n");
-        }
         let hashes = component_hashes(pkg);
         if !hashes.is_empty() {
             xml.push_str("      <hashes>\n");
@@ -97,6 +95,12 @@ pub(crate) fn write_cyclonedx_xml(output: &Output, writer: &mut dyn Write) -> io
             xml.push_str("      <licenses><expression>");
             xml.push_str(&xml_escape(&license_expression));
             xml.push_str("</expression></licenses>\n");
+        }
+        // `purl` must follow `licenses`/`copyright`/`cpe` per the CycloneDX 1.3 XSD.
+        if let Some(purl) = &pkg.purl {
+            xml.push_str("      <purl>");
+            xml.push_str(&xml_escape(purl));
+            xml.push_str("</purl>\n");
         }
         let external_refs = component_external_references(pkg);
         if !external_refs.is_empty() {

--- a/testdata/output-formats/cyclonedx-expected.xml
+++ b/testdata/output-formats/cyclonedx-expected.xml
@@ -12,18 +12,18 @@
   </metadata>
   <components>
     <component type="library" bom-ref="pkg:npm/npm@2.13.5">
+      <author>Isaac Z. Schlueter</author>
       <name>npm</name>
       <version>2.13.5</version>
       <description>a package manager for JavaScript</description>
-      <author>Isaac Z. Schlueter</author>
       <scope>required</scope>
-      <purl>pkg:npm/npm@2.13.5</purl>
       <hashes>
         <hash alg="SHA-1">a124386bce4a90506f28ad4b1d1a804a17baaf32</hash>
       </hashes>
       <licenses>
         <expression>Artistic-2.0</expression>
       </licenses>
+      <purl>pkg:npm/npm@2.13.5</purl>
       <externalReferences>
         <reference type="bom">
           <url>https://registry.npmjs.org/npm/2.13.5</url>


### PR DESCRIPTION
## Summary

- Run the real reference tooling from each spec — CycloneDX JSON-Schema/XSD validation via `cyclonedx-python-lib`, and SPDX tag-value/RDF parsing plus full SPDX-2.2/2.3 document validation via `spdx-tools`' `pyspdxtools` — against `testdata/output-formats/` fixtures and a tiny live scan, as a new step in the `rust-sharded-tests` job's `integration` shard (rather than a standalone job — see CI shape below).
- `tests/output_format_golden.rs` proves output *stability* against checked-in fixtures; this check proves spec *conformance*, so a change that shifts the writer and its golden fixture together in the same wrong direction (element order, a missing required field, a `uniqueItems` violation) can no longer slip through goldens alone, as happened in #1288.
- Fix a real CycloneDX 1.3 XSD element-order violation this check surfaced: `<author>` and `<purl>` were emitted in positions the schema does not allow within `<component>`.

## Issues

- Covers: #1288

## CI shape

- The validator steps live in the existing `rust-sharded-tests` / `integration` shard rather than a standalone job. That shard's `progress_cli_integration` suite already builds the `provenant` binary (`target/ci-release/provenant`, via `CARGO_BIN_EXE_provenant`), so reusing it there means the new check only adds a Python setup + pinned `pip install` + a script run (a few seconds locally with a warm pip cache) instead of paying for a second full CLI build in its own job.
- A standalone job was the initial shape, but it duplicated a CLI build (checkout + toolchain + cache restore + `cargo build`) that the integration shard already pays for, with no meaningful isolation benefit — the validators only need a binary and some fixtures, not a clean job sandbox.
- The new steps are gated to `matrix.shard == 'integration'` so they don't run (and don't need a binary) on the `contracts` shard.

## Scope and exclusions

- Included:
  - `scripts/validate_output_format_fixtures.py` + `scripts/requirements-output-format-validators.txt`: pinned validator tooling and validation logic, runnable locally or in CI.
  - New steps in the `rust-sharded-tests` / `integration` shard of `.github/workflows/check.yml` that install the pinned Python validators and run the script against the binary that shard's own suite already builds.
  - Minimal element-order fix in `src/output/cyclonedx.rs` (and the matching fixture) required to make the new check pass; no new emission logic or fields.
  - A short pointer in `docs/TESTING_STRATEGY.md` explaining how this check complements `output_format_golden.rs` and why it lives in that shard.
- Explicit exclusions:
  - No SPDX/CycloneDX emission logic expansion (new fields, new formats, new detection).
  - `cyclonedx-expected-without-packages.json` is intentionally excluded from schema validation — it's a partial fixture with `metadata`/`serialNumber` normalized away for a narrow unit-test comparison, not a realistic document.
  - `spdx-empty-expected.tv` is intentionally excluded — Provenant emits a `# No results for package '...'.` placeholder comment (not a full SPDX document) when a scan has no files, so it's out of scope for spec validation.

## How to verify

- CI: the `rust-sharded-tests` / `integration` shard installs the pinned validators and runs `python3 scripts/validate_output_format_fixtures.py --provenant-bin target/ci-release/provenant` after its existing test suites (which already produce that binary).
- Locally: `pip install -r scripts/requirements-output-format-validators.txt && cargo build --bin provenant && python3 scripts/validate_output_format_fixtures.py --provenant-bin target/debug/provenant`.
- To confirm the job would have caught the historical regressions: checking out the pre-#1289 `spdx-simple-expected.tv` and running `pyspdxtools -i` on it fails with `CreationInfo.__init__() missing ... 'creators' and 'created'`; feeding the CycloneDX JSON validator a synthetic BOM with two identical `dependencies[].ref` entries fails with `... has non-unique elements` (the exact `uniqueItems` regression from #1289).

## Intentional differences from Python

- N/A (CI/tooling change only; no scanner behavior change beyond the CycloneDX XML element-order fix).

## Follow-up work

- Created or intentionally deferred: none. SPDX RDF validation intentionally runs only against a live-scan fixture in this PR rather than converting `spdx-simple-expected.rdf` into a real RDF/XML golden, to keep scope narrow; a follow-up could add a genuine checked-in RDF fixture if that comparison-projection approach ever becomes a pain point.

## Expected-output fixture changes

- Files changed: `testdata/output-formats/cyclonedx-expected.xml`.
- Why the new expected output is correct: `<author>` and `<purl>` are reordered to match the CycloneDX 1.3 XSD's required `<component>` element sequence (`author` before `name`/`version`; `purl` after `licenses`/`copyright`/`cpe`). Verified against the official schema via `cyclonedx-python-lib`, and `tests/output_format_golden.rs` still passes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)
