### PR TITLE
fix(cli): refuse hollow SBOM export from --from-json reshapes lacking package data

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -393,7 +393,7 @@ In practice:
 - SPDX is often the better fit for compliance-oriented exchange.
 - `--package` is usually part of these workflows because package/dependency data is central to SBOM output.
 
-Reshaping with `--from-json` (see section 14) into an SBOM format needs the original scan to have run package detection. If the JSON being reshaped never ran `--package`/`--package-only`/`--system-package`/`--package-in-compiled` and it has no packages, Provenant refuses the SBOM export instead of silently writing an empty `components` array or SPDX's no-package projection. Rescan with one of those flags first, or reshape to `--json`/`--json-pp` instead if you only need file-level data.
+Reshaping with `--from-json` (see section 14) into an SBOM format needs the original scan to have run package detection. If the JSON being reshaped never ran `--package`/`--package-only`/`--system-package`/`--package-in-compiled` and it has no packages, Provenant refuses the SBOM export instead of silently writing an empty `components` array or SPDX's no-package projection. This check runs per merged `--from-json` input, so merging several JSON files where even one of them never ran package detection still refuses — a different merged input that did request detection does not override it. Rescan with one of those flags first, or reshape to `--json`/`--json-pp` instead if you only need file-level data. A refused SBOM target does not block other, non-SBOM output targets requested in the same run (e.g. `--cyclonedx bom.json --json out.json`): the non-SBOM outputs are still written, and the process exits with a dedicated non-zero exit code distinct from a scan/runtime error or the license-policy gate.
 
 ### 11. "I need Debian copyright output"
 
@@ -452,6 +452,8 @@ Important: `--from-json` is for reshaping existing results. It is not a second s
 Also note that `--from-json` cannot recover newer native-only evidence details that were never serialized in the original JSON. For example, replaying older ScanCode-style or compatibility-mode JSON cannot reconstruct the newer less-normalized file-level copyright text without rescanning the original files.
 
 For the same reason, reshaping into an SBOM format (`--spdx-tv`, `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml`) fails instead of silently succeeding when the source JSON has scanned files but never ran package detection: with no package data to recover, the export would otherwise be a hollow document (an empty CycloneDX `components` array, or SPDX's no-package projection) that still looks like a normal successful scan. Rescan with `--package`/`--package-only`/`--system-package`/`--package-in-compiled` before reshaping into an SBOM format. A source scan that ran package detection and genuinely found no packages reshapes normally — only the "package detection was never attempted" case is refused. A genuinely empty scan document (no files at all) also reshapes normally, since that keeps its existing documented empty-SBOM behavior.
+
+This is tracked per merged `--from-json` input, not as a single flag for the whole request: when `--from-json` is given multiple JSON paths to merge into one replay (see "merging or reshaping multiple prior JSON scans" above), a merged input that never ran package detection still refuses an SBOM export even if a different merged input honestly requested it (or already carries real packages) — one input's package-detection request can never silence another merged input's hollow files. A refusal only blocks the requested SBOM target(s); any other, non-SBOM output targets in the same request (e.g. `--json`/`--json-pp`) are still written, and the overall run exits non-zero with a dedicated exit code once all allowed outputs have been produced, matching the "write the artifact, then fail the gate" pattern used by `--fail-on` (see [ADR 0011](adr/0011-license-compliance-gating-and-sarif.md)).
 
 ### 15. "I want a codebase-level summary instead of reading raw file-by-file results"
 
@@ -687,6 +689,7 @@ These are worth learning early because they change what the output means:
 - `--tallies-by-facet` requires `--facet` and `--tallies`
 - `--debian <FILE>` requires `--license`, `--copyright`, and `--license-text`
 - `--fail-on <LEVEL>` requires `--license-policy`; a violation exits with code 3
+- an SBOM format (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) combined with `--from-json` on an input that never ran package detection is refused and exits with code 4, while any other requested non-SBOM output targets are still written
 - `--sarif <FILE>` only emits results for `--license-policy` entries that carry a `compliance_alert`
 - `--paths-file <FILE>` requires exactly one native scan root and is currently native-scan only (no `--from-json`)
 - `--reindex` only matters when the license engine is initialized (`--license` and some `--from-json` reference-recompute flows)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -393,6 +393,8 @@ In practice:
 - SPDX is often the better fit for compliance-oriented exchange.
 - `--package` is usually part of these workflows because package/dependency data is central to SBOM output.
 
+Reshaping with `--from-json` (see section 14) into an SBOM format needs the original scan to have run package detection. If the JSON being reshaped never ran `--package`/`--package-only`/`--system-package`/`--package-in-compiled` and it has no packages, Provenant refuses the SBOM export instead of silently writing an empty `components` array or SPDX's no-package projection. Rescan with one of those flags first, or reshape to `--json`/`--json-pp` instead if you only need file-level data.
+
 ### 11. "I need Debian copyright output"
 
 ```sh
@@ -448,6 +450,8 @@ This is especially useful for:
 Important: `--from-json` is for reshaping existing results. It is not a second scan pass, and scan-time options such as fresh detection flags are intentionally restricted in this mode.
 
 Also note that `--from-json` cannot recover newer native-only evidence details that were never serialized in the original JSON. For example, replaying older ScanCode-style or compatibility-mode JSON cannot reconstruct the newer less-normalized file-level copyright text without rescanning the original files.
+
+For the same reason, reshaping into an SBOM format (`--spdx-tv`, `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml`) fails instead of silently succeeding when the source JSON has scanned files but never ran package detection: with no package data to recover, the export would otherwise be a hollow document (an empty CycloneDX `components` array, or SPDX's no-package projection) that still looks like a normal successful scan. Rescan with `--package`/`--package-only`/`--system-package`/`--package-in-compiled` before reshaping into an SBOM format. A source scan that ran package detection and genuinely found no packages reshapes normally — only the "package detection was never attempted" case is refused. A genuinely empty scan document (no files at all) also reshapes normally, since that keeps its existing documented empty-SBOM behavior.
 
 ### 15. "I want a codebase-level summary instead of reading raw file-by-file results"
 

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -64,14 +64,19 @@ pub(crate) struct ScanSession {
     pub(crate) active_license_engine: Option<Arc<LicenseDetectionEngine>>,
     pub(crate) shared_cache_config: Option<CacheConfig>,
     pub(crate) shared_license_cache_config: Option<LicenseCacheConfig>,
-    /// For `--from-json` sessions: whether any merged input's header options
-    /// recorded a package-detection flag (`--package`, `--package-only`,
-    /// `--system-package`, `--package-in-compiled`). Always `true` for native
-    /// scans, where this distinction does not apply. Lets a later SBOM-export
-    /// guard tell "reshaped input never ran package detection" (hollow) apart
-    /// from "package detection ran and honestly found nothing" (a real empty
-    /// inventory).
-    pub(crate) package_detection_requested_in_source: bool,
+    /// For `--from-json` sessions: whether at least one merged input had
+    /// scanned files but no packages of its own, and its own recorded header
+    /// options never showed a package-detection flag (`--package`,
+    /// `--package-only`, `--system-package`, `--package-in-compiled`) having
+    /// been requested. Tracked per input at merge time (see
+    /// `load_and_merge_json_inputs`) so one input's real packages or
+    /// package-detection request can never mask another merged input's
+    /// hollow contribution. Always `false` for native scans, where every
+    /// file is freshly examined and this distinction does not apply. Lets a
+    /// later SBOM-export guard tell "some reshaped input never ran package
+    /// detection" (hollow) apart from "package detection ran and honestly
+    /// found nothing" (a real empty inventory).
+    pub(crate) has_hollow_package_detection_input: bool,
 }
 
 pub(crate) fn load_scan_session(
@@ -114,7 +119,7 @@ pub(crate) fn load_scan_session(
             extra_errors,
             imported_spdx_license_list_version,
             imported_license_index_provenance,
-            package_detection_requested_in_source,
+            has_hollow_package_detection_input,
         ) = loaded.into_parts()?;
         return Ok(ScanSession {
             scan_result: process_result,
@@ -130,7 +135,7 @@ pub(crate) fn load_scan_session(
             active_license_engine: None,
             shared_cache_config,
             shared_license_cache_config,
-            package_detection_requested_in_source,
+            has_hollow_package_detection_input,
         });
     }
 
@@ -142,10 +147,10 @@ pub(crate) struct ExecutedRequest {
     pub(crate) output: Output,
     pub(crate) progress: Arc<ScanProgress>,
     pub(crate) start_time: DateTime<Utc>,
-    /// Carried from [`ScanSession::package_detection_requested_in_source`] so
+    /// Carried from [`ScanSession::has_hollow_package_detection_input`] so
     /// the CLI layer can gate hollow-SBOM detection without re-deriving it
     /// from raw header options after the session has been consumed.
-    pub(crate) package_detection_requested_in_source: bool,
+    pub(crate) has_hollow_package_detection_input: bool,
 }
 
 pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> {
@@ -168,7 +173,7 @@ pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> 
     progress.finish_setup();
 
     let session = load_scan_session(request, &scan_plan, &progress)?;
-    let package_detection_requested_in_source = session.package_detection_requested_in_source;
+    let has_hollow_package_detection_input = session.has_hollow_package_detection_input;
     let output = build_output_model(
         session,
         request,
@@ -183,7 +188,7 @@ pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> 
         output,
         progress,
         start_time,
-        package_detection_requested_in_source,
+        has_hollow_package_detection_input,
     })
 }
 
@@ -731,7 +736,7 @@ fn load_native_scan_session(
         active_license_engine: license_engine,
         shared_cache_config,
         shared_license_cache_config,
-        package_detection_requested_in_source: true,
+        has_hollow_package_detection_input: false,
     })
 }
 

--- a/src/app/scan_pipeline.rs
+++ b/src/app/scan_pipeline.rs
@@ -64,6 +64,14 @@ pub(crate) struct ScanSession {
     pub(crate) active_license_engine: Option<Arc<LicenseDetectionEngine>>,
     pub(crate) shared_cache_config: Option<CacheConfig>,
     pub(crate) shared_license_cache_config: Option<LicenseCacheConfig>,
+    /// For `--from-json` sessions: whether any merged input's header options
+    /// recorded a package-detection flag (`--package`, `--package-only`,
+    /// `--system-package`, `--package-in-compiled`). Always `true` for native
+    /// scans, where this distinction does not apply. Lets a later SBOM-export
+    /// guard tell "reshaped input never ran package detection" (hollow) apart
+    /// from "package detection ran and honestly found nothing" (a real empty
+    /// inventory).
+    pub(crate) package_detection_requested_in_source: bool,
 }
 
 pub(crate) fn load_scan_session(
@@ -106,6 +114,7 @@ pub(crate) fn load_scan_session(
             extra_errors,
             imported_spdx_license_list_version,
             imported_license_index_provenance,
+            package_detection_requested_in_source,
         ) = loaded.into_parts()?;
         return Ok(ScanSession {
             scan_result: process_result,
@@ -121,6 +130,7 @@ pub(crate) fn load_scan_session(
             active_license_engine: None,
             shared_cache_config,
             shared_license_cache_config,
+            package_detection_requested_in_source,
         });
     }
 
@@ -132,6 +142,10 @@ pub(crate) struct ExecutedRequest {
     pub(crate) output: Output,
     pub(crate) progress: Arc<ScanProgress>,
     pub(crate) start_time: DateTime<Utc>,
+    /// Carried from [`ScanSession::package_detection_requested_in_source`] so
+    /// the CLI layer can gate hollow-SBOM detection without re-deriving it
+    /// from raw header options after the session has been consumed.
+    pub(crate) package_detection_requested_in_source: bool,
 }
 
 pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> {
@@ -154,6 +168,7 @@ pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> 
     progress.finish_setup();
 
     let session = load_scan_session(request, &scan_plan, &progress)?;
+    let package_detection_requested_in_source = session.package_detection_requested_in_source;
     let output = build_output_model(
         session,
         request,
@@ -168,6 +183,7 @@ pub(crate) fn execute_request(request: &ScanRequest) -> Result<ExecutedRequest> 
         output,
         progress,
         start_time,
+        package_detection_requested_in_source,
     })
 }
 
@@ -715,6 +731,7 @@ fn load_native_scan_session(
         active_license_engine: license_engine,
         shared_cache_config,
         shared_license_cache_config,
+        package_detection_requested_in_source: true,
     })
 }
 

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::app::request::ScanRequest;
+use crate::app::request::{InputMode, ScanRequest};
 use crate::app::scan_pipeline::execute_request;
 use crate::cli::{Cli, Command, ScanArgs};
 use crate::compare::compare_json_files;
 use crate::license_detection::dataset::export_embedded_license_dataset;
-use crate::output::{OutputWriteConfig, write_output_file};
+use crate::models::{FileType, Output};
+use crate::output::{OutputFormat, OutputWriteConfig, write_output_file};
 use crate::progress::{ScanProgress, init_cli_logger};
 use crate::serve::run as run_serve_shell;
 use crate::time::format_scancode_timestamp;
@@ -100,6 +101,12 @@ pub fn run() -> Result<ExitCode> {
     let output = executed.output;
     let progress = executed.progress;
     let start_time = executed.start_time;
+
+    guard_against_hollow_from_json_sbom(
+        &request,
+        &output,
+        executed.package_detection_requested_in_source,
+    )?;
 
     let output_schema_output =
         crate::output_schema::Output::from_with_compat_mode(&output, cli.compat_mode);
@@ -238,6 +245,92 @@ fn validate_scan_option_compatibility(cli: &ScanArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// SBOM-oriented output formats whose entire value proposition is the package
+/// inventory: an SPDX or CycloneDX document with zero packages looks like a
+/// normal, successful export while actually reporting no components at all.
+const SBOM_OUTPUT_FORMATS: &[OutputFormat] = &[
+    OutputFormat::SpdxTv,
+    OutputFormat::SpdxRdf,
+    OutputFormat::CycloneDxJson,
+    OutputFormat::CycloneDxXml,
+];
+
+fn sbom_output_flag(format: OutputFormat) -> &'static str {
+    match format {
+        OutputFormat::SpdxTv => "--spdx-tv",
+        OutputFormat::SpdxRdf => "--spdx-rdf",
+        OutputFormat::CycloneDxJson => "--cyclonedx",
+        OutputFormat::CycloneDxXml => "--cyclonedx-xml",
+        _ => "<sbom-format>",
+    }
+}
+
+/// Refuses a `--from-json` reshape that requests an SBOM format
+/// (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) when the result
+/// would be a hollow document: real scanned files, but zero packages, because
+/// the JSON being reshaped never ran package detection in the first place.
+///
+/// `--from-json` reshapes an existing scan without rescanning (see
+/// `docs/CLI_GUIDE.md`), so it cannot recover package data the original scan
+/// never collected. Emitting the SBOM anyway would silently succeed with an
+/// empty inventory: CycloneDX would write an empty `components` array and
+/// SPDX would fall back to its single-synthetic-package "no packages"
+/// projection, both indistinguishable from a normal successful export.
+///
+/// This intentionally does **not** fire for:
+/// - native scans (only `--from-json` reshapes lack a fresh detection pass);
+/// - requests that do not ask for an SBOM format;
+/// - a truly empty scan document (no files at all) — that keeps the existing
+///   documented empty-SBOM sentinel behavior;
+/// - input whose recorded header options show package detection
+///   (`--package`, `--package-only`, `--system-package`, or
+///   `--package-in-compiled`) actually ran upstream, since zero packages then
+///   means the codebase honestly has none, not that nothing looked.
+fn guard_against_hollow_from_json_sbom(
+    request: &ScanRequest,
+    output: &Output,
+    package_detection_requested_in_source: bool,
+) -> Result<()> {
+    if !matches!(request.input_mode, InputMode::FromJson) || package_detection_requested_in_source {
+        return Ok(());
+    }
+
+    if !output.packages.is_empty() {
+        return Ok(());
+    }
+
+    let scanned_file_count = output
+        .files
+        .iter()
+        .filter(|file| file.file_type == FileType::File)
+        .count();
+    if scanned_file_count == 0 {
+        return Ok(());
+    }
+
+    let requested_sbom_flags: Vec<&'static str> = request
+        .output_targets
+        .iter()
+        .map(|target| target.format)
+        .filter(|format| SBOM_OUTPUT_FORMATS.contains(format))
+        .map(sbom_output_flag)
+        .collect();
+    if requested_sbom_flags.is_empty() {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "Refusing to write a hollow SBOM for {}: the --from-json input has {} scanned file(s) but no \
+         packages, and its recorded scan options never requested package detection (--package, \
+         --package-only, --system-package, or --package-in-compiled). Rerun the original scan with one \
+         of those flags before reshaping to an SBOM format, or drop {} if a package-less scan was \
+         intended.",
+        requested_sbom_flags.join(", "),
+        scanned_file_count,
+        requested_sbom_flags.join(", "),
+    ))
 }
 
 fn record_detail_timing<T, F>(progress: &Arc<ScanProgress>, name: impl Into<String>, f: F) -> T

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -22,6 +22,16 @@ use std::time::Instant;
 /// the code used for scan/runtime errors (see ADR 0011).
 const POLICY_GATE_EXIT_CODE: u8 = 3;
 
+/// Exit code returned when one or more `--from-json` SBOM output targets were
+/// refused by [`hollow_from_json_sbom_refusal`] because the reshaped input
+/// never ran package detection. Distinct from the scan/runtime error code (1)
+/// and the license-policy gate code (3), so CI can tell "an SBOM target was
+/// skipped for honesty reasons" apart from "the tool broke" or "a policy
+/// violation." Non-SBOM output targets in the same request are still written
+/// (see the output loop in `run`), matching the ADR 0011 pattern of never
+/// losing an artifact to a gate.
+const HOLLOW_SBOM_GUARD_EXIT_CODE: u8 = 4;
+
 pub fn run() -> Result<ExitCode> {
     #[cfg(feature = "golden-tests")]
     touch_license_golden_symbols();
@@ -102,16 +112,30 @@ pub fn run() -> Result<ExitCode> {
     let progress = executed.progress;
     let start_time = executed.start_time;
 
-    guard_against_hollow_from_json_sbom(
+    // A hollow-SBOM refusal only blocks the specific SBOM output target(s)
+    // below; it must not short-circuit non-SBOM outputs in the same request
+    // (e.g. `--spdx-tv out.spdx --json out.json`), so it is computed as a
+    // value up front instead of using `?` to bail out of `run` immediately.
+    let hollow_sbom_refusal = hollow_from_json_sbom_refusal(
         &request,
         &output,
-        executed.package_detection_requested_in_source,
-    )?;
+        executed.has_hollow_package_detection_input,
+    );
 
     let output_schema_output =
         crate::output_schema::Output::from_with_compat_mode(&output, cli.compat_mode);
     progress.start_output();
     for target in &request.output_targets {
+        if hollow_sbom_refusal.is_some() && SBOM_OUTPUT_FORMATS.contains(&target.format) {
+            log::error!(
+                "Skipping {:?} output to {}: {}",
+                target.format,
+                target.file,
+                hollow_sbom_refusal.as_deref().unwrap_or_default()
+            );
+            continue;
+        }
+
         let output_config = OutputWriteConfig {
             format: target.format,
             custom_template: target.custom_template.clone(),
@@ -140,6 +164,15 @@ pub fn run() -> Result<ExitCode> {
         &format_scancode_timestamp(&start_time),
         &format_scancode_timestamp(&summary_end),
     );
+
+    // Fails the run after all allowed outputs are already written (same
+    // never-lose-the-artifact shape as the license-policy gate below).
+    if let Some(refusal) = hollow_sbom_refusal {
+        log::error!(
+            "Hollow-SBOM guard: {refusal} Failing with exit code {HOLLOW_SBOM_GUARD_EXIT_CODE}."
+        );
+        return Ok(ExitCode::from(HOLLOW_SBOM_GUARD_EXIT_CODE));
+    }
 
     // License-policy gate: evaluated after the report is written so the artifact is
     // never lost to a failing gate (ADR 0011). Covers file-level detections plus
@@ -267,38 +300,52 @@ fn sbom_output_flag(format: OutputFormat) -> &'static str {
     }
 }
 
-/// Refuses a `--from-json` reshape that requests an SBOM format
-/// (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) when the result
-/// would be a hollow document: real scanned files, but zero packages, because
-/// the JSON being reshaped never ran package detection in the first place.
+/// Returns a refusal message when a `--from-json` reshape requests an SBOM
+/// format (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) but at
+/// least one merged input would contribute a hollow document: real scanned
+/// files that no package detection ever examined.
 ///
 /// `--from-json` reshapes an existing scan without rescanning (see
 /// `docs/CLI_GUIDE.md`), so it cannot recover package data the original scan
 /// never collected. Emitting the SBOM anyway would silently succeed with an
-/// empty inventory: CycloneDX would write an empty `components` array and
-/// SPDX would fall back to its single-synthetic-package "no packages"
-/// projection, both indistinguishable from a normal successful export.
+/// empty (or partially examined) inventory: CycloneDX would write an empty
+/// `components` array and SPDX would fall back to its single-synthetic-package
+/// "no packages" projection, both indistinguishable from a normal successful
+/// export.
+///
+/// This is a query, not a hard gate: it returns `Some(message)` instead of an
+/// `Err` so the caller can skip only the requested SBOM output target(s)
+/// while still writing any other requested output formats in the same
+/// request, then fail the run's exit code once all allowed outputs are
+/// written (see the output loop and [`HOLLOW_SBOM_GUARD_EXIT_CODE`] in `run`).
+///
+/// `has_hollow_package_detection_input` is `true` when *any* merged
+/// `--from-json` input had scanned files, no packages of its own, and never
+/// requested package detection in its own recorded header options
+/// (`--package`, `--package-only`, `--system-package`, or
+/// `--package-in-compiled`) — see `is_hollow_package_detection_input` in
+/// `src/scan_result_shaping/json_input.rs`. This is tracked per input at
+/// merge time, so **one merged input honestly requesting package detection
+/// (or already carrying real packages) can never silence another merged
+/// input's hollow contribution**: the refusal fires even if the overall
+/// `output.packages` ends up non-empty because of a different input.
 ///
 /// This intentionally does **not** fire for:
 /// - native scans (only `--from-json` reshapes lack a fresh detection pass);
 /// - requests that do not ask for an SBOM format;
 /// - a truly empty scan document (no files at all) — that keeps the existing
 ///   documented empty-SBOM sentinel behavior;
-/// - input whose recorded header options show package detection
-///   (`--package`, `--package-only`, `--system-package`, or
-///   `--package-in-compiled`) actually ran upstream, since zero packages then
-///   means the codebase honestly has none, not that nothing looked.
-fn guard_against_hollow_from_json_sbom(
+/// - a `--from-json` input (or merge of inputs) where every input either had
+///   no files or actually requested package detection upstream, since zero
+///   packages then means the codebase honestly has none, not that nothing
+///   looked.
+fn hollow_from_json_sbom_refusal(
     request: &ScanRequest,
     output: &Output,
-    package_detection_requested_in_source: bool,
-) -> Result<()> {
-    if !matches!(request.input_mode, InputMode::FromJson) || package_detection_requested_in_source {
-        return Ok(());
-    }
-
-    if !output.packages.is_empty() {
-        return Ok(());
+    has_hollow_package_detection_input: bool,
+) -> Option<String> {
+    if !matches!(request.input_mode, InputMode::FromJson) || !has_hollow_package_detection_input {
+        return None;
     }
 
     let scanned_file_count = output
@@ -307,7 +354,7 @@ fn guard_against_hollow_from_json_sbom(
         .filter(|file| file.file_type == FileType::File)
         .count();
     if scanned_file_count == 0 {
-        return Ok(());
+        return None;
     }
 
     let requested_sbom_flags: Vec<&'static str> = request
@@ -318,15 +365,16 @@ fn guard_against_hollow_from_json_sbom(
         .map(sbom_output_flag)
         .collect();
     if requested_sbom_flags.is_empty() {
-        return Ok(());
+        return None;
     }
 
-    Err(anyhow!(
-        "Refusing to write a hollow SBOM for {}: the --from-json input has {} scanned file(s) but no \
-         packages, and its recorded scan options never requested package detection (--package, \
-         --package-only, --system-package, or --package-in-compiled). Rerun the original scan with one \
-         of those flags before reshaping to an SBOM format, or drop {} if a package-less scan was \
-         intended.",
+    Some(format!(
+        "Refusing to write a hollow SBOM for {}: the merged --from-json input has {} scanned file(s) \
+         overall, but at least one merged source's files were never examined for packages (its recorded \
+         scan options never requested --package, --package-only, --system-package, or \
+         --package-in-compiled), even though another merged source may have. Rerun that source's original \
+         scan with one of those flags before reshaping to an SBOM format, or drop {} if a package-less \
+         scan was intended.",
         requested_sbom_flags.join(", "),
         scanned_file_count,
         requested_sbom_flags.join(", "),

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -253,6 +253,114 @@ fn validate_scan_option_compatibility_allows_multiple_inputs_with_from_json() {
     assert!(validate_scan_option_compatibility(&cli).is_ok());
 }
 
+fn from_json_sbom_request(sbom_flag: &str, output_file: &str) -> ScanRequest {
+    let cli = crate::cli::Cli::try_parse_from([
+        "provenant",
+        sbom_flag,
+        output_file,
+        "--from-json",
+        "input.json",
+    ])
+    .expect("cli parse should succeed");
+    ScanRequest::from(cli.scan_args().expect("scan args should be present"))
+}
+
+fn output_with_files(files: Vec<crate::models::FileInfo>) -> crate::models::Output {
+    crate::models::Output {
+        summary: None,
+        tallies: None,
+        tallies_of_key_files: None,
+        tallies_by_facet: None,
+        headers: vec![],
+        packages: vec![],
+        dependencies: vec![],
+        license_detections: vec![],
+        files,
+        license_references: vec![],
+        license_rule_references: vec![],
+    }
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_fails_when_source_never_ran_package_detection() {
+    let request = from_json_sbom_request("--cyclonedx", "bom.json");
+    let output = output_with_files(vec![json_file(
+        "src/main.rs",
+        crate::models::FileType::File,
+    )]);
+
+    let error = guard_against_hollow_from_json_sbom(&request, &output, false)
+        .expect_err("hollow cyclonedx reshape must be refused");
+    assert!(error.to_string().contains("hollow"));
+    assert!(error.to_string().contains("--cyclonedx"));
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_allows_native_scans() {
+    let cli = crate::cli::Cli::try_parse_from([
+        "provenant",
+        "--cyclonedx",
+        "bom.json",
+        "--package",
+        "sample-dir",
+    ])
+    .expect("cli parse should succeed");
+    let request = ScanRequest::from(cli.scan_args().expect("scan args should be present"));
+    let output = output_with_files(vec![json_file(
+        "src/main.rs",
+        crate::models::FileType::File,
+    )]);
+
+    assert!(guard_against_hollow_from_json_sbom(&request, &output, true).is_ok());
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_allows_non_sbom_output_formats() {
+    let request = from_json_sbom_request("--json-pp", "-");
+    let output = output_with_files(vec![json_file(
+        "src/main.rs",
+        crate::models::FileType::File,
+    )]);
+
+    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_allows_truly_empty_scan_documents() {
+    let request = from_json_sbom_request("--spdx-tv", "sbom.spdx");
+    let output = output_with_files(vec![]);
+
+    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_allows_honest_zero_packages_when_detection_ran() {
+    let request = from_json_sbom_request("--spdx-rdf", "sbom.rdf");
+    let output = output_with_files(vec![json_file("README.md", crate::models::FileType::File)]);
+
+    assert!(guard_against_hollow_from_json_sbom(&request, &output, true).is_ok());
+}
+
+#[test]
+fn guard_against_hollow_from_json_sbom_allows_requests_with_real_packages() {
+    let request = from_json_sbom_request("--cyclonedx-xml", "bom.xml");
+    let mut output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+    output.packages = vec![crate::models::Package::from_package_data(
+        &crate::models::PackageData {
+            package_type: Some(crate::models::PackageType::Npm),
+            name: Some("demo".to_string()),
+            version: Some("1.0.0".to_string()),
+            ..Default::default()
+        },
+        "package.json".to_string(),
+    )];
+
+    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+}
+
 #[test]
 fn compile_regex_patterns_rejects_invalid_regex() {
     let result = compile_regex_patterns("--ignore-author", &["[".to_string()]);

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -282,21 +282,48 @@ fn output_with_files(files: Vec<crate::models::FileInfo>) -> crate::models::Outp
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_fails_when_source_never_ran_package_detection() {
+fn hollow_from_json_sbom_refusal_fires_when_source_never_ran_package_detection() {
     let request = from_json_sbom_request("--cyclonedx", "bom.json");
     let output = output_with_files(vec![json_file(
         "src/main.rs",
         crate::models::FileType::File,
     )]);
 
-    let error = guard_against_hollow_from_json_sbom(&request, &output, false)
-        .expect_err("hollow cyclonedx reshape must be refused");
-    assert!(error.to_string().contains("hollow"));
-    assert!(error.to_string().contains("--cyclonedx"));
+    let refusal = hollow_from_json_sbom_refusal(&request, &output, true)
+        .expect("hollow cyclonedx reshape must be refused");
+    assert!(refusal.contains("hollow"));
+    assert!(refusal.contains("--cyclonedx"));
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_allows_native_scans() {
+fn hollow_from_json_sbom_refusal_fires_even_when_output_packages_are_non_empty() {
+    // Regression for a merge that includes a hollow source (files present,
+    // package detection never requested) alongside another merged input that
+    // did request detection and found real packages: the merged
+    // `output.packages` ends up non-empty, but the hollow input's files were
+    // still never examined, so the refusal must still fire.
+    let request = from_json_sbom_request("--cyclonedx", "bom.json");
+    let mut output = output_with_files(vec![json_file(
+        "src/main.rs",
+        crate::models::FileType::File,
+    )]);
+    output.packages = vec![crate::models::Package::from_package_data(
+        &crate::models::PackageData {
+            package_type: Some(crate::models::PackageType::Npm),
+            name: Some("demo".to_string()),
+            version: Some("1.0.0".to_string()),
+            ..Default::default()
+        },
+        "package.json".to_string(),
+    )];
+
+    let refusal = hollow_from_json_sbom_refusal(&request, &output, true)
+        .expect("hollow merged input must not be silenced by another input's real packages");
+    assert!(refusal.contains("hollow"));
+}
+
+#[test]
+fn hollow_from_json_sbom_refusal_allows_native_scans() {
     let cli = crate::cli::Cli::try_parse_from([
         "provenant",
         "--cyclonedx",
@@ -311,38 +338,38 @@ fn guard_against_hollow_from_json_sbom_allows_native_scans() {
         crate::models::FileType::File,
     )]);
 
-    assert!(guard_against_hollow_from_json_sbom(&request, &output, true).is_ok());
+    assert!(hollow_from_json_sbom_refusal(&request, &output, false).is_none());
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_allows_non_sbom_output_formats() {
+fn hollow_from_json_sbom_refusal_allows_non_sbom_output_formats() {
     let request = from_json_sbom_request("--json-pp", "-");
     let output = output_with_files(vec![json_file(
         "src/main.rs",
         crate::models::FileType::File,
     )]);
 
-    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+    assert!(hollow_from_json_sbom_refusal(&request, &output, true).is_none());
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_allows_truly_empty_scan_documents() {
+fn hollow_from_json_sbom_refusal_allows_truly_empty_scan_documents() {
     let request = from_json_sbom_request("--spdx-tv", "sbom.spdx");
     let output = output_with_files(vec![]);
 
-    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+    assert!(hollow_from_json_sbom_refusal(&request, &output, true).is_none());
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_allows_honest_zero_packages_when_detection_ran() {
+fn hollow_from_json_sbom_refusal_allows_honest_zero_packages_when_detection_ran() {
     let request = from_json_sbom_request("--spdx-rdf", "sbom.rdf");
     let output = output_with_files(vec![json_file("README.md", crate::models::FileType::File)]);
 
-    assert!(guard_against_hollow_from_json_sbom(&request, &output, true).is_ok());
+    assert!(hollow_from_json_sbom_refusal(&request, &output, false).is_none());
 }
 
 #[test]
-fn guard_against_hollow_from_json_sbom_allows_requests_with_real_packages() {
+fn hollow_from_json_sbom_refusal_allows_requests_with_real_packages() {
     let request = from_json_sbom_request("--cyclonedx-xml", "bom.xml");
     let mut output = output_with_files(vec![json_file(
         "package.json",
@@ -358,7 +385,7 @@ fn guard_against_hollow_from_json_sbom_allows_requests_with_real_packages() {
         "package.json".to_string(),
     )];
 
-    assert!(guard_against_hollow_from_json_sbom(&request, &output, false).is_ok());
+    assert!(hollow_from_json_sbom_refusal(&request, &output, false).is_none());
 }
 
 #[test]
@@ -533,6 +560,7 @@ fn from_json_skips_final_native_projection_block() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     let cli = crate::cli::Cli::try_parse_from([

--- a/src/scan_result_shaping/json_input.rs
+++ b/src/scan_result_shaping/json_input.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Result, anyhow};
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -28,6 +29,7 @@ type JsonInputParts = (
     Vec<String>,
     Option<String>,
     Option<LicenseIndexProvenance>,
+    bool,
 );
 
 #[cfg(test)]
@@ -42,7 +44,7 @@ pub(crate) struct JsonHeaderExtraDataInput {
     license_index_provenance: Option<LicenseIndexProvenance>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub(crate) struct JsonHeaderInput {
     #[serde(default)]
     errors: Vec<String>,
@@ -50,6 +52,33 @@ pub(crate) struct JsonHeaderInput {
     warnings: Vec<String>,
     #[serde(default)]
     extra_data: Option<JsonHeaderExtraDataInput>,
+    /// Raw `header.options` flags recorded by the scan that produced this JSON,
+    /// e.g. `"--package": true`. Used only to detect whether package detection
+    /// was ever requested upstream, distinguishing "no packages because
+    /// nothing looked for them" from "no packages because none exist" so a
+    /// `--from-json` reshape into an SBOM format can tell hollow output from an
+    /// honest empty inventory (see [`Self::requested_package_detection`]).
+    #[serde(default)]
+    options: serde_json::Map<String, serde_json::Value>,
+}
+
+/// CLI flags that cause package/dependency metadata to be collected. Mirrors
+/// the flags forbidden alongside `--from-json` in
+/// `validate_scan_option_compatibility`, since those are exactly the flags a
+/// prior *native* scan needed in order to have produced real package data.
+const PACKAGE_DETECTION_OPTION_KEYS: &[&str] = &[
+    "--package",
+    "--package-only",
+    "--system-package",
+    "--package-in-compiled",
+];
+
+impl JsonHeaderInput {
+    fn requested_package_detection(&self) -> bool {
+        PACKAGE_DETECTION_OPTION_KEYS
+            .iter()
+            .any(|key| self.options.get(*key).and_then(Value::as_bool) == Some(true))
+    }
 }
 
 #[derive(Deserialize)]
@@ -148,6 +177,11 @@ impl JsonScanInput {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| anyhow!("Failed to convert license rule reference from JSON: {}", e))?;
 
+        let package_detection_requested_in_source = self
+            .headers
+            .iter()
+            .any(JsonHeaderInput::requested_package_detection);
+
         let imported_spdx_license_list_version =
             consistent_header_value(self.headers.iter().filter_map(|header| {
                 header
@@ -171,6 +205,7 @@ impl JsonScanInput {
                      errors,
                      warnings: _,
                      extra_data: _,
+                     options: _,
                  }| errors,
             )
             .filter(|error| !is_imported_file_summary_error(error, &files))
@@ -191,6 +226,7 @@ impl JsonScanInput {
             preserved_header_errors,
             imported_spdx_license_list_version,
             imported_license_index_provenance,
+            package_detection_requested_in_source,
         ))
     }
 }

--- a/src/scan_result_shaping/json_input.rs
+++ b/src/scan_result_shaping/json_input.rs
@@ -81,7 +81,7 @@ impl JsonHeaderInput {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub(crate) struct JsonScanInput {
     #[serde(default)]
     pub(crate) headers: Vec<JsonHeaderInput>,
@@ -99,6 +99,16 @@ pub(crate) struct JsonScanInput {
     pub(crate) license_rule_references: Vec<OutputLicenseRuleReference>,
     #[serde(default)]
     pub(crate) excluded_count: usize,
+    /// Whether *this* loaded input — before merging with any other
+    /// `--from-json` path — has scanned files, no packages of its own, and
+    /// none of its recorded headers requested package detection. Never
+    /// present in the raw JSON; computed by [`load_and_merge_json_inputs`]
+    /// per input and OR'd into the merged value, so one input's real
+    /// packages or package-detection request can never mask another
+    /// merged input's hollow contribution (see
+    /// [`is_hollow_package_detection_input`]).
+    #[serde(skip)]
+    pub(crate) has_hollow_package_detection_input: bool,
 }
 
 impl JsonScanInput {
@@ -122,6 +132,21 @@ impl JsonScanInput {
             .filter(|file| file.file_type == OutputFileType::File)
             .map(|file| file.size)
             .sum()
+    }
+
+    /// Whether this input, considered on its own before any merge, has
+    /// scanned files but no packages, and none of its recorded headers show
+    /// package detection having been requested upstream. This is the
+    /// per-input hollow check; see [`load_and_merge_json_inputs`] for how it
+    /// is combined across merged `--from-json` inputs so one input's real
+    /// packages or request flag cannot silence another's hollow files.
+    fn is_hollow_package_detection_input(&self) -> bool {
+        self.file_count() > 0
+            && self.packages.is_empty()
+            && !self
+                .headers
+                .iter()
+                .any(JsonHeaderInput::requested_package_detection)
     }
 
     pub(crate) fn into_parts(self) -> Result<JsonInputParts> {
@@ -177,10 +202,7 @@ impl JsonScanInput {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| anyhow!("Failed to convert license rule reference from JSON: {}", e))?;
 
-        let package_detection_requested_in_source = self
-            .headers
-            .iter()
-            .any(JsonHeaderInput::requested_package_detection);
+        let has_hollow_package_detection_input = self.has_hollow_package_detection_input;
 
         let imported_spdx_license_list_version =
             consistent_header_value(self.headers.iter().filter_map(|header| {
@@ -226,7 +248,7 @@ impl JsonScanInput {
             preserved_header_errors,
             imported_spdx_license_list_version,
             imported_license_index_provenance,
-            package_detection_requested_in_source,
+            has_hollow_package_detection_input,
         ))
     }
 }
@@ -291,6 +313,14 @@ pub(crate) fn load_and_merge_json_inputs(
             namespace_loaded_input(&mut loaded, index + 1);
         }
 
+        // Computed before merging: hollowness must be judged per merged
+        // input, using only that input's own files/packages/headers.
+        // Deriving it from `acc`/`loaded` after the appends below would let
+        // one input's real packages or package-detection request mask
+        // another input's hollow files (see `hollow_from_json_sbom_refusal`
+        // in `src/cli/run/mod.rs`).
+        let loaded_is_hollow = loaded.is_hollow_package_detection_input();
+
         if let Some(acc) = &mut merged {
             acc.files.append(&mut loaded.files);
             acc.packages.append(&mut loaded.packages);
@@ -303,7 +333,9 @@ pub(crate) fn load_and_merge_json_inputs(
                 .append(&mut loaded.license_rule_references);
             acc.headers.append(&mut loaded.headers);
             acc.excluded_count += loaded.excluded_count;
+            acc.has_hollow_package_detection_input |= loaded_is_hollow;
         } else {
+            loaded.has_hollow_package_detection_input = loaded_is_hollow;
             merged = Some(loaded);
         }
     }

--- a/src/scan_result_shaping/json_input_test.rs
+++ b/src/scan_result_shaping/json_input_test.rs
@@ -12,6 +12,94 @@ fn output_json_file(path: &str, file_type: crate::models::FileType) -> OutputFil
     OutputFileInfo::from(&internal)
 }
 
+fn header_with_options(options: serde_json::Map<String, serde_json::Value>) -> JsonHeaderInput {
+    JsonHeaderInput {
+        options,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn requested_package_detection_is_false_without_package_flags() {
+    let header = header_with_options(serde_json::Map::new());
+    assert!(!header.requested_package_detection());
+}
+
+#[test]
+fn requested_package_detection_is_false_when_flag_present_but_disabled() {
+    // `push_bool_option` only ever records a `true` flag, but the raw options
+    // map is untrusted JSON, so an explicit `false` must not be mistaken for
+    // "package detection ran".
+    let header = header_with_options(serde_json::Map::from_iter([(
+        "--package".to_string(),
+        serde_json::Value::Bool(false),
+    )]));
+    assert!(!header.requested_package_detection());
+}
+
+#[test]
+fn requested_package_detection_is_true_for_each_recognized_package_flag() {
+    for flag in [
+        "--package",
+        "--package-only",
+        "--system-package",
+        "--package-in-compiled",
+    ] {
+        let header = header_with_options(serde_json::Map::from_iter([(
+            flag.to_string(),
+            serde_json::Value::Bool(true),
+        )]));
+        assert!(
+            header.requested_package_detection(),
+            "{flag} should be recognized as package detection"
+        );
+    }
+}
+
+#[test]
+fn into_parts_reports_package_detection_requested_when_any_merged_header_ran_it() {
+    let loaded = JsonScanInput {
+        headers: vec![
+            header_with_options(serde_json::Map::new()),
+            header_with_options(serde_json::Map::from_iter([(
+                "--package".to_string(),
+                serde_json::Value::Bool(true),
+            )])),
+        ],
+        files: vec![],
+        packages: vec![],
+        dependencies: vec![],
+        license_detections: vec![],
+        license_references: vec![],
+        license_rule_references: vec![],
+        excluded_count: 0,
+    };
+
+    let (.., package_detection_requested_in_source) =
+        loaded.into_parts().expect("into_parts should succeed");
+
+    assert!(package_detection_requested_in_source);
+}
+
+#[test]
+fn into_parts_reports_package_detection_not_requested_when_no_header_ran_it() {
+    let loaded = JsonScanInput {
+        headers: vec![header_with_options(serde_json::Map::new())],
+        files: vec![],
+        packages: vec![],
+        dependencies: vec![],
+        license_detections: vec![],
+        license_references: vec![],
+        license_rule_references: vec![],
+        excluded_count: 0,
+    };
+
+    let (.., package_detection_requested_in_source) =
+        loaded.into_parts().expect("into_parts should succeed");
+
+    assert!(!package_detection_requested_in_source);
+}
+
 #[test]
 fn load_scan_from_json_reads_files_and_metadata_sections() {
     let temp_path = std::env::temp_dir().join("provenant-from-json-test.json");
@@ -172,6 +260,7 @@ fn normalize_loaded_json_scan_applies_strip_root_per_loaded_input() {
             ],
             warnings: vec!["custom recoverable warning: archive/root/src/main.rs".to_string()],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![
             output_json_file("archive/root", crate::models::FileType::Directory),
@@ -235,6 +324,7 @@ fn normalize_loaded_json_scan_trims_full_root_display_without_absolutizing() {
             errors: vec!["Path: /tmp/archive/root/src/main.rs".to_string()],
             warnings: vec!["custom recoverable warning: /tmp/archive/root/src/main.rs".to_string()],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![output_json_file(
             "/tmp/archive/root/src/main.rs",
@@ -541,6 +631,7 @@ fn into_parts_preserves_imported_header_errors_as_extra_errors() {
                     replaced_licenses: vec![],
                 }),
             }),
+            ..Default::default()
         }],
         files: vec![output_json_file(
             "src/main.rs",
@@ -563,6 +654,7 @@ fn into_parts_preserves_imported_header_errors_as_extra_errors() {
         extra_errors,
         imported_spdx_license_list_version,
         imported_license_index_provenance,
+        _package_detection_requested_in_source,
     ) = loaded.into_parts().expect("into_parts should succeed");
 
     assert_eq!(extra_errors, vec!["Failed to read directory: src/main.rs"]);
@@ -585,6 +677,7 @@ fn into_parts_drops_imported_warnings_and_file_summary_errors() {
             ],
             warnings: vec!["Imported warning".to_string()],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![{
             let mut file = output_json_file("src/main.rs", crate::models::FileType::File);
@@ -608,6 +701,7 @@ fn into_parts_drops_imported_warnings_and_file_summary_errors() {
         extra_errors,
         imported_spdx_license_list_version,
         imported_license_index_provenance,
+        _package_detection_requested_in_source,
     ) = loaded.into_parts().expect("into_parts should succeed");
 
     assert_eq!(extra_errors, vec!["Failed to read directory: src/vendor"]);
@@ -622,6 +716,7 @@ fn into_parts_restores_file_warning_severity_from_header_warnings() {
             errors: vec![],
             warnings: vec!["custom recoverable warning: src/main.rs".to_string()],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![{
             let mut file = output_json_file("src/main.rs", crate::models::FileType::File);
@@ -636,7 +731,7 @@ fn into_parts_restores_file_warning_severity_from_header_warnings() {
         excluded_count: 0,
     };
 
-    let (process_result, _assembly_result, _dets, _refs, _rule_refs, extra_errors, _, _) =
+    let (process_result, _assembly_result, _dets, _refs, _rule_refs, extra_errors, _, _, _) =
         loaded.into_parts().expect("into_parts should succeed");
 
     assert!(extra_errors.is_empty());
@@ -661,6 +756,7 @@ fn normalize_loaded_json_scan_rewrites_verbose_header_error_path_prefix() {
             ],
             warnings: vec![],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![output_json_file(
             "/tmp/archive/root/src/main.rs",
@@ -691,6 +787,7 @@ fn normalize_loaded_json_scan_rewrites_header_warnings_too() {
             errors: vec![],
             warnings: vec!["custom recoverable warning: /tmp/archive/root/src/main.rs".to_string()],
             extra_data: None,
+            ..Default::default()
         }],
         files: vec![output_json_file(
             "/tmp/archive/root/src/main.rs",
@@ -733,6 +830,7 @@ fn into_parts_discards_conflicting_imported_header_provenance() {
                         replaced_licenses: vec![],
                     }),
                 }),
+                ..Default::default()
             },
             JsonHeaderInput {
                 errors: vec![],
@@ -751,6 +849,7 @@ fn into_parts_discards_conflicting_imported_header_provenance() {
                         replaced_licenses: vec![],
                     }),
                 }),
+                ..Default::default()
             },
         ],
         files: vec![output_json_file(
@@ -774,6 +873,7 @@ fn into_parts_discards_conflicting_imported_header_provenance() {
         _extra_errors,
         imported_spdx_license_list_version,
         imported_license_index_provenance,
+        _package_detection_requested_in_source,
     ) = loaded.into_parts().expect("into_parts should succeed");
 
     assert!(imported_spdx_license_list_version.is_none());

--- a/src/scan_result_shaping/json_input_test.rs
+++ b/src/scan_result_shaping/json_input_test.rs
@@ -57,7 +57,7 @@ fn requested_package_detection_is_true_for_each_recognized_package_flag() {
 }
 
 #[test]
-fn into_parts_reports_package_detection_requested_when_any_merged_header_ran_it() {
+fn is_hollow_package_detection_input_is_false_when_any_header_requested_it() {
     let loaded = JsonScanInput {
         headers: vec![
             header_with_options(serde_json::Map::new()),
@@ -66,38 +66,85 @@ fn into_parts_reports_package_detection_requested_when_any_merged_header_ran_it(
                 serde_json::Value::Bool(true),
             )])),
         ],
-        files: vec![],
-        packages: vec![],
-        dependencies: vec![],
-        license_detections: vec![],
-        license_references: vec![],
-        license_rule_references: vec![],
-        excluded_count: 0,
+        files: vec![output_json_file(
+            "src/main.rs",
+            crate::models::FileType::File,
+        )],
+        ..Default::default()
     };
 
-    let (.., package_detection_requested_in_source) =
-        loaded.into_parts().expect("into_parts should succeed");
-
-    assert!(package_detection_requested_in_source);
+    assert!(!loaded.is_hollow_package_detection_input());
 }
 
 #[test]
-fn into_parts_reports_package_detection_not_requested_when_no_header_ran_it() {
+fn is_hollow_package_detection_input_is_true_when_no_header_requested_it() {
+    let loaded = JsonScanInput {
+        headers: vec![header_with_options(serde_json::Map::new())],
+        files: vec![output_json_file(
+            "src/main.rs",
+            crate::models::FileType::File,
+        )],
+        ..Default::default()
+    };
+
+    assert!(loaded.is_hollow_package_detection_input());
+}
+
+#[test]
+fn is_hollow_package_detection_input_is_false_without_scanned_files() {
+    // A truly empty scan document (no files at all) is not "hollow": that
+    // case keeps the existing documented empty-SBOM sentinel behavior and is
+    // guarded separately by the scanned-file-count check in
+    // `hollow_from_json_sbom_refusal` (`src/cli/run/mod.rs`).
     let loaded = JsonScanInput {
         headers: vec![header_with_options(serde_json::Map::new())],
         files: vec![],
-        packages: vec![],
-        dependencies: vec![],
-        license_detections: vec![],
-        license_references: vec![],
-        license_rule_references: vec![],
-        excluded_count: 0,
+        ..Default::default()
     };
 
-    let (.., package_detection_requested_in_source) =
-        loaded.into_parts().expect("into_parts should succeed");
+    assert!(!loaded.is_hollow_package_detection_input());
+}
 
-    assert!(!package_detection_requested_in_source);
+#[test]
+fn is_hollow_package_detection_input_is_false_when_packages_already_present() {
+    // Real package data outweighs a missing/absent header flag: this input
+    // was clearly examined for packages regardless of what its recorded
+    // options say.
+    let package = crate::models::Package::from_package_data(
+        &crate::models::PackageData {
+            package_type: Some(crate::models::PackageType::Npm),
+            name: Some("demo".to_string()),
+            version: Some("1.0.0".to_string()),
+            ..Default::default()
+        },
+        "package.json".to_string(),
+    );
+    let loaded = JsonScanInput {
+        headers: vec![header_with_options(serde_json::Map::new())],
+        files: vec![output_json_file(
+            "package.json",
+            crate::models::FileType::File,
+        )],
+        packages: vec![crate::output_schema::OutputPackage::from(&package)],
+        ..Default::default()
+    };
+
+    assert!(!loaded.is_hollow_package_detection_input());
+}
+
+#[test]
+fn into_parts_passes_through_has_hollow_package_detection_input_flag() {
+    for flag in [true, false] {
+        let loaded = JsonScanInput {
+            has_hollow_package_detection_input: flag,
+            ..Default::default()
+        };
+
+        let (.., has_hollow_package_detection_input) =
+            loaded.into_parts().expect("into_parts should succeed");
+
+        assert_eq!(has_hollow_package_detection_input, flag);
+    }
 }
 
 #[test]
@@ -295,6 +342,7 @@ fn normalize_loaded_json_scan_applies_strip_root_per_loaded_input() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, true, false);
@@ -359,6 +407,7 @@ fn normalize_loaded_json_scan_trims_full_root_display_without_absolutizing() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, false, true);
@@ -394,6 +443,7 @@ fn normalize_loaded_json_scan_prefixes_multi_resource_relative_replay_with_virtu
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, false, false);
@@ -421,6 +471,7 @@ fn normalize_loaded_json_scan_adds_virtual_root_directory_for_relative_replay() 
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, false, false);
@@ -507,6 +558,140 @@ fn load_and_merge_json_inputs_namespaces_multiple_replay_inputs() {
 
     let _ = fs::remove_file(first);
     let _ = fs::remove_file(second);
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn load_and_merge_json_inputs_flags_hollow_when_any_input_never_requested_detection() {
+    // Regression for the merge-masking bug: input A never ran package
+    // detection (hollow) but input B did. An aggregate `any()` across all
+    // merged headers would report "requested" for the whole merge and hide
+    // A's hollow files. The merged flag must stay hollow regardless.
+    let temp_dir = std::env::temp_dir().join("provenant-from-json-hollow-merge-masking-test");
+    let _ = fs::create_dir_all(&temp_dir);
+    let hollow_input = temp_dir.join("hollow.json");
+    let requested_input = temp_dir.join("requested.json");
+
+    fs::write(
+        &hollow_input,
+        json!({
+            "headers": [{"options": {}}],
+            "files": [
+                {"path": "src/main.rs", "type": "file", "scan_errors": []}
+            ],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write hollow json fixture");
+    fs::write(
+        &requested_input,
+        json!({
+            "headers": [{"options": {"--package": true}}],
+            "files": [
+                {"path": "README.md", "type": "file", "scan_errors": []}
+            ],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write requested json fixture");
+
+    let merged = load_and_merge_json_inputs(
+        &[
+            hollow_input.to_str().expect("utf-8 path").to_string(),
+            requested_input.to_str().expect("utf-8 path").to_string(),
+        ],
+        false,
+        false,
+    )
+    .expect("merged inputs should load");
+
+    assert!(merged.has_hollow_package_detection_input);
+
+    // Order must not matter: the hollow input silencing the merge would be
+    // just as wrong regardless of which side of the merge it is on.
+    let merged_reversed = load_and_merge_json_inputs(
+        &[
+            requested_input.to_str().expect("utf-8 path").to_string(),
+            hollow_input.to_str().expect("utf-8 path").to_string(),
+        ],
+        false,
+        false,
+    )
+    .expect("merged inputs should load in reverse order");
+
+    assert!(merged_reversed.has_hollow_package_detection_input);
+
+    let (.., has_hollow_package_detection_input) =
+        merged.into_parts().expect("into_parts should succeed");
+    assert!(has_hollow_package_detection_input);
+
+    let _ = fs::remove_file(hollow_input);
+    let _ = fs::remove_file(requested_input);
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn load_and_merge_json_inputs_not_hollow_when_every_input_requested_or_empty() {
+    let temp_dir = std::env::temp_dir().join("provenant-from-json-hollow-merge-safe-test");
+    let _ = fs::create_dir_all(&temp_dir);
+    let requested_input = temp_dir.join("requested.json");
+    let empty_input = temp_dir.join("empty.json");
+
+    fs::write(
+        &requested_input,
+        json!({
+            "headers": [{"options": {"--package": true}}],
+            "files": [
+                {"path": "README.md", "type": "file", "scan_errors": []}
+            ],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write requested json fixture");
+    fs::write(
+        &empty_input,
+        json!({
+            "headers": [{"options": {}}],
+            "files": [],
+            "packages": [],
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("write empty json fixture");
+
+    let merged = load_and_merge_json_inputs(
+        &[
+            requested_input.to_str().expect("utf-8 path").to_string(),
+            empty_input.to_str().expect("utf-8 path").to_string(),
+        ],
+        false,
+        false,
+    )
+    .expect("merged inputs should load");
+
+    assert!(!merged.has_hollow_package_detection_input);
+
+    let _ = fs::remove_file(requested_input);
+    let _ = fs::remove_file(empty_input);
     let _ = fs::remove_dir_all(temp_dir);
 }
 
@@ -643,6 +828,7 @@ fn into_parts_preserves_imported_header_errors_as_extra_errors() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     let (
@@ -690,6 +876,7 @@ fn into_parts_drops_imported_warnings_and_file_summary_errors() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     let (
@@ -729,6 +916,7 @@ fn into_parts_restores_file_warning_severity_from_header_warnings() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     let (process_result, _assembly_result, _dets, _refs, _rule_refs, extra_errors, _, _, _) =
@@ -768,6 +956,7 @@ fn normalize_loaded_json_scan_rewrites_verbose_header_error_path_prefix() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, false, true);
@@ -799,6 +988,7 @@ fn normalize_loaded_json_scan_rewrites_header_warnings_too() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     normalize_loaded_json_scan(&mut loaded, false, true);
@@ -862,6 +1052,7 @@ fn into_parts_discards_conflicting_imported_header_provenance() {
         license_references: vec![],
         license_rule_references: vec![],
         excluded_count: 0,
+        has_hollow_package_detection_input: false,
     };
 
     let (

--- a/tests/from_json_hollow_sbom_guard.rs
+++ b/tests/from_json_hollow_sbom_guard.rs
@@ -5,7 +5,7 @@
 //! `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml`) against silently emitting a
 //! hollow document when the reshaped input never ran package detection.
 //!
-//! See `guard_against_hollow_from_json_sbom` in `src/cli/run/mod.rs`.
+//! See `hollow_from_json_sbom_refusal` in `src/cli/run/mod.rs`.
 
 use std::fs;
 use std::process::Command;
@@ -31,7 +31,20 @@ fn write_from_json_fixture(
     files: Vec<Value>,
     packages: Vec<Value>,
 ) -> String {
-    let input_file = dir.path().join("input.json");
+    write_named_from_json_fixture(dir, "input.json", header_options, files, packages)
+}
+
+/// Same as [`write_from_json_fixture`], but with a caller-chosen file name so
+/// a single test can write more than one fixture (e.g. to merge two
+/// `--from-json` inputs).
+fn write_named_from_json_fixture(
+    dir: &TempDir,
+    file_name: &str,
+    header_options: Value,
+    files: Vec<Value>,
+    packages: Vec<Value>,
+) -> String {
+    let input_file = dir.path().join(file_name);
     fs::write(
         &input_file,
         json!({
@@ -322,4 +335,95 @@ fn from_json_plain_json_output_is_unaffected_by_the_hollow_sbom_guard() {
         "the guard must only apply to SBOM formats, not plain JSON reshapes: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn from_json_cyclonedx_fails_when_one_merged_input_is_hollow_even_if_another_requested_detection() {
+    // Regression: a merge that includes a hollow source (files present,
+    // package detection never requested) must not be silenced just because
+    // another merged input honestly requested detection.
+    let temp = TempDir::new().expect("temp dir");
+    let hollow_input = write_named_from_json_fixture(
+        &temp,
+        "hollow.json",
+        json!({}),
+        vec![sample_file("src/main.rs")],
+        vec![],
+    );
+    let requested_input = write_named_from_json_fixture(
+        &temp,
+        "requested.json",
+        json!({"--package": true}),
+        vec![sample_file("README.md")],
+        vec![],
+    );
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &hollow_input,
+            &requested_input,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "a merge including a hollow source must fail even though another merged input requested \
+         package detection"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow"),
+        "error should explain the hollow-SBOM guard, got: {stderr}"
+    );
+}
+
+#[test]
+fn from_json_hollow_sbom_target_is_skipped_but_other_outputs_still_write() {
+    // A refused SBOM target must not prevent other, non-SBOM output targets
+    // in the same request from being written.
+    let temp = TempDir::new().expect("temp dir");
+    let input_file =
+        write_from_json_fixture(&temp, json!({}), vec![sample_file("src/main.rs")], vec![]);
+    let bom_file = temp.path().join("bom.json");
+    let json_file_path = temp.path().join("out.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            bom_file.to_str().expect("utf-8 path"),
+            "--json-pp",
+            json_file_path.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "the run must still fail overall when an SBOM target is refused"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "hollow-SBOM guard failures use a dedicated exit code distinct from \
+         scan/runtime errors (1) and the license-policy gate (3)"
+    );
+    assert!(
+        !bom_file.exists(),
+        "the refused hollow CycloneDX target must not be written"
+    );
+    assert!(
+        json_file_path.exists(),
+        "the non-SBOM --json-pp target must still be written even though the SBOM target was refused"
+    );
+    let plain_json: Value =
+        serde_json::from_str(&fs::read_to_string(&json_file_path).expect("read plain json output"))
+            .expect("plain json output should be valid json");
+    assert!(plain_json.get("files").is_some());
 }

--- a/tests/from_json_hollow_sbom_guard.rs
+++ b/tests/from_json_hollow_sbom_guard.rs
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Guards `--from-json` reshapes that request an SBOM format (`--spdx-tv`,
+//! `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml`) against silently emitting a
+//! hollow document when the reshaped input never ran package detection.
+//!
+//! See `guard_against_hollow_from_json_sbom` in `src/cli/run/mod.rs`.
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn provenant_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_provenant"));
+    command.current_dir(env!("CARGO_MANIFEST_DIR"));
+    command
+}
+
+/// Builds a minimal `--from-json`-loadable scan document.
+///
+/// `header_options` mirrors the `header.options` map a real scan would record
+/// (e.g. `{"--package": true}`), and `packages` is the top-level packages
+/// array. `files` lets tests choose between a scan with real content and a
+/// truly empty scan document.
+fn write_from_json_fixture(
+    dir: &TempDir,
+    header_options: Value,
+    files: Vec<Value>,
+    packages: Vec<Value>,
+) -> String {
+    let input_file = dir.path().join("input.json");
+    fs::write(
+        &input_file,
+        json!({
+            "headers": [{
+                "tool_name": "provenant",
+                "tool_version": "0.0.0-test",
+                "options": header_options,
+                "notice": "test",
+                "start_timestamp": "2026-01-01T000000.000000",
+                "end_timestamp": "2026-01-01T000001.000000",
+                "output_format_version": "4.1.0",
+                "duration": 1.0,
+                "errors": [],
+                "warnings": [],
+                "extra_data": {
+                    "system_environment": {
+                        "operating_system": "linux",
+                        "cpu_architecture": "x86_64",
+                        "platform": "linux",
+                        "platform_version": "test",
+                        "rust_version": "1.0.0"
+                    },
+                    "spdx_license_list_version": "9.99",
+                    "files_count": files.len(),
+                    "directories_count": 0,
+                    "excluded_count": 0
+                }
+            }],
+            "files": files,
+            "packages": packages,
+            "dependencies": [],
+            "license_detections": [],
+            "license_references": [],
+            "license_rule_references": []
+        })
+        .to_string(),
+    )
+    .expect("failed to write from-json fixture");
+
+    input_file.to_string_lossy().to_string()
+}
+
+fn sample_file(path: &str) -> Value {
+    json!({
+        "path": path,
+        "type": "file",
+        "name": path,
+        "base_name": path,
+        "extension": "",
+        "size": 10,
+        "programming_language": "Rust"
+    })
+}
+
+fn sample_package() -> Value {
+    json!({
+        "package_uid": "pkg:npm/demo@1.0.0",
+        "type": "npm",
+        "name": "demo",
+        "version": "1.0.0",
+        "parties": [],
+        "datafile_paths": ["package.json"],
+        "datasource_ids": ["npm_package_json"]
+    })
+}
+
+#[test]
+fn from_json_cyclonedx_fails_when_source_never_ran_package_detection() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file =
+        write_from_json_fixture(&temp, json!({}), vec![sample_file("src/main.rs")], vec![]);
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "a hollow CycloneDX reshape must fail, not silently succeed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow"),
+        "error should explain the hollow-SBOM guard, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--cyclonedx"),
+        "error should name the offending flag, got: {stderr}"
+    );
+}
+
+#[test]
+fn from_json_spdx_tv_fails_when_source_never_ran_package_detection() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file =
+        write_from_json_fixture(&temp, json!({}), vec![sample_file("src/main.rs")], vec![]);
+    let output_file = temp.path().join("sbom.spdx");
+
+    let output = provenant_command()
+        .args([
+            "--spdx-tv",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "a hollow SPDX reshape must fail, not silently succeed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow"),
+        "error should explain the hollow-SBOM guard, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--spdx-tv"),
+        "error should name the offending flag, got: {stderr}"
+    );
+}
+
+#[test]
+fn from_json_cyclonedx_succeeds_when_source_ran_package_detection_and_found_none() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file = write_from_json_fixture(
+        &temp,
+        json!({"--package": true}),
+        vec![sample_file("README.md")],
+        vec![],
+    );
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "package detection honestly finding zero packages must not be treated as hollow: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bom: Value =
+        serde_json::from_str(&fs::read_to_string(&output_file).expect("read bom file"))
+            .expect("bom should be valid json");
+    assert_eq!(bom["components"], json!([]));
+}
+
+#[test]
+fn from_json_cyclonedx_succeeds_with_real_packages_in_input() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file = write_from_json_fixture(
+        &temp,
+        json!({}),
+        vec![sample_file("package.json")],
+        vec![sample_package()],
+    );
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a --from-json input with real packages must still emit a real SBOM: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bom: Value =
+        serde_json::from_str(&fs::read_to_string(&output_file).expect("read bom file"))
+            .expect("bom should be valid json");
+    let components = bom["components"].as_array().expect("components array");
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0]["name"], "demo");
+}
+
+#[test]
+fn from_json_spdx_tv_succeeds_with_real_packages_in_input() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file = write_from_json_fixture(
+        &temp,
+        json!({}),
+        vec![sample_file("package.json")],
+        vec![sample_package()],
+    );
+    let output_file = temp.path().join("sbom.spdx");
+
+    let output = provenant_command()
+        .args([
+            "--spdx-tv",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a --from-json input with real packages must still emit a real SBOM: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sbom = fs::read_to_string(&output_file).expect("read sbom file");
+    assert!(sbom.contains("PackageName: demo"));
+}
+
+#[test]
+fn from_json_cyclonedx_allows_truly_empty_scan_document() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file = write_from_json_fixture(&temp, json!({}), vec![], vec![]);
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a truly empty scan document is a legitimate empty SBOM, not a hollow one: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn from_json_spdx_tv_allows_truly_empty_scan_document() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file = write_from_json_fixture(&temp, json!({}), vec![], vec![]);
+    let output_file = temp.path().join("sbom.spdx");
+
+    let output = provenant_command()
+        .args([
+            "--spdx-tv",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a truly empty scan document is a legitimate empty SBOM, not a hollow one: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sbom = fs::read_to_string(&output_file).expect("read sbom file");
+    assert!(sbom.contains("No results for package"));
+}
+
+#[test]
+fn from_json_plain_json_output_is_unaffected_by_the_hollow_sbom_guard() {
+    let temp = TempDir::new().expect("temp dir");
+    let input_file =
+        write_from_json_fixture(&temp, json!({}), vec![sample_file("src/main.rs")], vec![]);
+
+    let output = provenant_command()
+        .args(["--json-pp", "-", "--from-json", &input_file])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "the guard must only apply to SBOM formats, not plain JSON reshapes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- `--from-json` can request `--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml` without ever rerunning package detection, so a reshape of a scan that never collected packages previously wrote a silently hollow SBOM: an empty CycloneDX `components` array or SPDX's no-package projection that looks like a normal successful export.
- Add a guard that refuses the SBOM export when the `--from-json` input has scanned files but no packages, and its recorded header options show package detection was never requested (`--package`, `--package-only`, `--system-package`, `--package-in-compiled`) in the original scan.

## Scope and exclusions

- Included:
  - Track whether any merged `--from-json` input's header options requested package detection, threaded through `JsonHeaderInput` → `JsonScanInput::into_parts` → `ScanSession` → `ExecutedRequest`.
  - New `guard_against_hollow_from_json_sbom` check in `src/cli/run/mod.rs`, run after `execute_request` and before output is written.
  - `docs/CLI_GUIDE.md` notes on the new contract in the SPDX/CycloneDX and `--from-json` reshape sections.
  - Unit tests for `JsonHeaderInput::requested_package_detection` and `guard_against_hollow_from_json_sbom`, plus a new CLI integration test file.
- Explicit exclusions:
  - No change to SPDX/CycloneDX emission semantics themselves (the existing empty-SBOM sentinel behavior for a genuinely empty scan document is untouched).
  - No change to native-scan behavior; native scans always run their own detection pass, so `package_detection_requested_in_source` is always `true` for them.

## How to verify

- CI covers the new unit tests (`src/scan_result_shaping/json_input_test.rs`, `src/cli/run/tests.rs`) and the new integration suite (`tests/from_json_hollow_sbom_guard.rs`), including: a hollow reshape failing for both SPDX and CycloneDX, a reshape succeeding when the source ran package detection and honestly found none, a reshape succeeding when the source JSON has real packages, a reshape into a non-SBOM format being unaffected, and a truly empty scan document (no files) still reshaping successfully.
- To poke at it manually: scan without `--package`, save as `--json`, then reshape with `--from-json <file> --cyclonedx -` — expect a non-zero exit and an explanatory error instead of an empty `components` array.

## Follow-up work

- Created or intentionally deferred: none identified; the guard is scoped to the `--from-json` → SBOM path described in the issue.