### PR TITLE
fix(cli): refuse or warn on SBOM export from assembly-starved native scans

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -329,6 +329,8 @@ If you explicitly ask for non-license detections such as `--email`, `--url`, or 
 
 If you want assembled top-level packages and dependencies, use `--package` instead.
 
+Because `--package-only` (and `--no-assemble`) skip top-level package assembly outright, Provenant refuses to combine either flag with an SBOM format (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) when there is real scanned content — see section 10.
+
 ### 7. "I need system package data"
 
 ```sh
@@ -394,6 +396,12 @@ In practice:
 - `--package` is usually part of these workflows because package/dependency data is central to SBOM output.
 
 Reshaping with `--from-json` (see section 14) into an SBOM format needs the original scan to have run package detection. If the JSON being reshaped never ran `--package`/`--package-only`/`--system-package`/`--package-in-compiled` and it has no packages, Provenant refuses the SBOM export instead of silently writing an empty `components` array or SPDX's no-package projection. This check runs per merged `--from-json` input, so merging several JSON files where even one of them never ran package detection still refuses — a different merged input that did request detection does not override it. Rescan with one of those flags first, or reshape to `--json`/`--json-pp` instead if you only need file-level data. A refused SBOM target does not block other, non-SBOM output targets requested in the same run (e.g. `--cyclonedx bom.json --json out.json`): the non-SBOM outputs are still written, and the process exits with a dedicated non-zero exit code distinct from a scan/runtime error or the license-policy gate.
+
+The same refusal applies to a native (non-`--from-json`) scan that combines an SBOM format with `--package-only` or `--no-assemble`: both flags unconditionally skip the top-level package assembly that SBOM export reads from, for the whole run, regardless of what was scanned. Drop `--package-only`/`--no-assemble` (use `--package` instead) before requesting an SBOM format, or reshape to `--json`/`--json-pp` if a package-less export was intended. This shares the same dedicated exit code and "write the artifact, then fail" behavior as the `--from-json` case above.
+
+Combining an SBOM format with `--paths-file` (see section 21) only warns, since assembly still runs and can produce a genuinely well-formed SBOM from whatever was selected — but that export can understate a monorepo's real inventory if the selection omitted sibling member manifests or a workspace root. The export is still written; rerun without `--paths-file` (or widen the selection to the full workspace) when you need a guaranteed-complete SBOM.
+
+Both the refusal and the warning above are always printed to stderr, even under `--quiet`, so a caller that only checks the exit code still has an explanation available if they look; `--quiet` otherwise suppresses Provenant's normal progress and informational logging for the scan subcommand.
 
 ### 11. "I need Debian copyright output"
 
@@ -666,6 +674,7 @@ Current behavior:
 - missing entries are skipped with a warning
 - `--paths-file -` reads the list from stdin
 - `--paths-file` cannot currently be combined with `--from-json`
+- combining `--paths-file` with an SBOM format (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) still writes the export, but Provenant emits a loud warning that the selection may omit sibling manifests or a workspace root, so the inventory can understate the full repository — see section 10
 
 Example with stdin:
 
@@ -690,6 +699,8 @@ These are worth learning early because they change what the output means:
 - `--debian <FILE>` requires `--license`, `--copyright`, and `--license-text`
 - `--fail-on <LEVEL>` requires `--license-policy`; a violation exits with code 3
 - an SBOM format (`--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml`) combined with `--from-json` on an input that never ran package detection is refused and exits with code 4, while any other requested non-SBOM output targets are still written
+- an SBOM format combined with `--package-only` or `--no-assemble` on a native scan with real scanned content is refused the same way and shares exit code 4
+- an SBOM format combined with `--paths-file` still writes the export but logs a loud warning that the inventory may understate the full repository
 - `--sarif <FILE>` only emits results for `--license-policy` entries that carry a `compliance_alert`
 - `--paths-file <FILE>` requires exactly one native scan root and is currently native-scan only (no `--from-json`)
 - `--reindex` only matters when the license engine is initialized (`--license` and some `--from-json` reference-recompute flows)

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::app::request::{InputMode, ScanRequest};
+use crate::app::request::{InputMode, OutputTarget, ScanRequest};
 use crate::app::scan_pipeline::execute_request;
 use crate::cli::{Cli, Command, ScanArgs};
 use crate::compare::compare_json_files;
 use crate::license_detection::dataset::export_embedded_license_dataset;
 use crate::models::{FileType, Output};
 use crate::output::{OutputFormat, OutputWriteConfig, write_output_file};
-use crate::progress::{ScanProgress, init_cli_logger};
+use crate::progress::{ProgressMode, ScanProgress, init_cli_logger};
 use crate::serve::run as run_serve_shell;
 use crate::time::format_scancode_timestamp;
 use anyhow::{Result, anyhow};
@@ -116,22 +116,42 @@ pub fn run() -> Result<ExitCode> {
     // below; it must not short-circuit non-SBOM outputs in the same request
     // (e.g. `--spdx-tv out.spdx --json out.json`), so it is computed as a
     // value up front instead of using `?` to bail out of `run` immediately.
+    // Covers two independent causes: a `--from-json` reshape whose source
+    // scan never ran package detection, and a native `--package-only`/
+    // `--no-assemble` scan that unconditionally skipped assembly this run.
     let hollow_sbom_refusal = hollow_from_json_sbom_refusal(
         &request,
         &output,
         executed.has_hollow_package_detection_input,
-    );
+    )
+    .or_else(|| assembly_skipped_sbom_refusal(&request, &output));
+
+    // Unlike the refusal above, this only warns: `--paths-file` assembly can
+    // produce a genuinely well-formed SBOM, just one that may understate the
+    // repository if the selection omitted sibling manifests or a workspace
+    // root. Skipped once a hollow-SBOM refusal already blocks every SBOM
+    // target this run, since there is then no written SBOM left to warn
+    // about.
+    if hollow_sbom_refusal.is_none()
+        && let Some(warning) = paths_file_sbom_completeness_warning(&request)
+    {
+        emit_sbom_guard_diagnostic(request.progress_mode, &warning, false);
+    }
 
     let output_schema_output =
         crate::output_schema::Output::from_with_compat_mode(&output, cli.compat_mode);
     progress.start_output();
     for target in &request.output_targets {
         if hollow_sbom_refusal.is_some() && SBOM_OUTPUT_FORMATS.contains(&target.format) {
-            log::error!(
-                "Skipping {:?} output to {}: {}",
-                target.format,
-                target.file,
-                hollow_sbom_refusal.as_deref().unwrap_or_default()
+            emit_sbom_guard_diagnostic(
+                request.progress_mode,
+                &format!(
+                    "Skipping {:?} output to {}: {}",
+                    target.format,
+                    target.file,
+                    hollow_sbom_refusal.as_deref().unwrap_or_default()
+                ),
+                true,
             );
             continue;
         }
@@ -168,8 +188,12 @@ pub fn run() -> Result<ExitCode> {
     // Fails the run after all allowed outputs are already written (same
     // never-lose-the-artifact shape as the license-policy gate below).
     if let Some(refusal) = hollow_sbom_refusal {
-        log::error!(
-            "Hollow-SBOM guard: {refusal} Failing with exit code {HOLLOW_SBOM_GUARD_EXIT_CODE}."
+        emit_sbom_guard_diagnostic(
+            request.progress_mode,
+            &format!(
+                "Hollow-SBOM guard: {refusal} Failing with exit code {HOLLOW_SBOM_GUARD_EXIT_CODE}."
+            ),
+            true,
         );
         return Ok(ExitCode::from(HOLLOW_SBOM_GUARD_EXIT_CODE));
     }
@@ -280,6 +304,29 @@ fn validate_scan_option_compatibility(cli: &ScanArgs) -> Result<()> {
     Ok(())
 }
 
+/// Emits an SBOM-guard diagnostic (a refusal explanation or a completeness
+/// warning) so it is never silently dropped.
+///
+/// `ScanProgress::init_logging_bridge` deliberately never installs a logger
+/// at all in `--quiet` mode (see `src/progress.rs`), so a plain
+/// `log::error!`/`log::warn!` call would vanish with no trace — even though a
+/// refusal still changes the process's exit code, and a `--quiet` caller who
+/// only checks the exit code would otherwise have no way to learn why an SBOM
+/// target was skipped. Falling back to a direct `eprintln!` in that case
+/// keeps the message honest without depending on whether a logger happens to
+/// be installed. In Default/Verbose mode the bridge is installed and active,
+/// so this routes through `log` as usual to stay interleaved with progress
+/// bars instead of writing over them.
+fn emit_sbom_guard_diagnostic(progress_mode: ProgressMode, message: &str, is_error: bool) {
+    if progress_mode == ProgressMode::Quiet {
+        eprintln!("{message}");
+    } else if is_error {
+        log::error!("{message}");
+    } else {
+        log::warn!("{message}");
+    }
+}
+
 /// SBOM-oriented output formats whose entire value proposition is the package
 /// inventory: an SPDX or CycloneDX document with zero packages looks like a
 /// normal, successful export while actually reporting no components at all.
@@ -298,6 +345,17 @@ fn sbom_output_flag(format: OutputFormat) -> &'static str {
         OutputFormat::CycloneDxXml => "--cyclonedx-xml",
         _ => "<sbom-format>",
     }
+}
+
+/// CLI flags for whichever SBOM formats (see [`SBOM_OUTPUT_FORMATS`]) appear
+/// among `output_targets`, in request order. Empty when none were requested.
+fn requested_sbom_flags(output_targets: &[OutputTarget]) -> Vec<&'static str> {
+    output_targets
+        .iter()
+        .map(|target| target.format)
+        .filter(|format| SBOM_OUTPUT_FORMATS.contains(format))
+        .map(sbom_output_flag)
+        .collect()
 }
 
 /// Returns a refusal message when a `--from-json` reshape requests an SBOM
@@ -357,13 +415,7 @@ fn hollow_from_json_sbom_refusal(
         return None;
     }
 
-    let requested_sbom_flags: Vec<&'static str> = request
-        .output_targets
-        .iter()
-        .map(|target| target.format)
-        .filter(|format| SBOM_OUTPUT_FORMATS.contains(format))
-        .map(sbom_output_flag)
-        .collect();
+    let requested_sbom_flags = requested_sbom_flags(&request.output_targets);
     if requested_sbom_flags.is_empty() {
         return None;
     }
@@ -377,6 +429,120 @@ fn hollow_from_json_sbom_refusal(
          scan was intended.",
         requested_sbom_flags.join(", "),
         scanned_file_count,
+        requested_sbom_flags.join(", "),
+    ))
+}
+
+/// Returns a refusal message when a **native** scan requests an SBOM format
+/// while `--package-only` or `--no-assemble` forced top-level package
+/// assembly to be skipped for the whole run (see `skip_assembly` in
+/// `src/app/scan_pipeline.rs`).
+///
+/// Both flags unconditionally zero out `output.packages`/`output.dependencies`
+/// regardless of what was scanned: `--package-only` intentionally trades the
+/// top-level assembled view for a faster, narrower per-file pass, and
+/// `--no-assemble` disables assembly outright. Either way, CycloneDX would
+/// write an empty `components` array and SPDX would fall back to its
+/// no-package projection — both indistinguishable from a normal, honest
+/// export with zero packages, even though the scanned files may carry
+/// per-file package manifests that were simply never assembled into the
+/// top-level view the SBOM formats read from.
+///
+/// Like [`hollow_from_json_sbom_refusal`], this is a query, not a hard gate:
+/// it returns `Some(message)` so the caller can skip only the requested SBOM
+/// output target(s) while still writing any other requested output formats
+/// in the same request (see the output loop and
+/// [`HOLLOW_SBOM_GUARD_EXIT_CODE`] in `run`).
+///
+/// This intentionally does **not** fire for:
+/// - `--from-json` reshapes (covered separately by
+///   [`hollow_from_json_sbom_refusal`], which reasons about the *source*
+///   scan's recorded options rather than this run's flags);
+/// - requests that do not ask for an SBOM format;
+/// - a truly empty scan document (no files at all);
+/// - the (currently impossible, but defensively checked) case where
+///   `output.packages` is non-empty despite the skip, so this guard degrades
+///   gracefully rather than fires a false positive if that invariant ever
+///   changes.
+fn assembly_skipped_sbom_refusal(request: &ScanRequest, output: &Output) -> Option<String> {
+    if !matches!(request.input_mode, InputMode::Native) {
+        return None;
+    }
+    if !(request.package_only || request.no_assemble) {
+        return None;
+    }
+    if !output.packages.is_empty() {
+        return None;
+    }
+
+    let scanned_file_count = output
+        .files
+        .iter()
+        .filter(|file| file.file_type == FileType::File)
+        .count();
+    if scanned_file_count == 0 {
+        return None;
+    }
+
+    let requested_sbom_flags = requested_sbom_flags(&request.output_targets);
+    if requested_sbom_flags.is_empty() {
+        return None;
+    }
+
+    let cause_flag = if request.package_only {
+        "--package-only"
+    } else {
+        "--no-assemble"
+    };
+
+    Some(format!(
+        "Refusing to write a hollow SBOM for {}: {cause_flag} skips top-level package assembly for \
+         this entire scan, so the {} scanned file(s) were never assembled into the top-level \
+         packages/dependencies view that SBOM export reads from, even if some of those files carry \
+         their own per-file package manifests. Rerun without {cause_flag} (e.g. with --package \
+         instead) before requesting an SBOM format, or drop {} if a package-less export was intended.",
+        requested_sbom_flags.join(", "),
+        scanned_file_count,
+        requested_sbom_flags.join(", "),
+    ))
+}
+
+/// Returns a loud, non-blocking warning when a **native** `--paths-file` scan
+/// requests an SBOM format.
+///
+/// `--paths-file` deliberately narrows collection to a caller-selected subset
+/// of files under the scan root (see `docs/CLI_GUIDE.md`), so assembly only
+/// ever sees the manifests, lockfiles, and workspace context that fell inside
+/// that selection. Unlike [`assembly_skipped_sbom_refusal`], assembly still
+/// runs and can produce a genuinely non-empty, well-formed SBOM — but that
+/// SBOM can silently understate a monorepo's real inventory whenever the
+/// selection omits sibling member manifests or a workspace root that
+/// topology-aware assembly would otherwise use to complete the picture.
+/// Provenant has no bounded, static way to tell "this selection happens to be
+/// complete" apart from "this selection quietly dropped sibling manifests"
+/// without rescanning the whole tree, which would defeat the point of
+/// `--paths-file`. So this warns instead of refusing: the export is still
+/// written, and callers who need a guaranteed-complete inventory should
+/// rerun without `--paths-file`.
+///
+/// Returns `None` when `--paths-file` was not used, the request is not a
+/// native scan, or no SBOM format was requested.
+fn paths_file_sbom_completeness_warning(request: &ScanRequest) -> Option<String> {
+    if !matches!(request.input_mode, InputMode::Native) || request.paths_files.is_empty() {
+        return None;
+    }
+
+    let requested_sbom_flags = requested_sbom_flags(&request.output_targets);
+    if requested_sbom_flags.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "--paths-file restricted this scan to a caller-selected subset of files, so the {} export \
+         only reflects packages whose manifests fell inside that selection. If this repository has \
+         sibling member manifests, lockfiles, or a workspace root outside the selection, the \
+         resulting inventory may understate the full repository. Rerun without --paths-file (or \
+         widen the selection to include the full workspace) if you need a guaranteed-complete SBOM.",
         requested_sbom_flags.join(", "),
     ))
 }

--- a/src/cli/run/tests.rs
+++ b/src/cli/run/tests.rs
@@ -265,6 +265,14 @@ fn from_json_sbom_request(sbom_flag: &str, output_file: &str) -> ScanRequest {
     ScanRequest::from(cli.scan_args().expect("scan args should be present"))
 }
 
+fn native_sbom_request(sbom_flag: &str, output_file: &str, extra_args: &[&str]) -> ScanRequest {
+    let mut args = vec!["provenant", sbom_flag, output_file];
+    args.extend_from_slice(extra_args);
+    args.push("sample-dir");
+    let cli = crate::cli::Cli::try_parse_from(args).expect("cli parse should succeed");
+    ScanRequest::from(cli.scan_args().expect("scan args should be present"))
+}
+
 fn output_with_files(files: Vec<crate::models::FileInfo>) -> crate::models::Output {
     crate::models::Output {
         summary: None,
@@ -386,6 +394,107 @@ fn hollow_from_json_sbom_refusal_allows_requests_with_real_packages() {
     )];
 
     assert!(hollow_from_json_sbom_refusal(&request, &output, false).is_none());
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_fires_for_package_only_with_scanned_files() {
+    let request = native_sbom_request("--cyclonedx", "bom.json", &["--package-only"]);
+    let output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+
+    let refusal = assembly_skipped_sbom_refusal(&request, &output)
+        .expect("--package-only must refuse a hollow cyclonedx export");
+    assert!(refusal.contains("--package-only"));
+    assert!(refusal.contains("--cyclonedx"));
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_fires_for_no_assemble_with_scanned_files() {
+    let request = native_sbom_request("--spdx-tv", "sbom.spdx", &["--no-assemble", "--package"]);
+    let output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+
+    let refusal = assembly_skipped_sbom_refusal(&request, &output)
+        .expect("--no-assemble must refuse a hollow spdx-tv export");
+    assert!(refusal.contains("--no-assemble"));
+    assert!(refusal.contains("--spdx-tv"));
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_allows_non_sbom_output_formats() {
+    let request = native_sbom_request("--json-pp", "-", &["--package-only"]);
+    let output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+
+    assert!(assembly_skipped_sbom_refusal(&request, &output).is_none());
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_allows_truly_empty_scan_documents() {
+    let request = native_sbom_request("--cyclonedx-xml", "bom.xml", &["--package-only"]);
+    let output = output_with_files(vec![]);
+
+    assert!(assembly_skipped_sbom_refusal(&request, &output).is_none());
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_allows_package_without_assembly_skip() {
+    let request = native_sbom_request("--cyclonedx", "bom.json", &["--package"]);
+    let output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+
+    assert!(assembly_skipped_sbom_refusal(&request, &output).is_none());
+}
+
+#[test]
+fn assembly_skipped_sbom_refusal_does_not_fire_for_from_json() {
+    let request = from_json_sbom_request("--cyclonedx", "bom.json");
+    let output = output_with_files(vec![json_file(
+        "package.json",
+        crate::models::FileType::File,
+    )]);
+
+    assert!(assembly_skipped_sbom_refusal(&request, &output).is_none());
+}
+
+#[test]
+fn paths_file_sbom_completeness_warning_fires_for_native_paths_file_sbom_export() {
+    let request = native_sbom_request(
+        "--cyclonedx",
+        "bom.json",
+        &["--package", "--paths-file", "changed.txt"],
+    );
+
+    let warning = paths_file_sbom_completeness_warning(&request)
+        .expect("--paths-file combined with an SBOM format must warn");
+    assert!(warning.contains("--paths-file"));
+    assert!(warning.contains("--cyclonedx"));
+}
+
+#[test]
+fn paths_file_sbom_completeness_warning_allows_non_sbom_output_formats() {
+    let request = native_sbom_request(
+        "--json-pp",
+        "-",
+        &["--package", "--paths-file", "changed.txt"],
+    );
+
+    assert!(paths_file_sbom_completeness_warning(&request).is_none());
+}
+
+#[test]
+fn paths_file_sbom_completeness_warning_allows_requests_without_paths_file() {
+    let request = native_sbom_request("--spdx-rdf", "sbom.rdf", &["--package"]);
+
+    assert!(paths_file_sbom_completeness_warning(&request).is_none());
 }
 
 #[test]

--- a/tests/from_json_hollow_sbom_guard.rs
+++ b/tests/from_json_hollow_sbom_guard.rs
@@ -383,6 +383,35 @@ fn from_json_cyclonedx_fails_when_one_merged_input_is_hollow_even_if_another_req
 }
 
 #[test]
+fn from_json_cyclonedx_refusal_is_explained_even_in_quiet_mode() {
+    // Regression: `ScanProgress::init_logging_bridge` never installs a
+    // logger at all in `--quiet` mode, so a plain `log::error!` refusal
+    // message would otherwise vanish, leaving only the exit code.
+    let temp = TempDir::new().expect("temp dir");
+    let input_file =
+        write_from_json_fixture(&temp, json!({}), vec![sample_file("src/main.rs")], vec![]);
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--from-json",
+            &input_file,
+            "--quiet",
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow") && stderr.contains("--cyclonedx"),
+        "the refusal must still explain itself under --quiet, got: {stderr}"
+    );
+}
+
+#[test]
 fn from_json_hollow_sbom_target_is_skipped_but_other_outputs_still_write() {
     // A refused SBOM target must not prevent other, non-SBOM output targets
     // in the same request from being written.

--- a/tests/native_sbom_inventory_guard.rs
+++ b/tests/native_sbom_inventory_guard.rs
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Guards native scans that request an SBOM format (`--spdx-tv`,
+//! `--spdx-rdf`, `--cyclonedx`, `--cyclonedx-xml`) against two CLI footguns
+//! that can produce a schema-valid but hollow or understated inventory:
+//!
+//! - `--package-only`/`--no-assemble` unconditionally skip top-level package
+//!   assembly for the whole run, so the SBOM would read an empty
+//!   `packages`/`dependencies` view even though the scanned files may carry
+//!   their own per-file package manifests (refused; see
+//!   `assembly_skipped_sbom_refusal` in `src/cli/run/mod.rs`).
+//! - `--paths-file` narrows collection to a caller-selected subset of files,
+//!   so assembly can silently understate a monorepo if the selection omits
+//!   sibling manifests or a workspace root (warned, not refused; see
+//!   `paths_file_sbom_completeness_warning` in `src/cli/run/mod.rs`).
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn provenant_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_provenant"));
+    command.current_dir(env!("CARGO_MANIFEST_DIR"));
+    command
+}
+
+fn npm_project(temp: &TempDir) -> std::path::PathBuf {
+    let project_dir = temp.path().join("project");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    fs::write(
+        project_dir.join("package.json"),
+        r#"{"name": "demo", "version": "1.0.0"}"#,
+    )
+    .expect("write package.json");
+    project_dir
+}
+
+#[test]
+fn package_only_cyclonedx_is_refused_when_files_were_scanned() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--package-only",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "--package-only must refuse a hollow CycloneDX export, not silently succeed"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "the assembly-skipped SBOM guard uses the same dedicated exit code as the \
+         --from-json hollow-SBOM guard"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow"),
+        "error should explain the assembly-skipped guard, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--package-only"),
+        "error should name the offending flag, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--cyclonedx"),
+        "error should name the refused output flag, got: {stderr}"
+    );
+    assert!(
+        !output_file.exists(),
+        "the refused hollow CycloneDX target must not be written"
+    );
+}
+
+#[test]
+fn no_assemble_spdx_tv_is_refused_when_files_were_scanned() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let output_file = temp.path().join("sbom.spdx");
+
+    let output = provenant_command()
+        .args([
+            "--spdx-tv",
+            output_file.to_str().expect("utf-8 path"),
+            "--package",
+            "--no-assemble",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "--no-assemble must refuse a hollow SPDX export, not silently succeed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow"),
+        "error should explain the assembly-skipped guard, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--no-assemble"),
+        "error should name the offending flag, got: {stderr}"
+    );
+    assert!(
+        !output_file.exists(),
+        "the refused hollow SPDX target must not be written"
+    );
+}
+
+#[test]
+fn package_only_cyclonedx_refusal_is_explained_even_in_quiet_mode() {
+    // Regression: `ScanProgress::init_logging_bridge` never installs a
+    // logger at all in `--quiet` mode, so a plain `log::error!` refusal
+    // message would otherwise vanish, leaving only the exit code.
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--package-only",
+            "--quiet",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hollow") && stderr.contains("--package-only"),
+        "the refusal must still explain itself under --quiet, got: {stderr}"
+    );
+}
+
+#[test]
+fn package_only_hollow_sbom_target_is_skipped_but_other_outputs_still_write() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let bom_file = temp.path().join("bom.json");
+    let json_file_path = temp.path().join("out.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            bom_file.to_str().expect("utf-8 path"),
+            "--json-pp",
+            json_file_path.to_str().expect("utf-8 path"),
+            "--package-only",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        !output.status.success(),
+        "the run must still fail overall when an SBOM target is refused"
+    );
+    assert_eq!(output.status.code(), Some(4));
+    assert!(!bom_file.exists());
+    assert!(
+        json_file_path.exists(),
+        "the non-SBOM --json-pp target must still be written even though the SBOM target was refused"
+    );
+}
+
+#[test]
+fn package_only_plain_json_output_is_unaffected_by_the_guard() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+
+    let output = provenant_command()
+        .args([
+            "--json-pp",
+            "-",
+            "--package-only",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "the guard must only apply to SBOM formats, not plain JSON output: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn package_only_cyclonedx_allows_truly_empty_scan_document() {
+    let temp = TempDir::new().expect("temp dir");
+    let empty_dir = temp.path().join("empty");
+    fs::create_dir_all(&empty_dir).expect("create empty dir");
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--package-only",
+            empty_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a truly empty scan document is a legitimate empty SBOM, not a hollow one: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn paths_file_cyclonedx_warns_but_still_writes_the_export() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let paths_file = temp.path().join("changed.txt");
+    fs::write(&paths_file, "package.json\n").expect("write paths file");
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--package",
+            "--paths-file",
+            paths_file.to_str().expect("utf-8 path"),
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "--paths-file must warn, not fail, since assembly can still produce a real SBOM: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--paths-file"),
+        "stderr should carry a loud completeness warning, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--cyclonedx"),
+        "warning should name the SBOM flag it applies to, got: {stderr}"
+    );
+    assert!(
+        output_file.exists(),
+        "the SBOM target must still be written"
+    );
+    let bom: Value =
+        serde_json::from_str(&fs::read_to_string(&output_file).expect("read bom file"))
+            .expect("bom should be valid json");
+    let components = bom["components"].as_array().expect("components array");
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0]["name"], "demo");
+}
+
+#[test]
+fn paths_file_cyclonedx_warning_is_visible_even_in_quiet_mode() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let paths_file = temp.path().join("changed.txt");
+    fs::write(&paths_file, "package.json\n").expect("write paths file");
+    let output_file = temp.path().join("bom.json");
+
+    let output = provenant_command()
+        .args([
+            "--cyclonedx",
+            output_file.to_str().expect("utf-8 path"),
+            "--package",
+            "--paths-file",
+            paths_file.to_str().expect("utf-8 path"),
+            "--quiet",
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--paths-file") && stderr.contains("--cyclonedx"),
+        "the completeness warning must still be visible under --quiet, got: {stderr}"
+    );
+    assert!(output_file.exists());
+}
+
+#[test]
+fn paths_file_plain_json_output_does_not_carry_the_completeness_warning() {
+    let temp = TempDir::new().expect("temp dir");
+    let project_dir = npm_project(&temp);
+    let paths_file = temp.path().join("changed.txt");
+    fs::write(&paths_file, "package.json\n").expect("write paths file");
+
+    let output = provenant_command()
+        .args([
+            "--json-pp",
+            "-",
+            "--package",
+            "--paths-file",
+            paths_file.to_str().expect("utf-8 path"),
+            project_dir.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to run provenant");
+
+    assert!(
+        output.status.success(),
+        "a plain JSON --paths-file scan should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("may understate the full repository"),
+        "the SBOM completeness warning must not fire for non-SBOM output formats, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- `--package-only` and `--no-assemble` unconditionally skip top-level package assembly for the whole run, so `--spdx-tv`/`--spdx-rdf`/`--cyclonedx`/`--cyclonedx-xml` could silently write an empty inventory that still looks like a normal, successful export even when the scanned files carry per-file package manifests.
- `--paths-file` narrows collection to a caller-selected subset of files, so assembly can produce a genuinely well-formed but understated SBOM if the selection omits sibling member manifests or a workspace root.
- Add `assembly_skipped_sbom_refusal` (refuses, exit code 4, same "write other outputs, then fail" contract as the existing `--from-json` hollow-SBOM guard from #1295) for the first case, and `paths_file_sbom_completeness_warning` (loud, non-blocking `log::warn!`) for the second.

## Issues

- Covers: CLI footguns around incomplete SBOM inventory when assembly/topology context is amputated (package-only assembly skip and sparse paths-file selection), from a prior survey.

## Scope and exclusions

- Included:
  - `assembly_skipped_sbom_refusal` in `src/cli/run/mod.rs`: refuses an SBOM target for a native scan combining `--package-only`/`--no-assemble` with real scanned content, sharing the existing `HOLLOW_SBOM_GUARD_EXIT_CODE` (4) and per-target skip behavior with the `--from-json` guard.
  - `paths_file_sbom_completeness_warning` in `src/cli/run/mod.rs`: emits a loud warning (not a refusal) when `--paths-file` is combined with an SBOM format, since assembly still runs and can produce a real, non-hollow SBOM — just possibly an understated one.
  - `docs/CLI_GUIDE.md` updates in the SBOM, `--package-only`, `--paths-file`, and flag-combination sections describing both new contracts.
  - Unit tests in `src/cli/run/tests.rs` and a new CLI integration suite `tests/native_sbom_inventory_guard.rs`.
- Explicit exclusions:
  - No changes to monorepo/workspace topology assembly logic itself (owned by other in-flight work); the `--paths-file` case intentionally warns rather than trying to detect "this selection omitted a workspace root," which would require topology knowledge or a full rescan.
  - No change to `--from-json` behavior; the existing hollow-SBOM guard from #1295 is untouched (a shared `requested_sbom_flags` helper was factored out, but its behavior is unchanged, and a new unit test confirms the new native-scan guard does not fire for `--from-json`).
  - No change to legitimate `--package-only`/`--paths-file` workflows that don't request an SBOM format, or to `--package-only`/`--paths-file` combined with an SBOM format on a truly empty scan (no files at all).

## How to verify

- CI covers the new unit tests (`src/cli/run/tests.rs`) and the new integration suite (`tests/native_sbom_inventory_guard.rs`): `--package-only`/`--no-assemble` refusing an SBOM export with real content, that refusal not blocking a co-requested `--json-pp` target, a truly empty scan still succeeding, `--paths-file` warning but still writing a real SBOM, and plain `--json-pp` output being unaffected by either guard.
- To poke at it manually: `provenant scan --cyclonedx bom.json --package-only /path/to/project` should fail with a non-zero exit and an explanatory "hollow" error instead of an empty `components` array; `provenant scan --cyclonedx bom.json --package --paths-file changed.txt /path/to/project` should still succeed but print a stderr warning about the selection possibly understating the inventory.

## Follow-up work

- Created or intentionally deferred: a topology-aware "this `--paths-file` selection actually omitted a workspace root" check is intentionally deferred — it would require the monorepo topology assembly work owned by a separate in-flight PR, and a purely static check without that work would either be too narrow to catch real cases or too broad to avoid false positives on non-monorepo repos.

Made with [Cursor](https://cursor.com)