### PR TITLE
fix(assembly): unify scanned path identity for ./ scan roots

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -428,6 +428,58 @@ mod tests {
     }
 
     #[test]
+    fn test_maven_reactor_owns_sources_when_scan_paths_use_dot_prefix() {
+        // A CLI input of `.` (used by compare-outputs and some wrappers) keeps a
+        // `./` prefix on scanned paths. Topology must still resolve members and
+        // attribute nested sources to the module package, same as a path-rooted
+        // scan that omits the prefix.
+        let mut files = vec![
+            create_maven_reactor_root_file_info(
+                "./pom.xml",
+                "org.example",
+                "parent",
+                "1.0",
+                &["module-a", "module-b"],
+            ),
+            create_maven_pom_file_info("./module-a/pom.xml", "org.example", "module-a", "1.0"),
+            create_plain_source_file_info("./module-a/src/main/java/com/example/Foo.java"),
+            create_maven_pom_file_info("./module-b/pom.xml", "org.example", "module-b", "1.0"),
+            create_plain_source_file_info("./module-b/src/main/java/com/example/Bar.java"),
+        ];
+
+        let result = assemble(&mut files);
+
+        let owning_purls = |path: &str| -> Vec<String> {
+            let file = files
+                .iter()
+                .find(|f| f.path == path)
+                .unwrap_or_else(|| panic!("file {path} should exist"));
+            file.for_packages
+                .iter()
+                .map(|uid| {
+                    result
+                        .packages
+                        .iter()
+                        .find(|pkg| pkg.package_uid == *uid)
+                        .and_then(|pkg| pkg.purl.clone())
+                        .unwrap_or_default()
+                })
+                .collect()
+        };
+
+        assert_eq!(
+            owning_purls("./module-a/src/main/java/com/example/Foo.java"),
+            vec!["pkg:maven/org.example/module-a@1.0"],
+            "`./`-prefixed module sources must attach to the module, not the reactor parent"
+        );
+        assert_eq!(
+            owning_purls("./module-b/src/main/java/com/example/Bar.java"),
+            vec!["pkg:maven/org.example/module-b@1.0"],
+            "`./`-prefixed module sources must attach to the module, not the reactor parent"
+        );
+    }
+
+    #[test]
     fn test_maven_reactor_rejects_over_escaped_module_paths() {
         // An over-escaped `<module>` path such as `../../../module-a` must not
         // collapse onto an unrelated in-scan `module-a/` just because lexical
@@ -573,6 +625,77 @@ mod tests {
                 .for_packages
                 .is_empty(),
             "an over-escaped declared project must not claim an unrelated directory"
+        );
+    }
+
+    #[test]
+    fn test_gradle_multi_project_owns_sources_when_scan_paths_use_dot_prefix() {
+        // Same contract as the Maven `./` case: a scan root of `.` must still
+        // synthesize the member package and attribute nested sources to it.
+        let mut settings = create_test_file_info(
+            "./settings.gradle",
+            DatasourceId::GradleSettings,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        settings.package_data[0].package_type = Some(PackageType::Maven);
+        settings.package_data[0].extra_data = Some(HashMap::from([
+            ("projects".to_string(), json!(["modules/app"])),
+            ("root_project_name".to_string(), json!("gradle-root")),
+        ]));
+
+        let mut root_build = create_test_file_info(
+            "./build.gradle",
+            DatasourceId::BuildGradle,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        root_build.package_data[0].package_type = Some(PackageType::Maven);
+        root_build.package_data[0].extra_data = Some(HashMap::from([
+            ("group".to_string(), json!("org.example")),
+            ("version".to_string(), json!("1.0")),
+        ]));
+
+        let mut member_build = create_test_file_info(
+            "./modules/app/build.gradle.kts",
+            DatasourceId::BuildGradle,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        member_build.package_data[0].package_type = Some(PackageType::Maven);
+        member_build.package_data[0].extra_data = Some(HashMap::from([
+            ("group".to_string(), json!("org.example")),
+            ("version".to_string(), json!("1.0")),
+        ]));
+
+        let mut files = vec![
+            settings,
+            root_build,
+            member_build,
+            create_plain_source_file_info("./modules/app/src/main/java/App.java"),
+        ];
+
+        let result = assemble(&mut files);
+        let member = result
+            .packages
+            .iter()
+            .find(|package| package.purl.as_deref() == Some("pkg:maven/org.example/app@1.0"))
+            .expect("member Gradle package must be synthesized under `./` scan paths");
+
+        assert!(
+            files
+                .iter()
+                .find(|file| file.path == "./modules/app/src/main/java/App.java")
+                .expect("member source")
+                .for_packages
+                .contains(&member.package_uid),
+            "`./`-prefixed Gradle member sources must attach to the member package"
         );
     }
 
@@ -944,6 +1067,57 @@ mod tests {
                 .expect("escaped source")
                 .for_packages
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_dart_workspace_owns_members_when_scan_paths_use_dot_prefix() {
+        // Same `./` scan-root contract as Maven/Gradle: member resolution and
+        // nested file ownership must survive the CLI `.` path prefix.
+        let mut root = create_test_file_info(
+            "./pubspec.yaml",
+            DatasourceId::PubspecYaml,
+            Some("pkg:pub/workspace_root@1.0.0"),
+            Some("workspace_root"),
+            Some("1.0.0"),
+            vec![],
+        );
+        root.package_data[0].package_type = Some(PackageType::Pub);
+        root.package_data[0].extra_data = Some(HashMap::from([(
+            "workspace_members".to_string(),
+            json!(["packages/app"]),
+        )]));
+
+        let mut member = create_test_file_info(
+            "./packages/app/pubspec.yaml",
+            DatasourceId::PubspecYaml,
+            Some("pkg:pub/app@0.1.0"),
+            Some("app"),
+            Some("0.1.0"),
+            vec![],
+        );
+        member.package_data[0].package_type = Some(PackageType::Pub);
+
+        let mut files = vec![
+            root,
+            member,
+            create_plain_source_file_info("./packages/app/lib/app.dart"),
+        ];
+        let result = assemble(&mut files);
+        let app = result
+            .packages
+            .iter()
+            .find(|package| package.purl.as_deref() == Some("pkg:pub/app@0.1.0"))
+            .expect("Dart member package must resolve under `./` scan paths");
+
+        assert!(
+            files
+                .iter()
+                .find(|file| file.path == "./packages/app/lib/app.dart")
+                .expect("Dart member source")
+                .for_packages
+                .contains(&app.package_uid),
+            "`./`-prefixed Dart member sources must attach to the member package"
         );
     }
 

--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -356,6 +356,10 @@ fn matches_member_pattern(path: &Path, pattern: &str) -> bool {
         .parent()
         .and_then(|parent| parent.to_str())
         .unwrap_or("");
+    let pattern = super::path_identity::strip_declared_dot_slash(pattern);
+    if pattern.is_empty() {
+        return false;
+    }
 
     if !pattern.contains('*') {
         return parent_str == pattern;
@@ -994,5 +998,25 @@ fn assign_for_packages(
         for uid in member_uids {
             file.for_packages.push(uid.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod matches_member_pattern_tests {
+    use super::*;
+
+    #[test]
+    fn matches_member_pattern_strips_declared_dot_slash() {
+        let path = Path::new("crates/foo/Cargo.toml");
+        assert!(matches_member_pattern(path, "crates/foo"));
+        assert!(
+            matches_member_pattern(path, "./crates/foo"),
+            "declared `./crates/foo` must match the same member as `crates/foo`"
+        );
+        assert!(matches_member_pattern(path, "crates/*"));
+        assert!(
+            matches_member_pattern(path, "./crates/*"),
+            "declared `./crates/*` must match the same members as `crates/*`"
+        );
     }
 }

--- a/src/assembly/dart_workspace_merge.rs
+++ b/src/assembly/dart_workspace_merge.rs
@@ -11,7 +11,7 @@ use packageurl::PackageUrl;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
-use super::topology::normalize_lexical_path;
+use super::path_identity::{normalize_lexical_path, scanned_file_dir, scanned_path};
 use super::{ASSEMBLERS, AssemblerConfig, sibling_merge};
 
 pub(super) struct DartWorkspaceRootHint {
@@ -62,11 +62,11 @@ pub(super) fn collect_dart_workspace_hints(files: &[FileInfo]) -> Vec<DartWorksp
             if member_paths.is_empty() {
                 continue;
             }
-            let Some(root_dir) = path.parent() else {
+            let Some(root_dir) = scanned_file_dir(&file.path) else {
                 continue;
             };
             hints.push(DartWorkspaceRootHint {
-                root_dir: root_dir.to_path_buf(),
+                root_dir,
                 root_pubspec_idx: idx,
                 member_paths,
             });
@@ -89,7 +89,7 @@ pub(super) fn plan_dart_workspace_domains(
                 let dir_path = normalize_lexical_path(&hint.root_dir.join(member));
                 let manifest_path = dir_path.join("pubspec.yaml");
                 let pubspec_idx = files.iter().position(|file| {
-                    Path::new(&file.path) == manifest_path
+                    scanned_path(&file.path) == manifest_path
                         && file.package_data.iter().any(|data| {
                             data.datasource_id == Some(DatasourceId::PubspecYaml)
                                 && data.purl.is_some()
@@ -99,7 +99,8 @@ pub(super) fn plan_dart_workspace_domains(
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, file)| {
-                        (Path::new(&file.path).parent() == Some(dir_path.as_path())).then_some(idx)
+                        (scanned_file_dir(&file.path).as_deref() == Some(dir_path.as_path()))
+                            .then_some(idx)
                     })
                     .collect();
                 Some(DartWorkspaceMemberDomain {
@@ -209,11 +210,12 @@ pub(super) fn apply_dart_workspace_domain(
         .iter()
         .find(|candidate| candidate.manifest_idx == domain.root_pubspec_idx)
         .map(|candidate| candidate.package_uid.clone());
+    let root_dir = normalize_lexical_path(&domain.root_dir);
     for file in files.iter_mut() {
         if !file.for_packages.is_empty() {
             continue;
         }
-        let Some(file_dir) = Path::new(&file.path).parent() else {
+        let Some(file_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
         if let Some(member) = domain
@@ -233,7 +235,7 @@ pub(super) fn apply_dart_workspace_domain(
         // identity, e.g. `publish_to: none` with no name) leaves its files
         // unowned rather than over-claiming them into every member package,
         // which would pollute per-package file and license attribution.
-        if file_dir.starts_with(&domain.root_dir)
+        if file_dir.starts_with(&root_dir)
             && let Some(root_uid) = &root_uid
         {
             file.for_packages.push(root_uid.clone());
@@ -304,9 +306,10 @@ fn pubspec_data(file: &FileInfo) -> Option<&PackageData> {
 }
 
 fn find_root_lock(files: &[FileInfo], root_dir: &Path) -> Option<usize> {
+    let root_dir = normalize_lexical_path(root_dir);
     files.iter().position(|file| {
         let path = Path::new(&file.path);
-        path.parent() == Some(root_dir)
+        scanned_file_dir(&file.path).as_deref() == Some(root_dir.as_path())
             && path.file_name().and_then(|name| name.to_str()) == Some("pubspec.lock")
             && file
                 .package_data

--- a/src/assembly/file_ref_resolve.rs
+++ b/src/assembly/file_ref_resolve.rs
@@ -5,10 +5,12 @@
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
+
+use super::path_identity::scanned_path;
 use packageurl::PackageUrl;
 use strum::EnumIter;
 
@@ -250,7 +252,7 @@ fn resolve_relative_to_datafile_parent(
             } else {
                 format!("{}/{}", root, file_ref.path.trim_start_matches('/'))
             };
-            if let Some(&file_idx) = path_index.get(&resolved_path) {
+            if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
                 let package_uid = package.package_uid.clone();
                 if !files[file_idx].for_packages.contains(&package_uid) {
                     files[file_idx].for_packages.push(package_uid);
@@ -289,7 +291,7 @@ fn resolve_attached_manifest_file_references(
             format!("{}/{}", root, file_ref.path.trim_start_matches('/'))
         };
 
-        if let Some(&file_idx) = path_index.get(&resolved_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
             let package_uid = package.package_uid.clone();
             if !files[file_idx].for_packages.contains(&package_uid) {
                 files[file_idx].for_packages.push(package_uid);
@@ -330,7 +332,7 @@ fn resolve_conda_file_references(
     let mut missing_refs = Vec::new();
     for file_ref in &file_references {
         let resolved_path = format!("{}{}", root, file_ref.path.trim_start_matches('/'));
-        if let Some(&file_idx) = path_index.get(&resolved_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
             let package_uid = package.package_uid.clone();
             if !files[file_idx].for_packages.contains(&package_uid) {
                 files[file_idx].for_packages.push(package_uid);
@@ -387,7 +389,7 @@ fn resolve_installed_db_file_references(
             format!("{}{}", root, ref_path)
         };
 
-        if let Some(&file_idx) = path_index.get(&resolved_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
             let package_uid = package.package_uid.clone();
             if !files[file_idx].for_packages.contains(&package_uid) {
                 files[file_idx].for_packages.push(package_uid);
@@ -427,7 +429,7 @@ fn resolve_debian_extracted_deb_file_references(
     };
     let root = extracted_root.to_string_lossy().to_string();
 
-    let Some(&file_idx) = path_index.get(datafile_path) else {
+    let Some(file_idx) = path_index_lookup(path_index, datafile_path) else {
         return;
     };
     let file_references: Vec<_> = files[file_idx]
@@ -447,7 +449,7 @@ fn resolve_debian_extracted_deb_file_references(
             format!("{}/{}", root, file_ref.path.trim_start_matches('/'))
         };
 
-        if let Some(&file_idx) = path_index.get(&resolved_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
             let package_uid = package.package_uid.clone();
             if !files[file_idx].for_packages.contains(&package_uid) {
                 files[file_idx].for_packages.push(package_uid);
@@ -496,7 +498,7 @@ fn resolve_python_metadata_file_references(
             continue;
         };
 
-        if let Some(&file_idx) = path_index.get(&resolved_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, &resolved_path) {
             let package_uid = package.package_uid.clone();
             if !files[file_idx].for_packages.contains(&package_uid) {
                 files[file_idx].for_packages.push(package_uid);
@@ -607,24 +609,34 @@ fn find_python_metadata_root(package: &Package) -> Option<PythonMetadataResoluti
 
 fn normalize_relative_path(base: &str, allowed_root: &str, relative: &str) -> Option<String> {
     let joined = Path::new(base).join(relative.trim_start_matches('/'));
-    let mut normalized = Path::new("").to_path_buf();
+    let normalized = normalize_file_ref_path(&joined);
+    let allowed = normalize_file_ref_path(Path::new(allowed_root));
 
-    for component in joined.components() {
+    let normalized_str = normalized.to_string_lossy().to_string();
+    if normalized.starts_with(&allowed) {
+        Some(normalized_str)
+    } else {
+        None
+    }
+}
+
+/// Lexically collapse `.` / `..` for file-reference joins.
+///
+/// Unlike assembly [`super::path_identity::normalize_lexical_path`], unresolved
+/// `..` components are discarded (via `pop` on an empty path) so references
+/// cannot escape the allowed root by over-escaping.
+fn normalize_file_ref_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
         match component {
             std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
                 normalized.pop();
             }
-            _ => normalized.push(component.as_os_str()),
+            other => normalized.push(other.as_os_str()),
         }
     }
-
-    let normalized_str = normalized.to_string_lossy().to_string();
-    if Path::new(&normalized_str).starts_with(Path::new(allowed_root)) {
-        Some(normalized_str)
-    } else {
-        None
-    }
+    normalized
 }
 
 fn compute_conda_root(datafile_path: Option<&str>) -> Option<String> {
@@ -742,8 +754,16 @@ fn build_path_index(files: &[FileInfo]) -> HashMap<String, usize> {
     files
         .iter()
         .enumerate()
-        .map(|(idx, file)| (file.path.clone(), idx))
+        .map(|(idx, file)| (path_index_key(&file.path), idx))
         .collect()
+}
+
+fn path_index_key(path: &str) -> String {
+    scanned_path(path).to_string_lossy().into_owned()
+}
+
+fn path_index_lookup(path_index: &HashMap<String, usize>, path: &str) -> Option<usize> {
+    path_index.get(&path_index_key(path)).copied()
 }
 
 fn find_db_config(package: &Package) -> Option<&'static DbPathConfig> {
@@ -801,9 +821,8 @@ fn collect_file_references(
     config_datasource_ids: &[DatasourceId],
     package_purl: Option<&str>,
 ) -> Vec<crate::models::FileReference> {
-    let file_idx = match path_index.get(datafile_path) {
-        Some(&idx) => idx,
-        None => return Vec::new(),
+    let Some(file_idx) = path_index_lookup(path_index, datafile_path) else {
+        return Vec::new();
     };
 
     let file = &files[file_idx];
@@ -1063,7 +1082,7 @@ fn resolve_rpm_namespace(
     ];
 
     for os_release_path in &os_release_paths {
-        if let Some(&file_idx) = path_index.get(os_release_path) {
+        if let Some(file_idx) = path_index_lookup(path_index, os_release_path) {
             let file = &files[file_idx];
             for pkg_data in &file.package_data {
                 if pkg_data.datasource_id == Some(DatasourceId::EtcOsRelease)

--- a/src/assembly/go_workspace.rs
+++ b/src/assembly/go_workspace.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, Package, TopLevelDependency};
 
+use super::path_identity::scanned_file_dir;
 use super::topology::apply_directory_merge_result;
 use super::{ASSEMBLERS, AssemblerConfig, sibling_merge};
 
@@ -38,10 +39,9 @@ pub(super) fn collect_go_workspace_hints(files: &[FileInfo]) -> Vec<GoWorkspaceR
             continue;
         }
 
-        let Some(parent) = path.parent() else {
+        let Some(root_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
-        let root_dir = parent.to_path_buf();
         if seen.insert(root_dir.clone()) {
             hints.push(GoWorkspaceRootHint { root_dir });
         }

--- a/src/assembly/gradle_multiproject.rs
+++ b/src/assembly/gradle_multiproject.rs
@@ -10,7 +10,8 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, TopLevelDependency};
 
-use super::topology::{assign_unowned_files_to_anchors, normalize_lexical_path};
+use super::path_identity::{normalize_lexical_path, scanned_file_dir};
+use super::topology::assign_unowned_files_to_anchors;
 
 pub(super) struct GradleMultiProjectRootHint {
     pub(super) root_dir: PathBuf,
@@ -61,7 +62,7 @@ pub(super) fn collect_gradle_multi_project_hints(
         if project_paths.is_empty() {
             continue;
         }
-        let Some(root_dir) = path.parent() else {
+        let Some(root_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
         let root_project_name = file.package_data.iter().find_map(|data| {
@@ -92,7 +93,7 @@ pub(super) fn collect_gradle_multi_project_hints(
             })
             .unwrap_or_default();
         hints.push(GradleMultiProjectRootHint {
-            root_dir: root_dir.to_path_buf(),
+            root_dir,
             project_paths,
             root_project_name,
             project_dir_overrides,
@@ -145,7 +146,7 @@ pub(super) fn plan_gradle_multi_project_domains(
 fn find_gradle_build_index(files: &[FileInfo], directory: &Path) -> Option<usize> {
     files.iter().position(|file| {
         let path = Path::new(&file.path);
-        path.parent() == Some(directory)
+        scanned_file_dir(&file.path).as_deref() == Some(directory)
             && matches!(
                 path.file_name().and_then(|name| name.to_str()),
                 Some("build.gradle" | "build.gradle.kts")
@@ -167,7 +168,7 @@ pub(super) fn apply_gradle_multi_project_domains<'a>(
     let mut anchor_indices = Vec::new();
 
     for domain in domains {
-        scope_roots.push(domain.root_dir.clone());
+        scope_roots.push(normalize_lexical_path(&domain.root_dir));
         if let Some(root_idx) = domain.root_build_idx {
             ensure_gradle_package(
                 root_idx,
@@ -179,8 +180,8 @@ pub(super) fn apply_gradle_multi_project_domains<'a>(
             anchor_indices.push(root_idx);
         }
         for &member_idx in &domain.member_build_indices {
-            if let Some(member_dir) = Path::new(&files[member_idx].path).parent() {
-                scope_roots.push(member_dir.to_path_buf());
+            if let Some(member_dir) = scanned_file_dir(&files[member_idx].path) {
+                scope_roots.push(member_dir);
             }
             ensure_gradle_package(member_idx, None, files, packages, dependencies);
             anchor_indices.push(member_idx);
@@ -229,7 +230,7 @@ fn ensure_gradle_package(
     else {
         return;
     };
-    let Some(build_dir) = Path::new(&files[build_idx].path).parent() else {
+    let Some(build_dir) = scanned_file_dir(&files[build_idx].path) else {
         return;
     };
 
@@ -271,7 +272,7 @@ fn ensure_gradle_package(
     let mut datafile_indices = vec![build_idx];
     for (idx, file) in files.iter().enumerate() {
         let path = Path::new(&file.path);
-        if path.parent() != Some(build_dir)
+        if scanned_file_dir(&file.path).as_deref() != Some(build_dir.as_path())
             || path.file_name().and_then(|name| name.to_str()) != Some("gradle.lockfile")
         {
             continue;

--- a/src/assembly/hackage_merge.rs
+++ b/src/assembly/hackage_merge.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, Package, PackageData, PackageUid, TopLevelDependency};
 
+use super::path_identity::scanned_file_dir;
 use super::topology::apply_directory_merge_result;
 
 pub(super) struct HackageProjectHint {
@@ -46,10 +47,9 @@ pub(super) fn collect_hackage_project_hints(files: &[FileInfo]) -> Vec<HackagePr
             continue;
         }
 
-        let Some(parent) = path.parent() else {
+        let Some(root_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
-        let root_dir = parent.to_path_buf();
         if seen.insert(root_dir.clone()) {
             hints.push(HackageProjectHint { root_dir });
         }

--- a/src/assembly/maven_reactor.rs
+++ b/src/assembly/maven_reactor.rs
@@ -8,7 +8,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, PackageUid};
 
-use super::topology::normalize_lexical_path;
+use super::path_identity::{normalize_lexical_path, scanned_file_dir, scanned_path};
 
 /// A `pom.xml` that declares a non-empty `<modules>` list (stashed by the parser
 /// under `extra_data.modules`). Every such POM — root or nested — contributes its
@@ -61,12 +61,12 @@ pub(super) fn collect_maven_reactor_hints(files: &[FileInfo]) -> Vec<MavenReacto
                 continue;
             }
 
-            let Some(parent) = path.parent() else {
+            let Some(root_dir) = scanned_file_dir(&file.path) else {
                 continue;
             };
 
             hints.push(MavenReactorRootHint {
-                root_dir: parent.to_path_buf(),
+                root_dir,
                 root_pom_idx: idx,
                 module_paths,
             });
@@ -109,10 +109,12 @@ fn resolve_maven_reactor_members(files: &[FileInfo], hint: &MavenReactorRootHint
     for module in &hint.module_paths {
         let candidate_path = normalize_lexical_path(&hint.root_dir.join(module)).join("pom.xml");
 
-        let Some(found_idx) = files
-            .iter()
-            .position(|file| Path::new(&file.path) == candidate_path)
-        else {
+        let Some(found_idx) = files.iter().position(|file| {
+            // Scan roots of `.` keep a `./` prefix on file paths; compare the
+            // lexically normalized form so `./module-a/pom.xml` matches
+            // `module-a/pom.xml`.
+            scanned_path(&file.path) == candidate_path
+        }) else {
             continue;
         };
 
@@ -161,17 +163,14 @@ pub(super) fn apply_maven_reactor_domains<'a>(
     let mut anchors: Vec<(PathBuf, Vec<PackageUid>)> = Vec::new();
 
     for domain in domains {
-        scope_roots.push(domain.root_dir.clone());
-        anchors.push((
-            domain.root_dir.clone(),
-            files[domain.root_pom_idx].for_packages.clone(),
-        ));
+        let root_dir = normalize_lexical_path(&domain.root_dir);
+        scope_roots.push(root_dir.clone());
+        anchors.push((root_dir, files[domain.root_pom_idx].for_packages.clone()));
 
         for &member_idx in &domain.member_pom_indices {
-            let Some(member_dir) = Path::new(&files[member_idx].path).parent() else {
+            let Some(member_dir) = scanned_file_dir(&files[member_idx].path) else {
                 continue;
             };
-            let member_dir = member_dir.to_path_buf();
             // A declared module normally lives under the reactor root
             // directory, which already covers it via `scope_roots` above.
             // But `<module>` strings may legally escape it with a `../`
@@ -194,8 +193,7 @@ pub(super) fn apply_maven_reactor_domains<'a>(
             continue;
         }
 
-        let file_path = Path::new(&file.path);
-        let Some(file_dir) = file_path.parent() else {
+        let Some(file_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
 
@@ -211,7 +209,7 @@ pub(super) fn apply_maven_reactor_domains<'a>(
             continue;
         };
 
-        if package_uids.is_empty() || crosses_maven_build_output_dir(anchor_dir, file_dir) {
+        if package_uids.is_empty() || crosses_maven_build_output_dir(anchor_dir, &file_dir) {
             continue;
         }
 

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -29,6 +29,7 @@ mod nix_flake_compat_merge;
 mod npm_resource_assign;
 mod npm_workspace_merge;
 mod nuget_cpm_resolve;
+mod path_identity;
 mod pixi_topology;
 mod project_dependency_assign;
 mod python_requirements_assign;
@@ -440,12 +441,16 @@ fn active_config_keys(
     groups
 }
 
-/// Group file indices by their parent directory path.
+/// Group file indices by their lexically normalized parent directory.
+///
+/// Keys use [`path_identity::scanned_file_dir`] so a scan root of `.` (paths
+/// like `./go.work`) buckets under the same empty/`module` keys as a
+/// path-rooted scan, matching topology collectors that store normalized roots.
 fn group_files_by_directory(files: &[FileInfo]) -> HashMap<PathBuf, Vec<usize>> {
     let mut groups: HashMap<PathBuf, Vec<usize>> = HashMap::new();
     for (idx, file) in files.iter().enumerate() {
-        if let Some(parent) = std::path::Path::new(&file.path).parent() {
-            groups.entry(parent.to_path_buf()).or_default().push(idx);
+        if let Some(parent) = path_identity::scanned_file_dir(&file.path) {
+            groups.entry(parent).or_default().push(idx);
         }
     }
     groups

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -420,6 +420,10 @@ fn discover_members(files: &[FileInfo], workspace_root: &NpmWorkspaceRootHint) -
 fn matches_workspace_pattern(path: &Path, pattern: &str) -> bool {
     // Convert path to string with forward slashes
     let path_str = path.to_str().unwrap_or("");
+    let pattern = super::path_identity::strip_declared_dot_slash(pattern);
+    if pattern.is_empty() {
+        return false;
+    }
 
     // Handle simple patterns without wildcards
     if !pattern.contains('*') && !pattern.contains('?') {
@@ -891,12 +895,20 @@ mod tests {
         let path = Path::new("packages/foo/package.json");
         assert!(matches_workspace_pattern(path, "packages/foo"));
         assert!(!matches_workspace_pattern(path, "packages/bar"));
+        assert!(
+            matches_workspace_pattern(path, "./packages/foo"),
+            "declared `./` prefixes must still match relative member paths"
+        );
     }
 
     #[test]
     fn test_matches_workspace_pattern_single_star() {
         let path = Path::new("packages/foo/package.json");
         assert!(matches_workspace_pattern(path, "packages/*"));
+        assert!(
+            matches_workspace_pattern(path, "./packages/*"),
+            "declared `./packages/*` must match the same members as `packages/*`"
+        );
 
         let nested = Path::new("packages/foo/bar/package.json");
         assert!(!matches_workspace_pattern(nested, "packages/*"));

--- a/src/assembly/path_identity.rs
+++ b/src/assembly/path_identity.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared lexical path identity for assembly.
+//!
+//! A CLI scan root of `.` keeps a `./` prefix on [`crate::models::FileInfo`]
+//! paths through the scanner pipeline. Declared workspace/member paths and
+//! lexically resolved candidates omit that prefix, so raw string/`Path`
+//! equality and `starts_with` checks silently miss. These helpers put both
+//! shapes on the same identity.
+//!
+//! Assembly assumes POSIX `/` separators on `FileInfo.path` (the scanner
+//! already normalizes via `to_posix_string`). This module does not treat `\`
+//! as a path separator.
+
+use std::path::{Path, PathBuf};
+
+/// Lexically resolve `.` and `..` components in a path without touching the
+/// filesystem, so a declared module path such as `./module-a` or
+/// `../sibling-module` compares equal to the scanned path's own normalized
+/// form.
+///
+/// Unresolved parent components are kept rather than discarded. Dropping them
+/// would let an over-escaped module like `../../../module-a` collapse onto an
+/// unrelated in-scan `module-a/` and incorrectly accept it as a reactor member.
+pub(super) fn normalize_lexical_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => match normalized.components().next_back() {
+                Some(std::path::Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(std::path::Component::ParentDir) | None => {
+                    normalized.push(std::path::Component::ParentDir.as_os_str());
+                }
+                // Never escape a filesystem root / Windows prefix.
+                Some(std::path::Component::RootDir) | Some(std::path::Component::Prefix(_)) => {}
+                // CurDir is skipped above, so it never accumulates here.
+                Some(std::path::Component::CurDir) => unreachable!(),
+            },
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+/// Lexically normalized form of a scanned [`crate::models::FileInfo`] path.
+pub(super) fn scanned_path(path: &str) -> PathBuf {
+    normalize_lexical_path(Path::new(path))
+}
+
+/// Parent directory of a scanned file path, with `.`/`..` lexically resolved.
+///
+/// A scan whose CLI input is `.` emits paths like `./module-a/pom.xml`; without
+/// normalization those parents stay as `./module-a` and fail to match lexically
+/// resolved member candidates such as `module-a`.
+pub(super) fn scanned_file_dir(path: &str) -> Option<PathBuf> {
+    Path::new(path).parent().map(normalize_lexical_path)
+}
+
+/// Trim whitespace and strip one leading `./` from a declared workspace/member
+/// pattern so glob and exact matches compare against relative scan paths.
+pub(super) fn strip_declared_dot_slash(pattern: &str) -> &str {
+    let trimmed = pattern.trim();
+    trimmed.strip_prefix("./").unwrap_or(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_lexical_path_strips_curdir_keeps_unresolved_parent() {
+        assert_eq!(
+            normalize_lexical_path(Path::new(".")),
+            PathBuf::new(),
+            "`.` collapses to the empty relative root"
+        );
+        assert_eq!(
+            normalize_lexical_path(Path::new("./module-a")),
+            PathBuf::from("module-a")
+        );
+        assert_eq!(
+            normalize_lexical_path(Path::new("../../../module-a")),
+            PathBuf::from("../../../module-a"),
+            "unresolved `..` must be preserved so over-escaped modules do not collapse"
+        );
+    }
+
+    #[test]
+    fn scanned_path_matches_dot_prefixed_fileinfo() {
+        assert_eq!(
+            scanned_path("./module-a/pom.xml"),
+            PathBuf::from("module-a/pom.xml")
+        );
+        assert_eq!(
+            scanned_path("module-a/pom.xml"),
+            PathBuf::from("module-a/pom.xml")
+        );
+    }
+
+    #[test]
+    fn scanned_file_dir_handles_dot_root_and_empty_parent() {
+        assert_eq!(
+            scanned_file_dir("./pom.xml").as_deref(),
+            Some(Path::new("")),
+            "parent of `./pom.xml` is `.`, which normalizes to empty"
+        );
+        assert_eq!(
+            scanned_file_dir("pom.xml").as_deref(),
+            Some(Path::new("")),
+            "parent of a root-level file is already empty"
+        );
+        assert_eq!(
+            scanned_file_dir("./module-a/src/Foo.java").as_deref(),
+            Some(Path::new("module-a/src"))
+        );
+    }
+
+    #[test]
+    fn strip_declared_dot_slash_trims_and_strips_one_prefix() {
+        assert_eq!(strip_declared_dot_slash("  ./packages/*  "), "packages/*");
+        assert_eq!(strip_declared_dot_slash("crates/foo"), "crates/foo");
+        assert_eq!(
+            strip_declared_dot_slash("././nested"),
+            "./nested",
+            "only one leading `./` is stripped"
+        );
+    }
+}

--- a/src/assembly/pixi_topology.rs
+++ b/src/assembly/pixi_topology.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DatasourceId, FileInfo, Package, TopLevelDependency};
 
+use super::path_identity::scanned_file_dir;
 use super::topology::apply_directory_merge_result;
 use super::{ASSEMBLERS, AssemblerConfig, sibling_merge};
 
@@ -38,10 +39,9 @@ pub(super) fn collect_pixi_root_hints(files: &[FileInfo]) -> Vec<PixiRootHint> {
             continue;
         }
 
-        let Some(parent) = path.parent() else {
+        let Some(root_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
-        let root_dir = parent.to_path_buf();
         if seen.insert(root_dir.clone()) {
             hints.push(PixiRootHint { root_dir });
         }

--- a/src/assembly/topology.rs
+++ b/src/assembly/topology.rs
@@ -328,7 +328,8 @@ impl TopologyPlan {
         let Some(&first_idx) = file_indices.first() else {
             return false;
         };
-        let Some(parent_dir) = Path::new(&files[first_idx].path).parent() else {
+        let Some(parent_dir) = super::path_identity::scanned_file_dir(&files[first_idx].path)
+        else {
             return false;
         };
 
@@ -344,7 +345,7 @@ impl TopologyPlan {
                 return self
                     .claimed_dirs
                     .get(&handler.family)
-                    .is_some_and(|dirs| dirs.contains(parent_dir));
+                    .is_some_and(|dirs| dirs.contains(&parent_dir));
             }
         }
 
@@ -486,12 +487,21 @@ pub(super) fn assign_unowned_files_to_anchors(
     excluded_immediate_children: &[&OsStr],
     protected_dirs: &[PathBuf],
 ) {
+    // Normalize so a scan root of `.` (paths like `./module-a/...`) matches the
+    // same lexical parents as a path-rooted scan (`module-a/...`).
+    let scope_roots: Vec<PathBuf> = scope_roots
+        .iter()
+        .map(|root| super::path_identity::normalize_lexical_path(root))
+        .collect();
+    let protected_dirs: Vec<PathBuf> = protected_dirs
+        .iter()
+        .map(|dir| super::path_identity::normalize_lexical_path(dir))
+        .collect();
     let anchors: Vec<(PathBuf, Vec<PackageUid>)> = anchor_indices
         .iter()
         .filter_map(|idx| {
-            Path::new(&files[*idx].path)
-                .parent()
-                .map(|dir| (dir.to_path_buf(), files[*idx].for_packages.clone()))
+            super::path_identity::scanned_file_dir(&files[*idx].path)
+                .map(|dir| (dir, files[*idx].for_packages.clone()))
         })
         .collect();
 
@@ -499,7 +509,7 @@ pub(super) fn assign_unowned_files_to_anchors(
         if !file.for_packages.is_empty() {
             continue;
         }
-        let Some(file_dir) = Path::new(&file.path).parent() else {
+        let Some(file_dir) = super::path_identity::scanned_file_dir(&file.path) else {
             continue;
         };
         if !scope_roots.iter().any(|root| file_dir.starts_with(root)) {
@@ -520,7 +530,7 @@ pub(super) fn assign_unowned_files_to_anchors(
             continue;
         };
         if package_uids.is_empty()
-            || crosses_excluded_build_output(anchor_dir, file_dir, excluded_immediate_children)
+            || crosses_excluded_build_output(anchor_dir, &file_dir, excluded_immediate_children)
         {
             continue;
         }
@@ -551,39 +561,6 @@ fn crosses_excluded_build_output(
                 .iter()
                 .any(|excluded| first == Component::Normal(excluded))
         })
-}
-
-/// Lexically resolve `.` and `..` components in a path without touching the
-/// filesystem, so a declared module path such as `./module-a` or
-/// `../sibling-module` compares equal to the scanned path's own normalized
-/// form.
-///
-/// Unresolved parent components are kept rather than discarded. Dropping them
-/// would let an over-escaped module like `../../../module-a` collapse onto an
-/// unrelated in-scan `module-a/` and incorrectly accept it as a reactor member.
-pub(super) fn normalize_lexical_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => match normalized.components().next_back() {
-                Some(std::path::Component::Normal(_)) => {
-                    normalized.pop();
-                }
-                Some(std::path::Component::ParentDir) | None => {
-                    normalized.push(std::path::Component::ParentDir.as_os_str());
-                }
-                // Never escape a filesystem root / Windows prefix.
-                Some(std::path::Component::RootDir) | Some(std::path::Component::Prefix(_)) => {}
-                // CurDir is skipped above, so it never accumulates here.
-                Some(std::path::Component::CurDir) => unreachable!(),
-            },
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-
-    normalized
 }
 
 pub(super) fn apply_directory_merge_result(

--- a/src/assembly/uv_workspace.rs
+++ b/src/assembly/uv_workspace.rs
@@ -14,7 +14,8 @@ use crate::models::{
     DatasourceId, Dependency, FileInfo, PackageData, PackageUid, TopLevelDependency,
 };
 
-use super::topology::{assign_unowned_files_to_anchors, normalize_lexical_path};
+use super::path_identity::{normalize_lexical_path, scanned_file_dir, strip_declared_dot_slash};
+use super::topology::assign_unowned_files_to_anchors;
 
 pub(super) struct UvWorkspaceRootHint {
     pub(super) root_dir: PathBuf,
@@ -56,11 +57,11 @@ pub(super) fn collect_uv_workspace_hints(files: &[FileInfo]) -> Vec<UvWorkspaceR
             if member_patterns.is_empty() {
                 continue;
             }
-            let Some(root_dir) = path.parent() else {
+            let Some(root_dir) = scanned_file_dir(&file.path) else {
                 continue;
             };
             hints.push(UvWorkspaceRootHint {
-                root_dir: root_dir.to_path_buf(),
+                root_dir,
                 root_pyproject_idx: idx,
                 member_patterns,
                 exclude_patterns: extra_string_array(data, "workspace_exclude"),
@@ -101,12 +102,12 @@ pub(super) fn plan_uv_workspace_domains(
                     {
                         return None;
                     }
-                    let member_dir = path.parent()?;
+                    let member_dir = scanned_file_dir(&file.path)?;
                     let included = hint.member_patterns.iter().any(|pattern| {
-                        workspace_pattern_matches(&hint.root_dir, member_dir, pattern)
+                        workspace_pattern_matches(&hint.root_dir, &member_dir, pattern)
                     });
                     let excluded = hint.exclude_patterns.iter().any(|pattern| {
-                        workspace_exclude_matches(&hint.root_dir, member_dir, pattern)
+                        workspace_exclude_matches(&hint.root_dir, &member_dir, pattern)
                     });
                     (included && !excluded).then_some(idx)
                 })
@@ -139,7 +140,7 @@ fn extra_string_array(data: &PackageData, key: &str) -> Vec<String> {
 }
 
 fn workspace_pattern_matches(root_dir: &Path, member_dir: &Path, pattern: &str) -> bool {
-    let pattern = pattern.trim().strip_prefix("./").unwrap_or(pattern.trim());
+    let pattern = strip_declared_dot_slash(pattern);
     if pattern.is_empty() {
         return false;
     }
@@ -169,7 +170,7 @@ fn workspace_pattern_matches(root_dir: &Path, member_dir: &Path, pattern: &str) 
 /// `packages/ignored` does not spuriously exclude a sibling like
 /// `packages/ignored-2`.
 fn workspace_exclude_matches(root_dir: &Path, member_dir: &Path, pattern: &str) -> bool {
-    let trimmed = pattern.trim().strip_prefix("./").unwrap_or(pattern.trim());
+    let trimmed = strip_declared_dot_slash(pattern);
     if trimmed.is_empty() {
         return false;
     }
@@ -221,11 +222,11 @@ pub(super) fn apply_uv_workspace_domains<'a>(
     let mut protected_project_dirs = Vec::new();
 
     for domain in &domains {
-        scope_roots.push(domain.root_dir.clone());
+        scope_roots.push(normalize_lexical_path(&domain.root_dir));
         anchor_indices.push(domain.root_pyproject_idx);
         for &member_idx in &domain.member_pyproject_indices {
-            if let Some(member_dir) = Path::new(&files[member_idx].path).parent() {
-                scope_roots.push(member_dir.to_path_buf());
+            if let Some(member_dir) = scanned_file_dir(&files[member_idx].path) {
+                scope_roots.push(member_dir);
             }
             anchor_indices.push(member_idx);
         }
@@ -241,11 +242,11 @@ pub(super) fn apply_uv_workspace_domains<'a>(
         {
             continue;
         }
-        let Some(project_dir) = Path::new(&file.path).parent() else {
+        let Some(project_dir) = scanned_file_dir(&file.path) else {
             continue;
         };
         if scope_roots.iter().any(|root| project_dir.starts_with(root)) {
-            protected_project_dirs.push(project_dir.to_path_buf());
+            protected_project_dirs.push(project_dir);
         }
     }
 
@@ -357,9 +358,10 @@ fn uv_lock_candidate(files: &[FileInfo], pyproject_idx: usize) -> Option<UvLockC
 }
 
 fn find_uv_lock_index(files: &[FileInfo], root_dir: &Path) -> Option<usize> {
+    let root_dir = normalize_lexical_path(root_dir);
     files.iter().position(|file| {
         let path = Path::new(&file.path);
-        path.parent() == Some(root_dir)
+        scanned_file_dir(&file.path).as_deref() == Some(root_dir.as_path())
             && path.file_name().and_then(|name| name.to_str()) == Some("uv.lock")
             && file
                 .package_data


### PR DESCRIPTION
## Summary

- Introduce shared `src/assembly/path_identity.rs` (`normalize_lexical_path`, `scanned_path`, `scanned_file_dir`, `strip_declared_dot_slash`) so assembly treats `./module-a/...` (CLI input `.`) and `module-a/...` as the same identity.
- Key `group_files_by_directory` with `scanned_file_dir` so Go/Pixi/Hackage topology buckets match normalized roots (addresses Greptile P1 properly).
- Apply the helpers across Maven/Gradle/uv/Dart topology, file-reference resolution, and npm/Cargo declared workspace/member patterns that keep a leading `./`.

## Scope and exclusions

- Included: path-identity helper; directory grouping; topology families; Dart workspace; file_ref_resolve index/lookup; npm/Cargo pattern `./` stripping; regression tests.
- Explicit exclusions: no change to scanner ingest (already POSIX via `to_posix_string`); no Windows `\` handling in assembly (FileInfo paths are `/`-normalized before assembly).

## How to verify

- `provenant scan --json-pp - --package --strip-root .` from `testdata/assembly-golden/maven-reactor-basic`, `gradle-multiproject`, and a Dart workspace fixture — member sources should own to the member package.
- CI covers new unit regressions (`scan_paths_use_dot_prefix`, path_identity, pattern matchers, file_ref_resolve).

## Intentional differences from Python

- None; restores Provenant's intended assembly contracts for an input-shape edge case.

## Follow-up work

- Created or intentionally deferred: Mix/other raw-vs-raw assemblers not re-audited beyond the known normalize/raw asymmetry sites; optional `compare-outputs` path-rooted scan is still belt-and-suspenders.