### PR TITLE
fix(copyright): keep a trailing acronym-with-period holder (e.g. CERN.)

### DIFF
--- a/src/copyright/detector/tests.rs
+++ b/src/copyright/detector/tests.rs
@@ -2347,3 +2347,84 @@ fn test_single_holder_obfuscated_email_kept_in_copyright() {
     assert_eq!(h.len(), 1);
     assert_eq!(h[0].holder, "Salvatore Sanfilippo");
 }
+
+// ── Trailing acronym-with-period holder (e.g. `CERN.`) ───────────
+//
+// A single all-caps acronym carrying a sentence-final period lexes as a `Pn`
+// token (`CERN.`), unlike its period-less spelling `CERN`, which lexes as
+// `Caps`. Before the absorption fix, a trailing `Pn` was dropped from a
+// year-only copyright whenever prose preceded the marker (so the copyright
+// statement began mid-line), yielding a holder-less `Copyright (c) <year>`.
+// Observed on flask `tests/test_cli.py`: `... Revised BSD License. Copyright ©
+// 2015 CERN.` reported `Copyright (c) 2015` with no holder.
+
+#[test]
+fn test_trailing_acronym_period_holder_kept_after_leading_prose() {
+    // The flask `tests/test_cli.py` shape: prose ending in a sentence, then the
+    // copyright mid-line. The `CERN.` holder must survive.
+    let input = "its Revised BSD License. Copyright \u{00A9} 2015 CERN.";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert_eq!(
+        c.iter().map(|x| x.copyright.as_str()).collect::<Vec<_>>(),
+        vec!["Copyright (c) 2015 CERN."],
+        "holder acronym must stay in the copyright statement"
+    );
+    assert_eq!(
+        h.iter().map(|x| x.holder.as_str()).collect::<Vec<_>>(),
+        vec!["CERN"],
+        "CERN must be captured as the holder"
+    );
+}
+
+#[test]
+fn test_trailing_acronym_period_holder_variants() {
+    // Each holder form must be captured when the copyright is preceded by prose
+    // (which forces the mid-line span path rather than the line-anchored repair).
+    for (input, want_copyright, want_holder) in [
+        (
+            "foo bar baz. Copyright \u{00A9} 2015 CERN.",
+            "Copyright (c) 2015 CERN.",
+            "CERN",
+        ),
+        (
+            "foo bar baz. Copyright (c) 2020 Example Corp",
+            "Copyright (c) 2020 Example Corp",
+            "Example Corp",
+        ),
+        (
+            "foo bar baz. Copyright \u{00A9} 2019 Bj\u{00F6}rn",
+            "Copyright (c) 2019 Bj\u{00F6}rn",
+            "Bj\u{00F6}rn",
+        ),
+    ] {
+        let (c, h, _a) = detect_copyrights_from_text(input);
+        assert!(
+            c.iter().any(|x| x.copyright == want_copyright),
+            "input {input:?}: expected copyright {want_copyright:?}, got {:?}",
+            c.iter().map(|x| &x.copyright).collect::<Vec<_>>()
+        );
+        assert!(
+            h.iter().any(|x| x.holder == want_holder),
+            "input {input:?}: expected holder {want_holder:?}, got {:?}",
+            h.iter().map(|x| &x.holder).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_year_only_copyright_after_prose_has_no_holder() {
+    // Guard against over-correction: a genuinely holder-less year-only copyright
+    // must not manufacture a holder from surrounding prose.
+    let input = "foo bar baz. Copyright \u{00A9} 2015";
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert_eq!(
+        c.iter().map(|x| x.copyright.as_str()).collect::<Vec<_>>(),
+        vec!["Copyright (c) 2015"],
+        "year-only copyright stays year-only"
+    );
+    assert!(
+        h.is_empty(),
+        "no holder should be invented, got {:?}",
+        h.iter().map(|x| &x.holder).collect::<Vec<_>>()
+    );
+}

--- a/src/copyright/detector/tree_walk/copyright/absorb.rs
+++ b/src/copyright/detector/tree_walk/copyright/absorb.rs
@@ -293,6 +293,22 @@ pub fn should_start_absorbing(
         }
     }
 
+    // A trailing standalone acronym-with-period on the same line — lexed as
+    // `Pn` because of the sentence-final period (e.g. `CERN.`, `DMTF.`) — is the
+    // holder of an otherwise year-only copyright, so absorb it. Its period-less
+    // spelling (`CERN`) lexes as `Caps`, reduces to a `NameCaps` node, and is
+    // already absorbed via `strong_first` below; handling the `Pn` leaf here
+    // keeps the two source-faithful spellings consistent instead of dropping
+    // the holder whenever a period trails it. Scoped to a lone leaf following a
+    // holder-less, year-bearing clause so it cannot swallow ordinary prose.
+    if let ParseNode::Leaf(token) = first
+        && token.tag == PosTag::Pn
+        && last_line.is_some_and(|l| l == token.start_line)
+        && is_year_only_copyright_clause_node(copyright_node)
+    {
+        return true;
+    }
+
     if let ParseNode::Leaf(token) = first
         && last_line.is_some_and(|l| l == token.start_line)
         && (token.value == "," || token.tag == PosTag::Cc)


### PR DESCRIPTION
## Summary

- Fixes a copyright-detection bug where the holder was dropped from a statement of the shape `Copyright © <year> <ACRONYM>.` when prose preceded the marker on the same line.
- Root cause: an all-caps acronym with a sentence-final period (`CERN.`) lexes as a `Pn` token, whereas its period-less spelling (`CERN`) lexes as `Caps`. A bare `Caps` reduces to a `NameCaps` node and is absorbed onto a year-only copyright via the `strong_first` path in `should_start_absorbing`; a bare trailing `Pn` matched no absorption branch and was dropped, yielding a holder-less `Copyright (c) <year>`.
- Isolated lines were rescued only by the line-anchored `extend_year_only_copyrights_with_trailing_text` repair (regex anchored at `^copyright`), which cannot fire when prose precedes the copyright — so any real-world file with the copyright mid-line lost the holder.
- Observed on flask `tests/test_cli.py` @ `22d924701a6ae2e4cd01e9a15bbaf3946094af65` (`... Revised BSD License. Copyright © 2015 CERN.`): reported `Copyright © 2015` with no holder; now reports `Copyright © 2015 CERN.` with holder `CERN`.
- Fix: in `should_start_absorbing`, absorb a lone trailing `Pn` leaf on the same line as a holder-less, year-bearing copyright clause, mirroring the existing `Caps`/`NameCaps` treatment so the two source-faithful spellings behave consistently. Scoped to a year-only clause so it cannot swallow ordinary prose.

## Scope and exclusions

- Included: general absorption fix for a trailing `Pn` acronym holder; detector regression tests.
- Explicit exclusions: no lexer retagging of `CERN.` (kept as `Pn`, which is still correct in name contexts such as `Name Pn`); no change to the line-anchored repair heuristic.

## How to verify

- Scan a file whose copyright is preceded by prose on the same line, e.g. a line containing `its Revised BSD License. Copyright © 2015 CERN.` with `--copyright`; observe the holder `CERN` is captured and the statement keeps `CERN.`.
- Edge cases exercised manually: `Copyright © 2015 CERN. All rights reserved.` (rights-reserved stripped from holder, holder still `CERN`); `Copyright © 2015 U.S. Government` (multi-token name unaffected); a bare year-only `Copyright © 2015` after prose (correctly yields no holder — no over-capture of surrounding prose).

## Expected-output fixture changes

- Files changed: none. No golden/expected fixtures shifted; the existing copyright golden suite (`copyright_golden`), `scanner_copyright_credits`, `post_processing_golden`, and the `copyright::` unit tests all pass unchanged. New coverage is added as unit tests in `src/copyright/detector/tests.rs`.
