### PR TITLE
fix(output): emit valid SPDX tag-value for resolved deps and exceptions

### DIFF
--- a/examples/sbom/express/sbom.cdx.json
+++ b/examples/sbom/express/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:7d872aba-ff30-46a4-85c2-e82390230f22",
+  "serialNumber": "urn:uuid:91ad61c4-42a1-4321-ad30-83a7bcbd583c",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-07-23T20:19:16Z",
+    "timestamp": "2026-07-23T22:12:14Z",
     "tools": [
       {
         "name": "Provenant",

--- a/examples/sbom/express/sbom.spdx
+++ b/examples/sbom/express/sbom.spdx
@@ -13,7 +13,7 @@ Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
 Creator: Tool: Provenant-1.0.1
-Created: 2026-07-23T20:19:15Z
+Created: 2026-07-23T22:12:13Z
 ## Package Information
 PackageName: express
 SPDXID: SPDXRef-Package-1
@@ -29,358 +29,6 @@ Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
 Copyright(c) 2009-2013 TJ Holowaychuk
 Copyright(c) 2013 Roman Shtylman
 Copyright(c) 2014-2015 Douglas Christopher Wilson</text>
-## Package Information
-PackageName: accepts
-SPDXID: SPDXRef-Package-Dependency-1
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: after
-SPDXID: SPDXRef-Package-Dependency-2
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: body-parser
-SPDXID: SPDXRef-Package-Dependency-3
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: connect-redis
-SPDXID: SPDXRef-Package-Dependency-4
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: content-disposition
-SPDXID: SPDXRef-Package-Dependency-5
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: content-type
-SPDXID: SPDXRef-Package-Dependency-6
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cookie
-SPDXID: SPDXRef-Package-Dependency-7
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cookie-parser
-SPDXID: SPDXRef-Package-Dependency-8
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cookie-session
-SPDXID: SPDXRef-Package-Dependency-9
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cookie-signature
-SPDXID: SPDXRef-Package-Dependency-10
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: debug
-SPDXID: SPDXRef-Package-Dependency-11
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: depd
-SPDXID: SPDXRef-Package-Dependency-12
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: ejs
-SPDXID: SPDXRef-Package-Dependency-13
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: encodeurl
-SPDXID: SPDXRef-Package-Dependency-14
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: escape-html
-SPDXID: SPDXRef-Package-Dependency-15
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: eslint
-SPDXID: SPDXRef-Package-Dependency-16
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: etag
-SPDXID: SPDXRef-Package-Dependency-17
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: express-session
-SPDXID: SPDXRef-Package-Dependency-18
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: finalhandler
-SPDXID: SPDXRef-Package-Dependency-19
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: fresh
-SPDXID: SPDXRef-Package-Dependency-20
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: hbs
-SPDXID: SPDXRef-Package-Dependency-21
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: http-errors
-SPDXID: SPDXRef-Package-Dependency-22
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: marked
-SPDXID: SPDXRef-Package-Dependency-23
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: merge-descriptors
-SPDXID: SPDXRef-Package-Dependency-24
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: method-override
-SPDXID: SPDXRef-Package-Dependency-25
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: mime-types
-SPDXID: SPDXRef-Package-Dependency-26
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: mocha
-SPDXID: SPDXRef-Package-Dependency-27
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: morgan
-SPDXID: SPDXRef-Package-Dependency-28
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: nyc
-SPDXID: SPDXRef-Package-Dependency-29
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: on-finished
-SPDXID: SPDXRef-Package-Dependency-30
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: once
-SPDXID: SPDXRef-Package-Dependency-31
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: parseurl
-SPDXID: SPDXRef-Package-Dependency-32
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pbkdf2-password
-SPDXID: SPDXRef-Package-Dependency-33
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: proxy-addr
-SPDXID: SPDXRef-Package-Dependency-34
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: qs
-SPDXID: SPDXRef-Package-Dependency-35
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: range-parser
-SPDXID: SPDXRef-Package-Dependency-36
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: router
-SPDXID: SPDXRef-Package-Dependency-37
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: send
-SPDXID: SPDXRef-Package-Dependency-38
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serve-static
-SPDXID: SPDXRef-Package-Dependency-39
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: statuses
-SPDXID: SPDXRef-Package-Dependency-40
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: supertest
-SPDXID: SPDXRef-Package-Dependency-41
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: type-is
-SPDXID: SPDXRef-Package-Dependency-42
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: vary
-SPDXID: SPDXRef-Package-Dependency-43
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: vhost
-SPDXID: SPDXRef-Package-Dependency-44
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
 ## File Information
 FileName: ./.editorconfig
 SPDXID: SPDXRef-1
@@ -1901,6 +1549,358 @@ LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NONE
 FileCopyrightText: NONE
 
+## Package Information
+PackageName: accepts
+SPDXID: SPDXRef-Package-Dependency-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: after
+SPDXID: SPDXRef-Package-Dependency-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: body-parser
+SPDXID: SPDXRef-Package-Dependency-3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: connect-redis
+SPDXID: SPDXRef-Package-Dependency-4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: content-disposition
+SPDXID: SPDXRef-Package-Dependency-5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: content-type
+SPDXID: SPDXRef-Package-Dependency-6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cookie
+SPDXID: SPDXRef-Package-Dependency-7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cookie-parser
+SPDXID: SPDXRef-Package-Dependency-8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cookie-session
+SPDXID: SPDXRef-Package-Dependency-9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cookie-signature
+SPDXID: SPDXRef-Package-Dependency-10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: debug
+SPDXID: SPDXRef-Package-Dependency-11
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: depd
+SPDXID: SPDXRef-Package-Dependency-12
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: ejs
+SPDXID: SPDXRef-Package-Dependency-13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: encodeurl
+SPDXID: SPDXRef-Package-Dependency-14
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: escape-html
+SPDXID: SPDXRef-Package-Dependency-15
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: eslint
+SPDXID: SPDXRef-Package-Dependency-16
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: etag
+SPDXID: SPDXRef-Package-Dependency-17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: express-session
+SPDXID: SPDXRef-Package-Dependency-18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: finalhandler
+SPDXID: SPDXRef-Package-Dependency-19
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: fresh
+SPDXID: SPDXRef-Package-Dependency-20
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: hbs
+SPDXID: SPDXRef-Package-Dependency-21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: http-errors
+SPDXID: SPDXRef-Package-Dependency-22
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: marked
+SPDXID: SPDXRef-Package-Dependency-23
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: merge-descriptors
+SPDXID: SPDXRef-Package-Dependency-24
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: method-override
+SPDXID: SPDXRef-Package-Dependency-25
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: mime-types
+SPDXID: SPDXRef-Package-Dependency-26
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: mocha
+SPDXID: SPDXRef-Package-Dependency-27
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: morgan
+SPDXID: SPDXRef-Package-Dependency-28
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: nyc
+SPDXID: SPDXRef-Package-Dependency-29
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: on-finished
+SPDXID: SPDXRef-Package-Dependency-30
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: once
+SPDXID: SPDXRef-Package-Dependency-31
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: parseurl
+SPDXID: SPDXRef-Package-Dependency-32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pbkdf2-password
+SPDXID: SPDXRef-Package-Dependency-33
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: proxy-addr
+SPDXID: SPDXRef-Package-Dependency-34
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: qs
+SPDXID: SPDXRef-Package-Dependency-35
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: range-parser
+SPDXID: SPDXRef-Package-Dependency-36
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: router
+SPDXID: SPDXRef-Package-Dependency-37
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: send
+SPDXID: SPDXRef-Package-Dependency-38
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serve-static
+SPDXID: SPDXRef-Package-Dependency-39
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: statuses
+SPDXID: SPDXRef-Package-Dependency-40
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: supertest
+SPDXID: SPDXRef-Package-Dependency-41
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: type-is
+SPDXID: SPDXRef-Package-Dependency-42
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: vary
+SPDXID: SPDXRef-Package-Dependency-43
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: vhost
+SPDXID: SPDXRef-Package-Dependency-44
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
 ## Relationships
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
 Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-1

--- a/examples/sbom/flask/sbom.cdx.json
+++ b/examples/sbom/flask/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:e76648da-149a-4d07-8efd-37ae3d7026d6",
+  "serialNumber": "urn:uuid:4d23bf82-3939-4f54-b4e2-e1a2a4c59ee8",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-07-23T20:19:18Z",
+    "timestamp": "2026-07-23T22:12:16Z",
     "tools": [
       {
         "name": "Provenant",

--- a/examples/sbom/flask/sbom.spdx
+++ b/examples/sbom/flask/sbom.spdx
@@ -13,7 +13,7 @@ Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
 Creator: Tool: Provenant-1.0.1
-Created: 2026-07-23T20:19:17Z
+Created: 2026-07-23T22:12:15Z
 ## Package Information
 PackageName: flask-example-celery
 SPDXID: SPDXRef-Package-1
@@ -70,406 +70,6 @@ PackageCopyrightText: <text>(c) Copyright 2010 by <a href="http://domain.invalid
 Copyright 2010 Pallets
 Copyright © 2015 CERN.
 copyright = "2010 Pallets"</text>
-## Package Information
-PackageName: amqp
-SPDXID: SPDXRef-Package-Dependency-1
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: asgiref
-SPDXID: SPDXRef-Package-Dependency-2
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: async-timeout
-SPDXID: SPDXRef-Package-Dependency-3
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: billiard
-SPDXID: SPDXRef-Package-Dependency-4
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: blinker
-SPDXID: SPDXRef-Package-Dependency-5
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: blinker
-SPDXID: SPDXRef-Package-Dependency-6
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: celery
-SPDXID: SPDXRef-Package-Dependency-7
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: celery
-SPDXID: SPDXRef-Package-Dependency-8
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: click
-SPDXID: SPDXRef-Package-Dependency-9
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: click-didyoumean
-SPDXID: SPDXRef-Package-Dependency-10
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: click-plugins
-SPDXID: SPDXRef-Package-Dependency-11
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: click-repl
-SPDXID: SPDXRef-Package-Dependency-12
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: click
-SPDXID: SPDXRef-Package-Dependency-13
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cryptography
-SPDXID: SPDXRef-Package-Dependency-14
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: flask
-SPDXID: SPDXRef-Package-Dependency-15
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: flask
-SPDXID: SPDXRef-Package-Dependency-16
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: gha-update
-SPDXID: SPDXRef-Package-Dependency-17
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: greenlet
-SPDXID: SPDXRef-Package-Dependency-18
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: importlib-metadata
-SPDXID: SPDXRef-Package-Dependency-19
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: itsdangerous
-SPDXID: SPDXRef-Package-Dependency-20
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: itsdangerous
-SPDXID: SPDXRef-Package-Dependency-21
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: jinja2
-SPDXID: SPDXRef-Package-Dependency-22
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: jinja2
-SPDXID: SPDXRef-Package-Dependency-23
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: kombu
-SPDXID: SPDXRef-Package-Dependency-24
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: markupsafe
-SPDXID: SPDXRef-Package-Dependency-25
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: markupsafe
-SPDXID: SPDXRef-Package-Dependency-26
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: mypy
-SPDXID: SPDXRef-Package-Dependency-27
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pallets-sphinx-themes
-SPDXID: SPDXRef-Package-Dependency-28
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pre-commit
-SPDXID: SPDXRef-Package-Dependency-29
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pre-commit-uv
-SPDXID: SPDXRef-Package-Dependency-30
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: prompt-toolkit
-SPDXID: SPDXRef-Package-Dependency-31
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pyright
-SPDXID: SPDXRef-Package-Dependency-32
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pytest
-SPDXID: SPDXRef-Package-Dependency-33
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: python-dotenv
-SPDXID: SPDXRef-Package-Dependency-34
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pytz
-SPDXID: SPDXRef-Package-Dependency-35
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: redis
-SPDXID: SPDXRef-Package-Dependency-36
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: ruff
-SPDXID: SPDXRef-Package-Dependency-37
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: six
-SPDXID: SPDXRef-Package-Dependency-38
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: sphinx
-SPDXID: SPDXRef-Package-Dependency-39
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: sphinx-autobuild
-SPDXID: SPDXRef-Package-Dependency-40
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: sphinx-tabs
-SPDXID: SPDXRef-Package-Dependency-41
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: sphinxcontrib-log-cabinet
-SPDXID: SPDXRef-Package-Dependency-42
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tox
-SPDXID: SPDXRef-Package-Dependency-43
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tox-uv
-SPDXID: SPDXRef-Package-Dependency-44
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: types-contextvars
-SPDXID: SPDXRef-Package-Dependency-45
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: types-dataclasses
-SPDXID: SPDXRef-Package-Dependency-46
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: vine
-SPDXID: SPDXRef-Package-Dependency-47
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: wcwidth
-SPDXID: SPDXRef-Package-Dependency-48
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: werkzeug
-SPDXID: SPDXRef-Package-Dependency-49
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: werkzeug
-SPDXID: SPDXRef-Package-Dependency-50
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
 ## File Information
 FileName: ./.devcontainer/devcontainer.json
 SPDXID: SPDXRef-1
@@ -2098,6 +1698,406 @@ LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NONE
 FileCopyrightText: NONE
 
+## Package Information
+PackageName: amqp
+SPDXID: SPDXRef-Package-Dependency-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: asgiref
+SPDXID: SPDXRef-Package-Dependency-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: async-timeout
+SPDXID: SPDXRef-Package-Dependency-3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: billiard
+SPDXID: SPDXRef-Package-Dependency-4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: blinker
+SPDXID: SPDXRef-Package-Dependency-5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: blinker
+SPDXID: SPDXRef-Package-Dependency-6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: celery
+SPDXID: SPDXRef-Package-Dependency-7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: celery
+SPDXID: SPDXRef-Package-Dependency-8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: click
+SPDXID: SPDXRef-Package-Dependency-9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: click-didyoumean
+SPDXID: SPDXRef-Package-Dependency-10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: click-plugins
+SPDXID: SPDXRef-Package-Dependency-11
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: click-repl
+SPDXID: SPDXRef-Package-Dependency-12
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: click
+SPDXID: SPDXRef-Package-Dependency-13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cryptography
+SPDXID: SPDXRef-Package-Dependency-14
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: flask
+SPDXID: SPDXRef-Package-Dependency-15
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: flask
+SPDXID: SPDXRef-Package-Dependency-16
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: gha-update
+SPDXID: SPDXRef-Package-Dependency-17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: greenlet
+SPDXID: SPDXRef-Package-Dependency-18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: importlib-metadata
+SPDXID: SPDXRef-Package-Dependency-19
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: itsdangerous
+SPDXID: SPDXRef-Package-Dependency-20
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: itsdangerous
+SPDXID: SPDXRef-Package-Dependency-21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: jinja2
+SPDXID: SPDXRef-Package-Dependency-22
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: jinja2
+SPDXID: SPDXRef-Package-Dependency-23
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: kombu
+SPDXID: SPDXRef-Package-Dependency-24
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-Dependency-25
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-Dependency-26
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: mypy
+SPDXID: SPDXRef-Package-Dependency-27
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pallets-sphinx-themes
+SPDXID: SPDXRef-Package-Dependency-28
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pre-commit
+SPDXID: SPDXRef-Package-Dependency-29
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pre-commit-uv
+SPDXID: SPDXRef-Package-Dependency-30
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: prompt-toolkit
+SPDXID: SPDXRef-Package-Dependency-31
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pyright
+SPDXID: SPDXRef-Package-Dependency-32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pytest
+SPDXID: SPDXRef-Package-Dependency-33
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: python-dotenv
+SPDXID: SPDXRef-Package-Dependency-34
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pytz
+SPDXID: SPDXRef-Package-Dependency-35
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: redis
+SPDXID: SPDXRef-Package-Dependency-36
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: ruff
+SPDXID: SPDXRef-Package-Dependency-37
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: six
+SPDXID: SPDXRef-Package-Dependency-38
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: sphinx
+SPDXID: SPDXRef-Package-Dependency-39
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: sphinx-autobuild
+SPDXID: SPDXRef-Package-Dependency-40
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: sphinx-tabs
+SPDXID: SPDXRef-Package-Dependency-41
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: sphinxcontrib-log-cabinet
+SPDXID: SPDXRef-Package-Dependency-42
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tox
+SPDXID: SPDXRef-Package-Dependency-43
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tox-uv
+SPDXID: SPDXRef-Package-Dependency-44
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: types-contextvars
+SPDXID: SPDXRef-Package-Dependency-45
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: types-dataclasses
+SPDXID: SPDXRef-Package-Dependency-46
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: vine
+SPDXID: SPDXRef-Package-Dependency-47
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: wcwidth
+SPDXID: SPDXRef-Package-Dependency-48
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: werkzeug
+SPDXID: SPDXRef-Package-Dependency-49
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: werkzeug
+SPDXID: SPDXRef-Package-Dependency-50
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
 ## Relationships
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
 Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-106

--- a/examples/sbom/ripgrep/sbom.cdx.json
+++ b/examples/sbom/ripgrep/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:b1c72b94-7cb9-4735-8c98-69ec7962da64",
+  "serialNumber": "urn:uuid:25e50a03-8450-46b0-b06a-42b0ff0b606c",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-07-23T20:19:14Z",
+    "timestamp": "2026-07-23T22:12:12Z",
     "tools": [
       {
         "name": "Provenant",

--- a/examples/sbom/ripgrep/sbom.spdx
+++ b/examples/sbom/ripgrep/sbom.spdx
@@ -13,7 +13,7 @@ Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
 Creator: Tool: Provenant-1.0.1
-Created: 2026-07-23T20:19:13Z
+Created: 2026-07-23T22:12:12Z
 ## Package Information
 PackageName: fuzz
 SPDXID: SPDXRef-Package-1
@@ -139,7 +139,6 @@ PackageLicenseInfoFromFiles: BSD-2-Clause
 PackageLicenseInfoFromFiles: BSD-3-Clause
 PackageLicenseInfoFromFiles: CC-BY-4.0
 PackageLicenseInfoFromFiles: LGPL-2.0-or-later
-PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-gutenberg-2020
 PackageLicenseInfoFromFiles: LicenseRef-scancode-other-copyleft
 PackageLicenseInfoFromFiles: LicenseRef-scancode-unknown-license-reference
@@ -149,830 +148,6 @@ PackageLicenseDeclared: MIT OR Unlicense
 PackageCopyrightText: <text>Copyright (c) 2011 Github
 Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
 Copyright (c) 2015 Andrew Gallant</text>
-## Package Information
-PackageName: aho-corasick
-SPDXID: SPDXRef-Package-Dependency-1
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: aho-corasick
-SPDXID: SPDXRef-Package-Dependency-2
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: aho-corasick
-SPDXID: SPDXRef-Package-Dependency-3
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: anyhow
-SPDXID: SPDXRef-Package-Dependency-4
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: anyhow
-SPDXID: SPDXRef-Package-Dependency-5
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: arbitrary
-SPDXID: SPDXRef-Package-Dependency-6
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: arbitrary
-SPDXID: SPDXRef-Package-Dependency-7
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: arbitrary
-SPDXID: SPDXRef-Package-Dependency-8
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: bstr
-SPDXID: SPDXRef-Package-Dependency-9
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: bstr
-SPDXID: SPDXRef-Package-Dependency-10
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: bstr
-SPDXID: SPDXRef-Package-Dependency-11
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cc
-SPDXID: SPDXRef-Package-Dependency-12
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cc
-SPDXID: SPDXRef-Package-Dependency-13
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: cfg-if
-SPDXID: SPDXRef-Package-Dependency-14
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-channel
-SPDXID: SPDXRef-Package-Dependency-15
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-channel
-SPDXID: SPDXRef-Package-Dependency-16
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-deque
-SPDXID: SPDXRef-Package-Dependency-17
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-deque
-SPDXID: SPDXRef-Package-Dependency-18
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-epoch
-SPDXID: SPDXRef-Package-Dependency-19
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: crossbeam-utils
-SPDXID: SPDXRef-Package-Dependency-20
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: derive_arbitrary
-SPDXID: SPDXRef-Package-Dependency-21
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: derive_arbitrary
-SPDXID: SPDXRef-Package-Dependency-22
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: encoding_rs
-SPDXID: SPDXRef-Package-Dependency-23
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: encoding_rs
-SPDXID: SPDXRef-Package-Dependency-24
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: encoding_rs_io
-SPDXID: SPDXRef-Package-Dependency-25
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: encoding_rs_io
-SPDXID: SPDXRef-Package-Dependency-26
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: find-msvc-tools
-SPDXID: SPDXRef-Package-Dependency-27
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: getrandom
-SPDXID: SPDXRef-Package-Dependency-28
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: glob
-SPDXID: SPDXRef-Package-Dependency-29
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: glob
-SPDXID: SPDXRef-Package-Dependency-30
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: globset
-SPDXID: SPDXRef-Package-Dependency-31
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: globset
-SPDXID: SPDXRef-Package-Dependency-32
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep
-SPDXID: SPDXRef-Package-Dependency-33
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-cli
-SPDXID: SPDXRef-Package-Dependency-34
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-matcher
-SPDXID: SPDXRef-Package-Dependency-35
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-pcre2
-SPDXID: SPDXRef-Package-Dependency-36
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-printer
-SPDXID: SPDXRef-Package-Dependency-37
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-regex
-SPDXID: SPDXRef-Package-Dependency-38
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: grep-searcher
-SPDXID: SPDXRef-Package-Dependency-39
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: ignore
-SPDXID: SPDXRef-Package-Dependency-40
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: itoa
-SPDXID: SPDXRef-Package-Dependency-41
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: jobserver
-SPDXID: SPDXRef-Package-Dependency-42
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: jobserver
-SPDXID: SPDXRef-Package-Dependency-43
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: lexopt
-SPDXID: SPDXRef-Package-Dependency-44
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: lexopt
-SPDXID: SPDXRef-Package-Dependency-45
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: libc
-SPDXID: SPDXRef-Package-Dependency-46
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: libc
-SPDXID: SPDXRef-Package-Dependency-47
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: libfuzzer-sys
-SPDXID: SPDXRef-Package-Dependency-48
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: libfuzzer-sys
-SPDXID: SPDXRef-Package-Dependency-49
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: log
-SPDXID: SPDXRef-Package-Dependency-50
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: log
-SPDXID: SPDXRef-Package-Dependency-51
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: log
-SPDXID: SPDXRef-Package-Dependency-52
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: memchr
-SPDXID: SPDXRef-Package-Dependency-53
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: memchr
-SPDXID: SPDXRef-Package-Dependency-54
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: memchr
-SPDXID: SPDXRef-Package-Dependency-55
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: memmap
-SPDXID: SPDXRef-Package-Dependency-56
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: memmap2
-SPDXID: SPDXRef-Package-Dependency-57
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: once_cell
-SPDXID: SPDXRef-Package-Dependency-58
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pcre2
-SPDXID: SPDXRef-Package-Dependency-59
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pcre2-sys
-SPDXID: SPDXRef-Package-Dependency-60
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pcre2
-SPDXID: SPDXRef-Package-Dependency-61
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pkg-config
-SPDXID: SPDXRef-Package-Dependency-62
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: proc-macro2
-SPDXID: SPDXRef-Package-Dependency-63
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: proc-macro2
-SPDXID: SPDXRef-Package-Dependency-64
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: quote
-SPDXID: SPDXRef-Package-Dependency-65
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: quote
-SPDXID: SPDXRef-Package-Dependency-66
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: r-efi
-SPDXID: SPDXRef-Package-Dependency-67
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex
-SPDXID: SPDXRef-Package-Dependency-68
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-automata
-SPDXID: SPDXRef-Package-Dependency-69
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-automata
-SPDXID: SPDXRef-Package-Dependency-70
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-automata
-SPDXID: SPDXRef-Package-Dependency-71
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-syntax
-SPDXID: SPDXRef-Package-Dependency-72
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-syntax
-SPDXID: SPDXRef-Package-Dependency-73
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex-syntax
-SPDXID: SPDXRef-Package-Dependency-74
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: regex
-SPDXID: SPDXRef-Package-Dependency-75
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: same-file
-SPDXID: SPDXRef-Package-Dependency-76
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: same-file
-SPDXID: SPDXRef-Package-Dependency-77
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde
-SPDXID: SPDXRef-Package-Dependency-78
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde
-SPDXID: SPDXRef-Package-Dependency-79
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde
-SPDXID: SPDXRef-Package-Dependency-80
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_core
-SPDXID: SPDXRef-Package-Dependency-81
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_derive
-SPDXID: SPDXRef-Package-Dependency-82
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_derive
-SPDXID: SPDXRef-Package-Dependency-83
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_derive
-SPDXID: SPDXRef-Package-Dependency-84
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_json
-SPDXID: SPDXRef-Package-Dependency-85
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_json
-SPDXID: SPDXRef-Package-Dependency-86
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: shlex
-SPDXID: SPDXRef-Package-Dependency-87
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: syn
-SPDXID: SPDXRef-Package-Dependency-88
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: syn
-SPDXID: SPDXRef-Package-Dependency-89
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: termcolor
-SPDXID: SPDXRef-Package-Dependency-90
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: termcolor
-SPDXID: SPDXRef-Package-Dependency-91
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: textwrap
-SPDXID: SPDXRef-Package-Dependency-92
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: textwrap
-SPDXID: SPDXRef-Package-Dependency-93
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tikv-jemalloc-sys
-SPDXID: SPDXRef-Package-Dependency-94
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tikv-jemallocator
-SPDXID: SPDXRef-Package-Dependency-95
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: unicode-ident
-SPDXID: SPDXRef-Package-Dependency-96
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: unicode-ident
-SPDXID: SPDXRef-Package-Dependency-97
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: walkdir
-SPDXID: SPDXRef-Package-Dependency-98
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: walkdir
-SPDXID: SPDXRef-Package-Dependency-99
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: winapi-util
-SPDXID: SPDXRef-Package-Dependency-100
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: windows-link
-SPDXID: SPDXRef-Package-Dependency-101
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: windows-sys
-SPDXID: SPDXRef-Package-Dependency-102
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: zmij
-SPDXID: SPDXRef-Package-Dependency-103
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
 ## File Information
 FileName: ./.cargo/config.toml
 SPDXID: SPDXRef-1
@@ -1089,8 +264,7 @@ FileCopyrightText: NONE
 FileName: ./GUIDE.md
 SPDXID: SPDXRef-16
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
-LicenseConcluded: MIT AND Unlicense AND LicenseRef-scancode-generic-exception
-LicenseInfoInFile: LicenseRef-scancode-generic-exception
+LicenseConcluded: MIT AND Unlicense
 LicenseInfoInFile: MIT
 LicenseInfoInFile: Unlicense
 FileCopyrightText: NONE
@@ -2541,6 +1715,830 @@ LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NONE
 FileCopyrightText: NONE
 
+## Package Information
+PackageName: aho-corasick
+SPDXID: SPDXRef-Package-Dependency-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: aho-corasick
+SPDXID: SPDXRef-Package-Dependency-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: aho-corasick
+SPDXID: SPDXRef-Package-Dependency-3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: anyhow
+SPDXID: SPDXRef-Package-Dependency-4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: anyhow
+SPDXID: SPDXRef-Package-Dependency-5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: arbitrary
+SPDXID: SPDXRef-Package-Dependency-6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: arbitrary
+SPDXID: SPDXRef-Package-Dependency-7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: arbitrary
+SPDXID: SPDXRef-Package-Dependency-8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: bstr
+SPDXID: SPDXRef-Package-Dependency-9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: bstr
+SPDXID: SPDXRef-Package-Dependency-10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: bstr
+SPDXID: SPDXRef-Package-Dependency-11
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cc
+SPDXID: SPDXRef-Package-Dependency-12
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cc
+SPDXID: SPDXRef-Package-Dependency-13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: cfg-if
+SPDXID: SPDXRef-Package-Dependency-14
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-channel
+SPDXID: SPDXRef-Package-Dependency-15
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-channel
+SPDXID: SPDXRef-Package-Dependency-16
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-deque
+SPDXID: SPDXRef-Package-Dependency-17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-deque
+SPDXID: SPDXRef-Package-Dependency-18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-epoch
+SPDXID: SPDXRef-Package-Dependency-19
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: crossbeam-utils
+SPDXID: SPDXRef-Package-Dependency-20
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: derive_arbitrary
+SPDXID: SPDXRef-Package-Dependency-21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: derive_arbitrary
+SPDXID: SPDXRef-Package-Dependency-22
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: encoding_rs
+SPDXID: SPDXRef-Package-Dependency-23
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: encoding_rs
+SPDXID: SPDXRef-Package-Dependency-24
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: encoding_rs_io
+SPDXID: SPDXRef-Package-Dependency-25
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: encoding_rs_io
+SPDXID: SPDXRef-Package-Dependency-26
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: find-msvc-tools
+SPDXID: SPDXRef-Package-Dependency-27
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: getrandom
+SPDXID: SPDXRef-Package-Dependency-28
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: glob
+SPDXID: SPDXRef-Package-Dependency-29
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: glob
+SPDXID: SPDXRef-Package-Dependency-30
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: globset
+SPDXID: SPDXRef-Package-Dependency-31
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: globset
+SPDXID: SPDXRef-Package-Dependency-32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep
+SPDXID: SPDXRef-Package-Dependency-33
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-cli
+SPDXID: SPDXRef-Package-Dependency-34
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-matcher
+SPDXID: SPDXRef-Package-Dependency-35
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-pcre2
+SPDXID: SPDXRef-Package-Dependency-36
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-printer
+SPDXID: SPDXRef-Package-Dependency-37
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-regex
+SPDXID: SPDXRef-Package-Dependency-38
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: grep-searcher
+SPDXID: SPDXRef-Package-Dependency-39
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: ignore
+SPDXID: SPDXRef-Package-Dependency-40
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: itoa
+SPDXID: SPDXRef-Package-Dependency-41
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: jobserver
+SPDXID: SPDXRef-Package-Dependency-42
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: jobserver
+SPDXID: SPDXRef-Package-Dependency-43
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: lexopt
+SPDXID: SPDXRef-Package-Dependency-44
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: lexopt
+SPDXID: SPDXRef-Package-Dependency-45
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: libc
+SPDXID: SPDXRef-Package-Dependency-46
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: libc
+SPDXID: SPDXRef-Package-Dependency-47
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: libfuzzer-sys
+SPDXID: SPDXRef-Package-Dependency-48
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: libfuzzer-sys
+SPDXID: SPDXRef-Package-Dependency-49
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: log
+SPDXID: SPDXRef-Package-Dependency-50
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: log
+SPDXID: SPDXRef-Package-Dependency-51
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: log
+SPDXID: SPDXRef-Package-Dependency-52
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: memchr
+SPDXID: SPDXRef-Package-Dependency-53
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: memchr
+SPDXID: SPDXRef-Package-Dependency-54
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: memchr
+SPDXID: SPDXRef-Package-Dependency-55
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: memmap
+SPDXID: SPDXRef-Package-Dependency-56
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: memmap2
+SPDXID: SPDXRef-Package-Dependency-57
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: once_cell
+SPDXID: SPDXRef-Package-Dependency-58
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pcre2
+SPDXID: SPDXRef-Package-Dependency-59
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pcre2-sys
+SPDXID: SPDXRef-Package-Dependency-60
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pcre2
+SPDXID: SPDXRef-Package-Dependency-61
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pkg-config
+SPDXID: SPDXRef-Package-Dependency-62
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: proc-macro2
+SPDXID: SPDXRef-Package-Dependency-63
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: proc-macro2
+SPDXID: SPDXRef-Package-Dependency-64
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: quote
+SPDXID: SPDXRef-Package-Dependency-65
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: quote
+SPDXID: SPDXRef-Package-Dependency-66
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: r-efi
+SPDXID: SPDXRef-Package-Dependency-67
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex
+SPDXID: SPDXRef-Package-Dependency-68
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-automata
+SPDXID: SPDXRef-Package-Dependency-69
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-automata
+SPDXID: SPDXRef-Package-Dependency-70
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-automata
+SPDXID: SPDXRef-Package-Dependency-71
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-syntax
+SPDXID: SPDXRef-Package-Dependency-72
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-syntax
+SPDXID: SPDXRef-Package-Dependency-73
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex-syntax
+SPDXID: SPDXRef-Package-Dependency-74
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: regex
+SPDXID: SPDXRef-Package-Dependency-75
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: same-file
+SPDXID: SPDXRef-Package-Dependency-76
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: same-file
+SPDXID: SPDXRef-Package-Dependency-77
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde
+SPDXID: SPDXRef-Package-Dependency-78
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde
+SPDXID: SPDXRef-Package-Dependency-79
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde
+SPDXID: SPDXRef-Package-Dependency-80
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_core
+SPDXID: SPDXRef-Package-Dependency-81
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_derive
+SPDXID: SPDXRef-Package-Dependency-82
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_derive
+SPDXID: SPDXRef-Package-Dependency-83
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_derive
+SPDXID: SPDXRef-Package-Dependency-84
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_json
+SPDXID: SPDXRef-Package-Dependency-85
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_json
+SPDXID: SPDXRef-Package-Dependency-86
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: shlex
+SPDXID: SPDXRef-Package-Dependency-87
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: syn
+SPDXID: SPDXRef-Package-Dependency-88
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: syn
+SPDXID: SPDXRef-Package-Dependency-89
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: termcolor
+SPDXID: SPDXRef-Package-Dependency-90
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: termcolor
+SPDXID: SPDXRef-Package-Dependency-91
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: textwrap
+SPDXID: SPDXRef-Package-Dependency-92
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: textwrap
+SPDXID: SPDXRef-Package-Dependency-93
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tikv-jemalloc-sys
+SPDXID: SPDXRef-Package-Dependency-94
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tikv-jemallocator
+SPDXID: SPDXRef-Package-Dependency-95
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: unicode-ident
+SPDXID: SPDXRef-Package-Dependency-96
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: unicode-ident
+SPDXID: SPDXRef-Package-Dependency-97
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: walkdir
+SPDXID: SPDXRef-Package-Dependency-98
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: walkdir
+SPDXID: SPDXRef-Package-Dependency-99
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: winapi-util
+SPDXID: SPDXRef-Package-Dependency-100
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: windows-link
+SPDXID: SPDXRef-Package-Dependency-101
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: windows-sys
+SPDXID: SPDXRef-Package-Dependency-102
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: zmij
+SPDXID: SPDXRef-Package-Dependency-103
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
 ## Relationships
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
 Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-192
@@ -3046,12 +3044,6 @@ ExtractedText: <text>See details at https://github.com/aboutcode-org/scancode-to
 </text>
 LicenseName: LicenseRef-scancode-other-copyleft
 LicenseComment: <text>See details at https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/other-copyleft_16.RULE
-</text>
-LicenseID: LicenseRef-scancode-generic-exception
-ExtractedText: <text>See details at https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-intro_8.RULE
-</text>
-LicenseName: LicenseRef-scancode-generic-exception
-LicenseComment: <text>See details at https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-intro_8.RULE
 </text>
 LicenseID: LicenseRef-scancode-gutenberg-2020
 ExtractedText: <text>See details at https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/gutenberg-2020_3.RULE

--- a/examples/sbom/tokio/sbom.cdx.json
+++ b/examples/sbom/tokio/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:7d04cf5c-bc48-4ce7-9c58-c3f33d0a17ce",
+  "serialNumber": "urn:uuid:8c52a871-dde8-4702-aa98-ffbbb205c6a9",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-07-23T20:19:20Z",
+    "timestamp": "2026-07-23T22:12:18Z",
     "tools": [
       {
         "name": "Provenant",

--- a/examples/sbom/tokio/sbom.spdx
+++ b/examples/sbom/tokio/sbom.spdx
@@ -13,7 +13,7 @@ Visit https://github.com/getprovenant/provenant/ for support and download.
 SPDX License List: 3.27</text>
 ## Creation Information
 Creator: Tool: Provenant-1.0.1
-Created: 2026-07-23T20:19:20Z
+Created: 2026-07-23T22:12:17Z
 ## Package Information
 PackageName: benches
 SPDXID: SPDXRef-Package-1
@@ -22,7 +22,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 5a81fff35ef5c81e42ebcbcef9537afcde153a5a
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -35,7 +34,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 39464e61fe27a50459cd14ae93d09e177b0542b7
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -48,7 +46,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 30fd08be04f99aadba1d69d7a35b492a7645482e
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -61,7 +58,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 39464e61fe27a50459cd14ae93d09e177b0542b7
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -74,7 +70,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 43e08c01a8b8a3c516f98e6ef7b1083a92536974
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -97,7 +92,6 @@ FilesAnalyzed: true
 PackageVerificationCode: f55b97d80aed21c1644c24c49e35cc86aa8c9bb9
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -121,7 +115,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 8fa7072d1e15a3e9a6c95d428b2b954294d58e5e
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -134,7 +127,6 @@ FilesAnalyzed: true
 PackageVerificationCode: 1836b8628c3230a8677fcb87ad28bad263e7eb94
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -147,7 +139,6 @@ FilesAnalyzed: true
 PackageVerificationCode: f852916d00afee02b0e8a70733712d23e8323ebe
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
@@ -160,323 +151,10 @@ FilesAnalyzed: true
 PackageVerificationCode: 9688db982320e1d79a81501339bc4593b0c3099a
 PackageLicenseConcluded: MIT
 PackageLicenseInfoFromFiles: Apache-2.0
-PackageLicenseInfoFromFiles: LLVM-exception
 PackageLicenseInfoFromFiles: LicenseRef-scancode-generic-cla
 PackageLicenseInfoFromFiles: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: Copyright (c) Tokio Contributors
-## Package Information
-PackageName: async-stream
-SPDXID: SPDXRef-Package-Dependency-1
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: bytes
-SPDXID: SPDXRef-Package-Dependency-2
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: criterion
-SPDXID: SPDXRef-Package-Dependency-3
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: doc-comment
-SPDXID: SPDXRef-Package-Dependency-4
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures
-SPDXID: SPDXRef-Package-Dependency-5
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-concurrency
-SPDXID: SPDXRef-Package-Dependency-6
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-core
-SPDXID: SPDXRef-Package-Dependency-7
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-io
-SPDXID: SPDXRef-Package-Dependency-8
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-sink
-SPDXID: SPDXRef-Package-Dependency-9
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-test
-SPDXID: SPDXRef-Package-Dependency-10
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: futures-util
-SPDXID: SPDXRef-Package-Dependency-11
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: hashbrown
-SPDXID: SPDXRef-Package-Dependency-12
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: http
-SPDXID: SPDXRef-Package-Dependency-13
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: httparse
-SPDXID: SPDXRef-Package-Dependency-14
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: httpdate
-SPDXID: SPDXRef-Package-Dependency-15
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: libfuzzer-sys
-SPDXID: SPDXRef-Package-Dependency-16
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: mio
-SPDXID: SPDXRef-Package-Dependency-17
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: mockall
-SPDXID: SPDXRef-Package-Dependency-18
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: once_cell
-SPDXID: SPDXRef-Package-Dependency-19
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: parking_lot
-SPDXID: SPDXRef-Package-Dependency-20
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: pin-project-lite
-SPDXID: SPDXRef-Package-Dependency-21
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: proc-macro2
-SPDXID: SPDXRef-Package-Dependency-22
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: quote
-SPDXID: SPDXRef-Package-Dependency-23
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: rand
-SPDXID: SPDXRef-Package-Dependency-24
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: rand_chacha
-SPDXID: SPDXRef-Package-Dependency-25
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde
-SPDXID: SPDXRef-Package-Dependency-26
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_derive
-SPDXID: SPDXRef-Package-Dependency-27
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: serde_json
-SPDXID: SPDXRef-Package-Dependency-28
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: slab
-SPDXID: SPDXRef-Package-Dependency-29
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: syn
-SPDXID: SPDXRef-Package-Dependency-30
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tempfile
-SPDXID: SPDXRef-Package-Dependency-31
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tokio
-SPDXID: SPDXRef-Package-Dependency-32
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tokio-macros
-SPDXID: SPDXRef-Package-Dependency-33
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tokio-stream
-SPDXID: SPDXRef-Package-Dependency-34
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tokio-test
-SPDXID: SPDXRef-Package-Dependency-35
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tokio-util
-SPDXID: SPDXRef-Package-Dependency-36
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tracing
-SPDXID: SPDXRef-Package-Dependency-37
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: tracing-subscriber
-SPDXID: SPDXRef-Package-Dependency-38
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
-## Package Information
-PackageName: trybuild
-SPDXID: SPDXRef-Package-Dependency-39
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
-PackageCopyrightText: NONE
 ## File Information
 FileName: ./.github/FUNDING.yml
 SPDXID: SPDXRef-1
@@ -630,7 +308,6 @@ SPDXID: SPDXRef-22
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -1278,7 +955,6 @@ SPDXID: SPDXRef-114
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -1330,7 +1006,6 @@ SPDXID: SPDXRef-121
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -1865,7 +1540,6 @@ SPDXID: SPDXRef-197
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -1966,7 +1640,6 @@ SPDXID: SPDXRef-211
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -2620,7 +2293,6 @@ SPDXID: SPDXRef-304
 FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 LicenseConcluded: MIT
 LicenseInfoInFile: Apache-2.0
-LicenseInfoInFile: LLVM-exception
 LicenseInfoInFile: LicenseRef-scancode-generic-cla
 LicenseInfoInFile: MIT
 FileCopyrightText: NONE
@@ -6531,6 +6203,318 @@ LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NONE
 FileCopyrightText: NONE
 
+## Package Information
+PackageName: async-stream
+SPDXID: SPDXRef-Package-Dependency-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: bytes
+SPDXID: SPDXRef-Package-Dependency-2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: criterion
+SPDXID: SPDXRef-Package-Dependency-3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: doc-comment
+SPDXID: SPDXRef-Package-Dependency-4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures
+SPDXID: SPDXRef-Package-Dependency-5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-concurrency
+SPDXID: SPDXRef-Package-Dependency-6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-core
+SPDXID: SPDXRef-Package-Dependency-7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-io
+SPDXID: SPDXRef-Package-Dependency-8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-sink
+SPDXID: SPDXRef-Package-Dependency-9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-test
+SPDXID: SPDXRef-Package-Dependency-10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: futures-util
+SPDXID: SPDXRef-Package-Dependency-11
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: hashbrown
+SPDXID: SPDXRef-Package-Dependency-12
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: http
+SPDXID: SPDXRef-Package-Dependency-13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: httparse
+SPDXID: SPDXRef-Package-Dependency-14
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: httpdate
+SPDXID: SPDXRef-Package-Dependency-15
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: libfuzzer-sys
+SPDXID: SPDXRef-Package-Dependency-16
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: mio
+SPDXID: SPDXRef-Package-Dependency-17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: mockall
+SPDXID: SPDXRef-Package-Dependency-18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: once_cell
+SPDXID: SPDXRef-Package-Dependency-19
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: parking_lot
+SPDXID: SPDXRef-Package-Dependency-20
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: pin-project-lite
+SPDXID: SPDXRef-Package-Dependency-21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: proc-macro2
+SPDXID: SPDXRef-Package-Dependency-22
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: quote
+SPDXID: SPDXRef-Package-Dependency-23
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: rand
+SPDXID: SPDXRef-Package-Dependency-24
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: rand_chacha
+SPDXID: SPDXRef-Package-Dependency-25
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde
+SPDXID: SPDXRef-Package-Dependency-26
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_derive
+SPDXID: SPDXRef-Package-Dependency-27
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: serde_json
+SPDXID: SPDXRef-Package-Dependency-28
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: slab
+SPDXID: SPDXRef-Package-Dependency-29
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: syn
+SPDXID: SPDXRef-Package-Dependency-30
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tempfile
+SPDXID: SPDXRef-Package-Dependency-31
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tokio
+SPDXID: SPDXRef-Package-Dependency-32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tokio-macros
+SPDXID: SPDXRef-Package-Dependency-33
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tokio-stream
+SPDXID: SPDXRef-Package-Dependency-34
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tokio-test
+SPDXID: SPDXRef-Package-Dependency-35
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tokio-util
+SPDXID: SPDXRef-Package-Dependency-36
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tracing
+SPDXID: SPDXRef-Package-Dependency-37
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: tracing-subscriber
+SPDXID: SPDXRef-Package-Dependency-38
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Package Information
+PackageName: trybuild
+SPDXID: SPDXRef-Package-Dependency-39
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
 ## Relationships
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
 Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-1

--- a/scripts/validate_output_format_fixtures.py
+++ b/scripts/validate_output_format_fixtures.py
@@ -60,6 +60,10 @@ CYCLONEDX_XML_FIXTURES = [
 # validation.
 SPDX_TAGVALUE_FIXTURES = [
     "spdx-simple-expected.tv",
+    # Exercises promoted resolved-dependency packages (FilesAnalyzed: false):
+    # regression guard for their placement relative to the file section and for
+    # WITH-exception license handling. `spdx-simple` has neither.
+    "spdx-dependencies-expected.tv",
 ]
 
 CYCLONEDX_SPEC_VERSION = "1.3"

--- a/src/license_detection/spdx_lid/mod.rs
+++ b/src/license_detection/spdx_lid/mod.rs
@@ -494,7 +494,7 @@ fn is_likely_license_key(text: &str) -> bool {
     true
 }
 
-fn is_spdx_exception(text: &str) -> bool {
+pub(crate) fn is_spdx_exception(text: &str) -> bool {
     let lowered = text.to_lowercase();
     if lowered.ends_with("-exception")
         || lowered.contains("-exception-")

--- a/src/output/spdx.rs
+++ b/src/output/spdx.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use sha1::{Digest, Sha1};
 
+use crate::license_detection::spdx_lid::is_spdx_exception;
 use crate::output_schema::{
     Output, OutputFileInfo as FileInfo, OutputFileType, OutputMatch as Match, OutputPackage,
 };
@@ -18,7 +19,8 @@ use crate::utils::time::{convert_header_timestamp_to_iso_utc, fallback_iso_utc_t
 use super::sbom;
 use super::shared::{sorted_files, xml_escape};
 use super::spdx_plan::{
-    inventory_spdx_ids, plan_spdx_packages, primary_package_name, sanitize_spdx_package_name,
+    SpdxPackagePlan, inventory_spdx_ids, plan_spdx_packages, primary_package_name,
+    sanitize_spdx_package_name,
 };
 use super::{OutputWriteConfig, SPDX_DOCUMENT_NOTICE};
 
@@ -77,57 +79,27 @@ pub(crate) fn write_spdx_tag_value(
     writeln!(writer, "Creator: {}", creator)?;
     writeln!(writer, "Created: {}", created)?;
 
-    for plan in &plans {
-        let package_copyright_text = spdx_package_copyright_text(&plan.files);
-        let package_license_concluded = spdx_package_license_concluded(plan.package);
-        let package_license_declared = spdx_package_license_declared(plan.package);
-
-        writeln!(writer, "## Package Information")?;
-        writeln!(writer, "PackageName: {}", plan.name)?;
-        writeln!(writer, "SPDXID: {}", plan.spdx_id)?;
-        writeln!(writer, "PackageDownloadLocation: NOASSERTION")?;
-        writeln!(writer, "FilesAnalyzed: {}", plan.role.files_analyzed())?;
-        // SPDX 2.2: a package verification code and per-file license info are
-        // only meaningful (and only valid) when files were analyzed. A promoted
-        // dependency owns no scanned files, so both are omitted for it.
-        if plan.role.files_analyzed() {
-            writeln!(
-                writer,
-                "PackageVerificationCode: {}",
-                spdx_package_verification_code(&plan.files)
-            )?;
-        }
-        writeln!(
-            writer,
-            "PackageLicenseConcluded: {}",
-            spdx_tv_license_value(package_license_concluded.as_deref())
-        )?;
-        if plan.role.files_analyzed() {
-            let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
-            for license_id in &package_license_info_from_files {
-                writeln!(writer, "PackageLicenseInfoFromFiles: {}", license_id)?;
-            }
-            if package_license_info_from_files.is_empty() {
-                writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
-            }
-        }
-        writeln!(
-            writer,
-            "PackageLicenseDeclared: {}",
-            spdx_tv_license_value(package_license_declared.as_deref())
-        )?;
-        writeln!(
-            writer,
-            "PackageCopyrightText: {}",
-            format_spdx_text_field(&package_copyright_text)
-        )?;
+    // Emit the scanned-subject packages (FilesAnalyzed: true) before the file
+    // section. In SPDX tag-value, a file's package association is positional —
+    // files bind to the most recently declared package — so promoted-dependency
+    // packages (FilesAnalyzed: false, which own no scanned files) MUST come
+    // after the file section, or the files would bind to a FilesAnalyzed: false
+    // package and fail spec validation.
+    for plan in plans.iter().filter(|plan| plan.role.files_analyzed()) {
+        write_spdx_tag_value_package(writer, plan)?;
     }
 
     writeln!(writer, "## File Information")?;
     for (file_index, file) in (1usize..).zip(files.iter()) {
         let sha1 = file.sha1.as_deref().unwrap_or(EMPTY_SHA1_HEX);
-        let file_license_info = spdx_file_license_info(file);
-        let file_license_concluded = spdx_file_license_concluded(file);
+        // Exception symbols are not licenses; keep them out of the id list, and
+        // strip any floating (non-`WITH`) exception from the concluded expression.
+        let file_license_info: Vec<String> = spdx_file_license_info(file)
+            .into_iter()
+            .filter(|id| !is_spdx_exception(id))
+            .collect();
+        let file_license_concluded = spdx_file_license_concluded(file)
+            .and_then(|expression| strip_unattached_exceptions(&expression));
         writeln!(
             writer,
             "FileName: {}",
@@ -167,6 +139,13 @@ pub(crate) fn write_spdx_tag_value(
         writeln!(writer)?;
     }
 
+    // Promoted-dependency packages (FilesAnalyzed: false) trail the file
+    // section so no file positionally binds to them (see the subject-package
+    // loop above).
+    for plan in plans.iter().filter(|plan| !plan.role.files_analyzed()) {
+        write_spdx_tag_value_package(writer, plan)?;
+    }
+
     writeln!(writer, "## Relationships")?;
     for plan in &plans {
         // The document DESCRIBES the scanned subject packages; promoted
@@ -198,6 +177,12 @@ pub(crate) fn write_spdx_tag_value(
         }
     }
 
+    // Exception refs are stripped from every expression above, so drop their
+    // now-unreferenced ExtractedLicensingInfo declarations too.
+    let extracted_license_infos: Vec<ExtractedLicenseInfo> = extracted_license_infos
+        .into_iter()
+        .filter(|info| !is_spdx_exception(&info.license_id))
+        .collect();
     if !extracted_license_infos.is_empty() {
         writeln!(writer, "## License Information")?;
         for info in extracted_license_infos {
@@ -218,6 +203,65 @@ pub(crate) fn write_spdx_tag_value(
         }
     }
 
+    Ok(())
+}
+
+/// Write one SPDX tag-value `## Package Information` block. Called for the
+/// scanned-subject packages before the file section and the promoted-dependency
+/// packages after it (see `write_spdx_tag_value`).
+fn write_spdx_tag_value_package(
+    writer: &mut dyn Write,
+    plan: &SpdxPackagePlan<'_>,
+) -> io::Result<()> {
+    let package_copyright_text = spdx_package_copyright_text(&plan.files);
+    let package_license_concluded = spdx_package_license_concluded(plan.package)
+        .and_then(|expression| strip_unattached_exceptions(&expression));
+    let package_license_declared = spdx_package_license_declared(plan.package)
+        .and_then(|expression| strip_unattached_exceptions(&expression));
+
+    writeln!(writer, "## Package Information")?;
+    writeln!(writer, "PackageName: {}", plan.name)?;
+    writeln!(writer, "SPDXID: {}", plan.spdx_id)?;
+    writeln!(writer, "PackageDownloadLocation: NOASSERTION")?;
+    writeln!(writer, "FilesAnalyzed: {}", plan.role.files_analyzed())?;
+    // SPDX 2.2: a package verification code and per-file license info are
+    // only meaningful (and only valid) when files were analyzed. A promoted
+    // dependency owns no scanned files, so both are omitted for it.
+    if plan.role.files_analyzed() {
+        writeln!(
+            writer,
+            "PackageVerificationCode: {}",
+            spdx_package_verification_code(&plan.files)
+        )?;
+    }
+    writeln!(
+        writer,
+        "PackageLicenseConcluded: {}",
+        spdx_tv_license_value(package_license_concluded.as_deref())
+    )?;
+    if plan.role.files_analyzed() {
+        let package_license_info_from_files: Vec<String> =
+            spdx_package_license_info_from_files(&plan.files)
+                .into_iter()
+                .filter(|id| !is_spdx_exception(id))
+                .collect();
+        for license_id in &package_license_info_from_files {
+            writeln!(writer, "PackageLicenseInfoFromFiles: {}", license_id)?;
+        }
+        if package_license_info_from_files.is_empty() {
+            writeln!(writer, "PackageLicenseInfoFromFiles: NONE")?;
+        }
+    }
+    writeln!(
+        writer,
+        "PackageLicenseDeclared: {}",
+        spdx_tv_license_value(package_license_declared.as_deref())
+    )?;
+    writeln!(
+        writer,
+        "PackageCopyrightText: {}",
+        format_spdx_text_field(&package_copyright_text)
+    )?;
     Ok(())
 }
 
@@ -259,8 +303,10 @@ pub(crate) fn write_spdx_rdf_xml(
     for plan in &plans {
         let package_copyright_text = xml_escape(&spdx_package_copyright_text(&plan.files));
         let package_name = xml_escape(&plan.name);
-        let package_license_concluded = spdx_package_license_concluded(plan.package);
-        let package_license_declared = spdx_package_license_declared(plan.package);
+        let package_license_concluded = spdx_package_license_concluded(plan.package)
+            .and_then(|expression| strip_unattached_exceptions(&expression));
+        let package_license_declared = spdx_package_license_declared(plan.package)
+            .and_then(|expression| strip_unattached_exceptions(&expression));
         let files_analyzed = plan.role.files_analyzed();
 
         xml.push_str("  <spdx:Package rdf:about=\"");
@@ -291,7 +337,11 @@ pub(crate) fn write_spdx_rdf_xml(
         // Per-file license info and a verification code are only valid when
         // files were analyzed; a promoted dependency owns no files (ADR 0012).
         if files_analyzed {
-            let package_license_info_from_files = spdx_package_license_info_from_files(&plan.files);
+            let package_license_info_from_files: Vec<String> =
+                spdx_package_license_info_from_files(&plan.files)
+                    .into_iter()
+                    .filter(|id| !is_spdx_exception(id))
+                    .collect();
             if package_license_info_from_files.is_empty() {
                 xml.push_str(
                     "    <spdx:licenseInfoFromFiles rdf:resource=\"http://spdx.org/rdf/terms#none\"/>\n",
@@ -332,8 +382,12 @@ pub(crate) fn write_spdx_rdf_xml(
             let Some(file_id) = file_spdx_ids.get(file.path.as_str()) else {
                 continue;
             };
-            let file_license_info = spdx_file_license_info(file);
-            let file_license_concluded = spdx_file_license_concluded(file);
+            let file_license_info: Vec<String> = spdx_file_license_info(file)
+                .into_iter()
+                .filter(|id| !is_spdx_exception(id))
+                .collect();
+            let file_license_concluded = spdx_file_license_concluded(file)
+                .and_then(|expression| strip_unattached_exceptions(&expression));
             xml.push_str("    <spdx:relationship><spdx:Relationship>");
             xml.push_str("<spdx:relationshipType rdf:resource=\"http://spdx.org/rdf/terms#relationshipType_contains\"/>");
             xml.push_str("<spdx:relatedSpdxElement><spdx:File rdf:about=\"");
@@ -407,7 +461,10 @@ pub(crate) fn write_spdx_rdf_xml(
     xml.push_str("    <rdfs:comment>");
     xml.push_str(&xml_escape(SPDX_DOCUMENT_NOTICE));
     xml.push_str("</rdfs:comment>\n");
-    for info in extracted_license_infos {
+    for info in extracted_license_infos
+        .into_iter()
+        .filter(|info| !is_spdx_exception(&info.license_id))
+    {
         xml.push_str(
             "    <spdx:hasExtractedLicensingInfo><spdx:ExtractedLicensingInfo rdf:about=\"",
         );
@@ -692,16 +749,28 @@ fn spdx_license_rdf_resource(license_id: &str, document_namespace: &str) -> Stri
     }
 }
 
+/// Split an SPDX expression into the individual *license* identifiers it names,
+/// for the id-list fields (`LicenseInfoInFile`, `PackageLicenseInfoFromFiles`)
+/// and single-id RDF resolution. The token immediately after `WITH` is a
+/// license *exception*, not a license id; it is only valid inside a `WITH`
+/// statement, so it is dropped here (the full `… WITH …` expression is still
+/// rendered verbatim in the `LicenseConcluded`/`LicenseDeclared` fields).
 fn spdx_ids_from_expression(expression: &str) -> Vec<String> {
     let mut ids = Vec::new();
     let mut token = String::new();
+    let mut expect_exception = false;
 
-    let flush = |token: &mut String, ids: &mut Vec<String>| {
+    let flush = |token: &mut String, ids: &mut Vec<String>, expect_exception: &mut bool| {
         if token.is_empty() {
             return;
         }
-        if !matches!(token.as_str(), "AND" | "OR" | "WITH") {
-            ids.push(token.clone());
+        match token.as_str() {
+            "AND" | "OR" => {}
+            "WITH" => *expect_exception = true,
+            // The symbol following `WITH` is an exception; consume it without
+            // emitting it as a standalone license id.
+            _ if *expect_exception => *expect_exception = false,
+            _ => ids.push(token.clone()),
         }
         token.clear();
     };
@@ -711,12 +780,87 @@ fn spdx_ids_from_expression(expression: &str) -> Vec<String> {
         if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '.' | '+' | '_') {
             token.push(ch);
         } else {
-            flush(&mut token, &mut ids);
+            flush(&mut token, &mut ids, &mut expect_exception);
         }
     }
-    flush(&mut token, &mut ids);
+    flush(&mut token, &mut ids, &mut expect_exception);
 
     ids
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Split an SPDX expression into its top-level operands and the `AND`/`OR`
+/// operators between them, respecting parenthesis depth (a `WITH` stays inside
+/// its operand).
+fn split_top_level_operands(expression: &str) -> (Vec<String>, Vec<String>) {
+    let mut operands = Vec::new();
+    let mut operators = Vec::new();
+    let mut depth: i32 = 0;
+    let mut current = String::new();
+    for token in expression.split_whitespace() {
+        if depth == 0 && (token == "AND" || token == "OR") {
+            operands.push(current.trim().to_string());
+            operators.push(token.to_string());
+            current.clear();
+            continue;
+        }
+        depth += token.matches('(').count() as i32 - token.matches(')').count() as i32;
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(token);
+    }
+    operands.push(current.trim().to_string());
+    (operands, operators)
+}
+
+/// Remove exception operands that are not attached to a license via `WITH`.
+/// SPDX cannot represent a standalone or `AND`/`OR`-joined exception, so a
+/// detected floating exception (e.g. ScanCode's
+/// `LicenseRef-scancode-generic-exception`) is dropped from the expression,
+/// while a valid `license WITH exception` operand is kept intact. Returns
+/// `None` when nothing valid remains.
+fn strip_unattached_exceptions(expression: &str) -> Option<String> {
+    let (operands, operators) = split_top_level_operands(expression);
+    let cleaned: Vec<Option<String>> = operands
+        .iter()
+        .map(|operand| clean_spdx_operand(operand))
+        .collect();
+
+    let mut result = String::new();
+    for (index, operand) in cleaned.iter().enumerate() {
+        let Some(text) = operand else { continue };
+        if !result.is_empty() {
+            let operator = operators
+                .get(index.wrapping_sub(1))
+                .map(String::as_str)
+                .unwrap_or("AND");
+            result.push_str(&format!(" {operator} "));
+        }
+        result.push_str(text);
+    }
+    non_empty(&result)
+}
+
+/// Clean a single top-level operand: recurse into a parenthesized group, drop a
+/// bare exception symbol, or keep the operand (including a `license WITH
+/// exception`) unchanged.
+fn clean_spdx_operand(operand: &str) -> Option<String> {
+    let operand = operand.trim();
+    if let Some(inner) = operand.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
+        return strip_unattached_exceptions(inner.trim()).map(|cleaned| format!("({cleaned})"));
+    }
+    // A bare, unattached exception (single token, no `WITH`) cannot stand in an
+    // SPDX expression, so drop it. `license WITH exception` contains a space and
+    // is kept.
+    if !operand.contains(' ') && is_spdx_exception(operand) {
+        return None;
+    }
+    Some(operand.to_string())
 }
 
 fn spdx_creator() -> String {
@@ -1190,6 +1334,56 @@ mod tests {
         undetected.license_detections = vec![];
         let schema_undetected = crate::output_schema::OutputFileInfo::from(&undetected);
         assert_eq!(spdx_file_license_concluded(&schema_undetected), None);
+    }
+
+    #[test]
+    fn spdx_ids_from_expression_drops_the_with_exception_symbol() {
+        // The exception after WITH is not a standalone license id (SPDX rejects
+        // it in LicenseInfoInFile), but the licenses around it are kept.
+        assert_eq!(
+            spdx_ids_from_expression("Apache-2.0 WITH LLVM-exception"),
+            vec!["Apache-2.0".to_string()]
+        );
+        assert_eq!(
+            spdx_ids_from_expression("(GPL-2.0-only WITH Classpath-exception-2.0) OR MIT"),
+            vec!["GPL-2.0-only".to_string(), "MIT".to_string()]
+        );
+        // Plain expressions are unaffected.
+        assert_eq!(
+            spdx_ids_from_expression("MIT AND Apache-2.0"),
+            vec!["MIT".to_string(), "Apache-2.0".to_string()]
+        );
+    }
+
+    #[test]
+    fn strip_unattached_exceptions_drops_floating_exceptions_but_keeps_with() {
+        // Floating exception joined with AND is dropped; the licenses stay.
+        assert_eq!(
+            strip_unattached_exceptions(
+                "MIT AND Unlicense AND LicenseRef-scancode-generic-exception"
+            ),
+            Some("MIT AND Unlicense".to_string())
+        );
+        // A standalone exception leaves nothing valid.
+        assert_eq!(
+            strip_unattached_exceptions("LicenseRef-scancode-generic-exception"),
+            None
+        );
+        // A validly-attached `WITH` exception is preserved, at top level and in
+        // a parenthesized group.
+        assert_eq!(
+            strip_unattached_exceptions("Apache-2.0 WITH LLVM-exception"),
+            Some("Apache-2.0 WITH LLVM-exception".to_string())
+        );
+        assert_eq!(
+            strip_unattached_exceptions("(GPL-2.0-only WITH Classpath-exception-2.0) OR MIT"),
+            Some("(GPL-2.0-only WITH Classpath-exception-2.0) OR MIT".to_string())
+        );
+        // Plain expressions are untouched.
+        assert_eq!(
+            strip_unattached_exceptions("MIT OR Apache-2.0"),
+            Some("MIT OR Apache-2.0".to_string())
+        );
     }
 
     #[test]

--- a/testdata/output-formats/spdx-dependencies-expected.tv
+++ b/testdata/output-formats/spdx-dependencies-expected.tv
@@ -1,0 +1,54 @@
+## Document Information
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: SPDX Document created by Provenant
+DocumentNamespace: http://spdx.org/spdxdocs/root
+DocumentComment: <text>Generated with Provenant and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+Provenant should be considered or used as legal advice. Consult an attorney
+for legal advice.
+Provenant is a free software code scanning tool.
+Visit https://github.com/getprovenant/provenant/ for support and download.
+SPDX License List: 3.27</text>
+## Creation Information
+Creator: Tool: Provenant-1.0.1-g934b1ca7-dirty
+Created: 2026-01-01T00:00:00Z
+## Package Information
+PackageName: root
+SPDXID: SPDXRef-Package-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: true
+PackageVerificationCode: 2a4976b2c9ac8e1fc0747dba6f0c5588b1318680
+PackageLicenseConcluded: MIT
+PackageLicenseInfoFromFiles: NONE
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NONE
+## File Information
+FileName: ./index.js
+SPDXID: SPDXRef-1
+FileChecksum: SHA1: e2466d5b764d27fb301ceb439ffb5da22e43ab1d
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: NONE
+
+FileName: ./package.json
+SPDXID: SPDXRef-2
+FileChecksum: SHA1: b8a793cce3c3a4cd3a4646ddbe86edd542ed0cd8
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NONE
+FileCopyrightText: NONE
+
+## Package Information
+PackageName: dep
+SPDXID: SPDXRef-Package-Dependency-1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NONE
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1
+Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-1
+Relationship: SPDXRef-Package-1 CONTAINS SPDXRef-2
+Relationship: SPDXRef-Package-1 DEPENDS_ON SPDXRef-Package-Dependency-1

--- a/tests/output_format_golden.rs
+++ b/tests/output_format_golden.rs
@@ -2486,6 +2486,136 @@ fn sample_cyclonedx_dependency_output() -> Output {
     )
 }
 
+/// A scanned subject package that owns files, plus one promoted resolved
+/// dependency. Unlike [`sample_cyclonedx_dependency_output`], this carries real
+/// files so it exercises SPDX tag-value's positional file→package association.
+fn sample_spdx_dependency_output() -> Output {
+    let root_uid = PackageUid::from_raw(
+        "pkg:npm/root@1.0.0?uuid=00000000-0000-0000-0000-000000000000".to_string(),
+    );
+    let root_pkg = {
+        let mut pkg = Package::from_package_data(
+            &PackageData {
+                package_type: Some(PackageType::Npm),
+                name: Some("root".to_string()),
+                version: Some("1.0.0".to_string()),
+                purl: Some("pkg:npm/root@1.0.0".to_string()),
+                declared_license_expression: Some("mit".to_string()),
+                declared_license_expression_spdx: Some("MIT".to_string()),
+                ..Default::default()
+            },
+            "scan/package.json".to_string(),
+        );
+        pkg.package_uid = root_uid.clone();
+        pkg
+    };
+
+    let owned_dep = TopLevelDependency {
+        purl: Some("pkg:npm/dep@2.0.0".to_string()),
+        extracted_requirement: Some("2.0.0".to_string()),
+        scope: Some("dependencies".to_string()),
+        is_runtime: Some(true),
+        is_optional: Some(false),
+        is_pinned: Some(true),
+        is_direct: Some(true),
+        resolved_package: Some(Box::new(ResolvedPackage {
+            purl: Some("pkg:npm/dep@2.0.0".to_string()),
+            ..ResolvedPackage::new(
+                PackageType::Npm,
+                String::new(),
+                "dep".to_string(),
+                "2.0.0".to_string(),
+            )
+        })),
+        extra_data: None,
+        dependency_uid: DependencyUid::from_raw(
+            "pkg:npm/dep@2.0.0?uuid=00000000-0000-0000-0000-000000000001".to_string(),
+        ),
+        for_package_uid: Some(root_uid.clone()),
+        datafile_path: "scan/package-lock.json".to_string(),
+        datasource_id: DatasourceId::NpmPackageLockJson,
+        namespace: None,
+    };
+
+    let mut manifest = sample_plain_text_file(
+        "package.json",
+        "package",
+        ".json",
+        "scan/package.json",
+        30,
+        "b8a793cce3c3a4cd3a4646ddbe86edd542ed0cd8",
+        vec![],
+    );
+    manifest.for_packages = vec![root_uid.clone()];
+    let mut source = sample_plain_text_file(
+        "index.js",
+        "index",
+        ".js",
+        "scan/index.js",
+        20,
+        "e2466d5b764d27fb301ceb439ffb5da22e43ab1d",
+        vec![],
+    );
+    source.for_packages = vec![root_uid];
+
+    sample_output_with_sections(
+        2,
+        0,
+        vec![root_pkg],
+        vec![owned_dep],
+        vec![manifest, source],
+    )
+}
+
+// Regression (SPDX tag-value): promoted-dependency packages are `FilesAnalyzed:
+// false` and own no files. Because tag-value binds a file to the most recently
+// declared package, every such package MUST be emitted AFTER the file section —
+// otherwise the scanned files positionally bind to a `FilesAnalyzed: false`
+// package and the document fails official SPDX validation (spdx-tools). This
+// once shipped inverted (all packages before the file section); the four
+// checked-in `examples/sbom/*/sbom.spdx` all failed `pyspdxtools` validation.
+#[test]
+fn test_spdx_tag_value_emits_promoted_dependency_packages_after_file_section() {
+    let output = sample_spdx_dependency_output();
+    let schema_output = OutputSchemaOutput::from(&output);
+    let mut bytes = Vec::new();
+    writer_for_format(OutputFormat::SpdxTv)
+        .write(
+            &schema_output,
+            &mut bytes,
+            &OutputWriteConfig {
+                format: OutputFormat::SpdxTv,
+                custom_template: None,
+                scanned_path: Some("scan".to_string()),
+            },
+        )
+        .expect("spdx tag-value output should be generated");
+    let actual = String::from_utf8(bytes).expect("spdx output should be utf-8");
+
+    let file_info_at = actual
+        .find("## File Information")
+        .expect("document has a file section");
+    let subject_at = actual
+        .find("FilesAnalyzed: true")
+        .expect("scanned subject package present");
+    let promoted_at = actual
+        .find("FilesAnalyzed: false")
+        .expect("promoted dependency package present");
+    assert!(
+        subject_at < file_info_at,
+        "the scanned-subject package (FilesAnalyzed: true) must precede the file section"
+    );
+    assert!(
+        promoted_at > file_info_at,
+        "a promoted-dependency package (FilesAnalyzed: false) must not precede the file section, \
+         or files positionally bind to it and SPDX validation fails"
+    );
+
+    let expected = fs::read_to_string("testdata/output-formats/spdx-dependencies-expected.tv")
+        .expect("spdx dependency fixture should be readable");
+    assert_eq!(actual, expected);
+}
+
 fn empty_output() -> Output {
     Output {
         summary: None,


### PR DESCRIPTION
## Summary

The checked-in SBOM examples (and any real scan with resolved dependencies or an unattached license exception) produced **SPDX tag-value documents that fail official SPDX validation** (`spdx-tools` / `pyspdxtools`). CycloneDX was and is valid; this fixes two SPDX tag-value renderer bugs and adds the regression coverage that would have caught them.

Both were surfaced by validating the committed `examples/sbom/*/sbom.spdx` against the official validator — something CI did not do (its `testdata/smoke` scan is too small to have resolved-dependency packages or exception detections).

## Bug 1 — promoted-dependency packages placed before the file section

SPDX tag-value associates a file with the **most recently declared package** (positional). The writer emitted every package — including promoted resolved dependencies, which are `FilesAnalyzed: false` and own no files — *before* the `## File Information` section, so the scanned files positionally bound to a `FilesAnalyzed: false` package. spdx-tools rejects this: *"package must contain no elements if files_analyzed is False."*

Fix (`src/output/spdx.rs`): emit scanned-subject packages (`FilesAnalyzed: true`) before the file section and promoted-dependency packages **after** it. (Before #1321 there was only the subject package, so this was latent.)

## Bug 2 — license exception symbols used outside a `WITH`

A detected exception (e.g. ScanCode's `LicenseRef-scancode-generic-exception`, or a listed `LLVM-exception`) reached SPDX license fields as a standalone id (`LicenseInfoInFile`, `PackageLicenseInfoFromFiles`) and inside an `AND`-joined expression (`LicenseConcluded: MIT AND Unlicense AND LicenseRef-scancode-generic-exception`). SPDX only permits an exception on the right of a `WITH`, so spdx-tools rejects it.

Fix:
- The token after `WITH` is an exception, not a license id — `spdx_ids_from_expression` no longer emits it as a standalone id.
- `strip_unattached_exceptions` drops floating (non-`WITH`) exception operands from license expressions while preserving a valid `license WITH exception`; applied to file and package `LicenseConcluded`/`LicenseDeclared` in both the tag-value and RDF writers.
- Exception symbols are filtered out of the id-list fields and their now-unreferenced `ExtractedLicensingInfo` declarations.
- Exceptions are identified with the existing `license_detection::spdx_lid::is_spdx_exception` (promoted to `pub(crate)`) — a pure function of the token, since `output.license_references` is empty by default (ScanCode-compatible; only populated with `--license-references`).

## Regression coverage

- New golden fixture `testdata/output-formats/spdx-dependencies-expected.tv` and test `test_spdx_tag_value_emits_promoted_dependency_packages_after_file_section` (tests/output_format_golden.rs): a scanned subject package that **owns files** plus a promoted dependency (the existing CycloneDX dependency sample has no files). The test asserts the subject package precedes, and the dependency package follows, the file section.
- The new fixture is added to the official-validator set in `scripts/validate_output_format_fixtures.py` (`SPDX_TAGVALUE_FIXTURES`), so CI now validates a deps-bearing SPDX document against `pyspdxtools` on every run — closing the gap that let both bugs ship.
- Unit tests for the exception handling (`spdx_ids_from_expression_drops_the_with_exception_symbol`, `strip_unattached_exceptions_drops_floating_exceptions_but_keeps_with`).

## Examples regenerated

All four `examples/sbom/` regenerated (stamped 1.0.1). Validated locally against the official validators: **CycloneDX valid ×4, SPDX valid ×4.**

## Release note

This is the fix that the cancelled 1.0.1 was blocked on. `main` is already at the 1.0.1 version bump; nothing was published (no crate, image, release, or Homebrew bump). After merge, re-tag `v1.0.1` on the new HEAD to re-trigger the release.
