### PR TITLE
docs: name the principal authors in README and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,10 @@ license: Apache-2.0
 repository-code: "https://github.com/getprovenant/provenant"
 url: "https://getprovenant.dev"
 authors:
+  - given-names: Maxim
+    family-names: Stykow
+  - given-names: Adrian
+    family-names: Braemer
   - name: "The Provenant contributors"
 abstract: >-
   Rust scanner for ScanCode-compatible workflows, licenses,

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ For deeper contributor documentation, see the [Documentation Index](docs/DOCUMEN
 
 ## Support and Acknowledgements
 
-Provenant is an independent open source project developed by its contributors. Its development has been made possible in substantial part by support from [TNG Technology Consulting GmbH](https://www.tngtech.com/), including paid contributor time on internal non-client work, compute and inference resources provided by TNG's internal GPU cluster, Skainet, and company-funded usage of third-party AI models. Without that support, Provenant would not have been possible in its current scope and form.
+Provenant is an independent open source project. It was created by **Maxim Stykow** and **Adrian Braemer**, with [contributions from others](https://github.com/getprovenant/provenant/graphs/contributors). Its development has been made possible in substantial part by support from [TNG Technology Consulting GmbH](https://www.tngtech.com/), including paid contributor time on internal non-client work, compute and inference resources provided by TNG's internal GPU cluster, Skainet, and company-funded usage of third-party AI models. Without that support, Provenant would not have been possible in its current scope and form.
 
 A substantial portion of Provenant's development has been contributed by people working on the project as TNG employees, and work on the project has been done both during TNG-supported work time and during personal unpaid time. For a fuller acknowledgement of project support, see [ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md).
 


### PR DESCRIPTION
Provenant's own attribution was collective only — `NOTICE`, `CITATION.cff` and the README all said some variant of *"the Provenant contributors"*, with no contributor named anywhere. Adrian Braemer has **344 commits** (285 personal + 59 under a TNG address) and appeared in no documentation or metadata.

For a project whose whole subject matter is attribution, that gap was worth closing.

## Changes

- **`README.md`** (`## Support and Acknowledgements`) — "It was created by **Maxim Stykow** and **Adrian Braemer**, with [contributions from others](https://github.com/getprovenant/provenant/graphs/contributors)."
- **`CITATION.cff`** — `authors` now lists both named authors followed by the collective entity entry (valid CFF 1.2.0 allows mixing person and entity entries).

## Why this shape

Named credit is limited to the **two principal authors**, which is a stable historical fact that no future PR changes — and everyone else is credited through the **contributors graph**, which is exhaustive and self-updating. That avoids an `AUTHORS.md` needing an edit per contributor, and avoids the worse failure mode of a hand-maintained list going stale and looking like selective credit. It also matches how academic citation works: named authors of the cited work, not every drive-by contributor. Side benefit — David Tolnay, Lee Sang Hoon and Sebastian Schuberth all have merged commits and are now discoverable via that link.

## Deliberately not changed

`NOTICE` and the per-file copyright headers keep `Copyright (c) 2026 Provenant contributors`. Collective copyright is legally sound — contributors hold copyright in their contributions regardless of being listed — and restructuring copyright lines is a materially riskier change than adding credit. Crediting and copyright attribution are separate acts.

## Verification

`check_release_version_sync.sh` passes (CITATION.cff version untouched), `prettier --check` clean, `markdownlint` 0 errors, and CITATION.cff parses as valid CFF 1.2.0 with three author entries.