### PR TITLE
fix(deps): update rkyv to 0.8.18 for RUSTSEC-2026-0234/0235

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5044,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -5064,13 +5064,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5847,6 +5847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,7 +5913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ reqwest = { version = "0.13.3", default-features = false, features = [
     "blocking",
     "rustls",
 ] }
-rkyv = "0.8.16"
+rkyv = "0.8.18"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 sha2 = "0.11.0"


### PR DESCRIPTION
`cargo deny check advisories` is failing on **every** PR in the repo right now (it surfaced on #1335, a docs-only change). Two new RustSec advisories target **rkyv 0.8.16**:

- Insufficient archive validation causing out-of-bounds reads in archives containing `Rc`/`Arc`
- Shared-pointer validation keyed already-validated pointees by address and type but omitted pointer metadata, so an archive could carry multiple pointers sharing an address with different slice lengths; once the first was validated the rest skipped validation, letting the safe checked `rkyv::access` return a slice with a forged length. Also reachable via `rkyv::from_bytes`.

Fixed upstream in 0.8.17. This takes **0.8.18**.

## Why this matters here, beyond the CI gate

rkyv deserializes Provenant's **on-disk license-index cache** (`license_detection/license_cache.rs`, `token_set.rs`). That cache is `[32-byte rules fingerprint][32-byte payload digest][rkyv payload]` and lives in a user-writable cache directory. The digest catches corruption, but not a forged-length reinterpretation of otherwise-intact bytes — which is exactly the class this advisory covers. Stricter upstream validation is a genuine improvement, not just a green checkmark.

## Changes

- `Cargo.lock`: rkyv + rkyv_derive 0.8.16 → 0.8.18 (via `cargo update -p rkyv`)
- `Cargo.toml`: declared floor 0.8.16 → 0.8.18, so the fix reaches downstream consumers with stale lockfiles instead of only this repo's lockfile

`deny.toml` is untouched — the advisory is fixed at the dependency layer rather than suppressed.

## Verification

- `cargo deny check advisories bans licenses sources` → **advisories ok, bans ok, licenses ok, sources ok**
- `npm run format:manifests:check` clean · `check_unused_deps.sh` clean
- `cargo check --all-targets` clean
- Narrow tests over every rkyv-serialized path: `license_cache` 10 passed, `token_set` 5 passed, `license_detection::embedded` 17 passed