### PR TITLE
fix(triage): move inference to a configurable OpenAI-compatible provider

### DIFF
--- a/.github/workflows/scancode-triage.yml
+++ b/.github/workflows/scancode-triage.yml
@@ -4,9 +4,9 @@
 name: ScanCode weekly triage
 
 # Weekly triage of upstream ScanCode Toolkit issues for relevance to Provenant.
-# Uses GitHub Models (free tier) for the judgment and a freshly built binary for
-# ground-truth reproduction. Each actionable finding becomes a deduplicated
-# Provenant issue; the full run summary lives in this workflow's run output.
+# An LLM makes the judgment and a freshly built binary provides ground-truth
+# reproduction. Each actionable finding becomes a deduplicated Provenant issue;
+# the full run summary lives in this workflow's run output.
 on:
   schedule:
     - cron: "0 8 * * 1" # Mondays 08:00 UTC
@@ -16,10 +16,15 @@ on:
         description: "Issue-creation window in days"
         required: false
         default: "8"
+      dry_run:
+        description: "Triage and report only; do not open issues"
+        type: boolean
+        required: false
+        default: false
 
 # GITHUB_TOKEN needs issues:write to open per-finding issues (contents:read for
-# checkout). Models inference does NOT use GITHUB_TOKEN -- it uses MODELS_TOKEN
-# (see the Run triage step) because this org has no Models entitlement.
+# checkout). Inference does NOT use GITHUB_TOKEN -- it uses TRIAGE_API_KEY (see
+# the Run triage step), a third-party model-provider credential.
 permissions:
   contents: read
   issues: write
@@ -50,22 +55,33 @@ jobs:
           # findings) via the org repo's own issues:write/contents:read.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # GitHub Models inference needs a separate credential: on this org-owned
-          # repo the built-in GITHUB_TOKEN resolves against the org, which has no
-          # Models entitlement (403 on scheduled runs). MODELS_TOKEN is a personal
-          # fine-grained PAT (resource owner = a user, Models: read only) carrying
-          # a personal Models entitlement. See docs in the triage tool.
-          MODELS_TOKEN: ${{ secrets.MODELS_TOKEN }}
+          # Inference needs its own credential: a model-provider API key, wholly
+          # unrelated to GITHUB_TOKEN. The tool defaults to the Gemini API's
+          # OpenAI-compatibility layer, whose free tier covers a few calls a week.
+          # Set TRIAGE_API_BASE to move to any other OpenAI-compatible provider
+          # (e.g. https://api.groq.com/openai/v1) without a code change.
+          TRIAGE_API_KEY: ${{ secrets.TRIAGE_API_KEY }}
+          TRIAGE_API_BASE: ${{ vars.TRIAGE_API_BASE }}
           # Passed via env (never interpolated into the run script) so a dispatch
           # input cannot break out of the shell command. The tool also validates
           # it is a positive integer.
           TRIAGE_DAYS: ${{ github.event.inputs.days || '8' }}
+          # Lets a manual run exercise the full path (including inference and the
+          # tool-loop) without side effects -- useful when validating a provider
+          # or model change. Empty on scheduled runs, which always post.
+          TRIAGE_DRY_RUN: ${{ github.event.inputs.dry_run }}
           # Set the model in repo Settings -> Variables (SCANCODE_TRIAGE_MODEL).
-          # It is required — the tool errors out if it is unset.
+          # It is required — the tool errors out if it is unset. Must name a
+          # model the configured provider serves.
           SCANCODE_TRIAGE_MODEL: ${{ vars.SCANCODE_TRIAGE_MODEL }}
         run: |
+          post_args=(--post-to "${GITHUB_REPOSITORY}")
+          if [ "${TRIAGE_DRY_RUN}" = "true" ]; then
+            echo "Dry run: findings will be reported but no issues opened."
+            post_args=()
+          fi
           ./target/release/scancode-triage \
             --days "${TRIAGE_DAYS}" \
             --binary target/release/provenant \
             --repo-root . \
-            --post-to "${{ github.repository }}"
+            "${post_args[@]}"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -30,7 +30,7 @@ cargo run --manifest-path xtask/Cargo.toml --bin <command> -- ...
 | `generate-index-artifact`         | Regenerate the embedded license index artifact from ScanCode rules and licenses.                                                            |
 | `generate-sbom-examples`          | Regenerate the checked-in SBOM examples under `examples/sbom/` from pinned upstream targets.                                                |
 | `classify-rule-overmatch`         | Classify upstream license rules by overmatch-risk class and rank un-covered overlay candidates.                                             |
-| `scancode-triage`                 | Weekly triage of upstream ScanCode issues for Provenant relevance, via GitHub Models with real reproduction scans.                          |
+| `scancode-triage`                 | Weekly triage of upstream ScanCode issues for Provenant relevance, LLM-judged with real reproduction scans.                                 |
 
 ## `benchmark-target`
 
@@ -661,21 +661,33 @@ cargo run --manifest-path xtask/Cargo.toml --bin classify-rule-overmatch -- --js
 
 `scancode-triage` checks recent [ScanCode Toolkit](https://github.com/aboutcode-org/scancode-toolkit)
 issues for ones that also affect Provenant and are worth fixing. The binary does
-the plumbing; a [GitHub Models](https://docs.github.com/github-models) LLM does
-the judgment. It is normally run on a weekly schedule by
+the plumbing; an LLM does the judgment. It is normally run on a weekly schedule by
 [`.github/workflows/scancode-triage.yml`](../.github/workflows/scancode-triage.yml),
 but is a plain xtask bin you can also run locally.
 
-### Model and token
+### Provider, model, and key
 
-- Inference runs on GitHub Models via a GitHub token that carries `models:read`
-  (in CI, the built-in `GITHUB_TOKEN` with `permissions: models: read`; locally,
-  `gh auth token`).
+Inference goes to any OpenAI-compatible `/chat/completions` endpoint, so the
+provider is configuration rather than code.
+
+- `TRIAGE_API_KEY` (**required**) is the provider API key, sent as a bearer
+  token. It is unrelated to `GITHUB_TOKEN`, which only drives the `gh` CLI calls
+  that fetch upstream issues and open findings.
+- `TRIAGE_API_BASE` (optional) is the OpenAI-compatible base URL, without the
+  `/chat/completions` suffix. It defaults to the Gemini API compatibility layer,
+  `https://generativelanguage.googleapis.com/v1beta/openai`. Point it at another
+  provider (for example `https://api.groq.com/openai/v1`) to switch without a
+  code change.
 - The model is **required and has no built-in default**: supply it via `--model`
   or the `SCANCODE_TRIAGE_MODEL` env var. In CI it comes from the
   `SCANCODE_TRIAGE_MODEL` repository variable (Settings → Variables); the tool
-  errors out if it is unset. Choose a model whose free-tier limits cover a weekly
-  run.
+  errors out if it is unset. It must name a model the configured provider serves,
+  and whose free-tier limits cover a weekly run — the job makes only a handful of
+  calls per week, so free tiers have ample headroom.
+
+In CI, `TRIAGE_API_KEY` is a repository secret and `TRIAGE_API_BASE` an optional
+repository variable. Switching providers means updating those plus
+`SCANCODE_TRIAGE_MODEL`.
 
 ### Usage
 
@@ -683,15 +695,15 @@ but is a plain xtask bin you can also run locally.
 cargo run --manifest-path xtask/Cargo.toml --bin scancode-triage -- --help
 
 # Report to stdout over the last N days (requires target/release/provenant built):
-SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
+TRIAGE_API_KEY=<key> SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
   --bin scancode-triage -- --days 8 --binary target/release/provenant
 
 # Cheap check over a few recent candidates:
-SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
+TRIAGE_API_KEY=<key> SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
   --bin scancode-triage -- --days 21 --max-issues 5 --binary target/release/provenant
 
 # Open a deduplicated Provenant issue per actionable finding:
-SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
+TRIAGE_API_KEY=<key> SCANCODE_TRIAGE_MODEL=<model-id> cargo run --release --manifest-path xtask/Cargo.toml \
   --bin scancode-triage -- --days 8 --binary target/release/provenant --post-to <owner>/<repo>
 ```
 
@@ -701,7 +713,7 @@ CLI arguments:
 - `--since YYYY-MM-DD`: explicit lower bound on issue creation date.
 - `--binary PATH`: the provenant binary used for reproduction scans (default `target/release/provenant`).
 - `--repo-root PATH`: Provenant repo root, used by the `list_parsers` tool.
-- `--model ID`: GitHub Models model id (env `SCANCODE_TRIAGE_MODEL`).
+- `--model ID`: model id (env `SCANCODE_TRIAGE_MODEL`).
 - `--max-issues N`: cap candidates triaged (`0` = no cap).
 - `--out PATH`: also write the run summary to a file (it is always printed to stdout).
 - `--post-to owner/name`: open a deduplicated issue per actionable finding in that repo.

--- a/xtask/src/bin/scancode-triage.rs
+++ b/xtask/src/bin/scancode-triage.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Provenant contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Weekly ScanCode -> Provenant issue triage, driven by a GitHub Models LLM.
+//! Weekly ScanCode -> Provenant issue triage, driven by an LLM.
 //!
 //! The tool is deliberately thin: it fetches recent ScanCode issues, exposes a
 //! `run_provenant` tool (real scans against the built binary) plus a
@@ -9,16 +9,16 @@
 //! "New license request:" noise, classifying, deciding what to reproduce, and
 //! writing the verdict table.
 //!
-//! The tool uses two independent credentials, because a single GitHub token
-//! cannot satisfy both jobs when the repo lives in an org without a GitHub
-//! Models entitlement:
-//!   * GitHub Models inference needs a token carrying a `models:read`
-//!     entitlement. On an org-owned repo the built-in GITHUB_TOKEN resolves
-//!     against the org (403 on scheduled runs when the org has no Models
-//!     entitlement), so the inference token is read from `MODELS_TOKEN` -- a
-//!     personal fine-grained PAT whose resource owner is a user with a personal
-//!     Models entitlement. It falls back to GITHUB_TOKEN/GH_TOKEN/`gh auth
-//!     token` for local runs.
+//! Inference targets any OpenAI-compatible `/chat/completions` endpoint, so the
+//! provider is configuration rather than code. The default is the Gemini API's
+//! OpenAI-compatibility layer, whose free tier covers this workload (a handful
+//! of calls once a week) with a wide margin.
+//!
+//! Two independent credentials are in play, because inference and the GitHub
+//! REST calls are unrelated services:
+//!   * Inference uses `TRIAGE_API_KEY`, sent as a bearer token to
+//!     `TRIAGE_API_BASE` (default: the Gemini compatibility base URL). Moving
+//!     providers is a change to those two values plus the model, not to code.
 //!   * The GitHub REST calls (fetching upstream issues, opening findings) run
 //!     through the `gh` CLI, which uses the built-in GITHUB_TOKEN/GH_TOKEN.
 //!
@@ -37,7 +37,10 @@ use serde_json::{Value, json};
 
 const SCANCODE_REPO: &str = "aboutcode-org/scancode-toolkit";
 const TRIAGE_LABEL: &str = "scancode-triage";
-const MODELS_ENDPOINT: &str = "https://models.github.ai/inference/chat/completions";
+// Default inference base URL: the Gemini API's OpenAI-compatibility layer.
+// Override via TRIAGE_API_BASE to reach any other OpenAI-compatible provider
+// (e.g. https://api.groq.com/openai/v1).
+const DEFAULT_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 const THROTTLE: Duration = Duration::from_secs(6); // space requests within rate limits
 const MAX_TURNS: usize = 6; // tool-loop backstop per issue
 const TOOL_RESULT_CHARS: usize = 2500; // cap tool output fed back to the model
@@ -87,7 +90,7 @@ PV`, `not relevant`, `needs manual check`; <evidence> is a terse note (what the 
 scan showed, which parser already exists, or why not relevant). No other text.";
 
 #[derive(Parser)]
-#[command(about = "Weekly ScanCode -> Provenant issue triage via GitHub Models")]
+#[command(about = "Weekly ScanCode -> Provenant issue triage")]
 struct Args {
     /// YYYY-MM-DD lower bound on issue creation date (default: --days ago)
     #[arg(long)]
@@ -101,7 +104,7 @@ struct Args {
     /// Provenant repo root (for list_parsers)
     #[arg(long = "repo-root", default_value = ".")]
     repo_root: PathBuf,
-    /// GitHub Models model id (env: SCANCODE_TRIAGE_MODEL)
+    /// Model id (env: SCANCODE_TRIAGE_MODEL)
     #[arg(long)]
     model: Option<String>,
     /// Cap candidates triaged (0 = no cap)
@@ -200,14 +203,15 @@ fn main() -> Result<()> {
     if llm_errors > 0 {
         bail!(
             "{llm_errors} candidate(s) could not be triaged: the model call failed \
-             for them (check MODELS_TOKEN and its Models entitlement)"
+             for them (check TRIAGE_API_KEY, TRIAGE_API_BASE and the configured model)"
         );
     }
     Ok(())
 }
 
 fn run(args: &Args, model: &str, since: &str) -> Result<(String, Vec<Finding>, usize)> {
-    let token = models_token()?;
+    let token = api_key()?;
+    let endpoint = chat_completions_url();
     let client = reqwest::blocking::Client::builder()
         .user_agent("provenant-triage")
         .build()?;
@@ -238,7 +242,8 @@ fn run(args: &Args, model: &str, since: &str) -> Result<(String, Vec<Finding>, u
             issue.number,
             truncate(&issue.title, 60)
         );
-        let Triaged { row, llm_error } = triage_one_issue(&client, &token, model, args, issue);
+        let Triaged { row, llm_error } =
+            triage_one_issue(&client, &endpoint, &token, model, args, issue);
         if llm_error {
             llm_errors += 1;
         }
@@ -317,6 +322,7 @@ fn assemble_report(
 /// whether the model call failed (vs. a genuine verdict).
 fn triage_one_issue(
     client: &reqwest::blocking::Client,
+    endpoint: &str,
     token: &str,
     model: &str,
     args: &Args,
@@ -350,7 +356,7 @@ fn triage_one_issue(
     ];
 
     for _turn in 0..MAX_TURNS {
-        let resp = match call_model(client, token, model, &messages) {
+        let resp = match call_model(client, endpoint, token, model, &messages) {
             Ok(v) => v,
             Err(e) => {
                 return Triaged {
@@ -452,6 +458,7 @@ fn tools() -> Value {
 
 fn call_model(
     client: &reqwest::blocking::Client,
+    endpoint: &str,
     token: &str,
     model: &str,
     messages: &[Value],
@@ -465,7 +472,7 @@ fn call_model(
     let body = serde_json::to_vec(&payload)?;
     for attempt in 0..5u64 {
         let resp = client
-            .post(MODELS_ENDPOINT)
+            .post(endpoint)
             .header("Authorization", format!("Bearer {token}"))
             .header("Content-Type", "application/json")
             .body(body.clone())
@@ -674,32 +681,36 @@ fn list_parsers(repo_root: &Path) -> Vec<String> {
     names.into_iter().collect()
 }
 
-// ---- GitHub (via gh CLI) ---------------------------------------------------
+// ---- Inference endpoint and credential -------------------------------------
 
-/// Resolve the token used for GitHub Models inference. Prefers the dedicated
-/// `MODELS_TOKEN` (a personal PAT carrying a Models entitlement, kept separate
-/// from the org GITHUB_TOKEN used for REST calls), then falls back to
-/// GITHUB_TOKEN/GH_TOKEN/`gh auth token` for local runs.
-fn models_token() -> Result<String> {
-    for var in ["MODELS_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] {
-        if let Ok(v) = std::env::var(var)
-            && !v.is_empty()
-        {
-            return Ok(v);
-        }
-    }
-    let out = Command::new("gh")
-        .args(["auth", "token"])
-        .output()
-        .context("running `gh auth token`")?;
-    if !out.status.success() {
-        bail!(
-            "no Models token (MODELS_TOKEN/GITHUB_TOKEN/GH_TOKEN unset and \
-             `gh auth token` failed)"
-        );
-    }
-    Ok(String::from_utf8(out.stdout)?.trim().to_string())
+/// Resolve the inference API key. `TRIAGE_API_KEY` is the only source: this is
+/// a model-provider credential with nothing in common with the GitHub token
+/// used for REST calls, so falling back to a GitHub credential would only turn
+/// a missing-key mistake into a 401 from the provider.
+fn api_key() -> Result<String> {
+    std::env::var("TRIAGE_API_KEY")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "TRIAGE_API_KEY is unset: set it to an API key for TRIAGE_API_BASE \
+                 (default: the Gemini API OpenAI-compatibility layer)"
+            )
+        })
 }
+
+/// Build the chat-completions URL from the configured base. `TRIAGE_API_BASE`
+/// holds the OpenAI-compatible base (no `/chat/completions` suffix), so
+/// switching providers stays a configuration change.
+fn chat_completions_url() -> String {
+    let base = std::env::var("TRIAGE_API_BASE")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_API_BASE.to_string());
+    format!("{}/chat/completions", base.trim().trim_end_matches('/'))
+}
+
+// ---- GitHub (via gh CLI) ---------------------------------------------------
 
 fn fetch_issues(since: &str) -> Result<Vec<Issue>> {
     let out = Command::new("gh")


### PR DESCRIPTION
## Summary

- GitHub Models was [retired on 2026-07-30](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/); the inference endpoint `scancode-triage` posted to now returns `410 Gone`, so the next scheduled run would have failed with every candidate untriaged.
- Rather than hardcode a replacement, inference is now configuration: `TRIAGE_API_BASE` selects any OpenAI-compatible `/chat/completions` provider (default: the Gemini API compatibility layer) and `TRIAGE_API_KEY` supplies the credential.
- Gemini's free tier carries this workload with wide margin — recent runs triage 2–3 candidates a week, a tiny fraction of free-tier request limits.

## Scope and exclusions

- Included: provider/credential configuration in `scancode-triage`, the workflow env wiring, a `dry_run` dispatch input, and the `xtask/README.md` section that documents them.
- Explicit exclusions: no change to triage logic, the system prompt, the tool definitions, issue creation, or dedup behavior. Model choice stays a repository variable with no built-in default.

## How to verify

CI does not cover this — the workflow is schedule/dispatch-only and inference needs a real key. Verified by dispatching the branch with `dry_run=true` over a widened 30-day window ([run 30704104889](https://github.com/getprovenant/provenant/actions/runs/30704104889), green, 8 candidates, zero LLM errors):

- **Tool-loop round-trip confirmed.** Four `run_provenant` calls fired across three issues. #5220 made two *sequential* calls, which is only possible if the `role:"tool"` reply plus `tool_call_id` from the first call was accepted and understood — the one behavior Gemini's compat layer does not explicitly document.
- **Real reproduction worked end to end.** #5229 and #5220 each fetched a live fixture, scanned it, and reached `already fixed/better in PV` quoting actual scanner output (`mpl-2.0 OR gpl-2.0 OR apache-2.0`; holder `Jinzhu`).
- **Honest unknowns preserved.** #5250 returned `needs manual check` because the upstream issue ships no fixture, rather than guessing.
- **Dry run opened no issues**, as intended.

A widened window was used deliberately: the last four scheduled runs made zero tool calls, so a default 8-day window would likely have left the tool loop unproven.

To re-verify after any provider or model change, dispatch with `dry_run=true` rather than waiting for a Monday.

## Follow-up work

- Created or intentionally deferred: the `MODELS_TOKEN` repository secret is now unused and can be deleted once this merges. Left in place here so the rollback path stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
