### PR TITLE
ci: soft-fail Validate URLs on flaky external hosts

### DIFF
--- a/.agents/skills/generated-docs-maintenance/SKILL.md
+++ b/.agents/skills/generated-docs-maintenance/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the task mentions:
 - `docs/SUPPORTED_FORMATS.md` can drift when parser metadata changes even if parser tests pass.
 - `generate-benchmark-chart` reads timing rows from `docs/BENCHMARKS.md`; the SVG and headline are not independent data sources.
 - `npm run check:docs` uses `git ls-files`, so untracked new Markdown needs explicit targeted formatting/lint checks before it is staged.
-- URL validation is a blocking CI check: a broken/removed production link fails `check.yml`. Re-point rotted benchmark-artifact URLs to a committed `testdata/` fixture, or remove the non-reproducible row.
+- URL validation runs in CI with `continue-on-error` (external hosts are too flaky to gate merges). Still re-point rotted benchmark-artifact URLs to a committed `testdata/` fixture, or remove the non-reproducible row, when you notice a dead link locally.
 - Prettier and markdownlint are Node/npm-managed, so docs validation needs the repo's Node toolchain.
 
 ## Source Documents

--- a/.claude/skills/generated-docs-maintenance/SKILL.md
+++ b/.claude/skills/generated-docs-maintenance/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the task mentions:
 - `docs/SUPPORTED_FORMATS.md` can drift when parser metadata changes even if parser tests pass.
 - `generate-benchmark-chart` reads timing rows from `docs/BENCHMARKS.md`; the SVG and headline are not independent data sources.
 - `npm run check:docs` uses `git ls-files`, so untracked new Markdown needs explicit targeted formatting/lint checks before it is staged.
-- URL validation is a blocking CI check: a broken/removed production link fails `check.yml`. Re-point rotted benchmark-artifact URLs to a committed `testdata/` fixture, or remove the non-reproducible row.
+- URL validation runs in CI with `continue-on-error` (external hosts are too flaky to gate merges). Still re-point rotted benchmark-artifact URLs to a committed `testdata/` fixture, or remove the non-reproducible row, when you notice a dead link locally.
 - Prettier and markdownlint are Node/npm-managed, so docs validation needs the repo's Node toolchain.
 
 ## Source Documents

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -161,7 +161,10 @@ jobs:
       - name: Check formatting (Prettier)
         run: npm run format:check
 
+      # Soft-fail: external hosts (e.g. googlesource) often return transient
+      # 5xx/timeouts that flake Code Quality without reflecting a real docs bug.
       - name: Validate URLs
+        continue-on-error: true
         run: npm run validate:urls
 
       - name: Lint Markdown

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -494,12 +494,14 @@ Exit codes:
 - `0`: all URLs valid
 - `1`: some URLs failed validation
 
-This command is a blocking CI check: a failed URL fails the `check.yml` run. It
-probes with a single-byte ranged GET (falling back to HTTP HEAD only when the
-ranged request itself is at fault — a transport failure such as a server that
-ignores `Range:` and streams a large body, or a `416`/`501` range rejection)
-and retries transient failures, so it flags genuinely broken or removed
-links rather than large-download timeouts or momentary network blips.
+This command runs in CI under `check.yml` with `continue-on-error`, so a
+failed URL is reported in the job log but does not fail the run (external
+hosts are too flaky to gate merges). It probes with a single-byte ranged GET
+(falling back to HTTP HEAD only when the ranged request itself is at fault —
+a transport failure such as a server that ignores `Range:` and streams a
+large body, or a `416`/`501` range rejection) and retries transient failures,
+so local runs still surface genuinely broken or removed links rather than
+large-download timeouts or momentary network blips.
 Loopback/example hosts and `…`/`...` placeholder URLs are skipped. When a
 benchmark artifact URL rots, re-point it to the committed `testdata/` fixture or
 remove the non-reproducible row rather than leaving a dead link.


### PR DESCRIPTION
## Summary

- Set `continue-on-error: true` on the Code Quality **Validate URLs** step so transient 5xx/timeouts from external doc hosts (e.g. `android.googlesource.com`) no longer fail the job.
- Document the soft-fail contract in `xtask/README.md` and the generated-docs maintenance skill so maintainers still treat broken links as actionable when seen locally or in CI logs.

## Issues

- Covers: PR #1323 was blocked when Code Quality failed on a transient HTTP 503 from `android.googlesource.com` during `npm run validate:urls`.

## Scope and exclusions

- Included: `.github/workflows/check.yml`; maintainer docs in `xtask/README.md` and mirrored generated-docs skill notes.
- Explicit exclusions: no change to `validate-urls` probe/retry logic or which URLs are checked.

## How to verify

- Confirm `.github/workflows/check.yml` marks **Validate URLs** with `continue-on-error: true` and keeps the inline rationale comment.
- Optionally run `npm run validate:urls` locally; failures should still print in the log even though CI will not fail the job on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)