### PR TITLE
docs: surface monorepo inventory and SBOM selection advantages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ On macOS or Linux you can also `brew install getprovenant/tap/provenant`. Prefer
 
 - [Benchmark-backed](docs/BENCHMARKS.md) speedups — frequently about an order of magnitude faster than ScanCode on recorded same-host runs
 - Broader package and dependency extraction across [many ecosystems](docs/SUPPORTED_FORMATS.md), with intentional parser improvements on surfaces that overlap ScanCode
+- Clearer monorepo inventories — workspace, reactor, and multiproject layouts (Cargo, npm/pnpm/yarn, Maven, Gradle, uv, Mix, Dart, and related) attribute nested sources and shared locks to the right packages instead of leaving a flat per-directory view
 - [Documented parser and detection fixes](docs/improvements/README.md) that cut noisy results and false-positive classes, including better bare-word GPL/LGPL clue handling
 - CI license-compliance gating — policy severities with a build-failing [`--fail-on`](docs/CLI_GUIDE.md#17-i-want-policy-aware-license-review) gate and SARIF output for the code-scanning UI
-- Native workflows: `--incremental` cache reuse, `--paths-file` changed-file scans, and long-lived HTTP service mode via [`provenant serve`](docs/SERVE_API_GUIDE.md)
+- Native workflows: `--incremental` cache reuse, `--paths-file` changed-file scans with SBOM completeness warnings when a selection may understate a workspace, and long-lived HTTP service mode via [`provenant serve`](docs/SERVE_API_GUIDE.md)
+- Source-faithful file-level copyright text by default (ScanCode-style rendering available via `--compat-mode scancode`)
 - Single self-contained binary with parallel native execution
 - [Security-first](docs/adr/0004-security-first-parsing.md) static parsing — no execution of scanned code or package-manager code, with bounded resource use
 

--- a/docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md
+++ b/docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md
@@ -117,7 +117,19 @@ If your downstream workflow needs the historic ScanCode-style rendered value in 
 provenant scan --json-pp scan.json --copyright --compat-mode scancode /path/to/project
 ```
 
-### 6. Parser behavior can be more capable than ScanCode on some documented surfaces
+### 6. Monorepo and workspace inventories are topology-aware
+
+On multi-package trees, ScanCode often stops at per-directory package rows: a Maven reactor’s module sources, a Gradle multiproject’s nested files, or a uv/Cargo/npm/Mix/Dart workspace’s shared lock may not be attributed to the declaring packages in a way that matches how the project is structured.
+
+Provenant’s assembly uses declared project topology (workspace members, reactor `<modules>`, Gradle `include`, Mix umbrellas, and similar) so that:
+
+- nested sources under a member belong to that member’s package when ownership is proven
+- a shared root lockfile (for example `uv.lock`, `pubspec.lock`, or Mix lock state) is attributed to members that actually declare the locked dependency, and otherwise stays honestly hoisted
+- incomplete selections are called out when you combine `--paths-file` with an SBOM export — including named missing Cargo/npm/Mix workspace roots when the selected files carry an unambiguous member marker
+
+If you evaluate Provenant on a monorepo primarily by counting packages, prefer inspecting `for_packages` / file ownership and shared-lock attribution, not only package cardinality. Details live in [Architecture](ARCHITECTURE.md) (TopologyPlan) and the relevant [improvement notes](improvements/README.md) (Maven, Gradle, uv, npm workspace, Cargo, Dart, Mix).
+
+### 7. Parser behavior can be more capable than ScanCode on some documented surfaces
 
 Provenant includes many documented parser fixes and intentional differences and improvements, for example in:
 
@@ -131,7 +143,7 @@ These are documented improvements on specific surfaces, not random incompatibili
 
 See [Intentional Differences and Improvements](improvements/README.md) for the full index.
 
-### 7. Path selection is split more explicitly between patterns and exact rooted paths
+### 8. Path selection is split more explicitly between patterns and exact rooted paths
 
 If you previously relied on `--include` as a rough way to express “scan this subtree”, pay close attention to Provenant's newer split here.
 
@@ -144,6 +156,8 @@ That means Provenant now prefers:
 - `--include '*.rs' --include 'src/**/*.toml'` when you mean pattern filtering
 - `--paths-file changed-files.txt /path/to/repo` when you already know the exact rooted file or directory list
 
+When the selection is incomplete relative to a workspace or reactor, SBOM exports still write, but Provenant warns that the inventory may understate the full tree — see [CLI Guide](CLI_GUIDE.md) section 10.
+
 This is a workflow-level difference worth knowing if you are testing Provenant against existing ScanCode habits or shell wrappers.
 
 See also:
@@ -151,7 +165,7 @@ See also:
 - [CLI Guide](CLI_GUIDE.md)
 - [CLI Workflows](improvements/cli-workflows.md)
 
-### 8. Custom templates expose ScanCode variables under a `scancode` namespace
+### 9. Custom templates expose ScanCode variables under a `scancode` namespace
 
 If you drive `--custom-output`/`--custom-template` with your own report templates, note two things.
 
@@ -197,9 +211,10 @@ If you are moving an existing ScanCode workflow to Provenant:
 
 1. start with the same broad scan shape you already use
 2. compare outputs on one representative codebase with `provenant compare`
-3. check this guide if you see a meaningful delta
-4. use the exported dataset workflow if you previously customized license/rule data in a ScanCode checkout
-5. if your old workflow used `--include` to approximate explicit path lists, consider switching that part to `--paths-file`
+3. for monorepos, pick a target that declares workspace/reactor/multiproject structure and review file ownership and shared-lock attribution, not only package counts
+4. check this guide if you see a meaningful delta
+5. use the exported dataset workflow if you previously customized license/rule data in a ScanCode checkout
+6. if your old workflow used `--include` to approximate explicit path lists, consider switching that part to `--paths-file`
 
 ## Other differences worth knowing
 


### PR DESCRIPTION
## Summary

- Elevate topology-aware monorepo/workspace inventory (file ownership and shared-lock attribution) in the README "Why Provenant?" list.
- Document the same advantage, plus `--paths-file` SBOM completeness warnings, in the ScanCode evaluation guide so evaluators know what to inspect beyond package counts.
- Lightly call out source-faithful copyright defaults and paths-file SBOM guardrails next to existing native-workflow messaging.

## Scope and exclusions

- Included: `README.md`, `docs/EVALUATING_WITH_SCANCODE_WORKFLOWS.md` messaging only.
- Explicit exclusions: no BENCHMARKS updates, no architecture/implementation changes, no CI changes.

## How to verify

- Read the new README bullets and eval-guide §6 / path-selection SBOM note as a first-time evaluator would: confirm they describe user-visible inventory quality without internal TopologyPlan jargon.
- CI covers docs lint/format.

## Intentional differences from Python

- Documentation of existing Provenant advantages only; no new behavioral change.

## Follow-up work

- Created or intentionally deferred: optional public-repo compare demo / BENCHMARKS callout remains out of scope for this PR.


Made with [Cursor](https://cursor.com)